### PR TITLE
add gpu usage to training panel

### DIFF
--- a/src/visualizer/gui/panels/main_panel.cpp
+++ b/src/visualizer/gui/panels/main_panel.cpp
@@ -333,7 +333,7 @@ namespace gs::gui::panels {
             std::snprintf(loss_label, sizeof(loss_label), "Loss: %.4f", loss_data.back());
 
             widgets::DrawLossPlot(loss_data.data(), static_cast<int>(loss_data.size()),
-                                  min_val, max_val, "");
+                                  min_val, max_val, loss_label);
         }
     }
 } // namespace gs::gui::panels

--- a/src/visualizer/gui/panels/training_panel.cpp
+++ b/src/visualizer/gui/panels/training_panel.cpp
@@ -857,6 +857,20 @@ namespace gs::gui::panels {
         int num_splats = trainer_manager->getNumSplats();
         ImGui::Text("num Splats: %d", num_splats);
 
+        // display memory usage
+        size_t free_t, total_t;
+        cudaMemGetInfo(&free_t, &total_t);
+        size_t used_t = total_t - free_t;
+
+        ImVec4 memColor = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
+        float pctUsed = (used_t / 1e9f) / (total_t / 1e9f) * 100;
+
+        if (pctUsed > 75) {
+            memColor = ImVec4(0.9f, 0.2f, 0.2f, 1.0f); // red
+        }
+
+        ImGui::TextColored(memColor, "Used GPU Memory: %.1f%% (%.1f/%.1f GB)", pctUsed, used_t / 1e9f, total_t / 1e9f);
+
         // Render save project file browser
         if (state.show_save_browser) {
             state.save_browser.render(&state.show_save_browser);

--- a/src/visualizer/gui/ui_widgets.cpp
+++ b/src/visualizer/gui/ui_widgets.cpp
@@ -73,11 +73,11 @@ namespace gs::gui::widgets {
 
         // Simple line plot using ImGui
         ImGui::PlotLines(
-            plot_label,
+            "",
             values,
             count,
             0,
-            nullptr,
+            plot_label,
             min_val,
             max_val,
             ImVec2(ImGui::GetContentRegionAvail().x, 80));


### PR DESCRIPTION
* add gpu usage to training panel
* added label to the "loss" graph

before:
<img width="312" height="476" alt="image" src="https://github.com/user-attachments/assets/3c2b44fa-f501-401a-96ba-00eaebd1015a" />

after:
<img width="320" height="495" alt="image" src="https://github.com/user-attachments/assets/c6e5ec5d-dbdb-4183-8b60-8ce7d7df1d90" />
