### PR TITLE
Update index on README.md to match current page layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@
 
 <img src="docs/viewer_demo.gif" alt="3D Gaussian Splatting Viewer" width="85%"/>
 
-[**Quick Start**](#quick-start) •
+[**Overview**](#overview) •
+[**Community & Support**](#community--support) •
+[**Active Bounties**](#active-bounties) •
 [**Installation**](#installation) •
-[**Usage**](#usage) •
-[**Results**](#benchmark-results) •
-[**Community**](#community--support)
+[**Contributing**](#contributing) •
+[**Acknowledgments**](#acknowledgments) •
+[**Citation**](#citation) •
+[**License**](#license)
 
 </div>
 


### PR DESCRIPTION
Another really minor documentation patch I just happened across, on the current README.md half the index anchors don't exist anymore. This updates the list.