### PR TITLE
Expose --gut (GUT) and --rc (Reality Capture) in GUI

### DIFF
--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -586,7 +586,7 @@ namespace gs::training {
                     return std::unexpected("Training on cameras with ortho model is not supported yet.");
                 }
             } else {
-                // Flag is workaround for non-RC datasets with distortion. By default it is off.                
+                // Flag is workaround for non-RC datasets with distortion. By default it is off.
                 if (!params_.optimization.rc) {
                     if (cam->radial_distortion().numel() != 0 ||
                         cam->tangential_distortion().numel() != 0) {

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -586,11 +586,11 @@ namespace gs::training {
                     return std::unexpected("Training on cameras with ortho model is not supported yet.");
                 }
             } else {
-                // Flag is workaround for non-RC datasets with distortion. By default it is off.
+                // Flag is workaround for non-RC datasets with distortion. By default it is off.                
                 if (!params_.optimization.rc) {
                     if (cam->radial_distortion().numel() != 0 ||
                         cam->tangential_distortion().numel() != 0) {
-                        return std::unexpected("You must use --gut option to train on cameras with distortion.");
+                        return std::unexpected("Distorted images detected.  Enable 'GUT' if true or 'Reality Capture' if applicable.");
                     }
                     if (cam->camera_model_type() != gsplat::CameraModelType::PINHOLE) {
                         return std::unexpected("You must use --gut option to train on cameras with non-pinhole model.");

--- a/src/visualizer/gui/panels/training_panel.cpp
+++ b/src/visualizer/gui/panels/training_panel.cpp
@@ -197,13 +197,41 @@ namespace gs::gui::panels {
                 }
 
                 ImGui::EndTable();
+
+                // Reality Capture checkbox
+                bool rc_enabled = opt_params.rc;
+                if (!can_edit) {
+                    ImGui::BeginDisabled();
+                }
+                if (ImGui::Checkbox("Import from Reality Capture", &rc_enabled)) {
+                    opt_params.rc = rc_enabled;
+                    opt_params_changed = true;
+                }
+                if (!can_edit) {
+                    ImGui::EndDisabled();
+                }
             }
             ImGui::TreePop();
         }
 
         // Optimization Parameters
         if (ImGui::TreeNode("Optimization")) {
+
+            // Enabled GUI checkbox
+            if (!can_edit) {
+                ImGui::BeginDisabled();
+            }
+            bool gut_enabled = opt_params.gut;
+            if (ImGui::Checkbox("GUT", &gut_enabled)) {
+                opt_params.gut = gut_enabled;
+                opt_params_changed = true;
+            }
+            if (!can_edit) {
+                ImGui::EndDisabled();
+            }
+
             if (ImGui::BeginTable("OptimizationTable", 2, ImGuiTableFlags_SizingStretchProp)) {
+
                 ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_WidthFixed, 120.0f);
                 ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
 
@@ -717,6 +745,14 @@ namespace gs::gui::panels {
                 if (!error_msg.empty()) {
                     ImGui::TextWrapped("%s", error_msg.c_str());
                 }
+                // Reset button
+                ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.5f, 0.5f, 0.7f, 1.0f));
+                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.6f, 0.6f, 0.8f, 1.0f));
+                if (ImGui::Button("Reset Training", ImVec2(-1, 0))) {
+                    trainer_manager->resetTraining();
+                }
+                ImGui::PopStyleColor(2);
+
             }
             break;
 

--- a/src/visualizer/gui/panels/training_panel.cpp
+++ b/src/visualizer/gui/panels/training_panel.cpp
@@ -216,7 +216,6 @@ namespace gs::gui::panels {
 
         // Optimization Parameters
         if (ImGui::TreeNode("Optimization")) {
-
             // Enabled GUI checkbox
             if (!can_edit) {
                 ImGui::BeginDisabled();
@@ -231,7 +230,6 @@ namespace gs::gui::panels {
             }
 
             if (ImGui::BeginTable("OptimizationTable", 2, ImGuiTableFlags_SizingStretchProp)) {
-
                 ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_WidthFixed, 120.0f);
                 ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
 


### PR DESCRIPTION
This change adds 2 checkboxes to to GUI:
* under dataset, we add "import from Reality Capture"
* under optimization, we add "GUT"

These checkboxes can be used to enable training of distorted images through the GUI without the need to specify their startup parameters.

<img width="237" height="317" alt="image" src="https://github.com/user-attachments/assets/77e2b030-80ca-4d66-9517-14d96150b46f" />


We also change the error message that is displayed when training with distorted images is detected.
Finally, we allow a "reset" of the dataset in case a training error occurs. This allows the user to restart training with adjusted parameters without having to close the application.

<img width="236" height="93" alt="image" src="https://github.com/user-attachments/assets/6c38bbb4-cc6d-46ae-8797-31106dcdd524" />
