### PR TITLE
proper build type in about window

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -206,6 +206,8 @@ set_target_properties(lfs_py PROPERTIES
 
 target_compile_definitions(lfs_py PRIVATE
     LFS_PYTHON_EXECUTABLE="${Python_EXECUTABLE}"
+    $<$<CONFIG:Debug>:DEBUG_BUILD>
+    $<$<CONFIG:Release>:RELEASE_BUILD>
 )
 
 if(CMAKE_CXX_LINK_GROUP_USING_RESCAN_SUPPORTED)


### PR DESCRIPTION
When viewing the "about" window, the build type always shows "release", even with a debug build.  this makes it hard to identify what build is actually running.
The panel already was having the option to distinguish between  these build types but the correct parameter was not passed and thus it always defaulted to "release".

this patch passes the correct config to the compile definitions so that the code can set the proper label.

<img width="492" height="356" alt="image" src="https://github.com/user-attachments/assets/360b8888-22b2-42a7-83f2-05a3e459a588" />
