### PR TITLE
fix unresolved external symbols related to imgui for tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -313,6 +313,7 @@ target_link_libraries(lichtfeld_tests PRIVATE
 
     # External libraries
     GTest::gtest
+    imgui::imgui
     nanobind-static
     ${TORCH_LIBRARIES}
     ${OPENGL_LIBRARIES}


### PR DESCRIPTION
Since py_ui_modals.cpp is now included as part of the test source (is this a good idea?), which means we need imgui, Although the test target link to `lfs_visualizer`, that target links to imgui privately, meaning the symbols were not being propagated to the test target, and results in unresolved external symbols during linking.

Assuming `lfs_visualizer` links to imgui privately for a reason, so instead let the tests links to imgui explicitly.