### PR TITLE
Expose --bilateral-grid  in GUI

### DIFF
--- a/src/visualizer/gui/panels/training_panel.cpp
+++ b/src/visualizer/gui/panels/training_panel.cpp
@@ -602,9 +602,6 @@ namespace gs::gui::panels {
 
                 ImGui::EndTable();
             }
-
-
-
             ImGui::TreePop();
         }
 

--- a/src/visualizer/gui/panels/training_panel.cpp
+++ b/src/visualizer/gui/panels/training_panel.cpp
@@ -218,19 +218,6 @@ namespace gs::gui::panels {
 
         // Optimization Parameters
         if (ImGui::TreeNode("Optimization")) {
-            // Enabled GUI checkbox
-            if (!can_edit) {
-                ImGui::BeginDisabled();
-            }
-            bool gut_enabled = opt_params.gut;
-            if (ImGui::Checkbox("GUT", &gut_enabled)) {
-                opt_params.gut = gut_enabled;
-                opt_params_changed = true;
-            }
-            if (!can_edit) {
-                ImGui::EndDisabled();
-            }
-
             if (ImGui::BeginTable("OptimizationTable", 2, ImGuiTableFlags_SizingStretchProp)) {
                 ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_WidthFixed, 120.0f);
                 ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
@@ -533,21 +520,58 @@ namespace gs::gui::panels {
                                    opt_params.antialiasing ||
                                    opt_params.gut;
 
+        has_active_features = true; // force show for now
+
         if (has_active_features && ImGui::TreeNode("Active Features")) {
             if (ImGui::BeginTable("FeaturesTable", 2, ImGuiTableFlags_SizingStretchProp)) {
                 ImGui::TableSetupColumn("Feature", ImGuiTableColumnFlags_WidthFixed, 120.0f);
                 ImGui::TableSetupColumn("Configuration", ImGuiTableColumnFlags_WidthStretch);
 
-                if (opt_params.use_bilateral_grid) {
-                    ImGui::TableNextRow();
-                    ImGui::TableNextColumn();
-                    ImGui::Text("Bilateral Grid:");
-                    ImGui::TableNextColumn();
-                    ImGui::Text("%dx%dx%d (LR: %.4f)",
-                                opt_params.bilateral_grid_X,
-                                opt_params.bilateral_grid_Y,
-                                opt_params.bilateral_grid_W,
-                                opt_params.bilateral_grid_lr);
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                bool use_bilateral_grid_enabled = opt_params.use_bilateral_grid;
+                if (!can_edit) {
+                    ImGui::BeginDisabled();
+                }
+                if (ImGui::Checkbox("Bilateral Grid", &use_bilateral_grid_enabled)) {
+                    opt_params.use_bilateral_grid = use_bilateral_grid_enabled;
+                    opt_params_changed = true;
+                }
+                if (!can_edit) {
+                    ImGui::EndDisabled();
+                }
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%dx%dx%d (LR: %.4f)",
+                            opt_params.bilateral_grid_X,
+                            opt_params.bilateral_grid_Y,
+                            opt_params.bilateral_grid_W,
+                            opt_params.bilateral_grid_lr);
+
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                if (!can_edit) {
+                    ImGui::BeginDisabled();
+                }
+                bool use_antialiasing = opt_params.antialiasing;
+                if (ImGui::Checkbox("Anti Aliasing", &use_antialiasing)) {
+                    opt_params.antialiasing = use_antialiasing;
+                    opt_params_changed = true;
+                }
+                if (!can_edit) {
+                    ImGui::EndDisabled();
+                }
+
+                if (!can_edit) {
+                    ImGui::BeginDisabled();
+                }
+                bool gut_enabled = opt_params.gut;
+                if (ImGui::Checkbox("GUT", &gut_enabled)) {
+                    opt_params.gut = gut_enabled;
+                    opt_params_changed = true;
+                }
+                if (!can_edit) {
+                    ImGui::EndDisabled();
                 }
 
                 if (opt_params.pose_optimization != "none") {
@@ -576,24 +600,11 @@ namespace gs::gui::panels {
                     }
                 }
 
-                if (opt_params.antialiasing) {
-                    ImGui::TableNextRow();
-                    ImGui::TableNextColumn();
-                    ImGui::Text("Antialiasing:");
-                    ImGui::TableNextColumn();
-                    ImGui::Text("Enabled");
-                }
-
-                if (opt_params.gut) {
-                    ImGui::TableNextRow();
-                    ImGui::TableNextColumn();
-                    ImGui::Text("GUT Rasterizer:");
-                    ImGui::TableNextColumn();
-                    ImGui::Text("Enabled");
-                }
-
                 ImGui::EndTable();
             }
+
+
+
             ImGui::TreePop();
         }
 

--- a/src/visualizer/gui/panels/training_panel.cpp
+++ b/src/visualizer/gui/panels/training_panel.cpp
@@ -550,17 +550,6 @@ namespace gs::gui::panels {
 
                 ImGui::TableNextRow();
                 ImGui::TableNextColumn();
-                if (!can_edit) {
-                    ImGui::BeginDisabled();
-                }
-                bool use_antialiasing = opt_params.antialiasing;
-                if (ImGui::Checkbox("Anti Aliasing", &use_antialiasing)) {
-                    opt_params.antialiasing = use_antialiasing;
-                    opt_params_changed = true;
-                }
-                if (!can_edit) {
-                    ImGui::EndDisabled();
-                }
 
                 if (!can_edit) {
                     ImGui::BeginDisabled();


### PR DESCRIPTION
This PR exposes the settings --bilateral-grid in GUI
We also move the GUT checkbox to the "features" tab.

Before:
<img width="507" height="707" alt="image" src="https://github.com/user-attachments/assets/4b249e9b-1a8c-4461-a661-1ebd50fa235e" />

After:
<img width="424" height="435" alt="image" src="https://github.com/user-attachments/assets/7f44c112-ebe7-445c-857a-6dea7b5b7988" />
