### PR TITLE
#798 - add init_path to params upon reset

### DIFF
--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -164,6 +164,7 @@ namespace lfs::vis {
                 trainer_manager_->waitForCompletion();
             }
             const auto& path = scene_manager_->getDatasetPath();
+            const auto& init_path = data_loader_->getParameters().init_path;
             if (path.empty()) {
                 LOG_ERROR("Cannot reset: empty path");
                 return;
@@ -174,6 +175,7 @@ namespace lfs::vis {
                 if (trainer_manager_) {
                     params.dataset = trainer_manager_->getEditableDatasetParams();
                     params.dataset.data_path = path;
+                    params.init_path = init_path;
                 }
                 data_loader_->setParameters(params);
             }


### PR DESCRIPTION
In case a --init-ply was used at the start of the training, when pressing reset after a training, the init_path was copied over to the parameters for loading the dataset. 

This PR adds the missing init_path for loading the dataset after reset.

fixes #798 