### PR TITLE
Changes to camera rotation

### DIFF
--- a/include/core/events.hpp
+++ b/include/core/events.hpp
@@ -56,6 +56,7 @@ namespace gs {
             EVENT(CyclePLY, );
             EVENT(ToggleSplitView, );
             EVENT(ToggleGTComparison, );
+            EVENT(ToggleGimbalLock, bool locked;);
         } // namespace cmd
 
         // ============================================================================

--- a/src/visualizer/gui/panels/main_panel.cpp
+++ b/src/visualizer/gui/panels/main_panel.cpp
@@ -173,6 +173,9 @@ namespace gs::gui::panels {
         // Camera Rotation
         if (ImGui::Checkbox("Lock Gimbal", &settings.lock_gimbal)) {
             settings_changed = true;
+            events::cmd::ToggleGimbalLock{
+                .locked = settings.lock_gimbal}
+            .emit();
         }
 
         // Camera Frustums

--- a/src/visualizer/gui/panels/main_panel.cpp
+++ b/src/visualizer/gui/panels/main_panel.cpp
@@ -170,6 +170,11 @@ namespace gs::gui::panels {
             ImGui::Unindent();
         }
 
+        // Camera Rotation
+        if (ImGui::Checkbox("Lock Gimbal", &settings.lock_gimbal)) {
+            settings_changed = true;
+        }
+
         // Camera Frustums
         ImGui::Separator();
         if (ImGui::Checkbox("Show Camera Frustums", &settings.show_camera_frustums)) {

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -432,7 +432,7 @@ namespace gs::visualizer {
                 viewport_.camera.translate(pos);
                 break;
             case DragMode::Rotate:
-                viewport_.camera.rotate(pos);
+                viewport_.camera.rotate(pos, rendering_manager_->getSettings().lock_gimbal);
                 break;
             case DragMode::Orbit: {
                 float current_time = static_cast<float>(glfwGetTime());

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -28,6 +28,10 @@ namespace gs::visualizer {
             std::fill(std::begin(keys_wasd_), std::end(keys_wasd_), false);
             hovered_camera_id_ = -1;
         });
+        // Subscribe to GimbalLock events
+        events::cmd::ToggleGimbalLock::when([this](const events::cmd::ToggleGimbalLock &e) {
+            gimbal_locked = e.locked;
+        });
 
         LOG_DEBUG("InputController created");
     }
@@ -432,7 +436,7 @@ namespace gs::visualizer {
                 viewport_.camera.translate(pos);
                 break;
             case DragMode::Rotate:
-                viewport_.camera.rotate(pos, rendering_manager_->getSettings().lock_gimbal);
+                viewport_.camera.rotate(pos, gimbal_locked);
                 break;
             case DragMode::Orbit: {
                 float current_time = static_cast<float>(glfwGetTime());

--- a/src/visualizer/input/input_controller.hpp
+++ b/src/visualizer/input/input_controller.hpp
@@ -128,6 +128,7 @@ namespace gs::visualizer {
         glm::dvec2 last_mouse_pos_{0, 0};
         float splitter_start_pos_ = 0.5f;
         double splitter_start_x_ = 0.0;
+        bool gimbal_locked = false;
 
         // Key states (only what we actually need)
         bool key_r_pressed_ = false;

--- a/src/visualizer/internal/viewport.hpp
+++ b/src/visualizer/internal/viewport.hpp
@@ -60,13 +60,27 @@ class Viewport {
 
         CameraMotion() = default;
 
-        void rotate(const glm::vec2& pos) {
+        void rotate(const glm::vec2& pos, bool enforceUpright = true, bool invertAxis = true) {
             glm::vec2 delta = pos - prePos;
-            float y = -delta.x * rotateSpeed;
-            float p = +delta.y * rotateSpeed;
-            glm::mat3 Ry = glm::mat3(glm::rotate(glm::mat4(1.0f), y, R[1]));
+
+            float axisInversion = invertAxis ? -1.0f : 1.0f;
+            float y = -delta.x * rotateSpeed * axisInversion;
+            float p = +delta.y * rotateSpeed * axisInversion;
+            glm::vec3 worldUp(0.0f, 1.0f, 0.0f);
+
+            glm::mat3 Ry = glm::mat3(glm::rotate(glm::mat4(1.0f), y, glm::vec3(0.0f, 1.0f, 0.0f)));
             glm::mat3 Rp = glm::mat3(glm::rotate(glm::mat4(1.0f), p, R[0]));
             R = Rp * Ry * R;
+
+            if (enforceUpright){
+                glm::vec3 forward = glm::normalize(R[2]);
+                glm::vec3 right = glm::normalize(glm::cross(worldUp, forward));
+                glm::vec3 up = glm::normalize(glm::cross(forward, right));
+                R[0] = right;
+                R[1] = up;
+                R[2] = forward;
+            }
+
             prePos = pos;
         }
 

--- a/src/visualizer/internal/viewport.hpp
+++ b/src/visualizer/internal/viewport.hpp
@@ -24,6 +24,7 @@ class Viewport {
         float maxWasdSpeed = 1000.0f;
         float wasdSpeedChangePercentage = 10.0f;
 
+
         // REMOVED: Orbit velocity and inertia - we don't want spinning to continue
         // glm::vec2 orbitVelocity = glm::vec2(0.0f);
         // float preTime = 0.0f;
@@ -63,17 +64,17 @@ class Viewport {
         void rotate(const glm::vec2& pos, bool enforceUpright = false) {
             glm::vec2 delta = pos - prePos;
 
-            float y = +delta.x * rotateSpeed ;
+            float y = +delta.x * rotateSpeed;
             float p = -delta.y * rotateSpeed;
-            glm::vec3 up = enforceUpright ? glm::vec3(0.0f, 1.0f, 0.0f) : R[1];
+            glm::vec3 upVec = enforceUpright ? glm::vec3(0.0f, 1.0f, 0.0f) : R[1];
 
-            glm::mat3 Ry = glm::mat3(glm::rotate(glm::mat4(1.0f), y, up));
+            glm::mat3 Ry = glm::mat3(glm::rotate(glm::mat4(1.0f), y, upVec));
             glm::mat3 Rp = glm::mat3(glm::rotate(glm::mat4(1.0f), p, R[0]));
             R = Rp * Ry * R;
 
-            if (enforceUpright){
+            if (enforceUpright) {
                 glm::vec3 forward = glm::normalize(R[2]);
-                glm::vec3 right = glm::normalize(glm::cross(up, forward));
+                glm::vec3 right = glm::normalize(glm::cross(upVec, forward));
                 glm::vec3 up = glm::normalize(glm::cross(forward, right));
                 R[0] = right;
                 R[1] = up;

--- a/src/visualizer/internal/viewport.hpp
+++ b/src/visualizer/internal/viewport.hpp
@@ -65,15 +65,15 @@ class Viewport {
 
             float y = +delta.x * rotateSpeed ;
             float p = -delta.y * rotateSpeed;
-            glm::vec3 worldUp(0.0f, 1.0f, 0.0f);
+            glm::vec3 up = enforceUpright ? glm::vec3(0.0f, 1.0f, 0.0f) : R[1];
 
-            glm::mat3 Ry = glm::mat3(glm::rotate(glm::mat4(1.0f), y, glm::vec3(0.0f, 1.0f, 0.0f)));
+            glm::mat3 Ry = glm::mat3(glm::rotate(glm::mat4(1.0f), y, up));
             glm::mat3 Rp = glm::mat3(glm::rotate(glm::mat4(1.0f), p, R[0]));
             R = Rp * Ry * R;
 
             if (enforceUpright){
                 glm::vec3 forward = glm::normalize(R[2]);
-                glm::vec3 right = glm::normalize(glm::cross(worldUp, forward));
+                glm::vec3 right = glm::normalize(glm::cross(up, forward));
                 glm::vec3 up = glm::normalize(glm::cross(forward, right));
                 R[0] = right;
                 R[1] = up;

--- a/src/visualizer/internal/viewport.hpp
+++ b/src/visualizer/internal/viewport.hpp
@@ -60,12 +60,11 @@ class Viewport {
 
         CameraMotion() = default;
 
-        void rotate(const glm::vec2& pos, bool enforceUpright = true, bool invertAxis = true) {
+        void rotate(const glm::vec2& pos, bool enforceUpright = false) {
             glm::vec2 delta = pos - prePos;
 
-            float axisInversion = invertAxis ? -1.0f : 1.0f;
-            float y = -delta.x * rotateSpeed * axisInversion;
-            float p = +delta.y * rotateSpeed * axisInversion;
+            float y = +delta.x * rotateSpeed ;
+            float p = -delta.y * rotateSpeed;
             glm::vec3 worldUp(0.0f, 1.0f, 0.0f);
 
             glm::mat3 Ry = glm::mat3(glm::rotate(glm::mat4(1.0f), y, glm::vec3(0.0f, 1.0f, 0.0f)));

--- a/src/visualizer/rendering/rendering_manager.hpp
+++ b/src/visualizer/rendering/rendering_manager.hpp
@@ -50,6 +50,9 @@ namespace gs::visualizer {
         float axes_size = 2.0f;
         std::array<bool, 3> axes_visibility = {true, true, true};
 
+        // Camera Rotation
+        bool lock_gimbal = false;
+
         // World transform
         geometry::EuclideanTransform world_transform;
 


### PR DESCRIPTION
- A checkbox to set a gimbal lock
- Inverted rotation axes

<img width="1282" height="759" alt="image" src="https://github.com/user-attachments/assets/b439d07d-c8b3-426a-9478-cc65b6685099" />


How to test:
Right-click drag to rotate the camera. When moving the mouse in circles on the screen this usually leads to a tilted horizon.

With the "Lock Gimbal" checkbox enabled, the horizon should stay leveled.
When starting a rotation with a tilted horizon but the checkbox checked, the camera will correct its up-direction in the first frame.