### PR TITLE
remove unnecessary slicing when calculating selected_pts_mask

### DIFF
--- a/src/gaussian.cu
+++ b/src/gaussian.cu
@@ -230,8 +230,8 @@ void GaussianModel::densify_and_split(torch::Tensor& grads, float grad_threshold
 void GaussianModel::densify_and_clone(torch::Tensor& grads, float grad_threshold, float scene_extent) {
     // Extract points that satisfy the gradient condition
     torch::Tensor selected_pts_mask = torch::where(grads >= grad_threshold,
-                                                   torch::ones_like(grads.index({torch::indexing::Slice()})).to(torch::kBool),
-                                                   torch::zeros_like(grads.index({torch::indexing::Slice()})).to(torch::kBool));
+                                                   torch::ones_like(grads).to(torch::kBool),
+                                                   torch::zeros_like(grads).to(torch::kBool));
 
     selected_pts_mask = torch::logical_and(selected_pts_mask, std::get<0>(Get_scaling().max(1)).unsqueeze(-1) <= _percent_dense * scene_extent);
 


### PR DESCRIPTION
slicing seems unnecessary when grads is size [N, 1]