### PR TITLE
windows: consider CUDA 13 for cudart and curand dll copying

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,10 +434,9 @@ endif()
 
 # Copy CUDA runtime DLLs for Windows (needed for Python module loading)
 if(WIN32 AND CUDAToolkit_FOUND)
-    set(CUDA_RUNTIME_DLLS
-        "${CUDAToolkit_BIN_DIR}/cudart64_12.dll"
-        "${CUDAToolkit_BIN_DIR}/curand64_10.dll"
-    )
+    file(GLOB CUDA_DLLS_1 "${CUDAToolkit_BIN_DIR}/cudart64*.dll" "${CUDAToolkit_BIN_DIR}/curand64*.dll")
+    file(GLOB CUDA_DLLS_2 "${CUDAToolkit_BIN_DIR}/x64/cudart64*.dll" "${CUDAToolkit_BIN_DIR}/x64/curand64*.dll")
+    set(CUDA_RUNTIME_DLLS ${CUDA_DLLS_1} ${CUDA_DLLS_2})
     foreach(CUDA_DLL ${CUDA_RUNTIME_DLLS})
         if(EXISTS "${CUDA_DLL}")
             add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -227,10 +227,9 @@ if(WIN32)
     )
 
     # Copy CUDA DLLs
-    set(CUDA_DLLS_FOR_PYD
-        "${CUDAToolkit_BIN_DIR}/cudart64_12.dll"
-        "${CUDAToolkit_BIN_DIR}/curand64_10.dll"
-    )
+    file(GLOB CUDA_DLLS_1 "${CUDAToolkit_BIN_DIR}/cudart64*.dll" "${CUDAToolkit_BIN_DIR}/curand64*.dll")
+    file(GLOB CUDA_DLLS_2 "${CUDAToolkit_BIN_DIR}/x64/cudart64*.dll" "${CUDAToolkit_BIN_DIR}/x64/curand64*.dll")
+    set(CUDA_DLLS_FOR_PYD ${CUDA_DLLS_1} ${CUDA_DLLS_2})
     foreach(DLL ${CUDA_DLLS_FOR_PYD})
         if(EXISTS "${DLL}")
             add_custom_command(TARGET lfs_py POST_BUILD
@@ -288,6 +287,7 @@ dll_dirs = [
     r'${CMAKE_BINARY_DIR}/vcpkg_installed/x64-windows/bin',
     r'${CMAKE_BINARY_DIR}/external/nvImageCodec/src',
     r'${CUDAToolkit_BIN_DIR}',
+    r'${CUDAToolkit_BIN_DIR}/x64',
 ]
 
 for d in dll_dirs:


### PR DESCRIPTION
For CUDA 13, the dlls are in `${CUDAToolkit_BIN_DIR}/x64`, and also it's `cudart64_13.dll` in CUDA 13 instead of `cudart64_12.dll`. This PR makes it work for both CUDA 12 and 13