### PR TITLE
Fix debug build with tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -206,7 +206,7 @@ target_link_libraries(lichtfeld_tests PRIVATE
 
 # Compiler options for CUDA debugging
 target_compile_options(lichtfeld_tests PRIVATE
-    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-G -lineinfo -Xcudafe --device-debug>
+    $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-G -lineinfo>
     $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
     $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
 )


### PR DESCRIPTION
Debug build was not possible with enabled tests, because of invalid CUDA debug compile flag combination.
Removed the flag.

Reproducer:
`cmake -B build_Debug -S . -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -Wno-dev -DBUILD_LEGACY=ON`