### PR TITLE
#1083 Fix: USD export crash on Windows due to missing plugin resources (this bug was annoying!)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,6 +655,45 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMENT "Copying locale files"
 )
 
+# =============================================================================
+# OpenUSD PLUGIN RESOURCES - Required for USD import/export at runtime.
+# OpenUSD discovers its schema and file-format plugins through plugInfo.json
+# files.  vcpkg places per-module resources under bin/usd/ and a root index
+# under lib/usd/.  At runtime the compiled-in search path may not match the
+# deployed layout, so we place them under <exe_dir>/../lib/usd/ (the vcpkg
+# convention) and set PXR_PLUGINPATH_NAME at startup.
+# =============================================================================
+# Per-module plugin dirs live in vcpkg's bin/usd/ after install; the CMake
+# build also mirrors them under build/src/python/usd/.  Use whichever exists.
+set(_VCPKG_USD_BIN_PLUGINS "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/bin/usd")
+if(NOT EXISTS "${_VCPKG_USD_BIN_PLUGINS}")
+    set(_VCPKG_USD_BIN_PLUGINS "${CMAKE_BINARY_DIR}/src/python/usd")
+endif()
+set(_VCPKG_USD_ROOT_INDEX  "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/usd/plugInfo.json")
+set(_USD_PLUGIN_DEST       "$<TARGET_FILE_DIR:${PROJECT_NAME}>/../lib/usd")
+
+if(EXISTS "${_VCPKG_USD_BIN_PLUGINS}")
+    # Copy per-module plugin dirs (sdf/resources/plugInfo.json, usdVol/resources/*, …)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${_USD_PLUGIN_DEST}"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+            "${_VCPKG_USD_BIN_PLUGINS}"
+            "${_USD_PLUGIN_DEST}"
+        COMMENT "Copying OpenUSD plugin resources (per-module)"
+    )
+    message(STATUS "Post-build: OpenUSD plugin resources will be copied from ${_VCPKG_USD_BIN_PLUGINS}")
+endif()
+
+if(EXISTS "${_VCPKG_USD_ROOT_INDEX}")
+    # Copy the root plugInfo.json that tells Plug to scan */resources/
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${_VCPKG_USD_ROOT_INDEX}"
+            "${_USD_PLUGIN_DEST}/plugInfo.json"
+        COMMENT "Copying OpenUSD root plugin index"
+    )
+endif()
+
 message(STATUS "Post-build: Resources will be copied to \${BUILD_DIR}/resources/")
 
 # Platform-specific settings
@@ -867,6 +906,16 @@ install(FILES "${CMAKE_SOURCE_DIR}/src/visualizer/gui/assets/volinga-logo.png" D
 install(FILES "${CMAKE_SOURCE_DIR}/src/visualizer/gui/assets/volinga-logo-dark.png" DESTINATION "${INSTALL_RESOURCE_DIR}/assets")
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/src/visualizer/gui/rmlui/resources/" DESTINATION "${INSTALL_RESOURCE_DIR}/assets/rmlui")
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/src/visualizer/gui/resources/locales" DESTINATION "${INSTALL_RESOURCE_DIR}")
+
+# OpenUSD plugin resources (schema definitions + plugInfo.json files)
+if(EXISTS "${_VCPKG_USD_BIN_PLUGINS}")
+    install(DIRECTORY "${_VCPKG_USD_BIN_PLUGINS}/" DESTINATION "${CMAKE_INSTALL_LIBDIR}/usd"
+            PATTERN "__pycache__" EXCLUDE
+            PATTERN "*.pyc" EXCLUDE)
+endif()
+if(EXISTS "${_VCPKG_USD_ROOT_INDEX}")
+    install(FILES "${_VCPKG_USD_ROOT_INDEX}" DESTINATION "${CMAKE_INSTALL_LIBDIR}/usd")
+endif()
 
 # Plugin development documentation
 set(DOC_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/doc/LichtFeld-Studio")

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -6,13 +6,67 @@
 #include "app/converter.hpp"
 #include "core/argument_parser.hpp"
 #include "core/logger.hpp"
+#include "core/path_utils.hpp"
 #include "git_version.h"
 #include "python/plugin_runner.hpp"
 #include "python/runner.hpp"
 
+#include <cstdlib>
+#include <filesystem>
 #include <print>
 
+#include <pxr/base/plug/registry.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace {
+    std::filesystem::path get_exe_directory() {
+#ifdef _WIN32
+        wchar_t buf[MAX_PATH]{};
+        if (GetModuleFileNameW(nullptr, buf, MAX_PATH) > 0) {
+            return std::filesystem::path(buf).parent_path();
+        }
+#else
+        std::error_code ec;
+        auto p = std::filesystem::read_symlink("/proc/self/exe", ec);
+        if (!ec) return p.parent_path();
+#endif
+        return {};
+    }
+
+    // Register OpenUSD plugin resources deployed at <exe_dir>/../lib/usd/.
+    // Must be called before any USD API usage (stage creation, schema lookup).
+    // The env-var approach (PXR_PLUGINPATH_NAME) does not work reliably on
+    // Windows because USD DLLs may initialise before main() runs.
+    void configure_usd_plugins() {
+        const auto exe_dir = get_exe_directory();
+        if (exe_dir.empty()) return;
+
+        auto usd_dir = exe_dir / ".." / "lib" / "usd";
+        std::error_code ec;
+        usd_dir = std::filesystem::canonical(usd_dir, ec);
+        if (ec || !std::filesystem::is_directory(usd_dir, ec)) return;
+
+        const std::string path_utf8 = lfs::core::path_to_utf8(usd_dir);
+
+        // Also set the env var for any code that reads it directly.
+#ifdef _WIN32
+        _putenv_s("PXR_PLUGINPATH_NAME", path_utf8.c_str());
+#else
+        setenv("PXR_PLUGINPATH_NAME", path_utf8.c_str(), /*overwrite=*/0);
+#endif
+
+        // Programmatically register plugins so the Plug system finds them
+        // regardless of compiled-in search paths or env var timing.
+        pxr::PlugRegistry::GetInstance().RegisterPlugins(path_utf8);
+    }
+} // namespace
+
 int main(int argc, char* argv[]) {
+    configure_usd_plugins();
+
     auto result = lfs::core::args::parse_args(argc, argv);
     if (!result) {
         std::println(stderr, "Error: {}", result.error());

--- a/src/io/formats/usd.cpp
+++ b/src/io/formats/usd.cpp
@@ -18,6 +18,9 @@
 #include <string>
 #include <vector>
 
+#include <pxr/base/tf/diagnostic.h>
+#include <pxr/base/tf/diagnosticMgr.h>
+#include <pxr/base/tf/errorMark.h>
 #include <pxr/base/gf/half.h>
 #include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/gf/quatf.h>
@@ -766,7 +769,24 @@ namespace lfs::io {
 
         const auto sh_coefficients = flatten_sh_coefficients(splat_data);
 
-        auto stage = pxr::UsdStage::CreateNew(lfs::core::path_to_utf8(options.output_path));
+        // TfErrorMark captures OpenUSD diagnostic errors that don't throw.
+        pxr::TfErrorMark error_mark;
+
+        pxr::UsdStageRefPtr stage;
+        try {
+            stage = pxr::UsdStage::CreateNew(lfs::core::path_to_utf8(options.output_path));
+        } catch (const std::exception& e) {
+            return make_error(ErrorCode::WRITE_FAILURE,
+                              std::format("UsdStage::CreateNew threw: {}", e.what()),
+                              options.output_path);
+        }
+        if (!error_mark.IsClean()) {
+            for (const auto& err : error_mark) {
+                LOG_ERROR("OpenUSD error during stage creation: {} ({}:{})",
+                          err.GetCommentary(), err.GetSourceFileName(), err.GetSourceLineNumber());
+            }
+            error_mark.Clear();
+        }
         if (!stage) {
             return make_error(ErrorCode::WRITE_FAILURE,
                               "Failed to create USD stage",
@@ -774,37 +794,62 @@ namespace lfs::io {
         }
 
         const pxr::SdfPath prim_path("/GaussianSplats");
-        auto splat_prim = pxr::UsdVolParticleField3DGaussianSplat::Define(stage, prim_path);
+        pxr::UsdVolParticleField3DGaussianSplat splat_prim;
+        try {
+            splat_prim = pxr::UsdVolParticleField3DGaussianSplat::Define(stage, prim_path);
+        } catch (const std::exception& e) {
+            return make_error(ErrorCode::WRITE_FAILURE,
+                              std::format("ParticleField3DGaussianSplat::Define threw: {}", e.what()),
+                              options.output_path);
+        }
         if (!splat_prim) {
             return make_error(ErrorCode::WRITE_FAILURE,
                               "Failed to define USD gaussian prim",
                               options.output_path);
         }
 
-        stage->SetDefaultPrim(splat_prim.GetPrim());
-        pxr::UsdGeomSetStageUpAxis(stage, pxr::UsdGeomTokens->y);
-        pxr::UsdGeomSetStageMetersPerUnit(stage, 1.0);
-
-        pxr::UsdGeomBoundable boundable(splat_prim.GetPrim());
-
-        if (!splat_prim.CreatePositionsAttr().Set(make_vec3_array(means_ptr, num_gaussians)) ||
-            !splat_prim.CreateOrientationsAttr().Set(make_quat_array(rotation_ptr, num_gaussians)) ||
-            !splat_prim.CreateScalesAttr().Set(make_vec3_array(scales_linear.data(), num_gaussians)) ||
-            !splat_prim.CreateOpacitiesAttr().Set(make_scalar_array(opacity_linear.data(), num_gaussians)) ||
-            !splat_prim.CreateRadianceSphericalHarmonicsDegreeAttr().Set(splat_data.get_max_sh_degree()) ||
-            !splat_prim.CreateRadianceSphericalHarmonicsCoefficientsAttr().Set(
-                make_vec3_array(sh_coefficients.data(),
-                                num_gaussians * static_cast<size_t>((splat_data.get_max_sh_degree() + 1) *
-                                                                    (splat_data.get_max_sh_degree() + 1)))) ||
-            !boundable.CreateExtentAttr().Set(make_extent_array(means_ptr, num_gaussians))) {
+        try {
+            stage->SetDefaultPrim(splat_prim.GetPrim());
+            pxr::UsdGeomSetStageUpAxis(stage, pxr::UsdGeomTokens->y);
+            pxr::UsdGeomSetStageMetersPerUnit(stage, 1.0);
+        } catch (const std::exception& e) {
             return make_error(ErrorCode::WRITE_FAILURE,
-                              "Failed to author USD gaussian attributes",
+                              std::format("Stage metadata threw: {}", e.what()),
                               options.output_path);
         }
 
-        if (const auto root_layer = stage->GetRootLayer(); !root_layer || !root_layer->Save()) {
+        pxr::UsdGeomBoundable boundable(splat_prim.GetPrim());
+
+        try {
+            if (!splat_prim.CreatePositionsAttr().Set(make_vec3_array(means_ptr, num_gaussians)) ||
+                !splat_prim.CreateOrientationsAttr().Set(make_quat_array(rotation_ptr, num_gaussians)) ||
+                !splat_prim.CreateScalesAttr().Set(make_vec3_array(scales_linear.data(), num_gaussians)) ||
+                !splat_prim.CreateOpacitiesAttr().Set(make_scalar_array(opacity_linear.data(), num_gaussians)) ||
+                !splat_prim.CreateRadianceSphericalHarmonicsDegreeAttr().Set(splat_data.get_max_sh_degree()) ||
+                !splat_prim.CreateRadianceSphericalHarmonicsCoefficientsAttr().Set(
+                    make_vec3_array(sh_coefficients.data(),
+                                    num_gaussians * static_cast<size_t>((splat_data.get_max_sh_degree() + 1) *
+                                                                        (splat_data.get_max_sh_degree() + 1)))) ||
+                !boundable.CreateExtentAttr().Set(make_extent_array(means_ptr, num_gaussians))) {
+                return make_error(ErrorCode::WRITE_FAILURE,
+                                  "Failed to author USD gaussian attributes",
+                                  options.output_path);
+            }
+        } catch (const std::exception& e) {
             return make_error(ErrorCode::WRITE_FAILURE,
-                              "Failed to save USD stage",
+                              std::format("Authoring attributes threw: {}", e.what()),
+                              options.output_path);
+        }
+
+        try {
+            if (const auto root_layer = stage->GetRootLayer(); !root_layer || !root_layer->Save()) {
+                return make_error(ErrorCode::WRITE_FAILURE,
+                                  "Failed to save USD stage",
+                                  options.output_path);
+            }
+        } catch (const std::exception& e) {
+            return make_error(ErrorCode::WRITE_FAILURE,
+                              std::format("Layer save threw: {}", e.what()),
                               options.output_path);
         }
 

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -757,6 +757,8 @@ namespace lfs::vis::gui {
                 bool success = false;
                 std::string error_msg;
 
+                try {
+
                 switch (format) {
                 case ExportFormat::PLY: {
                     update_progress(0.1f, "Writing PLY");
@@ -831,6 +833,14 @@ namespace lfs::vis::gui {
                     }
                     break;
                 }
+                }
+
+                } catch (const std::exception& e) {
+                    error_msg = std::string("Export crashed with exception: ") + e.what();
+                    LOG_ERROR("{}", error_msg);
+                } catch (...) {
+                    error_msg = "Export crashed with unknown exception";
+                    LOG_ERROR("{}", error_msg);
                 }
 
                 if (success) {


### PR DESCRIPTION
OpenUSD requires plugInfo.json and generatedSchema.usda files at runtime for plugin/schema discovery.  These were never deployed from vcpkg to the build output or install prefix, causing UsdStage::CreateNew() to hit TF_FATAL_ERROR -> abort() -> instant crash with no error message.

Changes:

- CMakeLists.txt: deploy USD plugin resources from vcpkg to <exe_dir>/../lib/usd/ via post-build commands and install() rules

- main.cpp: register USD plugins via PlugRegistry::RegisterPlugins() at the start of main(), before any USD API usage.  The env-var-only approach (PXR_PLUGINPATH_NAME) is unreliable on Windows because USD DLLs may initialise static data before main() runs.

- usd.cpp: add TfErrorMark to capture OpenUSD diagnostics and try/catch around each USD API call so failures produce error messages instead of crashes

- async_task_manager.cpp: wrap the export thread body in try/catch to prevent any uncaught exception from terminating the process

This should close issue: https://github.com/MrNeRF/LichtFeld-Studio/issues/1083