### PR TITLE
fix(rotation_gizmo): invert view (yellow) ring rotation direction

### DIFF
--- a/src/visualizer/gui/rotation_gizmo.cpp
+++ b/src/visualizer/gui/rotation_gizmo.cpp
@@ -299,7 +299,7 @@ namespace lfs::vis::gui {
             const glm::vec2 b = safeNormalize(current - center, glm::vec2(1.0f, 0.0f));
             const float cross = a.x * b.y - a.y * b.x;
             const float dot = glm::dot(a, b);
-            return -std::atan2(cross, dot);
+            return std::atan2(cross, dot);
         }
 
         [[nodiscard]] bool unprojectRay(const RotationGizmoConfig& config,


### PR DESCRIPTION
The screen-space view ring was rotating the model opposite to the mouse drag direction. Removed the negation in screenSignedAngle so the rotation follows the cursor's circular motion around the pivot. The X/Y/Z rings are unaffected since this helper is only used by the View axis.