### PR TITLE
fix: Vulkan branch build failures on Windows with CUDA 12.8 + MSVC 14.44

### DIFF
--- a/src/rendering/cuda_vulkan_interop.cpp
+++ b/src/rendering/cuda_vulkan_interop.cpp
@@ -1,0 +1,665 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "cuda_vulkan_interop.hpp"
+
+#include "core/tensor/internal/cuda_stream_context.hpp"
+#include "image_layout.hpp"
+
+#include <algorithm>
+#include <format>
+#include <stdexcept>
+#include <utility>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace lfs::rendering {
+    namespace {
+#ifdef _WIN32
+        constexpr cudaExternalMemoryHandleType kCudaExternalMemoryHandleType =
+            cudaExternalMemoryHandleTypeOpaqueWin32;
+        constexpr cudaExternalSemaphoreHandleType kCudaExternalSemaphoreHandleType =
+            cudaExternalSemaphoreHandleTypeTimelineSemaphoreWin32;
+#else
+        constexpr cudaExternalMemoryHandleType kCudaExternalMemoryHandleType =
+            cudaExternalMemoryHandleTypeOpaqueFd;
+        constexpr cudaExternalSemaphoreHandleType kCudaExternalSemaphoreHandleType =
+            cudaExternalSemaphoreHandleTypeTimelineSemaphoreFd;
+#endif
+
+        [[nodiscard]] bool nativeHandleValid(const CudaVulkanExternalHandle handle) {
+#ifdef _WIN32
+            return handle != nullptr;
+#else
+            return handle >= 0;
+#endif
+        }
+
+        void closeNativeHandle(CudaVulkanExternalHandle& handle) {
+            if (!nativeHandleValid(handle)) {
+                return;
+            }
+#ifdef _WIN32
+            CloseHandle(static_cast<HANDLE>(handle));
+            handle = nullptr;
+#else
+            ::close(handle);
+            handle = -1;
+#endif
+        }
+
+        class NativeHandleOwner {
+        public:
+            explicit NativeHandleOwner(const CudaVulkanExternalHandle handle)
+                : handle_(handle) {}
+
+            ~NativeHandleOwner() {
+                closeNativeHandle(handle_);
+            }
+
+            NativeHandleOwner(const NativeHandleOwner&) = delete;
+            NativeHandleOwner& operator=(const NativeHandleOwner&) = delete;
+
+            [[nodiscard]] CudaVulkanExternalHandle get() const { return handle_; }
+
+            void release() {
+                handle_ = kInvalidCudaVulkanExternalHandle;
+            }
+
+        private:
+            CudaVulkanExternalHandle handle_ = kInvalidCudaVulkanExternalHandle;
+        };
+
+        [[nodiscard]] cudaChannelFormatDesc channelDescForFormat(const CudaVulkanImageFormat format) {
+            switch (format) {
+            case CudaVulkanImageFormat::Rgba8Unorm:
+                return cudaCreateChannelDesc(8, 8, 8, 8, cudaChannelFormatKindUnsigned);
+            }
+            return {};
+        }
+
+        [[nodiscard]] const char* formatName(const CudaVulkanImageFormat format) {
+            switch (format) {
+            case CudaVulkanImageFormat::Rgba8Unorm:
+                return "RGBA8_UNORM";
+            }
+            return "unknown";
+        }
+
+        [[nodiscard]] bool formatSupported(const CudaVulkanImageFormat format) {
+            return format == CudaVulkanImageFormat::Rgba8Unorm;
+        }
+
+        struct PreparedCudaImageTensor {
+            lfs::core::Tensor tensor;
+            int width = 0;
+            int height = 0;
+            int channels = 0;
+            detail::CudaVulkanTensorLayout layout = detail::CudaVulkanTensorLayout::Hwc;
+            detail::CudaVulkanTensorElementType element_type = detail::CudaVulkanTensorElementType::UInt8;
+        };
+
+        [[nodiscard]] bool prepareCudaImageTensor(const lfs::core::Tensor& tensor,
+                                                  const CudaVulkanExtent2D extent,
+                                                  const cudaStream_t stream,
+                                                  PreparedCudaImageTensor& out,
+                                                  std::string& error) {
+            if (!tensor.is_valid() || tensor.ndim() != 3) {
+                error = "CUDA/Vulkan image copy requires a valid 3D tensor";
+                return false;
+            }
+
+            const ImageLayout layout = detectImageLayout(tensor);
+            if (layout == ImageLayout::Unknown) {
+                error = "CUDA/Vulkan image copy received an unsupported tensor layout";
+                return false;
+            }
+
+            const int width = imageWidth(tensor, layout);
+            const int height = imageHeight(tensor, layout);
+            const int channels = imageChannels(tensor, layout);
+            if (width != static_cast<int>(extent.width) || height != static_cast<int>(extent.height)) {
+                error = std::format("CUDA/Vulkan image copy size mismatch: tensor {}x{}, target {}x{}",
+                                    width,
+                                    height,
+                                    extent.width,
+                                    extent.height);
+                return false;
+            }
+            if (channels != 1 && channels != 3 && channels != 4) {
+                error = std::format("CUDA/Vulkan image copy requires 1, 3, or 4 channels, got {}",
+                                    channels);
+                return false;
+            }
+
+            lfs::core::Tensor prepared = tensor;
+            if (prepared.dtype() != lfs::core::DataType::UInt8 &&
+                prepared.dtype() != lfs::core::DataType::Float32) {
+                prepared = prepared.to(lfs::core::DataType::Float32);
+            }
+            if (prepared.device() != lfs::core::Device::CUDA) {
+                prepared = prepared.to(lfs::core::Device::CUDA, stream);
+            }
+            if (!prepared.is_contiguous()) {
+                prepared = prepared.contiguous();
+            }
+
+            out.tensor = std::move(prepared);
+            out.width = width;
+            out.height = height;
+            out.channels = channels;
+            out.layout = layout == ImageLayout::HWC
+                             ? detail::CudaVulkanTensorLayout::Hwc
+                             : detail::CudaVulkanTensorLayout::Chw;
+            out.element_type = out.tensor.dtype() == lfs::core::DataType::UInt8
+                                   ? detail::CudaVulkanTensorElementType::UInt8
+                                   : detail::CudaVulkanTensorElementType::Float32;
+            error.clear();
+            return true;
+        }
+    } // namespace
+
+    namespace detail {
+        [[nodiscard]] cudaError_t launchCudaVulkanCopyTensorToSurface(
+            cudaSurfaceObject_t surface,
+            const void* source,
+            std::uint32_t width,
+            std::uint32_t height,
+            int channels,
+            CudaVulkanTensorLayout layout,
+            CudaVulkanTensorElementType element_type,
+            const cudaStream_t stream);
+
+        [[nodiscard]] cudaError_t launchCudaVulkanPackTensorToRgba8(
+            unsigned char* destination,
+            const void* source,
+            std::uint32_t width,
+            std::uint32_t height,
+            int channels,
+            CudaVulkanTensorLayout layout,
+            CudaVulkanTensorElementType element_type,
+            const cudaStream_t stream);
+    } // namespace detail
+
+    CudaVulkanRgba8HostBuffer packTensorToRgba8Host(const lfs::core::Tensor& tensor,
+                                                    const CudaVulkanExtent2D extent,
+                                                    const cudaStream_t stream) {
+        CudaVulkanRgba8HostBuffer result{};
+        if (extent.width == 0 || extent.height == 0) {
+            result.error = "CUDA/Vulkan RGBA8 packing requires a non-zero extent";
+            return result;
+        }
+
+        PreparedCudaImageTensor prepared{};
+        if (!prepareCudaImageTensor(tensor, extent, stream, prepared, result.error)) {
+            return result;
+        }
+
+        lfs::core::Tensor packed = lfs::core::Tensor::empty(
+            {static_cast<std::size_t>(extent.height), static_cast<std::size_t>(extent.width), std::size_t{4}},
+            lfs::core::Device::CUDA,
+            lfs::core::DataType::UInt8);
+        if (stream != nullptr) {
+            packed.set_stream(stream);
+        }
+
+        lfs::core::waitForCUDAStream(stream, prepared.tensor.stream());
+        const cudaError_t launch_status = detail::launchCudaVulkanPackTensorToRgba8(
+            packed.ptr<std::uint8_t>(),
+            prepared.tensor.data_ptr(),
+            extent.width,
+            extent.height,
+            prepared.channels,
+            prepared.layout,
+            prepared.element_type,
+            stream);
+        if (launch_status != cudaSuccess) {
+            result.error = std::format("pack tensor to RGBA8 failed: {} ({})",
+                                       cudaGetErrorName(launch_status),
+                                       cudaGetErrorString(launch_status));
+            return result;
+        }
+
+        const cudaError_t sync_status = stream != nullptr ? cudaStreamSynchronize(stream) : cudaDeviceSynchronize();
+        if (sync_status != cudaSuccess) {
+            result.error = std::format("synchronize packed RGBA8 tensor failed: {} ({})",
+                                       cudaGetErrorName(sync_status),
+                                       cudaGetErrorString(sync_status));
+            return result;
+        }
+
+        const lfs::core::Tensor cpu = packed.to(lfs::core::Device::CPU);
+        const auto* pixels = cpu.ptr<std::uint8_t>();
+        if (pixels == nullptr) {
+            result.error = "packed RGBA8 tensor returned null host data";
+            return result;
+        }
+        result.pixels.assign(pixels, pixels + cpu.numel());
+        return result;
+    }
+
+    CudaVulkanInterop::CudaVulkanInterop(CudaVulkanExternalImageImport image,
+                                         CudaVulkanExternalSemaphoreImport semaphore) {
+        if (!init(std::move(image), std::move(semaphore))) {
+            throw std::runtime_error(last_error_);
+        }
+    }
+
+    CudaVulkanInterop::~CudaVulkanInterop() {
+        reset();
+    }
+
+    CudaVulkanInterop::CudaVulkanInterop(CudaVulkanInterop&& other) noexcept {
+        *this = std::move(other);
+    }
+
+    CudaVulkanInterop& CudaVulkanInterop::operator=(CudaVulkanInterop&& other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+
+        reset();
+        cuda_mem_ = std::exchange(other.cuda_mem_, nullptr);
+        cuda_mip_ = std::exchange(other.cuda_mip_, nullptr);
+        cuda_array_ = std::exchange(other.cuda_array_, nullptr);
+        surface_ = std::exchange(other.surface_, 0);
+        cuda_timeline_ = std::exchange(other.cuda_timeline_, nullptr);
+        extent_ = std::exchange(other.extent_, {});
+        format_ = std::exchange(other.format_, CudaVulkanImageFormat::Rgba8Unorm);
+        staging_tensor_ = std::move(other.staging_tensor_);
+        upload_source_ = std::move(other.upload_source_);
+        last_error_ = std::move(other.last_error_);
+        return *this;
+    }
+
+    bool CudaVulkanInterop::init(CudaVulkanExternalImageImport image,
+                                 CudaVulkanExternalSemaphoreImport semaphore) {
+        reset();
+        last_error_.clear();
+
+        if (!nativeHandleValid(image.memory_handle)) {
+            return fail("CUDA/Vulkan external image import requires a valid memory handle");
+        }
+        if (!nativeHandleValid(semaphore.semaphore_handle)) {
+            return fail("CUDA/Vulkan external semaphore import requires a valid semaphore handle");
+        }
+        if (image.allocation_size == 0 || image.extent.width == 0 || image.extent.height == 0) {
+            return fail("CUDA/Vulkan external image import requires non-zero allocation and extent");
+        }
+        if (!formatSupported(image.format)) {
+            return fail(std::format("CUDA/Vulkan external image format {} is unsupported",
+                                    formatName(image.format)));
+        }
+        int cuda_device = 0;
+        cudaError_t status = cudaGetDevice(&cuda_device);
+        if (status != cudaSuccess) {
+            return failCuda("cudaGetDevice", status);
+        }
+        int timeline_interop_supported = 0;
+        status = cudaDeviceGetAttribute(&timeline_interop_supported,
+                                        cudaDevAttrTimelineSemaphoreInteropSupported,
+                                        cuda_device);
+        if (status != cudaSuccess) {
+            return failCuda("cudaDeviceGetAttribute(cudaDevAttrTimelineSemaphoreInteropSupported)", status);
+        }
+        if (timeline_interop_supported == 0) {
+            return fail("CUDA device does not support external timeline semaphore interop");
+        }
+
+        NativeHandleOwner memory_handle(image.memory_handle);
+        NativeHandleOwner semaphore_handle(semaphore.semaphore_handle);
+
+        cudaExternalMemoryHandleDesc memory_desc{};
+        memory_desc.type = kCudaExternalMemoryHandleType;
+        memory_desc.size = image.allocation_size;
+        if (image.dedicated_allocation) {
+            memory_desc.flags = cudaExternalMemoryDedicated;
+        }
+#ifdef _WIN32
+        memory_desc.handle.win32.handle = memory_handle.get();
+#else
+        memory_desc.handle.fd = memory_handle.get();
+#endif
+
+        status = cudaImportExternalMemory(&cuda_mem_, &memory_desc);
+        if (status != cudaSuccess) {
+            reset();
+            return failCuda("cudaImportExternalMemory", status);
+        }
+#ifndef _WIN32
+        memory_handle.release();
+#endif
+
+        cudaExternalMemoryMipmappedArrayDesc array_desc{};
+        array_desc.offset = 0;
+        array_desc.formatDesc = channelDescForFormat(image.format);
+        array_desc.extent = make_cudaExtent(image.extent.width, image.extent.height, 0);
+        array_desc.flags = cudaArraySurfaceLoadStore;
+        array_desc.numLevels = 1;
+
+        status = cudaExternalMemoryGetMappedMipmappedArray(&cuda_mip_, cuda_mem_, &array_desc);
+        if (status != cudaSuccess) {
+            reset();
+            return failCuda("cudaExternalMemoryGetMappedMipmappedArray", status);
+        }
+
+        status = cudaGetMipmappedArrayLevel(&cuda_array_, cuda_mip_, 0);
+        if (status != cudaSuccess) {
+            reset();
+            return failCuda("cudaGetMipmappedArrayLevel", status);
+        }
+
+        cudaResourceDesc resource_desc{};
+        resource_desc.resType = cudaResourceTypeArray;
+        resource_desc.res.array.array = cuda_array_;
+        status = cudaCreateSurfaceObject(&surface_, &resource_desc);
+        if (status != cudaSuccess) {
+            reset();
+            return failCuda("cudaCreateSurfaceObject", status);
+        }
+
+        cudaExternalSemaphoreHandleDesc semaphore_desc{};
+        semaphore_desc.type = kCudaExternalSemaphoreHandleType;
+#ifdef _WIN32
+        semaphore_desc.handle.win32.handle = semaphore_handle.get();
+#else
+        semaphore_desc.handle.fd = semaphore_handle.get();
+#endif
+
+        status = cudaImportExternalSemaphore(&cuda_timeline_, &semaphore_desc);
+        if (status != cudaSuccess) {
+            reset();
+            return failCuda("cudaImportExternalSemaphore", status);
+        }
+#ifndef _WIN32
+        semaphore_handle.release();
+#endif
+
+        extent_ = image.extent;
+        format_ = image.format;
+        return true;
+    }
+
+    void CudaVulkanInterop::reset() {
+        staging_tensor_ = {};
+        upload_source_ = {};
+        if (surface_ != 0) {
+            cudaDestroySurfaceObject(surface_);
+            surface_ = 0;
+        }
+        cuda_array_ = nullptr;
+        if (cuda_mip_ != nullptr) {
+            cudaFreeMipmappedArray(cuda_mip_);
+            cuda_mip_ = nullptr;
+        }
+        if (cuda_mem_ != nullptr) {
+            cudaDestroyExternalMemory(cuda_mem_);
+            cuda_mem_ = nullptr;
+        }
+        if (cuda_timeline_ != nullptr) {
+            cudaDestroyExternalSemaphore(cuda_timeline_);
+            cuda_timeline_ = nullptr;
+        }
+        extent_ = {};
+        format_ = CudaVulkanImageFormat::Rgba8Unorm;
+    }
+
+    bool CudaVulkanInterop::valid() const {
+        return cuda_mem_ != nullptr &&
+               cuda_mip_ != nullptr &&
+               cuda_array_ != nullptr &&
+               surface_ != 0 &&
+               cuda_timeline_ != nullptr &&
+               extent_.width > 0 &&
+               extent_.height > 0;
+    }
+
+    lfs::core::Tensor CudaVulkanInterop::view_as_tensor() const {
+        if (!valid()) {
+            last_error_ = "CUDA/Vulkan interop target is not initialized";
+            return {};
+        }
+        const lfs::core::TensorShape shape{
+            static_cast<std::size_t>(extent_.height),
+            static_cast<std::size_t>(extent_.width),
+            std::size_t{4},
+        };
+        if (!staging_tensor_.is_valid() ||
+            staging_tensor_.shape() != shape ||
+            staging_tensor_.dtype() != lfs::core::DataType::UInt8 ||
+            staging_tensor_.device() != lfs::core::Device::CUDA) {
+            staging_tensor_ = lfs::core::Tensor::empty(shape, lfs::core::Device::CUDA, lfs::core::DataType::UInt8);
+            staging_tensor_.set_name("cuda_vulkan_interop_staging");
+        }
+        return staging_tensor_;
+    }
+
+    bool CudaVulkanInterop::copyViewToSurface(const cudaStream_t stream) const {
+        if (!staging_tensor_.is_valid()) {
+            return fail("CUDA/Vulkan interop staging tensor has not been requested");
+        }
+        return copyTensorToSurface(staging_tensor_, stream);
+    }
+
+    bool CudaVulkanInterop::copyTensorToSurface(const lfs::core::Tensor& tensor,
+                                                const cudaStream_t stream) const {
+        last_error_.clear();
+        if (!valid()) {
+            return fail("CUDA/Vulkan interop target is not initialized");
+        }
+        PreparedCudaImageTensor prepared{};
+        if (!prepareCudaImageTensor(tensor, extent_, stream, prepared, last_error_)) {
+            return false;
+        }
+        upload_source_ = std::move(prepared.tensor);
+
+        const void* data = upload_source_.data_ptr();
+        if (data == nullptr) {
+            return fail("CUDA/Vulkan interop copy received a tensor with null data");
+        }
+
+        lfs::core::waitForCUDAStream(stream, upload_source_.stream());
+        const cudaError_t status = detail::launchCudaVulkanCopyTensorToSurface(
+            surface_,
+            data,
+            extent_.width,
+            extent_.height,
+            prepared.channels,
+            prepared.layout,
+            prepared.element_type,
+            stream);
+        return failCuda("copy tensor to CUDA surface", status);
+    }
+
+    bool CudaVulkanInterop::wait(const std::uint64_t value, const cudaStream_t stream) const {
+        last_error_.clear();
+        if (cuda_timeline_ == nullptr) {
+            return fail("CUDA/Vulkan timeline semaphore is not initialized");
+        }
+
+        cudaExternalSemaphoreWaitParams params{};
+        params.params.fence.value = value;
+        const cudaError_t status = cudaWaitExternalSemaphoresAsync(&cuda_timeline_, &params, 1, stream);
+        return failCuda("cudaWaitExternalSemaphoresAsync", status);
+    }
+
+    bool CudaVulkanInterop::signal(const std::uint64_t value, const cudaStream_t stream) const {
+        last_error_.clear();
+        if (cuda_timeline_ == nullptr) {
+            return fail("CUDA/Vulkan timeline semaphore is not initialized");
+        }
+
+        cudaExternalSemaphoreSignalParams params{};
+        params.params.fence.value = value;
+        const cudaError_t status = cudaSignalExternalSemaphoresAsync(&cuda_timeline_, &params, 1, stream);
+        return failCuda("cudaSignalExternalSemaphoresAsync", status);
+    }
+
+    bool CudaVulkanInterop::fail(std::string message) const {
+        last_error_ = std::move(message);
+        return false;
+    }
+
+    bool CudaVulkanInterop::failCuda(const char* const operation, const cudaError_t status) const {
+        if (status == cudaSuccess) {
+            return true;
+        }
+        last_error_ = std::format("{} failed: {} ({})",
+                                  operation,
+                                  cudaGetErrorName(status),
+                                  cudaGetErrorString(status));
+        return false;
+    }
+
+    CudaVulkanBufferInterop::CudaVulkanBufferInterop(CudaVulkanExternalBufferImport buffer) {
+        if (!init(std::move(buffer))) {
+            throw std::runtime_error(last_error_);
+        }
+    }
+
+    CudaVulkanBufferInterop::~CudaVulkanBufferInterop() {
+        reset();
+    }
+
+    CudaVulkanBufferInterop::CudaVulkanBufferInterop(CudaVulkanBufferInterop&& other) noexcept {
+        *this = std::move(other);
+    }
+
+    CudaVulkanBufferInterop& CudaVulkanBufferInterop::operator=(CudaVulkanBufferInterop&& other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+        reset();
+        cuda_mem_ = std::exchange(other.cuda_mem_, nullptr);
+        device_ptr_ = std::exchange(other.device_ptr_, nullptr);
+        allocation_size_ = std::exchange(other.allocation_size_, 0);
+        size_ = std::exchange(other.size_, 0);
+        upload_source_ = std::move(other.upload_source_);
+        last_error_ = std::move(other.last_error_);
+        return *this;
+    }
+
+    bool CudaVulkanBufferInterop::init(CudaVulkanExternalBufferImport buffer) {
+        reset();
+        last_error_.clear();
+
+        if (!nativeHandleValid(buffer.memory_handle)) {
+            return fail("CUDA/Vulkan external buffer import requires a valid memory handle");
+        }
+        if (buffer.allocation_size == 0 || buffer.size == 0 || buffer.size > buffer.allocation_size) {
+            return fail("CUDA/Vulkan external buffer import requires a non-zero size within the allocation");
+        }
+
+        NativeHandleOwner memory_handle(buffer.memory_handle);
+
+        cudaExternalMemoryHandleDesc memory_desc{};
+        memory_desc.type = kCudaExternalMemoryHandleType;
+        memory_desc.size = buffer.allocation_size;
+        if (buffer.dedicated_allocation) {
+            memory_desc.flags = cudaExternalMemoryDedicated;
+        }
+#ifdef _WIN32
+        memory_desc.handle.win32.handle = memory_handle.get();
+#else
+        memory_desc.handle.fd = memory_handle.get();
+#endif
+
+        cudaError_t status = cudaImportExternalMemory(&cuda_mem_, &memory_desc);
+        if (status != cudaSuccess) {
+            reset();
+            return failCuda("cudaImportExternalMemory(buffer)", status);
+        }
+#ifndef _WIN32
+        memory_handle.release();
+#endif
+
+        cudaExternalMemoryBufferDesc buffer_desc{};
+        buffer_desc.offset = 0;
+        buffer_desc.size = buffer.size;
+        status = cudaExternalMemoryGetMappedBuffer(&device_ptr_, cuda_mem_, &buffer_desc);
+        if (status != cudaSuccess) {
+            reset();
+            return failCuda("cudaExternalMemoryGetMappedBuffer", status);
+        }
+
+        allocation_size_ = buffer.allocation_size;
+        size_ = buffer.size;
+        return true;
+    }
+
+    void CudaVulkanBufferInterop::reset() {
+        upload_source_ = {};
+        if (device_ptr_ != nullptr) {
+            cudaFree(device_ptr_);
+            device_ptr_ = nullptr;
+        }
+        if (cuda_mem_ != nullptr) {
+            cudaDestroyExternalMemory(cuda_mem_);
+            cuda_mem_ = nullptr;
+        }
+        allocation_size_ = 0;
+        size_ = 0;
+    }
+
+    bool CudaVulkanBufferInterop::valid() const {
+        return cuda_mem_ != nullptr && device_ptr_ != nullptr && size_ > 0;
+    }
+
+    bool CudaVulkanBufferInterop::copyFromTensor(const lfs::core::Tensor& tensor,
+                                                 const std::size_t byte_count,
+                                                 const cudaStream_t stream) const {
+        last_error_.clear();
+        if (!valid()) {
+            return fail("CUDA/Vulkan external buffer is not initialized");
+        }
+        if (byte_count == 0 || byte_count > size_) {
+            return fail(std::format("CUDA/Vulkan buffer copy size {} exceeds target {}", byte_count, size_));
+        }
+        if (!tensor.is_valid() || tensor.data_ptr() == nullptr) {
+            return fail("CUDA/Vulkan buffer copy received an invalid tensor");
+        }
+
+        upload_source_ = tensor;
+        if (upload_source_.device() != lfs::core::Device::CUDA) {
+            upload_source_ = upload_source_.to(lfs::core::Device::CUDA, stream);
+        }
+        if (!upload_source_.is_contiguous()) {
+            upload_source_ = upload_source_.contiguous();
+        }
+        if (byte_count > upload_source_.bytes()) {
+            return fail(std::format("CUDA/Vulkan buffer copy requested {} bytes from {} byte tensor",
+                                    byte_count,
+                                    upload_source_.bytes()));
+        }
+
+        lfs::core::waitForCUDAStream(stream, upload_source_.stream());
+        const cudaError_t status = cudaMemcpyAsync(
+            device_ptr_, upload_source_.data_ptr(), byte_count, cudaMemcpyDeviceToDevice, stream);
+        return failCuda("cudaMemcpyAsync(CUDA tensor -> Vulkan buffer)", status);
+    }
+
+    bool CudaVulkanBufferInterop::fail(std::string message) const {
+        last_error_ = std::move(message);
+        return false;
+    }
+
+    bool CudaVulkanBufferInterop::failCuda(const char* const operation, const cudaError_t status) const {
+        if (status == cudaSuccess) {
+            return true;
+        }
+        last_error_ = std::format("{} failed: {} ({})",
+                                  operation,
+                                  cudaGetErrorName(status),
+                                  cudaGetErrorString(status));
+        return false;
+    }
+
+} // namespace lfs::rendering

--- a/src/rendering/cuda_vulkan_interop.cu
+++ b/src/rendering/cuda_vulkan_interop.cu
@@ -1,0 +1,179 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "cuda_vulkan_interop.hpp"
+
+namespace lfs::rendering::detail {
+    namespace {
+        __device__ __forceinline__ unsigned char toByte(const float value) {
+            const float clamped = fminf(fmaxf(value, 0.0f), 1.0f);
+            return static_cast<unsigned char>(clamped * 255.0f + 0.5f);
+        }
+
+        __device__ __forceinline__ unsigned char loadUInt8Channel(
+            const unsigned char* source,
+            const std::uint32_t width,
+            const std::uint32_t height,
+            const int channels,
+            const CudaVulkanTensorLayout layout,
+            const std::uint32_t x,
+            const std::uint32_t y,
+            const int channel) {
+            if (channel >= channels) {
+                return channel == 3 ? 255 : 0;
+            }
+            if (layout == CudaVulkanTensorLayout::Hwc) {
+                return source[(static_cast<std::size_t>(y) * width + x) * channels + channel];
+            }
+            return source[(static_cast<std::size_t>(channel) * height + y) * width + x];
+        }
+
+        __device__ __forceinline__ unsigned char loadFloatChannel(
+            const float* source,
+            const std::uint32_t width,
+            const std::uint32_t height,
+            const int channels,
+            const CudaVulkanTensorLayout layout,
+            const std::uint32_t x,
+            const std::uint32_t y,
+            const int channel) {
+            if (channel >= channels) {
+                return channel == 3 ? 255 : 0;
+            }
+            const float value = layout == CudaVulkanTensorLayout::Hwc
+                                    ? source[(static_cast<std::size_t>(y) * width + x) * channels + channel]
+                                    : source[(static_cast<std::size_t>(channel) * height + y) * width + x];
+            return toByte(value);
+        }
+
+        __global__ void copyTensorToSurfaceKernel(
+            cudaSurfaceObject_t surface,
+            const void* source,
+            std::uint32_t width,
+            std::uint32_t height,
+            int channels,
+            CudaVulkanTensorLayout layout,
+            CudaVulkanTensorElementType element_type) {
+            const std::uint32_t x = blockIdx.x * blockDim.x + threadIdx.x;
+            const std::uint32_t y = blockIdx.y * blockDim.y + threadIdx.y;
+            if (x >= width || y >= height) {
+                return;
+            }
+
+            uchar4 rgba{};
+            if (element_type == CudaVulkanTensorElementType::UInt8) {
+                const auto* bytes = static_cast<const unsigned char*>(source);
+                rgba.x = loadUInt8Channel(bytes, width, height, channels, layout, x, y, 0);
+                rgba.y = loadUInt8Channel(bytes, width, height, channels, layout, x, y, 1);
+                rgba.z = loadUInt8Channel(bytes, width, height, channels, layout, x, y, 2);
+                rgba.w = loadUInt8Channel(bytes, width, height, channels, layout, x, y, 3);
+            } else {
+                const auto* floats = static_cast<const float*>(source);
+                rgba.x = loadFloatChannel(floats, width, height, channels, layout, x, y, 0);
+                rgba.y = loadFloatChannel(floats, width, height, channels, layout, x, y, 1);
+                rgba.z = loadFloatChannel(floats, width, height, channels, layout, x, y, 2);
+                rgba.w = loadFloatChannel(floats, width, height, channels, layout, x, y, 3);
+            }
+
+            surf2Dwrite(rgba, surface, static_cast<int>(x * sizeof(uchar4)), static_cast<int>(y));
+        }
+
+        __global__ void packTensorToRgba8Kernel(
+            unsigned char* destination,
+            const void* source,
+            std::uint32_t width,
+            std::uint32_t height,
+            int channels,
+            CudaVulkanTensorLayout layout,
+            CudaVulkanTensorElementType element_type) {
+            const std::uint32_t x = blockIdx.x * blockDim.x + threadIdx.x;
+            const std::uint32_t y = blockIdx.y * blockDim.y + threadIdx.y;
+            if (x >= width || y >= height) {
+                return;
+            }
+
+            uchar4 rgba{};
+            if (element_type == CudaVulkanTensorElementType::UInt8) {
+                const auto* bytes = static_cast<const unsigned char*>(source);
+                rgba.x = loadUInt8Channel(bytes, width, height, channels, layout, x, y, 0);
+                rgba.y = loadUInt8Channel(bytes, width, height, channels, layout, x, y, 1);
+                rgba.z = loadUInt8Channel(bytes, width, height, channels, layout, x, y, 2);
+                rgba.w = loadUInt8Channel(bytes, width, height, channels, layout, x, y, 3);
+            } else {
+                const auto* floats = static_cast<const float*>(source);
+                rgba.x = loadFloatChannel(floats, width, height, channels, layout, x, y, 0);
+                rgba.y = loadFloatChannel(floats, width, height, channels, layout, x, y, 1);
+                rgba.z = loadFloatChannel(floats, width, height, channels, layout, x, y, 2);
+                rgba.w = loadFloatChannel(floats, width, height, channels, layout, x, y, 3);
+            }
+
+            const std::size_t offset = (static_cast<std::size_t>(y) * width + x) * 4;
+            destination[offset + 0] = rgba.x;
+            destination[offset + 1] = rgba.y;
+            destination[offset + 2] = rgba.z;
+            destination[offset + 3] = rgba.w;
+        }
+    } // namespace
+
+    cudaError_t launchCudaVulkanCopyTensorToSurface(
+        const cudaSurfaceObject_t surface,
+        const void* source,
+        const std::uint32_t width,
+        const std::uint32_t height,
+        const int channels,
+        const CudaVulkanTensorLayout layout,
+        const CudaVulkanTensorElementType element_type,
+        const cudaStream_t stream) {
+        if (surface == 0 || source == nullptr || width == 0 || height == 0) {
+            return cudaErrorInvalidValue;
+        }
+
+        const dim3 block{16, 16, 1};
+        const dim3 grid{
+            (width + block.x - 1) / block.x,
+            (height + block.y - 1) / block.y,
+            1,
+        };
+        copyTensorToSurfaceKernel<<<grid, block, 0, stream>>>(
+            surface,
+            source,
+            width,
+            height,
+            channels,
+            layout,
+            element_type);
+        return cudaGetLastError();
+    }
+
+    cudaError_t launchCudaVulkanPackTensorToRgba8(
+        unsigned char* destination,
+        const void* source,
+        const std::uint32_t width,
+        const std::uint32_t height,
+        const int channels,
+        const CudaVulkanTensorLayout layout,
+        const CudaVulkanTensorElementType element_type,
+        const cudaStream_t stream) {
+        if (destination == nullptr || source == nullptr || width == 0 || height == 0) {
+            return cudaErrorInvalidValue;
+        }
+
+        const dim3 block{16, 16, 1};
+        const dim3 grid{
+            (width + block.x - 1) / block.x,
+            (height + block.y - 1) / block.y,
+            1,
+        };
+        packTensorToRgba8Kernel<<<grid, block, 0, stream>>>(
+            destination,
+            source,
+            width,
+            height,
+            channels,
+            layout,
+            element_type);
+        return cudaGetLastError();
+    }
+
+} // namespace lfs::rendering::detail

--- a/src/visualizer/rendering/vksplat_input_packer.cpp
+++ b/src/visualizer/rendering/vksplat_input_packer.cpp
@@ -1,0 +1,366 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "vksplat_input_packer.hpp"
+
+#include "core/tensor.hpp"
+#include "rendering/rasterizer/vksplat_fwd/src/config.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <format>
+#include <string_view>
+#include <vector>
+
+namespace lfs::vis::vksplat {
+    namespace {
+        using lfs::core::DataType;
+        using lfs::core::Device;
+        using lfs::core::Tensor;
+
+        [[nodiscard]] std::expected<std::vector<float>, std::string> tensorToCpuVector(
+            Tensor tensor,
+            const std::string_view label) {
+            if (!tensor.is_valid() || tensor.numel() == 0) {
+                return std::vector<float>{};
+            }
+            try {
+                const Tensor* current = &tensor;
+                Tensor float_tensor;
+                if (current->dtype() != DataType::Float32) {
+                    float_tensor = current->to(DataType::Float32);
+                    current = &float_tensor;
+                }
+                Tensor cpu_tensor;
+                if (current->device() != Device::CPU) {
+                    cpu_tensor = current->to(Device::CPU);
+                    current = &cpu_tensor;
+                }
+                Tensor contiguous_tensor;
+                if (!current->is_contiguous()) {
+                    contiguous_tensor = current->contiguous();
+                    current = &contiguous_tensor;
+                }
+                if (current->dtype() != DataType::Float32 || current->device() != Device::CPU) {
+                    return std::unexpected(std::format("VkSplat failed to stage {} as CPU float32", label));
+                }
+                const float* ptr = current->ptr<float>();
+                if (!ptr) {
+                    return std::unexpected(std::format("VkSplat got a null CPU pointer for {}", label));
+                }
+                std::vector<float> result(current->numel());
+                std::memcpy(result.data(), ptr, result.size() * sizeof(float));
+                return result;
+            } catch (const std::exception& e) {
+                return std::unexpected(std::format("VkSplat failed to stage {}: {}", label, e.what()));
+            }
+        }
+    } // namespace
+
+    std::expected<void, std::string> packHostInputs(
+        const lfs::core::SplatData& splat_data,
+        Buffer<float>& xyz_ws,
+        Buffer<float>& rotations,
+        Buffer<float>& scales_opacs,
+        Buffer<float>& sh_coeffs) {
+        const std::size_t n = static_cast<std::size_t>(splat_data.size());
+        if (n == 0) {
+            return std::unexpected("VkSplat cannot render an empty model");
+        }
+
+        const Tensor means_tensor = splat_data.get_means();
+        const Tensor rotations_tensor = splat_data.get_rotation();
+        const Tensor scales_tensor = splat_data.get_scaling();
+        const Tensor opacities_tensor = splat_data.get_opacity();
+        if (means_tensor.ndim() != 2 || means_tensor.size(0) != n || means_tensor.size(1) != 3 ||
+            rotations_tensor.ndim() != 2 || rotations_tensor.size(0) != n || rotations_tensor.size(1) != 4 ||
+            scales_tensor.ndim() != 2 || scales_tensor.size(0) != n || scales_tensor.size(1) != 3 ||
+            opacities_tensor.ndim() != 1 || opacities_tensor.size(0) != n) {
+            return std::unexpected("VkSplat input tensor shapes do not match [N,3]/[N,4]/[N]");
+        }
+
+        auto means = tensorToCpuVector(means_tensor, "model.means");
+        auto rotations_cpu = tensorToCpuVector(rotations_tensor, "model.rotation");
+        auto scales = tensorToCpuVector(scales_tensor, "model.scaling");
+        auto opacities = tensorToCpuVector(opacities_tensor, "model.opacity");
+        if (!means || !rotations_cpu || !scales || !opacities) {
+            return std::unexpected(!means           ? means.error()
+                                   : !rotations_cpu ? rotations_cpu.error()
+                                   : !scales        ? scales.error()
+                                                    : opacities.error());
+        }
+        if (means->size() != 3 * n || rotations_cpu->size() != 4 * n ||
+            scales->size() != 3 * n || opacities->size() != n) {
+            return std::unexpected("VkSplat staged input tensor sizes do not match the model splat count");
+        }
+
+        xyz_ws.assign(means->begin(), means->end());
+        rotations.assign(rotations_cpu->begin(), rotations_cpu->end());
+        VulkanGSPipelineBuffers::assignScalesOpacs(scales_opacs, n, scales->data(), opacities->data());
+
+        sh_coeffs.assign(n * 16 * 3, 0.0f);
+        const Tensor& sh0_tensor = splat_data.sh0();
+        if (!sh0_tensor.is_valid() || sh0_tensor.numel() == 0 ||
+            sh0_tensor.size(0) != n || sh0_tensor.size(sh0_tensor.ndim() - 1) != 3) {
+            return std::unexpected("VkSplat expected SH DC coefficients shaped [N, 1, 3] or [N, 3]");
+        }
+        auto sh0 = tensorToCpuVector(sh0_tensor, "model.sh0");
+        if (!sh0) {
+            return std::unexpected(sh0.error());
+        }
+        if (sh0->size() < 3 * n) {
+            return std::unexpected("VkSplat staged SH DC tensor is smaller than [N, 3]");
+        }
+        for (std::size_t i = 0; i < n; ++i) {
+            for (std::size_t c = 0; c < 3; ++c) {
+                sh_coeffs[(i * 16) * 3 + c] = (*sh0)[i * 3 + c];
+            }
+        }
+
+        const Tensor& shn_tensor = splat_data.shN();
+        if (shn_tensor.is_valid() && shn_tensor.numel() > 0) {
+            if (shn_tensor.ndim() != 3 || shn_tensor.size(0) != n || shn_tensor.size(2) != 3) {
+                return std::unexpected("VkSplat expected SH rest coefficients shaped [N, coeffs, 3]");
+            }
+            auto shn = tensorToCpuVector(shn_tensor, "model.shN");
+            if (!shn) {
+                return std::unexpected(shn.error());
+            }
+            const std::size_t source_rest = static_cast<std::size_t>(shn_tensor.size(1));
+            const std::size_t rest = std::min<std::size_t>(15, source_rest);
+            if (shn->size() < n * source_rest * 3) {
+                return std::unexpected("VkSplat staged SH rest tensor is smaller than [N, coeffs, 3]");
+            }
+            for (std::size_t i = 0; i < n; ++i) {
+                for (std::size_t k = 0; k < rest; ++k) {
+                    for (std::size_t c = 0; c < 3; ++c) {
+                        sh_coeffs[((i * 16) + (k + 1)) * 3 + c] =
+                            (*shn)[(i * source_rest + k) * 3 + c];
+                    }
+                }
+            }
+        }
+        VulkanGSPipelineBuffers::reorderSH(sh_coeffs);
+        return {};
+    }
+
+    namespace {
+
+        constexpr int kShDim = 12;            // 16 SH coefficients * 3 channels / 4 floats per chunk
+        constexpr int kShChunkFloats = 4;     // float4 chunks expected by the rasterizer
+        constexpr int kShCoeffsPerSplat = 16; // 1 DC + up to 15 shN slots
+        constexpr int kShChannels = 3;
+
+        [[nodiscard]] Tensor activatedRotation(const Tensor& rotation_raw) {
+            Tensor squared = rotation_raw.square();
+            Tensor sum_squared = squared.sum({1}, true);
+            Tensor norm = sum_squared.sqrt().clamp_min(1e-12f);
+            return rotation_raw.div(norm);
+        }
+
+        [[nodiscard]] std::expected<Tensor, std::string> buildPaddedShTensor(
+            const lfs::core::SplatData& splat_data) {
+            const std::size_t n = static_cast<std::size_t>(splat_data.size());
+
+            const Tensor& sh0_raw = splat_data.sh0();
+            if (!sh0_raw.is_valid() || sh0_raw.numel() == 0 ||
+                sh0_raw.size(0) != n || sh0_raw.size(sh0_raw.ndim() - 1) != 3) {
+                return std::unexpected("VkSplat expected SH DC coefficients shaped [N, 1, 3] or [N, 3]");
+            }
+            Tensor sh0 = sh0_raw;
+            if (sh0.dtype() != DataType::Float32) {
+                sh0 = sh0.to(DataType::Float32);
+            }
+            if (sh0.device() != Device::CUDA) {
+                sh0 = sh0.to(Device::CUDA);
+            }
+            if (sh0.ndim() == 2) {
+                sh0 = sh0.unsqueeze(1); // [N, 1, 3]
+            }
+            if (sh0.size(1) != 1) {
+                return std::unexpected("VkSplat expected SH DC tensor with a single coefficient slot");
+            }
+
+            const Tensor& shN_raw = splat_data.shN();
+            const std::size_t source_rest = (shN_raw.is_valid() && shN_raw.numel() > 0)
+                                                ? static_cast<std::size_t>(shN_raw.size(1))
+                                                : 0;
+            const std::size_t rest = std::min<std::size_t>(15, source_rest);
+
+            std::vector<Tensor> parts;
+            parts.reserve(3);
+            parts.push_back(sh0.contiguous());
+
+            if (rest > 0) {
+                if (shN_raw.ndim() != 3 || shN_raw.size(0) != n || shN_raw.size(2) != 3) {
+                    return std::unexpected("VkSplat expected SH rest coefficients shaped [N, coeffs, 3]");
+                }
+                Tensor shn = shN_raw;
+                if (shn.dtype() != DataType::Float32) {
+                    shn = shn.to(DataType::Float32);
+                }
+                if (shn.device() != Device::CUDA) {
+                    shn = shn.to(Device::CUDA);
+                }
+                if (rest < source_rest) {
+                    shn = shn.slice(1, 0, rest);
+                }
+                parts.push_back(shn.contiguous());
+            }
+
+            const std::size_t pad_slots = static_cast<std::size_t>(kShCoeffsPerSplat) - 1 - rest;
+            if (pad_slots > 0) {
+                parts.push_back(Tensor::zeros({n, pad_slots, std::size_t{3}},
+                                              Device::CUDA,
+                                              DataType::Float32));
+            }
+
+            return Tensor::cat(parts, 1).contiguous(); // [N, 16, 3]
+        }
+
+    } // namespace
+
+    std::expected<DevicePackedInputs, std::string> packDeviceInputs(
+        const lfs::core::SplatData& splat_data) {
+        const std::size_t n = static_cast<std::size_t>(splat_data.size());
+        if (n == 0) {
+            return std::unexpected("VkSplat cannot render an empty model");
+        }
+
+        const Tensor& means_raw = splat_data.means_raw();
+        const Tensor& rotation_raw = splat_data.rotation_raw();
+        const Tensor& scaling_raw = splat_data.scaling_raw();
+        const Tensor& opacity_raw = splat_data.opacity_raw();
+        if (means_raw.ndim() != 2 || means_raw.size(0) != n || means_raw.size(1) != 3 ||
+            rotation_raw.ndim() != 2 || rotation_raw.size(0) != n || rotation_raw.size(1) != 4 ||
+            scaling_raw.ndim() != 2 || scaling_raw.size(0) != n || scaling_raw.size(1) != 3) {
+            return std::unexpected("VkSplat input tensor shapes do not match [N,3]/[N,4]/[N,3]");
+        }
+        if (opacity_raw.ndim() == 0 ||
+            (opacity_raw.ndim() == 1 && opacity_raw.size(0) != n) ||
+            (opacity_raw.ndim() == 2 && (opacity_raw.size(0) != n || opacity_raw.size(1) != 1))) {
+            return std::unexpected("VkSplat opacity tensor must be [N] or [N, 1]");
+        }
+
+        try {
+            const auto to_cuda_f32 = [](const Tensor& t) {
+                Tensor out = t;
+                if (out.dtype() != DataType::Float32) {
+                    out = out.to(DataType::Float32);
+                }
+                if (out.device() != Device::CUDA) {
+                    out = out.to(Device::CUDA);
+                }
+                return out.contiguous();
+            };
+
+            DevicePackedInputs result;
+            result.num_splats = n;
+
+            result.xyz_ws = to_cuda_f32(means_raw);
+
+            const Tensor rotation_in = to_cuda_f32(rotation_raw);
+            result.rotations = activatedRotation(rotation_in).contiguous();
+
+            const Tensor scaling_in = to_cuda_f32(scaling_raw);
+            const Tensor scales_exp = scaling_in.exp().contiguous();
+            Tensor opacity_in = to_cuda_f32(opacity_raw);
+            if (opacity_in.ndim() == 1) {
+                opacity_in = opacity_in.unsqueeze(1);
+            }
+            const Tensor opacity_sig = opacity_in.sigmoid().contiguous();
+            // Cat through a 3D shape so the tensor library's last-dim path
+            // (which hardcodes alpha=1.0f for [N,3]+[N,1] floats) is bypassed.
+            const Tensor scales_3d = scales_exp.unsqueeze(2);
+            const Tensor opacity_3d = opacity_sig.unsqueeze(2);
+            result.scales_opacs = Tensor::cat({scales_3d, opacity_3d}, 1)
+                                      .reshape({static_cast<int>(n), 4})
+                                      .contiguous();
+
+            auto sh_padded = buildPaddedShTensor(splat_data);
+            if (!sh_padded) {
+                return std::unexpected(sh_padded.error());
+            }
+
+            const std::size_t reorder = static_cast<std::size_t>(SH_REORDER_SIZE);
+            const std::size_t padded_n = ((n + reorder - 1) / reorder) * reorder;
+            Tensor sh_chunks = sh_padded->reshape({static_cast<int>(n),
+                                                   kShDim,
+                                                   kShChunkFloats});
+            if (padded_n != n) {
+                Tensor pad = Tensor::zeros({padded_n - n,
+                                            static_cast<std::size_t>(kShDim),
+                                            static_cast<std::size_t>(kShChunkFloats)},
+                                           Device::CUDA,
+                                           DataType::Float32);
+                sh_chunks = Tensor::cat({sh_chunks, pad}, 0);
+            }
+            const std::size_t n_groups = padded_n / reorder;
+            Tensor sh_grouped = sh_chunks.reshape({static_cast<int>(n_groups),
+                                                   static_cast<int>(reorder),
+                                                   kShDim,
+                                                   kShChunkFloats});
+            result.sh_coeffs = sh_grouped.permute({0, 2, 1, 3}).contiguous();
+            result.sh_padded_floats = static_cast<std::size_t>(result.sh_coeffs.numel());
+
+            assert(static_cast<std::size_t>(result.xyz_ws.numel()) == n * 3);
+            assert(static_cast<std::size_t>(result.rotations.numel()) == n * 4);
+            assert(static_cast<std::size_t>(result.scales_opacs.numel()) == n * 4);
+            assert(result.sh_padded_floats == n_groups * reorder * static_cast<std::size_t>(kShDim) *
+                                                  static_cast<std::size_t>(kShChunkFloats));
+
+            return result;
+        } catch (const std::exception& e) {
+            return std::unexpected(std::format("VkSplat device-side packing failed: {}", e.what()));
+        }
+    }
+
+    std::expected<std::vector<float>, std::string> buildPaddedShReference(
+        const lfs::core::SplatData& splat_data) {
+        const std::size_t n = static_cast<std::size_t>(splat_data.size());
+        if (n == 0) {
+            return std::unexpected("VkSplat cannot render an empty model");
+        }
+        std::vector<float> sh(n * 16 * 3, 0.0f);
+
+        const Tensor& sh0_tensor = splat_data.sh0();
+        if (!sh0_tensor.is_valid() || sh0_tensor.numel() == 0 ||
+            sh0_tensor.size(0) != n || sh0_tensor.size(sh0_tensor.ndim() - 1) != 3) {
+            return std::unexpected("VkSplat expected SH DC coefficients shaped [N, 1, 3] or [N, 3]");
+        }
+        auto sh0 = tensorToCpuVector(sh0_tensor, "model.sh0");
+        if (!sh0) {
+            return std::unexpected(sh0.error());
+        }
+        for (std::size_t i = 0; i < n; ++i) {
+            for (std::size_t c = 0; c < 3; ++c) {
+                sh[(i * 16) * 3 + c] = (*sh0)[i * 3 + c];
+            }
+        }
+
+        const Tensor& shn_tensor = splat_data.shN();
+        if (shn_tensor.is_valid() && shn_tensor.numel() > 0) {
+            if (shn_tensor.ndim() != 3 || shn_tensor.size(0) != n || shn_tensor.size(2) != 3) {
+                return std::unexpected("VkSplat expected SH rest coefficients shaped [N, coeffs, 3]");
+            }
+            auto shn = tensorToCpuVector(shn_tensor, "model.shN");
+            if (!shn) {
+                return std::unexpected(shn.error());
+            }
+            const std::size_t source_rest = static_cast<std::size_t>(shn_tensor.size(1));
+            const std::size_t rest = std::min<std::size_t>(15, source_rest);
+            for (std::size_t i = 0; i < n; ++i) {
+                for (std::size_t k = 0; k < rest; ++k) {
+                    for (std::size_t c = 0; c < 3; ++c) {
+                        sh[((i * 16) + (k + 1)) * 3 + c] =
+                            (*shn)[(i * source_rest + k) * 3 + c];
+                    }
+                }
+            }
+        }
+        return sh;
+    }
+
+} // namespace lfs::vis::vksplat


### PR DESCRIPTION
Three issues prevented the vulkan branch from building on Windows with CUDA 12.8 and MSVC 14.44:

## 1. \constexpr dim3\ — CUDA 12.8 compatibility
**File:** \src/rendering/cuda_vulkan_interop.cu\ (lines 132, 162)

CUDA 12.8's \dim3\ constructor is not marked \constexpr\, so \constexpr dim3 block{16, 16, 1}\ fails to compile. Changed to \const\.

## 2. \size_t\ → \int\ narrowing — MSVC C++20 strictness
**File:** \src/visualizer/rendering/vksplat_input_packer.cpp\ (lines 279, 289, 301)

\eshape()\ takes \ector<int>\ but was passed \size_t\ values via initializer lists. MSVC treats this as a narrowing error in C++20 mode. Added \static_cast<int>()\.

## 3. NVCC/MSVC \cudaStream_t\ ABI mismatch — linker failure
**File:** \src/rendering/cuda_vulkan_interop.cpp\ (forward declarations at lines 171–189)

NVCC mangles \cudaStream_t\ parameters as \const CUstream_st*\ (\Q\ pointer in MSVC mangling) while MSVC mangles them as \CUstream_st*\ (\P\ pointer). This caused LNK2019 unresolved externals for \launchCudaVulkanCopyTensorToSurface\ and \launchCudaVulkanPackTensorToRgba8\. Added \const\ to the forward declarations to match NVCC's ABI.
