### PR TITLE
Missing .gitignore pattern for auto-generated USD files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ build*/**
 !weights/*.pt
 lichtfeld-studio.aps
 __pycache__/
+.vs__pycache__/
 *.pyc
 *.pyo
 src/python/stubs/lichtfeld/build_info.pyi

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,13 @@ build*/**
 *.pt
 !weights/*.pt
 lichtfeld-studio.aps
-.vs__pycache__/
+__pycache__/
 *.pyc
+*.pyo
 src/python/stubs/lichtfeld/build_info.pyi
 tasks/
+
+# USD generated files
+lib/
+generatedSchema.usda
+plugInfo.json


### PR DESCRIPTION
There used to be a bunch of generated USD files that were shown as untracked. The PR fixes it