### PR TITLE
fix python module loading on MSVC and add API docs

### DIFF
--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -1,0 +1,956 @@
+# LichtFeld Studio Python API
+
+Python integration for LichtFeld Studio built on **nanobind**, providing scripting, automation, and plugin development capabilities.
+
+## Table of Contents
+
+- [Installation & Setup](#installation--setup)
+- [Tensor API](#tensor-api)
+- [Scene Graph API](#scene-graph-api)
+- [Camera API](#camera-api)
+- [I/O Operations](#io-operations)
+- [Rendering](#rendering)
+- [Training Control](#training-control)
+- [UI Framework](#ui-framework)
+- [Plugin System](#plugin-system)
+- [Package Management](#package-management)
+- [Logging](#logging)
+- [Advanced Topics](#advanced-topics)
+
+---
+
+## Installation & Setup
+
+Enable Python bindings in CMake:
+
+```bash
+cmake -DBUILD_PYTHON_BINDINGS=ON ..
+```
+
+```python
+import lichtfeld as lf
+```
+
+---
+
+## Tensor API
+
+The `Tensor` class provides GPU-accelerated tensor operations with NumPy interoperability.
+
+### Creating Tensors
+
+```python
+# From NumPy
+arr = np.array([[1, 2], [3, 4]], dtype=np.float32)
+t = lf.Tensor.from_numpy(arr)                    # Copy to GPU
+t = lf.Tensor.from_numpy(arr, copy=False)        # Share memory (CPU only)
+
+# Factory functions (all use lf.Tensor.* prefix)
+zeros = lf.Tensor.zeros([3, 4])                  # 3x4 zeros on CUDA
+ones = lf.Tensor.ones([3, 4], device="cpu")      # 3x4 ones on CPU
+full = lf.Tensor.full([2, 2], 5.0)               # 2x2 filled with 5.0
+eye = lf.Tensor.eye(3)                           # 3x3 identity matrix
+rand = lf.Tensor.rand([10, 10])                  # Uniform random [0, 1)
+randn = lf.Tensor.randn([10, 10])                # Normal distribution
+arange = lf.Tensor.arange(0, 10, 2)              # [0, 2, 4, 6, 8]
+linspace = lf.Tensor.linspace(0, 1, 5)           # [0, 0.25, 0.5, 0.75, 1]
+                                                 # Note: dtype parameter is currently ignored
+randint = lf.Tensor.randint(0, 10, [5, 5])       # Random integers
+empty = lf.Tensor.empty([100, 100])              # Uninitialized
+```
+
+### Data Types
+
+Supported dtypes: `float32`, `float16`, `int32`, `int64`, `uint8`, `bool`
+
+```python
+t = lf.Tensor.zeros([3, 3], dtype="float16")
+t = t.to("int32")  # Type conversion
+
+# Type extraction methods (in-place, returns self)
+t.float_()  # Convert to float32
+t.int_()    # Convert to int32
+t.bool_()   # Convert to bool
+```
+
+### Properties
+
+| Property | Description |
+|----------|-------------|
+| `t.shape` | Tuple of dimensions |
+| `t.ndim` | Number of dimensions |
+| `t.numel` | Total number of elements |
+| `t.device` | "cuda" or "cpu" |
+| `t.dtype` | Data type string |
+| `t.is_cuda` | True if on GPU |
+| `t.is_contiguous` | True if memory is contiguous |
+
+### Arithmetic Operations
+
+```python
+c = a + b; c = a - b; c = a * b; c = a / b  # Element-wise
+c = a + 5.0; c = a * 2.0; c = 10.0 - a      # Scalar
+a += b; a *= 2.0                             # In-place
+```
+
+### Mathematical Functions
+
+```python
+# Unary functions
+t.exp(), t.log(), t.sqrt(), t.abs(), t.neg()
+
+# Trigonometric
+t.sin(), t.cos(), t.tan(), t.asin(), t.acos(), t.atan()
+t.sinh(), t.cosh(), t.tanh()
+
+# Activation functions
+t.sigmoid(), t.relu(), t.gelu(), t.swish()
+
+# Other math
+t.floor(), t.ceil(), t.round(), t.trunc()
+t.sign(), t.reciprocal(), t.rsqrt()
+t.square(), t.log2(), t.log10(), t.log1p(), t.exp2()
+t.pow(2.0)
+t.isnan(), t.isinf(), t.isfinite()
+```
+
+### Reduction Operations
+
+```python
+t.sum(), t.sum_scalar()          # Sum (tensor / float)
+t.mean(), t.mean_scalar()        # Mean
+t.max(), t.max_scalar()          # Max
+t.min(), t.min_scalar()          # Min
+t.prod()                         # Product
+t.std(), t.var()                 # Standard deviation, variance
+t.norm(p=2.0)                    # Lp norm
+t.all(), t.any()                 # Boolean reductions
+
+# Dimension-wise
+t.sum(dim=0)
+t.mean(dim=1, keepdim=True)
+t.argmax(dim=0), t.argmin(dim=1)
+```
+
+### Shape Operations
+
+```python
+t.reshape([2, 6])          # New shape (may copy)
+t.view([2, 6])             # New shape (shares memory)
+t.flatten()                # Flatten to 1D
+t.flatten(start_dim=1)     # Flatten from dim 1
+t.squeeze(), t.squeeze(dim=0)
+t.unsqueeze(dim=0)
+t.expand([3, 4, 5])        # Broadcast to new shape
+t.t()                      # 2D transpose
+t.transpose(0, 1)          # Swap dimensions
+t.permute([2, 0, 1])       # Reorder dimensions
+```
+
+### Indexing
+
+```python
+t[0], t[1:3], t[:, 0], t[..., -1]                    # Basic indexing
+t.index_select(dim=0, indices=indices)
+t.gather(dim=1, indices=indices)
+mask = t > 0.5
+t.masked_select(mask), t.masked_fill(mask, 0.0)
+t.nonzero()
+t[0] = 1.0; t[:, 0] = other_tensor                   # Assignment
+```
+
+### Linear Algebra
+
+```python
+a.matmul(b), a @ b         # Matrix multiplication
+a.mm(b)                    # 2D matrix multiply
+a.bmm(b)                   # Batched matrix multiply
+a.dot(b)                   # Dot product
+```
+
+### Element-wise Operations
+
+```python
+t.clamp(min=0.0, max=1.0)  # Clamp values (both min AND max required)
+t.maximum(other)           # Element-wise max
+t.minimum(other)           # Element-wise min
+lf.Tensor.where(cond, x, y)  # Conditional selection
+```
+
+### Memory Operations
+
+```python
+t.clone()              # Deep copy
+t.contiguous()         # Ensure contiguous memory
+t.cpu(), t.cuda()      # Move between devices
+t.sync()               # Synchronize CUDA operations
+t.item()               # Extract scalar value
+t.size(dim)            # Get size of dimension
+```
+
+### NumPy Interoperability
+
+```python
+arr = t.numpy()                   # Copy to NumPy
+arr = t.numpy(copy=False)         # Share memory (CPU tensors only)
+arr = np.asarray(t)               # Via __array__ protocol
+t = lf.Tensor.from_numpy(arr)
+```
+
+### DLPack Protocol (Zero-Copy)
+
+```python
+capsule = t.__dlpack__()
+device = t.__dlpack_device__()
+t = lf.Tensor.from_dlpack(other_tensor)
+
+# PyTorch interop
+torch_tensor = torch.from_dlpack(t)
+lf_tensor = lf.Tensor.from_dlpack(torch_tensor)
+```
+
+### Combining Tensors
+
+```python
+c = lf.Tensor.cat([a, b, c], dim=0)    # Concatenation
+s = lf.Tensor.stack([a, b, c], dim=0)  # Stacking
+```
+
+---
+
+## Scene Graph API
+
+Manages all objects in the 3D scene including Gaussian splats, point clouds, cameras, and groups.
+
+### Accessing the Scene
+
+```python
+scene = lf.get_scene()
+lf.list_scene()  # Print scene tree to console
+```
+
+### Scene Properties
+
+| Property | Description |
+|----------|-------------|
+| `scene.node_count` | Total number of nodes |
+| `scene.total_gaussian_count` | Total gaussians in scene |
+| `scene.has_nodes()` | True if scene has any nodes |
+| `scene.has_training_data()` | True if training model exists |
+| `scene.scene_center` | PyTensor [3] scene center |
+
+### Adding Nodes
+
+```python
+group_id = scene.add_group("MyGroup")
+child_group_id = scene.add_group("ChildGroup", parent=group_id)
+
+splat_id = scene.add_splat(
+    name="MySplat",
+    means=means_tensor,        # [N, 3]
+    sh0=sh0_tensor,            # [N, 1, 3]
+    shN=shN_tensor,            # [N, (degree+1)^2-1, 3]
+    scaling=scaling_tensor,    # [N, 3]
+    rotation=rotation_tensor,  # [N, 4]
+    opacity=opacity_tensor,    # [N, 1]
+    sh_degree=3,
+    scene_scale=1.0,
+    parent=group_id            # Optional parent
+)
+```
+
+### Querying Nodes
+
+```python
+node = scene.get_node("NodeName")
+node = scene.get_node_by_id(node_id)
+all_nodes = scene.get_nodes()
+visible = scene.get_visible_nodes()
+roots = scene.root_nodes()
+is_visible = scene.is_node_effectively_visible(node_id)
+```
+
+### Node Operations
+
+```python
+scene.remove_node("NodeName")
+scene.remove_node("NodeName", keep_children=True)
+scene.rename_node("OldName", "NewName")
+scene.reparent(node_id, new_parent_id)
+scene.duplicate_node("NodeName")
+scene.merge_group("GroupName")
+scene.clear()
+```
+
+### Transforms
+
+```python
+transform = scene.get_world_transform(node_id)  # 4x4 matrix as nested tuples
+scene.set_node_transform("NodeName", transform_tuple)
+scene.set_node_transform("NodeName", transform_tensor)  # PyTensor 4x4
+```
+
+### Node Properties
+
+| Property | Description |
+|----------|-------------|
+| `node.id` | Unique ID |
+| `node.parent_id` | Parent node ID (-1 if root) |
+| `node.children` | List of child IDs |
+| `node.type` | NodeType enum |
+| `node.name` | Node name |
+| `node.gaussian_count` | Number of gaussians (splat nodes) |
+| `node.centroid` | Center point (splat nodes) |
+| `node.visible` | Visibility flag (read-write) |
+| `node.locked` | Lock flag (read-write) |
+| `node.local_transform` | Local transform (tuple) |
+| `node.world_transform` | World transform (tuple) |
+
+```python
+splat_data = node.splat_data()      # PySplatData or None
+point_cloud = node.point_cloud()    # PyPointCloud or None
+cropbox = node.cropbox()            # PyCropBox or None
+
+# Camera nodes only
+node.camera_index, node.camera_uid, node.image_path, node.mask_path
+```
+
+### Node Types
+
+```python
+from lichtfeld import NodeType
+# SPLAT, POINTCLOUD, GROUP, CROPBOX, DATASET, CAMERA_GROUP, CAMERA, IMAGE_GROUP, IMAGE
+```
+
+### Training Model
+
+```python
+combined = scene.combined_model()
+training = scene.training_model()
+scene.set_training_model_node("SplatName")
+name = scene.training_model_node_name
+```
+
+### Bounds
+
+```python
+bounds = scene.get_node_bounds(node_id)
+if bounds:
+    (min_x, min_y, min_z), (max_x, max_y, max_z) = bounds
+center = scene.get_node_bounds_center(node_id)
+```
+
+### CropBox Operations
+
+```python
+cropbox_id = scene.get_cropbox_for_splat(splat_id)
+cropbox_id = scene.get_or_create_cropbox_for_splat(splat_id)
+cropbox = scene.get_cropbox_data(cropbox_id)
+cropbox.min = (-1.0, -1.0, -1.0)  # tuple[float, float, float]
+cropbox.max = (1.0, 1.0, 1.0)     # tuple[float, float, float]
+cropbox.enabled = True
+cropbox.inverse = False
+cropbox.color = (1.0, 0.0, 0.0)   # tuple[float, float, float]
+cropbox.line_width = 2.0
+scene.set_cropbox_data(cropbox_id, cropbox)
+```
+
+### Selection System
+
+```python
+scene.set_selection(indices_tensor)
+scene.set_selection_mask(bool_tensor)
+scene.clear_selection()
+has_sel = scene.has_selection()
+mask = scene.selection_mask
+
+# Selection groups
+group_id = scene.add_selection_group("Region1", (1.0, 0.0, 0.0))
+scene.remove_selection_group(group_id)
+scene.rename_selection_group(group_id, "NewName")
+scene.set_selection_group_color(group_id, (0.0, 1.0, 0.0))
+scene.set_selection_group_locked(group_id, True)
+is_locked = scene.is_selection_group_locked(group_id)
+scene.active_selection_group = group_id
+
+for group in scene.selection_groups():
+    print(f"{group.name}: {group.count} points, color={group.color}")
+```
+
+### Splat Data (PySplatData)
+
+```python
+splat = scene.combined_model()
+
+# Raw tensor access (views, modify in-place)
+means = splat.means_raw           # [N, 3]
+sh0 = splat.sh0_raw               # [N, 1, 3]
+shN = splat.shN_raw               # [N, (degree+1)^2-1, 3]
+scaling = splat.scaling_raw       # [N, 3] log-space
+rotation = splat.rotation_raw     # [N, 4] quaternions
+opacity = splat.opacity_raw       # [N, 1] logit-space
+
+# Computed getters (with activations applied)
+means = splat.get_means()
+opacity = splat.get_opacity()     # Sigmoid applied
+rotation = splat.get_rotation()   # Normalized
+scaling = splat.get_scaling()     # Exp applied
+shs = splat.get_shs()             # Concatenated SH coefficients
+
+# Properties
+splat.num_points
+splat.active_sh_degree
+splat.max_sh_degree
+splat.scene_scale
+splat.visible_count()
+
+# SH degree control
+splat.increment_sh_degree()
+splat.set_active_sh_degree(2)
+splat.set_max_sh_degree(3)
+
+# Soft deletion
+splat.soft_delete(mask_tensor)    # Returns previous state
+splat.undelete(mask_tensor)
+splat.clear_deleted()
+removed_count = splat.apply_deleted()  # Permanently remove
+splat.has_deleted_mask()
+deleted = splat.deleted           # Boolean tensor
+
+# Memory
+splat.reserve_capacity(100000)
+```
+
+### Point Cloud (PyPointCloud)
+
+```python
+pc = node.point_cloud()
+
+# Properties (tensors, some may be None)
+pc.means
+pc.colors     # Optional[PyTensor]
+pc.normals    # Optional[PyTensor]
+pc.sh0        # Optional[PyTensor]
+pc.shN        # Optional[PyTensor]
+pc.opacity    # Optional[PyTensor]
+pc.scaling    # Optional[PyTensor]
+pc.rotation   # Optional[PyTensor]
+
+# Metadata
+pc.size
+pc.is_gaussian()
+pc.attribute_names
+
+# Operations
+pc.normalize_colors()
+removed = pc.filter(keep_mask)
+removed = pc.filter_indices(indices)
+```
+
+---
+
+## Camera API
+
+### Camera Dataset
+
+```python
+train_cams = lf.train_cameras()  # Returns PyCameraDataset
+val_cams = lf.val_cameras()      # Returns PyCameraDataset
+
+for i in range(len(train_cams)):
+    cam = train_cams[i]
+
+for cam in train_cams.cameras():
+    print(cam.image_name)
+
+cam = train_cams.get_camera_by_filename("image001.jpg")
+train_cams.set_resize_factor(2)
+train_cams.set_max_width(1920)
+```
+
+### Camera Properties
+
+| Property | Description |
+|----------|-------------|
+| `cam.focal_x`, `cam.focal_y` | Focal lengths |
+| `cam.center_x`, `cam.center_y` | Principal point |
+| `cam.fov_x`, `cam.fov_y` | Field of view |
+| `cam.image_width`, `cam.image_height` | Original size |
+| `cam.camera_width`, `cam.camera_height` | After resize |
+| `cam.image_name`, `cam.image_path` | Image info |
+| `cam.mask_path`, `cam.has_mask` | Mask info |
+| `cam.uid` | Unique identifier |
+| `cam.R` | [3, 3] rotation (NumPy) |
+| `cam.T` | [3] translation (NumPy) |
+| `cam.K` | [3, 3] intrinsics (NumPy) |
+| `cam.world_view_transform` | [4, 4] (NumPy) |
+| `cam.cam_position` | [3] world position (NumPy) |
+
+### Loading Images
+
+```python
+image = cam.load_image()                    # [C, H, W] CUDA tensor
+image = cam.load_image(resize_factor=2)
+image = cam.load_image(max_width=1920)
+mask = cam.load_mask()                      # [1, H, W]
+mask = cam.load_mask(invert=True)
+mask = cam.load_mask(threshold=0.5)
+```
+
+---
+
+## I/O Operations
+
+### Loading Data
+
+```python
+result = lf.io.load("path/to/file.ply")
+
+result = lf.io.load(
+    "path/to/dataset",
+    resize_factor=2,
+    images_folder="images/",
+    progress=lambda p, msg: print(f"{p:.1f}%: {msg}")
+)
+```
+
+### Load Result
+
+| Property | Description |
+|----------|-------------|
+| `result.splat_data` | PySplatData or None |
+| `result.scene_center` | PyTensor [3] |
+| `result.loader_used` | Loader name string |
+| `result.load_time_ms` | Load time in milliseconds |
+| `result.warnings` | List of warning strings |
+| `result.is_dataset` | True if loaded a dataset |
+
+### Saving Data
+
+```python
+lf.io.save_ply(data, path, binary=True, progress=None)
+lf.io.save_sog(data, path, kmeans_iterations=10, use_gpu=True, progress=None)
+lf.io.save_spz(data, path)
+lf.io.export_html(data, path, kmeans_iterations=10, progress=None)
+```
+
+### Format Information
+
+```python
+formats = lf.io.get_supported_formats()      # e.g., ["PLY", "Splat"]
+extensions = lf.io.get_supported_extensions() # e.g., [".ply", ".splat"]
+is_dataset = lf.io.is_dataset_path("path/to/check")
+```
+
+### Opening in UI
+
+```python
+lf.app.open("path/to/file.ply")
+```
+
+---
+
+## Rendering
+
+### Render a View
+
+```python
+image = lf.render_view(
+    rotation=rotation,           # [3, 3] rotation matrix
+    translation=translation,     # [3] translation vector
+    width=1920,
+    height=1080,
+    fov_degrees=60.0,
+    bg_color=bg_tensor           # Optional [3] RGB
+)
+# Returns: PyTensor [H, W, 3] RGB image or None
+```
+
+### Viewport Functions
+
+```python
+lf.get_viewport_render()    # Get current viewport render
+lf.capture_viewport()       # Capture viewport (cloned for async use)
+lf.get_current_view()       # Get current viewport camera info
+lf.get_render_scene()       # Get current render scene
+```
+
+### Compute Screen Positions
+
+```python
+positions = lf.compute_screen_positions(
+    rotation=rotation,
+    translation=translation,
+    width=1920,
+    height=1080,
+    fov_degrees=60.0
+)
+# Returns: PyTensor [N, 2] screen coordinates or None
+```
+
+---
+
+## Training Control
+
+### Training Context
+
+```python
+ctx = lf.context()
+ctx.iteration, ctx.max_iterations
+ctx.loss, ctx.num_gaussians
+ctx.is_training, ctx.is_paused, ctx.is_refining
+ctx.phase, ctx.strategy
+ctx.refresh()
+```
+
+### Gaussian Info
+
+```python
+g = lf.gaussians()
+g.count, g.sh_degree, g.max_sh_degree
+```
+
+### Training Session
+
+```python
+session = lf.session()
+session.pause(), session.resume(), session.request_stop()
+
+opt = session.optimizer()
+opt.set_lr(0.001), opt.scale_lr(0.5), opt.get_lr()
+
+model = session.model()
+model.clamp("opacity", min=0.0, max=1.0)
+model.scale("scaling", factor=0.9)
+model.set("rotation_w", value=1.0)
+```
+
+### Training Hooks (Decorators)
+
+```python
+@lf.on_training_start
+def on_start(ctx): pass
+
+@lf.on_iteration_start
+def on_iter(ctx): pass
+
+@lf.on_pre_optimizer_step
+def before_opt(ctx): pass
+
+@lf.on_post_step
+def after_step(ctx): pass
+
+@lf.on_training_end
+def on_end(ctx): pass
+```
+
+### Hook Context Dictionary
+
+```python
+{'iter': int, 'loss': float, 'num_splats': int, 'is_refining': bool}
+```
+
+### Scoped Handlers (RAII Pattern)
+
+```python
+handler = lf.ScopedHandler()
+handler.on_training_start(callback)
+handler.on_iteration_start(callback)
+handler.on_post_step(callback)
+handler.clear()  # Or let handler go out of scope
+```
+
+---
+
+## UI Framework
+
+ImGui-backed widgets for creating custom panels.
+
+### Text Elements
+
+```python
+ui.label("Simple text")
+ui.heading("Section Heading")
+ui.text_colored("Warning!", (1.0, 0.5, 0.0, 1.0))
+ui.text_selectable("Selectable text", height=100.0)
+ui.bullet_text("Bullet point")
+```
+
+### Interactive Controls
+
+```python
+if ui.button("Click Me", (100, 30)): pass
+if ui.small_button("Small"): pass
+
+changed, value = ui.checkbox("Enable", self.enabled)
+changed, value = ui.radio_button("Option A", self.option == "A")
+changed, value = ui.input_float("Scale", self.scale, step=0.1)
+changed, value = ui.input_int("Count", self.count)
+changed, value = ui.input_text("Name", self.name, max_size=128)
+changed, idx = ui.combo("Select", options, self.selected_idx)
+changed, idx = ui.listbox("Items", items, self.selected)
+ui.color_button()
+ui.path_input()
+```
+
+### Sliders
+
+```python
+changed, value = ui.slider_float("Value", current, min, max)
+changed, value = ui.slider_float2("Vec2", current, min, max)
+changed, value = ui.slider_float3("Vec3", current, min, max)
+changed, value = ui.slider_int("Int", current, min, max)
+```
+
+### Layout
+
+```python
+ui.separator()
+ui.new_line()
+ui.same_line()
+ui.spacing()
+ui.set_next_item_width(width)
+ui.indent(20.0)
+ui.unindent(20.0)
+
+ui.group_begin()
+ui.group_end()
+
+ui.push_id("unique_section")
+ui.pop_id()
+```
+
+### Tree/Collapsing
+
+```python
+if ui.collapsing_header("Section"):
+    ui.label("Content")
+
+if ui.tree_node("Node"):
+    ui.label("Content")
+    ui.tree_pop()
+```
+
+### Tables
+
+```python
+if ui.begin_table("my_table", num_columns, flags):
+    ui.table_next_row()
+    ui.table_next_column()
+    ui.label("Cell 1")
+    ui.table_next_column()
+    ui.label("Cell 2")
+    ui.table_set_column_index(0)  # Jump to column
+    ui.end_table()
+```
+
+### Tooltips
+
+```python
+ui.button("Hover me")
+ui.set_item_tooltip("This is a tooltip")
+```
+
+### Application State
+
+```python
+ui.is_training()
+ui.iteration()
+ui.loss()
+ui.has_scene()
+ui.num_gaussians()
+ui.has_selection()
+```
+
+---
+
+## Plugin System
+
+### Plugin Structure
+
+Create a folder with `plugin.toml`:
+
+```toml
+[plugin]
+name = "my_plugin"
+version = "0.1.0"
+description = "My custom plugin"
+author = "Your Name"
+entry_point = "__init__"
+dependencies = ["numpy"]
+auto_start = true
+hot_reload = true
+min_lichtfeld_version = "0.1.0"
+```
+
+### Plugin Entry Point
+
+```python
+from lichtfeld.plugins import Capability, PluginContext
+
+@Capability("my_capability")
+def my_feature(ctx: PluginContext):
+    scene = ctx.scene
+    pass
+
+def on_load():
+    print("Plugin loaded!")
+
+def on_unload():
+    print("Plugin unloaded!")
+```
+
+### Plugin Manager
+
+```python
+from lichtfeld import plugins
+
+plugins.discover()
+plugins.load("my_plugin")
+plugins.load_all()
+plugins.unload("my_plugin")
+plugins.reload("my_plugin")
+plugins.create()           # Create plugin from template
+plugins.check_updates()    # Check for plugin updates
+
+loaded = plugins.list_loaded()
+state = plugins.get_state("my_plugin")
+error = plugins.get_error("my_plugin")
+traceback = plugins.get_traceback("my_plugin")
+
+plugins.start_watcher()
+plugins.stop_watcher()
+```
+
+### Installing Plugins
+
+```python
+name = plugins.install("https://github.com/user/plugin.git")
+plugins.update("my_plugin")
+plugins.uninstall("my_plugin")
+
+plugins.search("gaussian")
+plugins.install_from_registry("plugin_id", "1.0.0")
+```
+
+---
+
+## Package Management
+
+LichtFeld uses `uv` for Python package management.
+
+```python
+from lichtfeld import packages
+
+venv_path = packages.init()
+
+# Install packages
+packages.install("numpy")
+packages.install("torch>=2.0")
+packages.install_async("large_package")
+
+# Uninstall
+packages.uninstall("package_name")
+
+# Query packages
+is_installed = packages.is_installed("numpy")
+pkg_list = packages.list()
+for pkg in pkg_list:
+    print(f"{pkg.name}=={pkg.version} at {pkg.path}")
+
+# Install PyTorch with CUDA
+packages.install_torch(cuda="auto")
+packages.install_torch(cuda="12.1")
+packages.install_torch(version="2.1.0")
+packages.install_torch_async()  # Background install
+
+# Status
+packages.is_busy()  # Check if async operation running
+
+# Utilities
+site_packages = packages.site_packages_dir()
+uv_available = packages.is_uv_available()
+```
+
+---
+
+## Logging
+
+```python
+lf.log.debug("Debug message")
+lf.log.info("Info message")
+lf.log.warn("Warning message")
+lf.log.error("Error message")
+```
+
+---
+
+## Advanced Topics
+
+### Transform Utilities
+
+```python
+transform = lf.mat4([
+    [1, 0, 0, tx],
+    [0, 1, 0, ty],
+    [0, 0, 1, tz],
+    [0, 0, 0, 1]
+])
+```
+
+### Animation Callbacks
+
+```python
+@lf.on_frame
+def animate(delta_time):
+    pass
+
+lf.stop_animation()
+```
+
+### Running Scripts
+
+```python
+lf.run("path/to/script.py")
+```
+
+### Memory Management
+
+- Tensors track ownership with `owns_data` flag
+- Scene/model references are non-owning (views)
+- DLPack provides zero-copy interop
+- Use `sync()` to ensure CUDA operations complete
+
+### Thread Safety
+
+- GIL is acquired in callbacks automatically
+- Scene context uses thread-local storage during training
+- Hook callbacks run on the training thread
+
+---
+
+## API Reference Summary
+
+| Module | Description |
+|--------|-------------|
+| `lf.Tensor` | GPU-accelerated tensor operations |
+| `lf.get_scene()` | Access scene graph |
+| `lf.io.load()` | Load datasets and models |
+| `lf.io.save_*()` | Save to various formats |
+| `lf.render_view()` | Render from camera |
+| `lf.context()` | Training state |
+| `lf.session()` | Training control |
+| `lf.on_*` | Training hook decorators |
+| `lf.log.*` | Logging functions |
+| `lf.app.open()` | Open file in UI |
+| `lf.packages.*` | Package management |
+| `lf.plugins.*` | Plugin system |
+
+---
+
+## Version Information
+
+- **Binding Framework**: nanobind (STABLE_ABI)
+- **Python Support**: Python 3.x
+- **CUDA Support**: Required for GPU tensors
+- **Type Stubs**: Generated for IDE support

--- a/docs/Python_API_issues.md
+++ b/docs/Python_API_issues.md
@@ -1,0 +1,176 @@
+# Python API Issues
+
+Issues discovered during documentation review comparing `docs/PYTHON_API.md` against the actual C++ implementations.
+
+---
+
+## Critical Issues
+
+### 1. `repeat()` Not Bound to Python
+
+**Location:** `src/python/lfs/py_tensor.cpp`
+
+The `repeat()` function is fully implemented in C++ (lines 1045-1075) and declared in the header (line 177), but **not registered** in the nanobind bindings. No `.def("repeat", ...)` call exists.
+
+**Fix Required:** Add binding at ~line 1574:
+```cpp
+.def("repeat", &PyTensor::repeat, nb::arg("repeats"), "Tile the tensor")
+```
+
+---
+
+### 2. `linspace()` Ignores dtype Parameter
+
+**Location:** `src/python/lfs/py_tensor.cpp:1302-1306`
+
+The `dtype` parameter is accepted but ignored in the implementation:
+```cpp
+PyTensor PyTensor::linspace(float start, float end, int64_t steps,
+                            const std::string& device,
+                            const std::string& dtype) {
+    // dtype is never used!
+    return PyTensor(Tensor::linspace(start, end, static_cast<size_t>(steps), parse_device(device)));
+}
+```
+
+**Fix Required:** Pass dtype to underlying `Tensor::linspace()` or document the limitation.
+
+---
+
+### 3. `packages.uninstall_async()` Not Implemented
+
+**Location:** `src/python/lfs/py_packages.cpp`
+
+Function was previously documented but does not exist in the implementation. Only `install_async()` is implemented.
+
+**Status:** Removed from documentation. If needed, implement the function.
+
+---
+
+## Implementation Gaps
+
+### UI Framework - Functions Not Implemented
+
+These were documented but do not exist in `src/python/lfs/py_ui.cpp`:
+
+| Function | Status |
+|----------|--------|
+| `push_style_color()` | Not implemented |
+| `pop_style_color()` | Not implemented |
+| `get_style_color()` | Not implemented |
+| `set_style_color()` | Not implemented |
+| `push_style_var_float()` | Not implemented |
+| `push_style_var_vec2()` | Not implemented |
+| `pop_style_var()` | Not implemented |
+| `is_key_pressed()` | Not implemented |
+| `is_mouse_down()` | Not implemented |
+| `begin_disabled()` | Not implemented |
+| `end_disabled()` | Not implemented |
+
+**Status:** Removed from documentation. Consider implementing if needed.
+
+---
+
+## Documentation Corrections Made
+
+### Tensor API
+
+| Issue | Correction |
+|-------|------------|
+| Factory functions at module level | Changed `lf.zeros()` to `lf.Tensor.zeros()` etc. |
+| `lf.cat()`, `lf.stack()`, `lf.where()` | Changed to `lf.Tensor.cat()` etc. |
+| Missing type extraction methods | Added `t.float_()`, `t.int_()`, `t.bool_()` |
+| `clamp()` parameters optional | Clarified both min AND max are required |
+| `repeat()` documented | Removed (not bound) |
+
+### I/O Operations - Added Missing Functions
+
+| Function | Signature |
+|----------|-----------|
+| `lf.io.save_ply()` | `save_ply(data, path, binary=True, progress=None)` |
+| `lf.io.save_sog()` | `save_sog(data, path, kmeans_iterations=10, use_gpu=True, progress=None)` |
+| `lf.io.save_spz()` | `save_spz(data, path)` |
+| `lf.io.export_html()` | `export_html(data, path, kmeans_iterations=10, progress=None)` |
+
+### Rendering - Added Missing Functions
+
+| Function | Description |
+|----------|-------------|
+| `lf.get_viewport_render()` | Get current viewport render |
+| `lf.capture_viewport()` | Capture viewport (cloned for async use) |
+| `lf.get_current_view()` | Get current viewport camera info |
+| `lf.get_render_scene()` | Get current render scene |
+
+### UI Framework - Added Missing Functions
+
+| Function | Description |
+|----------|-------------|
+| `slider_float2()`, `slider_float3()` | Multi-component sliders |
+| `color_button()` | Color button widget |
+| `path_input()` | File/folder path input with dialog |
+| `spacing()` | Add vertical spacing |
+| `set_next_item_width()` | Set width of next item |
+| `collapsing_header()` | Collapsible section header |
+| `tree_node()`, `tree_pop()` | Tree view widgets |
+| `begin_table()`, `end_table()` | Table container |
+| `table_next_row()`, `table_next_column()` | Table navigation |
+| `table_set_column_index()` | Jump to specific column |
+
+### Plugin System - Added Missing Functions
+
+| Function | Description |
+|----------|-------------|
+| `plugins.create()` | Create plugin from template |
+| `plugins.check_updates()` | Check for plugin updates |
+
+### Package Management - Corrections
+
+| Change | Details |
+|--------|---------|
+| Removed `uninstall_async()` | Not implemented |
+| Added `install_torch_async()` | Background PyTorch installation |
+| Added `is_busy()` | Check if async operation running |
+
+### Scene/Camera API - Minor Fixes
+
+| Issue | Correction |
+|-------|------------|
+| CropBox tuple types | Added `tuple[float, float, float]` annotations |
+| PointCloud optional properties | Added `# Optional[PyTensor]` comments |
+| Camera dataset return types | Clarified returns `PyCameraDataset` |
+
+---
+
+## Recommendations
+
+### High Priority
+
+1. **Bind `repeat()` function** - Implementation exists, just needs registration
+2. **Fix `linspace()` dtype** - Either implement or document limitation
+
+### Medium Priority
+
+3. **Implement UI styling functions** - If style customization is needed
+4. **Implement UI input functions** - `is_key_pressed()`, `is_mouse_down()` for interactive plugins
+5. **Implement `packages.uninstall_async()`** - For consistency with `install_async()`
+
+### Low Priority
+
+6. **Add `begin_disabled()`/`end_disabled()`** - For conditional UI disabling
+7. **Consider module-level tensor factory functions** - For convenience (`lf.zeros()` instead of `lf.Tensor.zeros()`)
+
+---
+
+## Files Reviewed
+
+| File | Purpose |
+|------|---------|
+| `src/python/lfs/py_tensor.cpp` | Tensor class bindings |
+| `src/python/lfs/py_scene.cpp` | Scene graph bindings |
+| `src/python/lfs/py_cameras.cpp` | Camera API bindings |
+| `src/python/lfs/py_io.cpp` | I/O operations |
+| `src/python/lfs/py_rendering.cpp` | Rendering functions |
+| `src/python/lfs/py_ui.cpp` | UI framework |
+| `src/python/lfs/py_plugins.cpp` | Plugin system |
+| `src/python/lfs/py_packages.cpp` | Package management |
+| `src/python/lfs/module.cpp` | Main module, training hooks, logging |

--- a/docs/Python_UI.md
+++ b/docs/Python_UI.md
@@ -1,0 +1,488 @@
+# LichtFeld Studio Python UI Framework
+
+Create custom UI panels and widgets using Python with the ImGui-backed UI system.
+
+---
+
+## Panel System
+
+### Defining a Panel
+
+```python
+import lichtfeld as lf
+
+class MyPanel:
+    # Panel metadata
+    panel_label = "My Custom Panel"
+    panel_space = "SIDE_PANEL"  # SIDE_PANEL, FLOATING, VIEWPORT_OVERLAY
+    panel_order = 100           # Lower = higher in list
+
+    def __init__(self):
+        self.value = 0.5
+        self.name = ""
+        self.enabled = True
+
+    @classmethod
+    def poll(cls, ctx):
+        """Optional: return False to hide panel conditionally"""
+        return ctx.has_scene
+
+    def draw(self, ui):
+        """Called every frame to render the panel"""
+        ui.heading("Settings")
+
+        changed, self.enabled = ui.checkbox("Enabled", self.enabled)
+        changed, self.value = ui.slider_float("Value", self.value, 0.0, 1.0)
+
+        if ui.button("Apply"):
+            self.apply_settings()
+
+# Register the panel
+lf.register_panel(MyPanel)
+```
+
+### Panel Spaces
+
+| Space | Description |
+|-------|-------------|
+| `SIDE_PANEL` | Collapsible section in the sidebar |
+| `FLOATING` | Standalone draggable window |
+| `VIEWPORT_OVERLAY` | Transparent overlay on the 3D viewport |
+
+### Panel Management
+
+```python
+lf.register_panel(MyPanel)
+lf.unregister_panel(MyPanel)
+lf.unregister_all_panels()
+
+lf.set_panel_enabled("My Custom Panel", False)
+lf.is_panel_enabled("My Custom Panel")
+lf.get_panel_names("SIDE_PANEL")  # List panels in a space
+```
+
+### Poll Context
+
+The `poll()` classmethod receives a `PanelContext` with:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ctx.is_training` | bool | Training is active |
+| `ctx.has_scene` | bool | Scene is loaded |
+| `ctx.has_selection` | bool | Gaussians are selected |
+| `ctx.num_gaussians` | int | Total gaussian count |
+| `ctx.iteration` | int | Current training iteration |
+| `ctx.loss` | float | Current loss value |
+
+---
+
+## UI Widgets
+
+All widgets are called on the `ui` parameter passed to `draw()`.
+
+### Text
+
+```python
+ui.label("Simple text")
+ui.heading("Bold heading")
+ui.text_colored("Warning!", (1.0, 0.5, 0.0, 1.0))  # RGBA
+ui.bullet_text("Bullet point")
+ui.text_selectable("Copyable text", height=100.0)
+```
+
+### Buttons
+
+```python
+if ui.button("Click Me"):
+    do_something()
+
+if ui.button("Sized", (120, 30)):  # width, height
+    pass
+
+if ui.small_button("Small"):
+    pass
+
+if ui.color_button("##color", (1.0, 0.0, 0.0, 1.0), (20, 20)):
+    pass
+```
+
+### Checkboxes & Radio Buttons
+
+```python
+changed, self.enabled = ui.checkbox("Enable Feature", self.enabled)
+
+changed, self.choice = ui.radio_button("Option A", self.choice, 0)
+changed, self.choice = ui.radio_button("Option B", self.choice, 1)
+changed, self.choice = ui.radio_button("Option C", self.choice, 2)
+```
+
+### Input Fields
+
+```python
+changed, self.name = ui.input_text("Name", self.name)
+changed, self.scale = ui.input_float("Scale", self.scale)
+changed, self.count = ui.input_int("Count", self.count)
+
+# Path input with browse button
+changed, self.path = ui.path_input("Output", self.path, folder_mode=True)
+changed, self.file = ui.path_input("Image", self.file, folder_mode=False)
+```
+
+### Sliders
+
+```python
+changed, self.value = ui.slider_float("Float", self.value, 0.0, 1.0)
+changed, self.amount = ui.slider_int("Int", self.amount, 0, 100)
+
+# Multi-component sliders
+changed, self.vec2 = ui.slider_float2("Vec2", self.vec2, 0.0, 1.0)
+changed, self.vec3 = ui.slider_float3("Vec3", self.vec3, -1.0, 1.0)
+```
+
+### Drag Inputs
+
+```python
+changed, self.value = ui.drag_float("Value", self.value, speed=0.01, min=0.0, max=10.0)
+changed, self.index = ui.drag_int("Index", self.index, speed=1, min=0, max=100)
+```
+
+### Color Pickers
+
+```python
+changed, self.color = ui.color_edit3("Color", self.color)       # (r, g, b)
+changed, self.color = ui.color_edit4("Color", self.color)       # (r, g, b, a)
+```
+
+### Dropdowns & Lists
+
+```python
+options = ["Option A", "Option B", "Option C"]
+changed, self.selected = ui.combo("Select", self.selected, options)
+
+changed, self.selected = ui.listbox("Items", self.selected, options, height_items=5)
+```
+
+### Progress Bar
+
+```python
+ui.progress_bar(0.75)                          # 75%
+ui.progress_bar(0.5, "Loading...")             # With overlay text
+```
+
+---
+
+## Layout
+
+### Spacing & Separators
+
+```python
+ui.separator()          # Horizontal line
+ui.spacing()            # Vertical space
+ui.new_line()           # Force new line
+ui.same_line()          # Next widget on same line
+ui.same_line(100)       # With offset
+```
+
+### Indentation
+
+```python
+ui.indent(20.0)
+ui.label("Indented content")
+ui.unindent(20.0)
+```
+
+### Width Control
+
+```python
+ui.set_next_item_width(200)
+changed, value = ui.input_float("Fixed Width", value)
+```
+
+### Groups
+
+```python
+ui.begin_group()
+ui.label("Grouped")
+ui.button("Together")
+ui.end_group()
+```
+
+### Collapsible Sections
+
+```python
+if ui.collapsing_header("Advanced Settings"):
+    ui.label("Hidden by default")
+
+if ui.collapsing_header("Open Section", default_open=True):
+    ui.label("Visible by default")
+```
+
+### Tree Nodes
+
+```python
+if ui.tree_node("Parent"):
+    ui.label("Child content")
+    if ui.tree_node("Nested"):
+        ui.label("Deeply nested")
+        ui.tree_pop()
+    ui.tree_pop()
+```
+
+### Tables
+
+```python
+if ui.begin_table("my_table", 3):
+    ui.table_next_row()
+    ui.table_next_column()
+    ui.label("Col 1")
+    ui.table_next_column()
+    ui.label("Col 2")
+    ui.table_next_column()
+    ui.label("Col 3")
+
+    ui.table_next_row()
+    ui.table_set_column_index(0)  # Jump to column
+    ui.label("Row 2")
+
+    ui.end_table()
+```
+
+---
+
+## Interaction
+
+### Tooltips
+
+```python
+ui.button("Hover Me")
+ui.set_tooltip("This tooltip appears on hover")
+
+# Or check manually
+if ui.is_item_hovered():
+    ui.set_tooltip("Custom tooltip")
+```
+
+### Click Detection
+
+```python
+ui.button("Click Me")
+if ui.is_item_clicked(0):  # 0 = left, 1 = right, 2 = middle
+    print("Clicked!")
+```
+
+### ID Management
+
+Prevent widget ID conflicts:
+
+```python
+for i, item in enumerate(items):
+    ui.push_id(i)  # or ui.push_id(f"item_{i}")
+    if ui.button("Delete"):
+        delete_item(i)
+    ui.pop_id()
+```
+
+---
+
+## UI Hooks
+
+Inject custom UI into existing panels:
+
+```python
+# Decorator style
+@lf.hook("training", "status")
+def add_custom_info(ui):
+    ui.separator()
+    ui.label("Custom training info")
+
+@lf.hook("training", "controls", position="prepend")
+def add_before(ui):
+    ui.label("Prepended content")
+
+# Functional style
+def my_hook(ui):
+    ui.label("Hook content")
+
+lf.add_hook("panel_name", "section_name", my_hook, position="append")
+lf.remove_hook("panel_name", "section_name", my_hook)
+lf.clear_hooks("panel_name", "section_name")
+lf.clear_hooks("panel_name")  # Clear all sections
+lf.clear_all_hooks()
+
+# List registered hook points
+points = lf.get_hook_points()
+```
+
+---
+
+## File Dialogs
+
+```python
+# Folder selection
+folder = lf.open_folder_dialog("Select Output Folder", "/default/path")
+if folder:
+    print(f"Selected: {folder}")
+
+# Image file selection
+image = lf.open_image_dialog("/images")
+if image:
+    print(f"Selected: {image}")
+```
+
+---
+
+## Theme Access
+
+Access the current UI theme colors and sizes:
+
+```python
+theme = lf.theme()
+
+# Palette (all are RGBA tuples)
+theme.palette.background
+theme.palette.surface
+theme.palette.primary
+theme.palette.secondary
+theme.palette.text
+theme.palette.text_dim
+theme.palette.border
+theme.palette.success
+theme.palette.warning
+theme.palette.error
+theme.palette.info
+
+# Sizes
+theme.sizes.window_rounding
+theme.sizes.frame_rounding
+theme.sizes.border_size
+theme.sizes.window_padding   # (x, y)
+theme.sizes.frame_padding    # (x, y)
+theme.sizes.item_spacing     # (x, y)
+```
+
+---
+
+## Tool Switching
+
+```python
+lf.set_tool("selection")
+lf.set_tool("translate")
+lf.set_tool("rotate")
+lf.set_tool("scale")
+lf.set_tool("brush")
+lf.set_tool("cropbox")
+lf.set_tool("none")
+```
+
+---
+
+## Property Widgets
+
+Auto-generate widgets from property metadata:
+
+```python
+def draw(self, ui):
+    # Automatically creates appropriate widget based on property type
+    changed, value = ui.prop(params, "learning_rate")
+    changed, value = ui.prop(params, "iterations", text="Max Iterations")
+```
+
+---
+
+## Complete Example
+
+```python
+import lichtfeld as lf
+
+class GaussianFilterPanel:
+    panel_label = "Gaussian Filter"
+    panel_space = "SIDE_PANEL"
+    panel_order = 50
+
+    def __init__(self):
+        self.opacity_threshold = 0.01
+        self.scale_threshold = 0.001
+        self.preview = True
+        self.selected_only = False
+
+    @classmethod
+    def poll(cls, ctx):
+        return ctx.has_scene and ctx.num_gaussians > 0
+
+    def draw(self, ui):
+        ui.heading("Filter Settings")
+
+        changed, self.preview = ui.checkbox("Preview", self.preview)
+        changed, self.selected_only = ui.checkbox("Selected Only", self.selected_only)
+
+        ui.separator()
+
+        ui.label("Thresholds")
+        changed, self.opacity_threshold = ui.slider_float(
+            "Min Opacity", self.opacity_threshold, 0.0, 1.0
+        )
+        changed, self.scale_threshold = ui.drag_float(
+            "Min Scale", self.scale_threshold, 0.0001, 0.0, 0.1
+        )
+
+        ui.separator()
+
+        if ui.collapsing_header("Statistics"):
+            scene = lf.get_scene()
+            if scene:
+                model = scene.combined_model()
+                if model:
+                    ui.label(f"Total: {model.num_points:,}")
+                    ui.label(f"Visible: {model.visible_count():,}")
+
+        ui.separator()
+
+        ui.begin_group()
+        if ui.button("Apply Filter", (100, 0)):
+            self.apply_filter()
+        ui.same_line()
+        if ui.button("Reset", (60, 0)):
+            self.reset()
+        ui.end_group()
+
+        ui.set_tooltip("Apply filter to remove low-quality gaussians")
+
+    def apply_filter(self):
+        scene = lf.get_scene()
+        if not scene:
+            return
+
+        model = scene.training_model()
+        if not model:
+            return
+
+        opacity = model.get_opacity().squeeze()
+        mask = opacity < self.opacity_threshold
+        model.soft_delete(mask)
+        lf.log.info(f"Filtered {mask.sum_scalar():.0f} gaussians")
+
+    def reset(self):
+        self.opacity_threshold = 0.01
+        self.scale_threshold = 0.001
+
+lf.register_panel(GaussianFilterPanel)
+```
+
+---
+
+## Widget Reference
+
+| Category | Widgets |
+|----------|---------|
+| **Text** | `label`, `heading`, `text_colored`, `bullet_text`, `text_selectable` |
+| **Buttons** | `button`, `small_button`, `color_button` |
+| **Toggle** | `checkbox`, `radio_button` |
+| **Input** | `input_text`, `input_float`, `input_int`, `path_input` |
+| **Sliders** | `slider_float`, `slider_int`, `slider_float2`, `slider_float3` |
+| **Drags** | `drag_float`, `drag_int` |
+| **Color** | `color_edit3`, `color_edit4` |
+| **Selection** | `combo`, `listbox` |
+| **Layout** | `separator`, `spacing`, `same_line`, `new_line`, `indent`, `unindent`, `set_next_item_width` |
+| **Grouping** | `begin_group`, `end_group`, `collapsing_header`, `tree_node`, `tree_pop` |
+| **Tables** | `begin_table`, `end_table`, `table_next_row`, `table_next_column`, `table_set_column_index` |
+| **Misc** | `progress_bar`, `set_tooltip`, `is_item_hovered`, `is_item_clicked`, `push_id`, `pop_id` |

--- a/src/core/event_bridge/CMakeLists.txt
+++ b/src/core/event_bridge/CMakeLists.txt
@@ -21,6 +21,8 @@ target_include_directories(lfs_event_bridge
 target_link_libraries(lfs_event_bridge
     PUBLIC
         CUDA::cudart
+    PRIVATE
+        spdlog::spdlog
 )
 
 target_compile_definitions(lfs_event_bridge
@@ -35,4 +37,7 @@ set_target_properties(lfs_event_bridge PROPERTIES
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN ON
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/Release
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/Debug
 )

--- a/src/core/event_bridge/control_boundary.cpp
+++ b/src/core/event_bridge/control_boundary.cpp
@@ -4,7 +4,7 @@
 
 #include "control_boundary.hpp"
 
-#include "core/logger.hpp"
+#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <cuda_runtime.h>
@@ -84,7 +84,7 @@ namespace lfs::training {
         }
 
         if (cudaSetDevice(0) != cudaSuccess) {
-            LOG_ERROR("cudaSetDevice failed in hook drain");
+            spdlog::error("cudaSetDevice failed in hook drain");
             return;
         }
 
@@ -92,7 +92,7 @@ namespace lfs::training {
             try {
                 pending.cb(pending.ctx);
             } catch (...) {
-                LOG_ERROR("Hook callback threw");
+                spdlog::error("Hook callback threw");
             }
         }
     }

--- a/src/mcp/mcp_training_context.cpp
+++ b/src/mcp/mcp_training_context.cpp
@@ -601,7 +601,7 @@ namespace lfs::mcp {
                 }
 
                 const auto& screen_positions = *screen_pos_result;
-                const int64_t N = screen_positions.shape()[0];
+                const auto N = static_cast<size_t>(screen_positions.shape()[0]);
 
                 core::Tensor selection = core::Tensor::zeros({N}, core::Device::CUDA, core::DataType::UInt8);
 
@@ -682,7 +682,7 @@ namespace lfs::mcp {
 
                 const std::string mode = args.value("mode", "replace");
                 const auto& screen_positions = *screen_pos_result;
-                const int64_t N = screen_positions.shape()[0];
+                const auto N = static_cast<size_t>(screen_positions.shape()[0]);
 
                 core::Tensor selection = core::Tensor::zeros({N}, core::Device::CUDA, core::DataType::UInt8);
 
@@ -750,7 +750,7 @@ namespace lfs::mcp {
                 const float radius = args.value("radius", 20.0f);
 
                 const auto& screen_positions = *screen_pos_result;
-                const int64_t N = screen_positions.shape()[0];
+                const auto N = static_cast<size_t>(screen_positions.shape()[0]);
 
                 core::Tensor selection = core::Tensor::zeros({N}, core::Device::CUDA, core::DataType::UInt8);
                 rendering::brush_select_tensor(screen_positions, x, y, radius, selection);
@@ -826,7 +826,7 @@ namespace lfs::mcp {
                     return json{{"error", "No model loaded"}};
                 }
 
-                const int64_t N = static_cast<int64_t>(model->size());
+                const auto N = model->size();
                 auto empty_mask = std::make_shared<core::Tensor>(
                     core::Tensor::zeros({N}, core::Device::CUDA, core::DataType::UInt8));
                 scene->setSelectionMask(empty_mask);
@@ -987,7 +987,7 @@ namespace lfs::mcp {
                 }
 
                 const auto& screen_positions = *screen_pos_result;
-                const int64_t N = screen_positions.shape()[0];
+                const auto N = static_cast<size_t>(screen_positions.shape()[0]);
 
                 core::Tensor selection = core::Tensor::zeros({static_cast<size_t>(N)}, core::Device::CUDA, core::DataType::UInt8);
                 rendering::rect_select_tensor(screen_positions, x0, y0, x1, y1, selection);

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -29,11 +29,19 @@ target_link_libraries(lfs_panel_registry
         Python::Python
 )
 
+target_compile_definitions(lfs_panel_registry
+    PRIVATE
+        LFS_PANEL_REGISTRY_EXPORTS
+)
+
 set_target_properties(lfs_panel_registry PROPERTIES
     POSITION_INDEPENDENT_CODE ON
     CXX_STANDARD 23
     CXX_STANDARD_REQUIRED ON
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/Release
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/Debug
 )
 
 # Static library for other Python utilities
@@ -124,14 +132,24 @@ target_include_directories(lfs_py PRIVATE
     ${CMAKE_SOURCE_DIR}/src/visualizer
 )
 
-# Generate type stubs for IDE support
+# Multi-config generators (MSVC) output to Release/Debug subdirs - copy to parent for Python to find
+if(CMAKE_CONFIGURATION_TYPES)
+    add_custom_command(TARGET lfs_py POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE:lfs_py>"
+            "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:lfs_py>"
+        COMMENT "Copying $<TARGET_FILE_NAME:lfs_py> to ${CMAKE_CURRENT_BINARY_DIR}"
+    )
+endif()
+
+# Type stubs for IDE support (output to typings/ to avoid runtime conflicts)
 nanobind_add_stub(lichtfeld_stub
     MODULE lichtfeld
-    OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}
+    OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/typings
     PYTHON_PATH ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS lfs_py
     RECURSIVE
-    MARKER_FILE ${CMAKE_CURRENT_BINARY_DIR}/lichtfeld/py.typed
+    MARKER_FILE ${CMAKE_CURRENT_BINARY_DIR}/typings/lichtfeld/py.typed
 )
 
 # Copy lfs_plugins Python module to build directory

--- a/src/python/py_panel_registry.hpp
+++ b/src/python/py_panel_registry.hpp
@@ -10,6 +10,16 @@
 #include <string>
 #include <vector>
 
+#ifdef _WIN32
+#ifdef LFS_PANEL_REGISTRY_EXPORTS
+#define LFS_PANEL_REGISTRY_API __declspec(dllexport)
+#else
+#define LFS_PANEL_REGISTRY_API __declspec(dllimport)
+#endif
+#else
+#define LFS_PANEL_REGISTRY_API
+#endif
+
 namespace lfs::vis {
     class Scene;
 }
@@ -31,23 +41,23 @@ namespace lfs::python {
     using CleanupCallback = std::function<void()>;
 
     // Register callbacks from the Python module
-    void set_panel_draw_callback(DrawPanelsCallback cb);
-    void set_panel_draw_single_callback(DrawSinglePanelCallback cb);
-    void set_panel_has_callback(HasPanelsCallback cb);
-    void set_panel_names_callback(GetPanelNamesCallback cb);
-    void set_python_cleanup_callback(CleanupCallback cb);
-    void clear_panel_callbacks();
+    LFS_PANEL_REGISTRY_API void set_panel_draw_callback(DrawPanelsCallback cb);
+    LFS_PANEL_REGISTRY_API void set_panel_draw_single_callback(DrawSinglePanelCallback cb);
+    LFS_PANEL_REGISTRY_API void set_panel_has_callback(HasPanelsCallback cb);
+    LFS_PANEL_REGISTRY_API void set_panel_names_callback(GetPanelNamesCallback cb);
+    LFS_PANEL_REGISTRY_API void set_python_cleanup_callback(CleanupCallback cb);
+    LFS_PANEL_REGISTRY_API void clear_panel_callbacks();
 
     // C++ interface for the visualizer
-    void draw_python_panels(PanelSpace space, lfs::vis::Scene* scene = nullptr);
-    void draw_python_panel(const std::string& name, lfs::vis::Scene* scene = nullptr);
-    bool has_python_panels(PanelSpace space);
-    std::vector<std::string> get_python_panel_names(PanelSpace space);
-    void invoke_python_cleanup();
+    LFS_PANEL_REGISTRY_API void draw_python_panels(PanelSpace space, lfs::vis::Scene* scene = nullptr);
+    LFS_PANEL_REGISTRY_API void draw_python_panel(const std::string& name, lfs::vis::Scene* scene = nullptr);
+    LFS_PANEL_REGISTRY_API bool has_python_panels(PanelSpace space);
+    LFS_PANEL_REGISTRY_API std::vector<std::string> get_python_panel_names(PanelSpace space);
+    LFS_PANEL_REGISTRY_API void invoke_python_cleanup();
 
     // Operation context for Python code (short-lived, per-call)
-    void set_scene_for_python(void* scene);
-    void* get_scene_for_python();
+    LFS_PANEL_REGISTRY_API void set_scene_for_python(void* scene);
+    LFS_PANEL_REGISTRY_API void* get_scene_for_python();
 
     // RAII guard for operation context (used for capability invocations)
     class SceneContextGuard {
@@ -62,7 +72,7 @@ namespace lfs::python {
     };
 
     // Application scene context (long-lived, persists while model is loaded)
-    class ApplicationSceneContext {
+    class LFS_PANEL_REGISTRY_API ApplicationSceneContext {
     public:
         void set(vis::Scene* scene);
         vis::Scene* get() const;
@@ -73,7 +83,7 @@ namespace lfs::python {
         std::atomic<uint64_t> generation_{0};
     };
 
-    void set_application_scene(vis::Scene* scene);
-    vis::Scene* get_application_scene();
+    LFS_PANEL_REGISTRY_API void set_application_scene(vis::Scene* scene);
+    LFS_PANEL_REGISTRY_API vis::Scene* get_application_scene();
 
 } // namespace lfs::python

--- a/src/python/subprocess.hpp
+++ b/src/python/subprocess.hpp
@@ -9,6 +9,8 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <BaseTsd.h>
+using ssize_t = SSIZE_T;
 #else
 #include <sys/types.h>
 #endif

--- a/src/training/control/command_api.cpp
+++ b/src/training/control/command_api.cpp
@@ -325,7 +325,7 @@ namespace lfs::training {
                 return std::unexpected("Vector length mismatch with attribute dimension");
             }
             const std::vector<float> vec_f(vec.begin(), vec.end());
-            auto value_tensor = core::Tensor::from_vector(vec_f, {1, static_cast<int>(dim)}, tensor.device());
+            auto value_tensor = core::Tensor::from_vector(vec_f, {size_t{1}, dim}, tensor.device());
             value_tensor = value_tensor.broadcast_to(tensor.shape());
             const auto mask_float = mask_full.to(tensor.dtype());
             const auto keep = mask_full.logical_not().to(tensor.dtype());

--- a/src/visualizer/gui/panels/menu_bar.cpp
+++ b/src/visualizer/gui/panels/menu_bar.cpp
@@ -30,6 +30,10 @@ using namespace lichtfeld::Strings;
 #ifdef LFS_BUILD_PYTHON_BINDINGS
 #include "python/runner.hpp"
 #include <Python.h>
+// Python.h defines PLATFORM macro that conflicts with string_keys.hpp
+#ifdef PLATFORM
+#undef PLATFORM
+#endif
 #endif
 
 #define CPPHTTPLIB_OPENSSL_SUPPORT

--- a/src/visualizer/gui/terminal/pty_process.hpp
+++ b/src/visualizer/gui/terminal/pty_process.hpp
@@ -8,6 +8,8 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <BaseTsd.h>
+using ssize_t = SSIZE_T;
 #else
 #include <sys/types.h>
 #endif

--- a/src/visualizer/ipc/selection_server.cpp
+++ b/src/visualizer/ipc/selection_server.cpp
@@ -7,20 +7,186 @@
 
 #include <cstring>
 #include <nlohmann/json.hpp>
+
+#ifdef _WIN32
+// Windows headers already included via selection_server.hpp
+#else
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+#endif
 
 namespace lfs::vis {
 
     using json = nlohmann::json;
     using namespace lfs::core::events;
 
+#ifdef _WIN32
+    namespace {
+        std::string socket_path_to_pipe_name(const std::string& socket_path) {
+            // Convert Unix socket path to Windows named pipe
+            // /tmp/lichtfeld-selection.sock -> \\.\pipe\lichtfeld-selection
+            std::string name = socket_path;
+            if (name.find("/tmp/") == 0) {
+                name = name.substr(5);
+            }
+            auto dot_pos = name.rfind('.');
+            if (dot_pos != std::string::npos) {
+                name = name.substr(0, dot_pos);
+            }
+            return R"(\\.\pipe\)" + name;
+        }
+    } // namespace
+#endif
+
     SelectionServer::SelectionServer() = default;
 
     SelectionServer::~SelectionServer() {
         stop();
     }
+
+#ifdef _WIN32
+
+    bool SelectionServer::start(const std::string& socket_path) {
+        if (running_)
+            return true;
+
+        socket_path_ = socket_path;
+        const std::string pipe_name = socket_path_to_pipe_name(socket_path_);
+
+        pipe_handle_ = CreateNamedPipeA(
+            pipe_name.c_str(),
+            PIPE_ACCESS_DUPLEX,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+            PIPE_UNLIMITED_INSTANCES,
+            static_cast<DWORD>(RECV_BUFFER_SIZE),
+            static_cast<DWORD>(RECV_BUFFER_SIZE),
+            0,
+            nullptr);
+
+        if (pipe_handle_ == INVALID_HANDLE_VALUE) {
+            LOG_ERROR("SelectionServer: CreateNamedPipe() failed: {}", GetLastError());
+            return false;
+        }
+
+        running_ = true;
+        server_thread_ = std::thread(&SelectionServer::server_loop, this);
+        LOG_INFO("SelectionServer started: {}", pipe_name);
+        return true;
+    }
+
+    void SelectionServer::stop() {
+        if (!running_)
+            return;
+
+        running_ = false;
+
+        if (pipe_handle_ != INVALID_HANDLE_VALUE) {
+            // Cancel any pending ConnectNamedPipe
+            CancelIoEx(pipe_handle_, nullptr);
+            CloseHandle(pipe_handle_);
+            pipe_handle_ = INVALID_HANDLE_VALUE;
+        }
+
+        if (server_thread_.joinable())
+            server_thread_.join();
+    }
+
+    void SelectionServer::server_loop() {
+        const std::string pipe_name = socket_path_to_pipe_name(socket_path_);
+
+        while (running_) {
+            // Wait for a client to connect
+            if (ConnectNamedPipe(pipe_handle_, nullptr) || GetLastError() == ERROR_PIPE_CONNECTED) {
+                handle_client(pipe_handle_);
+                DisconnectNamedPipe(pipe_handle_);
+            } else {
+                DWORD error = GetLastError();
+                if (error != ERROR_OPERATION_ABORTED && running_) {
+                    LOG_ERROR("SelectionServer: ConnectNamedPipe() failed: {}", error);
+                }
+            }
+        }
+    }
+
+    void SelectionServer::send_response(HANDLE client_pipe, bool success, const char* error) {
+        const json response = error ? json{{"success", success}, {"error", error}} : json{{"success", success}};
+        const std::string str = response.dump();
+        DWORD bytes_written = 0;
+        WriteFile(client_pipe, str.c_str(), static_cast<DWORD>(str.size()), &bytes_written, nullptr);
+    }
+
+    void SelectionServer::handle_client(HANDLE client_pipe) {
+        char buffer[RECV_BUFFER_SIZE];
+        DWORD bytes_read = 0;
+
+        if (!ReadFile(client_pipe, buffer, sizeof(buffer) - 1, &bytes_read, nullptr) || bytes_read == 0)
+            return;
+
+        buffer[bytes_read] = '\0';
+
+        try {
+            const auto request = json::parse(buffer);
+            const auto command = request.value("command", "");
+
+            if (command == "select_rect") {
+                queue_command(SelectRectCmd{.x0 = request.value("x0", 0.0f),
+                                            .y0 = request.value("y0", 0.0f),
+                                            .x1 = request.value("x1", 0.0f),
+                                            .y1 = request.value("y1", 0.0f),
+                                            .camera_index = request.value("camera_index", 0),
+                                            .mode = request.value("mode", "replace")});
+                send_response(client_pipe, true);
+
+            } else if (command == "apply_mask") {
+                std::vector<uint8_t> mask;
+                if (request.contains("mask")) {
+                    mask = request["mask"].get<std::vector<uint8_t>>();
+                }
+                queue_command(ApplyMaskCmd{.mask = std::move(mask)});
+                send_response(client_pipe, true);
+
+            } else if (command == "deselect_all") {
+                queue_command(DeselectAllCmd{});
+                send_response(client_pipe, true);
+
+            } else if (command == "invoke_capability") {
+                const auto capability = request.value("capability", "");
+                const auto args = request.value("args", "{}");
+                if (capability.empty()) {
+                    send_response(client_pipe, false, "Missing capability name");
+                } else if (!invoke_capability_callback_) {
+                    LOG_ERROR("SelectionServer: capability callback not set");
+                    send_response(client_pipe, false, "Capability invocation not available");
+                } else {
+                    const auto result = invoke_capability_callback_(capability, args);
+                    json response;
+                    response["success"] = result.success;
+                    if (!result.result_json.empty()) {
+                        try {
+                            response["result"] = json::parse(result.result_json);
+                        } catch (...) {
+                            response["result"] = result.result_json;
+                        }
+                    }
+                    if (!result.error.empty())
+                        response["error"] = result.error;
+                    const std::string str = response.dump();
+                    DWORD bytes_written = 0;
+                    WriteFile(client_pipe, str.c_str(), static_cast<DWORD>(str.size()), &bytes_written, nullptr);
+                }
+
+            } else {
+                send_response(client_pipe, false, "Unknown command");
+            }
+
+        } catch (const std::exception& e) {
+            LOG_ERROR("SelectionServer: {}", e.what());
+            send_response(client_pipe, false, e.what());
+        }
+    }
+
+#else // Unix implementation
 
     bool SelectionServer::start(const std::string& socket_path) {
         if (running_)
@@ -104,44 +270,6 @@ namespace lfs::vis {
         }
     }
 
-    void SelectionServer::queue_command(SelectionCommand cmd) {
-        std::lock_guard lock(command_queue_mutex_);
-        command_queue_.push(std::move(cmd));
-    }
-
-    void SelectionServer::process_pending_commands() {
-        std::queue<SelectionCommand> commands;
-        {
-            std::lock_guard lock(command_queue_mutex_);
-            std::swap(commands, command_queue_);
-        }
-
-        while (!commands.empty()) {
-            auto& cmd = commands.front();
-
-            std::visit(
-                [](auto&& arg) {
-                    using T = std::decay_t<decltype(arg)>;
-                    if constexpr (std::is_same_v<T, SelectRectCmd>) {
-                        cmd::SelectRect{.x0 = arg.x0,
-                                        .y0 = arg.y0,
-                                        .x1 = arg.x1,
-                                        .y1 = arg.y1,
-                                        .camera_index = arg.camera_index,
-                                        .mode = std::move(arg.mode)}
-                            .emit();
-                    } else if constexpr (std::is_same_v<T, ApplyMaskCmd>) {
-                        cmd::ApplySelectionMask{.mask = std::move(arg.mask)}.emit();
-                    } else if constexpr (std::is_same_v<T, DeselectAllCmd>) {
-                        cmd::DeselectAll{}.emit();
-                    }
-                },
-                cmd);
-
-            commands.pop();
-        }
-    }
-
     void SelectionServer::send_response(int client_fd, bool success, const char* error) {
         const json response = error ? json{{"success", success}, {"error", error}} : json{{"success", success}};
         const std::string str = response.dump();
@@ -213,6 +341,48 @@ namespace lfs::vis {
         } catch (const std::exception& e) {
             LOG_ERROR("SelectionServer: {}", e.what());
             send_response(client_fd, false, e.what());
+        }
+    }
+
+#endif // _WIN32
+
+    // Shared implementations (platform-independent)
+
+    void SelectionServer::queue_command(SelectionCommand cmd) {
+        std::lock_guard lock(command_queue_mutex_);
+        command_queue_.push(std::move(cmd));
+    }
+
+    void SelectionServer::process_pending_commands() {
+        std::queue<SelectionCommand> commands;
+        {
+            std::lock_guard lock(command_queue_mutex_);
+            std::swap(commands, command_queue_);
+        }
+
+        while (!commands.empty()) {
+            auto& cmd = commands.front();
+
+            std::visit(
+                [](auto&& arg) {
+                    using T = std::decay_t<decltype(arg)>;
+                    if constexpr (std::is_same_v<T, SelectRectCmd>) {
+                        cmd::SelectRect{.x0 = arg.x0,
+                                        .y0 = arg.y0,
+                                        .x1 = arg.x1,
+                                        .y1 = arg.y1,
+                                        .camera_index = arg.camera_index,
+                                        .mode = std::move(arg.mode)}
+                            .emit();
+                    } else if constexpr (std::is_same_v<T, ApplyMaskCmd>) {
+                        cmd::ApplySelectionMask{.mask = std::move(arg.mask)}.emit();
+                    } else if constexpr (std::is_same_v<T, DeselectAllCmd>) {
+                        cmd::DeselectAll{}.emit();
+                    }
+                },
+                cmd);
+
+            commands.pop();
         }
     }
 

--- a/src/visualizer/ipc/selection_server.hpp
+++ b/src/visualizer/ipc/selection_server.hpp
@@ -13,6 +13,10 @@
 #include <variant>
 #include <vector>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 namespace lfs::vis {
 
 struct SelectRectCmd {
@@ -61,12 +65,22 @@ private:
     static constexpr int SELECT_TIMEOUT_US = 100000;
 
     void server_loop();
-    void handle_client(int client_fd);
     void queue_command(SelectionCommand cmd);
+
+#ifdef _WIN32
+    void handle_client(HANDLE client_pipe);
+    void send_response(HANDLE client_pipe, bool success, const char* error = nullptr);
+#else
+    void handle_client(int client_fd);
     void send_response(int client_fd, bool success, const char* error = nullptr);
+#endif
 
     std::string socket_path_;
+#ifdef _WIN32
+    HANDLE pipe_handle_ = INVALID_HANDLE_VALUE;
+#else
     int server_fd_ = -1;
+#endif
     std::atomic<bool> running_{false};
     std::thread server_thread_;
 


### PR DESCRIPTION
## Summary
- Fix `lichtfeld.pyd` not being found on MSVC multi-config builds (was output to `Release/` subdir)
- Add POST_BUILD command to copy `.pyd` to parent directory where Python can find it
- Move type stubs to `typings/` subdirectory to avoid runtime import conflicts
- Add comprehensive Python API documentation

## Changes
- `src/python/CMakeLists.txt`: Fix module loading and stub paths
- `docs/PYTHON_API.md`: Full Python API reference
- `docs/Python_UI.md`: UI framework documentation  
- `docs/Python_API_issues.md`: Known issues and gaps
- Various fixes to event_bridge, mcp, training, visualizer components

## Test plan
- [ ] Build on Windows with MSVC
- [ ] Verify `import lichtfeld` works without manual .pyd copying
- [ ] Check type stubs are generated in `typings/` directory