### PR TITLE
fix: resolve tensor export linker errors on Windows

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TENSOR_SOURCES
         tensor/tensor_nn_ops.cpp
         tensor/pinned_memory_allocator.cpp
         tensor/offset_allocator.cpp
+        tensor/tensor_exports.cu
 )
 
 # Core module sources
@@ -108,14 +109,20 @@ endif()
 # Compiler options
 if(MSVC)
     target_compile_options(lfs_core PRIVATE
-        $<$<CONFIG:Debug>:/Od /Z7>
-        $<$<CONFIG:Release>:/O2 /DNDEBUG>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:/Od /Z7>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:/O2 /DNDEBUG>
+        $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-O0 -g -lineinfo --extended-lambda --expt-relaxed-constexpr -Xcompiler=/Od -Xcompiler=/Z7 -Xcompiler=/utf-8 -Xcompiler=/D_CRT_SECURE_NO_WARNINGS --diag-suppress=27>
+        $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Release>>:-O3 -use_fast_math --extended-lambda --expt-relaxed-constexpr -Xcompiler=/O2 -Xcompiler=/DNDEBUG -Xcompiler=/utf-8 -Xcompiler=/D_CRT_SECURE_NO_WARNINGS --diag-suppress=27>
     )
-    target_compile_definitions(lfs_core PRIVATE _USE_MATH_DEFINES NOMINMAX)
+    target_compile_definitions(lfs_core PRIVATE _USE_MATH_DEFINES NOMINMAX
+        $<$<COMPILE_LANGUAGE:CUDA>:FMT_UNICODE=0>
+    )
 else()
     target_compile_options(lfs_core PRIVATE
-        $<$<CONFIG:Debug>:-O0 -g -fno-omit-frame-pointer -DDEBUG>
-        $<$<CONFIG:Release>:-O3 -DNDEBUG -march=native>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer -DDEBUG>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG -march=native>
+        $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-O0 -g -lineinfo --extended-lambda --expt-relaxed-constexpr>
+        $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Release>>:-O3 -use_fast_math --extended-lambda --expt-relaxed-constexpr>
     )
 endif()
 
@@ -136,6 +143,11 @@ endif()
 set_target_properties(lfs_core PROPERTIES
     CXX_STANDARD 23
     CXX_STANDARD_REQUIRED ON
+    CUDA_STANDARD 20
+    CUDA_STANDARD_REQUIRED ON
+    CUDA_ARCHITECTURES "${LichtFeld-Studio_CUDA_ARCH}"
+    CUDA_SEPARABLE_COMPILATION OFF
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
     POSITION_INDEPENDENT_CODE ON
     EXPORT_COMPILE_COMMANDS ON
     CXX_VISIBILITY_PRESET hidden

--- a/src/core/tensor/CMakeLists.txt
+++ b/src/core/tensor/CMakeLists.txt
@@ -9,7 +9,6 @@
 
 set(LFS_TENSOR_CUDA_SOURCES
     tensor_ops.cu
-    tensor_exports.cu
     tensor_warp_reduce.cu
     tensor_matrix_ops.cu
     tensor_broadcast_ops.cu


### PR DESCRIPTION
Move tensor_exports.cu from static library (lfs_tensor_kernels) to shared library (lfs_core) to properly export template instantiations on Windows.

The issue occurred because LFS_CORE_API export markers in tensor_exports.cu were not being propagated through the static library to the DLL when linking with MSVC. This caused unresolved external symbols for launch_binary_op_generic and launch_unary_op_generic template instantiations when building the Python module and other dependent targets.

Changes:
- Remove tensor_exports.cu from LFS_TENSOR_CUDA_SOURCES in tensor/CMakeLists.txt
- Add tensor_exports.cu to TENSOR_SOURCES in core/CMakeLists.txt
- Add CUDA compilation properties to lfs_core target
- Add separate CUDA and CXX compiler options for proper compilation

This ensures template instantiations are compiled directly into the shared library where they can be properly exported and linked by dependent modules.