### PR TITLE
Improve CUDA-OpenGL interop capability check for ARM64 Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,13 @@ if(ENABLE_CUDA_GL_INTEROP)
         #include <windows.h>
         #endif
         #include <cuda_runtime.h>
+
+        // On ARM machines, you must include the gl headers before including cuda_gl_interop.h
+        // Please refer to /usr/local/cuda/include/cuda_gl_interop.h
+        #if defined(__arm__) || defined(__aarch64__)
+        #include <GL/gl.h>
+        #endif
+
         #include <cuda_gl_interop.h>
         int main() {
             cudaGraphicsResource_t resource;


### PR DESCRIPTION
Hi everyone,

First of all, thank you for creating such fantastic software.

I ran into a problem when trying to build on an ARM‑64 Linux system (specifically the NVIDIA DGX Spark). Even after pulling in all the required libraries, the **CUDA‑GL Interop Available** flag never gets set to 1, which causes the build to fail.

After some digging, I discovered that on ARM (aarch64) the gl headers must be included before `cuda_gl_interop.h`.

This pull request fixes the issue described above.