### PR TITLE
windows: fix test compilation caused by windows.h

### DIFF
--- a/tests/test_sog_html_export.cpp
+++ b/tests/test_sog_html_export.cpp
@@ -11,6 +11,9 @@
  * 3. K-means clustering (cluster1d) works correctly for SH data
  */
 
+#ifdef WIN32
+#define NOMINMAX 
+#endif
 #include <algorithm>
 #include <archive.h>
 #include <archive_entry.h>

--- a/tests/test_uv_runner_proof.cpp
+++ b/tests/test_uv_runner_proof.cpp
@@ -2,6 +2,9 @@
  *
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#ifdef WIN32
+#define NOMINMAX 
+#endif
 #include "python/package_manager.hpp"
 #include "python/uv_runner.hpp"
 #include <atomic>


### PR DESCRIPTION
Annoying `windows.h` header defining its own min and max macros, which conflicts with the standard C++ library's `std::min` and `std::max` functions, which are defined in the `<algorithm>` header. 