### PR TITLE
fix(visualizer): export TRS gizmo draw functions from lfs_visualizer DLL

### DIFF
--- a/src/visualizer/gui/rotation_gizmo.hpp
+++ b/src/visualizer/gui/rotation_gizmo.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "core/export.hpp"
+
 #include <glm/glm.hpp>
 #include <imgui.h>
 
@@ -40,7 +42,7 @@ namespace lfs::vis::gui {
         glm::mat3 delta_rotation{1.0f};
     };
 
-    RotationGizmoResult drawRotationGizmo(const RotationGizmoConfig& config);
+    LFS_VIS_API RotationGizmoResult drawRotationGizmo(const RotationGizmoConfig& config);
 
     [[nodiscard]] bool isRotationGizmoHovered();
     [[nodiscard]] bool isRotationGizmoActive();

--- a/src/visualizer/gui/scale_gizmo.hpp
+++ b/src/visualizer/gui/scale_gizmo.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "core/export.hpp"
+
 #include <glm/glm.hpp>
 #include <imgui.h>
 
@@ -44,7 +46,7 @@ namespace lfs::vis::gui {
         glm::vec3 total_scale{1.0f};
     };
 
-    ScaleGizmoResult drawScaleGizmo(const ScaleGizmoConfig& config);
+    LFS_VIS_API ScaleGizmoResult drawScaleGizmo(const ScaleGizmoConfig& config);
 
     [[nodiscard]] bool isScaleGizmoHovered();
     [[nodiscard]] bool isScaleGizmoActive();

--- a/src/visualizer/gui/translation_gizmo.hpp
+++ b/src/visualizer/gui/translation_gizmo.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "core/export.hpp"
+
 #include <glm/glm.hpp>
 #include <imgui.h>
 
@@ -44,7 +46,7 @@ namespace lfs::vis::gui {
         glm::vec3 total_translation{0.0f};
     };
 
-    TranslationGizmoResult drawTranslationGizmo(const TranslationGizmoConfig& config);
+    LFS_VIS_API TranslationGizmoResult drawTranslationGizmo(const TranslationGizmoConfig& config);
 
     [[nodiscard]] bool isTranslationGizmoHovered();
     [[nodiscard]] bool isTranslationGizmoActive();


### PR DESCRIPTION
On Windows lfs_visualizer is built as a SHARED library, but the new free

functions drawTranslationGizmo, drawRotationGizmo, and drawScaleGizmo were

missing the LFS_VIS_API export macro. As a result MSVC did not export them

from lfs_visualizer.dll, and linking lfs_py (the lichtfeld Python module)

failed with three LNK2019 unresolved external errors in py_gizmo.obj.

Annotate the three free functions with LFS_VIS_API (and include core/export.hpp)

so the symbols are exported when building the DLL and imported when consumed

by lfs_py.