### PR TITLE
enable fast build mode for windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -144,7 +144,7 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cmake -B build -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_PYTHON_STUBS=OFF -DLFS_DEV_IMPORT_SOURCE_PYTHON=OFF -DLFS_DEV_IMPORT_SOURCE_RESOURCES=OFF -DCUDA_DEVICE_DEBUG=OFF
+          cmake -B build -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DLFS_FAST_COMPILE=ON -DBUILD_PYTHON_STUBS=OFF -DLFS_DEV_IMPORT_SOURCE_PYTHON=OFF -DLFS_DEV_IMPORT_SOURCE_RESOURCES=OFF -DCUDA_DEVICE_DEBUG=OFF
 
       - name: Build
         shell: cmd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ get_filename_component(PROJ_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
 option(BUILD_TESTS "Build tests" OFF)
 option(BUILD_UNICODE_TEST_ONLY "Build only Unicode path test (no CUDA)" OFF)
 option(ENABLE_ALLOCATION_PROFILING "Enable tensor allocation profiling" OFF)
+option(LFS_FAST_COMPILE "Optimize measured slow C++ components for build speed instead of runtime speed" OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Debug options
@@ -935,6 +936,33 @@ configure_build_type(lfs_visualizer)
 configure_build_type(lfs_io)
 configure_build_type(lfs_geometry)
 configure_build_type(${PROJECT_NAME})
+
+if(LFS_FAST_COMPILE AND MSVC)
+    function(lfs_enable_fast_cxx_compile target)
+        if(TARGET ${target})
+            target_compile_options(${target} PRIVATE
+                $<$<COMPILE_LANGUAGE:CXX>:/Od>
+                $<$<COMPILE_LANGUAGE:CXX>:/Ob0>
+            )
+        endif()
+    endfunction()
+
+    # Selected from build_time_comparison.md: only components with >20s summed
+    # edge-time improvement in build-fast are included. CUDA-heavy regressions
+    # stay on their target defaults.
+    foreach(_lfs_fast_target IN ITEMS
+        lfs_visualizer
+        lfs_py
+        lfs_core
+        lfs_training
+        lfs_io
+        lfs_mcp
+        Zep
+        OpenMeshCore
+    )
+        lfs_enable_fast_cxx_compile(${_lfs_fast_target})
+    endforeach()
+endif()
 
 # Set the default startup project in Visual Studio to LichtFeld-Studio
 # (without this, VS defaults to ALL_BUILD when opening the solution)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ get_filename_component(PROJ_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
 option(BUILD_TESTS "Build tests" OFF)
 option(BUILD_UNICODE_TEST_ONLY "Build only Unicode path test (no CUDA)" OFF)
 option(ENABLE_ALLOCATION_PROFILING "Enable tensor allocation profiling" OFF)
-option(LFS_FAST_COMPILE "Optimize measured slow C++ components for build speed instead of runtime speed" OFF)
+option(LFS_FAST_COMPILE "Optimize measured slow C++ components for build speed instead of runtime speed (WIN32 only)" OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Debug options
@@ -947,9 +947,8 @@ if(LFS_FAST_COMPILE AND MSVC)
         endif()
     endfunction()
 
-    # Selected from build_time_comparison.md: only components with >20s summed
-    # edge-time improvement in build-fast are included. CUDA-heavy regressions
-    # stay on their target defaults.
+    # curated list of components to optimize for fast compilation (WIN32 only)
+    # CUDA-heavy regressions stay on their target defaults.
     foreach(_lfs_fast_target IN ITEMS
         lfs_visualizer
         lfs_py


### PR DESCRIPTION
adds -DLFS_FAST_COMPILE=ON to speed up compilation of specific targets

cmake -B build-fast -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="../vcpkg/scripts/buildsystems/vcpkg.cmake" -DLFS_FAST_COMPILE=ON -DBUILD_PORTABLE=ON

cmake --build build-fast -j 



# LFS_FAST_COMPILE Build Time Report

This report compares a baseline Release/portable Ninja build in `build/` with an `LFS_FAST_COMPILE=ON` Release/portable Ninja build in `build-fast/`. Times are taken from Ninja logs.

## Summary

| Metric | baseline `build` | fast `build-fast` | Difference |
|---|---:|---:|---:|
| Invocation index | 0 | 0 |  |
| Logged edges | 672 | 672 | 0 |
| Approx wall time (s) | 1.137,4 | 556,6 | -580,8 (-51,1%) |
| BUILD_PORTABLE | ON | ON |  |
| BUILD_CUDA_PTX_ONLY | ON | ON |  |
| LFS_FAST_COMPILE | OFF | ON |  |

Overall wall time improved by **580,8 seconds (-51,1%)**.

Component times below are summed Ninja edge durations, not wall-clock time, because parallel jobs overlap. They are useful for identifying where compiler work moved.

## Largest Component Improvements

| Component | baseline (s) | fast (s) | Difference (s) | Change |
|---|---:|---:|---:|---:|
| `lfs_py` | 1.108,1 | 247,3 | -860,8 | -77,7% |
| `lfs_visualizer` | 1.180,8 | 775,3 | -405,5 | -34,3% |
| `lfs_core` | 506,1 | 192,2 | -314,0 | -62,0% |
| `lfs_io` | 258,2 | 149,5 | -108,7 | -42,1% |
| `lfs_training` | 255,6 | 206,5 | -49,1 | -19,2% |
| `gsplat_backend_lfs` | 297,8 | 255,5 | -42,3 | -14,2% |
| `lfs_mcp` | 119,5 | 84,9 | -34,6 | -28,9% |
| `Zep` | 96,5 | 67,2 | -29,2 | -30,3% |
| `OpenMeshCore` | 81,9 | 55,3 | -26,6 | -32,4% |
| `lfs_core_cuda` | 480,8 | 456,6 | -24,2 | -5,0% |

## Largest Component Regressions

| Component | baseline (s) | fast (s) | Difference (s) | Change |
|---|---:|---:|---:|---:|
| `(custom/other)` | 35,1 | 53,5 | +18,4 | +52,3% |
| `lfs_training_kernels` | 262,4 | 272,2 | +9,9 | +3,8% |
| `lichtfeld.cp312-win_amd64` | 9,4 | 13,3 | +4,0 | +42,3% |
| `fastlfs_backend` | 115,1 | 117,5 | +2,3 | +2,0% |
| `lfs_io_cuda` | 139,9 | 141,9 | +2,0 | +1,4% |
| `OpenMeshTools` | 11,3 | 12,3 | +1,0 | +8,9% |
| `lfs_sequencer` | 17,6 | 17,6 | +0,0 | +0,0% |

## Component Details

| Component | baseline (s) | fast (s) | Difference (s) | Change |
|---|---:|---:|---:|---:|
| `lfs_visualizer` | 1.180,8 | 775,3 | -405,5 | -34,3% |
| `lfs_py` | 1.108,1 | 247,3 | -860,8 | -77,7% |
| `lfs_core` | 506,1 | 192,2 | -314,0 | -62,0% |
| `lfs_core_cuda` | 480,8 | 456,6 | -24,2 | -5,0% |
| `lfs_tensor_kernels` | 480,7 | 476,0 | -4,7 | -1,0% |
| `gsplat_backend_lfs` | 297,8 | 255,5 | -42,3 | -14,2% |
| `lfs_training_kernels` | 262,4 | 272,2 | +9,9 | +3,8% |
| `lfs_io` | 258,2 | 149,5 | -108,7 | -42,1% |
| `lfs_training` | 255,6 | 206,5 | -49,1 | -19,2% |
| `LichtFeld-Studio` | 174,6 | 161,2 | -13,4 | -7,7% |
| `lfs_io_cuda` | 139,9 | 141,9 | +2,0 | +1,4% |
| `lfs_rendering_tensor` | 119,7 | 114,1 | -5,6 | -4,7% |
| `lfs_mcp` | 119,5 | 84,9 | -34,6 | -28,9% |
| `fastlfs_backend` | 115,1 | 117,5 | +2,3 | +2,0% |
| `Zep` | 96,5 | 67,2 | -29,2 | -30,3% |
| `OpenMeshCore` | 81,9 | 55,3 | -26,6 | -32,4% |
| `edge_compute_backend` | 75,5 | 57,6 | -17,9 | -23,8% |
| `nvimgcodec_obj` | 70,9 | 68,5 | -2,4 | -3,4% |
| `(custom/other)` | 35,1 | 53,5 | +18,4 | +52,3% |
| `lfs_python_utils` | 35,2 | 31,6 | -3,6 | -10,2% |
| `lfs_event_bridge` | 30,0 | 26,3 | -3,7 | -12,3% |
| `nvimgcodec_imgproc_static` | 26,5 | 21,6 | -4,9 | -18,6% |
| `lfs_logger` | 25,9 | 14,0 | -11,9 | -46,1% |
| `nvjpeg_ext_obj` | 24,4 | 17,1 | -7,3 | -30,0% |
| `nanobind-static` | 23,2 | 14,8 | -8,4 | -36,2% |
| `lfs_video` | 19,4 | 16,7 | -2,7 | -13,9% |
| `lfs_sequencer` | 17,6 | 17,6 | +0,0 | +0,0% |
| `lfs_vulkan_rasterizer` | 16,9 | 16,1 | -0,8 | -4,9% |
| `lichtfeld.cp312-win_amd64` | 9,4 | 13,3 | +4,0 | +42,3% |
| `OpenMeshTools` | 11,3 | 12,3 | +1,0 | +8,9% |
| `lfs_python_runtime` | 9,5 | 8,8 | -0,8 | -8,2% |
| `lfs_tree_sitter` | 8,5 | 7,9 | -0,6 | -6,9% |
| `lfs_geometry` | 7,4 | 6,7 | -0,7 | -9,9% |
| `lfs_shader_compiler` | 5,5 | 5,0 | -0,5 | -8,8% |
| `spz_lib` | 4,4 | 3,3 | -1,1 | -24,8% |
| `nvjpeg_ext` | 3,1 | 2,3 | -0,8 | -24,9% |
| `nvjpeg_ext_0` | 3,0 | 2,2 | -0,7 | -24,9% |
| `lfs_tree_sitter_python` | 2,2 | 2,1 | 0,0 | -1,5% |
| `dynlink_cuda` | 2,0 | 1,9 | -0,2 | -7,4% |
| `vterm` | 2,0 | 1,7 | -0,3 | -13,0% |
| `nvimgcodec` | 0,7 | 0,6 | -0,1 | -12,3% |
| `nvimgcodec_0` | 0,7 | 0,6 | -0,1 | -12,3% |

## Slowest Edges: baseline `build`

| Seconds | Output |
|---:|---|
| 507,1 | `src/python/CMakeFiles/lfs_py.dir/lfs/py_ui.cpp.obj` |
| 166,1 | `src/python/CMakeFiles/lfs_py.dir/lfs/py_rml_im_mode_layout.cpp.obj` |
| 127,6 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_ops.cu.obj` |
| 101,2 | `src/training/rasterization/gsplat/CMakeFiles/gsplat_backend_lfs.dir/RasterizeToPixelsFromWorld3DGSFwd.cu.obj` |
| 86,4 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/kernels/kdtree_kmeans.cu.obj` |
| 81,4 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/kernels/morton_encoding_new.cu.obj` |
| 79,9 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/kernels/selection_ops.cu.obj` |
| 77,9 | `src/training/rasterization/gsplat/CMakeFiles/gsplat_backend_lfs.dir/RasterizeToPixelsFromWorld3DGSBwd.cu.obj` |
| 74,5 | `src/training/CMakeFiles/lfs_training_kernels.dir/kernels/mcmc_kernels.cu.obj` |
| 70,7 | `src/io/CMakeFiles/lfs_io_cuda.dir/cuda/morton_encoding.cu.obj` |
| 65,0 | `src/io/CMakeFiles/lfs_io_cuda.dir/cuda/kmeans.cu.obj` |
| 64,9 | `CMakeFiles/LichtFeld-Studio.dir/src/app/mcp_gui_tools.cpp.obj` |
| 61,6 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_random_ops.cu.obj` |
| 60,6 | `src/python/CMakeFiles/lfs_py.dir/lfs/py_mesh.cpp.obj` |
| 56,4 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_strided_ops.cu.obj` |
| 56,0 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/kernels/kmeans_new.cu.obj` |
| 55,7 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/tensor_debug.cu.obj` |
| 52,2 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_fused_pointwise.cu.obj` |
| 52,0 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_warp_reduce.cu.obj` |
| 50,2 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/lanczos_resize/lanczos_resize.cu.obj` |
| 49,5 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/undistort/undistort.cu.obj` |
| 48,1 | `src/python/CMakeFiles/lfs_py.dir/lfs/py_scene.cpp.obj` |
| 47,4 | `src/training/rasterization/edge_compute/CMakeFiles/edge_compute_backend.dir/rasterization/src/forward.cu.obj` |
| 46,7 | `src/training/CMakeFiles/lfs_training_kernels.dir/kernels/mrnf_kernels.cu.obj` |
| 46,1 | `src/training/rasterization/fastgs/CMakeFiles/fastlfs_backend.dir/rasterization/src/forward.cu.obj` |

## Slowest Edges: fast `build-fast`

| Seconds | Output |
|---:|---|
| 121,5 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_ops.cu.obj` |
| 83,0 | `src/training/rasterization/gsplat/CMakeFiles/gsplat_backend_lfs.dir/RasterizeToPixelsFromWorld3DGSFwd.cu.obj` |
| 81,9 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/kernels/kdtree_kmeans.cu.obj` |
| 75,4 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/kernels/morton_encoding_new.cu.obj` |
| 75,2 | `src/training/CMakeFiles/lfs_training_kernels.dir/kernels/mcmc_kernels.cu.obj` |
| 74,0 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/kernels/selection_ops.cu.obj` |
| 71,3 | `src/io/CMakeFiles/lfs_io_cuda.dir/cuda/morton_encoding.cu.obj` |
| 67,4 | `src/io/CMakeFiles/lfs_io_cuda.dir/cuda/kmeans.cu.obj` |
| 62,6 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_random_ops.cu.obj` |
| 62,3 | `src/training/rasterization/gsplat/CMakeFiles/gsplat_backend_lfs.dir/RasterizeToPixelsFromWorld3DGSBwd.cu.obj` |
| 57,6 | `CMakeFiles/LichtFeld-Studio.dir/src/app/mcp_gui_tools.cpp.obj` |
| 57,5 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_strided_ops.cu.obj` |
| 53,8 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/kernels/kmeans_new.cu.obj` |
| 51,6 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/tensor_debug.cu.obj` |
| 51,2 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_fused_pointwise.cu.obj` |
| 51,1 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_warp_reduce.cu.obj` |
| 49,6 | `src/training/CMakeFiles/lfs_training_kernels.dir/kernels/mrnf_kernels.cu.obj` |
| 49,2 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/lanczos_resize/lanczos_resize.cu.obj` |
| 48,8 | `src/core/cuda/CMakeFiles/lfs_core_cuda.dir/undistort/undistort.cu.obj` |
| 45,5 | `src/training/rasterization/fastgs/CMakeFiles/fastlfs_backend.dir/rasterization/src/forward.cu.obj` |
| 43,4 | `src/training/CMakeFiles/lfs_training_kernels.dir/kernels/ssim.cu.obj` |
| 42,7 | `src/core/tensor/CMakeFiles/lfs_tensor_kernels.dir/tensor_masking_ops.cu.obj` |
| 42,0 | `src/training/CMakeFiles/lfs_training.dir/components/ppisp_controller_pool.cu.obj` |
| 41,6 | `src/training/CMakeFiles/lfs_training.dir/components/ppisp_controller.cu.obj` |
| 41,2 | `src/rendering/CMakeFiles/lfs_rendering_tensor.dir/selection_ops.cu.obj` |
