### PR TITLE
Fix floating panel transparency and about dialog layout

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -562,7 +562,7 @@ namespace lfs::vis::gui {
                 fallback.key_super = fio.KeySuper;
                 fallback.screen_w = static_cast<int>(mvp->Size.x);
                 fallback.screen_h = static_cast<int>(mvp->Size.y);
-                fallback.bg_draw_list = ImGui::GetBackgroundDrawList(mvp);
+                fallback.bg_draw_list = ImGui::GetForegroundDrawList(mvp);
                 fallback.fg_draw_list = ImGui::GetForegroundDrawList(mvp);
                 hp->setInput(&fallback);
             }

--- a/src/visualizer/gui/rmlui/resources/about.rml
+++ b/src/visualizer/gui/rmlui/resources/about.rml
@@ -8,7 +8,8 @@
   <span class="panel-title">{{title}}</span>
   <div class="separator"></div>
 
-  <p class="description">{{description}}</p>
+  <div class="description">{{description}}</div>
+  <div class="separator"></div>
 
   <span class="section-label">{{build_info_label}}</span>
   <div class="info-table">


### PR DESCRIPTION
- Blit floating RmlUI panels to the foreground draw list instead of the background draw list, preventing the 3D viewport from bleeding through dialog backgrounds (About, Plugin Marketplace, etc.)
- Add separator before BUILD INFORMATION section in the About dialog for clearer visual separation from the description text.