### PR TITLE
feat: add color picker / eyedropper tool to image preview panel

### DIFF
--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -4410,6 +4410,49 @@ namespace lfs::python {
             nb::arg("path"), "Get image dimensions without loading pixel data, returns (width, height, channels)");
 
         m.def(
+            "sample_image_color",
+            [](const std::string& path, int x, int y, int radius) -> nb::tuple {
+                try {
+                    auto [data, w, h, channels] = lfs::core::load_image(lfs::core::utf8_to_path(path), -1, -1);
+                    if (!data)
+                        return nb::make_tuple(0.0f, 0.0f, 0.0f);
+
+                    const int x0 = std::max(0, x - radius);
+                    const int y0 = std::max(0, y - radius);
+                    const int x1 = std::min(w - 1, x + radius);
+                    const int y1 = std::min(h - 1, y + radius);
+
+                    double r_sum = 0.0, g_sum = 0.0, b_sum = 0.0;
+                    int count = 0;
+                    const int ch = std::min(channels, 3);
+                    for (int py = y0; py <= y1; ++py) {
+                        for (int px = x0; px <= x1; ++px) {
+                            const unsigned char* pixel = data + (static_cast<size_t>(py) * w + px) * channels;
+                            r_sum += pixel[0];
+                            g_sum += (ch > 1) ? pixel[1] : pixel[0];
+                            b_sum += (ch > 2) ? pixel[2] : pixel[0];
+                            ++count;
+                        }
+                    }
+
+                    lfs::core::free_image(data);
+
+                    if (count == 0)
+                        return nb::make_tuple(0.0f, 0.0f, 0.0f);
+
+                    return nb::make_tuple(
+                        static_cast<float>(r_sum / (count * 255.0)),
+                        static_cast<float>(g_sum / (count * 255.0)),
+                        static_cast<float>(b_sum / (count * 255.0)));
+                } catch (const std::exception& e) {
+                    LOG_WARN("sample_image_color failed for {}: {}", path, e.what());
+                    return nb::make_tuple(0.0f, 0.0f, 0.0f);
+                }
+            },
+            nb::arg("path"), nb::arg("x"), nb::arg("y"), nb::arg("radius") = 10,
+            "Sample average color around pixel (x, y) within given radius, returns (r, g, b) in 0..1");
+
+        m.def(
             "preload_image_async",
             [](const std::string& path) {
                 std::lock_guard lock(g_preload_mutex);

--- a/src/python/lfs_plugins/image_preview_panel.py
+++ b/src/python/lfs_plugins/image_preview_panel.py
@@ -11,9 +11,9 @@ from urllib.parse import quote
 import lichtfeld as lf
 from .types import Panel
 from .rml_keys import (
-    KI_1, KI_ADD, KI_DOWN, KI_END, KI_ESCAPE, KI_F, KI_HOME, KI_I, KI_LEFT,
-    KI_M, KI_OEM_MINUS, KI_OEM_PLUS, KI_R, KI_RIGHT, KI_SPACE, KI_SUBTRACT,
-    KI_T, KI_UP,
+    KI_1, KI_ADD, KI_C, KI_DOWN, KI_END, KI_ESCAPE, KI_F, KI_HOME, KI_I,
+    KI_LEFT, KI_M, KI_OEM_MINUS, KI_OEM_PLUS, KI_R, KI_RIGHT, KI_SPACE,
+    KI_SUBTRACT, KI_T, KI_UP,
 )
 
 ZOOM_MIN = 0.1
@@ -64,6 +64,7 @@ class ImagePreviewPanel(Panel):
         self._drag_start_pan_x = 0.0
         self._drag_start_pan_y = 0.0
         self._hover_image = False
+        self._color_picker_active = False
 
         self._doc = None
         self._dirty = True
@@ -349,10 +350,15 @@ class ImagePreviewPanel(Panel):
         self._dirty = True
 
     def _on_img_mousedown(self, event):
-        if self._fit_to_window:
-            return
         button = int(event.get_parameter("button", "0"))
         if button != 0:
+            return
+
+        if self._color_picker_active and self._image_paths:
+            self._perform_color_pick(event)
+            return
+
+        if self._fit_to_window:
             return
         self._dragging = True
         self._drag_start_x = float(event.get_parameter("mouse_x", "0"))
@@ -656,6 +662,7 @@ class ImagePreviewPanel(Panel):
             "hk-mask": tr("image_preview.mask"),
             "hk-reset": tr("common.reset"),
             "hk-close": tr("common.close"),
+            "hk-color-picker": tr("image_preview.color_picker"),
         }.items():
             _set_text(doc, element_id, text)
 
@@ -766,6 +773,83 @@ class ImagePreviewPanel(Panel):
         _set_text(doc, "st-zoom", f"{lf.ui.tr('image_preview.zoom')} {self._get_zoom_display()}")
         _set_text(doc, "st-counter", f"{self._current_index + 1} / {len(self._image_paths)}")
 
+    # -- Color Picker --
+
+    def _perform_color_pick(self, event):
+        """Sample the average color at the clicked position and set as bg_color."""
+        path = self._image_paths[self._current_index]
+        w, h, _ = self._get_image_info(path)
+        if w <= 0 or h <= 0:
+            return
+
+        viewport = self._doc.get_element_by_id("image-viewport") if self._doc else None
+        if not viewport:
+            return
+
+        dp_ratio = max(1.0, lf.ui.get_ui_scale())
+        vw = max(1, int(viewport.client_width / dp_ratio))
+        vh = max(1, int(viewport.client_height / dp_ratio))
+
+        if self._fit_to_window:
+            scale = min(1.0, vw / w, vh / h)
+        else:
+            scale = self._zoom
+
+        dw = max(1, int(round(w * scale)))
+        dh = max(1, int(round(h * scale)))
+
+        ox = (vw - dw) * 0.5
+        oy = (vh - dh) * 0.5
+        if not self._fit_to_window:
+            ox += self._pan_x
+            oy += self._pan_y
+
+        # Get click position relative to the viewport
+        vp_left = viewport.absolute_left
+        vp_top = viewport.absolute_top
+        mx = float(event.get_parameter("mouse_x", "0")) / dp_ratio - vp_left / dp_ratio
+        my = float(event.get_parameter("mouse_y", "0")) / dp_ratio - vp_top / dp_ratio
+
+        # Convert screen position to image pixel coordinates
+        ix = int(round((mx - ox) / scale))
+        iy = int(round((my - oy) / scale))
+
+        if ix < 0 or ix >= w or iy < 0 or iy >= h:
+            return
+
+        try:
+            r, g, b = lf.ui.sample_image_color(str(path), ix, iy, 10)
+        except Exception:
+            return
+
+        color = (r, g, b)
+        try:
+            params = lf.optimization_params()
+            params.bg_color = color
+        except Exception:
+            pass
+        try:
+            rs = lf.get_render_settings()
+            if rs:
+                rs.set("background_color", color)
+        except Exception:
+            pass
+
+        self._color_picker_active = False
+        self._update_picker_cursor()
+        self._dirty = True
+
+    def _update_picker_cursor(self):
+        """Toggle the picker-active CSS class on the image container."""
+        if not self._doc:
+            return
+        container = self._doc.get_element_by_id("image-container")
+        if container:
+            if self._color_picker_active:
+                container.set_attribute("class", "picker-active")
+            else:
+                container.set_attribute("class", "")
+
     # -- Keyboard --
 
     def _on_keydown(self, event):
@@ -824,8 +908,19 @@ class ImagePreviewPanel(Panel):
             self._reset_view()
             self._dirty = True
             event.stop_propagation()
+        elif key == KI_C:
+            if self._image_paths:
+                self._color_picker_active = not self._color_picker_active
+                self._update_picker_cursor()
+                self._dirty = True
+            event.stop_propagation()
         elif key == KI_ESCAPE:
-            self._close_panel()
+            if self._color_picker_active:
+                self._color_picker_active = False
+                self._update_picker_cursor()
+                self._dirty = True
+            else:
+                self._close_panel()
             event.stop_propagation()
 
     # -- Helpers --

--- a/src/python/lfs_plugins/rml_keys.py
+++ b/src/python/lfs_plugins/rml_keys.py
@@ -4,6 +4,7 @@
 
 KI_SPACE = 1
 KI_A = 12
+KI_C = 14
 KI_1 = 3
 KI_F = 17
 KI_I = 20

--- a/src/python/stubs/lichtfeld/ui/__init__.pyi
+++ b/src/python/stubs/lichtfeld/ui/__init__.pyi
@@ -2143,6 +2143,11 @@ def get_image_info(path: str) -> tuple:
     Get image dimensions without loading pixel data, returns (width, height, channels)
     """
 
+def sample_image_color(path: str, x: int, y: int, radius: int = 10) -> tuple:
+    """
+    Sample average color around pixel (x, y) within given radius, returns (r, g, b) in 0..1
+    """
+
 def preload_image_async(path: str) -> None:
     """Start async preload of image data"""
 

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -851,7 +851,8 @@
     "no_image": "Kein Bild",
     "zoom": "Zoom",
     "fit": "Anpassen",
-    "storage_section": "SPEICHER"
+    "storage_section": "SPEICHER",
+    "color_picker": "Pipette"
   },
   "startup": {
     "supported_by": "Unterstützt von",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -863,7 +863,8 @@
     "visible": "Visible",
     "hidden": "Hidden",
     "mask_section": "MASK",
-    "storage_section": "STORAGE"
+    "storage_section": "STORAGE",
+    "color_picker": "Pick"
   },
   "startup": {
     "supported_by": "Supported by",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -851,7 +851,8 @@
     "no_image": "Sin imagen",
     "zoom": "Zoom",
     "fit": "Ajustar",
-    "storage_section": "ALMACENAMIENTO"
+    "storage_section": "ALMACENAMIENTO",
+    "color_picker": "Tomar"
   },
   "startup": {
     "supported_by": "Apoyado por",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -851,7 +851,8 @@
     "no_image": "Pas d image",
     "zoom": "Zoom",
     "fit": "Ajuster",
-    "storage_section": "STOCKAGE"
+    "storage_section": "STOCKAGE",
+    "color_picker": "Pipette"
   },
   "startup": {
     "supported_by": "Soutenu par",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -851,7 +851,8 @@
     "no_image": "Nessuna immagine",
     "zoom": "Zoom",
     "fit": "Adatta",
-    "storage_section": "ARCHIVIAZIONE"
+    "storage_section": "ARCHIVIAZIONE",
+    "color_picker": "Preleva"
   },
   "startup": {
     "supported_by": "Supportato da",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -851,7 +851,8 @@
     "no_image": "画像なし",
     "zoom": "ズーム",
     "fit": "フィット",
-    "storage_section": "ストレージ"
+    "storage_section": "ストレージ",
+    "color_picker": "スポイト"
   },
   "startup": {
     "supported_by": "サポート",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -851,7 +851,8 @@
     "no_image": "이미지 없음",
     "zoom": "줌",
     "fit": "맞춤",
-    "storage_section": "저장소"
+    "storage_section": "저장소",
+    "color_picker": "스포이트"
   },
   "startup": {
     "supported_by": "지원:",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -851,7 +851,8 @@
     "no_image": "Geen afbeelding",
     "zoom": "Zoom",
     "fit": "Passend",
-    "storage_section": "OPSLAG"
+    "storage_section": "OPSLAG",
+    "color_picker": "Pipet"
   },
   "startup": {
     "supported_by": "Ondersteund door",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -851,7 +851,8 @@
     "no_image": "Brak obrazu",
     "zoom": "Zoom",
     "fit": "Dopasuj",
-    "storage_section": "MAGAZYN"
+    "storage_section": "MAGAZYN",
+    "color_picker": "Pobierz"
   },
   "startup": {
     "supported_by": "Wspierane przez",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -851,7 +851,8 @@
     "no_image": "无图像",
     "zoom": "缩放",
     "fit": "适配",
-    "storage_section": "存储"
+    "storage_section": "存储",
+    "color_picker": "取色"
   },
   "startup": {
     "supported_by": "支持：",

--- a/src/visualizer/gui/rmlui/resources/image_preview.rcss
+++ b/src/visualizer/gui/rmlui/resources/image_preview.rcss
@@ -83,6 +83,10 @@
     min-height: 0;
 }
 
+#image-container.picker-active {
+    cursor: pointer;
+}
+
 #image-viewport {
     position: absolute;
     top: 0;

--- a/src/visualizer/gui/rmlui/resources/image_preview.rml
+++ b/src/visualizer/gui/rmlui/resources/image_preview.rml
@@ -110,6 +110,7 @@
       <span class="hk"><span class="hk-key">I</span><span class="hk-label" id="hk-info"></span></span>
       <span class="hk"><span class="hk-key">T</span><span class="hk-label" id="hk-thumbnails"></span></span>
       <span class="hk"><span class="hk-key">M</span><span class="hk-label" id="hk-mask"></span></span>
+      <span class="hk"><span class="hk-key">C</span><span class="hk-label" id="hk-color-picker"></span></span>
       <span class="hk"><span class="hk-key">R</span><span class="hk-label" id="hk-reset"></span></span>
       <span class="hk"><span class="hk-key">Esc</span><span class="hk-label" id="hk-close"></span></span>
     </span>


### PR DESCRIPTION
Press C in the image preview to enter color picker mode, then click on the image to sample the average color of the surrounding ~10 pixels. The sampled color is written to the training background color (bg_color) and synced to the viewport render settings. Press Esc to cancel.

- New C++ API: lf.ui.sample_image_color(path, x, y, radius)
- Eyedropper mode with CSS-based pointer cursor (no flicker)
- Status bar hotkey hint (C / Pick)