### PR TITLE
Fix dataset load crash when loading unsupported formats from GUI

### DIFF
--- a/src/visualizer/core/data_loading_service.cpp
+++ b/src/visualizer/core/data_loading_service.cpp
@@ -28,7 +28,19 @@ namespace gs::visualizer {
 
     void DataLoadingService::handleLoadFileCommand(bool is_dataset, const std::filesystem::path& path) {
         if (is_dataset) {
-            loadDataset(path);
+            // Prevent GUI crash on unsupported dataset formats
+            try {
+                loadDataset(path);
+            } catch (const std::exception& e) {
+                events::state::DatasetLoadCompleted{
+                    .path = path,
+                    .success = false,
+                    .error = std::string(e.what()),
+                    .num_images = 0,
+                    .num_points = 0}
+                    .emit();
+            }
+
         } else {
             scene_manager_->changeContentType(SceneManager::ContentType::SplatFiles);
             // Determine file type and load appropriately

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -84,6 +84,10 @@ namespace gs {
             float current_speed_;
             float max_speed_;
 
+            // Dataset load error popup state
+            bool dataset_error_popup_pending_ = false;
+            std::string dataset_error_message_;
+
             // Viewport region tracking
             ImVec2 viewport_pos_;
             ImVec2 viewport_size_;
@@ -93,6 +97,9 @@ namespace gs {
             // Method declarations
             void renderSpeedOverlay();
             void showSpeedOverlay(float current_speed, float max_speed);
+            void renderDatasetErrorPopup();
+            void showDatasetErrorPopup(const std::string& message);
+
 
             std::unique_ptr<SaveProjectBrowser> save_project_browser_;
             std::unique_ptr<MenuBar> menu_bar_;


### PR DESCRIPTION
## Summary

This PR fixes a crash that occurred when loading unsupported dataset formats from the GUI.  
Instead of allowing the exception to terminate the application, the GUI now displays a modal error popup.

## Changes

- Added a try catch block in the dataset path of `DataLoadingService::handleLoadFileCommand`
- On failure, the code emits `events::state::DatasetLoadCompleted` with `success = false` and the error message
- `GuiManager` now listens to `DatasetLoadCompleted` and shows a modal ImGui popup when loading fails
- Introduced a simple user friendly error dialog without modifying the existing dataset loading logic
- Console and CLI dataset loading behavior remains unchanged

## Notes

The popup uses the same modal style already used in the application and does not affect normal loading flows.


Fixes #471