### PR TITLE
Traing tab for training settings

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -202,7 +202,7 @@ namespace gs::gui {
             ImGui::DockBuilderAddNode(dockspace_id, dockspace_flags | ImGuiDockNodeFlags_DockSpace);
             ImGui::DockBuilderSetNodeSize(dockspace_id, main_viewport->WorkSize);
 
-            ImGuiID dock_id_left = ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Left, 0.2f, nullptr, &dockspace_id);
+            ImGuiID dock_id_left = ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Left, 0.25f, nullptr, &dockspace_id);
             ImGuiID dock_id_right = ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Right, 0.2f, nullptr, &dockspace_id);
 
             // Dock windows

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -40,6 +40,7 @@ namespace gs::gui {
         window_states_["project_changed_dialog_box"] = false;
         window_states_["save_project_browser_before_exit"] = false;
         window_states_["system_console"] = false;
+        window_states_["training_tab"] = false;
 
         // Initialize speed overlay state
         speed_overlay_visible_ = false;
@@ -207,6 +208,7 @@ namespace gs::gui {
             // Dock windows
             ImGui::DockBuilderDockWindow("Rendering Settings", dock_id_left);
             ImGui::DockBuilderDockWindow("Scene", dock_id_right);
+            ImGui::DockBuilderDockWindow("Training Settings", dock_id_left);
 
             ImGui::DockBuilderFinish(dockspace_id);
         }
@@ -230,15 +232,31 @@ namespace gs::gui {
                 ImGui::Separator();
                 panels::DrawRenderingSettings(ctx);
                 ImGui::Separator();
-                if (viewer_->getTrainer()) {
-                    panels::DrawTrainingControls(ctx);
-                    ImGui::Separator();
-                }
                 panels::DrawProgressInfo(ctx);
                 ImGui::Separator();
                 panels::DrawToolsPanel(ctx);
             }
             ImGui::End();
+
+            if (viewer_->getTrainer() && !window_states_["training_tab"]) {
+                ImGui::SetWindowFocus("Rendering Settings");
+                window_states_["training_tab"] = true;
+            } 
+            
+            if (!viewer_->getTrainer()) {
+                window_states_["training_tab"] = false;
+            }
+
+            if (window_states_["training_tab"]) {
+                if (ImGui::Begin("Training Settings", &show_main_panel_)) {
+                    panels::DrawTrainingControls(ctx);
+                    ImGui::Separator();
+                }
+                ImGui::End();
+            }
+
+
+
             ImGui::PopStyleColor();
         }
 

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -255,8 +255,6 @@ namespace gs::gui {
                 ImGui::End();
             }
 
-
-
             ImGui::PopStyleColor();
         }
 

--- a/src/visualizer/gui/panels/training_panel.cpp
+++ b/src/visualizer/gui/panels/training_panel.cpp
@@ -119,7 +119,7 @@ namespace gs::gui::panels {
         if (trainer_state == TrainerManager::State::Ready) {
             // Before training - get from project (editable)
             opt_params = project->getOptimizationParams();
-            dataset_params = project->getProjectData().data_set_info;
+            dataset_params = project->getProjectData().data_set_info;            
         } else {
             // During/after training - get from trainer (read-only)
             const auto* trainer = trainer_manager->getTrainer();
@@ -136,6 +136,48 @@ namespace gs::gui::panels {
         bool dataset_params_changed = false;
 
         ImGui::PushStyleVar(ImGuiStyleVar_IndentSpacing, 12.0f);
+        if (ImGui::BeginTable("DatasetTable", 2, ImGuiTableFlags_SizingStretchProp)) {
+            ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_WidthFixed, 120.0f);
+            ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
+
+                // Iterations - EDITABLE
+            ImGui::TableNextRow();
+            ImGui::TableNextColumn();
+            ImGui::Text("Iterations:");
+            ImGui::TableNextColumn();
+            if (can_edit) {
+                ImGui::PushItemWidth(-1);
+                int iterations = static_cast<int>(opt_params.iterations);
+                if (ImGui::InputInt("##iterations", &iterations, 1000, 5000)) {
+                    if (iterations > 0 && iterations <= 1000000) {
+                        opt_params.iterations = static_cast<size_t>(iterations);
+                        opt_params_changed = true;
+                    }
+                }
+                ImGui::PopItemWidth();
+            } else {
+                ImGui::Text("%zu", opt_params.iterations);
+            }
+
+            if (opt_params.strategy == "mcmc") {
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::Text("Max Gaussians:");
+                ImGui::TableNextColumn();
+                if (can_edit) {
+                    ImGui::PushItemWidth(-1);
+                    if (ImGui::InputInt("##max_cap", &opt_params.max_cap, 10000, 100000)) {
+                        if (opt_params.max_cap > 0) {
+                            opt_params_changed = true;
+                        }
+                    }
+                    ImGui::PopItemWidth();
+                } else {
+                    ImGui::Text("%d", opt_params.max_cap);
+                }
+            }
+        }
+        ImGui::EndTable();
 
         // Dataset Parameters
         if (ImGui::TreeNode("Dataset")) {
@@ -234,25 +276,6 @@ namespace gs::gui::panels {
             if (ImGui::BeginTable("OptimizationTable", 2, ImGuiTableFlags_SizingStretchProp)) {
                 ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_WidthFixed, 120.0f);
                 ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
-
-                // Iterations - EDITABLE
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn();
-                ImGui::Text("Iterations:");
-                ImGui::TableNextColumn();
-                if (can_edit) {
-                    ImGui::PushItemWidth(-1);
-                    int iterations = static_cast<int>(opt_params.iterations);
-                    if (ImGui::InputInt("##iterations", &iterations, 1000, 5000)) {
-                        if (iterations > 0 && iterations <= 1000000) {
-                            opt_params.iterations = static_cast<size_t>(iterations);
-                            opt_params_changed = true;
-                        }
-                    }
-                    ImGui::PopItemWidth();
-                } else {
-                    ImGui::Text("%zu", opt_params.iterations);
-                }
 
                 ImGui::TableNextRow();
                 ImGui::TableNextColumn();
@@ -441,23 +464,7 @@ namespace gs::gui::panels {
                 }
 
                 // Strategy-specific parameters
-                if (opt_params.strategy == "mcmc") {
-                    ImGui::TableNextRow();
-                    ImGui::TableNextColumn();
-                    ImGui::Text("Max Gaussians:");
-                    ImGui::TableNextColumn();
-                    if (can_edit) {
-                        ImGui::PushItemWidth(-1);
-                        if (ImGui::InputInt("##max_cap", &opt_params.max_cap, 10000, 100000)) {
-                            if (opt_params.max_cap > 0) {
-                                opt_params_changed = true;
-                            }
-                        }
-                        ImGui::PopItemWidth();
-                    } else {
-                        ImGui::Text("%d", opt_params.max_cap);
-                    }
-                }
+
 
                 ImGui::EndTable();
             }

--- a/src/visualizer/gui/panels/training_panel.cpp
+++ b/src/visualizer/gui/panels/training_panel.cpp
@@ -119,7 +119,7 @@ namespace gs::gui::panels {
         if (trainer_state == TrainerManager::State::Ready) {
             // Before training - get from project (editable)
             opt_params = project->getOptimizationParams();
-            dataset_params = project->getProjectData().data_set_info;            
+            dataset_params = project->getProjectData().data_set_info;
         } else {
             // During/after training - get from trainer (read-only)
             const auto* trainer = trainer_manager->getTrainer();
@@ -464,7 +464,6 @@ namespace gs::gui::panels {
                 }
 
                 // Strategy-specific parameters
-
 
                 ImGui::EndTable();
             }


### PR DESCRIPTION
With extending the functionality of LFS, the current "rendering settinsg" tab was getting crowded with a lot of settings, buttons, checkboxes, ...

This PR implements a "training tab", where we move the training controls.
When the user adds a dataset, this tab becomes automatically visible.
When the user clears the dataset, this tab will be hidden.

We make the left panel slightyly bigger to fit the 2 tabs.

We also move 2 (important) training paramaters to a move visible location
* max gaussians
* iterations

Before:
<img width="1283" height="986" alt="image" src="https://github.com/user-attachments/assets/c81c2165-fd11-43b9-af44-859d538f3862" />

After:
<img width="1280" height="749" alt="image" src="https://github.com/user-attachments/assets/32bb6369-2b74-44cf-bec1-cae3e2f24bc0" />
