### PR TITLE
Fixed the build‑failure issue on environments that do not support AVX2

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -147,7 +147,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     # The splat simplifier is sensitive to tiny FP contraction differences.
     set_source_files_properties(
         ${CMAKE_CURRENT_SOURCE_DIR}/splat_simplify.cpp
-        PROPERTIES COMPILE_OPTIONS "-ffp-contract=off;-fno-tree-vectorize;-fno-unsafe-math-optimizations;-frounding-math;-ffloat-store;-fexcess-precision=standard;-mno-fma;-mno-avx2")
+        PROPERTIES COMPILE_OPTIONS "-ffp-contract=off;-fno-tree-vectorize;-fno-unsafe-math-optimizations;-frounding-math;-ffloat-store;-fexcess-precision=standard$<$<BOOL:${COMPILER_SUPPORTS_AVX2}>:;-mno-fma;-mno-avx2>")
 endif()
 
 # Visibility: hide by default, export only LFS_CORE_API symbols


### PR DESCRIPTION
Because the `COMPILE_OPTIONS` added to `splat_simplify.cpp` included `-mno-fma` and `-mno-avx2`, the following error occurred during compilation on systems that do not support AVX2:

```
g++-14: error: unrecognized command-line option ‘-mno-fma’
g++-14: error: unrecognized command-line option ‘-mno-avx2’
```

This PR resolves the problem described above.
