### PR TITLE
windows: fix test linking

### DIFF
--- a/src/visualizer/operation/undo_entry.hpp
+++ b/src/visualizer/operation/undo_entry.hpp
@@ -203,7 +203,7 @@ namespace lfs::vis::op {
 
     LFS_VIS_API bool pushSceneSnapshotIfChanged(std::unique_ptr<SceneSnapshot> snapshot);
 
-    class TensorUndoEntry : public UndoEntry {
+    class LFS_VIS_API TensorUndoEntry : public UndoEntry {
     public:
         using TensorAccessor = std::function<lfs::core::Tensor*()>;
 
@@ -241,7 +241,7 @@ namespace lfs::vis::op {
         bool captured_after_ = false;
     };
 
-    class CropBoxUndoEntry : public UndoEntry {
+    class LFS_VIS_API CropBoxUndoEntry : public UndoEntry {
     public:
         CropBoxUndoEntry(SceneManager& scene,
                          RenderingManager* rendering_manager,
@@ -275,7 +275,7 @@ namespace lfs::vis::op {
         bool use_after_ = false;
     };
 
-    class EllipsoidUndoEntry : public UndoEntry {
+    class LFS_VIS_API EllipsoidUndoEntry : public UndoEntry {
     public:
         EllipsoidUndoEntry(SceneManager& scene,
                            RenderingManager* rendering_manager,
@@ -309,7 +309,7 @@ namespace lfs::vis::op {
         bool use_after_ = false;
     };
 
-    class PropertyChangeUndoEntry : public UndoEntry {
+    class LFS_VIS_API PropertyChangeUndoEntry : public UndoEntry {
     public:
         PropertyChangeUndoEntry(std::string property_path,
                                 std::any before,


### PR DESCRIPTION
Fix
```
    test_undo_history.obj : error LNK2019: unresolved external symbol "public: __cdecl
     lfs::vis::op::TensorUndoEntry::TensorUndoEntry(...)"
    test_undo_history.obj : error LNK2019: unresolved external symbol "public: void __cdecl
     lfs::vis::op::TensorUndoEntry::captureAfter(void)"
    test_undo_history.obj : error LNK2019: unresolved external symbol "public: __cdecl
     lfs::vis::op::CropBoxUndoEntry::CropBoxUndoEntry(...)"
    test_undo_history.obj : error LNK2019: unresolved external symbol "public: __cdecl
     lfs::vis::op::EllipsoidUndoEntry::EllipsoidUndoEntry(...)"
    test_undo_history.obj : error LNK2019: unresolved external symbol "public: __cdecl
     lfs::vis::op::PropertyChangeUndoEntry::PropertyChangeUndoEntry(...)"
   
    C:\...\lichtfeld_tests.exe : fatal error LNK1120: 12 unresolved externals
```