### PR TITLE
Add snap option to gizmos (Ctrl/Cmd+drag)

### DIFF
--- a/src/visualizer/gui/gizmo_manager.cpp
+++ b/src/visualizer/gui/gizmo_manager.cpp
@@ -38,6 +38,9 @@ namespace lfs::vis::gui {
 
     constexpr float GIZMO_AXIS_LIMIT = 0.0001f;
     constexpr float MIN_GIZMO_SCALE = 0.001f;
+    constexpr float ROTATION_SNAP_DEGREES = 5.0f;
+    constexpr float TRANSLATE_SNAP_UNITS = 0.1f;
+    constexpr float SCALE_SNAP_RATIO = 0.1f;
 
     namespace {
         inline glm::mat3 extractRotation(const glm::mat4& m) {
@@ -48,6 +51,18 @@ namespace lfs::vis::gui {
         inline glm::vec3 extractScale(const glm::mat4& m) {
             return glm::vec3(glm::length(glm::vec3(m[0])), glm::length(glm::vec3(m[1])),
                              glm::length(glm::vec3(m[2])));
+        }
+
+        inline const float* computeSnapPtr(float* buf, ImGuizmo::OPERATION op) {
+            if (!ImGui::GetIO().KeyCtrl)
+                return nullptr;
+            if (op == ImGuizmo::ROTATE)
+                buf[0] = ROTATION_SNAP_DEGREES;
+            else if (op & ImGuizmo::TRANSLATE)
+                buf[0] = buf[1] = buf[2] = TRANSLATE_SNAP_UNITS;
+            else if (op & ImGuizmo::SCALE)
+                buf[0] = SCALE_SNAP_RATIO;
+            return buf;
         }
     } // namespace
 
@@ -485,10 +500,12 @@ namespace lfs::vis::gui {
         const ImGuizmo::MODE gizmo_mode = (actually_using_bounds || !use_world_space) ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
 
         glm::mat4 delta_matrix;
+        float snap_buf[3] = {};
+        const float* snap_ptr = computeSnapPtr(snap_buf, effective_op);
         const bool gizmo_changed = ImGuizmo::Manipulate(
             glm::value_ptr(view), glm::value_ptr(projection),
             effective_op, gizmo_mode,
-            glm::value_ptr(gizmo_matrix), glm::value_ptr(delta_matrix), nullptr, bounds_ptr);
+            glm::value_ptr(gizmo_matrix), glm::value_ptr(delta_matrix), snap_ptr, bounds_ptr);
 
         if (node_gizmo_operation_ == ImGuizmo::ROTATE) {
             const glm::vec3 pivot_pos = glm::vec3(gizmo_matrix[3]);
@@ -887,10 +904,12 @@ namespace lfs::vis::gui {
         glm::mat4 delta_matrix;
         const ImGuizmo::MODE gizmo_mode = gizmo_local_aligned ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
 
+        float snap_buf[3] = {};
+        const float* snap_ptr = computeSnapPtr(snap_buf, effective_op);
         const bool gizmo_changed = ImGuizmo::Manipulate(
             glm::value_ptr(view), glm::value_ptr(projection),
             effective_op, gizmo_mode, glm::value_ptr(gizmo_matrix),
-            glm::value_ptr(delta_matrix), nullptr, bounds_ptr);
+            glm::value_ptr(delta_matrix), snap_ptr, bounds_ptr);
 
         const bool is_using = ImGuizmo::IsUsing();
 
@@ -1065,10 +1084,12 @@ namespace lfs::vis::gui {
         glm::mat4 delta_matrix;
         const ImGuizmo::MODE gizmo_mode = gizmo_local_aligned ? ImGuizmo::LOCAL : ImGuizmo::WORLD;
 
+        float snap_buf[3] = {};
+        const float* snap_ptr = computeSnapPtr(snap_buf, effective_op);
         const bool gizmo_changed = ImGuizmo::Manipulate(
             glm::value_ptr(view), glm::value_ptr(projection),
             effective_op, gizmo_mode, glm::value_ptr(gizmo_matrix),
-            glm::value_ptr(delta_matrix), nullptr, bounds_ptr);
+            glm::value_ptr(delta_matrix), snap_ptr, bounds_ptr);
 
         const bool is_using = ImGuizmo::IsUsing();
 


### PR DESCRIPTION
 Summary

  - Add grid snapping to gizmo operations when holding Ctrl  during drag
  - Rotation snaps to 5° increments, translation to 0.1 units, scale to 0.1 ratio
  - Without Ctrl, gizmo behavior is unchanged

  Details

  Introduces a computeSnapPtr() helper that returns snap values based on the active gizmo operation
  when Ctrl is held, or nullptr otherwise. Applied to all three ImGuizmo::Manipulate call sites in
  GizmoManager (node gizmo, standard gizmo, and the third gizmo path).

Closes #746