### PR TITLE
windows: fix test linking

### DIFF
--- a/src/visualizer/CMakeLists.txt
+++ b/src/visualizer/CMakeLists.txt
@@ -242,9 +242,9 @@ if(NOT WIN32)
         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 
-    target_link_libraries(lfs_visualizer PRIVATE lfs_rmlui)
+    target_link_libraries(lfs_visualizer PUBLIC lfs_rmlui)
 else()
-    target_link_libraries(lfs_visualizer PRIVATE RmlUi::RmlUi)
+    target_link_libraries(lfs_visualizer PUBLIC RmlUi::RmlUi)
 endif()
 
 # Set C++ standard

--- a/src/visualizer/gui/rmlui/rml_text_input_handler.hpp
+++ b/src/visualizer/gui/rmlui/rml_text_input_handler.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "core/export.hpp"
+
 #include <RmlUi/Core/Core.h>
 #include <RmlUi/Core/Input.h>
 #include <RmlUi/Core/TextInputContext.h>
@@ -13,7 +15,7 @@
 
 namespace lfs::vis::gui {
 
-    class RmlTextInputHandler final : public Rml::TextInputHandler {
+    class LFS_VIS_API RmlTextInputHandler final : public Rml::TextInputHandler {
     public:
         void OnActivate(Rml::TextInputContext* input_context) override;
         void OnDeactivate(Rml::TextInputContext* input_context) override;

--- a/src/visualizer/operator/ops/edit_ops.hpp
+++ b/src/visualizer/operator/ops/edit_ops.hpp
@@ -4,11 +4,12 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include "operator/operator.hpp"
 
 namespace lfs::vis::op {
 
-    class UndoOperator : public Operator {
+    class LFS_VIS_API UndoOperator : public Operator {
     public:
         static const OperatorDescriptor DESCRIPTOR;
 
@@ -17,7 +18,7 @@ namespace lfs::vis::op {
         OperatorResult invoke(OperatorContext& ctx, OperatorProperties& props) override;
     };
 
-    class RedoOperator : public Operator {
+    class LFS_VIS_API RedoOperator : public Operator {
     public:
         static const OperatorDescriptor DESCRIPTOR;
 
@@ -26,7 +27,7 @@ namespace lfs::vis::op {
         OperatorResult invoke(OperatorContext& ctx, OperatorProperties& props) override;
     };
 
-    class DeleteOperator : public Operator {
+    class LFS_VIS_API DeleteOperator : public Operator {
     public:
         static const OperatorDescriptor DESCRIPTOR;
 
@@ -35,7 +36,7 @@ namespace lfs::vis::op {
         OperatorResult invoke(OperatorContext& ctx, OperatorProperties& props) override;
     };
 
-    void registerEditOperators();
-    void unregisterEditOperators();
+    LFS_VIS_API void registerEditOperators();
+    LFS_VIS_API void unregisterEditOperators();
 
 } // namespace lfs::vis::op

--- a/src/visualizer/operator/ops/transform_ops.hpp
+++ b/src/visualizer/operator/ops/transform_ops.hpp
@@ -4,11 +4,12 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include "operator/operator.hpp"
 
 namespace lfs::vis::op {
 
-    class TransformSetOperator : public Operator {
+    class LFS_VIS_API TransformSetOperator : public Operator {
     public:
         static const OperatorDescriptor DESCRIPTOR;
 
@@ -17,7 +18,7 @@ namespace lfs::vis::op {
         OperatorResult invoke(OperatorContext& ctx, OperatorProperties& props) override;
     };
 
-    class TransformTranslateOperator : public Operator {
+    class LFS_VIS_API TransformTranslateOperator : public Operator {
     public:
         static const OperatorDescriptor DESCRIPTOR;
 
@@ -26,7 +27,7 @@ namespace lfs::vis::op {
         OperatorResult invoke(OperatorContext& ctx, OperatorProperties& props) override;
     };
 
-    class TransformRotateOperator : public Operator {
+    class LFS_VIS_API TransformRotateOperator : public Operator {
     public:
         static const OperatorDescriptor DESCRIPTOR;
 
@@ -35,7 +36,7 @@ namespace lfs::vis::op {
         OperatorResult invoke(OperatorContext& ctx, OperatorProperties& props) override;
     };
 
-    class TransformScaleOperator : public Operator {
+    class LFS_VIS_API TransformScaleOperator : public Operator {
     public:
         static const OperatorDescriptor DESCRIPTOR;
 
@@ -44,7 +45,7 @@ namespace lfs::vis::op {
         OperatorResult invoke(OperatorContext& ctx, OperatorProperties& props) override;
     };
 
-    class TransformApplyBatchOperator : public Operator {
+    class LFS_VIS_API TransformApplyBatchOperator : public Operator {
     public:
         static const OperatorDescriptor DESCRIPTOR;
 
@@ -53,7 +54,7 @@ namespace lfs::vis::op {
         OperatorResult invoke(OperatorContext& ctx, OperatorProperties& props) override;
     };
 
-    void registerTransformOperators();
-    void unregisterTransformOperators();
+    LFS_VIS_API void registerTransformOperators();
+    LFS_VIS_API void unregisterTransformOperators();
 
 } // namespace lfs::vis::op


### PR DESCRIPTION
To fix errors like
```
      test_operator_registry_props.obj : error LNK2019: unresolved external symbol "void __cdecl
      lfs::vis::op::registerEditOperators(void)" (?registerEditOperators@op@vis@lfs@@YAXXZ) referenced in function
      "protected: virtual void __cdecl OperatorRegistryPropsTest::SetUp(void)"
      (?SetUp@OperatorRegistryPropsTest@@MEAAXXZ)
    2 test_operator_registry_props.obj : error LNK2019: unresolved external symbol "void __cdecl
      lfs::vis::op::unregisterEditOperators(void)" (?unregisterEditOperators@op@vis@lfs@@YAXXZ) referenced in function
      "protected: virtual void __cdecl OperatorRegistryPropsTest::TearDown(void)"
      (?TearDown@OperatorRegistryPropsTest@@MEAAXXZ)
    3 test_operator_registry_props.obj : error LNK2019: unresolved external symbol "void __cdecl
      lfs::vis::op::registerTransformOperators(void)" (?registerTransformOperators@op@vis@lfs@@YAXXZ) referenced in
      function "protected: virtual void __cdecl OperatorRegistryPropsTest::SetUp(void)"
      (?SetUp@OperatorRegistryPropsTest@@MEAAXXZ)
    4 test_operator_registry_props.obj : error LNK2019: unresolved external symbol "void __cdecl
      lfs::vis::op::unregisterTransformOperators(void)" (?unregisterTransformOperators@op@vis@lfs@@YAXXZ) referenced in
      function "protected: virtual void __cdecl OperatorRegistryPropsTest::TearDown(void)"
      (?TearDown@OperatorRegistryPropsTest@@MEAAXXZ)
    5
    6 test_rml_text_input_handler.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: virtual
      __cdecl Rml::TextInputContext::~TextInputContext(void)" (__imp_??1TextInputContext@Rml@@UEAA@XZ) referenced in
      function "public: virtual __cdecl `anonymous namespace'::StubTextInputContext::~StubTextInputContext(void)"
      (??1StubTextInputContext@?A0xe813295a@@UEAA@XZ)
    7 test_rml_text_input_handler.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: __cdecl
      Rml::TextInputContext::TextInputContext(void)" (__imp_??0TextInputContext@Rml@@QEAA@XZ) referenced in function
      "public: __cdecl `anonymous namespace'::StubTextInputContext::StubTextInputContext(void)"
      (??0StubTextInputContext@?A0xe813295a@@QEAA@XZ)
    8 test_rml_text_input_handler.obj : error LNK2019: unresolved external symbol "public: virtual void __cdecl
      lfs::vis::gui::RmlTextInputHandler::OnActivate(class Rml::TextInputContext *)"
      (?OnActivate@RmlTextInputHandler@gui@vis@lfs@@UEAAXPEAVTextInputContext@Rml@@@Z) referenced in function "private:
      virtual void __cdecl RmlTextInputHandlerTest_CtrlASelectsWholeInput_Test::TestBody(void)"
      (?TestBody@RmlTextInputHandlerTest_CtrlASelectsWholeInput_Test@@EEAAXXZ)
```