### PR TITLE
Fix regex to take only first GPU if multiple GPUs present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ if(NVIDIA_SMI)
             OUTPUT_VARIABLE DETECTED_COMPUTE_CAP
             OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    string(REGEX REPLACE "\n.*" "" DETECTED_COMPUTE_CAP "${DETECTED_COMPUTE_CAP}")
 
     message(STATUS "Detected GPU compute capability: ${DETECTED_COMPUTE_CAP}")
     set(LichtFeld-Studio_CUDA_ARCH "native")


### PR DESCRIPTION
Fix regex to take only first GPU if multiple GPUs present, so we can find compute capability