### PR TITLE
DPI Scaling for GUI Font loading

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -156,7 +156,7 @@ namespace gs::gui {
         if (mouse_in_viewport && !ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) {
             if (ImGui::IsMouseDown(ImGuiMouseButton_Right) ||
                 ImGui::IsMouseDown(ImGuiMouseButton_Middle)) {
-                ImGui::GetIO().WantCaptureMouse = false;                
+                ImGui::GetIO().WantCaptureMouse = false;
             }
         }
 
@@ -422,7 +422,7 @@ namespace gs::gui {
             ImGui::RenderPlatformWindowsDefault();
             glfwMakeContextCurrent(backup_current_context);
         }
-            }
+    }
 
     void GuiManager::updateViewportRegion() {
         const ImGuiViewport* main_viewport = ImGui::GetMainViewport();

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -69,6 +69,12 @@ namespace gs::gui {
         // Platform/Renderer initialization
         ImGui_ImplGlfw_InitForOpenGL(viewer_->getWindow(), true);
         ImGui_ImplOpenGL3_Init("#version 430");
+        
+        float xscale, yscale;
+        glfwGetWindowContentScale(viewer_->getWindow(), &xscale, &yscale);
+
+        // some clamping / safety net for weird DPI values
+        xscale = std::clamp(xscale, 1.0f, 2.0f);
 
         // Set application icon - use the resource path helper
         try {
@@ -85,7 +91,7 @@ namespace gs::gui {
         // Load fonts - use the resource path helper
         try {
             auto font_path = gs::visualizer::getAssetPath("JetBrainsMono-Regular.ttf");
-            io.Fonts->AddFontFromFileTTF(font_path.string().c_str(), 14.0f);
+            io.Fonts->AddFontFromFileTTF(font_path.string().c_str(), 14.0f * xscale );
         } catch (const std::exception& e) {
             // If font loading fails, just use the default font
             LOG_WARN("Could not load custom font: {}", e.what());
@@ -150,7 +156,7 @@ namespace gs::gui {
         if (mouse_in_viewport && !ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) {
             if (ImGui::IsMouseDown(ImGuiMouseButton_Right) ||
                 ImGui::IsMouseDown(ImGuiMouseButton_Middle)) {
-                ImGui::GetIO().WantCaptureMouse = false;
+                ImGui::GetIO().WantCaptureMouse = false;                
             }
         }
 
@@ -416,7 +422,7 @@ namespace gs::gui {
             ImGui::RenderPlatformWindowsDefault();
             glfwMakeContextCurrent(backup_current_context);
         }
-    }
+            }
 
     void GuiManager::updateViewportRegion() {
         const ImGuiViewport* main_viewport = ImGui::GetMainViewport();


### PR DESCRIPTION
This change will detect the OS dpi scaling and adjust the font used for displaying accordingly.

Also tried this, but the quality of the font was not very good when upscaling using this method
````
        // Scale fonts according to monitor DPI -> causes issues with pixel-perfect rendering
        // we will scale the font size instead
        // ImGui::GetIO().FontGlobalScale = xscale; 
        // ImGui::GetStyle().ScaleAllSizes(2.0f);
````