### PR TITLE
fixed loading json parameter

### DIFF
--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -344,7 +344,7 @@ namespace gs {
                 params.init_scaling = json["init_scaling"];
             }
             if (json.contains("num_workers")) {
-                params.num_workers = json["num_workers_cap"];
+                params.num_workers = json["num_workers"];
             }
             if (json.contains("max_cap")) {
                 params.max_cap = json["max_cap"];


### PR DESCRIPTION
the json parameter for num_workers was loaded using the wrong json index, causing a crash when loading a .ls file