### PR TITLE
Fix Python crash when pyd overwrites ensure_initialized callback

### DIFF
--- a/src/python/runner.cpp
+++ b/src/python/runner.cpp
@@ -244,6 +244,16 @@ _add_dll_dirs()
 
     void ensure_initialized() {
 #ifdef LFS_BUILD_PYTHON_BINDINGS
+        // Early exit if Python is already initialized by another binary.
+        // When lfs_python_utils is statically linked into both exe and pyd,
+        // each gets its own g_py_init_once. The pyd's g_registrar may overwrite
+        // the callback in lfs_panel_registry.dll to point to this copy.
+        // Without this check, the pyd's call_once would run and try to call
+        // PyEval_SaveThread() when the GIL isn't held, causing a crash.
+        if (Py_IsInitialized()) {
+            return;
+        }
+
         std::call_once(g_py_init_once, [] {
             if (!Py_IsInitialized()) {
                 PyImport_AppendInittab("_lfs_output", init_capture_module);


### PR DESCRIPTION
## Summary
- Fixes crash on Windows when Python bindings are enabled
- Root cause: `lfs_python_utils` statically linked into both exe and pyd creates duplicate `g_py_init_once` flags
- When pyd loads, its `g_registrar` overwrites the callback, and later calls to `ensure_initialized()` run with a fresh `call_once` flag, eventually calling `PyEval_SaveThread()` without holding the GIL

## Fix
Add early `Py_IsInitialized()` check at the start of `ensure_initialized()` to skip entirely if Python is already running.

## Test plan
- [x] Clean build from scratch with Python bindings enabled
- [x] Application starts without crash
- [x] Python console functional (`import lichtfeld as lf` works)