### PR TITLE
use public interface for test_visualizer_post_work

### DIFF
--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -4,7 +4,6 @@
 #include <SDL3/SDL.h>
 
 #include "visualizer/include/visualizer/visualizer.hpp"
-#include "visualizer_impl.hpp"
 
 #include <gtest/gtest.h>
 
@@ -17,10 +16,10 @@ TEST(VisualizerPostWorkTest, QueuedWorkWakesEventLoop) {
 
     bool ran = false;
     {
-        lfs::vis::VisualizerImpl viewer(options);
+        auto viewer = lfs::vis::Visualizer::create(options);
 
         EXPECT_FALSE(SDL_HasEvents(SDL_EVENT_USER, SDL_EVENT_USER));
-        EXPECT_TRUE(viewer.postWork({
+        EXPECT_TRUE(viewer->postWork({
             .run = [&ran]() { ran = true; },
             .cancel = nullptr,
         }));


### PR DESCRIPTION
Fixes
```
test_visualizer_post_work.obj : error LNK2019: unresolved external symbol "public: __cdecl lfs::vis::VisualizerImpl::Vi
sualizerImpl(struct lfs::vis::ViewerOptions const &)" (??0VisualizerImpl@vis@lfs@@QEAA@AEBUViewerOptions@12@@Z) referen
ced in function "private: virtual void __cdecl VisualizerPostWorkTest_QueuedWorkWakesEventLoop_Test::TestBody(void)" (?
TestBody@VisualizerPostWorkTest_QueuedWorkWakesEventLoop_Test@@EEAAXXZ)
test_visualizer_post_work.obj : error LNK2019: unresolved external symbol "public: virtual __cdecl lfs::vis::Visualizer
Impl::~VisualizerImpl(void)" (??1VisualizerImpl@vis@lfs@@UEAA@XZ) referenced in function "private: virtual void __cdecl
 VisualizerPostWorkTest_QueuedWorkWakesEventLoop_Test::TestBody(void)" (?TestBody@VisualizerPostWorkTest_QueuedWorkWake
sEventLoop_Test@@EEAAXXZ)
test_visualizer_post_work.obj : error LNK2019: unresolved external symbol "public: virtual bool __cdecl lfs::vis::Visua
lizerImpl::postWork(struct lfs::vis::Visualizer::WorkItem)" (?postWork@VisualizerImpl@vis@lfs@@UEAA_NUWorkItem@Visualiz
er@23@@Z) referenced in function "private: virtual void __cdecl VisualizerPostWorkTest_QueuedWorkWakesEventLoop_Test::T
estBody(void)" (?TestBody@VisualizerPostWorkTest_QueuedWorkWakesEventLoop_Test@@EEAAXXZ)
```