### PR TITLE
windows: fix test linking

### DIFF
--- a/src/visualizer/input/sdl_key_mapping.hpp
+++ b/src/visualizer/input/sdl_key_mapping.hpp
@@ -4,15 +4,16 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include <SDL3/SDL_keycode.h>
 #include <SDL3/SDL_mouse.h>
 #include <SDL3/SDL_scancode.h>
 
 namespace lfs::vis::input {
 
-    int sdlScancodeToAppKey(SDL_Scancode scancode);
-    int sdlModsToAppMods(SDL_Keymod sdl_mods);
-    int sdlMouseButtonToApp(uint8_t sdl_button);
-    SDL_Scancode appKeyToSdlScancode(int app_key);
+    LFS_VIS_API int sdlScancodeToAppKey(SDL_Scancode scancode);
+    LFS_VIS_API int sdlModsToAppMods(SDL_Keymod sdl_mods);
+    LFS_VIS_API int sdlMouseButtonToApp(uint8_t sdl_button);
+    LFS_VIS_API SDL_Scancode appKeyToSdlScancode(int app_key);
 
 } // namespace lfs::vis::input


### PR DESCRIPTION
To fix
```
     test_sdl_rml_key_mapping.obj : error LNK2019: unresolved external symbol "int __cdecl
     lfs::vis::input::sdlScancodeToAppKey(enum SDL_Scancode)" (?sdlScancodeToAppKey@input@vis@lfs@@YAHW4SDL_Scancode@@@Z)
     referenced in function ...
     test_sdl_rml_key_mapping.obj : error LNK2019: unresolved external symbol "enum SDL_Scancode __cdecl
     lfs::vis::input::appKeyToSdlScancode(int)" (?appKeyToSdlScancode@input@vis@lfs@@YA?AW4SDL_Scancode@@H@Z) referenced in
     function ...
```