### PR TITLE
fix compilation for CUDA 13 + libtorch 2.9

### DIFF
--- a/fastgs/rasterization/include/kernels_forward.cuh
+++ b/fastgs/rasterization/include/kernels_forward.cuh
@@ -453,7 +453,7 @@ namespace fast_gs::rasterization::kernels::forward {
         // max reduce the number of contributions
         typedef cub::BlockReduce<uint, config::tile_width, cub::BLOCK_REDUCE_WARP_REDUCTIONS, config::tile_height> BlockReduce;
         __shared__ typename BlockReduce::TempStorage temp_storage;
-        n_contributions = BlockReduce(temp_storage).Reduce(n_contributions, thrust::maximum<uint>);
+        n_contributions = BlockReduce(temp_storage).Reduce(n_contributions, thrust::maximum<uint>());
         if (thread_rank == 0)
             tile_max_n_contributions[tile_idx] = n_contributions;
     }


### PR DESCRIPTION
In CUDA 13, cub::Max() no longer exists, need to use cub::Max{}, because Max is now a struct template with a default constructor