### PR TITLE
fix usd export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -999,13 +999,20 @@ install(DIRECTORY "${CMAKE_SOURCE_DIR}/src/visualizer/gui/rmlui/resources/" DEST
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/src/visualizer/gui/resources/locales" DESTINATION "${INSTALL_RESOURCE_DIR}")
 
 # OpenUSD plugin resources (schema definitions + plugInfo.json files)
+# On Windows configure_usd_plugins() looks for <exe_dir>/usd → install next to the exe (bin/usd).
+# On Linux it looks for <exe_dir>/../lib/usd → install in lib/usd (unchanged).
+if(WIN32)
+    set(_USD_INSTALL_DEST "${CMAKE_INSTALL_BINDIR}/usd")
+else()
+    set(_USD_INSTALL_DEST "${CMAKE_INSTALL_LIBDIR}/usd")
+endif()
 if(EXISTS "${_USD_PLUGIN_SOURCE_DIR}")
-    install(DIRECTORY "${_USD_PLUGIN_SOURCE_DIR}/" DESTINATION "${CMAKE_INSTALL_LIBDIR}/usd"
+    install(DIRECTORY "${_USD_PLUGIN_SOURCE_DIR}/" DESTINATION "${_USD_INSTALL_DEST}"
             PATTERN "__pycache__" EXCLUDE
             PATTERN "*.pyc" EXCLUDE)
 endif()
 if(EXISTS "${_USD_ROOT_INDEX}")
-    install(FILES "${_USD_ROOT_INDEX}" DESTINATION "${CMAKE_INSTALL_LIBDIR}/usd")
+    install(FILES "${_USD_ROOT_INDEX}" DESTINATION "${_USD_INSTALL_DEST}")
 endif()
 
 # Plugin development documentation
@@ -1054,7 +1061,13 @@ if(BUILD_PORTABLE)
     # Search directories for runtime dependencies (quoted for paths with spaces on Windows)
     set(_SEARCH_DIRS_STR "\"${CMAKE_BINARY_DIR}\" \"${CMAKE_BINARY_DIR}/Release\" \"${CMAKE_BINARY_DIR}/external/nvImageCodec\" \"${CUDAToolkit_BIN_DIR}\" \"${CUDAToolkit_LIBRARY_DIR}\"")
 
-    # Helper: bundle runtime dependencies for a target
+    # Helper: bundle runtime dependencies for a target.
+    # On Windows DLLs must live beside the exe (bin/); on Linux they go in lib/.
+    if(WIN32)
+        set(_BUNDLE_DEST "${CMAKE_INSTALL_BINDIR}")
+    else()
+        set(_BUNDLE_DEST "${CMAKE_INSTALL_LIBDIR}")
+    endif()
     function(bundle_runtime_deps TARGET_FILE IS_LIBRARY)
         if(IS_LIBRARY)
             set(_type "LIBRARIES")
@@ -1062,7 +1075,6 @@ if(BUILD_PORTABLE)
             set(_type "EXECUTABLES")
         endif()
         install(CODE "
-            set(_lib \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}\")
             file(GET_RUNTIME_DEPENDENCIES
                 ${_type} \"${TARGET_FILE}\"
                 RESOLVED_DEPENDENCIES_VAR _deps
@@ -1070,7 +1082,7 @@ if(BUILD_PORTABLE)
                 PRE_EXCLUDE_REGEXES ${_PRE_EXCLUDE}
                 POST_EXCLUDE_REGEXES ${_POST_EXCLUDE})
             foreach(_d IN LISTS _deps)
-                file(INSTALL \"\${_d}\" DESTINATION \"\${_lib}\" FOLLOW_SYMLINK_CHAIN)
+                file(INSTALL \"\${_d}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${_BUNDLE_DEST}\" FOLLOW_SYMLINK_CHAIN)
             endforeach()
         " COMPONENT runtime)
     endfunction()
@@ -1087,13 +1099,7 @@ if(BUILD_PORTABLE)
                 @ONLY)
         install(PROGRAMS "${CMAKE_BINARY_DIR}/run_lichtfeld.sh" DESTINATION ${CMAKE_INSTALL_BINDIR})
     elseif(WIN32)
-        # Copy DLLs to bin/ for Windows search path
         install(CODE "
-            # Copy all DLLs from lib/ to bin/
-            file(GLOB _dlls \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/*.dll\")
-            foreach(_d IN LISTS _dlls)
-                file(INSTALL \"\${_d}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\")
-            endforeach()
             # Copy extensions/ from build to dist/extensions/
             # Handle both single-config (Ninja) and multi-config (VS) generators
             foreach(_cfg IN ITEMS \"\" \"Release\" \"Debug\" \"RelWithDebInfo\" \"MinSizeRel\")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -773,13 +773,16 @@ endif()
 
 message(STATUS "Post-build: Resources will be copied to \${BUILD_DIR}/resources/")
 
-# Per-config output directory variants — used by MSVC (multi-config); no-op for single-config generators
-set_target_properties(${PROJECT_NAME} PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY_DEBUG        "${CMAKE_BINARY_DIR}/Debug"
-    RUNTIME_OUTPUT_DIRECTORY_RELEASE      "${CMAKE_BINARY_DIR}/Release"
-    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/RelWithDebInfo"
-    RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL   "${CMAKE_BINARY_DIR}/MinSizeRel"
-)
+# Per-config output directory variants are Windows-only; Linux keeps the
+# default flat binary directory.
+if(WIN32)
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG        "${CMAKE_BINARY_DIR}/Debug"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE      "${CMAKE_BINARY_DIR}/Release"
+        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/RelWithDebInfo"
+        RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL   "${CMAKE_BINARY_DIR}/MinSizeRel"
+    )
+endif()
 
 # Platform-specific settings
 if(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,13 +721,16 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 )
 
 # OpenUSD runtime resources (schema/file-format plugin metadata).
-# Copy them beside the app under ../lib/usd and register that path at startup.
+# On Windows: copy to <exe>/usd/ so that relative LibraryPaths resolve to the
+# DLL copies already loaded from the exe directory.
+# On Linux: copy to <exe>/../lib/usd/ (conventional layout).
 set(_USD_PLUGIN_SOURCE_DIR "")
 foreach(_candidate
     "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/usd"
     "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/bin/usd"
     "${CMAKE_BINARY_DIR}/src/python/usd")
-    if(NOT _USD_PLUGIN_SOURCE_DIR AND EXISTS "${_candidate}")
+    # Require an actual plugin sub-directory (not just the root index).
+    if(NOT _USD_PLUGIN_SOURCE_DIR AND EXISTS "${_candidate}/ar/resources/plugInfo.json")
         set(_USD_PLUGIN_SOURCE_DIR "${_candidate}")
     endif()
 endforeach()
@@ -742,7 +745,11 @@ foreach(_candidate
     endif()
 endforeach()
 
-set(_USD_PLUGIN_DEST "$<TARGET_FILE_DIR:${PROJECT_NAME}>/../lib/usd")
+if(WIN32)
+    set(_USD_PLUGIN_DEST "$<TARGET_FILE_DIR:${PROJECT_NAME}>/usd")
+else()
+    set(_USD_PLUGIN_DEST "$<TARGET_FILE_DIR:${PROJECT_NAME}>/../lib/usd")
+endif()
 
 if(EXISTS "${_USD_PLUGIN_SOURCE_DIR}")
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
@@ -766,16 +773,13 @@ endif()
 
 message(STATUS "Post-build: Resources will be copied to \${BUILD_DIR}/resources/")
 
-# Per-config output directory variants are Windows-only; Linux keeps the
-# default flat binary directory.
-if(WIN32)
-    set_target_properties(${PROJECT_NAME} PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY_DEBUG        "${CMAKE_BINARY_DIR}/Debug"
-        RUNTIME_OUTPUT_DIRECTORY_RELEASE      "${CMAKE_BINARY_DIR}/Release"
-        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/RelWithDebInfo"
-        RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL   "${CMAKE_BINARY_DIR}/MinSizeRel"
-    )
-endif()
+# Per-config output directory variants — used by MSVC (multi-config); no-op for single-config generators
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG        "${CMAKE_BINARY_DIR}/Debug"
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE      "${CMAKE_BINARY_DIR}/Release"
+    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/RelWithDebInfo"
+    RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL   "${CMAKE_BINARY_DIR}/MinSizeRel"
+)
 
 # Platform-specific settings
 if(UNIX)
@@ -1044,8 +1048,7 @@ if(BUILD_PORTABLE)
             [[.*libstdc[+][+].*]] [[.*libgcc_s.*]]
             [[.*libnvimgcodec.*]] [[.*libnvjpeg_ext.*]])
 
-    # Search directories for runtime dependencies.
-    # Portable builds are Windows Release-only; binaries are in build/Release/.
+    # Search directories for runtime dependencies (quoted for paths with spaces on Windows)
     set(_SEARCH_DIRS_STR "\"${CMAKE_BINARY_DIR}\" \"${CMAKE_BINARY_DIR}/Release\" \"${CMAKE_BINARY_DIR}/external/nvImageCodec\" \"${CUDAToolkit_BIN_DIR}\" \"${CUDAToolkit_LIBRARY_DIR}\"")
 
     # Helper: bundle runtime dependencies for a target

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -54,13 +54,12 @@ namespace {
 #endif
         usd_dir = std::filesystem::canonical(usd_dir, ec);
         if (ec || !std::filesystem::is_directory(usd_dir, ec)) {
-            std::println(stderr, "[USD] plugin directory not found ({})",
-                         ec ? ec.message() : "not a directory");
+            LOG_ERROR("[USD] plugin directory not found ({})",
+                      ec ? ec.message() : "not a directory");
             return;
         }
 
         const std::string path_utf8 = lfs::core::path_to_utf8(usd_dir);
-        std::println(stderr, "[USD] registering plugins from: {}", path_utf8);
 
         // Also set the env var for any code that reads it directly.
 #ifdef _WIN32
@@ -72,8 +71,6 @@ namespace {
         // Programmatically register plugins so the Plug system finds them
         // regardless of compiled-in search paths or env var timing.
         pxr::PlugRegistry::GetInstance().RegisterPlugins(path_utf8);
-        std::println(stderr, "[USD] plugin registration complete ({} plugins)",
-                     pxr::PlugRegistry::GetInstance().GetAllPlugins().size());
     }
 } // namespace
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -27,7 +27,9 @@
 #endif
 
 namespace {
-    // Register OpenUSD plugin resources deployed at <exe_dir>/../lib/usd/.
+    // Register OpenUSD plugin resources deployed beside the executable.
+    // On Windows: <exe_dir>/usd/ — keeps relative LibraryPaths correct.
+    // On Linux:   <exe_dir>/../lib/usd/ — conventional layout.
     // Must be called before any USD API usage (stage creation, schema lookup).
     // The env-var approach (PXR_PLUGINPATH_NAME) does not work reliably on
     // Windows because USD DLLs may initialise before main() runs.
@@ -39,13 +41,26 @@ namespace {
             return;
         }
 
-        auto usd_dir = exe_dir / ".." / "lib" / "usd";
         std::error_code ec;
+
+        // On Windows, plugins sit next to the exe at <exe_dir>/usd/ so that
+        // relative LibraryPath entries (e.g. "../../usd_ar.dll") resolve to
+        // the DLL copies that are already loaded by Windows at startup.
+        // On Linux they follow the conventional <exe_dir>/../lib/usd/ layout.
+#ifdef _WIN32
+        auto usd_dir = exe_dir / "usd";
+#else
+        auto usd_dir = exe_dir / ".." / "lib" / "usd";
+#endif
         usd_dir = std::filesystem::canonical(usd_dir, ec);
-        if (ec || !std::filesystem::is_directory(usd_dir, ec))
+        if (ec || !std::filesystem::is_directory(usd_dir, ec)) {
+            std::println(stderr, "[USD] plugin directory not found ({})",
+                         ec ? ec.message() : "not a directory");
             return;
+        }
 
         const std::string path_utf8 = lfs::core::path_to_utf8(usd_dir);
+        std::println(stderr, "[USD] registering plugins from: {}", path_utf8);
 
         // Also set the env var for any code that reads it directly.
 #ifdef _WIN32
@@ -57,6 +72,8 @@ namespace {
         // Programmatically register plugins so the Plug system finds them
         // regardless of compiled-in search paths or env var timing.
         pxr::PlugRegistry::GetInstance().RegisterPlugins(path_utf8);
+        std::println(stderr, "[USD] plugin registration complete ({} plugins)",
+                     pxr::PlugRegistry::GetInstance().GetAllPlugins().size());
     }
 } // namespace
 

--- a/src/io/formats/usd.cpp
+++ b/src/io/formats/usd.cpp
@@ -757,7 +757,6 @@ namespace lfs::io {
         // Pre-flight check: ArResolver requires USD plugins to be registered.
         // If none are registered, the USD plugin path may not be configured.
         const auto plugin_count = pxr::PlugRegistry::GetInstance().GetAllPlugins().size();
-        LOG_DEBUG("[USD] registered plugin count: {}", plugin_count);
         if (plugin_count == 0) {
             LOG_ERROR("[USD] No USD plugins registered — UsdStage::CreateNew will crash fatally");
             return make_error(ErrorCode::WRITE_FAILURE,
@@ -792,7 +791,6 @@ namespace lfs::io {
         // TfErrorMark captures OpenUSD diagnostic errors that don't throw.
         pxr::TfErrorMark error_mark;
 
-        LOG_DEBUG("[USD] creating stage");
         pxr::UsdStageRefPtr stage;
         try {
             stage = pxr::UsdStage::CreateNew(lfs::core::path_to_utf8(options.output_path));
@@ -814,7 +812,6 @@ namespace lfs::io {
                               options.output_path);
         }
 
-        LOG_DEBUG("[USD] stage created — defining prim");
         const pxr::SdfPath prim_path("/GaussianSplats");
         pxr::UsdVolParticleField3DGaussianSplat splat_prim;
         try {
@@ -830,7 +827,6 @@ namespace lfs::io {
                               options.output_path);
         }
 
-        LOG_DEBUG("[USD] prim defined — setting stage metadata");
         try {
             stage->SetDefaultPrim(splat_prim.GetPrim());
             pxr::UsdGeomSetStageUpAxis(stage, pxr::UsdGeomTokens->y);
@@ -841,7 +837,6 @@ namespace lfs::io {
                               options.output_path);
         }
 
-        LOG_DEBUG("[USD] metadata set — authoring {} gaussian attributes", num_gaussians);
         pxr::UsdGeomBoundable boundable(splat_prim.GetPrim());
 
         try {
@@ -865,7 +860,6 @@ namespace lfs::io {
                               options.output_path);
         }
 
-        LOG_DEBUG("[USD] attributes authored — saving layer");
         try {
             if (const auto root_layer = stage->GetRootLayer(); !root_layer || !root_layer->Save()) {
                 return make_error(ErrorCode::WRITE_FAILURE,
@@ -878,7 +872,6 @@ namespace lfs::io {
                               options.output_path);
         }
 
-        LOG_DEBUG("[USD] export complete: {}", lfs::core::path_to_utf8(options.output_path));
         return {};
     }
 

--- a/src/io/formats/usd.cpp
+++ b/src/io/formats/usd.cpp
@@ -24,6 +24,7 @@
 #include <pxr/base/gf/quath.h>
 #include <pxr/base/gf/vec3f.h>
 #include <pxr/base/gf/vec3h.h>
+#include <pxr/base/plug/registry.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/diagnosticMgr.h>
 #include <pxr/base/tf/errorMark.h>
@@ -745,6 +746,17 @@ namespace lfs::io {
 
         LOG_INFO("Saving USD file: {}", lfs::core::path_to_utf8(options.output_path));
 
+        // Pre-flight check: ArResolver requires USD plugins to be registered.
+        // If none are registered configure_usd_plugins() failed at startup.
+        const auto plugin_count = pxr::PlugRegistry::GetInstance().GetAllPlugins().size();
+        LOG_DEBUG("[USD] registered plugin count: {}", plugin_count);
+        if (plugin_count == 0) {
+            LOG_ERROR("[USD] No USD plugins registered — UsdStage::CreateNew will crash fatally");
+            return make_error(ErrorCode::WRITE_FAILURE,
+                              "USD plugins not registered (configure_usd_plugins failed at startup)",
+                              options.output_path);
+        }
+
         const auto means = splat_data.means().contiguous().to(Device::CPU);
         const auto scaling = splat_data.scaling_raw().contiguous().to(Device::CPU);
         const auto rotation = splat_data.rotation_raw().contiguous().to(Device::CPU);
@@ -772,6 +784,7 @@ namespace lfs::io {
         // TfErrorMark captures OpenUSD diagnostic errors that don't throw.
         pxr::TfErrorMark error_mark;
 
+        LOG_DEBUG("[USD] creating stage");
         pxr::UsdStageRefPtr stage;
         try {
             stage = pxr::UsdStage::CreateNew(lfs::core::path_to_utf8(options.output_path));
@@ -793,6 +806,7 @@ namespace lfs::io {
                               options.output_path);
         }
 
+        LOG_DEBUG("[USD] stage created — defining prim");
         const pxr::SdfPath prim_path("/GaussianSplats");
         pxr::UsdVolParticleField3DGaussianSplat splat_prim;
         try {
@@ -808,6 +822,7 @@ namespace lfs::io {
                               options.output_path);
         }
 
+        LOG_DEBUG("[USD] prim defined — setting stage metadata");
         try {
             stage->SetDefaultPrim(splat_prim.GetPrim());
             pxr::UsdGeomSetStageUpAxis(stage, pxr::UsdGeomTokens->y);
@@ -818,6 +833,7 @@ namespace lfs::io {
                               options.output_path);
         }
 
+        LOG_DEBUG("[USD] metadata set — authoring {} gaussian attributes", num_gaussians);
         pxr::UsdGeomBoundable boundable(splat_prim.GetPrim());
 
         try {
@@ -841,6 +857,7 @@ namespace lfs::io {
                               options.output_path);
         }
 
+        LOG_DEBUG("[USD] attributes authored — saving layer");
         try {
             if (const auto root_layer = stage->GetRootLayer(); !root_layer || !root_layer->Save()) {
                 return make_error(ErrorCode::WRITE_FAILURE,
@@ -853,6 +870,7 @@ namespace lfs::io {
                               options.output_path);
         }
 
+        LOG_DEBUG("[USD] export complete: {}", lfs::core::path_to_utf8(options.output_path));
         return {};
     }
 

--- a/src/io/formats/usd.cpp
+++ b/src/io/formats/usd.cpp
@@ -24,7 +24,15 @@
 #include <pxr/base/gf/quath.h>
 #include <pxr/base/gf/vec3f.h>
 #include <pxr/base/gf/vec3h.h>
+// pxr/base/tf/hashset.h pulls in the deprecated <ext/hash_set> on GCC.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcpp"
+#endif
 #include <pxr/base/plug/registry.h>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/diagnosticMgr.h>
 #include <pxr/base/tf/errorMark.h>
@@ -747,13 +755,13 @@ namespace lfs::io {
         LOG_INFO("Saving USD file: {}", lfs::core::path_to_utf8(options.output_path));
 
         // Pre-flight check: ArResolver requires USD plugins to be registered.
-        // If none are registered configure_usd_plugins() failed at startup.
+        // If none are registered, the USD plugin path may not be configured.
         const auto plugin_count = pxr::PlugRegistry::GetInstance().GetAllPlugins().size();
         LOG_DEBUG("[USD] registered plugin count: {}", plugin_count);
         if (plugin_count == 0) {
             LOG_ERROR("[USD] No USD plugins registered — UsdStage::CreateNew will crash fatally");
             return make_error(ErrorCode::WRITE_FAILURE,
-                              "USD plugins not registered (configure_usd_plugins failed at startup)",
+                              "USD plugins not registered — ensure the USD plugin path is configured before calling save_usd",
                               options.output_path);
         }
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -486,6 +486,7 @@ add_custom_target(lfs_plugins_copy ALL
 )
 
 add_custom_target(lfs_python_support_copy ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:lfs_py>
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${CMAKE_CURRENT_SOURCE_DIR}/_lfs_panel_contract.py
         ${CMAKE_CURRENT_SOURCE_DIR}/lfs_splat_lod_hierarchy.py

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -486,7 +486,6 @@ add_custom_target(lfs_plugins_copy ALL
 )
 
 add_custom_target(lfs_python_support_copy ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:lfs_py>
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${CMAKE_CURRENT_SOURCE_DIR}/_lfs_panel_contract.py
         ${CMAKE_CURRENT_SOURCE_DIR}/lfs_splat_lod_hierarchy.py


### PR DESCRIPTION
fixes https://github.com/MrNeRF/LichtFeld-Studio/issues/1083

## Symptom

Clicking export to USD crashed the application with a fatal USD error:

```
usd_plug.dll!PlugRegistry::DemandPluginForType() — TF_FATAL_ERROR
usd_ar.dll!_GetAvailableResolvers()
usd_ar.dll!_DispatchingResolver::_DispatchingResolver()
usd_ar.dll!ArGetResolver()
usd_sdf.dll!SdfLayer::_CreateNew()
usd_usd.dll!UsdStage::CreateNew()
lfs_visualizer.dll!lfs::io::save_usd()
```

`TF_FATAL_ERROR` calls `ArchDebuggerTrap` → `abort()`. The error could not be caught by
`try/catch`.

## Root Cause

Two independent bugs in the OpenUSD plugin discovery setup:

### Bug 1 — Wrong plugin source directory

`CMakeLists.txt` searched for USD plugins in this order:

```cmake
"${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/usd"   # checked first
"${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/bin/usd"   # actual plugins
```

The existence check was just `if(EXISTS "${_candidate}")`.  
`lib/usd/` **exists** but contains only a root `plugInfo.json` with `"Includes": ["*/resources/"]`
and **no actual plugin subdirectories**.  
`bin/usd/` is where the real plugin tree lives (`ar/`, `sdf/`, `usd/`, etc.).

Result: the POST_BUILD copy only placed the empty root index at the destination. USD's
`RegisterPlugins()` found zero actual plugins.

### Bug 2 — Wrong plugin destination (LibraryPath mismatch)

Even if `bin/usd/` had been chosen as the source, the destination was:

```cmake
set(_USD_PLUGIN_DEST "$<TARGET_FILE_DIR:${PROJECT_NAME}>/../lib/usd")
```

Each plugin descriptor contains a relative `LibraryPath`, e.g.:

```json
{ "LibraryPath": "../../usd_ar.dll", "Root": ".." }
```

USD resolves `LibraryPath` relative to the plugin root directory. With the destination
`build/Release/../lib/usd/`:

| Path | Resolves to | DLL actually at |
|---|---|---|
| `build/lib/usd/ar/` (root) | `build/lib/usd/ar/../../usd_ar.dll` = `build/lib/usd_ar.dll` | `build/Release/usd_ar.dll` |

`LoadLibraryW` with a full absolute path that doesn't exist fails immediately with no fallback.

The correct destination is `build/Release/usd/`, where the LibraryPaths resolve to
`build/Release/usd/ar/../../usd_ar.dll` = **`build/Release/usd_ar.dll`** ✓ — the same DLL
copies that are already loaded by Windows at process startup.

## Why It Worked on Some Machines

If USD plugins are registered from their **original vcpkg location** (`bin/usd/ar/`), the
`LibraryPath` resolves to `bin/usd_ar.dll` which exists in vcpkg. But loading that DLL a second
time (it was already loaded from `build/Release/`) creates **two separate module instances**,
breaking USD's TfType singleton system. This path was never hit in practice; the crash always
occurred due to zero plugins being registered.

## Changes

### `CMakeLists.txt`

1. **Plugin source directory** — added sentinel check (`ar/resources/plugInfo.json`) to ensure
   only directories with actual plugin subdirectories are selected:

   ```cmake
   if(NOT _USD_PLUGIN_SOURCE_DIR AND EXISTS "${_candidate}/ar/resources/plugInfo.json")
   ```

2. **Plugin destination** — changed to `<exe_dir>/usd/` on Windows so that relative
   `LibraryPath` entries resolve to the DLL copies already loaded from `<exe_dir>/`:

   ```cmake
   if(WIN32)
       set(_USD_PLUGIN_DEST "$<TARGET_FILE_DIR:${PROJECT_NAME}>/usd")
   else()
       set(_USD_PLUGIN_DEST "$<TARGET_FILE_DIR:${PROJECT_NAME}>/../lib/usd")
   endif()
   ```

### `src/app/main.cpp` — `configure_usd_plugins()`

Changed the runtime lookup path to match the new destination:

```cpp
#ifdef _WIN32
    auto usd_dir = exe_dir / "usd";          // was: exe_dir / ".." / "lib" / "usd"
#else
    auto usd_dir = exe_dir / ".." / "lib" / "usd";
#endif
```

Added `std::println(stderr, ...)` diagnostics (logger not yet initialised at this point) that
show the plugin directory path and the total registered plugin count.

### `src/io/formats/usd.cpp` — `save_usd()`

- Added `#include <pxr/base/plug/registry.h>`.
- Pre-flight check: queries `PlugRegistry::GetAllPlugins().size()` before `UsdStage::CreateNew`.
  If the count is zero the function returns a proper `Result` error instead of calling
  `abort()`, giving a recoverable error message rather than a crash.
- Added `LOG_DEBUG("[USD] ...")` step logging through each stage of the save pipeline
  (stage creation, prim definition, metadata, attribute authoring, layer save).

## Post-Fix Log Output

Normal successful export (debug level, visible with `--log-level debug`):

```
[USD] registering plugins from: C:\...\build\Release\usd    (stderr, at startup)
[USD] plugin registration complete (47 plugins)             (stderr, at startup)
...
[info]  Saving USD file: C:\...\export.usd
[debug] [USD] registered plugin count: 47
[debug] [USD] creating stage
[debug] [USD] stage created — defining prim
[debug] [USD] prim defined — setting stage metadata
[debug] [USD] metadata set — authoring 1234567 gaussian attributes
[debug] [USD] attributes authored — saving layer
[debug] [USD] export complete: C:\...\export.usd
```

If plugins are missing (zero count), the error is now reported gracefully:

```
[error] [USD] No USD plugins registered — UsdStage::CreateNew will crash fatally
```

## Additional changes

Two bugs were fixed in the `cmake --install` / `BUILD_PORTABLE` workflow on Windows.

## Bug 1: USD plugins installed to wrong directory

### Symptom

```
[error] [USD] No USD plugins registered — UsdStage::CreateNew will crash fatally
```

Occurred when running `LichtFeld-Studio.exe` from a portable install (`cmake --install build --prefix ./dist`).

### Root cause

The CMake install rule placed USD plugin JSON files into `${CMAKE_INSTALL_LIBDIR}/usd` = `dist/lib/usd`.

At runtime, `configure_usd_plugins()` on Windows looks for `<exe_dir>/usd`. When the exe lives at `dist/bin/LichtFeld-Studio.exe`, it searches `dist/bin/usd` — which did not exist.

The plugin `LibraryPath` entries (e.g. `"../../usd_ar.dll"`) are also layout-sensitive: they are relative to `<plugin>/resources/`, so the entire `usd/` subtree must sit two directories above the actual USD DLLs. Placing it next to the exe (`bin/usd/`) means `bin/usd/ar/resources/../../usd_ar.dll` resolves to `bin/usd_ar.dll` ✓.

### Fix

Made the USD install destination platform-conditional in `CMakeLists.txt`:

```cmake
if(WIN32)
    set(_USD_INSTALL_DEST "${CMAKE_INSTALL_BINDIR}/usd")   # dist/bin/usd
else()
    set(_USD_INSTALL_DEST "${CMAKE_INSTALL_LIBDIR}/usd")   # dist/lib/usd (Linux unchanged)
endif()

install(DIRECTORY "${_USD_PLUGIN_SOURCE_DIR}/" DESTINATION "${_USD_INSTALL_DEST}" ...)
install(FILES    "${_USD_ROOT_INDEX}"          DESTINATION "${_USD_INSTALL_DEST}")
```

---

## Bug 2: Duplicate DLLs in `dist/lib/` and `dist/bin/`

### Symptom

After `cmake --install`, all USD DLLs (and other vcpkg DLLs) appeared in both `dist/lib/` and `dist/bin/`, roughly doubling the size of the distribution (~100 MB wasted).

### Root cause

The `bundle_runtime_deps()` helper was designed with a Unix-first layout: it staged all runtime DLLs into `${CMAKE_INSTALL_LIBDIR}` (`dist/lib/`). A subsequent Windows-only step then copied every `dist/lib/*.dll` to `dist/bin/`. This left the originals in `dist/lib/` as dead copies — Windows only searches the directory containing the exe (`dist/bin/`) for DLLs.

### Fix

1. `bundle_runtime_deps()` now writes directly to `${CMAKE_INSTALL_BINDIR}` on Windows:

```cmake
if(WIN32)
    set(_BUNDLE_DEST "${CMAKE_INSTALL_BINDIR}")
else()
    set(_BUNDLE_DEST "${CMAKE_INSTALL_LIBDIR}")
endif()
```

2. Removed the redundant `file(GLOB _dlls ... *.dll)` → `file(INSTALL ... DESTINATION bin/)` step from the Windows post-install block.

After this fix, `dist/lib/` contains only import libs (`.lib` files), and all DLLs are exclusively in `dist/bin/`.

