### PR TITLE
windows: fix test linking

### DIFF
--- a/src/visualizer/gui/rmlui/rmlui_system_interface.hpp
+++ b/src/visualizer/gui/rmlui/rmlui_system_interface.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include <RmlUi/Core/SystemInterface.h>
 
 #include <cstdint>
@@ -30,7 +31,7 @@ namespace lfs::vis::gui {
         NotAllowed,
     };
 
-    class RmlSystemInterface final : public Rml::SystemInterface {
+    class LFS_VIS_API RmlSystemInterface final : public Rml::SystemInterface {
     public:
         explicit RmlSystemInterface(SDL_Window* window);
 


### PR DESCRIPTION
Fix
```
     test_rml_path_utils.obj : error LNK2019: unresolved external symbol "public: __cdecl
     lfs::vis::gui::RmlSystemInterface::RmlSystemInterface(struct SDL_Window *)"
     (??0RmlSystemInterface@gui@vis@lfs@@QEAA@PEAUSDL_Window@@@Z) referenced in function "private: virtual void __cdecl
     RmlSystemInterfaceTest_JoinsWindowsDrivePathsWithoutTreatingDriveAsUriScheme_Test::TestBody(void)"
   
     test_rml_path_utils.obj : error LNK2019: unresolved external symbol "public: virtual void __cdecl
     lfs::vis::gui::RmlSystemInterface::JoinPath(class std::basic_string<char,struct std::char_traits<char>,class
     std::allocator<char> > &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >
     const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)"
     (?JoinPath@RmlSystemInterface@gui@vis@lfs@@UEAAXAEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AE
     BV56@1@Z) referenced in function "private: virtual void __cdecl
     RmlSystemInterfaceTest_JoinsWindowsDrivePathsWithoutTreatingDriveAsUriScheme_Test::TestBody(void)"
```