### PR TITLE
windows: fix tests linking

### DIFF
--- a/src/visualizer/input/input_controller.hpp
+++ b/src/visualizer/input/input_controller.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "core/events.hpp"
+#include "core/export.hpp"
 #include "core/services.hpp"
 #include "input/input_bindings.hpp"
 #include "input/input_types.hpp"
@@ -31,7 +32,7 @@ namespace lfs::vis {
     } // namespace tools
     class ToolContext;
 
-    class InputController {
+    class LFS_VIS_API InputController {
     public:
         InputController(SDL_Window* window, Viewport& viewport);
         ~InputController();

--- a/src/visualizer/rendering/passes/point_cloud_pass.hpp
+++ b/src/visualizer/rendering/passes/point_cloud_pass.hpp
@@ -5,13 +5,14 @@
 #pragma once
 
 #include "../render_pass.hpp"
+#include "core/export.hpp"
 #include "core/point_cloud.hpp"
 #include <glm/glm.hpp>
 #include <memory>
 
 namespace lfs::vis {
 
-    class PointCloudPass final : public RenderPass {
+    class LFS_VIS_API PointCloudPass final : public RenderPass {
     public:
         PointCloudPass() = default;
 

--- a/src/visualizer/rendering/passes/splat_raster_pass.hpp
+++ b/src/visualizer/rendering/passes/splat_raster_pass.hpp
@@ -5,11 +5,12 @@
 #pragma once
 
 #include "../render_pass.hpp"
+#include "core/export.hpp"
 #include <glm/glm.hpp>
 
 namespace lfs::vis {
 
-    class SplatRasterPass final : public RenderPass {
+    class LFS_VIS_API SplatRasterPass final : public RenderPass {
     public:
         SplatRasterPass() = default;
 

--- a/src/visualizer/rendering/split_view_service.hpp
+++ b/src/visualizer/rendering/split_view_service.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "rendering_types.hpp"
+#include "core/export.hpp"
 #include <mutex>
 #include <optional>
 
@@ -13,7 +14,7 @@ namespace lfs::vis {
     class SceneManager;
     struct FrameResources;
 
-    class SplitViewService {
+    class LFS_VIS_API SplitViewService {
     public:
         struct GTToggleResult {
             bool enabled = false;

--- a/src/visualizer/rendering/viewport_artifact_service.hpp
+++ b/src/visualizer/rendering/viewport_artifact_service.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "render_pass.hpp"
+#include "core/export.hpp"
 #include <memory>
 #include <optional>
 
@@ -14,7 +15,7 @@ namespace lfs::rendering {
 
 namespace lfs::vis {
 
-    class ViewportArtifactService {
+    class LFS_VIS_API ViewportArtifactService {
     public:
         ViewportArtifactService() = default;
         ~ViewportArtifactService();

--- a/src/visualizer/rendering/viewport_frame_lifecycle_service.hpp
+++ b/src/visualizer/rendering/viewport_frame_lifecycle_service.hpp
@@ -6,6 +6,7 @@
 
 #include "dirty_flags.hpp"
 #include "rendering_types.hpp"
+#include "core/export.hpp"
 #include <atomic>
 #include <chrono>
 #include <utility>
@@ -14,7 +15,7 @@ namespace lfs::vis {
 
     class ViewportArtifactService;
 
-    class ViewportFrameLifecycleService {
+    class LFS_VIS_API ViewportFrameLifecycleService {
     public:
         struct ResizeResult {
             DirtyMask dirty = 0;


### PR DESCRIPTION
Fixes
```
  test_rendering_refactor_services.obj : error LNK2019: unresolved external symbol "public: virtual bool __cdecl
  lfs::vis::PointCloudPass::shouldExecute(unsigned int,struct lfs::vis::FrameContext const &)const " (?shouldExec
  ute@PointCloudPass@vis@lfs@@UEBA_NIAEBUFrameContext@23@@Z) referenced in function ...
  
  test_rendering_refactor_services.obj : error LNK2001: unresolved external symbol "public: virtual void __cdecl
  lfs::vis::SplatRasterPass::execute(class lfs::rendering::RenderingEngine &,struct lfs::vis::FrameContext const
  &,struct lfs::vis::FrameResources &)" (?execute@SplatRasterPass@vis@lfs@@UEAAXAEAVRenderingEngine@rendering@3@A
  EBUFrameContext@23@AEAUFrameResources@23@@Z) ...
   
  test_rendering_refactor_services.obj : error LNK2019: unresolved external symbol "public: struct lfs::vis::Spli
  tViewService::GTToggleResult __cdecl lfs::vis::SplitViewService::toggleGTComparison(struct lfs::vis::RenderSett
  ings &)" ...
  
  test_input_controller_focus.obj : error LNK2019: unresolved external symbol "struct ImGuiContext * __cdecl ImGu
  i::CreateContext(struct ImFontAtlas *)" (?CreateContext@ImGui@@YAPEAUImGuiContext@@PEAUImFontAtlas@@@Z) ...
```