### PR TITLE
[Codex] Allow LFS to experimentally open in pure Vulkan without CUDA support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,22 @@ message(STATUS "CUDA Toolkit ${CUDAToolkit_VERSION} found at ${CUDAToolkit_TARGE
 find_package(TBB REQUIRED)
 find_package(Threads REQUIRED)
 if(ENABLE_VULKAN_VIEWER)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT BUILD_PORTABLE)
+        find_library(LFS_SYSTEM_VULKAN_LIBRARY
+            NAMES vulkan libvulkan.so
+            PATHS /lib64 /usr/lib64 /lib /usr/lib
+            NO_DEFAULT_PATH)
+        find_path(LFS_SYSTEM_VULKAN_INCLUDE_DIR
+            NAMES vulkan/vulkan.h
+            PATHS /usr/include
+            NO_DEFAULT_PATH)
+        if(LFS_SYSTEM_VULKAN_LIBRARY AND LFS_SYSTEM_VULKAN_INCLUDE_DIR)
+            set(Vulkan_LIBRARY "${LFS_SYSTEM_VULKAN_LIBRARY}" CACHE FILEPATH "System Vulkan loader" FORCE)
+            set(Vulkan_INCLUDE_DIR "${LFS_SYSTEM_VULKAN_INCLUDE_DIR}" CACHE PATH "System Vulkan headers" FORCE)
+            get_filename_component(LFS_SYSTEM_VULKAN_LIBRARY_DIR "${LFS_SYSTEM_VULKAN_LIBRARY}" DIRECTORY)
+            message(STATUS "Using system Vulkan loader on Linux: ${LFS_SYSTEM_VULKAN_LIBRARY}")
+        endif()
+    endif()
     find_package(Vulkan REQUIRED)
     find_package(VulkanMemoryAllocator CONFIG REQUIRED)
     find_package(volk CONFIG REQUIRED)
@@ -807,6 +823,9 @@ if(UNIX)
                 "$ORIGIN/lib"
                 "${CUDAToolkit_LIBRARY_DIR}"
         )
+        if(DEFINED LFS_SYSTEM_VULKAN_LIBRARY_DIR)
+            list(APPEND _lichtfeld_runtime_rpath_common "${LFS_SYSTEM_VULKAN_LIBRARY_DIR}")
+        endif()
         set(_lichtfeld_runtime_rpath_release "${_lichtfeld_runtime_rpath_common}")
         set(_lichtfeld_runtime_rpath_debug "${_lichtfeld_runtime_rpath_common}")
         if(DEFINED VCPKG_TARGET_TRIPLET)

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -226,33 +226,51 @@ namespace lfs::app {
             return true;
         }
 
+        bool hasCudaDeviceForGuiLaunch() {
+            checkCudaDriverVersion();
+
+            int device_count = 0;
+            const cudaError_t err = cudaGetDeviceCount(&device_count);
+            if (err != cudaSuccess) {
+                LOG_WARN("CUDA device probe failed: {}; launching GUI shell without CUDA warmup",
+                         cudaGetErrorString(err));
+                cudaGetLastError();
+                return false;
+            }
+            if (device_count <= 0) {
+                LOG_WARN("No CUDA-capable device detected; launching GUI shell without CUDA warmup");
+                return false;
+            }
+            return true;
+        }
+
+        void logPrimaryCudaDevice() {
+            cudaDeviceProp prop;
+            if (cudaGetDeviceProperties(&prop, 0) == cudaSuccess) {
+                LOG_INFO("GPU: {} (SM {}.{}, {} MB)", prop.name, prop.major, prop.minor,
+                         prop.totalGlobalMem / (1024 * 1024));
+            }
+        }
+
         std::future<void>& cudaWarmupFuture() {
             static std::future<void> fut;
             return fut;
         }
 
         void warmupCudaSync() {
-            checkCudaDriverVersion();
+            if (!hasCudaDeviceForGuiLaunch())
+                return;
 
-            cudaDeviceProp prop;
-            if (cudaGetDeviceProperties(&prop, 0) == cudaSuccess) {
-                LOG_INFO("GPU: {} (SM {}.{}, {} MB)", prop.name, prop.major, prop.minor,
-                         prop.totalGlobalMem / (1024 * 1024));
-            }
-
+            logPrimaryCudaDevice();
             LOG_INFO("Initializing CUDA...");
             fast_lfs::rasterization::warmup_kernels();
         }
 
         void warmupCudaAsync() {
-            checkCudaDriverVersion();
+            if (!hasCudaDeviceForGuiLaunch())
+                return;
 
-            cudaDeviceProp prop;
-            if (cudaGetDeviceProperties(&prop, 0) == cudaSuccess) {
-                LOG_INFO("GPU: {} (SM {}.{}, {} MB)", prop.name, prop.major, prop.minor,
-                         prop.totalGlobalMem / (1024 * 1024));
-            }
-
+            logPrimaryCudaDevice();
             LOG_INFO("Initializing CUDA (async)...");
             cudaWarmupFuture() = std::async(std::launch::async, [] {
                 fast_lfs::rasterization::warmup_kernels();

--- a/src/core/cuda/CMakeLists.txt
+++ b/src/core/cuda/CMakeLists.txt
@@ -20,6 +20,12 @@ set(LFS_CORE_CUDA_SOURCES
 
 add_library(lfs_core_cuda STATIC ${LFS_CORE_CUDA_SOURCES})
 
+if(TARGET dynlink_cuda)
+    set(LFS_CORE_CUDA_DRIVER_TARGET dynlink_cuda)
+else()
+    set(LFS_CORE_CUDA_DRIVER_TARGET CUDA::cuda_driver)
+endif()
+
 target_include_directories(lfs_core_cuda
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include
@@ -37,7 +43,7 @@ find_package(OpenMP REQUIRED COMPONENTS CXX)
 target_link_libraries(lfs_core_cuda
     PUBLIC
         CUDA::cudart
-        CUDA::cuda_driver
+        ${LFS_CORE_CUDA_DRIVER_TARGET}
         CUDA::curand
         spdlog::spdlog
         glm::glm

--- a/src/core/include/core/pinned_memory_allocator.hpp
+++ b/src/core/include/core/pinned_memory_allocator.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace lfs::core {
@@ -159,10 +160,12 @@ namespace lfs::core {
 
         // Track all allocated blocks (for deallocation lookup)
         std::unordered_map<void*, size_t> allocated_blocks_;
+        std::unordered_set<void*> pageable_blocks_;
 
         mutable std::mutex mutex_;
         Stats stats_;
         bool enabled_{true}; // Can disable for A/B testing
+        bool cuda_pinned_available_{true};
         std::atomic<bool> shutdown_{false};
     };
 

--- a/src/core/tensor/internal/memory_pool.hpp
+++ b/src/core/tensor/internal/memory_pool.hpp
@@ -225,14 +225,16 @@ namespace lfs::core {
             int device;
             cudaError_t err = cudaGetDevice(&device);
             if (err != cudaSuccess) {
-                LOG_ERROR(std::string("cudaGetDevice failed: ") + cudaGetErrorString(err));
+                LOG_WARN(std::string("CUDA memory pool unavailable: ") + cudaGetErrorString(err));
+                cudaGetLastError();
                 return;
             }
 
             cudaMemPool_t pool;
             err = cudaDeviceGetDefaultMemPool(&pool, device);
             if (err != cudaSuccess) {
-                LOG_ERROR(std::string("cudaDeviceGetDefaultMemPool failed: ") + cudaGetErrorString(err));
+                LOG_WARN(std::string("CUDA memory pool unavailable: ") + cudaGetErrorString(err));
+                cudaGetLastError();
                 return;
             }
 

--- a/src/core/tensor/pinned_memory_allocator.cpp
+++ b/src/core/tensor/pinned_memory_allocator.cpp
@@ -172,21 +172,28 @@ namespace lfs::core {
 
         // Cache miss - need to allocate new pinned memory
         void* ptr = nullptr;
-        cudaError_t err = cudaHostAlloc(&ptr, rounded_size, cudaHostAllocDefault);
+        cudaError_t err = cuda_pinned_available_
+                              ? cudaHostAlloc(&ptr, rounded_size, cudaHostAllocDefault)
+                              : cudaErrorUnknown;
 
-        if (err != cudaSuccess) {
-            LOG_ERROR("cudaHostAlloc failed for {} bytes: {}",
-                      rounded_size, cudaGetErrorString(err));
-            // Fall back to regular malloc as last resort
+        if (err == cudaSuccess) {
+            allocated_blocks_[ptr] = rounded_size;
+        } else {
+            if (cuda_pinned_available_) {
+                LOG_WARN("CUDA pinned host memory unavailable ({}); using regular host memory",
+                         cudaGetErrorString(err));
+                cudaGetLastError();
+                cuda_pinned_available_ = false;
+            }
             ptr = std::malloc(rounded_size);
             if (!ptr) {
                 LOG_ERROR("Fallback malloc also failed for {} bytes", rounded_size);
                 return nullptr;
             }
-            LOG_WARN("Falling back to regular malloc for {} bytes", rounded_size);
+            allocated_blocks_[ptr] = rounded_size;
+            pageable_blocks_.insert(ptr);
         }
 
-        allocated_blocks_[ptr] = rounded_size;
         stats_.allocated_bytes += rounded_size;
         stats_.num_allocs++;
         stats_.cache_misses++;
@@ -226,6 +233,12 @@ namespace lfs::core {
         allocated_blocks_.erase(it);
         stats_.allocated_bytes -= size;
         stats_.num_deallocs++;
+
+        if (const auto pageable = pageable_blocks_.find(ptr); pageable != pageable_blocks_.end()) {
+            pageable_blocks_.erase(pageable);
+            std::free(ptr);
+            return;
+        }
 
         // Create block with stream tracking and record event
         Block block{ptr, size, stream};

--- a/src/python/lfs/notification_bridge.cpp
+++ b/src/python/lfs/notification_bridge.cpp
@@ -58,12 +58,15 @@ namespace lfs::python {
 
         state::CudaVersionUnsupported::when([](const auto& e) {
             PyModalRegistry::instance().show_message(
-                "Unsupported CUDA Driver",
-                std::format("Your CUDA driver version ({}.{}) is not supported.\n\n"
+                "CUDA Not Detected",
+                std::format("No CUDA-capable device was detected.\n\n"
+                            "LichtFeld Studio is launching in pure Vulkan mode.\n\n"
+                            "This mode is highly experimental, highly incomplete and likely to crash or otherwise not work. "
+                            "Do not expect things to work.\n\n"
+                            "If you are running on Nvidia, you should stop here and install an up-to-date driver with CUDA support.\n\n"
                             "LichtFeld Studio requires CUDA {}.{} or later\n"
-                            "(NVIDIA driver 570+).\n\n"
-                            "Please update your NVIDIA driver for full functionality.",
-                            e.major, e.minor, e.min_major, e.min_minor),
+                            "(NVIDIA driver 570+).",
+                            e.min_major, e.min_minor),
                 MessageStyle::Warning);
         });
 

--- a/src/python/lfs/py_rendering.cpp
+++ b/src/python/lfs/py_rendering.cpp
@@ -21,7 +21,9 @@
 #include <cstring>
 #include <future>
 #include <numbers>
+#include <utility>
 
+#include <cuda_runtime.h>
 #include <glm/glm.hpp>
 
 namespace nb = nanobind;
@@ -91,6 +93,19 @@ namespace lfs::python {
 
             nb::gil_scoped_release release;
             return future.get();
+        }
+
+        [[nodiscard]] bool hasCudaDeviceForPythonView() {
+            static const bool has_device = [] {
+                int device_count = 0;
+                const cudaError_t err = cudaGetDeviceCount(&device_count);
+                if (err != cudaSuccess) {
+                    cudaGetLastError();
+                    return false;
+                }
+                return device_count > 0;
+            }();
+            return has_device;
         }
     } // namespace
 
@@ -793,9 +808,13 @@ namespace lfs::python {
         std::memcpy(R.data_ptr(), view_info->rotation.data(), 9 * sizeof(float));
         std::memcpy(T.data_ptr(), view_info->translation.data(), 3 * sizeof(float));
 
+        const bool use_cuda_view_tensors = hasCudaDeviceForPythonView();
+        auto rotation = use_cuda_view_tensors ? R.cuda() : std::move(R);
+        auto translation = use_cuda_view_tensors ? T.cuda() : std::move(T);
+
         return PyViewInfo{
-            .rotation = PyTensor(R.cuda(), true),
-            .translation = PyTensor(T.cuda(), true),
+            .rotation = PyTensor(std::move(rotation), true),
+            .translation = PyTensor(std::move(translation), true),
             .width = view_info->width,
             .height = view_info->height,
             .fov_x = vertical_fov_to_horizontal_fov(view_info->fov, view_info->width, view_info->height),

--- a/src/rendering/raster_rendering_engine.cpp
+++ b/src/rendering/raster_rendering_engine.cpp
@@ -71,6 +71,16 @@ namespace lfs::rendering {
             Tensor* screen_positions_out = nullptr;
         };
 
+        [[nodiscard]] bool hasCudaDeviceForRasterStartup() {
+            int device_count = 0;
+            const cudaError_t err = cudaGetDeviceCount(&device_count);
+            if (err != cudaSuccess) {
+                cudaGetLastError();
+                return false;
+            }
+            return device_count > 0;
+        }
+
         struct EnvironmentImage {
             std::filesystem::path path;
             int width = 0;
@@ -1911,7 +1921,13 @@ namespace lfs::rendering {
 
         Result<void> initializeRasterOnly() override {
             if (!background_.is_valid()) {
-                background_ = Tensor::zeros({3}, lfs::core::Device::CUDA, lfs::core::DataType::Float32);
+                const auto device = hasCudaDeviceForRasterStartup()
+                                        ? lfs::core::Device::CUDA
+                                        : lfs::core::Device::CPU;
+                background_ = Tensor::zeros({3}, device, lfs::core::DataType::Float32);
+                if (device == lfs::core::Device::CPU) {
+                    LOG_WARN("CUDA device unavailable; raster renderer initialized for GUI shell only");
+                }
             }
             raster_initialized_ = true;
             return {};

--- a/src/rendering/rasterizer/CMakeLists.txt
+++ b/src/rendering/rasterizer/CMakeLists.txt
@@ -16,6 +16,12 @@ set(RASTERIZER_SOURCES
 
 add_library(lfs_rasterizer STATIC ${RASTERIZER_SOURCES})
 
+if(TARGET dynlink_cuda)
+    set(LFS_RASTERIZER_CUDA_DRIVER_TARGET dynlink_cuda)
+else()
+    set(LFS_RASTERIZER_CUDA_DRIVER_TARGET CUDA::cuda_driver)
+endif()
+
 set_target_properties(lfs_rasterizer PROPERTIES
         CUDA_ARCHITECTURES "${LichtFeld-Studio_CUDA_ARCH}"
         CUDA_SEPARABLE_COMPILATION OFF
@@ -36,7 +42,7 @@ target_link_libraries(lfs_rasterizer
         PUBLIC
         CUDA::cudart
         CUDA::curand
-        CUDA::cuda_driver
+        ${LFS_RASTERIZER_CUDA_DRIVER_TARGET}
         spdlog::spdlog
         lfs_core_cuda       # Required for shared memory arena
         gsplat_fwd          # Forward-only GUT rasterization backend (no training dependency)

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -126,6 +126,17 @@ namespace lfs::vis::gui {
     namespace {
         const FrameInputBuffer* s_frame_input = nullptr;
 
+        [[nodiscard]] bool shouldInitNativeDragDrop() {
+#ifdef _WIN32
+            return true;
+#elif defined(__linux__)
+            const char* const video_driver = SDL_GetCurrentVideoDriver();
+            return video_driver && std::strcmp(video_driver, "x11") == 0;
+#else
+            return false;
+#endif
+        }
+
         [[nodiscard]] bool isTransformGizmoOverOrUsing() {
             return isBoundsGizmoHovered() ||
                    isBoundsGizmoActive() ||
@@ -2721,7 +2732,7 @@ namespace lfs::vis::gui {
 
         initMenuBar();
 
-        if (!drag_drop_.init(viewer_->getWindow())) {
+        if (shouldInitNativeDragDrop() && !drag_drop_.init(viewer_->getWindow())) {
             LOG_WARN("Native drag-drop initialization failed, drag-drop will use SDL events only");
         }
         drag_drop_.setFileDropCallback([this](const std::vector<std::string>& paths) {

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -82,6 +82,11 @@ namespace lfs::vis {
             return haystack && needle && std::strstr(haystack, needle) != nullptr;
         }
 
+        bool hasExplicitSdlVideoDriver() {
+            return std::getenv("SDL_VIDEODRIVER") != nullptr ||
+                   std::getenv("SDL_VIDEO_DRIVER") != nullptr;
+        }
+
         bool shouldPreferX11OnGnome() {
 #if defined(__linux__)
             // GNOME on Wayland can present undecorated SDL toplevels when the
@@ -95,7 +100,7 @@ namespace lfs::vis {
                                   containsToken(session_desktop, "GNOME");
             const bool has_wayland = std::getenv("WAYLAND_DISPLAY") != nullptr;
             const bool has_x11 = std::getenv("DISPLAY") != nullptr;
-            const bool explicit_driver = std::getenv("SDL_VIDEO_DRIVER") != nullptr;
+            const bool explicit_driver = hasExplicitSdlVideoDriver();
             return is_gnome && has_wayland && has_x11 && !explicit_driver;
 #else
             return false;


### PR DESCRIPTION
This is a WIP and only tested on AMDGPU so far.
Currently all it does is allow LFS to launch and change the "No cuda found" warning a bit.
It does not even allow loading a .ply yet in its current form.

Importantly: It also changes the Nvidia rendering path because it used a method not available on AMD, which means Nvidia definitely needs testing at some point too.

I intend to push more commits to this PR branch as I make more progress.

Note: It still needs to be built against cuda-toolkit. Making cuda-toolkit optional would require significantly deeper, nastier changes, changes that at this stage are probably not worth making. Cuda-toolkit is hardware-independent so it really doesn't matter much at this stage.