### PR TITLE
run gaussian-splatting-cuda successfully on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,18 @@ target_link_libraries(${PROJECT_NAME}
         Python3::Python
 )
 
+if(WIN32)
+  file(GLOB TORCH_DLLS "${Torch_DIR}/../../../lib/*.dll")
+
+  foreach(TORCH_DLL ${TORCH_DLLS})
+    add_custom_command(
+      TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${TORCH_DLL}"
+              "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
+  endforeach()
+endif()
+
 # Build type configuration - Updated to handle INTERFACE libraries
 function(configure_build_type target)
     # Check if target is an INTERFACE library

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -10,6 +10,10 @@
 #include <variant>
 #include <vector>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 namespace gs {
     namespace param {
         namespace {
@@ -19,8 +23,15 @@ namespace gs {
              * @return std::filesystem::path Full path to the configuration file
              */
             std::filesystem::path get_config_path(const std::string& filename) {
+#ifdef _WIN32
+                char executablePathWindows[MAX_PATH];
+                GetModuleFileNameA(nullptr, executablePathWindows, MAX_PATH);
+                std::filesystem::path executablePath = std::filesystem::path(executablePathWindows);
+                std::filesystem::path parentDir = executablePath.parent_path().parent_path().parent_path();
+#else
                 std::filesystem::path executablePath = std::filesystem::canonical("/proc/self/exe");
                 std::filesystem::path parentDir = executablePath.parent_path().parent_path();
+#endif
                 return parentDir / "parameter" / filename;
             }
 


### PR DESCRIPTION
I am able to run the truck dataset successfully on Windows with the changes in this PR.

Didn't use `TARGET_BUNDLE_DLLS` because some dlls (e.g. cudnn) are dynamic loaded so `TARGET_BUNDLE_DLLS` can't find them.

`.parent_path().parent_path().parent_path()` is needed because Visual Studio is assumed, and it is a multi config generator so there will be an extra layer of folder like `Debug` or `Release` 