### PR TITLE
Fix IGS+ CacheLoader not initialized crash at first densification step

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -294,6 +294,15 @@ namespace lfs::app {
     } // namespace
 
     int Application::run(std::unique_ptr<lfs::core::param::TrainingParameters> params) {
+        // Pre-initialize CacheLoader for the exe module.
+        // On Windows, lfs_io (static lib) is linked into both the exe and
+        // lfs_visualizer.dll, giving each its own CacheLoader singleton.
+        // The callback below executes in the exe's context, so the exe's
+        // copy must be initialized before it is invoked.
+        lfs::io::CacheLoader::getInstance(
+            params->dataset.loading_params.use_cpu_memory,
+            params->dataset.loading_params.use_fs_cache);
+
         lfs::core::set_image_loader([](const lfs::core::ImageLoadParams& p) {
             return lfs::io::CacheLoader::getInstance().load_cached_image(
                 p.path, {.resize_factor = p.resize_factor, .max_width = p.max_width, .cuda_stream = p.stream});


### PR DESCRIPTION
On Windows, lfs_io (static lib) is linked into both the exe and lfs_visualizer.dll, creating separate CacheLoader singletons per module. The trainer runs inside the DLL and initializes the DLL's copy, but Camera::load_and_get_image() routes through a callback defined in the exe (application.cpp), which calls CacheLoader::getInstance() on the exe's uninitialized copy — causing 'CacheLoader not initialized' at iter 500 (start_refine).

- Pre-initialize the exe's CacheLoader in Application::run() before the image loader callback is registered
- Move CacheLoader init before strategy setup in Trainer::initialize() so the DLL's copy is ready before any strategy code runs
- Add defensive hasInstance() guard in ImprovedGSPlus::get_all_edges()