### PR TITLE
windows: fix test linking

### DIFF
--- a/src/visualizer/rendering/split_view_composition.hpp
+++ b/src/visualizer/rendering/split_view_composition.hpp
@@ -25,7 +25,7 @@ namespace lfs::vis {
         [[nodiscard]] SplitViewInfo toInfo() const;
     };
 
-    [[nodiscard]] std::optional<SplitViewCompositionPlan> buildSplitViewCompositionPlan(
+    [[nodiscard]] LFS_VIS_API std::optional<SplitViewCompositionPlan> buildSplitViewCompositionPlan(
         const FrameContext& ctx,
         const FrameResources& res);
 


### PR DESCRIPTION
fixes 
```
test_rendering_refactor_services.obj : error LNK2019: unresolved external symbol "class std::optional<struct
     lfs::vis::SplitViewCompositionPlan> __cdecl lfs::vis::buildSplitViewCompositionPlan(struct lfs::vis::FrameContext
     const &,struct lfs::vis::FrameResources const &)"
     (?buildSplitViewCompositionPlan@vis@lfs@@YA?AV?$optional@USplitViewCompositionPlan@vis@lfs@@@std@@AEBUFrameContext@
     12@AEBUFrameResources@12@@Z) referenced in function "private: virtual void __cdecl
     lfs::vis::SceneManagerRenderStateTest_PlyComparisonBuildsFullFrameWipeFromCombinedSceneMasks_Test::TestBody(void)"
     (?TestBody@SceneManagerRenderStateTest_PlyComparisonBuildsFullFrameWipeFromCombinedSceneMasks_Test@vis@lfs@@EEAAXXZ
     )
```