### PR TITLE
add selection by distance from world center

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,13 +712,15 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMENT "Copying application assets"
 )
 
-# Copy locale files
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+# Copy locale files (named target so it can be run without rebuilding the exe)
+add_custom_target(copy_locale_files
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${RESOURCE_DIR}/locales"
     COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
         "${CMAKE_SOURCE_DIR}/src/visualizer/gui/resources/locales"
         "${RESOURCE_DIR}/locales"
-    COMMENT "Copying locale files"
+    COMMENT "Syncing locale files"
 )
+add_dependencies(${PROJECT_NAME} copy_locale_files)
 
 # OpenUSD runtime resources (schema/file-format plugin metadata).
 # Copy them beside the app under ../lib/usd and register that path at startup.

--- a/src/python/lfs_plugins/histogram_panel.py
+++ b/src/python/lfs_plugins/histogram_panel.py
@@ -710,6 +710,10 @@ class HistogramPanel(Panel):
             if metric_id == "opacity":
                 return self._float_tensor(model.get_opacity()).reshape([-1])
 
+            if metric_id == "world_distance":
+                world_means = self._extract_world_space_means(scene, model)
+                return self._distance_from_world_center(world_means)
+
             if metric_id in {"position_x", "position_y", "position_z", "distance"}:
                 world_means = self._extract_world_space_means(scene, model)
                 if metric_id == "position_x":
@@ -786,6 +790,15 @@ class HistogramPanel(Panel):
         distances = self._nan_tensor(int(positions.shape[0]), self._device_string(positions))
         centered = positions[finite_rows] - center.unsqueeze(0)
         distances[finite_rows] = centered.square().sum(1).sqrt().reshape([-1])
+        return distances
+
+    def _distance_from_world_center(self, positions: lf.Tensor) -> lf.Tensor:
+        finite_rows = positions.isfinite().all(1).reshape([-1])
+        if not self._any_true(finite_rows):
+            return self._nan_tensor(int(positions.shape[0]), self._device_string(positions))
+
+        distances = self._nan_tensor(int(positions.shape[0]), self._device_string(positions))
+        distances[finite_rows] = positions[finite_rows].square().sum(1).sqrt().reshape([-1])
         return distances
 
     def _visible_splat_nodes(self, scene) -> list:

--- a/src/python/lfs_plugins/histogram_panel.py
+++ b/src/python/lfs_plugins/histogram_panel.py
@@ -710,11 +710,7 @@ class HistogramPanel(Panel):
             if metric_id == "opacity":
                 return self._float_tensor(model.get_opacity()).reshape([-1])
 
-            if metric_id == "world_distance":
-                world_means = self._extract_world_space_means(scene, model)
-                return self._distance_from_world_center(world_means)
-
-            if metric_id in {"position_x", "position_y", "position_z", "distance"}:
+            if metric_id in {"position_x", "position_y", "position_z", "world_distance", "distance"}:
                 world_means = self._extract_world_space_means(scene, model)
                 if metric_id == "position_x":
                     return world_means[:, 0]
@@ -722,6 +718,8 @@ class HistogramPanel(Panel):
                     return world_means[:, 1]
                 if metric_id == "position_z":
                     return world_means[:, 2]
+                if metric_id == "world_distance":
+                    return self._distance_from_world_origin(world_means)
                 return self._distance_from_positions(scene, world_means)
 
             scaling = self._float_tensor(model.get_scaling()).reshape([-1, 3])
@@ -792,7 +790,7 @@ class HistogramPanel(Panel):
         distances[finite_rows] = centered.square().sum(1).sqrt().reshape([-1])
         return distances
 
-    def _distance_from_world_center(self, positions: lf.Tensor) -> lf.Tensor:
+    def _distance_from_world_origin(self, positions: lf.Tensor) -> lf.Tensor:
         finite_rows = positions.isfinite().all(1).reshape([-1])
         if not self._any_true(finite_rows):
             return self._nan_tensor(int(positions.shape[0]), self._device_string(positions))

--- a/src/python/lfs_plugins/histogram_support.py
+++ b/src/python/lfs_plugins/histogram_support.py
@@ -124,7 +124,7 @@ METRICS = (
         "histogram.metric.world_distance.label",
         "World Distance",
         "histogram.metric.world_distance.description",
-        "Distance from the current world center.",
+        "Distance from the world origin.",
     ),
 )
 

--- a/src/python/lfs_plugins/histogram_support.py
+++ b/src/python/lfs_plugins/histogram_support.py
@@ -117,7 +117,14 @@ METRICS = (
         "histogram.metric.distance.label",
         "Distance",
         "histogram.metric.distance.description",
-        "Distance from the current scene center.",
+        "Distance from the current splat center.",
+    ),
+    HistogramMetric(
+        "world_distance",
+        "histogram.metric.world_distance.label",
+        "World Distance",
+        "histogram.metric.world_distance.description",
+        "Distance from the current world center.",
     ),
 )
 

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1408,7 +1408,11 @@
       },
       "distance": {
         "label": "Distance",
-        "description": "Distance from the current scene center."
+        "description": "Distance from the current splat center."
+      },
+      "world_distance": {
+        "label": "World Distance",
+        "description": "Distance from the world origin."
       }
     },
     "undo": "Undo",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1408,7 +1408,11 @@
       },
       "distance": {
         "label": "Distance",
-        "description": "Distance from the current scene center."
+        "description": "Distance from the current splat center."
+      },
+      "world_distance": {
+        "label": "World Distance",
+        "description": "Distance from the world origin."
       }
     },
     "undo": "Undo",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -1408,7 +1408,11 @@
       },
       "distance": {
         "label": "Distance",
-        "description": "Distance from the current scene center."
+        "description": "Distance from the current splat center."
+      },
+      "world_distance": {
+        "label": "World Distance",
+        "description": "Distance from the world origin."
       }
     },
     "undo": "Undo",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1408,7 +1408,11 @@
       },
       "distance": {
         "label": "Distance",
-        "description": "Distance from the current scene center."
+        "description": "Distance from the current splat center."
+      },
+      "world_distance": {
+        "label": "World Distance",
+        "description": "Distance from the world origin."
       }
     },
     "undo": "Undo",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1408,7 +1408,11 @@
       },
       "distance": {
         "label": "Distance",
-        "description": "Distance from the current scene center."
+        "description": "Distance from the current splat center."
+      },
+      "world_distance": {
+        "label": "World Distance",
+        "description": "Distance from the world origin."
       }
     },
     "undo": "Undo",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1408,7 +1408,11 @@
       },
       "distance": {
         "label": "Distance",
-        "description": "Distance from the current scene center."
+        "description": "Distance from the current splat center."
+      },
+      "world_distance": {
+        "label": "World Distance",
+        "description": "Distance from the world origin."
       }
     },
     "undo": "Undo",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1408,7 +1408,11 @@
       },
       "distance": {
         "label": "Distance",
-        "description": "Distance from the current scene center."
+        "description": "Distance from the current splat center."
+      },
+      "world_distance": {
+        "label": "World Distance",
+        "description": "Distance from the world origin."
       }
     },
     "undo": "Undo",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1408,7 +1408,11 @@
       },
       "distance": {
         "label": "Distance",
-        "description": "Distance from the current scene center."
+        "description": "Distance from the current splat center."
+      },
+      "world_distance": {
+        "label": "World Distance",
+        "description": "Distance from the world origin."
       }
     },
     "undo": "Undo",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1408,7 +1408,11 @@
       },
       "distance": {
         "label": "Distance",
-        "description": "Distance from the current scene center."
+        "description": "Distance from the current splat center."
+      },
+      "world_distance": {
+        "label": "World Distance",
+        "description": "Distance from the world origin."
       }
     },
     "undo": "Undo",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -1408,7 +1408,11 @@
       },
       "distance": {
         "label": "Distance",
-        "description": "Distance from the current scene center."
+        "description": "Distance from the current splat center."
+      },
+      "world_distance": {
+        "label": "World Distance",
+        "description": "Distance from the world origin."
       }
     },
     "undo": "Undo",

--- a/tests/python/test_histogram_localization_regressions.py
+++ b/tests/python/test_histogram_localization_regressions.py
@@ -9,7 +9,7 @@ from pathlib import Path
 def test_histogram_locale_bundles_define_all_new_metric_keys():
     project_root = Path(__file__).parent.parent.parent
     locale_dir = project_root / "src" / "visualizer" / "gui" / "resources" / "locales"
-    required_metrics = {"position_x", "position_y", "position_z", "volume", "anisotropy", "erank"}
+    required_metrics = {"position_x", "position_y", "position_z", "volume", "anisotropy", "erank", "world_distance"}
 
     for locale_path in sorted(locale_dir.glob("*.json")):
         data = json.loads(locale_path.read_text())

--- a/tests/python/test_histogram_panel.py
+++ b/tests/python/test_histogram_panel.py
@@ -124,7 +124,44 @@ def histogram_panel_module():
 def test_histogram_metrics_include_positions_volume_anisotropy_and_erank(histogram_panel_module):
     metric_ids = {metric.id for metric in histogram_panel_module.METRICS}
 
-    assert {"position_x", "position_y", "position_z", "volume", "anisotropy", "erank"} <= metric_ids
+    assert {"position_x", "position_y", "position_z", "volume", "anisotropy", "erank", "world_distance"} <= metric_ids
+
+
+def test_histogram_world_distance_metric_measures_from_origin(histogram_panel_module, lf, numpy):
+    panel = histogram_panel_module.HistogramPanel()
+    # Two Gaussians at local positions (1,0,0) and (0,3,4).
+    # With a translation of (2,0,0) applied the world positions become (3,0,0) and (2,3,4).
+    # Expected distances from origin: 3.0 and sqrt(4+9+16)=sqrt(29).
+    model = _ModelStub(
+        lf,
+        numpy.array([[1.0, 0.0, 0.0], [0.0, 3.0, 4.0]], dtype=numpy.float32),
+        numpy.array([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], dtype=numpy.float32),
+    )
+
+    splat_type = getattr(getattr(lf, "NodeType", None), "SPLAT", None)
+    if splat_type is None:
+        splat_type = lf.scene.NodeType.SPLAT
+
+    scene = SimpleNamespace(
+        get_nodes=lambda: [
+            SimpleNamespace(
+                id=1,
+                parent_id=-1,
+                visible=True,
+                type=splat_type,
+                gaussian_count=2,
+                world_transform=_translation_matrix(2.0, 0.0, 0.0),
+            )
+        ]
+    )
+
+    panel._metric_id = "world_distance"
+    result = panel._extract_metric_values(scene, model).cpu().numpy()
+    numpy.testing.assert_allclose(
+        result,
+        numpy.array([3.0, numpy.sqrt(29.0)], dtype=numpy.float32),
+        rtol=1e-5,
+    )
 
 
 def test_histogram_position_metrics_use_world_space_means(histogram_panel_module, lf, numpy):


### PR DESCRIPTION
Added a `world_distance` histogram metric that measures each Gaussian's Euclidean distance from the world origin (0, 0, 0).

This complements the existing `distance` metric, which measures distance from the **scene centre** (the centroid of the loaded splat set).

Also updated `distance` metric description from `"Distance from the current scene center."` to `"Distance from the current splat center."`.

:exclamation: Also added an entry to cmake to copy locales (copy_locale_files) so that we dont need to recompile to copy over locales :)