### PR TITLE
Fix training "JSON" config not updating UI when imported after dataset

### DIFF
--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -1455,6 +1455,12 @@ namespace lfs::vis {
         }
         result->apply_step_scaling();
         parameter_manager_->importParams(*result);
+        parameter_manager_->markDirty();
+
+        // Bump scene generation so all panels (e.g. training panel) pick up
+        // the new parameter values.  Without this, importing a config after a
+        // dataset is already loaded leaves the UI showing stale defaults.
+        python::bump_scene_generation();
     }
 
     void VisualizerImpl::handleTrainingCompleted([[maybe_unused]] const state::TrainingCompleted& event) {


### PR DESCRIPTION
Importing a training config JSON after a dataset was already loaded did not refresh the training panel, leaving it showing stale default values. The root cause was that handleLoadConfigFile() updated the ParameterManager but never notified the UI to re-read the values.

- Call markDirty() so a running trainer thread also picks up changes.
- Call bump_scene_generation() so all panels (training panel in particular) trigger on_scene_changed and refresh their bindings.

Fixes the order-dependent bug where config-then-dataset worked but dataset-then-config did not.