### PR TITLE
Button states

### DIFF
--- a/src/visualizer/gui/panels/training_panel.cpp
+++ b/src/visualizer/gui/panels/training_panel.cpp
@@ -1428,7 +1428,6 @@ namespace lfs::vis::gui::panels {
     }
 
     void DrawTrainingControls(const UIContext& ctx) {
-        ImGui::Text("Training Control");
         ImGui::Separator();
 
         auto& state = TrainingPanelState::getInstance();
@@ -1463,6 +1462,9 @@ namespace lfs::vis::gui::panels {
                     lfs::core::events::cmd::ResetTraining{}.emit();
                 }
             }
+            if (ColoredButton("Clear", ButtonStyle::Error, FULL_WIDTH)) {
+                lfs::core::events::cmd::ClearScene{}.emit();
+            }
             break;
         }
 
@@ -1479,8 +1481,8 @@ namespace lfs::vis::gui::panels {
             if (ColoredButton("Reset Training", ButtonStyle::Secondary, FULL_WIDTH)) {
                 lfs::core::events::cmd::ResetTraining{}.emit();
             }
-            if (ColoredButton("Clear", ButtonStyle::Error, FULL_WIDTH)) {
-                lfs::core::events::cmd::ClearScene{}.emit();
+            if (ColoredButton("Stop Training", ButtonStyle::Error, FULL_WIDTH)) {
+                lfs::core::events::cmd::StopTraining{}.emit();
             }
             break;
 
@@ -1514,6 +1516,11 @@ namespace lfs::vis::gui::panels {
             if (ColoredButton("Reset Training", ButtonStyle::Secondary, FULL_WIDTH)) {
                 lfs::core::events::cmd::ResetTraining{}.emit();
             }
+
+            if (ColoredButton("Clear", ButtonStyle::Error, FULL_WIDTH)) {
+                lfs::core::events::cmd::ClearScene{}.emit();
+            }
+
             break;
         }
 


### PR DESCRIPTION
Small change to logic of how buttons are displayed:
* allow clear in initial state
* in "paused", remove clear, replace with "stop training"
* in "stopped", add "clear" button

this allows the user to stop the training and go to "edit" mode at any point in the training process.
Use case: user sets 30K seps, but after 15K wants to stop, edit and save the splat at that point.