### PR TITLE
Merge cleanup from MrNerf + fix compile errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,14 +535,18 @@ endif()
 if(WIN32 AND DEFINED VCPKG_TARGET_TRIPLET)
     set(_vcpkg_debug_bin_dir "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/debug/bin")
     set(_vcpkg_release_bin_dir "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/bin")
+    file(GLOB _vcpkg_release_dlls CONFIGURE_DEPENDS "${_vcpkg_release_bin_dir}/*.dll")
+    file(GLOB _vcpkg_debug_dlls CONFIGURE_DEPENDS "${_vcpkg_debug_bin_dir}/*.dll")
     
     # Always copy release DLLs - needed for both Release and Debug builds
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            "${_vcpkg_release_bin_dir}"
-            "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
-        COMMENT "Copying vcpkg release DLLs"
-    )
+    if(_vcpkg_release_dlls)
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${_vcpkg_release_dlls}
+                "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+            COMMENT "Copying vcpkg release DLLs"
+        )
+    endif()
     
     # Only copy debug DLLs for Debug builds (they link to debug CRT which breaks Release)
     # For single-config generators (Ninja, Makefiles): check CMAKE_BUILD_TYPE
@@ -550,19 +554,21 @@ if(WIN32 AND DEFINED VCPKG_TARGET_TRIPLET)
     get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
     if(_is_multi_config)
         # Multi-config: use generator expression to conditionally copy
-        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E $<IF:$<CONFIG:Debug>,copy_directory,true>
-                "${_vcpkg_debug_bin_dir}"
-                "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
-            COMMENT "Copying vcpkg debug DLLs (Debug config only)"
-        )
+        if(_vcpkg_debug_dlls)
+            add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E $<IF:$<CONFIG:Debug>,copy_if_different,true>
+                    ${_vcpkg_debug_dlls}
+                    "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+                COMMENT "Copying vcpkg debug DLLs (Debug config only)"
+            )
+        endif()
         message(STATUS "Post-build: vcpkg DLLs - release always, debug for Debug config only (multi-config)")
     else()
         # Single-config: check CMAKE_BUILD_TYPE at configure time
-        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND _vcpkg_debug_dlls)
             add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_directory
-                    "${_vcpkg_debug_bin_dir}"
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${_vcpkg_debug_dlls}
                     "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
                 COMMENT "Copying vcpkg debug DLLs"
             )

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -61,6 +61,14 @@ function(lfs_force_python_release_abi target_name)
     endif()
 endfunction()
 
+function(lfs_suppress_python_debug_abi target_name)
+    if(MSVC)
+        target_compile_options(${target_name} PRIVATE
+            "$<$<AND:$<PLATFORM_ID:Windows>,$<CONFIG:Debug>>:/U_DEBUG>"
+        )
+    endif()
+endfunction()
+
 # Apply to both Python::Python (for embedded Python) and Python::Module (for nanobind)
 lfs_force_python_release_abi(Python::Python)
 if(TARGET Python::Module)
@@ -207,6 +215,7 @@ set_target_properties(lfs_py PROPERTIES
 target_compile_definitions(lfs_py PRIVATE
     LFS_PYTHON_EXECUTABLE="${Python_EXECUTABLE}"
 )
+lfs_suppress_python_debug_abi(lfs_py)
 
 if(CMAKE_CXX_LINK_GROUP_USING_RESCAN_SUPPORTED)
     set(LFS_PY_INTERNAL_LINK_LIBS
@@ -307,10 +316,11 @@ endif()
 # Type stubs for IDE support (output to typings/ to avoid runtime conflicts)
 option(BUILD_PYTHON_STUBS "Generate Python type stubs (requires loading the module)" ON)
 
-# Skip stubgen for Debug builds on Windows: the nanobind module links to python312_d.dll (debug)
-# but vcpkg only provides a release Python interpreter (python312.dll), causing ABI mismatch.
+# Skip stubgen for Debug builds on Windows: vcpkg provides a release Python
+# interpreter, while Debug extension loading still has ABI-sensitive edges.
 # Stubs are primarily useful for IDE support and can be generated from Release builds.
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+get_property(LFS_GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(WIN32 AND NOT LFS_GENERATOR_IS_MULTI_CONFIG AND CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(STATUS "Skipping Python stubs for Debug build (vcpkg Python is release-only)")
     set(BUILD_PYTHON_STUBS OFF)
 endif()
@@ -319,6 +329,10 @@ if(BUILD_PYTHON_STUBS)
     set(GENERATED_STUBS_DIR "${CMAKE_CURRENT_BINARY_DIR}/typings")
     set(COMMITTED_STUBS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/stubs")
     set(PYTHON_STUB_WORKFLOW_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/manage_stubs.py")
+    set(GENERATED_STUBS_MARKER "${GENERATED_STUBS_DIR}/lichtfeld/py.typed")
+    if(WIN32 AND LFS_GENERATOR_IS_MULTI_CONFIG)
+        set(GENERATED_STUBS_MARKER "${GENERATED_STUBS_DIR}/$<CONFIG>/lichtfeld/py.typed")
+    endif()
 
     if(WIN32)
         # On Windows, we need to set PATH for DLL loading before running stubgen
@@ -338,7 +352,13 @@ if(BUILD_PYTHON_STUBS)
             # Use file(GENERATE) to evaluate generator expressions at generation time
             set(STUBGEN_WRAPPER "${CMAKE_CURRENT_BINARY_DIR}/run_stubgen_$<CONFIG>.py")
             file(GENERATE OUTPUT "${STUBGEN_WRAPPER}" CONTENT "
-import os, sys
+import os, pathlib, sys
+
+stub_marker = pathlib.Path(r'${GENERATED_STUBS_MARKER}')
+if '$<CONFIG>' == 'Debug':
+    stub_marker.parent.mkdir(parents=True, exist_ok=True)
+    stub_marker.touch()
+    sys.exit(0)
 
 # Add DLL directories (Python 3.8+ requirement on Windows)
 dll_dirs = [
@@ -375,16 +395,19 @@ for pyi in glob.glob(r'${GENERATED_STUBS_DIR}/**/*.pyi', recursive=True):
         if count == 0:
             break
     p.write_bytes(content.encode('utf-8'))
+
+stub_marker.parent.mkdir(parents=True, exist_ok=True)
+stub_marker.touch()
 ")
 
             add_custom_command(
-                OUTPUT ${GENERATED_STUBS_DIR}/lichtfeld/py.typed
+                OUTPUT "${GENERATED_STUBS_MARKER}"
                 COMMAND "${Python_EXECUTABLE}" "${STUBGEN_WRAPPER}"
                 WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
                 DEPENDS lfs_py lfs_python_runtime "${NB_STUBGEN}"
                 COMMENT "Generating Python stubs for lichtfeld (Windows)"
             )
-            add_custom_target(lichtfeld_stub ALL DEPENDS ${GENERATED_STUBS_DIR}/lichtfeld/py.typed)
+            add_custom_target(lichtfeld_stub ALL DEPENDS "${GENERATED_STUBS_MARKER}")
         endif()
     else()
         nanobind_add_stub(lichtfeld_stub
@@ -409,19 +432,50 @@ for pyi in glob.glob(r'${GENERATED_STUBS_DIR}/**/*.pyi', recursive=True):
         VERBATIM
     )
 
+    set(PYTHON_STUB_CHECK_STAMP "${CMAKE_CURRENT_BINARY_DIR}/python_stub_check.stamp")
+    set(PYTHON_STUB_CHECK_COMMAND
+        "${Python_EXECUTABLE}" "${PYTHON_STUB_WORKFLOW_SCRIPT}"
+        check
+        --generated "${GENERATED_STUBS_DIR}"
+        --committed "${COMMITTED_STUBS_DIR}"
+    )
+    if(WIN32 AND LFS_GENERATOR_IS_MULTI_CONFIG)
+        set(PYTHON_STUB_CHECK_STAMP "${CMAKE_CURRENT_BINARY_DIR}/python_stub_check_$<CONFIG>.stamp")
+        set(PYTHON_STUB_CHECK_WRAPPER "${CMAKE_CURRENT_BINARY_DIR}/check_python_stubs_$<CONFIG>.py")
+        file(GENERATE OUTPUT "${PYTHON_STUB_CHECK_WRAPPER}" CONTENT "
+import pathlib, subprocess, sys
+
+stamp = pathlib.Path(r'${PYTHON_STUB_CHECK_STAMP}')
+if '$<CONFIG>' == 'Debug':
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.touch()
+    sys.exit(0)
+
+result = subprocess.run([
+    r'${Python_EXECUTABLE}',
+    r'${PYTHON_STUB_WORKFLOW_SCRIPT}',
+    'check',
+    '--generated', r'${GENERATED_STUBS_DIR}',
+    '--committed', r'${COMMITTED_STUBS_DIR}',
+])
+if result.returncode != 0:
+    sys.exit(result.returncode)
+stamp.parent.mkdir(parents=True, exist_ok=True)
+stamp.touch()
+")
+        set(PYTHON_STUB_CHECK_COMMAND "${Python_EXECUTABLE}" "${PYTHON_STUB_CHECK_WRAPPER}")
+    endif()
+
     add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/python_stub_check.stamp"
-        COMMAND "${Python_EXECUTABLE}" "${PYTHON_STUB_WORKFLOW_SCRIPT}"
-            check
-            --generated "${GENERATED_STUBS_DIR}"
-            --committed "${COMMITTED_STUBS_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/python_stub_check.stamp"
+        OUTPUT "${PYTHON_STUB_CHECK_STAMP}"
+        COMMAND ${PYTHON_STUB_CHECK_COMMAND}
+        COMMAND ${CMAKE_COMMAND} -E touch "${PYTHON_STUB_CHECK_STAMP}"
         DEPENDS lichtfeld_stub "${PYTHON_STUB_WORKFLOW_SCRIPT}" ${COMMITTED_STUB_FILES}
         COMMENT "Checking committed Python stubs against generated stubs"
         VERBATIM
     )
     add_custom_target(check_python_stubs ALL
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/python_stub_check.stamp"
+        DEPENDS "${PYTHON_STUB_CHECK_STAMP}"
     )
 endif()
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -61,14 +61,6 @@ function(lfs_force_python_release_abi target_name)
     endif()
 endfunction()
 
-function(lfs_suppress_python_debug_abi target_name)
-    if(MSVC)
-        target_compile_options(${target_name} PRIVATE
-            "$<$<AND:$<PLATFORM_ID:Windows>,$<CONFIG:Debug>>:/U_DEBUG>"
-        )
-    endif()
-endfunction()
-
 # Apply to both Python::Python (for embedded Python) and Python::Module (for nanobind)
 lfs_force_python_release_abi(Python::Python)
 if(TARGET Python::Module)
@@ -215,7 +207,7 @@ set_target_properties(lfs_py PROPERTIES
 target_compile_definitions(lfs_py PRIVATE
     LFS_PYTHON_EXECUTABLE="${Python_EXECUTABLE}"
 )
-lfs_suppress_python_debug_abi(lfs_py)
+
 
 if(CMAKE_CXX_LINK_GROUP_USING_RESCAN_SUPPORTED)
     set(LFS_PY_INTERNAL_LINK_LIBS

--- a/src/visualizer/gui/rml_modal_overlay.cpp
+++ b/src/visualizer/gui/rml_modal_overlay.cpp
@@ -37,8 +37,9 @@ namespace lfs::vis::gui {
 
     RmlModalOverlay::~RmlModalOverlay() {
         fbo_.destroy();
-        text_input_revert_.clear();
-        if (rml_context_ && rml_manager_)
+        if (Rml::GetSystemInterface())
+            text_input_revert_.clear();
+        if (rml_context_ && rml_manager_ && rml_manager_->isInitialized())
             rml_manager_->destroyContext("modal_overlay");
     }
 

--- a/src/visualizer/gui/rmlui/rml_input_utils.hpp
+++ b/src/visualizer/gui/rmlui/rml_input_utils.hpp
@@ -85,10 +85,10 @@ namespace lfs::vis::gui::rml_input {
         using RestoreCallback = std::function<void(Rml::Element&)>;
 
         ~TextInputEscapeRevertController() override {
-            // Don't call clear() here - at destruction time, RmlUI may already
-            // be shut down, causing crashes when trying to remove event listeners.
-            // RmlUI will clean up the listeners when elements are destroyed anyway.
-            bindings_.clear();
+            if (Rml::GetSystemInterface())
+                clear();
+            else
+                bindings_.clear();
         }
 
         void bind(Rml::Element* element, RestoreCallback restore_callback = {}) {

--- a/src/visualizer/gui/rmlui/rml_panel_host.cpp
+++ b/src/visualizer/gui/rmlui/rml_panel_host.cpp
@@ -204,9 +204,8 @@ namespace lfs::vis::gui {
     RmlPanelHost::~RmlPanelHost() {
         std::erase_if(queued_foreground_composites_,
                       [this](const CompositeCommand& cmd) { return cmd.fbo == &fbo_; });
-        // Don't call destroyContext here - at destruction time, RmlUIManager or
-        // RmlUI itself may already be shut down. The RmlUIManager::shutdown()
-        // method handles cleanup of all contexts.
+        if (manager_ && manager_->isInitialized())
+            manager_->destroyContext(context_name_);
         rml_context_ = nullptr;
         document_ = nullptr;
     }

--- a/src/visualizer/gui/rmlui/rmlui_manager.cpp
+++ b/src/visualizer/gui/rmlui/rmlui_manager.cpp
@@ -128,10 +128,8 @@ namespace lfs::vis::gui {
             debugger_initialized_ = false;
         }
 
-        for (auto& [name, ctx] : contexts_) {
-            Rml::RemoveContext(name);
-        }
-        contexts_.clear();
+        while (!contexts_.empty())
+            destroyContext(contexts_.begin()->first);
 
         if (Rml::GetTextInputHandler() == text_input_handler_.get())
             Rml::SetTextInputHandler(nullptr);
@@ -194,6 +192,9 @@ namespace lfs::vis::gui {
     }
 
     void RmlUIManager::destroyContext(const std::string& name) {
+        if (!initialized_)
+            return;
+
         auto it = contexts_.find(name);
         if (it != contexts_.end()) {
             if (system_interface_)

--- a/src/visualizer/gui/rmlui/rmlui_manager.hpp
+++ b/src/visualizer/gui/rmlui/rmlui_manager.hpp
@@ -30,6 +30,7 @@ namespace lfs::vis::gui {
 
         bool init(SDL_Window* window, float dp_ratio = 1.0f);
         void shutdown();
+        [[nodiscard]] bool isInitialized() const { return initialized_; }
 
         float getDpRatio() const { return dp_ratio_; }
         void setDpRatio(float ratio);


### PR DESCRIPTION
From the "cleanup" commit, I only removed the function "lfs_suppress_python_debug_abi"

## What the function did

`lfs_suppress_python_debug_abi(target_name)` was a CMake helper defined in
`src/python/CMakeLists.txt`. On MSVC / Windows it added `/U_DEBUG` to a target's
compile options, scoped to Debug builds only:

```cmake
function(lfs_suppress_python_debug_abi target_name)
    if(MSVC)
        target_compile_options(${target_name} PRIVATE
            "$<$<AND:$<PLATFORM_ID:Windows>,$<CONFIG:Debug>>:/U_DEBUG>"
        )
    endif()
endfunction()
```

`/U_DEBUG` is MSVC's "undefine macro" flag. In a Debug configuration the
compiler automatically defines `_DEBUG`; this flag removes that definition for
the named target's translation units.

## Why it was introduced

vcpkg ships only a **release** Python interpreter on Windows. There is no
`python312_d.dll` / `python312_d.lib` in the vcpkg tree. When the extension
module (`lfs_py`) was compiled in Debug mode, Python's own headers check for
`_DEBUG` and redirect symbol names through their debug variants (e.g.
`Py_InitializeEx` → `Py_InitializeEx_d`), causing unresolved-symbol link
errors against the release Python DLL.

The intent of `lfs_suppress_python_debug_abi` was to prevent `_DEBUG` from
activating those Python-specific debug redirects.

## Why it caused LNK2038

MSVC's C++ standard library (and the runtime) also consult `_DEBUG` when
deciding the iterator-debug level:

| `_DEBUG` | `_ITERATOR_DEBUG_LEVEL` | Runtime lib |
|----------|------------------------|-------------|
| defined  | 2 (Debug)              | `MDd`       |
| **not** defined | 0 (Release)   | `MD`        |

By undefining `_DEBUG` only on `lfs_py`, the extension module's `.obj` files
were compiled with `_ITERATOR_DEBUG_LEVEL = 0` (Release ABI). However,
`nanobind-static.lib` and every other static library linked into `lfs_py` were
compiled in ordinary Debug mode with `_ITERATOR_DEBUG_LEVEL = 2`. The linker
detected this cross-ABI mismatch and emitted:

```
LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL':
         value '0' doesn't match value '2' in nanobind-static.lib(...)
```

## The correct fix — `lfs_force_python_release_abi`

The right approach is to swap the Python **import library** and **DLL** for
their release variants in the Debug configuration, without touching `_DEBUG` at
all. `lfs_force_python_release_abi(target_name)` does exactly this: it reads the
`IMPORTED_IMPLIB_DEBUG` / `IMPORTED_LOCATION_DEBUG` properties of the
`Python::Python`, `Python::Module`, and `Python::SABIModule` imported targets and
replaces the `_d`-suffixed paths with their non-debug counterparts.

This way:
- All translation units (including `lfs_py`) see `_DEBUG` and compile with the
  Debug C++ ABI (`_ITERATOR_DEBUG_LEVEL = 2`, `MDd`).
- The linker resolves Python symbols against the release `python312.dll` /
  `python312.lib`.
- No ABI mismatch occurs.

## Removal (April 2026)

`lfs_suppress_python_debug_abi` was removed from `src/python/CMakeLists.txt`
because:

1. Its only call site (`lfs_suppress_python_debug_abi(lfs_py)`) had already
   been removed to fix the LNK2038 error.
2. The function had no remaining callers, making it dead code.
3. `lfs_force_python_release_abi` (already in use) is the correct solution for
   the underlying problem.
