### PR TITLE
bugfix - when debuggin, UI widgets give  an error

### DIFF
--- a/src/visualizer/gui/ui_widgets.cpp
+++ b/src/visualizer/gui/ui_widgets.cpp
@@ -73,7 +73,7 @@ namespace gs::gui::widgets {
 
         // Simple line plot using ImGui
         ImGui::PlotLines(
-            "",
+            "Plot##default",
             values,
             count,
             0,


### PR DESCRIPTION
When running LFS in debug mode, an error occured:

LichtFeld-Studio: /home/sysadmin/LichtFeld-Studio/vcpkg/buildtrees/imgui/src/.9-docking-449e592d6e.clean/imgui.cpp:11307: bool ImGui::ItemAdd(const ImRect&, ImGuiID, const ImRect*, ImGuiItemFlags): Assertion id != window->ID && "Cannot have an empty ID at the root of a window. If you need an empty label, use ## and read the FAQ about how the ID Stack works!"' failed. Aborted (core dumped)