### PR TITLE
windows: fix test linking

### DIFF
--- a/src/mcp/selection_client.hpp
+++ b/src/mcp/selection_client.hpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include "core/export.hpp"
+
 namespace lfs::mcp {
 
     struct CapabilityCallResult {
@@ -16,7 +18,7 @@ namespace lfs::mcp {
         std::string error;
     };
 
-    class SelectionClient {
+    class LFS_MCP_API SelectionClient {
     public:
         static constexpr const char* SOCKET_PATH = "/tmp/lichtfeld-selection.sock";
 

--- a/src/visualizer/ipc/selection_server.hpp
+++ b/src/visualizer/ipc/selection_server.hpp
@@ -13,6 +13,8 @@
 #include <variant>
 #include <vector>
 
+#include "core/export.hpp"
+
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -66,7 +68,7 @@ namespace lfs::vis {
 
     using InvokeCapabilityCallback = std::function<CapabilityInvokeResult(const std::string& name, const std::string& args)>;
 
-    class SelectionServer {
+    class LFS_VIS_API SelectionServer {
     public:
         static constexpr const char* SOCKET_PATH = "/tmp/lichtfeld-selection.sock";
 

--- a/src/visualizer/operator/ops/selection_ops.hpp
+++ b/src/visualizer/operator/ops/selection_ops.hpp
@@ -6,10 +6,11 @@
 
 #include "operator/operator.hpp"
 #include "selection/selection_service.hpp"
+#include "core/export.hpp"
 
 namespace lfs::vis::op {
 
-    class SelectionStrokeOperator : public Operator {
+    class LFS_VIS_API SelectionStrokeOperator : public Operator {
     public:
         static const OperatorDescriptor DESCRIPTOR;
 


### PR DESCRIPTION
Otherwise seeing
```
test_selection_operator_modal.obj : error LNK2001: unresolved external symbol "public: virtual bool __cdecl
lfs::vis::op::SelectionStrokeOperator::poll(class lfs::vis::op::OperatorContext const &)const "
test_selection_ipc_roundtrip.obj : error LNK2019: unresolved external symbol "public: __cdecl
lfs::mcp::SelectionClient::SelectionClient(class std::basic_string<char,struct std::char_traits<char>,class
std::allocator<char> > const &)"
test_selection_ipc_roundtrip.obj : error LNK2019: unresolved external symbol "public: __cdecl
lfs::vis::SelectionServer::SelectionServer(void)"
C:\...\lichtfeld_tests.exe : fatal error LNK1120: 20 unresolved externals
```