### PR TITLE
fix memory leak bugs and get_image_info usage

### DIFF
--- a/src/loader/formats/colmap.cpp
+++ b/src/loader/formats/colmap.cpp
@@ -853,7 +853,7 @@ namespace gs::loader {
             LOG_DEBUG("Verifying actual image dimensions against COLMAP database");
 
             // Load first image to check actual dimensions
-            auto [img_data, actual_w, actual_h, channels] = load_image(out[0]._image_path);
+            auto [actual_w, actual_h, channels] = get_image_info(out[0]._image_path);
 
             int expected_w = out[0]._width;
             int expected_h = out[0]._height;
@@ -874,8 +874,6 @@ namespace gs::loader {
             } else {
                 LOG_DEBUG("Image dimensions match COLMAP database ({}x{})", actual_w, actual_h);
             }
-
-            free_image(img_data);
         }
 
         LOG_INFO("Training with {} images", out.size());

--- a/src/loader/formats/transforms.cpp
+++ b/src/loader/formats/transforms.cpp
@@ -102,9 +102,11 @@ namespace gs::loader {
             try {
                 LOG_DEBUG("Width/height not in transforms.json, reading from first image");
                 auto first_frame_img_path = GetTransformImagePath(dir_path, transforms["frames"][0]);
-                auto result = load_image(first_frame_img_path);
-                w = std::get<1>(result);
-                h = std::get<2>(result);
+                auto result = get_image_info(first_frame_img_path);
+
+                w = std::get<0>(result);
+                h = std::get<1>(result);
+
                 LOG_DEBUG("Got image dimensions: {}x{}", w, h);
             } catch (const std::exception& e) {
                 std::string error_msg = "Error while trying to read image dimensions: " + std::string(e.what());


### PR DESCRIPTION
1. fixed some memory leak bugs related to not freeing image after load_image
2. switch load_image with get_image_info when load_image was called only for the image size