### PR TITLE
Fix potential missing-source failure of libvterm during a Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1028,6 +1028,55 @@ if(TARGET nvimgcodec)
     endif()
 endif()
 
+# Linux install payload sanity copy. This mirrors the runtime layout used by the
+# build tree so manually assembled installs under prefixes such as /opt/lfs have
+# the Python extension, support modules, vcpkg shared libs, and Python stdlib.
+if(UNIX AND NOT APPLE AND DEFINED VCPKG_TARGET_TRIPLET)
+    install(CODE "
+        set(_lfs_prefix \"\${CMAKE_INSTALL_PREFIX}\")
+        set(_lfs_libdir \"\${_lfs_prefix}/${CMAKE_INSTALL_LIBDIR}\")
+        set(_lfs_build_dir \"${CMAKE_BINARY_DIR}\")
+        set(_lfs_triplet \"${VCPKG_TARGET_TRIPLET}\")
+        file(MAKE_DIRECTORY \"\${_lfs_libdir}\")
+
+        set(_lfs_rmlui \"\${_lfs_build_dir}/liblfs_rmlui.so\")
+        if(EXISTS \"\${_lfs_rmlui}\")
+            file(INSTALL \"\${_lfs_rmlui}\" DESTINATION \"\${_lfs_libdir}\")
+        endif()
+
+        set(_lfs_vcpkg_libdir \"\${_lfs_build_dir}/vcpkg_installed/\${_lfs_triplet}/lib\")
+        if(EXISTS \"\${_lfs_vcpkg_libdir}\")
+            file(GLOB _lfs_vcpkg_shared \"\${_lfs_vcpkg_libdir}/*.so\" \"\${_lfs_vcpkg_libdir}/*.so.*\")
+            foreach(_lfs_vcpkg_lib IN LISTS _lfs_vcpkg_shared)
+                file(INSTALL \"\${_lfs_vcpkg_lib}\" DESTINATION \"\${_lfs_libdir}\" FOLLOW_SYMLINK_CHAIN)
+            endforeach()
+        endif()
+
+        set(_lfs_built_python \"\${_lfs_build_dir}/src/python\")
+        if(EXISTS \"\${_lfs_built_python}\")
+            file(INSTALL DESTINATION \"\${_lfs_libdir}/python\" TYPE DIRECTORY FILES \"\${_lfs_built_python}/\"
+                PATTERN \"__pycache__\" EXCLUDE
+                PATTERN \"*.pyc\" EXCLUDE)
+        endif()
+
+        set(_lfs_vcpkg_python \"\${_lfs_vcpkg_libdir}/python3.12\")
+        if(EXISTS \"\${_lfs_vcpkg_python}\")
+            file(INSTALL DESTINATION \"\${_lfs_libdir}/python3.12\" TYPE DIRECTORY FILES \"\${_lfs_vcpkg_python}/\"
+                PATTERN \"__pycache__\" EXCLUDE
+                PATTERN \"*.pyc\" EXCLUDE
+                PATTERN \"test\" EXCLUDE
+                PATTERN \"tests\" EXCLUDE
+                PATTERN \"idle_test\" EXCLUDE
+                PATTERN \"tkinter\" EXCLUDE
+                PATTERN \"turtledemo\" EXCLUDE
+                PATTERN \"idlelib\" EXCLUDE
+                PATTERN \"lib2to3\" EXCLUDE
+                PATTERN \"ensurepip\" EXCLUDE
+                PATTERN \"unittest\" EXCLUDE)
+        endif()
+    " COMPONENT runtime)
+endif()
+
 # Portable build: bundle runtime dependencies via GET_RUNTIME_DEPENDENCIES
 if(BUILD_PORTABLE)
     # Exclusion patterns for system libraries

--- a/build_lichtfeld.ps1
+++ b/build_lichtfeld.ps1
@@ -397,11 +397,15 @@ function Setup-GitSubmodules {
     try {
         # Check if libvterm submodule is initialized
         $LibvtermPath = Join-Path $ProjectRoot "external\libvterm"
-        if (-not (Test-Path (Join-Path $LibvtermPath "src"))) {
+        $LibvtermSourceFile = Join-Path $LibvtermPath "src\encoding.c"
+        if (-not (Test-Path $LibvtermSourceFile)) {
             Write-Host "Initializing git submodules..." -ForegroundColor Yellow
-            git submodule update --init --recursive
+            git submodule update --init --recursive external/libvterm
             if ($LASTEXITCODE -ne 0) {
-                Write-Host "WARNING: Failed to initialize submodules" -ForegroundColor Yellow
+                throw "Failed to initialize external/libvterm. Run 'git submodule update --init --recursive external/libvterm' from $ProjectRoot, then retry the build."
+            }
+            if (-not (Test-Path $LibvtermSourceFile)) {
+                throw "external/libvterm is still incomplete after submodule initialization. Missing: $LibvtermSourceFile"
             } else {
                 Write-Host "Git submodules initialized successfully!" -ForegroundColor Green
             }

--- a/cmake/FetchLibvterm.cmake
+++ b/cmake/FetchLibvterm.cmake
@@ -9,6 +9,42 @@
 set(LIBVTERM_SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/libvterm)
 set(LIBVTERM_ENC_DIR ${LIBVTERM_SOURCE_DIR}/src/encoding)
 
+set(LIBVTERM_SOURCES
+    ${LIBVTERM_SOURCE_DIR}/src/encoding.c
+    ${LIBVTERM_SOURCE_DIR}/src/keyboard.c
+    ${LIBVTERM_SOURCE_DIR}/src/mouse.c
+    ${LIBVTERM_SOURCE_DIR}/src/parser.c
+    ${LIBVTERM_SOURCE_DIR}/src/pen.c
+    ${LIBVTERM_SOURCE_DIR}/src/screen.c
+    ${LIBVTERM_SOURCE_DIR}/src/state.c
+    ${LIBVTERM_SOURCE_DIR}/src/unicode.c
+    ${LIBVTERM_SOURCE_DIR}/src/vterm.c
+)
+
+if(NOT EXISTS ${LIBVTERM_SOURCE_DIR}/src/encoding.c)
+    find_package(Git QUIET)
+    if(GIT_FOUND AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
+        message(STATUS "libvterm sources not found; initializing external/libvterm submodule")
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive external/libvterm
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            RESULT_VARIABLE LIBVTERM_SUBMODULE_RESULT
+            OUTPUT_VARIABLE LIBVTERM_SUBMODULE_OUTPUT
+            ERROR_VARIABLE LIBVTERM_SUBMODULE_ERROR
+        )
+    endif()
+endif()
+
+foreach(LIBVTERM_SOURCE ${LIBVTERM_SOURCES})
+    if(NOT EXISTS ${LIBVTERM_SOURCE})
+        message(FATAL_ERROR
+            "libvterm submodule is missing or incomplete. "
+            "Run `git submodule update --init --recursive external/libvterm` from "
+            "${CMAKE_SOURCE_DIR}, then re-run CMake. Missing file: ${LIBVTERM_SOURCE}"
+        )
+    endif()
+endforeach()
+
 # Generate encoding tables if not present (pre-generated in submodule)
 if(NOT EXISTS ${LIBVTERM_ENC_DIR}/DECdrawing.inc OR NOT EXISTS ${LIBVTERM_ENC_DIR}/uk.inc)
     find_package(Perl REQUIRED)
@@ -29,18 +65,6 @@ if(NOT EXISTS ${LIBVTERM_ENC_DIR}/uk.inc)
         WORKING_DIRECTORY ${LIBVTERM_SOURCE_DIR}
     )
 endif()
-
-set(LIBVTERM_SOURCES
-    ${LIBVTERM_SOURCE_DIR}/src/encoding.c
-    ${LIBVTERM_SOURCE_DIR}/src/keyboard.c
-    ${LIBVTERM_SOURCE_DIR}/src/mouse.c
-    ${LIBVTERM_SOURCE_DIR}/src/parser.c
-    ${LIBVTERM_SOURCE_DIR}/src/pen.c
-    ${LIBVTERM_SOURCE_DIR}/src/screen.c
-    ${LIBVTERM_SOURCE_DIR}/src/state.c
-    ${LIBVTERM_SOURCE_DIR}/src/unicode.c
-    ${LIBVTERM_SOURCE_DIR}/src/vterm.c
-)
 
 add_library(vterm STATIC ${LIBVTERM_SOURCES})
 

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -192,6 +192,7 @@ namespace {
             ::args::Group output_sep(parser, " ");
             ::args::Group output_group(parser, "OUTPUT OPTIONS:");
             ::args::Flag enable_eval(output_group, "eval", "Enable evaluation during training", {"eval"});
+            ::args::Flag eval_final_checkpoint(output_group, "eval_final_checkpoint", "Run evaluation on the final checkpoint even if it is not in eval_steps", {"eval-final", "eval-final-checkpoint"});
             ::args::Flag enable_save_eval_images(output_group, "save_eval_images", "Save evaluation comparison images (GT vs rendered)", {"save-eval-images"});
             ::args::Flag save_depth(output_group, "save_depth", "[TODO] Save depth maps during training (not yet implemented)", {"save-depth"});
             ::args::ValueFlagList<std::string> timelapse_images(output_group, "timelapse_images", "Image filenames to render timelapse images for", {"timelapse-images"});
@@ -552,6 +553,7 @@ namespace {
                                         ppisp_freeze_from_sidecar_flag = bool(ppisp_freeze_from_sidecar),
                                         ppisp_sidecar_path_val = cli_option_present({"--ppisp-sidecar"}) ? std::optional<std::string>(::args::get(ppisp_sidecar_path)) : std::optional<std::string>(),
                                         enable_eval_flag = bool(enable_eval),
+                                        eval_final_checkpoint_flag = bool(eval_final_checkpoint),
                                         headless_flag = bool(headless),
                                         auto_train_flag = bool(auto_train),
 #ifdef LFS_BUILD_PORTABLE
@@ -628,6 +630,9 @@ namespace {
                 if (opt.ppisp_freeze_from_sidecar)
                     opt.use_ppisp = true;
                 setFlag(enable_eval_flag, opt.enable_eval);
+                setFlag(eval_final_checkpoint_flag, opt.eval_final_checkpoint);
+                if (opt.eval_final_checkpoint)
+                    opt.enable_eval = true;
                 setFlag(headless_flag, opt.headless);
                 setFlag(auto_train_flag, opt.auto_train);
                 setFlag(no_splash_flag, opt.no_splash);

--- a/src/core/include/core/executable_path.hpp
+++ b/src/core/include/core/executable_path.hpp
@@ -148,6 +148,12 @@ namespace lfs::core {
             return dev;
         }
 
+        // Development with configuration-specific executable dirs
+        // (e.g. build/Release/LichtFeld-Studio with module in build/src/python).
+        if (const auto dev_parent = exe_dir.parent_path() / "src" / "python"; module_exists(dev_parent)) {
+            return dev_parent;
+        }
+
         // Fallback: module in same directory as exe (Windows dev builds)
         if (module_exists(exe_dir)) {
             return exe_dir;

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -11,6 +11,7 @@
 #include <cctype>
 #include <expected>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -41,6 +42,23 @@ namespace lfs::core {
         inline constexpr std::string_view kStrategyLFSLegacy = "lfs";
         inline constexpr std::string_view kStrategyIGSPlus = "igs+";
 
+        [[nodiscard]] inline std::optional<std::filesystem::path> nerfstudio_project_root_from_sparse_path(
+            const std::filesystem::path& dataset_path) {
+            const auto normalized = dataset_path.lexically_normal();
+            const auto sparse_path = normalized.parent_path();
+            const auto colmap_path = sparse_path.parent_path();
+            const auto project_root = colmap_path.parent_path();
+
+            if (normalized.filename().empty() ||
+                sparse_path.filename() != "sparse" ||
+                colmap_path.filename() != "colmap" ||
+                project_root.empty()) {
+                return std::nullopt;
+            }
+
+            return project_root;
+        }
+
         [[nodiscard]] inline std::filesystem::path default_dataset_output_path(
             const std::filesystem::path& dataset_path) {
             auto base_path = dataset_path;
@@ -50,6 +68,8 @@ namespace lfs::core {
             });
             if (ext == ".json") {
                 base_path = dataset_path.parent_path();
+            } else if (const auto nerfstudio_root = nerfstudio_project_root_from_sparse_path(dataset_path)) {
+                base_path = *nerfstudio_root;
             }
             return base_path / "output";
         }

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -108,6 +108,7 @@ namespace lfs::core {
             std::vector<size_t> save_steps = {7'000, 30'000};  // Steps to save the model
             bool bg_modulation = false;                        // Enable sinusoidal background modulation
             bool enable_eval = false;                          // Only evaluate when explicitly enabled
+            bool eval_final_checkpoint = false;                // Always evaluate the final checkpoint
             bool enable_save_eval_images = true;               // Save during evaluation images
             bool headless = false;                             // Disable visualization during training
             bool auto_train = false;                           // Start training immediately on startup

--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -116,6 +116,7 @@ namespace lfs::core {
             opt_json["eval_steps"] = eval_steps;
             opt_json["save_steps"] = save_steps;
             opt_json["enable_eval"] = enable_eval;
+            opt_json["eval_final_checkpoint"] = eval_final_checkpoint;
             opt_json["enable_save_eval_images"] = enable_save_eval_images;
             opt_json["headless"] = headless;
             const auto canonical_strategy = canonical_strategy_name(strategy);
@@ -327,6 +328,12 @@ namespace lfs::core {
 
             if (json.contains("enable_eval")) {
                 params.enable_eval = json["enable_eval"];
+            }
+            if (json.contains("eval_final_checkpoint")) {
+                params.eval_final_checkpoint = json["eval_final_checkpoint"];
+                if (params.eval_final_checkpoint) {
+                    params.enable_eval = true;
+                }
             }
             if (json.contains("enable_save_eval_images")) {
                 params.enable_save_eval_images = json["enable_save_eval_images"];

--- a/src/io/include/io/filesystem_utils.hpp
+++ b/src/io/include/io/filesystem_utils.hpp
@@ -66,6 +66,8 @@ namespace lfs::io {
         ".mask.png",
     };
 
+    inline constexpr const char* NERFSTUDIO_IMAGES_DIR_FALLBACK = "../../../images";
+
     // Safe filesystem operations that don't throw
     inline bool safe_exists(const fs::path& path) {
         std::error_code ec;
@@ -212,12 +214,43 @@ namespace lfs::io {
     };
 
     // Get standard COLMAP search paths for a base directory
+    inline void append_colmap_sparse_model_dirs(std::vector<fs::path>& paths,
+                                                const fs::path& sparse_root) {
+        if (!safe_is_directory(sparse_root)) {
+            return;
+        }
+
+        std::vector<fs::path> model_dirs;
+        std::error_code ec;
+        for (fs::directory_iterator it(sparse_root, ec), end; !ec && it != end; it.increment(ec)) {
+            std::error_code file_ec;
+            if (!it->is_directory(file_ec) || file_ec) {
+                continue;
+            }
+            model_dirs.push_back(it->path());
+        }
+
+        std::sort(model_dirs.begin(), model_dirs.end());
+        for (const auto& model_dir : model_dirs) {
+            if (std::find(paths.begin(), paths.end(), model_dir) == paths.end()) {
+                paths.push_back(model_dir);
+            }
+        }
+    }
+
     inline std::vector<fs::path> get_colmap_search_paths(const fs::path& base) {
-        return {
-            base / "sparse" / "0", // Standard COLMAP
-            base / "sparse",       // Alternative COLMAP
-            base                   // Reality Capture / flat structure
-        };
+        std::vector<fs::path> paths;
+        paths.reserve(8);
+
+        paths.push_back(base / "sparse" / "0");          // Standard COLMAP
+        append_colmap_sparse_model_dirs(paths, base / "sparse");
+        paths.push_back(base / "sparse");                // Alternative COLMAP
+        paths.push_back(base / "colmap" / "sparse" / "0"); // Nerfstudio
+        append_colmap_sparse_model_dirs(paths, base / "colmap" / "sparse");
+        paths.push_back(base / "colmap" / "sparse");     // Alternative Nerfstudio
+        paths.push_back(base);                            // Reality Capture / flat structure
+
+        return paths;
     }
 
     // Check if a file has an image extension
@@ -414,6 +447,18 @@ namespace lfs::io {
             const bool recursive_image_scan =
                 !paths_equivalent_or_lexically_equal(info.images_path, base_path);
             info.image_count = count_image_files(info.images_path, recursive_image_scan);
+        }
+
+        if (info.image_count == 0) {
+            const fs::path nerfstudio_images_path =
+                (base_path / NERFSTUDIO_IMAGES_DIR_FALLBACK).lexically_normal();
+            if (!paths_equivalent_or_lexically_equal(nerfstudio_images_path, info.images_path)) {
+                const int nerfstudio_image_count = count_image_files(nerfstudio_images_path, true);
+                if (nerfstudio_image_count > 0) {
+                    info.images_path = nerfstudio_images_path;
+                    info.image_count = nerfstudio_image_count;
+                }
+            }
         }
 
         for (const auto& sp : get_colmap_search_paths(base_path)) {

--- a/src/io/loaders/colmap_loader.cpp
+++ b/src/io/loaders/colmap_loader.cpp
@@ -122,17 +122,74 @@ namespace lfs::io {
             return candidate.lexically_normal() == path.lexically_normal();
         };
 
-        // If specified folder doesn't exist, check for flat structure
+        auto try_nerfstudio_image_root_fallback = [&]() {
+            if (actual_images_folder != "images") {
+                return false;
+            }
+
+            const auto fallback_path = (path / NERFSTUDIO_IMAGES_DIR_FALLBACK).lexically_normal();
+            if (count_image_files(fallback_path, true) == 0) {
+                return false;
+            }
+
+            actual_images_folder = lfs::core::path_to_utf8(fallback_path);
+            image_dir = fallback_path;
+            LOG_INFO("Detected Nerfstudio COLMAP layout - using '{}' as image root",
+                     actual_images_folder);
+            return true;
+        };
+
+        // If specified folder doesn't exist, check for Nerfstudio and flat layouts.
         if (!std::filesystem::exists(image_dir)) {
-            const auto cameras_txt_parent =
-                cameras_txt.empty() ? std::filesystem::path{} : cameras_txt.parent_path();
-            const auto cameras_bin_parent =
-                cameras_bin.empty() ? std::filesystem::path{} : cameras_bin.parent_path();
+            if (!try_nerfstudio_image_root_fallback()) {
+                const auto cameras_txt_parent =
+                    cameras_txt.empty() ? std::filesystem::path{} : cameras_txt.parent_path();
+                const auto cameras_bin_parent =
+                    cameras_bin.empty() ? std::filesystem::path{} : cameras_bin.parent_path();
 
-            bool is_flat_structure = is_dataset_root(cameras_txt_parent) ||
-                                     is_dataset_root(cameras_bin_parent);
+                bool is_flat_structure = is_dataset_root(cameras_txt_parent) ||
+                                         is_dataset_root(cameras_bin_parent);
 
-            if (is_flat_structure) {
+                if (is_flat_structure) {
+                    bool has_images_in_root = false;
+                    for (const auto& entry : std::filesystem::directory_iterator(path)) {
+                        if (entry.is_regular_file() && is_image_file(entry.path())) {
+                            has_images_in_root = true;
+                            break;
+                        }
+                    }
+
+                    if (has_images_in_root) {
+                        actual_images_folder = ".";
+                        image_dir = path;
+                        LOG_INFO("Detected flat structure - using root directory for images");
+                    } else {
+                        return make_error(ErrorCode::MISSING_REQUIRED_FILES,
+                                          std::format("Images directory '{}' not found and no images in root",
+                                                      options.images_folder),
+                                          path);
+                    }
+                } else {
+                    return make_error(ErrorCode::MISSING_REQUIRED_FILES,
+                                      std::format("Images directory '{}' not found", options.images_folder), path);
+                }
+            }
+        } else if (count_image_files(image_dir, true) == 0) {
+            if (!try_nerfstudio_image_root_fallback()) {
+                const auto cameras_txt_parent =
+                    cameras_txt.empty() ? std::filesystem::path{} : cameras_txt.parent_path();
+                const auto cameras_bin_parent =
+                    cameras_bin.empty() ? std::filesystem::path{} : cameras_bin.parent_path();
+
+                bool is_flat_structure = is_dataset_root(cameras_txt_parent) ||
+                                         is_dataset_root(cameras_bin_parent);
+
+                if (!is_flat_structure) {
+                    return make_error(ErrorCode::MISSING_REQUIRED_FILES,
+                                      std::format("Images directory '{}' contains no images", options.images_folder),
+                                      image_dir);
+                }
+
                 bool has_images_in_root = false;
                 for (const auto& entry : std::filesystem::directory_iterator(path)) {
                     if (entry.is_regular_file() && is_image_file(entry.path())) {
@@ -147,13 +204,10 @@ namespace lfs::io {
                     LOG_INFO("Detected flat structure - using root directory for images");
                 } else {
                     return make_error(ErrorCode::MISSING_REQUIRED_FILES,
-                                      std::format("Images directory '{}' not found and no images in root",
+                                      std::format("Images directory '{}' contains no images and no images in root",
                                                   options.images_folder),
                                       path);
                 }
-            } else {
-                return make_error(ErrorCode::MISSING_REQUIRED_FILES,
-                                  std::format("Images directory '{}' not found", options.images_folder), path);
             }
         }
 

--- a/src/python/lfs_plugins/import_panels.py
+++ b/src/python/lfs_plugins/import_panels.py
@@ -186,8 +186,19 @@ class DatasetImportPanel(_ImportDialogPanel):
 
     def _default_output_path(self, dataset_path: str, info) -> str:
         preview_root = self._preview_base_path(dataset_path)
+        nerfstudio_root = self._nerfstudio_project_root(preview_root)
+        if nerfstudio_root is not None:
+            return str(nerfstudio_root / "output")
         base_path = Path(info.base_path) if info is not None else preview_root
         return str(base_path / "output")
+
+    def _nerfstudio_project_root(self, path: Path):
+        parts = path.parts
+        if len(parts) < 3:
+            return None
+        if parts[-2] == "sparse" and parts[-3] == "colmap":
+            return path.parent.parent.parent
+        return None
 
     def _apply_dataset_path(self, dataset_path: str, reset_output: bool) -> bool:
         next_value = str(dataset_path).strip()

--- a/src/python/runner.cpp
+++ b/src/python/runner.cpp
@@ -558,8 +558,12 @@ _add_dll_dirs()
                     LOG_INFO("Added Python module dir to path: {}", python_module_dir_utf8);
                 } else {
                     const auto exe_dir_utf8 = lfs::core::path_to_utf8(lfs::core::getExecutableDir());
-                    LOG_WARN("Python module 'lichtfeld' not found. Expected a lichtfeld*.so/.pyd in: {}/src/python, {}",
-                             exe_dir_utf8, exe_dir_utf8);
+                    const auto parent_dir_utf8 = lfs::core::path_to_utf8(lfs::core::getExecutableDir().parent_path());
+                    LOG_WARN("Python module 'lichtfeld' not found. Expected a lichtfeld*.so/.pyd in: {}/../lib/python, {}/src/python, {}/src/python, {}",
+                             exe_dir_utf8,
+                             exe_dir_utf8,
+                             parent_dir_utf8,
+                             exe_dir_utf8);
                 }
             }
 

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -3594,12 +3594,27 @@ namespace lfs::training {
                 cudaStreamSynchronize(callback_stream_);
             }
 
+            const bool completed_normally = !stop_requested_.load() && !stop_token.stop_requested();
+
             // Final save if not already saved by stop request
-            if (!stop_requested_.load() && !stop_token.stop_requested()) {
+            if (completed_normally) {
                 auto final_path = params_.dataset.output_path;
                 const bool rotate_checkpoint = get_active_sparsify_steps() == 0;
                 save_ply(final_path, params_.dataset.output_name, get_total_iterations(), /*join=*/true,
                          /*save_checkpoint=*/rotate_checkpoint);
+            }
+
+            if (completed_normally &&
+                params_.optimization.eval_final_checkpoint &&
+                evaluator_ &&
+                evaluator_->is_enabled() &&
+                !evaluator_->should_evaluate(get_total_iterations())) {
+                evaluator_->print_evaluation_header(get_total_iterations());
+                auto metrics = evaluator_->evaluate(get_total_iterations(),
+                                                    strategy_->get_model(),
+                                                    val_dataset_,
+                                                    background_);
+                LOG_INFO("Final checkpoint metrics: {}", metrics.to_string());
             }
 
             maybe_publish_camera_loss_heatmap(current_iteration_.load(), true);

--- a/src/visualizer/gui/utils/native_file_dialog.cpp
+++ b/src/visualizer/gui/utils/native_file_dialog.cpp
@@ -11,11 +11,17 @@
 #include <nfd.h>
 
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <utility>
 #include <vector>
+
+#if defined(__linux__)
+#include <sys/wait.h>
+#endif
 
 namespace lfs::vis::gui {
 
@@ -167,6 +173,107 @@ namespace lfs::vis::gui {
             return {};
         }
 
+        [[nodiscard]] bool isMissingLinuxPortalError(const char* error) {
+#if defined(__linux__)
+            return error &&
+                   std::strstr(error, "org.freedesktop.portal.Desktop") != nullptr &&
+                   std::strstr(error, "was not provided by any .service files") != nullptr;
+#else
+            (void)error;
+            return false;
+#endif
+        }
+
+#if defined(__linux__)
+        [[nodiscard]] std::string shellQuote(const std::string_view value) {
+            std::string quoted = "'";
+            for (const char ch : value) {
+                if (ch == '\'') {
+                    quoted += "'\\''";
+                } else {
+                    quoted += ch;
+                }
+            }
+            quoted += "'";
+            return quoted;
+        }
+
+        [[nodiscard]] std::string makeZenityFilenameArg(const DialogRequest& request,
+                                                        const std::filesystem::path& defaultDirectory) {
+            std::filesystem::path filename = defaultDirectory;
+            if (request.kind == DialogKind::SaveFile && !request.default_name.empty()) {
+                filename /= ensureDefaultExtension(request.default_name, request.required_extension);
+            }
+            if (filename.empty()) {
+                return {};
+            }
+            return " --filename=" + shellQuote(lfs::core::path_to_utf8(filename));
+        }
+
+        [[nodiscard]] std::string makeZenityFilterArgs(const std::vector<DialogFilter>& filters) {
+            std::string args;
+            for (const DialogFilter& filter : filters) {
+                std::string filterArg = filter.name + " |";
+                bool hasExtension = false;
+                for (const std::string& extension : filter.extensions) {
+                    const std::string normalized = normalizeExtension(extension);
+                    if (normalized.empty()) {
+                        continue;
+                    }
+                    filterArg += " *." + normalized;
+                    hasExtension = true;
+                }
+                if (hasExtension) {
+                    args += " --file-filter=" + shellQuote(filterArg);
+                }
+            }
+            return args;
+        }
+
+        bool runZenityDialog(const DialogRequest& request, std::filesystem::path& resultPath) {
+            resultPath.clear();
+
+            const std::filesystem::path defaultDirectory =
+                normalizeDefaultDirectory(request.default_path);
+            std::string command = "zenity --file-selection";
+            if (request.kind == DialogKind::SaveFile) {
+                command += " --save --confirm-overwrite";
+            } else if (request.kind == DialogKind::PickFolder) {
+                command += " --directory";
+            }
+            command += makeZenityFilenameArg(request, defaultDirectory);
+            command += makeZenityFilterArgs(request.filters);
+            command += " 2>/dev/null";
+
+            FILE* pipe = popen(command.c_str(), "r");
+            if (!pipe) {
+                LOG_WARN("Native file dialog fallback failed: could not launch zenity");
+                return false;
+            }
+
+            std::string output;
+            char buffer[4096];
+            while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+                output += buffer;
+            }
+            const int status = pclose(pipe);
+            if (status == -1 || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+                return false;
+            }
+
+            while (!output.empty() && (output.back() == '\n' || output.back() == '\r')) {
+                output.pop_back();
+            }
+            if (output.empty()) {
+                return false;
+            }
+
+            resultPath = appendRequiredExtension(lfs::core::utf8_to_path(output),
+                                                 request.required_extension);
+            return !resultPath.empty();
+        }
+#endif
+
         class FilterListStorage {
         public:
             explicit FilterListStorage(const std::vector<DialogFilter>& filters) {
@@ -312,8 +419,17 @@ namespace lfs::vis::gui {
 
             if (dialogResult != NFD_OKAY) {
                 const char* error = NFD_GetError();
-                LOG_ERROR("Native file dialog failed: {}",
-                          error ? error : "unknown error");
+                if (isMissingLinuxPortalError(error)) {
+#if defined(__linux__)
+                    LOG_WARN("Native file dialog portal unavailable; falling back to zenity.");
+                    return runZenityDialog(request, resultPath);
+#else
+                    LOG_WARN("Native file dialog unavailable: xdg-desktop-portal is not running or not installed.");
+#endif
+                } else {
+                    LOG_ERROR("Native file dialog failed: {}",
+                              error ? error : "unknown error");
+                }
                 return false;
             }
 

--- a/tests/python/test_import_dialog_panels.py
+++ b/tests/python/test_import_dialog_panels.py
@@ -249,6 +249,38 @@ def test_dataset_import_panel_loads_updated_dataset_path(import_dialog_module, t
     ]
 
 
+def test_dataset_import_panel_defaults_nerfstudio_sparse_output_to_project_root(import_dialog_module, tmp_path):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+
+    project_root = tmp_path / "nerfstudio_project"
+    sparse_dir = project_root / "colmap" / "sparse" / "0"
+    sparse_dir.mkdir(parents=True)
+    state.dataset_infos[str(sparse_dir)] = SimpleNamespace(
+        base_path=sparse_dir,
+        images_path=project_root / "images",
+        sparse_path=sparse_dir,
+        masks_path=project_root / "mask",
+        has_masks=False,
+        image_count=48,
+        mask_count=0,
+    )
+
+    assert panel.show(str(sparse_dir)) is True
+
+    panel._on_do_load()
+
+    assert state.load_file_calls == [
+        {
+            "path": str(sparse_dir),
+            "is_dataset": True,
+            "output_path": str(project_root / "output"),
+            "init_path": "",
+        }
+    ]
+
+
 def test_dataset_import_panel_clears_init_and_sidecar_on_dataset_change(import_dialog_module, tmp_path):
     module, state = import_dialog_module
     panel = module.DatasetImportPanel()

--- a/tests/test_colmap_image_layout.cpp
+++ b/tests/test_colmap_image_layout.cpp
@@ -330,6 +330,50 @@ TEST_F(ColmapImageLayoutTest, LoadCanBeCancelledDuringMetadataParse) {
     EXPECT_EQ(result.error().code, lfs::io::ErrorCode::CANCELLED);
 }
 
+TEST_F(ColmapImageLayoutTest, DetectDatasetInfoFallsBackToNerfstudioImageRootWhenDefaultImagesEmpty) {
+    const fs::path scene_dir = temp_dir_ / "nerfstudio_scene";
+    const fs::path sparse_dir = scene_dir / "colmap" / "sparse" / "0";
+
+    write_minimal_colmap_text_dataset(sparse_dir, "frame_0001.png");
+    write_png(scene_dir / "images" / "frame_0001.png");
+
+    auto info = lfs::io::detect_dataset_info(sparse_dir);
+
+    EXPECT_TRUE(fs::equivalent(info.images_path, scene_dir / "images"));
+    EXPECT_EQ(info.image_count, 1);
+}
+
+TEST_F(ColmapImageLayoutTest, LoaderFallsBackToNerfstudioImageRootWhenDefaultImagesEmpty) {
+    const fs::path scene_dir = temp_dir_ / "nerfstudio_scene";
+    const fs::path sparse_dir = scene_dir / "colmap" / "sparse" / "0";
+
+    write_minimal_colmap_text_dataset(sparse_dir, "frame_0001.png");
+    fs::create_directories(sparse_dir / "images");
+    write_png(scene_dir / "images" / "frame_0001.png");
+
+    lfs::io::ColmapLoader loader;
+    auto result = loader.load(sparse_dir, {.validate_only = true});
+
+    ASSERT_TRUE(result.has_value()) << result.error().format();
+}
+
+TEST_F(ColmapImageLayoutTest, LoaderFindsNerfstudioColmapSparseModelUnderSceneRoot) {
+    const fs::path scene_dir = temp_dir_ / "nerfstudio_scene";
+    const fs::path sparse_dir = scene_dir / "colmap" / "sparse" / "custom_model";
+
+    write_minimal_colmap_text_dataset(sparse_dir, "frame_0001.png");
+    write_png(scene_dir / "images" / "frame_0001.png");
+
+    const auto info = lfs::io::detect_dataset_info(scene_dir);
+    EXPECT_TRUE(fs::equivalent(info.images_path, scene_dir / "images"));
+    EXPECT_TRUE(fs::equivalent(info.sparse_path, sparse_dir));
+
+    lfs::io::ColmapLoader loader;
+    auto result = loader.load(scene_dir, {.validate_only = true});
+
+    ASSERT_TRUE(result.has_value()) << result.error().format();
+}
+
 TEST_F(ColmapImageLayoutTest, LoadCancelsInsteadOfFallingBackFromCustomPointCloudPly) {
     const fs::path dataset_dir = temp_dir_ / "dataset";
 

--- a/tests/test_parameter_manager.cpp
+++ b/tests/test_parameter_manager.cpp
@@ -3,6 +3,8 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
+
 #include "core/parameter_manager.hpp"
 #include "core/parameters.hpp"
 
@@ -17,6 +19,15 @@ namespace {
         EXPECT_EQ(manager.getActiveParams().strategy, "mrnf");
         EXPECT_EQ(lfs::core::param::OptimizationParameters{}.strategy, "mrnf");
         EXPECT_EQ(lfs::core::param::OptimizationParameters::mcmc_defaults().strategy, "mcmc");
+    }
+
+    TEST(ParameterManagerTest, DefaultDatasetOutputPathUsesNerfstudioProjectRootForSparseModelPath) {
+        const std::filesystem::path sparse_model_path =
+            "/workspace/projects/default/example/colmap/sparse/0";
+
+        EXPECT_EQ(
+            lfs::core::param::default_dataset_output_path(sparse_model_path),
+            std::filesystem::path("/workspace/projects/default/example/output"));
     }
 
     TEST(ParameterManagerTest, ImportTrainingParamsRestoresResolvedCheckpointState) {


### PR DESCRIPTION
This patch makes the Windows build reliably initialize and validate the external/libvterm submodule before CMake tries to compile it, replacing the missing-source failure with a clear fix path.