### PR TITLE
ui: clarify dataset images tooltip

### DIFF
--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -432,7 +432,7 @@
       "bg_image_browse": "Browse for a background image",
       "bg_image_clear": "Clear the selected background image",
       "dataset_path": "Path to the loaded dataset",
-      "dataset_images": "Number of images in the dataset",
+      "dataset_images": "Image files discovered in the loaded dataset directory.",
       "dataset_output": "Output directory for trained artifacts",
       "opt_strategy_display": "Active densification strategy",
       "bilateral_grid_x": "Bilateral grid X resolution",


### PR DESCRIPTION
Closes #1183.

The Training panel's Dataset section has a row labeled `Images:` whose value is the integer image count. The previous tooltip, `Number of images in the dataset`, only restated the label, which is what the issue called out as confusing.

The new wording explains where the count comes from -- the loaded dataset directory -- and mirrors the wording style already used for the sibling `dataset_path` tooltip (`Path to the loaded dataset`):

```diff
-      "dataset_images": "Number of images in the dataset",
+      "dataset_images": "Image files discovered in the loaded dataset directory.",
```

Only the English locale is touched. The other locales (de, es, fr, it, ja, ko, nl, pl, zh) still hold the older translation and can be retranslated in a follow-up if you want the new wording propagated.