### PR TITLE
Fix inconsistent font color in training tab loss graph ticks

### DIFF
--- a/src/visualizer/gui/rmlui/elements/loss_graph_element.cpp
+++ b/src/visualizer/gui/rmlui/elements/loss_graph_element.cpp
@@ -4,6 +4,8 @@
 
 #include "gui/rmlui/elements/loss_graph_element.hpp"
 
+#include "theme/theme.hpp"
+
 #include <RmlUi/Core/RenderManager.h>
 #include <algorithm>
 #include <cassert>
@@ -60,9 +62,12 @@ namespace lfs::vis::gui {
         if (graph_h <= 0.f)
             return;
 
+        const auto& pal = lfs::vis::theme().palette;
+        const auto to_byte = [](float v) { return static_cast<Rml::byte>(std::clamp(v * 255.0f, 0.0f, 255.0f)); };
         {
             Rml::Mesh mesh;
-            Rml::ColourbPremultiplied bg_col(25, 25, 25, 255);
+            Rml::ColourbPremultiplied bg_col(to_byte(pal.background.x), to_byte(pal.background.y),
+                                             to_byte(pal.background.z), 255);
             mesh.vertices.push_back({{0, 0}, bg_col, {0, 0}});
             mesh.vertices.push_back({{w, 0}, bg_col, {0, 0}});
             mesh.vertices.push_back({{w, h}, bg_col, {0, 0}});
@@ -73,7 +78,8 @@ namespace lfs::vis::gui {
 
         {
             Rml::Mesh mesh;
-            Rml::ColourbPremultiplied grid_col(60, 60, 60, 255);
+            Rml::ColourbPremultiplied grid_col(to_byte(pal.border.x), to_byte(pal.border.y),
+                                               to_byte(pal.border.z), 255);
             const float line_h = 1.0f;
 
             for (int i = 0; i < TICK_COUNT; ++i) {
@@ -103,7 +109,8 @@ namespace lfs::vis::gui {
                 return;
             }
 
-            const Rml::ColourbPremultiplied line_col(137, 180, 250, 255);
+            const Rml::ColourbPremultiplied line_col(to_byte(pal.primary.x), to_byte(pal.primary.y),
+                                                     to_byte(pal.primary.z), 255);
             const float half_lw = LINE_WIDTH * 0.5f;
             const float range = data_max_ - data_min_;
             assert(range > 0.0f);

--- a/src/visualizer/gui/rmlui/resources/training.rcss
+++ b/src/visualizer/gui/rmlui/resources/training.rcss
@@ -101,7 +101,7 @@ body {
 .loss-tick {
     font-family: "JetBrains Mono";
     font-size: 10dp;
-    color: #bac2de;
+    color: #a6adc8;
     text-align: right;
     white-space: nowrap;
 }

--- a/src/visualizer/gui/rmlui/resources/training.rml
+++ b/src/visualizer/gui/rmlui/resources/training.rml
@@ -604,9 +604,9 @@
 
   <!-- ── Status Section ────────────────────────────────── -->
   <div class="section-gap">
-    <span class="status-text status-info training-status-line">{{status_mode}}</span>
-    <span class="status-text status-info training-status-line">{{status_iteration}}</span>
-    <span class="status-text status-info training-status-line">{{status_gaussians}}</span>
+    <span class="status-text text-default training-status-line">{{status_mode}}</span>
+    <span class="status-text text-default training-status-line">{{status_iteration}}</span>
+    <span class="status-text text-default training-status-line">{{status_gaussians}}</span>
     <div data-if="show_progress">
       <div style="position: relative;">
         <progress id="training-progress" max="1" data-attr-value="progress_value" />
@@ -614,7 +614,7 @@
       </div>
     </div>
     <div id="loss-graph-container">
-      <span id="loss-label" class="status-text status-info training-status-line">{{loss_label}}</span>
+      <span id="loss-label" class="status-text text-default training-status-line">{{loss_label}}</span>
       <div class="loss-graph-wrap">
         <div class="loss-graph-ticks">
           <span id="loss-tick-max" class="loss-tick">{{loss_tick_max}}</span>

--- a/src/visualizer/gui/rmlui/rml_panel_host.cpp
+++ b/src/visualizer/gui/rmlui/rml_panel_host.cpp
@@ -270,6 +270,10 @@ namespace lfs::vis::gui {
                         warning);
         const auto histogram_selection_fill = colorToRmlAlpha(p.warning, t.isLightTheme() ? 0.14f : 0.18f);
         const auto histogram_history_icon_disabled = colorToRmlAlpha(p.text_dim, 0.48f);
+        const auto background = colorToRml(p.background);
+        const auto primary_border_soft = colorToRmlAlpha(p.primary, 0.33f);
+        const auto primary_border_faint = colorToRmlAlpha(p.primary, 0.13f);
+        const auto primary_accent = colorToRmlAlpha(p.primary, 0.22f);
 
         return std::format(
             "body {{ color: {0}; background-color: {12}; }}\n"
@@ -322,7 +326,15 @@ namespace lfs::vis::gui {
             "#histogram-selection, #compare-selection {{ border-color: {23}; background-color: {33}; decorator: none; }}\n"
             ".histogram-history-icon {{ image-color: {0}; }}\n"
             ".histogram-history-btn:disabled .histogram-history-icon {{ image-color: {34}; }}\n"
-            ".footer-history-actions {{ background-color: {35}; border-color: {28}; }}\n",
+            ".footer-history-actions {{ background-color: {35}; border-color: {28}; }}\n"
+            ".training-panel-title {{ color: {0}; border-top-color: {36}; }}\n"
+            ".training-panel-title-icon {{ image-color: {3}; }}\n"
+            ".training-subsection-title {{ color: {1}; border-top-color: {37}; }}\n"
+            ".loss-graph-wrap {{ background-color: {38}; }}\n"
+            ".loss-tick {{ color: {1}; }}\n"
+            ".color-picker-popup {{ background-color: {2}; border-color: {4}; }}\n"
+            ".mask-settings-group {{ border-left-color: {39}; }}\n"
+            ".mask-settings-divider {{ background-color: {37}; }}\n",
             text, text_dim, surface, primary, border, row_even, row_odd,
             row_hover, row_hover_border, row_selected, row_selected_hover,
             row_hover_border_selected, body_bg, tab_inactive_bg, tab_hover_border,
@@ -331,7 +343,8 @@ namespace lfs::vis::gui {
             histogram_hero_decor, histogram_surface, histogram_chart_bg, histogram_grid,
             histogram_toolbar_divider, histogram_toolbar_item, histogram_toolbar_select,
             histogram_fill_decor, histogram_fill_selected_decor, histogram_selection_fill,
-            histogram_history_icon_disabled, histogram_footer_chip);
+            histogram_history_icon_disabled, histogram_footer_chip, primary_border_soft,
+            primary_border_faint, background, primary_accent);
     }
 
     bool RmlPanelHost::syncThemeProperties() {


### PR DESCRIPTION
## Summary
- The loss graph tick labels (`.loss-tick`) used a non-standard color (`#bac2de`) that did not match any theme palette token
- Aligned them with the standard muted text color (`#a6adc8`) used consistently across all other panels (rendering, scene tree, components)

## Test plan
- [ ] Open the training panel and start/resume a training run
- [ ] Verify the loss graph Y-axis tick labels match the muted text color used elsewhere in the panel (subsection titles, slider values, etc.)
- [ ] Confirm no visual regression in other training panel elements

Closes #1002