### PR TITLE
deal with demangler differences between MSVC and GCC

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -316,13 +316,14 @@ sys.argv = ['stubgen', '-m', 'lichtfeld',
             '-r']
 runpy.run_path(r'${NB_STUBGEN}', run_name='__main__')
 
-# Normalize CRLF -> LF so git doesn't warn about line endings
-import glob, pathlib
+# Normalize CRLF -> LF and add space after comma in templates for consistency with linux
+import glob, pathlib, re
 for pyi in glob.glob(r'${CMAKE_CURRENT_BINARY_DIR}/typings/**/*.pyi', recursive=True):
     p = pathlib.Path(pyi)
-    content = p.read_bytes()
-    if b'\\r\\n' in content:
-        p.write_bytes(content.replace(b'\\r\\n', b'\\n'))
+    content = p.read_bytes().decode('utf-8').replace('\\r\\n', '\\n')
+    # Add space after comma in C++ templates (e.g., VectorT<float,3> -> VectorT<float, 3>)
+    content = re.sub(r',([a-zA-Z0-9_])', r', \\1', content)
+    p.write_bytes(content.encode('utf-8'))
 ")
 
             add_custom_command(


### PR DESCRIPTION
Apparently the demangler behaves differently between MSVC and GCC, MSVC tries to make it as compact as possible while GCC tries to make it look good. Since the stubs are committed from linux, after I compile the code on windows I am seeing diffs like
```
diff --git a/src/python/stubs/lichtfeld/mesh.pyi b/src/python/stubs/lichtfeld/mesh.pyi
index 08159c36..73a4f5cd 100644
--- a/src/python/stubs/lichtfeld/mesh.pyi
+++ b/src/python/stubs/lichtfeld/mesh.pyi
@@ -2090,7 +2090,7 @@ class TriMeshModRoundness(TriMeshModBase):

     def unset_min_roundness(self) -> None: ...

-    def roundness(self, arg0: "OpenMesh::VectorT<float, 3>", arg1: "OpenMesh::VectorT<float, 3>", arg2:
      "OpenMesh::VectorT<float, 3>", /) -> float: ...
+    def roundness(self, arg0: "OpenMesh::VectorT<float,3>", arg1: "OpenMesh::VectorT<float,3>", arg2:
      "OpenMesh::VectorT<float,3>", /) -> float: ...

class TriMeshModRoundnessHandle:
      def __init__(self) -> None: ...
 @@ -2338,7 +2338,7 @@ class PolyMeshModRoundness(PolyMeshModBase):

      def unset_min_roundness(self) -> None: ...

-    def roundness(self, arg0: "OpenMesh::VectorT<float, 3>", arg1: "OpenMesh::VectorT<float, 3>", arg2:
      "OpenMesh::VectorT<float, 3>", /) -> float: ...
+    def roundness(self, arg0: "OpenMesh::VectorT<float,3>", arg1: "OpenMesh::VectorT<float,3>", arg2:
      "OpenMesh::VectorT<float,3>", /) -> float: ...
```
This PR avoids the diff.