### PR TITLE
move camera up/down with Q and E keys

### DIFF
--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -579,53 +579,19 @@ namespace gs::visualizer {
             keys_wasd_[3] = pressed;
             changed = true;
             break;
+        case GLFW_KEY_Q:
+            keys_wasd_[4] = pressed;
+            changed = true;
+            break;
+        case GLFW_KEY_E:
+            keys_wasd_[5] = pressed;
+            changed = true;
+            break;
         }
 
         if (changed) {
-            LOG_TRACE("WASD state changed - W:{} A:{} S:{} D:{}",
-                      keys_wasd_[0], keys_wasd_[1], keys_wasd_[2], keys_wasd_[3]);
-        }
-    }
-
-    void InputController::processWASDMovement() {
-        // Calculate frame delta time
-        auto now = std::chrono::high_resolution_clock::now();
-        float delta_time = std::chrono::duration<float>(now - last_frame_time_).count();
-        last_frame_time_ = now;
-
-        // Clamp delta time to prevent huge jumps (60 FPS min)
-        delta_time = std::min(delta_time, 1.0f / 60.0f);
-
-        // Only process WASD if we should handle input and not dragging anything
-        if (!shouldCameraHandleInput() || drag_mode_ != DragMode::None) {
-            return;
-        }
-
-        bool any_movement = false;
-
-        // Process each WASD key with frame-time based movement
-        if (keys_wasd_[0]) { // W
-            viewport_.camera.advance_forward(delta_time);
-            any_movement = true;
-        }
-        if (keys_wasd_[1]) { // A
-            viewport_.camera.advance_left(delta_time);
-            any_movement = true;
-        }
-        if (keys_wasd_[2]) { // S
-            viewport_.camera.advance_backward(delta_time);
-            any_movement = true;
-        }
-        if (keys_wasd_[3]) { // D
-            viewport_.camera.advance_right(delta_time);
-            any_movement = true;
-        }
-
-        // Publish camera move if we moved
-        if (any_movement) {
-            publishCameraMove();
-            LOG_TRACE("WASD movement - W:{} A:{} S:{} D:{}",
-                      keys_wasd_[0], keys_wasd_[1], keys_wasd_[2], keys_wasd_[3]);
+            LOG_TRACE("WASD state changed - W:{} A:{} S:{} D:{} Q:{} E:{}",
+                      keys_wasd_[0], keys_wasd_[1], keys_wasd_[2], keys_wasd_[3], keys_wasd_[4], keys_wasd_[5]);
         }
     }
 
@@ -671,10 +637,16 @@ namespace gs::visualizer {
             if (keys_wasd_[3]) {
                 viewport_.camera.advance_right(delta_time);
             }
+            if (keys_wasd_[4]) {
+                viewport_.camera.advance_up(delta_time);
+            }
+            if (keys_wasd_[5]) {
+                viewport_.camera.advance_down(delta_time);
+            }
         }
 
         // Publish if moving (removed inertia check)
-        bool moving = keys_wasd_[0] || keys_wasd_[1] || keys_wasd_[2] || keys_wasd_[3];
+        bool moving = keys_wasd_[0] || keys_wasd_[1] || keys_wasd_[2] || keys_wasd_[3] || keys_wasd_[4] || keys_wasd_[5];
         if (moving) {
             publishCameraMove();
         }

--- a/src/visualizer/input/input_controller.hpp
+++ b/src/visualizer/input/input_controller.hpp
@@ -132,7 +132,7 @@ namespace gs::visualizer {
         // Key states (only what we actually need)
         bool key_r_pressed_ = false;
         bool key_ctrl_pressed_ = false;
-        bool keys_wasd_[4] = {false, false, false, false}; // W,A,S,D
+        bool keys_wasd_[6] = {false, false, false, false, false, false}; // W,A,S,D,Q,E
 
         // Special modes
         bool point_cloud_mode_ = false;

--- a/src/visualizer/internal/viewport.hpp
+++ b/src/visualizer/internal/viewport.hpp
@@ -105,6 +105,14 @@ class Viewport {
             t += R * glm::vec3(1, 0, 0) * deltaTime * wasdSpeed;
         }
 
+        void advance_up(float deltaTime) {
+            t += R * glm::vec3(0, -1, 0) * deltaTime * wasdSpeed;
+        }
+
+        void advance_down(float deltaTime) {
+            t += R * glm::vec3(0, 1, 0) * deltaTime * wasdSpeed;
+        }
+
         void initScreenPos(const glm::vec2& pos) {
             prePos = pos;
         }


### PR DESCRIPTION
* Added movement using the Q and E key
* removed processWASDMovement() as it was not being used by the code and is probably something historic - all movement is handled by the update() function