### PR TITLE
Remove Python dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,6 @@ find_package(imgui REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(args REQUIRED)
 find_package(spdlog REQUIRED)
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 find_package(Freetype REQUIRED)
 find_package(WebP REQUIRED)
 find_package(LibArchive REQUIRED)
@@ -358,7 +357,6 @@ if(KERNEL_SOURCES)
             ${CUDAToolkit_INCLUDE_DIRS}
             ${OPENGL_INCLUDE_DIRS}
             PRIVATE
-            ${Python3_INCLUDE_DIRS}
     )
 
     target_link_libraries(gs_kernels
@@ -407,7 +405,7 @@ target_include_directories(${PROJECT_NAME}
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_BINARY_DIR}/include
-        ${Python3_INCLUDE_DIRS}
+        
         ${CUDAToolkit_INCLUDE_DIRS}
         ${OPENGL_INCLUDE_DIRS}
 )
@@ -424,7 +422,7 @@ target_link_libraries(${PROJECT_NAME}
         gs_kernels
         gsplat_backend
         fastgs_backend
-        ${Python3_LIBRARIES}
+        
         ${OPENGL_LIBRARIES}
         CUDA::cudart
         spdlog::spdlog
@@ -520,7 +518,7 @@ if(BUILD_TESTS)
             ${CMAKE_CURRENT_SOURCE_DIR}/include
             ${CMAKE_CURRENT_BINARY_DIR}/include
             ${CMAKE_CURRENT_SOURCE_DIR}/tests
-            ${Python3_INCLUDE_DIRS}
+            
             ${CUDAToolkit_INCLUDE_DIRS}
             ${OPENGL_INCLUDE_DIRS}
     )
@@ -538,7 +536,7 @@ if(BUILD_TESTS)
             fastgs_backend
             GTest::gtest
             GTest::gtest_main
-            Python3::Python
+            
             ${OPENGL_LIBRARIES}
             CUDA::cudart
             spdlog::spdlog
@@ -586,7 +584,6 @@ message(STATUS "Build Configuration:")
 message(STATUS "  CUDA Version: ${CUDAToolkit_VERSION}")
 message(STATUS "  CUDA Archs: ${CMAKE_CUDA_ARCHITECTURES}")
 message(STATUS "  Torch Version: ${Torch_VERSION}")
-message(STATUS "  Python Version: ${Python3_VERSION}")
 message(STATUS "  OpenGL Found: ${OPENGL_FOUND}")
 message(STATUS "  FreeType Found: ${FREETYPE_FOUND}")
 message(STATUS "  WebP Found: ${WebP_FOUND}")

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cmake --build build -- -j$(nproc)
 - **CMake**: 3.24 or higher
 - **Compiler**: C++23 compatible (GCC 14+ or Clang 17+)
 - **CUDA**: 12.8 or higher (required)
-- **Python**: With development headers
+  
 - **LibTorch**: 2.7.0 (setup instructions below)
 - **vcpkg**: For dependency management
 

--- a/fastgs/CMakeLists.txt
+++ b/fastgs/CMakeLists.txt
@@ -42,7 +42,6 @@ target_include_directories(fastgs_backend
         ${OPENGL_INCLUDE_DIRS}
         ${TORCH_INCLUDE_DIRS}
         PRIVATE
-        ${Python3_INCLUDE_DIRS}
 )
 
 target_link_libraries(fastgs_backend

--- a/fastgs/optimizer/include/adam_api.h
+++ b/fastgs/optimizer/include/adam_api.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 namespace fast_gs::optimizer {
 

--- a/fastgs/rasterization/include/rasterization_api.h
+++ b/fastgs/rasterization/include/rasterization_api.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 #include <tuple>
 
 namespace fast_gs::rasterization {

--- a/fastgs/utils/torch_utils.h
+++ b/fastgs/utils/torch_utils.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <functional>
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 inline std::function<char*(size_t N)> resize_function_wrapper(torch::Tensor& t) {
     auto lambda = [&t](const size_t N) {

--- a/gsplat/CMakeLists.txt
+++ b/gsplat/CMakeLists.txt
@@ -59,7 +59,6 @@ target_include_directories(gsplat_backend
         ${TORCH_INCLUDE_DIRS}
         ${CUDAToolkit_INCLUDE_DIRS}
         PRIVATE
-        ${Python3_INCLUDE_DIRS}
 )
 
 target_link_libraries(gsplat_backend

--- a/include/kernels/ssim.cuh
+++ b/include/kernels/ssim.cuh
@@ -5,7 +5,7 @@
 #pragma once
 #include <cstdio>
 #include <string>
-#include <torch/extension.h>
+#include <torch/torch.h>
 #include <tuple>
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -26,7 +26,6 @@ target_include_directories(gs_core
     PRIVATE
         ${CMAKE_SOURCE_DIR}/src       # For inter-module includes (training/, visualizer/, etc.)
         ${CMAKE_SOURCE_DIR}/external  # For tinyply and STB headers
-        ${Python3_INCLUDE_DIRS}
         ${OPENGL_INCLUDE_DIRS}
 )
 
@@ -61,7 +60,6 @@ target_link_libraries(gs_core
         nlohmann_json::nlohmann_json
         glm::glm
         Threads::Threads
-        Python3::Python
         CUDA::cudart    # For Camera CUDA operations
         spdlog::spdlog
         ${WEBP_LIB}     # WebP for SOG compression

--- a/src/rendering/CMakeLists.txt
+++ b/src/rendering/CMakeLists.txt
@@ -61,7 +61,6 @@ target_include_directories(gs_rendering
         ${CMAKE_CURRENT_SOURCE_DIR}/cuda/utils
         ${CMAKE_SOURCE_DIR}/src
         ${OPENGL_INCLUDE_DIRS}
-        ${Python3_INCLUDE_DIRS}
 )
 
 # Handle shaders

--- a/src/rendering/cuda/CMakeLists.txt
+++ b/src/rendering/cuda/CMakeLists.txt
@@ -26,7 +26,6 @@ target_include_directories(rendering_cuda_backend
         ${CMAKE_SOURCE_DIR}/include
         ${CUDAToolkit_INCLUDE_DIRS}
         ${TORCH_INCLUDE_DIRS}
-        ${Python3_INCLUDE_DIRS}
 )
 
 target_link_libraries(rendering_cuda_backend

--- a/src/rendering/cuda/rasterization/include/rasterization_api.h
+++ b/src/rendering/cuda/rasterization/include/rasterization_api.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 #include <tuple>
 
 namespace gs::rendering {

--- a/src/rendering/cuda/utils/torch_utils.h
+++ b/src/rendering/cuda/utils/torch_utils.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <functional>
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 inline std::function<char*(size_t N)> resize_function_wrapper(torch::Tensor& t) {
     auto lambda = [&t](const size_t N) {

--- a/src/training/CMakeLists.txt
+++ b/src/training/CMakeLists.txt
@@ -59,7 +59,6 @@ target_include_directories(gs_training_kernels
         ${CMAKE_SOURCE_DIR}/gsplat
         ${CMAKE_SOURCE_DIR}/fastgs
         ${CUDAToolkit_INCLUDE_DIRS}
-        ${Python3_INCLUDE_DIRS}
 )
 
 target_link_libraries(gs_training_kernels
@@ -89,7 +88,6 @@ target_include_directories(gs_training
         ${CMAKE_SOURCE_DIR}/gsplat
         ${CMAKE_SOURCE_DIR}/fastgs
         ${CUDAToolkit_INCLUDE_DIRS}
-        ${Python3_INCLUDE_DIRS}
         ${OPENGL_INCLUDE_DIRS}
 )
 
@@ -106,7 +104,6 @@ target_link_libraries(gs_training
         nlohmann_json::nlohmann_json
         glm::glm
         Threads::Threads
-        Python3::Python
         CUDA::cudart
         spdlog::spdlog
         PRIVATE

--- a/src/training/kernels/ssim.cu
+++ b/src/training/kernels/ssim.cu
@@ -6,7 +6,7 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <cooperative_groups.h>
 #include <iostream>
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 namespace cg = cooperative_groups;
 

--- a/src/visualizer/CMakeLists.txt
+++ b/src/visualizer/CMakeLists.txt
@@ -55,7 +55,6 @@ target_include_directories(gs_visualizer
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/src
         ${OPENGL_INCLUDE_DIRS}
-        ${Python3_INCLUDE_DIRS}
 )
 
 # Link dependencies
@@ -76,7 +75,6 @@ target_link_libraries(gs_visualizer
         TBB::tbb
         spdlog::spdlog
         nlohmann_json::nlohmann_json
-        Python3::Python
         CUDA::cudart
         ${OPENGL_LIBRARIES}
 )


### PR DESCRIPTION
I noticed we only had one real place where Python3 headers were needed to do a build, that's due to "torch/extensions.h".  That was just replaceable with "torch/torch.h".

- Drop find_package(Python3) and all Python include/link usage in CMake
- Replace torch/extension.h with torch/torch.h to avoid Python.h
- Remove Python dev header note from README

So, no more python dependency needed at all anymore.
Happy Building!