### PR TITLE
Use executable relative paths for asset loading

### DIFF
--- a/src/rendering/shader_paths.hpp
+++ b/src/rendering/shader_paths.hpp
@@ -34,8 +34,15 @@ namespace gs::rendering {
         LOG_TRACE("Shader '{}' not found in source directory: {}", shader_name, source_path.string());
 #endif
 
-        // Last resort - try relative to current file
+        // Try relative to current file
         std::filesystem::path fallback_path = std::filesystem::path(__FILE__).parent_path() / "resources" / "shaders" / shader_name;
+        if (std::filesystem::exists(fallback_path)) {
+            LOG_DEBUG("Found shader '{}' in fallback path: {}", shader_name, fallback_path.string());
+            return fallback_path;
+        }
+                
+        // Last resort - try relative to the executable
+        fallback_path = std::filesystem::current_path() / "resources" / "shaders" / shader_name;
         if (std::filesystem::exists(fallback_path)) {
             LOG_DEBUG("Found shader '{}' in fallback path: {}", shader_name, fallback_path.string());
             return fallback_path;

--- a/src/rendering/viewport_gizmo.cpp
+++ b/src/rendering/viewport_gizmo.cpp
@@ -46,6 +46,13 @@ namespace gs::rendering {
         // Load font from our assets
         std::string font_path = std::string(PROJECT_ROOT_PATH) +
                                 "/src/rendering/resources/assets/JetBrainsMono-Regular.ttf";
+
+        if (!std::filesystem::exists(font_path)) {
+            font_path = (std::filesystem::current_path() /
+                         "/resources/assets/JetBrainsMono-Regular.ttf")
+                            .string();
+        }
+
         if (auto result = text_renderer_->LoadFont(font_path, 48); !result) {
             LOG_WARN("ViewportGizmo: Failed to load font: {}", result.error());
             text_renderer_.reset();


### PR DESCRIPTION
Assets ( shaders and TTF fonts) are now searched as a fallback from a 'resources' subdirectory relative to the executable.

This enables portable deployment where the executable and resources folder can be distributed together as a self-contained package, independent of installation path or working directory.