### PR TITLE
Add splat-vr-viewer and measurement-tool to curated marketplace plugins

### DIFF
--- a/src/python/lfs_plugins/marketplace.py
+++ b/src/python/lfs_plugins/marketplace.py
@@ -24,6 +24,7 @@ CURATED_PLUGIN_URLS: Tuple[str, ...] = (
     "https://github.com/jacobvanbeets/360_record",
     "https://github.com/jacobvanbeets/lichtfeld-depthmap-plugin",
     "https://github.com/jacobvanbeets/splat-vr-viewer",
+    "https://github.com/jacobvanbeets/lichtfeld-measurement-plugin",
 )
 
 


### PR DESCRIPTION
## Add splat-vr-viewer and measurement-tool to curated marketplace plugins

### Summary
Adds two community plugins to the curated marketplace plugin list in `marketplace.py`:

- **[Splat VR Viewer](https://github.com/jacobvanbeets/splat-vr-viewer)** — Exports the active Gaussian Splat to a temporary PLY and launches a VR-ready viewer window.
- **[Measurement Tool](https://github.com/jacobvanbeets/lichtfeld-measurement-plugin)** — 3D point-to-point measurement tool with viewport overlays for measuring distances on Gaussian Splats.

### Changes
- `src/python/lfs_plugins/marketplace.py`: Added two URLs to `CURATED_PLUGIN_URLS`

Both plugins are compatible with the unified v1 Panel API (`plugin_api >= 1, < 2`, `lichtfeld_version >= 0.4.2`).