### PR TITLE
Make scene context take training state into account

### DIFF
--- a/src/visualizer/gui/panels/scene_panel.cpp
+++ b/src/visualizer/gui/panels/scene_panel.cpp
@@ -270,17 +270,19 @@ namespace lfs::vis::gui {
         const bool blnTraininMode = m_trainerManager->hasTrainer();
 
         if (ImGui::BeginPopupContextItem("##ModelsMenu")) {
-            if (ImGui::MenuItem("Add PLY...", nullptr, false, !blnTraininMode)) {
-                cmd::ShowWindow{.window_name = "file_browser", .show = true}.emit();
+            if (!blnTraininMode) {
+                if (ImGui::MenuItem("Add PLY...")) {
+                    cmd::ShowWindow{.window_name = "file_browser", .show = true}.emit();
 #ifdef _WIN32
-                OpenPlyFileDialogNative();
-                cmd::ShowWindow{.window_name = "file_browser", .show = false}.emit();
+                    OpenPlyFileDialogNative();
+                    cmd::ShowWindow{.window_name = "file_browser", .show = false}.emit();
 #endif
+                }
+                if (ImGui::MenuItem("Add Group")) {
+                    cmd::AddGroup{.name = "New Group", .parent_name = ""}.emit();
+                }
+                ImGui::Separator();
             }
-            if (ImGui::MenuItem("Add Group", nullptr, false, !blnTraininMode)) {
-                cmd::AddGroup{.name = "New Group", .parent_name = ""}.emit();
-            }
-            ImGui::Separator();
             if (ImGui::MenuItem("Export...", nullptr, false, splat_count > 0)) {
                 cmd::ShowWindow{.window_name = "export_dialog", .show = true}.emit();
             }


### PR DESCRIPTION
When in "dataset" mode, the scene menu shows "Add Ply..." and "New Group".  Both these actions are not useful in case we are not in editing mode:
* add ply does not work as no .ply should be added when in dataset mode
* add group has no use as no .ply can be added in the group and no merging can be performed

This PR checks if we are in training mode or editing mode and shows/hides the menu items so that a user can only perform the action when it actually is possible