### PR TITLE
Support in-memory masks and float-dtype colors for direct-scene plugins

### DIFF
--- a/src/core/camera.cpp
+++ b/src/core/camera.cpp
@@ -149,6 +149,7 @@ namespace lfs::core {
           _cam_position(std::move(other._cam_position)),
           _cached_mask(std::move(other._cached_mask)),
           _mask_loaded(other._mask_loaded),
+          _in_memory_mask_raw(std::move(other._in_memory_mask_raw)),
           _undistort_precomputed(other._undistort_precomputed),
           _undistort_prepared(other._undistort_prepared),
           _undistort_params(other._undistort_params),
@@ -192,6 +193,7 @@ namespace lfs::core {
             _cam_position = std::move(other._cam_position);
             _cached_mask = std::move(other._cached_mask);
             _mask_loaded = other._mask_loaded;
+            _in_memory_mask_raw = std::move(other._in_memory_mask_raw);
             _undistort_precomputed = other._undistort_precomputed;
             _undistort_prepared = other._undistort_prepared;
             _undistort_params = other._undistort_params;
@@ -360,39 +362,69 @@ namespace lfs::core {
         return num_bytes;
     }
 
+    void Camera::set_mask_tensor(Tensor mask) {
+        _in_memory_mask_raw = std::move(mask);
+        // Force reprocessing on the next load_and_get_mask call.
+        _cached_mask = Tensor();
+        _mask_loaded = false;
+    }
+
     Tensor Camera::load_and_get_mask(const int resize_factor, const int max_width,
                                      const bool invert_mask, const float mask_threshold) {
         if (_mask_loaded && _cached_mask.is_valid()) {
             return _cached_mask;
         }
 
-        if (_mask_path.empty() || !std::filesystem::exists(_mask_path)) {
-            return Tensor();
-        }
-
-        const ImageLoadParams params{
-            .path = _mask_path,
-            .resize_factor = resize_factor,
-            .max_width = max_width,
-            .stream = _stream};
-
-        auto mask = load_image_cached(params);
-
-        if (mask.device() != Device::CUDA) {
-            mask = mask.to(Device::CUDA, _stream);
-            if (_stream) {
-                cudaStreamSynchronize(_stream);
+        Tensor mask;
+        if (_in_memory_mask_raw.is_valid()) {
+            // In-memory mask (set via set_mask_tensor). The plugin supplies it
+            // at the image's on-disk resolution; further resize_factor /
+            // max_width handling is the trainer's responsibility upstream.
+            mask = _in_memory_mask_raw;
+            if (mask.device() != Device::CUDA) {
+                mask = mask.to(Device::CUDA, _stream);
+                if (_stream) {
+                    cudaStreamSynchronize(_stream);
+                }
             }
-        }
+            if (mask.dtype() == DataType::UInt8) {
+                mask = mask.to(DataType::Float32).div(255.0f);
+            } else if (mask.dtype() != DataType::Float32) {
+                mask = mask.to(DataType::Float32);
+            }
+            // Allow (1, H, W) or (H, W, 1) shapes by squeezing the singleton.
+            if (mask.ndim() == 3 && mask.shape()[0] == 1) {
+                mask = mask.squeeze(0);
+            } else if (mask.ndim() == 3 && mask.shape()[2] == 1) {
+                mask = mask.squeeze(2);
+            }
+        } else if (!_mask_path.empty() && std::filesystem::exists(_mask_path)) {
+            const ImageLoadParams params{
+                .path = _mask_path,
+                .resize_factor = resize_factor,
+                .max_width = max_width,
+                .stream = _stream};
 
-        // Convert RGB [C,H,W] to grayscale [H,W]
-        if (mask.ndim() == 3 && mask.shape()[0] >= 3) {
-            const auto r = mask.slice(0, 0, 1).squeeze(0);
-            const auto g = mask.slice(0, 1, 2).squeeze(0);
-            const auto b = mask.slice(0, 2, 3).squeeze(0);
-            mask = (r + g + b) / 3.0f;
-        } else if (mask.ndim() == 3 && mask.shape()[0] == 1) {
-            mask = mask.squeeze(0);
+            mask = load_image_cached(params);
+
+            if (mask.device() != Device::CUDA) {
+                mask = mask.to(Device::CUDA, _stream);
+                if (_stream) {
+                    cudaStreamSynchronize(_stream);
+                }
+            }
+
+            // Convert RGB [C,H,W] to grayscale [H,W]
+            if (mask.ndim() == 3 && mask.shape()[0] >= 3) {
+                const auto r = mask.slice(0, 0, 1).squeeze(0);
+                const auto g = mask.slice(0, 1, 2).squeeze(0);
+                const auto b = mask.slice(0, 2, 3).squeeze(0);
+                mask = (r + g + b) / 3.0f;
+            } else if (mask.ndim() == 3 && mask.shape()[0] == 1) {
+                mask = mask.squeeze(0);
+            }
+        } else {
+            return Tensor();
         }
 
         if (invert_mask) {

--- a/src/core/include/core/camera.hpp
+++ b/src/core/include/core/camera.hpp
@@ -60,6 +60,11 @@ namespace lfs::core {
         Tensor load_and_get_mask(int resize_factor = -1, int max_width = 0,
                                  bool invert_mask = false, float mask_threshold = 0.5f);
 
+        // Attach an in-memory mask (skips file load). Expected (H,W) or
+        // (1,H,W) at the image's on-disk resolution; dtype uint8 [0,255] or
+        // float32 [0,1]. Lazily processed on the next load_and_get_mask call.
+        void set_mask_tensor(Tensor mask);
+
         // Load image from disk just to populate _image_width/_image_height
         void load_image_size(int resize_factor = -1, int max_width = 0);
 
@@ -108,7 +113,11 @@ namespace lfs::core {
         const std::string& image_name() const noexcept { return _image_name; }
         const std::filesystem::path& image_path() const noexcept { return _image_path; }
         const std::filesystem::path& mask_path() const noexcept { return _mask_path; }
-        bool has_mask() const noexcept { return !_mask_path.empty() && std::filesystem::exists(_mask_path); }
+        bool has_in_memory_mask() const noexcept { return _in_memory_mask_raw.is_valid(); }
+        bool has_mask() const noexcept {
+            return has_in_memory_mask() ||
+                   (!_mask_path.empty() && std::filesystem::exists(_mask_path));
+        }
         bool has_alpha() const noexcept { return _has_alpha; }
         void set_has_alpha(bool v) noexcept { _has_alpha = v; }
         CameraSplit split() const noexcept { return _split; }
@@ -169,6 +178,9 @@ namespace lfs::core {
         // Mask caching (processed mask stored on GPU)
         Tensor _cached_mask;
         bool _mask_loaded = false;
+        // Raw, pre-supplied in-memory mask (used by direct-scene plugins) —
+        // takes precedence over _mask_path when set. Processed on first use.
+        Tensor _in_memory_mask_raw;
 
         // Undistortion state
         bool _undistort_precomputed = false;

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -1028,10 +1028,18 @@ namespace lfs::core {
                           static_cast<void*>(positions.ptr<float>()),
                           positions.shape().str(), positions.numel());
 
-                // Normalize colors from uint8 [0,255] to float32 [0,1] to match old behavior
+                // Normalize colors from uint8 [0,255] to float32 [0,1]. When
+                // the caller already provided floats (e.g. in-memory plugins
+                // pushing scenes via PyScene::add_point_cloud), assume the
+                // values are already in [0,1] and skip the /255 step — that
+                // unconditional divide would otherwise crush them to near-zero.
                 LOG_DEBUG("  Converting pcd.colors (dtype={}) to float32...",
                           pcd.colors.dtype() == DataType::UInt8 ? "UInt8" : "Float32");
-                colors = pcd.colors.to(DataType::Float32).div(255.0f).cuda();
+                if (pcd.colors.dtype() == DataType::UInt8) {
+                    colors = pcd.colors.to(DataType::Float32).div(255.0f).cuda();
+                } else {
+                    colors = pcd.colors.to(DataType::Float32).cuda();
+                }
                 LOG_DEBUG("  colors after conversion: is_valid={}, device={}, shape={}, numel={}",
                           colors.is_valid(),
                           colors.device() == Device::CUDA ? "CUDA" : "CPU",

--- a/src/python/lfs/py_scene.cpp
+++ b/src/python/lfs/py_scene.cpp
@@ -516,7 +516,8 @@ namespace lfs::python {
                                 int width,
                                 int height,
                                 const std::string& image_path,
-                                int uid) {
+                                int uid,
+                                std::optional<PyTensor> mask) {
         std::optional<vis::op::SceneGraphStateSnapshot> history_before;
         if (auto* const scene_manager = get_scene_manager()) {
             history_before = vis::op::SceneGraphPatchEntry::captureState(*scene_manager, {name});
@@ -542,6 +543,12 @@ namespace lfs::python {
             std::filesystem::path{},
             width, height,
             uid);
+
+        // Attach an in-memory mask if the caller passed one (direct-scene
+        // plugins use this to bypass the on-disk masks/ workflow).
+        if (mask.has_value() && mask->tensor().is_valid()) {
+            camera->set_mask_tensor(mask->tensor().clone());
+        }
 
         const int32_t node_id = scene_->addCamera(name, parent, std::move(camera));
         if (auto* const scene_manager = get_scene_manager()) {
@@ -1222,6 +1229,7 @@ Returns:
                  nb::arg("height"),
                  nb::arg("image_path") = "",
                  nb::arg("uid") = -1,
+                 nb::arg("mask") = nb::none(),
                  R"doc(Add a camera node with intrinsic and extrinsic parameters.
 
 Args:
@@ -1235,6 +1243,11 @@ Args:
     height: Image height in pixels
     image_path: Optional path to camera image
     uid: Optional unique identifier (-1 for auto-assigned)
+    mask: Optional in-memory mask tensor (H, W) or (1, H, W) at the image
+        resolution. Bypasses the on-disk masks/ workflow — useful for
+        direct-scene plugins that want to attach per-frame masks without
+        writing files. Set the session's ``mask_mode`` to ``Ignore`` or
+        ``Segment`` for it to take effect during training.
 
 Returns:
     Node ID of created camera

--- a/src/python/lfs/py_scene.hpp
+++ b/src/python/lfs/py_scene.hpp
@@ -427,7 +427,8 @@ namespace lfs::python {
                            int width,
                            int height,
                            const std::string& image_path = "",
-                           int uid = -1);
+                           int uid = -1,
+                           std::optional<PyTensor> mask = std::nullopt);
         void remove_node(const std::string& name, bool keep_children = false);
         bool rename_node(const std::string& old_name, const std::string& new_name);
         void clear();

--- a/src/training/dataset.hpp
+++ b/src/training/dataset.hpp
@@ -573,6 +573,18 @@ namespace lfs::training {
                 // Attach mask if present
                 if (ready.mask && ready.mask->is_valid()) {
                     example.mask = std::move(*ready.mask);
+                } else if (mask_config_.load_masks && cam->has_in_memory_mask()) {
+                    // Direct-scene plugins attach masks as in-memory tensors
+                    // via Camera::set_mask_tensor — load_and_get_mask returns
+                    // the processed-and-cached tensor (skips file I/O).
+                    auto m = cam->load_and_get_mask(
+                        dataset_->get_resize_factor(),
+                        dataset_->get_max_width(),
+                        mask_config_.invert_masks,
+                        mask_config_.mask_threshold);
+                    if (m.is_valid()) {
+                        example.mask = std::move(m);
+                    }
                 }
 
                 return example;

--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
@@ -732,7 +732,9 @@ namespace lfs::vis::gui {
             snapshot.visible = static_cast<bool>(node->visible);
             snapshot.has_children = !node->children.empty();
             snapshot.training_enabled = node->training_enabled;
-            snapshot.has_mask = node->type == core::NodeType::CAMERA && !node->mask_path.empty();
+            snapshot.has_mask = node->type == core::NodeType::CAMERA &&
+                                (!node->mask_path.empty() ||
+                                 (node->camera && node->camera->has_in_memory_mask()));
 
             switch (node->type) {
             case core::NodeType::SPLAT:


### PR DESCRIPTION
## Summary

Adds two pieces of plumbing needed for Python plugins that push reconstructions directly into the scene (instead of via the COLMAP dataset loader). Both came up while integrating a feed-forward reconstruction plugin (VGGT-Omega), but the changes are general-purpose.

- **In-memory mask tensors per camera.** `scene.add_camera(..., mask=tensor)` attaches a `(H,W)` or `(1,H,W)` uint8/float mask to the camera — no `masks/` directory on disk. `Camera::has_mask()` becomes true for either an in-memory tensor or a valid `mask_path`, `Camera::load_and_get_mask()` branches on the in-memory source first, and `PipelinedDataLoader::next()` falls back to it when the file loader returned nothing. Existing file-mask flow is byte-identical when no in-memory mask is attached.

- **Float-dtype point cloud colors.** `init_model_from_pointcloud` previously did `colors.to(Float32).div(255)` unconditionally, which assumes the COLMAP loader's UInt8 [0,255] convention. A direct-scene plugin pushing float32 [0,1] colors got them crushed to near-zero and the Model initialised near-black. Now divides only on `UInt8`; otherwise passes floats through unchanged. The point-cloud renderer already handled both dtypes, so this just aligns the training-Model init.

## Test plan

- [ ] Build with the changes; existing tests still pass.
- [ ] COLMAP dataset (uint8 colors, file masks) trains identically to before.
- [ ] Python plugin pushes a scene via `scene.add_camera(..., mask=tensor)`; `cam.has_mask` returns `True` and the trainer logs the right mask count (verified with VGGT-Omega: `Found 32 masks`, `Mask mode: ignore`).
- [ ] Python plugin pushes a `PointCloud` with float32 [0,1] colors; Model initialises with the correct colors (no near-black flicker on Start).
- [ ] Plugin path without masks: `scene.add_camera(...)` without the `mask` kwarg → `has_mask() == False`, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)