### PR TITLE
Fix SOG loader not rendering higher-order SH properly (issue #696)

### DIFF
--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -116,7 +116,7 @@ namespace lfs::core {
                          Tensor opacity_,
                          float scene_scale_)
         : _max_sh_degree(sh_degree),
-          _active_sh_degree(0), // Start at 0, increases during training to match old behavior
+          _active_sh_degree(sh_degree), // Set to max degree when loading; training will override this
           _scene_scale(scene_scale_),
           _means(std::move(means_)),
           _sh0(std::move(sh0_)),

--- a/src/io/formats/sogs.cpp
+++ b/src/io/formats/sogs.cpp
@@ -219,7 +219,9 @@ namespace lfs::io {
                     sh_data.files = shN.at("files").get<std::vector<std::string>>();
 
                     // Optional fields
-                    if (shN.contains("palette_size")) {
+                    if (shN.contains("count")) {
+                        sh_data.palette_size = shN["count"].get<int>();
+                    } else if (shN.contains("palette_size")) {
                         sh_data.palette_size = shN["palette_size"].get<int>();
                     }
                     if (shN.contains("bands")) {


### PR DESCRIPTION
SOG files with spherical harmonics degree 3 data were rendering as if they only had SH degree 0 (flat, no view-dependent effects), while PLY files rendered correctly with SH3.

Root causes:
1. SplatData constructor always initialized _active_sh_degree to 0, regardless of the model's actual SH degree. This meant loaded models with SH3 data would render as SH0.

2. SOG exporter writes the SH palette size as "count" in the shN metadata, but the loader was looking for "palette_size". This caused all label lookups to be out of bounds (e.g., label 18212 vs palette_size 1024), preventing SH data from being assigned to splats.

Changes:
- Set _active_sh_degree to sh_degree in SplatData constructor (was hardcoded to 0)
- Fix SOG loader to read palette_size from "count" field (with fallback to "palette_size")

Training behavior unchanged: training code explicitly sets active_sh_degree to 0 and increments it during training as before.

Fixes #696