### PR TITLE
Abort training when an image is detected that is too large to process

### DIFF
--- a/src/core/camera.cpp
+++ b/src/core/camera.cpp
@@ -115,12 +115,6 @@ namespace gs {
         _image_width = w;
         _image_height = h;
 
-        if (w * h > 4096*4096) {
-            std::string error_msg = std::format("Failed to load image - image size too large {} - use a resize factor for this dataset", _image_path.filename().string());
-            LOG_ERROR("Failed to load image - image size too large: (image: {} - w: {} - h: {})", _image_path.filename().string(), w, h);
-            throw std::runtime_error(error_msg);
-        }
-
         // Create tensor from pinned memory and transfer asynchronously
         torch::Tensor image = torch::from_blob(
             data,

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -314,6 +314,13 @@ namespace gs::training {
             // Setup camera cache
             for (const auto& cam : base_dataset_->get_cameras()) {
                 m_cam_id_to_cam[cam->uid()] = cam;
+                cam->load_image_size(params.dataset.resize_factor);
+
+                if (cam->image_width() * cam->image_height() > 4096 * 4096) {
+                    std::string error_msg = std::format("image size too large {} - use a resize factor for this dataset", cam->image_name());
+                    LOG_ERROR("Image size too large: (image: {} - w: {} - h: {})", cam->image_name(), cam->camera_width(), cam->camera_height());
+                    throw std::runtime_error(error_msg);                                                       
+                }
             }
             LOG_DEBUG("Camera cache initialized with {} cameras", m_cam_id_to_cam.size());
 


### PR DESCRIPTION
Based on feedback from "Flo", we now abort training if the maximum size for an image is exceeded. This avoids that LFS and possibly also the user OS "hangs", forcing an application exit or reboot.

Reference:
> Remember that the fastgs rasterizer implementation is currently limited to images with a maximum of TILE_SIZE * UINT16_MAX = 256 * 2^16 = 16,777,216 pixels which is, e.g., 4096x4096 or 5461x3072 resolution.

When using headless, the folllowing is displayed (depending on the number of worker threads):
<img width="1087" height="61" alt="image" src="https://github.com/user-attachments/assets/4228ebbb-91b2-4b15-9bcd-8e0577ca51f8" />


When using GUI, the following is displayed:
<img width="233" height="119" alt="image" src="https://github.com/user-attachments/assets/328e4b7d-d5b7-48e3-9c4f-01c1c9d1ded2" />
