### PR TITLE
cmake: bump 3.30 and use CXX_COMPILER_FRONTEND_VARIANT

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,6 +28,22 @@ jobs:
       - name: Install GCC 14 and dependencies
         run: |
           apt-get update
+
+          # install cmake from https://apt.kitware.com to get cmake 3.30+
+          
+          apt-get install -y ca-certificates gpg wget 
+
+          test -f /usr/share/doc/kitware-archive-keyring/copyright ||
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+          
+          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+          apt-get update
+
+          test -f /usr/share/doc/kitware-archive-keyring/copyright ||
+          rm /usr/share/keyrings/kitware-archive-keyring.gpg
+
+          apt-get install -y kitware-archive-keyring
+
           apt-get install -y git curl unzip cmake gcc-14 g++-14 ccache ninja-build
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \
                               --slave /usr/bin/g++ g++ /usr/bin/g++-14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if ("${CMAKE_TOOLCHAIN_FILE}" STREQUAL "")
     set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
 endif()
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.30)
 project(LichtFeld-Studio LANGUAGES CUDA CXX C)
 
 # Setup

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cmake --build build -- -j$(nproc)
 
 #### Software
 - **OS**: Linux (Ubuntu 22.04+) or Windows
-- **CMake**: 3.24 or higher
+- **CMake**: 3.30 or higher
 - **Compiler**: C++23 compatible (GCC 14+ or Clang 17+)
 - **CUDA**: 12.8 or higher (required)
   

--- a/docs/docs/installation/building/windows.md
+++ b/docs/docs/installation/building/windows.md
@@ -80,7 +80,7 @@
 	
 	Python --version
 	```
-- Cmake: Must be 3.24 or higher
+- Cmake: Must be 3.30 or higher
 - nvcc: Verify that 12.8 is being used
 - git: Verify that git shows version information
 - python: Verify that 3.10 or above is used

--- a/fastgs/CMakeLists.txt
+++ b/fastgs/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-cmake_minimum_required(VERSION 3.24...3.30)
+cmake_minimum_required(VERSION 3.30)
 
 # TODO: This file is a bit of a mess and needs to be cleaned up.
 

--- a/gsplat/CMakeLists.txt
+++ b/gsplat/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24...3.30)
+cmake_minimum_required(VERSION 3.30)
 
 # Get torch from parent
 if(NOT DEFINED TORCH_INCLUDE_DIRS)

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -85,8 +85,8 @@ target_compile_features(gs_loader PUBLIC cxx_std_23)
 
 # Compiler options
 target_compile_options(gs_loader PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic>
-        $<$<CXX_COMPILER_ID:MSVC>:/W4>
+        $<$<CXX_COMPILER_FRONTEND_VARIANT:GNU>:-Wall -Wextra -Wpedantic>
+        $<$<CXX_COMPILER_FRONTEND_VARIANT:MSVC>:/W4>
 )
 
 # AVX2 support for ply.cpp

--- a/src/visualizer/CMakeLists.txt
+++ b/src/visualizer/CMakeLists.txt
@@ -84,8 +84,8 @@ target_compile_features(gs_visualizer PUBLIC cxx_std_23)
 
 # Compiler options
 target_compile_options(gs_visualizer PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic>
-        $<$<CXX_COMPILER_ID:MSVC>:/W4>
+        $<$<CXX_COMPILER_FRONTEND_VARIANT:GNU>:-Wall -Wextra -Wpedantic>
+        $<$<CXX_COMPILER_FRONTEND_VARIANT:MSVC>:/W4>
         $<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:GNU,Clang>>:-O0 -g>
         $<$<AND:$<CONFIG:Release>,$<CXX_COMPILER_ID:GNU,Clang>>:-O3>
 )


### PR DESCRIPTION
Suddenly I have to use clang-cl now, but it treats -Wall as -Weverything so clang-cl users have a lot of "not compatible with c++98" warnings

CXX_COMPILER_FRONTEND_VARIANT was added in version 3.30, which allows to separate clang-cl (MSVC frontend)
and clang (GNU frontend) to use different flags.
The other compilers (MSVC, GNU) can only have one frontend, so their flags remain unchanged.