### PR TITLE
claude fix to vulkan device lost bug

### DIFF
--- a/src/visualizer/rendering/point_cloud_vulkan_renderer.cpp
+++ b/src/visualizer/rendering/point_cloud_vulkan_renderer.cpp
@@ -873,6 +873,12 @@ namespace lfs::vis {
             // size change would otherwise destroy images the in-flight submit
             // is still sampling.
             vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
+            // Also wait for the VulkanContext's in-flight frame fence. pcFence signals
+            // when CB1 (point cloud render) finishes, but the VulkanContext's CB2
+            // (which reads the output image) may still be executing. If ensureOutputImages
+            // destroys the slot on a resize while CB2 is in-flight, the GPU reads freed
+            // memory → VK_ERROR_DEVICE_LOST.
+            context->waitForSubmittedFrames();
             vkResetFences(device, 1, &fence);
 
             auto& slot = slots[slot_idx];


### PR DESCRIPTION
This is the summary of the conversation:

tested it and it seems stable.


root cause: PointCloudVulkanRenderer::doRender() destroys the output image while it's still in use by the VulkanContext's frame command buffer.
Evidence: Line 245 in gs_renderer.cpp calls executeComputeIndirect() which reads dispatch dimensions from buffers.num_indices_offset computed by prior shaders. If those shaders have synchronization bugs, corruption propagates.
The sequence that causes device loss:
Frame N−1:
1.
doRender() submits CB1 (renders point cloud → slot.color_image) → signals pcFence
QUATERNARY SUSPECT: Missing Memory Barriers Between Dependent Compute Shaders
2.
gui_manager submits CB2 (VulkanContext frame that reads slot.color_image) → signals in_flight_[0]
Location: /c/Users/User/dev/LichtFeld-Studio/src/rendering/rasterizer/vksplat_fwd/src/gs_renderer.cpp:184-228 (executeGenerateKeys)
Frame N (viewport resized):
1.
doRender() waits for pcFence — CB1 of N−1 is done ✓
Issue: The sequence is:
2.
doRender() calls ensureOutputImages() → destroySlot() → vmaDestroyImage(slot.color_image)
1.
executeProjectionForward writes to tiles_touched, rect_tile_space, radii, etc.
2.
executeGenerateKeys reads those outputs to produce keys
3.
CB2 of N−1 is still executing on the GPU reading slot.color_image — the image is now a dangling pointer on the GPU → GPU error
3.
executeSort uses keys
4.
executeComputeTileRanges uses sorted results
4.
beginFrame() waits on in_flight_[0] → VK_ERROR_DEVICE_LOST ← this is exactly what you see
Each transition includes bufferMemoryBarrier() calls (lines 145-155, 205-210), but if any barrier is missing synchronization stages or uses wrong masks, the GPU can read stale data → out-of-bounds writes → device lost.
The bug: pcFence signals when CB1 of N−1 finishes, but says nothing about CB2 (which was submitted after CB1 on the same queue and reads the same image). Since kFramesInFlight = 1 and beginFrame() waits for in_flight_[0] after doRender() submits frame N's work, the wait comes too late.
Specific line: /c/Users/User/dev/LichtFeld-Studio/src/rendering/rasterizer/vksplat_fwd/src/gs_pipeline.cpp:469-476 - the vkCmdPipelineBarrier() call uses hardcoded stage masks constructed from toStageMask(). If this translation is incorrect for a given hardware generation, barriers could be insufficient.
The repro condition: resize the viewport while in point cloud mode (triggers ensureOutputImages → destroySlot). If the size never changes, ensureOutputImages returns early and the bug doesn't fire.
Fix: In doRender(), after waiting for pcFence, also wait for all VulkanContext-submitted work to complete before calling ensureOutputImages(). context->waitForSubmittedFrames() (line 151 of vulkan_context.hpp) is the right call — it waits for in_flight_[0], guaranteeing CB2 of the previous frame has finished before we destroy its inputs.
QUINARY SUSPECT: Validation Layer Silent Failure
Location: /c/Users/User/dev/LichtFeld-Studio/src/visualizer/window/vulkan_context.cpp:727-732
The change is in point_cloud_vulkan_renderer.cpp around line 875:
Issue:
// current (buggy):
vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
vkResetFences(device, 1, &fence);

// fixed:
vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
context->waitForSubmittedFrames();  // ensure CB2 of prev frame is done before destroySlot
vkResetFences(device, 1, &fence);
validation_enabled_ = validation_requested && validation_layer_available && debug_utils_enabled_;
Validation is only enabled if all three conditions are true. In a Release build or if VK_EXT_debug_utils is unavailable:
•
Validation layers are silently disabled without warning
•
GPU device loss happens without any validation error message preceding it
•
The only symptom is the VK_ERROR_DEVICE_LOST in vkWaitForFences()
The debug messenger (lines 2338-2350) would normally catch invalid operations before they cause device loss, but it's not running.
Want me to apply the fix?