### PR TITLE
RFC: CMake/VCPKG: Require SDL3 to have either X11 or Wayland backends

### DIFF
--- a/.github/overlays/imgui/portfile.cmake
+++ b/.github/overlays/imgui/portfile.cmake
@@ -1,0 +1,1 @@
+include("${VCPKG_ROOT_DIR}/ports/imgui/portfile.cmake")

--- a/.github/overlays/imgui/vcpkg.json
+++ b/.github/overlays/imgui/vcpkg.json
@@ -1,0 +1,164 @@
+{
+  "name": "imgui",
+  "version": "1.92.6",
+  "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
+  "homepage": "https://github.com/ocornut/imgui",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "allegro5-binding": {
+      "description": "Make available Allegro5 binding",
+      "dependencies": [
+        "allegro5"
+      ]
+    },
+    "android-binding": {
+      "description": "Make available Android native app support",
+      "supports": "android"
+    },
+    "docking-experimental": {
+      "description": "Build with docking support"
+    },
+    "dx10-binding": {
+      "description": "Make available DirectX10 binding",
+      "supports": "windows & !uwp"
+    },
+    "dx11-binding": {
+      "description": "Make available DirectX11 binding",
+      "supports": "windows & !uwp"
+    },
+    "dx12-binding": {
+      "description": "Make available DirectX12 binding",
+      "supports": "!x86 & windows & !uwp"
+    },
+    "dx9-binding": {
+      "description": "Make available DirectX9 binding",
+      "supports": "windows & !uwp"
+    },
+    "freetype": {
+      "description": "Build font atlases using FreeType instead of stb_truetype",
+      "dependencies": [
+        "freetype"
+      ]
+    },
+    "freetype-svg": {
+      "description": "Add support to render OpenType SVG fonts",
+      "dependencies": [
+        {
+          "name": "imgui",
+          "features": [
+            "freetype"
+          ]
+        },
+        {
+          "name": "plutosvg",
+          "features": [
+            "freetype"
+          ]
+        }
+      ]
+    },
+    "glfw-binding": {
+      "description": "Make available GLFW binding",
+      "dependencies": [
+        {
+          "name": "glfw3",
+          "platform": "!emscripten"
+        }
+      ]
+    },
+    "glut-binding": {
+      "description": "Make available Glut binding",
+      "dependencies": [
+        "freeglut"
+      ]
+    },
+    "libigl-imgui": {
+      "description": "Install the libigl-imgui headers"
+    },
+    "metal-binding": {
+      "description": "Make available Metal binding",
+      "supports": "osx"
+    },
+    "opengl2-binding": {
+      "description": "Make available OpenGL (legacy) binding",
+      "supports": "!(uwp | android)"
+    },
+    "opengl3-binding": {
+      "description": "Make available OpenGL3/ES/ES2 (modern) binding"
+    },
+    "osx-binding": {
+      "description": "Make available OSX binding",
+      "supports": "osx"
+    },
+    "sdl3-binding": {
+      "description": "Make available SDL3 binding",
+      "dependencies": [
+        {
+          "name": "sdl3",
+          "default-features": false
+        }
+      ]
+    },
+    "sdl3-renderer-binding": {
+      "description": "Make available SDL3 Renderer binding",
+      "dependencies": [
+        {
+          "name": "sdl3",
+          "default-features": false
+        }
+      ]
+    },
+    "sdlgpu3-binding": {
+      "description": "Make available SDLGPU3 binding",
+      "dependencies": [
+        {
+          "name": "imgui",
+          "features": [
+            "sdl3-binding"
+          ]
+        },
+        {
+          "name": "sdl3",
+          "default-features": false
+        }
+      ]
+    },
+    "test-engine": {
+      "description": "Build test engine",
+      "supports": "!uwp",
+      "license": null,
+      "dependencies": [
+        "stb"
+      ]
+    },
+    "vulkan-binding": {
+      "description": "Make available Vulkan binding",
+      "dependencies": [
+        "vulkan"
+      ]
+    },
+    "wchar32": {
+      "description": "Use WCHAR32 instead of WCHAR16"
+    },
+    "webgpu-binding": {
+      "description": "Make available WebGPU binding",
+      "dependencies": [
+        "dawn"
+      ]
+    },
+    "win32-binding": {
+      "description": "Make available Win32 binding",
+      "supports": "windows & !uwp"
+    }
+  }
+}

--- a/.github/overlays/sdl3/fix-freebsd.patch
+++ b/.github/overlays/sdl3/fix-freebsd.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9e19336..ff6424b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4038,7 +4038,7 @@ else()
+ endif()
+ set(SDL_INSTALL_CMAKEDIR_ROOT "${SDL_INSTALL_CMAKEDIR_ROOT_DEFAULT}" CACHE STRING "Root folder where to install SDL3Config.cmake related files (SDL3 subfolder for MSVC projects)")
+ 
+-if(FREEBSD)
++if(0)
+   # FreeBSD uses ${PREFIX}/libdata/pkgconfig
+   set(SDL_PKGCONFIG_INSTALLDIR "libdata/pkgconfig")
+ else()

--- a/.github/overlays/sdl3/portfile.cmake
+++ b/.github/overlays/sdl3/portfile.cmake
@@ -1,0 +1,128 @@
+set(_lfs_sdl3_x11_apt_packages
+    "libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev libxrandr-dev libxrender-dev libxss-dev libxtst-dev")
+set(_lfs_sdl3_wayland_apt_packages
+    "libwayland-dev libwayland-bin wayland-protocols libxkbcommon-dev libegl-dev")
+
+function(_lfs_find_library out_var)
+    find_library(_lfs_found_library NAMES ${ARGN})
+    set(${out_var} "${_lfs_found_library}" PARENT_SCOPE)
+endfunction()
+
+function(_lfs_find_header out_var)
+    find_path(_lfs_found_header_dir NAMES ${ARGN})
+    set(${out_var} "${_lfs_found_header_dir}" PARENT_SCOPE)
+endfunction()
+
+function(_lfs_append_missing_library list_var display_name)
+    _lfs_find_library(_lfs_library ${ARGN})
+    if(NOT _lfs_library)
+        set(_lfs_missing_items "${${list_var}}")
+        list(APPEND _lfs_missing_items "${display_name}")
+        set(${list_var} "${_lfs_missing_items}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(_lfs_require_sdl3_linux_desktop_deps)
+    if(NOT VCPKG_TARGET_IS_LINUX)
+        return()
+    endif()
+
+    if("x11" IN_LIST FEATURES)
+        set(_x11_missing_items)
+
+        foreach(_header IN ITEMS
+                X11/Xlib.h
+                X11/extensions/Xext.h
+                X11/Xcursor/Xcursor.h
+                X11/extensions/XInput2.h
+                X11/extensions/Xfixes.h
+                X11/extensions/Xrandr.h
+                X11/extensions/Xrender.h
+                X11/extensions/scrnsaver.h
+                X11/extensions/XTest.h
+                X11/extensions/Xdbe.h
+                X11/extensions/shape.h
+                X11/extensions/sync.h)
+            _lfs_find_header(_lfs_header_dir "${_header}")
+            if(NOT _lfs_header_dir)
+                list(APPEND _x11_missing_items "${_header}")
+            endif()
+        endforeach()
+
+        _lfs_append_missing_library(_x11_missing_items "libX11" X11)
+        _lfs_append_missing_library(_x11_missing_items "libXext" Xext)
+        _lfs_append_missing_library(_x11_missing_items "libXcursor" Xcursor)
+        _lfs_append_missing_library(_x11_missing_items "libXi" Xi)
+        _lfs_append_missing_library(_x11_missing_items "libXfixes" Xfixes)
+        _lfs_append_missing_library(_x11_missing_items "libXrandr" Xrandr)
+        _lfs_append_missing_library(_x11_missing_items "libXrender" Xrender)
+        _lfs_append_missing_library(_x11_missing_items "libXss" Xss)
+        _lfs_append_missing_library(_x11_missing_items "libXtst" Xtst)
+
+        if(_x11_missing_items)
+            list(REMOVE_DUPLICATES _x11_missing_items)
+            string(JOIN ", " _x11_missing_text ${_x11_missing_items})
+            message(FATAL_ERROR
+                "SDL3 was requested with the 'x11' feature, but the required X11 development packages were not found before SDL3 configuration.\n"
+                "\n"
+                "Missing headers/libraries: ${_x11_missing_text}\n"
+                "\n"
+                "For Debian/Ubuntu/Pop!_OS install:\n"
+                "  sudo apt install ${_lfs_sdl3_x11_apt_packages}\n"
+                "\n"
+                "Then re-run configuration so vcpkg rebuilds SDL3 with X11 support."
+            )
+        endif()
+    endif()
+
+    if("wayland" IN_LIST FEATURES)
+        set(_wayland_missing_items)
+
+        foreach(_header IN ITEMS
+                wayland-client.h
+                wayland-egl.h
+                wayland-cursor.h
+                xkbcommon/xkbcommon.h
+                EGL/egl.h)
+            _lfs_find_header(_lfs_header_dir "${_header}")
+            if(NOT _lfs_header_dir)
+                list(APPEND _wayland_missing_items "${_header}")
+            endif()
+        endforeach()
+
+        _lfs_append_missing_library(_wayland_missing_items "libwayland-client" wayland-client)
+        _lfs_append_missing_library(_wayland_missing_items "libwayland-egl" wayland-egl)
+        _lfs_append_missing_library(_wayland_missing_items "libwayland-cursor" wayland-cursor)
+        _lfs_append_missing_library(_wayland_missing_items "libxkbcommon" xkbcommon)
+        _lfs_append_missing_library(_wayland_missing_items "libEGL" EGL)
+
+        find_program(_lfs_wayland_scanner NAMES wayland-scanner)
+        if(NOT _lfs_wayland_scanner)
+            list(APPEND _wayland_missing_items wayland-scanner)
+        endif()
+
+        if(_wayland_missing_items)
+            list(REMOVE_DUPLICATES _wayland_missing_items)
+            string(JOIN ", " _wayland_missing_text ${_wayland_missing_items})
+            message(FATAL_ERROR
+                "SDL3 was requested with the 'wayland' feature, but the required Wayland development packages were not found before SDL3 configuration.\n"
+                "\n"
+                "Missing headers/libraries/tools: ${_wayland_missing_text}\n"
+                "\n"
+                "For Debian/Ubuntu/Pop!_OS install:\n"
+                "  sudo apt install ${_lfs_sdl3_wayland_apt_packages}\n"
+                "\n"
+                "Optional extras:\n"
+                "  sudo apt install libdecor-0-dev\n"
+                "  sudo apt install libdrm-dev libgbm-dev\n"
+                "\n"
+                "If both the X11 and Wayland package sets are installed before SDL3 is configured, SDL3 should be built with support for both backends. "
+                "Then re-run configuration so vcpkg rebuilds SDL3 with Wayland support."
+            )
+        endif()
+    endif()
+endfunction()
+
+_lfs_require_sdl3_linux_desktop_deps()
+
+include("${VCPKG_ROOT_DIR}/ports/sdl3/portfile.cmake")

--- a/.github/overlays/sdl3/vcpkg.json
+++ b/.github/overlays/sdl3/vcpkg.json
@@ -1,0 +1,73 @@
+{
+  "name": "sdl3",
+  "version": "3.4.2",
+  "port-version": 1,
+  "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
+  "homepage": "https://www.libsdl.org",
+  "license": "Zlib AND MIT AND Apache-2.0",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "ibus",
+      "platform": "linux"
+    },
+    {
+      "name": "wayland",
+      "platform": "linux"
+    },
+    {
+      "name": "x11",
+      "platform": "linux"
+    }
+  ],
+  "features": {
+    "alsa": {
+      "description": "Support for alsa audio",
+      "dependencies": [
+        {
+          "name": "alsa",
+          "platform": "linux"
+        }
+      ]
+    },
+    "dbus": {
+      "description": "Build with D-Bus support",
+      "dependencies": [
+        {
+          "name": "dbus",
+          "default-features": false,
+          "platform": "linux"
+        }
+      ]
+    },
+    "emscripten-pthreads": {
+      "description": "Build Emscripten pthreads support",
+      "supports": "emscripten"
+    },
+    "ibus": {
+      "description": "Build with ibus IME support",
+      "supports": "linux"
+    },
+    "vulkan": {
+      "description": "Vulkan functionality for SDL"
+    },
+    "wayland": {
+      "description": "Build with Wayland support",
+      "supports": "linux"
+    },
+    "x11": {
+      "description": "Build with X11 support",
+      "supports": "!windows"
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,11 @@
 {
   "builtin-baseline": "c3867e714dd3a51c272826eea77267876517ed99",
+  "default-features": [
+    {
+      "name": "desktop-sdl",
+      "platform": "linux"
+    }
+  ],
   "dependencies": [
     "args",
     "boost-preprocessor",
@@ -16,7 +22,10 @@
     },
     "freetype",
     "glad",
-    "sdl3",
+    {
+      "name": "sdl3",
+      "default-features": false
+    },
     "glm",
     "gtest",
     {
@@ -56,5 +65,25 @@
         "svg"
       ]
     }
-  ]
+  ],
+  "features": {
+    "desktop-sdl": {
+      "description": "Build SDL3 with desktop Linux backends enabled by default.",
+      "dependencies": [
+        {
+          "name": "sdl3",
+          "default-features": false,
+          "features": [
+            "ibus",
+            "wayland",
+            "x11"
+          ],
+          "platform": "linux"
+        }
+      ]
+    },
+    "headless-sdl": {
+      "description": "Build against SDL3 core only, without desktop Linux video backends."
+    }
+  }
 }


### PR DESCRIPTION
Probably not for merging. And untested. I'm drafting this, because I'm not happy with this solution, but I want to illustrate the problem.

Currently, SDL3 will happily build without wayland and/or x11 if the required dev libraries aren't available, without raising any errors.
The build will complete without any indication of something being wrong, and a LFS binary is produced that cannot launch a GUI under any circumstances, because it lacks X11/Wayland support:
```
$ ./build/LichtFeld-Studio
[...]
Failed to initialize SDL: No available video device

$ SDL_VIDEODRIVER=x11 ./build/LichtFeld-Studio
[...]
Failed to initialize SDL: x11 not available

$ SDL_VIDEODRIVER=wayland ./build/LichtFeld-Studio
[...]
Failed to initialize SDL: wayland not available
```

To make matters worse, installing these libraries later does not invalidate the build cache, so the user has to figure out what's wrong from no errors, figure out the missing packages, then do a full --fresh build, to solve the problem.

So, the solution would be simple you'd think. Make SDL3 require either X11 or Wayland or fail the build.
Except it doesn't seem SDL3's vcpkg exposes any way to control this.

It is possible to override SDL3's vcpkg portfile as done in this PR. But this gets messy fast. Because in order to do so, we also have to override rmgui's portfile, because it needs to pull in our new custom SDL3 version. And any other package pulling in SDL3 will also need a custom portfile.
Disregarding that this specific implementation is a mess of course, the whole portfile override solution is nasty. But I don't think there's any other solution, at least not pre-compile.

So in short:
- SDL3 will happily build without either X11 or Wayland if the required libraries aren't available at build time
- This is a problem because it doesn't throw errors and can't be enforced
- The solutions available are messy and nasty

What is the desired way forward here, if any?

The required (and currently undocumented) packages seem to be (Debian packages, Wayland and X11 mixed):
```
libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev libxrandr-dev libxrender-dev libxss-dev libxtst-dev libwayland-dev libwayland-bin wayland-protocols libxkbcommon-dev libegl-dev libdecor-0-dev libdrm-dev libgbm-dev
```