### PR TITLE
Add Viewport Export plugin to marketplace curated list

### DIFF
--- a/src/python/lfs_plugins/marketplace.py
+++ b/src/python/lfs_plugins/marketplace.py
@@ -45,6 +45,7 @@ CURATED_PLUGIN_URLS: Tuple[str, ...] = (
     "https://github.com/jacobvanbeets/lichtfeld-depthmap-plugin",
     "https://github.com/jacobvanbeets/splat-vr-viewer",
     "https://github.com/jacobvanbeets/lichtfeld-measurement-plugin",
+    "https://github.com/jacobvanbeets/viewport-export-lichtfeld",
 )
 
 


### PR DESCRIPTION
This plugin allows users to export the current viewport as a JPG image at 1080p, 4K, or 8K resolution directly from the Plugin Manager.