### PR TITLE
Fix masks not loading or applying (#1198)

### DIFF
--- a/src/training/dataset.hpp
+++ b/src/training/dataset.hpp
@@ -626,14 +626,14 @@ namespace lfs::training {
                     request.params.undistort = request.undistort;
                 }
 
-                if (mask_config_.use_alpha_as_mask && cam->has_alpha()) {
-                    request.extract_alpha_as_mask = true;
-                    request.alpha_mask_params.invert = mask_config_.invert_masks;
-                    request.alpha_mask_params.threshold = mask_config_.mask_threshold;
-                } else if (mask_config_.load_masks && cam->has_mask()) {
+                if (mask_config_.load_masks && cam->has_mask()) {
                     request.mask_path = cam->mask_path();
                     request.mask_params.invert = mask_config_.invert_masks;
                     request.mask_params.threshold = mask_config_.mask_threshold;
+                } else if (mask_config_.use_alpha_as_mask && cam->has_alpha()) {
+                    request.extract_alpha_as_mask = true;
+                    request.alpha_mask_params.invert = mask_config_.invert_masks;
+                    request.alpha_mask_params.threshold = mask_config_.mask_threshold;
                 }
 
                 loader_->prefetch({request});

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -287,7 +287,11 @@ namespace lfs::training {
                 mask_mode == lfs::core::param::MaskMode::Segment ||
                 mask_mode == lfs::core::param::MaskMode::Ignore;
 
-            if (use_masking && opt_params.use_alpha_as_mask && camera.has_alpha()) {
+            // Sidecar mask file wins when present; alpha-as-mask is only used as fallback
+            // (some datasets ship RGBA images with a degenerate constant alpha alongside
+            // real per-pixel masks in masks/, and we must not let the alpha channel mask
+            // them out).
+            if (use_masking && !camera.has_mask() && opt_params.use_alpha_as_mask && camera.has_alpha()) {
                 return load_alpha_masked_metrics_inputs(camera, gt_config, opt_params);
             }
 
@@ -1157,6 +1161,13 @@ namespace lfs::training {
                 ++masks_found;
         }
 
+        // Sidecar masks take precedence over the alpha channel (see dataset prefetch),
+        // so report them first; alpha-as-mask only covers cameras without a sidecar.
+        if (masks_found > 0) {
+            LOG_INFO("Found {} masks{}", masks_found, opt.invert_masks ? " (inverted)" : "");
+            return {};
+        }
+
         if (opt.use_alpha_as_mask && alpha_count > 0) {
             LOG_INFO("Using alpha channel as mask source ({}/{} cameras){}",
                      alpha_count, train_dataset_->get_cameras().size(),
@@ -1164,20 +1175,15 @@ namespace lfs::training {
             return {};
         }
 
-        if (masks_found == 0) {
-            const auto path_str = lfs::core::path_to_utf8(params_.dataset.data_path);
-            if (opt.use_alpha_as_mask) {
-                return std::unexpected(std::format(
-                    "Mask mode enabled with use_alpha_as_mask but no images have alpha and no mask files found in {}/masks/",
-                    path_str));
-            }
+        const auto path_str = lfs::core::path_to_utf8(params_.dataset.data_path);
+        if (opt.use_alpha_as_mask) {
             return std::unexpected(std::format(
-                "Mask mode enabled but no masks found in {}/masks/",
+                "Mask mode enabled with use_alpha_as_mask but no images have alpha and no mask files found in {}/masks/",
                 path_str));
         }
-
-        LOG_INFO("Found {} masks{}", masks_found, opt.invert_masks ? " (inverted)" : "");
-        return {};
+        return std::unexpected(std::format(
+            "Mask mode enabled but no masks found in {}/masks/",
+            path_str));
     }
 
     std::expected<Trainer::MaskLossResult, std::string> Trainer::compute_photometric_loss_with_mask(

--- a/src/visualizer/gui/rmlui/rml_path_utils.hpp
+++ b/src/visualizer/gui/rmlui/rml_path_utils.hpp
@@ -168,6 +168,17 @@ namespace lfs::vis::gui::rml_paths {
             return lfs::core::utf8_to_path(std::string(reference));
         }
 
+        // Decorator/style references reach RmlUI percent-encoded (e.g. an absolute
+        // mask path "C:%5CUsers%5C...png"). The raw form is not recognized as
+        // absolute, so RmlUI would otherwise join it against the document directory
+        // and produce a bogus "assets/rmlui/\Users\..." path. Retry after decoding.
+        if (reference.find('%') != std::string_view::npos) {
+            const std::string decoded = percentDecode(reference);
+            if (decoded != reference && isAbsoluteFilePath(decoded)) {
+                return lfs::core::utf8_to_path(decoded);
+            }
+        }
+
         return std::nullopt;
     }
 

--- a/src/visualizer/gui/rmlui/rmlui_vk_backend.cpp
+++ b/src/visualizer/gui/rmlui/rmlui_vk_backend.cpp
@@ -823,13 +823,39 @@ Rml::TextureHandle RenderInterface_VK::LoadTexture(Rml::Vector2i& texture_dimens
 
         texture_dimensions.x = width;
         texture_dimensions.y = height;
+
+        // Probe the file's native channel count. Single-channel images are masks:
+        // stbi expands them to (gray, gray, gray, 255) which renders as fully-opaque
+        // gray over the underlying image — useless as an overlay. The mask branch
+        // below instead drives the alpha from the gray value so an image-color CSS
+        // tint paints only the foreground.
+        int probe_w = 0, probe_h = 0, probe_channels = 0;
+        const bool is_single_channel =
+            stbi_info(path.c_str(), &probe_w, &probe_h, &probe_channels) &&
+            probe_channels == 1;
+
         const int pixel_count = width * height;
-        for (int i = 0; i < pixel_count; ++i) {
-            unsigned char* p = data + i * 4;
-            const unsigned int alpha = p[3];
-            p[0] = static_cast<unsigned char>((p[0] * alpha + 127) / 255);
-            p[1] = static_cast<unsigned char>((p[1] * alpha + 127) / 255);
-            p[2] = static_cast<unsigned char>((p[2] * alpha + 127) / 255);
+        if (is_single_channel) {
+            // Mask: the gray value becomes the alpha. RGB is set to the same value so
+            // the texture is premultiplied (matching the non-mask branch below and the
+            // backend's premultiplied-alpha blend), which keeps alpha==0 pixels fully
+            // transparent instead of adding their color over the image.
+            for (int i = 0; i < pixel_count; ++i) {
+                unsigned char* p = data + i * 4;
+                const unsigned char gray = p[0];
+                p[0] = gray;
+                p[1] = gray;
+                p[2] = gray;
+                p[3] = gray;
+            }
+        } else {
+            for (int i = 0; i < pixel_count; ++i) {
+                unsigned char* p = data + i * 4;
+                const unsigned int alpha = p[3];
+                p[0] = static_cast<unsigned char>((p[0] * alpha + 127) / 255);
+                p[1] = static_cast<unsigned char>((p[1] * alpha + 127) / 255);
+                p[2] = static_cast<unsigned char>((p[2] * alpha + 127) / 255);
+            }
         }
 
         const size_t image_size = static_cast<size_t>(width) * static_cast<size_t>(height) * 4;


### PR DESCRIPTION
## Summary

Fixes #1198 — masks not loading / not applied during training.

Datasets that ship **RGBA images alongside real per-pixel mask files** were silently ignoring the sidecar masks. This is common with Reality Scan and Unreal Engine exports, where the image's embedded alpha channel is a degenerate constant `255` (fully opaque) but the actual segmentation lives in `masks/*.png`. Reproduced on two such datasets.

Three independent issues are fixed:

### 1. Training & eval ignored sidecar masks (alpha-as-mask took precedence)
`use_alpha_as_mask` (default `true`) won over the sidecar mask file. With a constant alpha=255 the mask covered the whole frame, so `Segment`/`Ignore` modes had no effect and gaussians kept spawning in masked-out regions. PR #832 introduced this precedence; before it, sidecar masks were always preferred.

**Fix:** sidecar mask wins when present; alpha-as-mask is only used as a fallback for cameras without a sidecar. Applied in the training dataloader (`dataset.hpp`) and the eval/metrics input loader (`trainer.cpp`). The startup log now reports the actual source.

### 2. Preview mask overlay never loaded the texture
The image-preview panel passes an absolute mask path to RmlUI percent-encoded (`C:%5CUsers%5C...png`). `pathReferenceToFilesystemPath` didn't recognise the encoded form as absolute, so RmlUI joined it against the document directory and produced a bogus `assets/rmlui/\Users\...` path — the original symptom reported in #1198 (`RmlUI LoadTexture failed`).

**Fix:** percent-decode and re-test for absolute before giving up (`rml_path_utils.hpp`).

### 3. Loaded mask overlay tinted the whole image
A single-channel mask loaded via `stbi_load(req_comp=4)` becomes `(gray,gray,gray,255)` — fully opaque. The RmlUI backend blends with **premultiplied alpha** (`ONE / ONE_MINUS_SRC_ALPHA`), so even alpha=0 pixels add their colour.

**Fix:** remap masks to a premultiplied `(gray,gray,gray,gray)` texture so the gray value drives transparency; the `image-color` CSS tint then paints only the foreground (`rmlui_vk_backend.cpp`).

## Testing

Built on Windows (MSVC) and run on the affected datasets:

- **Training:** log now shows `Found 160 sidecar masks` (was `Using alpha channel as mask source`); Segment mode correctly suppresses background, confirmed on a 30k-iter run.
- **Preview overlay:** the red mask overlay now highlights only the foreground object instead of washing the entire frame (verified with an opaque-tint test isolating foreground vs background).

## Notes

- No behaviour change for alpha-only datasets (no sidecar): alpha-as-mask still applies via the fallback.
- The eval-path `MetricsEvaluator::load_eval_mask` was already sidecar-first; only the metrics *input* loader needed the same guard.
