### PR TITLE
fix for vcpkg lookup after moving to build specific paths

### DIFF
--- a/src/core/include/core/executable_path.hpp
+++ b/src/core/include/core/executable_path.hpp
@@ -212,10 +212,14 @@ namespace lfs::core {
     // Discover the vcpkg triplet directory under vcpkg_installed/ at runtime.
     // Returns empty path if no matching triplet is found.
     inline std::filesystem::path findVcpkgPrefix(const std::filesystem::path& exe_dir) {
-        const auto vcpkg_root = exe_dir / "vcpkg_installed";
         std::error_code ec;
+        auto vcpkg_root = exe_dir / "vcpkg_installed";
         if (!std::filesystem::exists(vcpkg_root, ec)) {
-            return {};
+            // Per-config build (e.g. build/Release/): vcpkg_installed lives one level up
+            vcpkg_root = exe_dir.parent_path() / "vcpkg_installed";
+            if (!std::filesystem::exists(vcpkg_root, ec)) {
+                return {};
+            }
         }
 
         if (const auto prefix = preferredVcpkgPrefix(vcpkg_root); !prefix.empty()) {


### PR DESCRIPTION
## Problem

After the per-config output directory changes (`build/Release/`, `build/Debug/` etc.),
LichtFeld-Studio failed to initialize Python on machines without a system Python 3.12 install.

## Root Cause

`findVcpkgPrefix()` in `src/core/include/core/executable_path.hpp` looks for
`vcpkg_installed/` relative to the executable directory:

When the lookup fails, `getPythonHome()` returns an empty path, `Py_SetPythonHome` is never
called, and CPython falls back to the Windows registry to find its stdlib. On machines with
Python 3.12 installed system-wide the registry fallback works silently, masking the bug.
On machines without system Python 3.12, initialization fails.
