### PR TITLE
fix shutdown crash on exit

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -303,12 +303,13 @@ namespace lfs::app {
 
             mcp_http.stop();
 
+            python::finalize();
+
             viewer.reset();
 
             core::Tensor::shutdown_memory_pool();
             core::PinnedMemoryAllocator::instance().shutdown();
 
-            python::finalize();
             std::_Exit(0);
         }
 


### PR DESCRIPTION
## Summary
- finalize Python before destroying the viewer/GL context
- avoid shutdown crashes when Python-owned RmlUI panels tear down OpenGL resources on exit

## Testing
- reproduced on Linux with `timeout --signal=INT 15s LichtFeld-Studio`
- before: exit `139`
- after: clean shutdown, no segfault