### PR TITLE
 Add snap option to gizmos (Ctrl+drag)

### DIFF
--- a/src/visualizer/gui/gizmo_manager.cpp
+++ b/src/visualizer/gui/gizmo_manager.cpp
@@ -56,12 +56,12 @@ namespace lfs::vis::gui {
         inline const float* computeSnapPtr(float* buf, ImGuizmo::OPERATION op) {
             if (!ImGui::GetIO().KeyCtrl)
                 return nullptr;
-            if (op == ImGuizmo::ROTATE)
+            if (op & ImGuizmo::ROTATE)
                 buf[0] = ROTATION_SNAP_DEGREES;
             else if (op & ImGuizmo::TRANSLATE)
                 buf[0] = buf[1] = buf[2] = TRANSLATE_SNAP_UNITS;
             else if (op & ImGuizmo::SCALE)
-                buf[0] = SCALE_SNAP_RATIO;
+                buf[0] = buf[1] = buf[2] = SCALE_SNAP_RATIO;
             return buf;
         }
     } // namespace


### PR DESCRIPTION
 Summary

  - Add grid snapping to gizmo operations when holding Ctrl during drag
  - Rotation snaps to 5° increments, translation to 0.1 units, scale to 0.1 ratio
  - Without Ctrl, gizmo behavior is unchanged

  Details

  Introduces a computeSnapPtr() helper that returns snap values based on the active gizmo operation
  when Ctrl is held, or nullptr otherwise. Applied to all three ImGuizmo::Manipulate call sites in
  GizmoManager (node gizmo, standard gizmo, and the third gizmo path).

#746