### PR TITLE
add version info to console log and GUI

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -6,6 +6,7 @@
 #include "core/argument_parser.hpp"
 #include "core/converter.hpp"
 #include "core/logger.hpp"
+#include "git_version.h"
 
 #include <print>
 
@@ -27,6 +28,7 @@ int main(int argc, char* argv[]) {
             return lfs::core::run_converter(mode.params);
         } else if constexpr (std::is_same_v<T, lfs::core::args::TrainingMode>) {
             LOG_INFO("LichtFeld Studio");
+            LOG_INFO("version {} | tag {}", GIT_TAGGED_VERSION, GIT_COMMIT_HASH_SHORT);
             lfs::app::Application app;
             return app.run(std::move(mode.params));
         }

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -48,6 +48,7 @@
 #include "visualizer_impl.hpp"
 #include <cuda_runtime.h>
 
+#include "git_version.h"
 #include <GLFW/glfw3.h>
 #include <algorithm>
 #include <cfloat>
@@ -1551,8 +1552,9 @@ namespace lfs::vis::gui {
             const float mem_label_w = font->CalcTextSizeA(font->FontSize, FLT_MAX, 0.0f, "GPU ").x;
             const float fps_w = font->CalcTextSizeA(font->FontSize, FLT_MAX, 0.0f, fps_buf).x;
             const float fps_label_w = font->CalcTextSizeA(font->FontSize, FLT_MAX, 0.0f, " FPS").x;
+            const float version_label_w = font->CalcTextSizeA(font->FontSize, FLT_MAX, 0.0f, GIT_COMMIT_HASH_SHORT).x;
 
-            ImGui::SameLine(size.x - (mem_label_w + mem_val_w + SPACING + fps_w + fps_label_w) - PADDING * 2);
+            ImGui::SameLine(size.x - (version_label_w + SPACING + mem_label_w + mem_val_w + SPACING + fps_w + fps_label_w) - PADDING * 2);
 
             ImGui::TextColored(t.palette.text_dim, "GPU ");
             ImGui::SameLine(0.0f, 0.0f);
@@ -1571,6 +1573,10 @@ namespace lfs::vis::gui {
             ImGui::TextColored(t.palette.text_dim, " %s", LOC(lichtfeld::Strings::Status::FPS));
             if (ctx.fonts.bold)
                 ImGui::PopFont();
+
+            ImGui::SameLine(0.0f, SPACING);
+
+            ImGui::TextColored(t.palette.text_dim, GIT_COMMIT_HASH_SHORT);
 
             if (ctx.fonts.regular)
                 ImGui::PopFont();


### PR DESCRIPTION
When users report issues and post screenshots or log files, it is not always clear what version of LFS they are using.
This PR adds the commit hash to the GUI. We also log the version and commit has to the console upon startup

<img width="1299" height="796" alt="image" src="https://github.com/user-attachments/assets/5da11eb9-292a-406d-99d4-3e1a50535ffb" />

<img width="823" height="153" alt="image" src="https://github.com/user-attachments/assets/302d5d80-1a1d-4dfb-bdf0-6e74e3d5f34e" />
