### PR TITLE
Fix VRAM leak on PLY/SOG export by trimming CUDA memory pool

### DIFF
--- a/src/app/mcp_gui_tools.cpp
+++ b/src/app/mcp_gui_tools.cpp
@@ -1405,6 +1405,11 @@ namespace lfs::app {
             }
             }
 
+            // Release merged CUDA tensors and trim the memory pool so that
+            // temporary VRAM allocated for the export is returned to the GPU.
+            merged.reset();
+            lfs::core::Tensor::trim_memory_pool();
+
             return {};
         }
 

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -665,7 +665,7 @@ namespace lfs::vis::gui {
         LOG_INFO("Export started: {} (format: {})", lfs::core::path_to_utf8(path), static_cast<int>(format));
 
         export_state_.thread.emplace(
-            [this, format, path, splat_data](std::stop_token stop_token) {
+            [this, format, path, splat_data](std::stop_token stop_token) mutable {
                 auto update_progress = [this, &stop_token](float progress, const std::string& stage) -> bool {
                     export_state_.progress.store(progress);
                     {
@@ -821,6 +821,11 @@ namespace lfs::vis::gui {
                         .error = error_msg}
                         .emit();
                 }
+
+                // Release merged CUDA tensors and trim the memory pool so that
+                // temporary VRAM allocated for the export is returned to the GPU.
+                splat_data.reset();
+                lfs::core::Tensor::trim_memory_pool();
 
                 export_state_.active.store(false);
             });


### PR DESCRIPTION
## Problem

VRAM usage increases every time a PLY or SOG is exported from LFS. On larger models the increase is significant and accumulates with each export.

Fixes #1196

## Root Cause

During export, temporary CUDA tensors are allocated for the merged splat data, Morton encoding, and k-means clustering. When these tensors are freed, their memory goes into the \CudaMemoryPool\'s \SizeBucketedPool\ cache (up to 4 entries per bucket) and the CUDA async memory pool (whose release threshold is \UINT64_MAX\). Neither export path called \	rim_cached_memory()\ afterward, so the cached VRAM was never returned to the GPU.

## Fix

Add \Tensor::trim_memory_pool()\ calls after both export paths:
- **Synchronous MCP export** (\xport_scene_nodes\ in \mcp_gui_tools.cpp\): reset the merged \SplatData\ unique_ptr then trim.
- **Async UI export** (\startAsyncExport\ in \sync_task_manager.cpp\): reset the shared_ptr then trim after the export try/catch block.

This follows the same pattern already used after training densification in \improved_gs_plus.cpp\ (lines 652 and 674).

---