### PR TITLE
Make scene context take training state into account #585

### DIFF
--- a/src/visualizer/gui/panels/scene_panel.cpp
+++ b/src/visualizer/gui/panels/scene_panel.cpp
@@ -266,7 +266,6 @@ namespace lfs::vis::gui {
 
         // Context menu for folder
         theme().pushContextMenuStyle();
-
         if (ImGui::BeginPopupContextItem("##ModelsMenu")) {
             if (!m_trainerManager->hasTrainer()) {
                 if (ImGui::MenuItem("Add PLY...")) {


### PR DESCRIPTION
When in "dataset" mode, the scene menu shows "Add Ply..." and "New Group". Both these actions are not useful in case we are not in editing mode:

add ply does not work as no .ply should be added when in dataset mode
add group has no use as no .ply can be added in the group and no merging can be performed
This PR checks if we are in training mode or editing mode and shows/hides the menu items so that a user can only perform the action when it actually is possible