### PR TITLE
#800 fix crop filter mode

### DIFF
--- a/src/rendering/rasterizer/rasterization/src/rasterization_api_tensor.cu
+++ b/src/rendering/rasterizer/rasterization/src/rasterization_api_tensor.cu
@@ -791,9 +791,9 @@ namespace lfs::rendering {
 
         if (crop_transform && crop_min && crop_max) {
             const float* const c = crop_transform;
-            const float lx = c[0] * pos.x + c[1] * pos.y + c[2] * pos.z + c[3];
-            const float ly = c[4] * pos.x + c[5] * pos.y + c[6] * pos.z + c[7];
-            const float lz = c[8] * pos.x + c[9] * pos.y + c[10] * pos.z + c[11];
+            const float lx = c[0] * pos.x + c[4] * pos.y + c[8] * pos.z + c[12];
+            const float ly = c[1] * pos.x + c[5] * pos.y + c[9] * pos.z + c[13];
+            const float lz = c[2] * pos.x + c[6] * pos.y + c[10] * pos.z + c[14];
 
             const float3 bmin = *crop_min;
             const float3 bmax = *crop_max;
@@ -809,9 +809,9 @@ namespace lfs::rendering {
 
         if (ellipsoid_transform && ellipsoid_radii) {
             const float* const e = ellipsoid_transform;
-            const float lx = e[0] * pos.x + e[1] * pos.y + e[2] * pos.z + e[3];
-            const float ly = e[4] * pos.x + e[5] * pos.y + e[6] * pos.z + e[7];
-            const float lz = e[8] * pos.x + e[9] * pos.y + e[10] * pos.z + e[11];
+            const float lx = e[0] * pos.x + e[4] * pos.y + e[8] * pos.z + e[12];
+            const float ly = e[1] * pos.x + e[5] * pos.y + e[9] * pos.z + e[13];
+            const float lz = e[2] * pos.x + e[6] * pos.y + e[10] * pos.z + e[14];
 
             const float3 r = *ellipsoid_radii;
             const float norm = (lx * lx) / (r.x * r.x) + (ly * ly) / (r.y * r.y) + (lz * lz) / (r.z * r.z);

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -883,8 +883,8 @@ namespace lfs::vis::gui {
         if (selection_tool && selection_tool->isEnabled() && !ui_hidden_) {
             selection_tool->renderUI(ctx, nullptr);
 
-            // Mini-toolbar for gizmo operation when crop filter is enabled
-            if (selection_tool->isCropFilterEnabled()) {
+            // Mini-toolbar for gizmo operation when crop box is selected
+            if (selection_tool->isCropBoxSelected()) {
                 renderCropGizmoMiniToolbar(ctx);
             }
         }
@@ -2080,17 +2080,8 @@ namespace lfs::vis::gui {
         NodeId cropbox_id = NULL_NODE;
         const SceneNode* cropbox_node = nullptr;
 
-        const auto* const selection_tool = ctx.viewer->getSelectionTool();
-        const bool crop_filter_active = selection_tool && selection_tool->isEnabled() &&
-                                        selection_tool->isCropFilterEnabled();
-
         if (scene_manager->getSelectedNodeType() == NodeType::CROPBOX) {
             cropbox_id = scene_manager->getSelectedNodeCropBoxId();
-        } else if (crop_filter_active) {
-            const auto& visible = scene_manager->getScene().getVisibleCropBoxes();
-            if (!visible.empty()) {
-                cropbox_id = visible[0].node_id;
-            }
         }
 
         if (cropbox_id == NULL_NODE)
@@ -2351,17 +2342,8 @@ namespace lfs::vis::gui {
         NodeId ellipsoid_id = NULL_NODE;
         const SceneNode* ellipsoid_node = nullptr;
 
-        const auto* const selection_tool = ctx.viewer->getSelectionTool();
-        const bool crop_filter_active = selection_tool && selection_tool->isEnabled() &&
-                                        selection_tool->isCropFilterEnabled();
-
         if (scene_manager->getSelectedNodeType() == NodeType::ELLIPSOID) {
             ellipsoid_id = scene_manager->getSelectedNodeEllipsoidId();
-        } else if (crop_filter_active) {
-            const auto& visible = scene_manager->getScene().getVisibleEllipsoids();
-            if (!visible.empty()) {
-                ellipsoid_id = visible[0].node_id;
-            }
         }
 
         if (ellipsoid_id == NULL_NODE)

--- a/src/visualizer/rendering/rendering_manager.cpp
+++ b/src/visualizer/rendering/rendering_manager.cpp
@@ -28,7 +28,7 @@ namespace lfs::vis {
 
     namespace {
         constexpr int GPU_ALIGNMENT = 16; // 16-pixel alignment for GPU texture efficiency
-    } // namespace
+    }                                     // namespace
 
     using namespace lfs::core::events;
 
@@ -1677,7 +1677,7 @@ namespace lfs::vis {
     }
 
     void RenderingManager::applyCropFilter(lfs::core::Tensor& selection) {
-        if (!selection.is_valid() || !settings_.crop_filter_for_selection)
+        if (!selection.is_valid())
             return;
 
         auto* const sm = services().sceneOrNull();

--- a/src/visualizer/rendering/rendering_manager.hpp
+++ b/src/visualizer/rendering/rendering_manager.hpp
@@ -102,9 +102,6 @@ namespace lfs::vis {
         glm::vec3 depth_filter_min = glm::vec3(-50.0f, -10000.0f, 0.0f);
         glm::vec3 depth_filter_max = glm::vec3(50.0f, 10000.0f, 100.0f);
         lfs::geometry::EuclideanTransform depth_filter_transform;
-
-        // Crop filter for selection (use scene crop box/ellipsoid as selection filter)
-        bool crop_filter_for_selection = false;
     };
 
     struct SplitViewInfo {

--- a/src/visualizer/tools/selection_tool.hpp
+++ b/src/visualizer/tools/selection_tool.hpp
@@ -47,9 +47,8 @@ namespace lfs::vis::tools {
         [[nodiscard]] bool isDepthFilterEnabled() const { return depth_filter_enabled_; }
         void resetDepthFilter();
 
-        // Crop filter (use scene crop box/ellipsoid as selection filter)
-        [[nodiscard]] bool isCropFilterEnabled() const { return crop_filter_enabled_; }
-        void setCropFilterEnabled(bool enabled);
+        // Check if crop box or ellipsoid is selected (disables brush painting)
+        [[nodiscard]] bool isCropBoxSelected() const;
 
         // Input bindings
         void setInputBindings(const input::InputBindings* bindings) { input_bindings_ = bindings; }
@@ -119,10 +118,6 @@ namespace lfs::vis::tools {
         bool depth_filter_enabled_ = false;
         float depth_far_ = 100.0f;
         float frustum_half_width_ = 50.0f;
-
-        // ========== Crop Filter ==========
-        bool crop_filter_enabled_ = false;
-        std::string node_before_crop_filter_; // Node to restore when disabling crop filter
 
         static constexpr float DEPTH_MIN = 0.01f;
         static constexpr float DEPTH_MAX = 1000.0f;


### PR DESCRIPTION
Usability unclear!

- Crop box/ellipsoid always constraints the area of selection
- CTRL+SHIFT+LEFT only toggles between model node and crop object. When crop objects selected, selecting Gaussians is off.

Fixes #800 