### PR TITLE
 Add CLI arguments for background mode initialization

### DIFF
--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <args.hxx>
 #include <array>
+#include <charconv>
 #include <cmath>
 #include <cstdlib>
 #include <expected>
@@ -17,6 +18,7 @@
 #include <optional>
 #include <print>
 #include <set>
+#include <sstream>
 #include <string_view>
 #include <unordered_map>
 #ifdef _WIN32
@@ -31,6 +33,84 @@ namespace {
     };
 
     const std::set<std::string> VALID_STRATEGIES = {"mcmc", "mrnf", "mnrf", "lfs", "igs+"};
+
+    std::optional<lfs::core::param::BackgroundMode> parse_bg_mode(const std::string& mode) {
+        using lfs::core::param::BackgroundMode;
+        if (mode == "solidcolor")
+            return BackgroundMode::SolidColor;
+        if (mode == "modulation")
+            return BackgroundMode::Modulation;
+        if (mode == "image")
+            return BackgroundMode::Image;
+        if (mode == "random")
+            return BackgroundMode::Random;
+        return std::nullopt;
+    }
+
+    std::string_view trim_view(std::string_view value) {
+        constexpr std::string_view whitespace = " \t\n\r\v\f";
+        const auto first = value.find_first_not_of(whitespace);
+        if (first == std::string_view::npos)
+            return {};
+        const auto last = value.find_last_not_of(whitespace);
+        return value.substr(first, (last - first + 1));
+    }
+
+    std::optional<std::array<float, 3>> parse_bg_hex_color(std::string_view color) {
+        if (color.size() != 7 || color[0] != '#')
+            return std::nullopt;
+
+        std::array<float, 3> values{};
+        for (size_t i = 0; i < values.size(); ++i) {
+            int channel = 0;
+            auto [ptr, ec] = std::from_chars(color.data() + 1 + i * 2, color.data() + 1 + i * 2 + 2, channel, 16);
+            if (ec != std::errc() || ptr != color.data() + 1 + i * 2 + 2)
+                return std::nullopt;
+            values[i] = static_cast<float>(channel) / 255.0f;
+        }
+
+        return values;
+    }
+
+    std::optional<std::array<float, 3>> parse_bg_rgb_color(std::string_view color) {
+        if (color.size() < 7 || color.front() != '(' || color.back() != ')')
+            return std::nullopt;
+
+        std::array<float, 3> values{};
+        std::string_view inner = color.substr(1, color.size() - 2);
+
+        for (size_t i = 0; i < values.size(); ++i) {
+            auto comma_pos = inner.find(',');
+            if (i < 2 && comma_pos == std::string_view::npos)
+                return std::nullopt;
+            if (i == 2 && comma_pos != std::string_view::npos)
+                return std::nullopt;
+
+            std::string_view token = inner.substr(0, comma_pos);
+            token = trim_view(token);
+
+            int channel = 0;
+            auto [ptr, ec] = std::from_chars(token.data(), token.data() + token.size(), channel);
+            if (ec != std::errc() || ptr != token.data() + token.size() || channel < 0 || channel > 255)
+                return std::nullopt;
+            
+            values[i] = static_cast<float>(channel) / 255.0f;
+            if (i < 2) {
+                inner.remove_prefix(comma_pos + 1);
+            }
+        }
+
+        return values;
+    }
+
+    std::optional<std::array<float, 3>> parse_bg_color(const std::string& color) {
+        const auto trimmed = trim_view(color);
+        if (auto value = parse_bg_hex_color(trimmed))
+            return value;
+        if (auto value = parse_bg_rgb_color(trimmed))
+            return value;
+        return std::nullopt;
+    }
 
     // Parse log level from string
     lfs::core::LogLevel parse_log_level(const std::string& level_str) {
@@ -118,6 +198,9 @@ namespace {
             ::args::ValueFlag<int> tile_mode(training_group, "tile_mode", "Tile mode for 3DGUT memory-efficient training: 1=1 tile, 2=2 tiles, 4=4 tiles (default: 1; ignored for 3DGS/FastGS)", {"tile-mode"});
             ::args::Flag use_error_map(training_group, "use_error_map", "Weight MRNF refine signal by per-pixel SSIM error map", {"use-error-map"});
             ::args::Flag use_edge_map(training_group, "use_edge_map", "Weight MRNF refine signal by Sobel edge map on GT images", {"use-edge-map"});
+            ::args::ValueFlag<std::string> bg_mode(training_group, "mode", "Background mode: solidcolor, modulation, image, random (default: solidcolor)", {"bg-mode"});
+            ::args::ValueFlag<std::string> bg_color(training_group, "color", "solidcolor background color as #RRGGBB or (R,G,B) with 0-255 channels (default: #000000)", {"bg-color"});
+            ::args::ValueFlag<std::string> bg_image_path(training_group, "path", "Background image path (required when --bg-mode image)", {"bg-image-path"});
 
             // =============================================================================
             // INITIALIZATION
@@ -193,7 +276,6 @@ namespace {
             ::args::Flag ppisp_controller(rendering_group, "ppisp_controller", "Enable PPISP controller for novel views", {"ppisp-controller"});
             ::args::Flag ppisp_freeze_from_sidecar(rendering_group, "ppisp_freeze", "Freeze PPISP learning and load PPISP weights from a sidecar file", {"ppisp-freeze"});
             ::args::ValueFlag<std::string> ppisp_sidecar_path(rendering_group, "path", "Path to PPISP sidecar (.ppisp) used for frozen PPISP training", {"ppisp-sidecar"});
-            ::args::Flag bg_modulation(rendering_group, "bg_modulation", "Enable sinusoidal background modulation", {"bg-modulation"});
             ::args::Flag gut(rendering_group, "gut", "Enable GUT mode", {"gut"});
 
             // =============================================================================
@@ -512,6 +594,27 @@ namespace {
                 }
             }
 
+            std::optional<lfs::core::param::BackgroundMode> parsed_bg_mode;
+            if (bg_mode) {
+                parsed_bg_mode = parse_bg_mode(::args::get(bg_mode));
+                if (!parsed_bg_mode) {
+                    return std::unexpected("ERROR: --bg-mode must be one of solidcolor, modulation, image, or random");
+                }
+            }
+
+            std::optional<std::array<float, 3>> parsed_bg_color;
+            if (bg_color) {
+                parsed_bg_color = parse_bg_color(::args::get(bg_color));
+                if (!parsed_bg_color) {
+                    return std::unexpected("ERROR: --bg-color must be #RRGGBB or (R,G,B) with 0-255 channels");
+                }
+            }
+
+            if (parsed_bg_mode == lfs::core::param::BackgroundMode::Image &&
+                (!bg_image_path || ::args::get(bg_image_path).empty())) {
+                return std::unexpected("ERROR: --bg-image-path is required when --bg-mode image");
+            }
+
             const auto cli_option_present = [&args](const std::initializer_list<std::string_view> names) {
                 for (size_t i = 1; i < args.size(); ++i) {
                     const std::string_view arg = args[i];
@@ -579,7 +682,9 @@ namespace {
                                         debug_python_flag = bool(debug_python),
                                         debug_python_port_val = cli_option_present({"--debug-python-port"}) ? std::optional<int>(::args::get(debug_python_port)) : std::optional<int>(),
                                         enable_save_eval_images_flag = bool(enable_save_eval_images),
-                                        bg_modulation_flag = bool(bg_modulation),
+                                        bg_mode_val = parsed_bg_mode,
+                                        bg_color_val = parsed_bg_color,
+                                        bg_image_path_val = cli_option_present({"--bg-image-path"}) ? std::optional<std::string>(::args::get(bg_image_path)) : std::optional<std::string>(),
                                         random_flag = bool(random),
                                         gut_flag = bool(gut),
                                         undistort_flag = bool(undistort),
@@ -650,7 +755,17 @@ namespace {
                 setFlag(debug_python_flag, opt.debug_python);
                 setVal(debug_python_port_val, opt.debug_python_port);
                 setFlag(enable_save_eval_images_flag, opt.enable_save_eval_images);
-                setFlag(bg_modulation_flag, opt.bg_modulation);
+                if (bg_mode_val) {
+                    opt.bg_mode = *bg_mode_val;
+                    opt.bg_modulation = *bg_mode_val == lfs::core::param::BackgroundMode::Modulation;
+                }
+                setVal(bg_color_val, opt.bg_color);
+                if (bg_color_val) {
+                    params.cli_bg_color_set = true;
+                }
+                if (bg_image_path_val) {
+                    opt.bg_image_path = lfs::core::utf8_to_path(*bg_image_path_val);
+                }
                 setFlag(random_flag, opt.random);
                 setFlag(gut_flag, opt.gut);
                 setFlag(undistort_flag, opt.undistort);

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -18,7 +18,6 @@
 #include <optional>
 #include <print>
 #include <set>
-#include <sstream>
 #include <string_view>
 #include <unordered_map>
 #ifdef _WIN32

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -267,6 +267,9 @@ namespace lfs::core {
             // Python scripts to execute for custom training callbacks
             std::vector<std::filesystem::path> python_scripts;
 
+            // True when --bg-color was provided on the command line.
+            bool cli_bg_color_set = false;
+
             [[nodiscard]] std::string validate() const;
         };
 

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -1348,6 +1348,13 @@ namespace lfs::vis {
         pending_auto_train_ = params.optimization.auto_train;
         pending_view_paths_ = params.view_paths;
         pending_dataset_path_ = params.dataset.data_path;
+
+        if (params.cli_bg_color_set && rendering_manager_) {
+            auto render_settings = rendering_manager_->getSettings();
+            const auto& color = params.optimization.bg_color;
+            render_settings.background_color = glm::vec3(color[0], color[1], color[2]);
+            rendering_manager_->updateSettings(render_settings);
+        }
     }
 
     std::expected<void, std::string> VisualizerImpl::loadPLY(const std::filesystem::path& path) {

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -37,6 +37,7 @@ TEST(ArgumentParserTest, TrainingDefaultsApplyMaxWidthCap) {
     auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
     ASSERT_TRUE(parsed.has_value()) << parsed.error();
 
+    EXPECT_FALSE((*parsed)->cli_bg_color_set);
     EXPECT_EQ((*parsed)->dataset.max_width, 3840);
     EXPECT_EQ((*parsed)->dataset.resize_factor, 1);
 }
@@ -175,4 +176,238 @@ TEST(ArgumentParserTest, TrainingParsesAddSplats) {
     ASSERT_EQ((*parsed)->add_splat_paths.size(), 2u);
     EXPECT_EQ((*parsed)->add_splat_paths[0], splat_a);
     EXPECT_EQ((*parsed)->add_splat_paths[1], splat_b);
+}
+
+TEST(ArgumentParserTest, TrainingParsesBackgroundModeModulation) {
+    const auto data_path = make_test_path("lfs_arg_parser_bg_mode_modulation_data");
+    const auto output_path = make_test_path("lfs_arg_parser_bg_mode_modulation_output");
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str(),
+        "--bg-mode",
+        "modulation"};
+
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+
+    EXPECT_EQ((*parsed)->optimization.bg_mode, lfs::core::param::BackgroundMode::Modulation);
+    EXPECT_TRUE((*parsed)->optimization.bg_modulation);
+}
+
+TEST(ArgumentParserTest, TrainingRejectsFloatBackgroundColor) {
+    const auto data_path = make_test_path("lfs_arg_parser_bg_color_data");
+    const auto output_path = make_test_path("lfs_arg_parser_bg_color_output");
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str(),
+        "--bg-mode",
+        "solidcolor",
+        "--bg-color",
+        "0.1,0.2,0.3"};
+
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_FALSE(parsed.has_value());
+    EXPECT_NE(parsed.error().find("--bg-color must be #RRGGBB"), std::string::npos);
+}
+
+TEST(ArgumentParserTest, TrainingParsesHexBackgroundColor) {
+    const auto data_path = make_test_path("lfs_arg_parser_bg_hex_color_data");
+    const auto output_path = make_test_path("lfs_arg_parser_bg_hex_color_output");
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str(),
+        "--bg-mode",
+        "solidcolor",
+        "--bg-color",
+        "#FF8040"};
+
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+
+    EXPECT_TRUE((*parsed)->cli_bg_color_set);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[0], 1.0f);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[1], 128.0f / 255.0f);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[2], 64.0f / 255.0f);
+}
+
+TEST(ArgumentParserTest, TrainingParsesLowercaseHexBackgroundColor) {
+    const auto data_path = make_test_path("lfs_arg_parser_bg_lower_hex_color_data");
+    const auto output_path = make_test_path("lfs_arg_parser_bg_lower_hex_color_output");
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str(),
+        "--bg-mode",
+        "solidcolor",
+        "--bg-color",
+        "#ff8040"};
+
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+
+    EXPECT_TRUE((*parsed)->cli_bg_color_set);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[0], 1.0f);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[1], 128.0f / 255.0f);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[2], 64.0f / 255.0f);
+}
+
+TEST(ArgumentParserTest, TrainingParsesIntegerRgbBackgroundColorWithSpaces) {
+    const auto data_path = make_test_path("lfs_arg_parser_bg_rgb_color_data");
+    const auto output_path = make_test_path("lfs_arg_parser_bg_rgb_color_output");
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str(),
+        "--bg-mode",
+        "solidcolor",
+        "--bg-color",
+        "(255, 64, 32)"};
+
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+
+    EXPECT_TRUE((*parsed)->cli_bg_color_set);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[0], 1.0f);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[1], 64.0f / 255.0f);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[2], 32.0f / 255.0f);
+}
+
+TEST(ArgumentParserTest, TrainingParsesIntegerRgbBackgroundColorWithoutSpaces) {
+    const auto data_path = make_test_path("lfs_arg_parser_bg_rgb_compact_color_data");
+    const auto output_path = make_test_path("lfs_arg_parser_bg_rgb_compact_color_output");
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str(),
+        "--bg-mode",
+        "solidcolor",
+        "--bg-color",
+        "(255,64,32)"};
+
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+
+    EXPECT_TRUE((*parsed)->cli_bg_color_set);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[0], 1.0f);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[1], 64.0f / 255.0f);
+    EXPECT_FLOAT_EQ((*parsed)->optimization.bg_color[2], 32.0f / 255.0f);
+}
+
+TEST(ArgumentParserTest, TrainingRejectsHexBackgroundColorWithoutHash) {
+    const auto data_path = make_test_path("lfs_arg_parser_bg_hex_no_hash_data");
+    const auto output_path = make_test_path("lfs_arg_parser_bg_hex_no_hash_output");
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str(),
+        "--bg-mode",
+        "solidcolor",
+        "--bg-color",
+        "FF8040"};
+
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_FALSE(parsed.has_value());
+    EXPECT_NE(parsed.error().find("--bg-color must be #RRGGBB"), std::string::npos);
+}
+
+TEST(ArgumentParserTest, TrainingRejectsRgbBackgroundColorOutOfRange) {
+    const auto data_path = make_test_path("lfs_arg_parser_bg_rgb_out_of_range_data");
+    const auto output_path = make_test_path("lfs_arg_parser_bg_rgb_out_of_range_output");
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str(),
+        "--bg-mode",
+        "solidcolor",
+        "--bg-color",
+        "(256,64,32)"};
+
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_FALSE(parsed.has_value());
+    EXPECT_NE(parsed.error().find("--bg-color must be #RRGGBB"), std::string::npos);
+}
+
+TEST(ArgumentParserTest, TrainingParsesImageBackgroundPath) {
+    const auto dir = make_test_path("lfs_arg_parser_bg_image");
+    const auto data_path = std::filesystem::path(dir) / "data";
+    const auto output_path = std::filesystem::path(dir) / "output";
+    const auto image_path = std::filesystem::path(dir) / "bg.png";
+    std::filesystem::create_directories(data_path);
+    std::filesystem::create_directories(output_path);
+    std::ofstream(image_path).put('\n');
+
+    const std::string data_str = data_path.string();
+    const std::string output_str = output_path.string();
+    const std::string image_str = image_path.string();
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_str.c_str(),
+        "--output-path",
+        output_str.c_str(),
+        "--bg-mode",
+        "image",
+        "--bg-image-path",
+        image_str.c_str()};
+
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+
+    EXPECT_EQ((*parsed)->optimization.bg_mode, lfs::core::param::BackgroundMode::Image);
+    EXPECT_EQ((*parsed)->optimization.bg_image_path, image_path);
+}
+
+TEST(ArgumentParserTest, TrainingRejectsImageBackgroundWithoutPath) {
+    const auto data_path = make_test_path("lfs_arg_parser_bg_image_missing_data");
+    const auto output_path = make_test_path("lfs_arg_parser_bg_image_missing_output");
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str(),
+        "--bg-mode",
+        "image"};
+
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_FALSE(parsed.has_value());
+    EXPECT_NE(parsed.error().find("--bg-image-path is required"), std::string::npos);
 }

--- a/tests/test_background_image.cpp
+++ b/tests/test_background_image.cpp
@@ -381,9 +381,9 @@ TEST_F(BackgroundImageTest, Checkpoint_OldCheckpointLoadsWithDefaults) {
 }
 
 TEST_F(BackgroundImageTest, Checkpoint_AllBackgroundModesSerialize) {
-    static constexpr const char* EXPECTED_NAMES[] = {"solid_color", "modulation", "image"};
+    static constexpr const char* EXPECTED_NAMES[] = {"solid_color", "modulation", "image", "random"};
 
-    for (int mode_int = 0; mode_int < 3; ++mode_int) {
+    for (int mode_int = 0; mode_int < 4; ++mode_int) {
         OptimizationParameters params;
         params.bg_mode = static_cast<BackgroundMode>(mode_int);
 


### PR DESCRIPTION
This PR introduces the ability to configure the background mode and background color directly via command-line arguments. This streamlines automated processes and headless runs by allowing background configurations to be set upon startup before the visualizer loads. 

**Key Features:**
- Added `--bg-mode <mode>` argument (supports `solidcolor`, `modulation`, `image`, and `random`).
- Added `--bg-color <color>` argument. Supports two formats:
  - Hexadecimal (e.g., `#FF8040` or `#ff8040`).
  - RGB Tuple with 0-255 channels (e.g., `(255, 64, 32)` or `(255,64,32)`).
- Added `--bg-image-path <path>` argument (required when `--bg-mode image` is selected).
- Plumbed parsed background settings through `VisualizerImpl` so the `rendering_manager_` initializes the background state early.

fixes https://github.com/MrNeRF/LichtFeld-Studio/issues/1215