### PR TITLE
windows: fix tests linking

### DIFF
--- a/src/visualizer/rendering/viewport_request_builder.hpp
+++ b/src/visualizer/rendering/viewport_request_builder.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include "render_pass.hpp"
 
 namespace lfs::vis {
@@ -11,25 +12,25 @@ namespace lfs::vis {
     // Centralized request builders for the public renderer boundary.
     // Visualizer-side code should prefer building FrameView/GpuFrame contracts first
     // and only translate to renderer request types here.
-    [[nodiscard]] lfs::rendering::ViewportRenderRequest buildViewportRenderRequest(
+    [[nodiscard]] LFS_VIS_API lfs::rendering::ViewportRenderRequest buildViewportRenderRequest(
         const FrameContext& ctx, glm::ivec2 render_size,
         const Viewport* source_viewport = nullptr,
         std::optional<SplitViewPanelId> render_panel = std::nullopt);
 
-    [[nodiscard]] lfs::rendering::HoveredGaussianQueryRequest buildHoveredGaussianQueryRequest(
+    [[nodiscard]] LFS_VIS_API lfs::rendering::HoveredGaussianQueryRequest buildHoveredGaussianQueryRequest(
         const FrameContext& ctx, glm::ivec2 render_size,
         const Viewport* source_viewport = nullptr);
 
-    [[nodiscard]] lfs::rendering::SplitViewGaussianPanelRenderState buildSplitViewGaussianPanelRenderState(
+    [[nodiscard]] LFS_VIS_API lfs::rendering::SplitViewGaussianPanelRenderState buildSplitViewGaussianPanelRenderState(
         const FrameContext& ctx, glm::ivec2 render_size,
         const Viewport* source_viewport = nullptr,
         std::optional<SplitViewPanelId> render_panel = std::nullopt);
 
-    [[nodiscard]] lfs::rendering::SplitViewPointCloudPanelRenderState buildSplitViewPointCloudPanelRenderState(
+    [[nodiscard]] LFS_VIS_API lfs::rendering::SplitViewPointCloudPanelRenderState buildSplitViewPointCloudPanelRenderState(
         const FrameContext& ctx, glm::ivec2 render_size,
         const Viewport* source_viewport = nullptr);
 
-    [[nodiscard]] lfs::rendering::PointCloudRenderRequest buildPointCloudRenderRequest(
+    [[nodiscard]] LFS_VIS_API lfs::rendering::PointCloudRenderRequest buildPointCloudRenderRequest(
         const FrameContext& ctx, glm::ivec2 render_size, const std::vector<glm::mat4>& model_transforms);
 
 } // namespace lfs::vis


### PR DESCRIPTION
Fixes
```
     test_rendering_refactor_services.obj : error LNK2019: unresolved external symbol "struct
     lfs::rendering::ViewportRenderRequest __cdecl lfs::vis::buildViewportRenderRequest(struct lfs::vis::FrameContext
     const &,struct glm::vec<2,int,0>,class Viewport const *,class std::optional<enum lfs::vis::SplitViewPanelId>)"
     (?buildViewportRenderRequest@vis@lfs@@YA?AUViewportRenderRequest@rendering@2@AEBUFrameContext@12@U?$vec@$01H$0A@@gl
     m@@PEBVViewport@@V?$optional@W4SplitViewPanelId@vis@lfs@@@std@@@Z) referenced in function "private: virtual void
     __cdecl lfs::vis::ViewportRequestBuilderTest_CursorPreviewTargetsOnlyItsSplitPanel_Test::TestBody(void)"
     (?TestBody@ViewportRequestBuilderTest_CursorPreviewTargetsOnlyItsSplitPanel_Test@vis@lfs@@EEAAXXZ)
```