### PR TITLE
Broken dropdown on vksplat

### DIFF
--- a/src/visualizer/gui/rmlui/resources/components.rcss
+++ b/src/visualizer/gui/rmlui/resources/components.rcss
@@ -240,6 +240,7 @@ selectbox {
 }
 
 selectbox option {
+    display: block;
     padding: 2dp 6dp;
     font-size: 11dp;
     transition: background-color 0.1s quadratic-out;


### PR DESCRIPTION
Before: 
<img width="355" height="255" alt="image" src="https://github.com/user-attachments/assets/e519e6c0-d888-4626-bb8f-5421ff5c683f" />

After: 
<img width="330" height="254" alt="image" src="https://github.com/user-attachments/assets/2d091589-6d5a-4b42-a5ec-179c96c77809" />
