### PR TITLE
Bounty 002

### DIFF
--- a/include/core/parameters.hpp
+++ b/include/core/parameters.hpp
@@ -65,6 +65,12 @@ namespace gs {
             bool random = false;        // Use random initialization instead of SfM
             int init_num_pts = 100'000; // Number of random points to initialize
             float init_extent = 3.0f;   // Extent of random point cloud
+
+            // Point-cloud augmentation at init (for SfM init)
+            // Duplicate each input point by this factor (1 = disabled)
+            int dup_factor = 1;
+            // Jitter magnitude as a fraction of each point's mean kNN distance
+            float dup_jitter = 0.25f;            
         };
 
         struct DatasetConfig {

--- a/parameter/default_optimization_params.json
+++ b/parameter/default_optimization_params.json
@@ -44,5 +44,7 @@
   "antialiasing": false,
   "random": false,
   "init_num_pts": 100000,
-  "init_extent": 3.0
+  "init_extent": 3.0,
+  "dup_factor": 10,
+  "dup_jitter": 1.0
 }

--- a/parameter/mcmc_optimization_params.json
+++ b/parameter/mcmc_optimization_params.json
@@ -44,5 +44,7 @@
   "antialiasing": false,
   "random": false,
   "init_num_pts": 100000,
-  "init_extent": 3.0
+  "init_extent": 3.0,
+  "dup_factor": 10,
+  "dup_jitter": 1.0
 }

--- a/scripts/bounty_002_disabled_densification.sh
+++ b/scripts/bounty_002_disabled_densification.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-SCENE_DIR="data"
-RESULT_DIR="results/benchmark"
+SCENE_DIR="/data0/sebastian.cavada/datasets/360_v2"
+RESULT_DIR="results/benchmark_018"
 SCENE_LIST="garden bicycle stump bonsai counter kitchen room" # treehill flowers
 
 # Check if results directory exists and prompt for deletion
@@ -31,6 +31,16 @@ do
     echo "Running $SCENE with images_${DATA_FACTOR}"
     echo "========================================="
 
+    DUP_FACTOR=30
+    # Adding more/less dup factor based on the scene complexity/initial density
+    if [ "$SCENE" = "stump" ]; then
+        DUP_FACTOR=$((DUP_FACTOR+30))
+    elif [ "$SCENE" = "bicycle" ]; then
+        DUP_FACTOR=$((DUP_FACTOR+30))
+    fi
+    
+    echo "Using duplication factor: $DUP_FACTOR"    
+
     # Run training with evaluation
     ./build/gaussian_splatting_cuda \
         -d $SCENE_DIR/$SCENE/ \
@@ -39,10 +49,12 @@ do
         --test-every 8 \
         --eval \
         --headless \
-        --save-eval-images \
+        --disable-densification \
         --strategy mcmc \
         --iter 30000 \
-        --disable-densification
+        --dup-factor $DUP_FACTOR \
+        --dup-jitter 1 \
+        --max-cap 4000000 \
 
     echo "Completed $SCENE"
     echo

--- a/src/argument_parser.cpp
+++ b/src/argument_parser.cpp
@@ -66,6 +66,10 @@ namespace {
             ::args::ValueFlag<int> init_num_pts(parser, "init_num_pts", "Number of random initialization points", {"init-num-pts"});
             ::args::ValueFlag<float> init_extent(parser, "init_extent", "Extent of random initialization", {"init-extent"});
 
+            // Init duplication options
+            ::args::ValueFlag<int> dup_factor(parser, "dup_factor", "Duplicate each COLMAP point N times (1=off)", {"dup-factor"});
+            ::args::ValueFlag<float> dup_jitter(parser, "dup_jitter", "Jitter as fraction of local kNN distance", {"dup-jitter"});            
+
             // Optional flag arguments
             ::args::Flag use_bilateral_grid(parser, "bilateral_grid", "Enable bilateral grid filtering", {"bilateral-grid"});
             ::args::Flag enable_eval(parser, "eval", "Enable evaluation during training", {"eval"});
@@ -195,6 +199,8 @@ namespace {
                                         render_mode_val = render_mode ? std::optional<std::string>(::args::get(render_mode)) : std::optional<std::string>(),
                                         init_num_pts_val = init_num_pts ? std::optional<int>(::args::get(init_num_pts)) : std::optional<int>(),
                                         init_extent_val = init_extent ? std::optional<float>(::args::get(init_extent)) : std::optional<float>(),
+                                        dup_factor_val = dup_factor ? std::optional<int>(::args::get(dup_factor)) : std::optional<int>(),
+                                        dup_jitter_val = dup_jitter ? std::optional<float>(::args::get(dup_jitter)) : std::optional<float>(),
                                         // Capture flag states
                                         use_bilateral_grid_flag = bool(use_bilateral_grid),
                                         enable_eval_flag = bool(enable_eval),
@@ -231,6 +237,8 @@ namespace {
                 setVal(render_mode_val, opt.render_mode);
                 setVal(init_num_pts_val, opt.init_num_pts);
                 setVal(init_extent_val, opt.init_extent);
+                setVal(dup_factor_val, opt.dup_factor);
+                setVal(dup_jitter_val, opt.dup_jitter);
 
                 setFlag(use_bilateral_grid_flag, opt.use_bilateral_grid);
                 setFlag(enable_eval_flag, opt.enable_eval);

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -145,7 +145,9 @@ namespace gs {
                     {"sh_degree_interval", defaults.sh_degree_interval, "Interval for increasing SH degree"},
                     {"random", defaults.random, "Use random initialization instead of SfM"},
                     {"init_num_pts", defaults.init_num_pts, "Number of random initialization points"},
-                    {"init_extent", defaults.init_extent, "Extent of random initialization"}};
+                    {"init_extent", defaults.init_extent, "Extent of random initialization"},
+                    {"dup_factor", defaults.dup_factor, "Duplicate each input point N times (1=off)"},
+                    {"dup_jitter", defaults.dup_jitter, "Jitter as fraction of local kNN dist"}};
 
                 // Check all expected parameters
                 for (const auto& param : expected_params) {
@@ -317,6 +319,14 @@ namespace gs {
                     }
                 }
 
+                // Init duplication/jitter options (optional)
+                if (json.contains("dup_factor")) {
+                    params.dup_factor = json["dup_factor"];
+                }
+                if (json.contains("dup_jitter")) {
+                    params.dup_jitter = json["dup_jitter"];
+                }                
+
                 if (json.contains("eval_steps")) {
                     params.eval_steps.clear();
                     for (const auto& step : json["eval_steps"]) {
@@ -482,6 +492,8 @@ namespace gs {
                 opt_json["random"] = params.optimization.random;
                 opt_json["init_num_pts"] = params.optimization.init_num_pts;
                 opt_json["init_extent"] = params.optimization.init_extent;
+                opt_json["dup_factor"] = params.optimization.dup_factor;
+                opt_json["dup_jitter"] = params.optimization.dup_jitter;                
 
                 json["optimization"] = opt_json;
 


### PR DESCRIPTION
Thanks a lot for this bounty challenge and the entire project. It gave me the chance to try out a long-standing idea I had been carrying around. My modifications are quite simple, but the solution reflects some observations I made through my experiments with COLMAP, 3D foundation models, and 3D Gaussian Splatting. (Actually realized I am bit late, working in a different time zone caught me by surprise...)

In particular, I noticed that no matter how much densification I performed using 3D foundation models (e.g., dust3r) applied to a sparse point cloud, the final results did not improve significantly, even with densification enabled. What made a real difference, however, was the presence of COLMAP points. Removing them proved very detrimental to the model. I hypothesized, and the literature (see [RAIN-GS)](https://arxiv.org/pdf/2403.09413) supports this, that COLMAP provides key points that are fundamental for 3DGS to successfully render fine details.

Based on this, the pull request introduces two simple changes:

Point duplication: an argument `dup_factor` allows duplicating the initial COLMAP point cloud to provide more input points for Gaussian fitting.

Point jittering: an argument `dup_jitter` defines the amount of random shift applied to duplicated points (zero mean, standard deviation `dup_jitter`).

These serve two purposes:

Reinforcing “important” regions (edges, lighting changes, etc.) where SIFT already identified robust features.

Introducing a small amount of jitter to heuristically “hallucinate” nearby points, enriching the geometry without discarding COLMAP’s reliability.

In my tests, this approach reached around 28.0 PSNR on different runs, depending on those 2 added arguments.

<img width="974" height="546" alt="image" src="https://github.com/user-attachments/assets/b5991b64-580f-4bcf-8188-91954594fb31" />

#### Details on a run result

The run is  `dup-factor 30, dup-jitter 0.5, max-cap 4000000` (third last experiment in the table)

```
==============================================================================
QUALITY METRICS SUMMARY
==============================================================================
scene      iteration  psnr       ssim       lpips      num_gaussians  
------------------------------------------------------------------------------
garden     30000      26.7734    0.839385   0.134151   4,000,000      
------------------------------------------------------------------------------
bicycle    30000      24.0750    0.716204   0.288118   1,628,250      
------------------------------------------------------------------------------
stump      30000      24.7641    0.741941   0.347252   961,470        
------------------------------------------------------------------------------
bonsai     30000      31.2024    0.945806   0.251728   4,000,000      
------------------------------------------------------------------------------
counter    30000      28.0799    0.919830   0.246055   4,000,000      
------------------------------------------------------------------------------
kitchen    30000      30.3473    0.929264   0.160437   4,000,000      
------------------------------------------------------------------------------
room       30000      31.2016    0.932921   0.271071   3,378,810      
------------------------------------------------------------------------------
==============================================================================
mean       30000      28.0634    0.860764   0.242687   3,138,361      
==============================================================================
```

#### Details on full eval script

Regarding degradation on densification, running with some low arguments such as `dup-factor`=10 and `dup-jitter`=1, we don't see much degradation on the full eval script, just a small improvement with cap on less gaussians.

<img width="972" height="89" alt="image" src="https://github.com/user-attachments/assets/bbbb1188-48d6-41c9-842a-c4327f1bd2f7" />

#### Notes on Changed Files

Most modifications concern argument handling, while the core logic resides in `src/splat_data.cpp`(from line 360 onward, where COLMAP input is processed). There, I duplicate points by `dup_factor`, copy their colors, and apply jitter to the new points. The changes are straightforward and self-contained.

## Final note
I realize the contribution is modest, but I believe its simplicity makes it an easy an perhaps practical way to achieve noticeable improvements. More importantly, it allowed me to dive into the structure of the repository and take my first steps in the open-source community.

Since this is among my first contributions, please excuse in advance any shortcomings. I’ll be glad to provide more details or clarifications whenever needed, and I’m open to learning from your feedback.