### PR TITLE
Allow selectino of SH degree in viewport

### DIFF
--- a/include/core/events.hpp
+++ b/include/core/events.hpp
@@ -137,6 +137,7 @@ namespace gs {
             EVENT(CameraMove, glm::mat3 rotation; glm::vec3 translation;);
             EVENT(SpeedChanged, float current_speed; float max_speed;);
             EVENT(RenderSettingsChanged,
+                  std::optional<int> sh_degree;
                   std::optional<float> fov;
                   std::optional<float> scaling_modifier;
                   std::optional<bool> antialiasing;

--- a/include/core/splat_data.hpp
+++ b/include/core/splat_data.hpp
@@ -80,6 +80,7 @@ namespace gs {
 
         // Utility methods
         void increment_sh_degree();
+        void set_active_sh_degree(int sh_degree);
 
         // Export methods - join_threads controls sync vs async
         // if stem is not empty save splat as stem.ply

--- a/include/rendering/rendering.hpp
+++ b/include/rendering/rendering.hpp
@@ -48,6 +48,7 @@ namespace gs::rendering {
         bool point_cloud_mode = false;
         float voxel_size = 0.01f;
         bool gut = false;
+        int sh_degree = 0;
     };
 
     struct RenderResult {
@@ -94,6 +95,7 @@ namespace gs::rendering {
         bool show_dividers = true;
         glm::vec4 divider_color{1.0f, 0.85f, 0.0f, 1.0f};
         bool show_labels = true;
+        int sh_degree = 0;
     };
 
     enum class GridPlane {
@@ -158,6 +160,7 @@ namespace gs::rendering {
         bool point_cloud_mode = false;
         float voxel_size = 0.01f;
         bool gut = false;
+        int sh_degree = 0;
     };
 
     struct RenderingPipelineResult {

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -386,6 +386,14 @@ namespace gs {
         }
     }
 
+    void SplatData::set_active_sh_degree(int sh_degree = 0) {
+        if (sh_degree <= _max_sh_degree) {
+            _active_sh_degree = sh_degree;
+        } else {
+            _active_sh_degree = _max_sh_degree;
+        }
+    }
+
     // Get attribute names for PLY format
     std::vector<std::string> SplatData::get_attribute_names() const {
         std::vector<std::string> a{"x", "y", "z", "nx", "ny", "nz"};

--- a/src/rendering/rendering_engine_impl.cpp
+++ b/src/rendering/rendering_engine_impl.cpp
@@ -147,7 +147,7 @@ namespace gs::rendering {
         LOG_TRACE("Rendering gaussians with viewport {}x{}", request.viewport.size.x, request.viewport.size.y);
 
         // Convert to internal pipeline request using designated initializers
-        RenderingPipeline::RenderRequest pipeline_req{
+        RenderingPipeline::RenderRequest pipeline_req {
             .view_rotation = request.viewport.rotation,
             .view_translation = request.viewport.translation,
             .viewport_size = request.viewport.size,
@@ -159,7 +159,8 @@ namespace gs::rendering {
             .background_color = request.background_color,
             .point_cloud_mode = request.point_cloud_mode,
             .voxel_size = request.voxel_size,
-            .gut = request.gut};
+            .gut = request.gut,
+            .sh_degree = request.sh_degree};
 
         // Convert crop box if present
         std::unique_ptr<gs::geometry::BoundingBox> temp_crop_box;
@@ -418,7 +419,8 @@ namespace gs::rendering {
             .background_color = request.background_color,
             .point_cloud_mode = request.point_cloud_mode,
             .voxel_size = request.voxel_size,
-            .gut = request.gut};
+            .gut = request.gut,
+            .sh_degree = request.sh_degree};
 
         auto result = pipeline_.render(model, internal_request);
 

--- a/src/rendering/rendering_pipeline.cpp
+++ b/src/rendering/rendering_pipeline.cpp
@@ -73,6 +73,8 @@ namespace gs::rendering {
 
             SplatData& mutable_model = request.crop_box ? const_cast<SplatData&>(cropped_model) : const_cast<SplatData&>(model);
 
+            mutable_model.set_active_sh_degree(request.sh_degree);
+
             RenderResult result;
             if (request.gut) {
                 auto render_result = gs::training::rasterize(

--- a/src/rendering/rendering_pipeline.hpp
+++ b/src/rendering/rendering_pipeline.hpp
@@ -30,6 +30,7 @@ namespace gs::rendering {
             bool point_cloud_mode = false;
             float voxel_size = 0.01f;
             bool gut = false;
+            int sh_degree = 0;
         };
 
         struct RenderResult {

--- a/src/rendering/split_view_renderer.cpp
+++ b/src/rendering/split_view_renderer.cpp
@@ -192,7 +192,8 @@ namespace gs::rendering {
                 .background_color = request.background_color,
                 .point_cloud_mode = request.point_cloud_mode,
                 .voxel_size = request.voxel_size,
-                .gut = request.gut};
+                .gut = request.gut,
+                .sh_degree = request.sh_degree};
 
             // Handle crop box if present
             std::unique_ptr<geometry::BoundingBox> temp_crop_box;

--- a/src/visualizer/gui/panels/main_panel.cpp
+++ b/src/visualizer/gui/panels/main_panel.cpp
@@ -246,7 +246,7 @@ namespace gs::gui::panels {
                 .emit();
         }
 
-            // Grid plane selection
+            // SH DEGREE selection
         const char* sh_degrees[] = {"0", "1", "2", "3"};
         int current_sh_degree = static_cast<int>(settings.sh_degree);
         if (ImGui::Combo("SH Degree", &current_sh_degree, sh_degrees, IM_ARRAYSIZE(sh_degrees))) {
@@ -261,7 +261,6 @@ namespace gs::gui::panels {
                 .background_color = std::nullopt}
                 .emit();
         }
-
 
         // Display current FPS and VSync control on the same line
         float average_fps = ctx.viewer->getAverageFPS();
@@ -306,21 +305,6 @@ namespace gs::gui::panels {
         int current_iter = trainer_manager->getCurrentIteration();
         int total_iter = trainer_manager->getTotalIterations();
         int num_splats = trainer_manager->getNumSplats();
-
-
-        HWND hwnd = GetConsoleWindow();
-        HWND owner = GetWindow(hwnd, GW_OWNER);
-        if (owner != NULL) {
-            ITaskbarList3* m_pITaskBarList3;
-            CoCreateInstance(CLSID_TaskbarList, NULL, CLSCTX_INPROC_SERVER, IID_ITaskbarList3, (void**)&m_pITaskBarList3);
-            if (m_pITaskBarList3) {
-                m_pITaskBarList3->SetProgressState(owner, TBPF_NORMAL);
-                m_pITaskBarList3->SetProgressValue(owner, current_iter, total_iter);
-                // Windows 11 - adjust console window title to show progress
-                //std::string title = std::format("LichtFeld Studio - Training Progress: {}/{} - Splats: {}", current_iter, total_iter, num_splats);
-                //SetWindowTextA(hwnd, title.c_str());
-            }
-        }
 
         // Fix: Convert deque to vector
         std::deque<float> loss_deque = trainer_manager->getLossBuffer();

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -760,6 +760,7 @@ namespace gs::visualizer {
 
         // Set the FOV
         events::ui::RenderSettingsChanged{
+            .sh_degree = std::nullopt,
             .fov = fov_y_deg,
             .scaling_modifier = std::nullopt,
             .antialiasing = std::nullopt,

--- a/src/visualizer/rendering/rendering_manager.cpp
+++ b/src/visualizer/rendering/rendering_manager.cpp
@@ -267,6 +267,10 @@ namespace gs::visualizer {
         // Listen for settings changes
         events::ui::RenderSettingsChanged::when([this](const auto& event) {
             std::lock_guard<std::mutex> lock(settings_mutex_);
+            if (event.sh_degree) {
+                settings_.sh_degree = *event.sh_degree;
+                LOG_TRACE("SH_DEGREE changed to: {}", settings_.sh_degree);
+            }
             if (event.fov) {
                 settings_.fov = *event.fov;
                 LOG_TRACE("FOV changed to: {}", settings_.fov);
@@ -533,7 +537,8 @@ namespace gs::visualizer {
             .crop_box = std::nullopt,
             .point_cloud_mode = settings_.point_cloud_mode,
             .voxel_size = settings_.voxel_size,
-            .gut = settings_.gut};
+            .gut = settings_.gut,
+            .sh_degree = settings_.sh_degree};
 
         // Add crop box if enabled
         if (settings_.use_crop_box) {
@@ -869,7 +874,9 @@ namespace gs::visualizer {
                 .gut = settings_.gut,
                 .show_dividers = true,
                 .divider_color = glm::vec4(1.0f, 0.85f, 0.0f, 1.0f),
-                .show_labels = true};
+                .show_labels = true,
+                .sh_degree = settings_.sh_degree
+            };
         }
 
         // Handle PLY comparison mode
@@ -911,7 +918,9 @@ namespace gs::visualizer {
                 .gut = settings_.gut,
                 .show_dividers = true,
                 .divider_color = glm::vec4(1.0f, 0.85f, 0.0f, 1.0f),
-                .show_labels = true};
+                .show_labels = true,
+                .sh_degree = settings_.sh_degree,
+            };
         }
 
         return std::nullopt;

--- a/src/visualizer/rendering/rendering_manager.hpp
+++ b/src/visualizer/rendering/rendering_manager.hpp
@@ -32,6 +32,7 @@ namespace gs::visualizer {
         float fov = 60.0f;
         float scaling_modifier = 1.0f;
         bool antialiasing = false;
+        int sh_degree = 0;
 
         // Crop box
         bool show_crop_box = false;


### PR DESCRIPTION
This change adds a setting for selecting the SH degree when viewing gaussians.
<img width="316" height="505" alt="image" src="https://github.com/user-attachments/assets/4d89b34a-659a-414f-9c9a-c22a6a72d89c" />


SH0:
<img width="2559" height="1386" alt="image" src="https://github.com/user-attachments/assets/97c6775b-7559-4f50-bae9-50a535a7ac7c" />

SH3:
<img width="2559" height="1392" alt="image" src="https://github.com/user-attachments/assets/268be094-500e-4081-b3f8-bae07370a499" />

This also solves
https://github.com/MrNeRF/LichtFeld-Studio/issues/456