### PR TITLE
fix: resolve washed out colors and double gamma in mesh2splat (#1159)

### DIFF
--- a/src/rendering/mesh2splat.cpp
+++ b/src/rendering/mesh2splat.cpp
@@ -431,7 +431,7 @@ namespace lfs::rendering {
                 break;
             case 3:
                 format = GL_RGB;
-                internal_format = GL_RGB8;
+                internal_format = is_srgb ? GL_SRGB8 : GL_RGB8;
                 break;
             case 4:
                 format = GL_RGBA;
@@ -812,9 +812,6 @@ namespace lfs::rendering {
             GLint loc_material = glGetUniformLocation(cleanup.program, "u_materialFactor");
             GLint loc_metallic = glGetUniformLocation(cleanup.program, "u_metallicFactor");
             GLint loc_roughness = glGetUniformLocation(cleanup.program, "u_roughnessFactor");
-            GLint loc_light_dir = glGetUniformLocation(cleanup.program, "u_lightDir");
-            GLint loc_light_int = glGetUniformLocation(cleanup.program, "u_lightIntensity");
-            GLint loc_ambient = glGetUniformLocation(cleanup.program, "u_ambient");
             GLint loc_bbox_min = glGetUniformLocation(cleanup.program, "u_bboxMin");
             GLint loc_bbox_max = glGetUniformLocation(cleanup.program, "u_bboxMax");
             GLint loc_has_vtx_colors = glGetUniformLocation(cleanup.program, "hasVertexColors");
@@ -825,12 +822,6 @@ namespace lfs::rendering {
                 glUniform1f(loc_metallic, metallic_factor);
             if (loc_roughness >= 0)
                 glUniform1f(loc_roughness, roughness_factor);
-            if (loc_light_dir >= 0)
-                glUniform3fv(loc_light_dir, 1, glm::value_ptr(options.light_dir));
-            if (loc_light_int >= 0)
-                glUniform1f(loc_light_int, options.light_intensity);
-            if (loc_ambient >= 0)
-                glUniform1f(loc_ambient, options.ambient);
             if (loc_has_vtx_colors >= 0)
                 glUniform1i(loc_has_vtx_colors, mesh.has_colors() ? 1 : 0);
             // Use GLOBAL bbox so all submeshes share the same orthogonal UV space.

--- a/src/rendering/mesh2splat.cpp
+++ b/src/rendering/mesh2splat.cpp
@@ -414,7 +414,7 @@ namespace lfs::rendering {
         // Texture upload
         // ========================================================================
 
-        GLuint upload_texture(const TextureImage& img) {
+        GLuint upload_texture(const TextureImage& img, bool is_srgb = false) {
             assert(img.width > 0 && img.height > 0);
             assert(!img.pixels.empty());
 
@@ -435,7 +435,7 @@ namespace lfs::rendering {
                 break;
             case 4:
                 format = GL_RGBA;
-                internal_format = GL_RGBA8;
+                internal_format = is_srgb ?  GL_SRGB8_ALPHA8 : GL_RGBA8;
                 break;
             default: return 0;
             }
@@ -584,7 +584,7 @@ namespace lfs::rendering {
                 if (!img.pixels.empty()) {
                     LOG_DEBUG("mesh2splat: uploading albedo texture {}x{} ({} ch, {} bytes)",
                               img.width, img.height, img.channels, img.pixels.size());
-                    albedo_gl = upload_texture(img);
+                    albedo_gl = upload_texture(img, true);
                     if (albedo_gl)
                         cleanup.textures.push_back(albedo_gl);
                 }

--- a/src/rendering/mesh_renderer.cpp
+++ b/src/rendering/mesh_renderer.cpp
@@ -13,14 +13,17 @@
 namespace lfs::rendering {
 
     namespace {
-        Texture create_gl_texture(const lfs::core::TextureImage& img) {
+        Texture create_gl_texture(const lfs::core::TextureImage& img, bool is_srgb = false) {
             assert(!img.pixels.empty());
             assert(img.width > 0 && img.height > 0);
 
             GLuint tex;
             glGenTextures(1, &tex);
             glBindTexture(GL_TEXTURE_2D, tex);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, img.width, img.height, 0,
+
+            GLint internal_format = is_srgb ? GL_SRGB8_ALPHA8 : GL_RGBA8;
+
+            glTexImage2D(GL_TEXTURE_2D, 0, internal_format, img.width, img.height, 0,
                          GL_RGBA, GL_UNSIGNED_BYTE, img.pixels.data());
             glGenerateMipmap(GL_TEXTURE_2D);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
@@ -298,13 +301,13 @@ namespace lfs::rendering {
             GLMaterialTextures gl_tex;
 
             if (mat.albedo_tex > 0 && mat.albedo_tex <= mesh.texture_images.size()) {
-                gl_tex.albedo = create_gl_texture(mesh.texture_images[mat.albedo_tex - 1]);
+                gl_tex.albedo = create_gl_texture(mesh.texture_images[mat.albedo_tex - 1], true);
             }
             if (mat.normal_tex > 0 && mat.normal_tex <= mesh.texture_images.size()) {
-                gl_tex.normal = create_gl_texture(mesh.texture_images[mat.normal_tex - 1]);
+                gl_tex.normal = create_gl_texture(mesh.texture_images[mat.normal_tex - 1], false);
             }
             if (mat.metallic_roughness_tex > 0 && mat.metallic_roughness_tex <= mesh.texture_images.size()) {
-                gl_tex.metallic_roughness = create_gl_texture(mesh.texture_images[mat.metallic_roughness_tex - 1]);
+                gl_tex.metallic_roughness = create_gl_texture(mesh.texture_images[mat.metallic_roughness_tex - 1], false);
             }
 
             if (gl_tex.albedo.get() || gl_tex.normal.get() || gl_tex.metallic_roughness.get()) {

--- a/src/rendering/resources/shaders/mesh2splat/converterFS.glsl
+++ b/src/rendering/resources/shaders/mesh2splat/converterFS.glsl
@@ -130,11 +130,7 @@ void main() {
     vec3 diffuse = kD * albedo / PI;
     vec3 spec = (NDF * G * F) / (4.0 * max(dot(N, V), 0.0) * NdotL + 0.0001);
 
-    vec3 Lo = (diffuse + spec) * NdotL * u_lightIntensity;
-    vec3 ambient_color = albedo * u_ambient * ao;
-    vec3 color = ambient_color + Lo;
-
-    color = pow(clamp(color, 0.0, 1.0), vec3(1.0 / 2.2));
+    vec3 color = pow(clamp(albedo, 0.0, 1.0), vec3(1.0 / 2.2));
 
     gaussianBuffer.vertices[index].position = vec4(Position.xyz, 1);
     gaussianBuffer.vertices[index].color = vec4(color, out_Color.a);

--- a/src/rendering/resources/shaders/mesh2splat/converterFS.glsl
+++ b/src/rendering/resources/shaders/mesh2splat/converterFS.glsl
@@ -50,30 +50,6 @@ flat in vec4 Quaternion;
 
 const float PI = 3.14159265359;
 
-float distribution_ggx(vec3 N, vec3 H, float roughness) {
-    float a = roughness * roughness;
-    float a2 = a * a;
-    float NdotH = max(dot(N, H), 0.0);
-    float NdotH2 = NdotH * NdotH;
-    float denom = NdotH2 * (a2 - 1.0) + 1.0;
-    return a2 / (PI * denom * denom);
-}
-
-float geometry_schlick_ggx(float NdotV, float roughness) {
-    float r = roughness + 1.0;
-    float k = (r * r) / 8.0;
-    return NdotV / (NdotV * (1.0 - k) + k);
-}
-
-float geometry_smith(vec3 N, vec3 V, vec3 L, float roughness) {
-    float NdotV = max(dot(N, V), 0.0);
-    float NdotL = max(dot(N, L), 0.0);
-    return geometry_schlick_ggx(NdotV, roughness) * geometry_schlick_ggx(NdotL, roughness);
-}
-
-vec3 fresnel_schlick(float cos_theta, vec3 F0) {
-    return F0 + (1.0 - F0) * pow(clamp(1.0 - cos_theta, 0.0, 1.0), 5.0);
-}
 
 void main() {
     uint index = atomicCounterIncrement(g_validCounter);
@@ -107,28 +83,6 @@ void main() {
     roughness = max(roughness, 0.04);
 
     vec3 albedo = (out_Color * u_materialFactor).rgb;
-    vec3 N = out_Normal;
-
-    vec3 V = u_lightDir;
-    vec3 L = u_lightDir;
-
-    if (dot(N, L) < 0.0)
-        N = -N;
-
-    vec3 H = normalize(V + L);
-
-    float NdotL = max(dot(N, L), 0.0);
-
-    vec3 F0 = mix(vec3(0.04), albedo, metallic);
-    float NDF = distribution_ggx(N, H, roughness);
-    float G = geometry_smith(N, V, L, roughness);
-    vec3 F = fresnel_schlick(max(dot(H, V), 0.0), F0);
-
-    vec3 kS = F;
-    vec3 kD = (1.0 - kS) * (1.0 - metallic);
-
-    vec3 diffuse = kD * albedo / PI;
-    vec3 spec = (NDF * G * F) / (4.0 * max(dot(N, V), 0.0) * NdotL + 0.0001);
 
     vec3 color = pow(clamp(albedo, 0.0, 1.0), vec3(1.0 / 2.2));
 


### PR DESCRIPTION
This PR fixes the issue #1159 where splats converted from meshes appear severely washed out and desaturated.

### Root Cause
1. **Texture Upload:** Albedo textures were uniformly uploaded as `GL_RGBA8` instead of `GL_SRGB8`/`GL_SRGB8_ALPHA8` in both `mesh_renderer.cpp` and `mesh2splat.cpp`, causing linear math to be performed on gamma-encoded textures.
2. **Double Gamma & Baked Lighting:** `converterFS.glsl` was calculating unnecessary PBR lighting (adding white specular/ambient wash) and explicitly applying a gamma curve `pow(color, 1.0/2.2)`. However, the C++ pipeline `build_splat_data` expects a linear color to compute the SH0 coefficients. This resulted in baked lighting and a double-gamma effect.

### Solution
- Added an `is_srgb` flag to `create_gl_texture` and `upload_texture`. Albedo maps are now correctly uploaded as `GL_SRGB8_ALPHA8`.
- Stripped the hardcoded lighting calculation in `converterFS.glsl`. It now passes the pure, unlit albedo color and correctly applies the standard gamma encoding for the SH0 representation.

### Visual Proof
**Before (Original mesh2splat):**
<img width="336" height="728" alt="image" src="https://github.com/user-attachments/assets/1078e83e-a84b-434b-8c87-00236ca4464a" />

**After (With this PR):**
<img width="227" height="559" alt="image" src="https://github.com/user-attachments/assets/21cde104-b620-463b-86b7-4473b2bff29b" />
