### PR TITLE
windows: fix test linking

### DIFF
--- a/src/visualizer/sequencer/sequencer_controller.hpp
+++ b/src/visualizer/sequencer/sequencer_controller.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include "sequencer/keyframe.hpp"
 #include "sequencer/timeline.hpp"
 #include <algorithm>
@@ -27,7 +28,7 @@ namespace lfs::vis {
         PING_PONG
     };
 
-    class SequencerController {
+    class LFS_VIS_API SequencerController {
     public:
         [[nodiscard]] sequencer::Timeline& timeline() { return timeline_; }
         [[nodiscard]] const sequencer::Timeline& timeline() const { return timeline_; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -314,6 +314,7 @@ target_compile_definitions(lichtfeld_tests PRIVATE
 target_link_libraries(lichtfeld_tests PRIVATE
     # LFS modules
     lfs_visualizer
+    lfs_sequencer
     lfs_rendering
     lfs_training
     lfs_core


### PR DESCRIPTION
Seeing the below in the latest master
```
test_sequencer_regressions.obj : error LNK2019: unresolved external symbol "public: __cdecl
lfs::sequencer::AnimationClip::AnimationClip(class std::basic_string<char,struct std::char_traits<char>,class
std::allocator<char> >)" referenced in function ...
test_sequencer_regressions.obj : error LNK2019: unresolved external symbol "public: unsigned __int64 __cdecl
lfs::sequencer::Timeline::addKeyframe(struct lfs::sequencer::Keyframe const &)" referenced in function ...
test_sequencer_regressions.obj : error LNK2019: unresolved external symbol "public: unsigned __int64 __cdecl
lfs::vis::SequencerController::addKeyframe(struct lfs::sequencer::Keyframe const &)" referenced in function ...
C:\Users\miriam\OneDrive\Desktop\LichtFeld-Studio\build\tests\Release\lichtfeld_tests.exe : fatal error LNK1120: 23
     unresolved externals
```
This PR fixes it