### PR TITLE
fixe interop problem in windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,9 @@ find_package(spdlog REQUIRED)
 # Python packages
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
-set(CMAKE_CUDA_RUNTIME_LIBRARY "Shared") # when using INTEROP in windows static and dynamic symbols are mixed
+if(WIN32)
+    set(CMAKE_CUDA_RUNTIME_LIBRARY "Shared") # when using INTEROP in windows static and dynamic symbols are mixed
+endif()
 
 # Check for CUDA-OpenGL interop capability (only if enabled)
 if(ENABLE_CUDA_GL_INTEROP)


### PR DESCRIPTION
1. had to  #include <cuda_runtime.h> to compilation in order for it to succeed.
2. after fixing this issue I had to force dynamic link since static and dynamic symbols were linked together

set(CMAKE_CUDA_RUNTIME_LIBRARY "Shared") 

Bad/good ??