### PR TITLE
Documentation update for the new name + some improvements for the windows build 

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ cmake --build build -- -j$(nproc)
 
 <details>
 <summary><b>Windows Build</b></summary>
+    
+note: [Detailed instructions here](https://github.com/MrNeRF/LichtFeld-Studio/blob/master/docs/windows_build_instructions.md)
 
 Run in <u>**x64 native tools command prompt for VS**</u>:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Previous winner: [Florian Hahlbohm](https://github.com/MrNeRF/LichtFeld-Studio/p
 ```bash
 # Clone and build (Linux)
 git clone https://github.com/MrNeRF/LichtFeld-Studio
-cd gaussian-splatting-cuda
+cd LichtFeld-Studio
 
 # Download LibTorch
 wget https://download.pytorch.org/libtorch/cu128/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcu128.zip  
@@ -106,7 +106,7 @@ export VCPKG_ROOT=/path/to/vcpkg  # Add to ~/.bashrc
 
 # Clone repository
 git clone https://github.com/MrNeRF/LichtFeld-Studio
-cd gaussian-splatting-cuda
+cd LichtFeld-Studio
 
 # Download LibTorch 2.7.0 with CUDA 12.8
 wget https://download.pytorch.org/libtorch/cu128/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcu128.zip  
@@ -139,7 +139,7 @@ set VCPKG_ROOT=%CD%\vcpkg
 
 # Clone repository
 git clone https://github.com/MrNeRF/LichtFeld-Studio
-cd gaussian-splatting-cuda
+cd LichtFeld-Studio
 
 # Create directories
 if not exist external mkdir external

--- a/docs/windows_build_instructions.md
+++ b/docs/windows_build_instructions.md
@@ -111,18 +111,14 @@ Note: Installation of dependencies and compiling of LichtFeld Studio will take a
 
 		git clone https://github.com/microsoft/vcpkg.git
   		cd vcpkg && .\bootstrap-vcpkg.bat -disableMetrics && cd ..
-
-- set environment variable
-
-		set VCPKG_ROOT=%CD%\vcpkg
   
 - Clone repository
   
-		git clone https://github.com/MrNeRF/gaussian-splatting-cuda
+		git clone https://github.com/MrNeRF/LichtFeld-Studio
   
 - Create directories
   
-		cd gaussian-splatting-cuda
+		cd LichtFeld-Studio
 		if not exist external mkdir external
 		if not exist external\debug mkdir external\debug
 		if not exist external\release mkdir external\release
@@ -141,15 +137,13 @@ Note: Installation of dependencies and compiling of LichtFeld Studio will take a
 
 - Build configuration files and download dependancies
  
-		cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja
-		## Or if you want you can specify your own vcpkg
-		# cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja -DCMAKE_TOOLCHAIN_FILE="<path-to-vcpkg>/scripts/buildsystems/vcpkg.cmake"
+		cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja -DCMAKE_TOOLCHAIN_FILE="../vcpkg/scripts/buildsystems/vcpkg.cmake"
 
 - build LichtFeld Studio
  
 		cmake --build build -j
 
-After the last step is complete, you should have a new directory "\build\releases" where you can find "gaussian_splatting_cuda.exe" and you can execute that file to run LichtFeld Studio.
+After the last step is complete, you should have a new directory "\build" where you can find "LichtFeld-Studio.exe" and you can execute that file to run LichtFeld Studio.
 
 <img width="1110" height="683" alt="image" src="https://github.com/user-attachments/assets/605c5b3a-53b3-4f16-85e2-05e9af2327cd" />
 
@@ -183,7 +177,7 @@ After the last step is complete, you should have a new directory "\build\release
 - Possible cause: build files not up-to date with latest changes
 - Solution: Re-generate the configuration files using in the command prompt and rebuild LichtFeld Studio
         
-			cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja
+			cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja -DCMAKE_TOOLCHAIN_FILE="../vcpkg/scripts/buildsystems/vcpkg.cmake"
 			cmake --build build -j
 
 #### Other things to check


### PR DESCRIPTION
Documentation update for the new name + some improvements for the windows build that were discussed in the #dev discord channel: 

do not use SET to set the environment variable for vcpkm, but just pass the entire path in the command. as users will be using copy/paste, this now takes less steps again and is more clear on what to copy/paste. also avoids errors when recreating the build files and forgetting to use "SET"