### PR TITLE
Add SplatReady plugin to marketplace curated list

### DIFF
--- a/src/python/lfs_plugins/marketplace.py
+++ b/src/python/lfs_plugins/marketplace.py
@@ -43,6 +43,7 @@ CURATED_PLUGIN_URLS: Tuple[str, ...] = (
     "https://github.com/jacobvanbeets/lichtfeld-depthmap-plugin",
     "https://github.com/jacobvanbeets/splat-vr-viewer",
     "https://github.com/jacobvanbeets/lichtfeld-measurement-plugin",
+    "https://github.com/jacobvanbeets/SplatReady",
 )
 
 


### PR DESCRIPTION
SplatReady converts video to COLMAP datasets ready for Gaussian splat training. Supports COLMAP, Agisoft Metashape, and RealityScan.

For those that use Potensic drones can now include the SRT file in the same folder as the video. 
Extracted images will have geotag information embedded for instant XYZ and scale information in your splat.