### PR TITLE
Fix: `lfs_python_support_copy` Build Error on MSVC (Directory Does Not Exist)

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -486,6 +486,7 @@ add_custom_target(lfs_plugins_copy ALL
 )
 
 add_custom_target(lfs_python_support_copy ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:lfs_py>
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${CMAKE_CURRENT_SOURCE_DIR}/_lfs_panel_contract.py
         ${CMAKE_CURRENT_SOURCE_DIR}/lfs_splat_lod_hierarchy.py


### PR DESCRIPTION

## Symptom

MSVC build failed with:

```
CUSTOMBUILD : error : Target (for copy_if_different command)
  "C:/Users/.../build/Release" is not a directory.
[...\lfs_python_support_copy.vcxproj]
MSB8066: Custom build ... exited with code 1.
```

## Root Cause

The `lfs_python_support_copy` custom target copies `_lfs_panel_contract.py` and
`lfs_splat_lod_hierarchy.py` to `$<TARGET_FILE_DIR:lfs_py>` (i.e. `build/Release/` in a
Release build).

This target is a **dependency of** `lfs_py` — it runs **before** `lfs_py` is built.
Because `lfs_py` has not compiled yet when the copy runs, `build/Release/` does not exist at
that point.

`cmake -E copy_if_different <files...> <dest-dir>` requires the destination directory to
**already exist**. If it does not, CMake returns the error above.

The original code used `${CMAKE_CURRENT_BINARY_DIR}` (`build/src/python/`) as the destination,
which is always created by CMake during configure. After switching to
`$<TARGET_FILE_DIR:lfs_py>` (per-config path, created only at link time) the assumption broke.

`lfs_plugins_copy` was unaffected because it uses `copy_directory_if_different`, which creates
the destination directory automatically.

## Fix

`src/python/CMakeLists.txt` — `lfs_python_support_copy`:

Added `make_directory` as the first command so the destination directory is created on demand
before the copy runs:

```cmake
add_custom_target(lfs_python_support_copy ALL
    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:lfs_py>
    COMMAND ${CMAKE_COMMAND} -E copy_if_different
        ${CMAKE_CURRENT_SOURCE_DIR}/_lfs_panel_contract.py
        ${CMAKE_CURRENT_SOURCE_DIR}/lfs_splat_lod_hierarchy.py
        $<TARGET_FILE_DIR:lfs_py>
    COMMENT "Copying internal Python support modules"
)
```

`make_directory` is idempotent — it is safe to call even if the directory already exists.
