### PR TITLE
Add action-only plugin toolbar support

### DIFF
--- a/src/python/lfs_plugins/tool_defs/definition.py
+++ b/src/python/lfs_plugins/tool_defs/definition.py
@@ -96,6 +96,8 @@ class ToolDef:
         poll: Optional callable to check if tool is available.
         plugin_name: Plugin name for custom icons.
         plugin_path: Plugin path for custom icons.
+        action_only: Invoke operator without becoming the active tool.
+        selected: Optional callable for custom toolbar highlight state.
     """
 
     id: str
@@ -112,6 +114,8 @@ class ToolDef:
     poll: Callable[[Any], bool] | None = None
     plugin_name: str = ""
     plugin_path: str = ""
+    action_only: bool = False
+    selected: Callable[[Any], bool] | None = None
 
     def can_activate(self, context: Any) -> bool:
         """Check if this tool can be activated in the given context.
@@ -148,4 +152,5 @@ class ToolDef:
             ],
             "plugin_name": self.plugin_name,
             "plugin_path": self.plugin_path,
+            "action_only": self.action_only,
         }

--- a/src/python/lfs_plugins/toolbar.py
+++ b/src/python/lfs_plugins/toolbar.py
@@ -2,11 +2,15 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Viewport toolbars rendered from a retained RmlUI data model."""
 
+from pathlib import Path
+from urllib.parse import quote
+
 from .histogram_support import histogram_mode_available
 from .tools import ToolRegistry
 
 
 _TOOLBAR_HIDDEN_STATES = ("running", "paused", "stopping", "completed")
+_RML_PATH_SAFE_CHARS = "/:._-~"
 
 _toolbar_controller = None
 
@@ -16,6 +20,26 @@ def _icon_src(icon_name):
     if "." in icon_name:
         return f"../icon/{icon_name}"
     return f"../icon/{icon_name}.png"
+
+
+def _tool_icon_src(tool_def):
+    """Resolve builtin toolbar icons or plugin-provided toolbar icons."""
+    plugin_path = getattr(tool_def, "plugin_path", "") or ""
+    if plugin_path:
+        candidate = Path(plugin_path) / "icons" / f"{tool_def.icon}.png"
+        if candidate.exists():
+            return quote(candidate.as_posix(), safe=_RML_PATH_SAFE_CHARS)
+    return _icon_src(tool_def.icon)
+
+
+def _tool_selected(tool_def, active_tool_id, context):
+    selected_fn = getattr(tool_def, "selected", None)
+    if callable(selected_fn):
+        try:
+            return bool(selected_fn(context))
+        except Exception:
+            return False
+    return active_tool_id == tool_def.id
 
 
 def _tooltip_text(label, shortcut=""):
@@ -129,10 +153,10 @@ class _GizmoToolbarController:
             f"tool-{tool_def.id}",
             "tool",
             tool_def.id,
-            _icon_src(tool_def.icon),
+            _tool_icon_src(tool_def),
             tooltip_key=tooltip_key,
             tooltip_text="" if tooltip_key else _tooltip_text(tool_def.label, tool_def.shortcut),
-            selected=active_tool_id == tool_def.id,
+            selected=_tool_selected(tool_def, active_tool_id, context),
             enabled=tool_def.can_activate(context),
         )
 

--- a/src/python/lfs_plugins/tools.py
+++ b/src/python/lfs_plugins/tools.py
@@ -55,6 +55,12 @@ class ToolRegistry:
         if not tool.can_activate(context):
             return False
 
+        if tool.action_only:
+            if not tool.operator:
+                return False
+            lf.ui.ops.invoke(tool.operator)
+            return True
+
         lf.ui.ops.cancel_modal()
         lf.ui.clear_gizmo()
 


### PR DESCRIPTION
Adds minimal plugin toolbar API support needed for true one-click action plugins.

This patch adds:
- ToolDef.action_only
- ToolDef.selected
- plugin toolbar icon loading from plugin_path/icons/{icon}.png

This allows sync-style plugins to behave as one-shot toolbar actions instead of persistent tools, and enables plugin-defined busy highlight state and custom toolbar icons.