### PR TITLE
Fix Linux Python module detection and hybrid GPU support

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -2,6 +2,10 @@
  *
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#ifdef __linux__
+#include <cstdlib>
+#endif
+
 #include "app/application.hpp"
 #include "core/argument_parser.hpp"
 #include "core/converter.hpp"
@@ -36,6 +40,14 @@ namespace {
 } // namespace
 
 int main(int argc, char* argv[]) {
+#ifdef __linux__
+    // On hybrid GPU laptops (Intel/AMD + NVIDIA), ensure OpenGL uses the NVIDIA
+    // driver to match CUDA context. Without this, GLX may default to the integrated
+    // GPU causing context creation failures.
+    setenv("__GLX_VENDOR_LIBRARY_NAME", "nvidia", 0);  // 0 = don't overwrite if set
+    setenv("__NV_PRIME_RENDER_OFFLOAD", "1", 0);
+#endif
+
     auto result = lfs::core::args::parse_args(argc, argv);
     if (!result) {
         std::println(stderr, "Error: {}", result.error());

--- a/src/core/include/core/executable_path.hpp
+++ b/src/core/include/core/executable_path.hpp
@@ -109,10 +109,23 @@ namespace lfs::core {
                 "lichtfeld.pyd",
                 "lichtfeld.abi3.pyd",
                 "lichtfeld.cp312-win_amd64.pyd",
-                "lichtfeld.cp311-win_amd64.pyd"
+                "lichtfeld.cp311-win_amd64.pyd",
+                "lichtfeld.cpython-312-x86_64-linux-gnu.so",
+                "lichtfeld.cpython-311-x86_64-linux-gnu.so"
             }) {
                 if (std::filesystem::exists(dir / name)) {
                     return true;
+                }
+            }
+            // Also check for any lichtfeld.cpython-*.so pattern (Linux)
+            if (std::filesystem::exists(dir) && std::filesystem::is_directory(dir)) {
+                std::error_code ec;
+                for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+                    if (ec) break;
+                    const auto filename = entry.path().filename().string();
+                    if (filename.starts_with("lichtfeld.cpython-") && filename.ends_with(".so")) {
+                        return true;
+                    }
                 }
             }
             return false;


### PR DESCRIPTION
I know the Python plugin system is still experimental and not yet released. Out of curiosity, I wanted to test it on Linux, and I ran into a few issues that prevented it from working out of the box. This PR adds some small fixes to improve the current behavior.

## Summary
- Fix Python module not found error on Linux by adding support for Linux-specific naming patterns (`lichtfeld.cpython-*-x86_64-linux-gnu.so`)
- Fix application startup on hybrid GPU laptops (Intel/AMD + NVIDIA) by setting NVIDIA GLX environment variables

## Changes
1. **`executable_path.hpp`**: Add Linux Python module naming patterns and fallback directory scan
2. **`main.cpp`**: Set `__GLX_VENDOR_LIBRARY_NAME=nvidia` and `__NV_PRIME_RENDER_OFFLOAD=1` on Linux before OpenGL init

## Test plan
- [x] Tested on Linux laptop with hybrid GPU (Intel + NVIDIA RTX)
- [x] Python module loads correctly
- [x] Application starts without manual environment variable export