### PR TITLE
Start looking at current folder for the parameters (better deployment in Windows)

### DIFF
--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -33,7 +33,7 @@ namespace gs {
                 char executablePathWindows[MAX_PATH];
                 GetModuleFileNameA(nullptr, executablePathWindows, MAX_PATH);
                 std::filesystem::path executablePath = std::filesystem::path(executablePathWindows);
-                std::filesystem::path searchDir = executablePath;
+                std::filesystem::path searchDir = executablePath.parent_path();
                 while (!searchDir.empty() && !std::filesystem::exists(searchDir / "parameter" / filename)) {
                     searchDir = searchDir.parent_path();
                 }


### PR DESCRIPTION
Instead of looking at the parent level it searches in the current folder and goes up level after level as before.

It allows the user to place the .xml in the same folder as the executable without breaking compatibility with the current folder tree.