### PR TITLE
fix(scene): render plugin-inserted splats (add_splat → Vulkan-external storage)

### DIFF
--- a/src/io/include/io/loader.hpp
+++ b/src/io/include/io/loader.hpp
@@ -42,6 +42,12 @@ namespace lfs::io {
     using ProgressCallback = std::function<void(float percentage, const std::string& message)>;
     using CancelCallback = std::function<bool()>;
 
+    // Re-home a model's parameter tensors into the given allocator (Vulkan-external interop)
+    // so the splat renderer can bind them. No-op when tensors are already allocator-backed or
+    // when the allocator is empty. Used by the loader and by Scene::add_splat (plugin inserts).
+    [[nodiscard]] Result<void> migrateSplatTensorsToAllocator(SplatData& model,
+                                                              const SplatTensorAllocator& allocator);
+
     // Dataset type enum
     enum class DatasetType {
         Unknown,

--- a/src/io/loader_service.cpp
+++ b/src/io/loader_service.cpp
@@ -44,75 +44,75 @@ namespace lfs::io {
             return tensor.is_external_storage() &&
                    tensor.external_storage_kind() == "vulkan_external_buffer";
         }
+    } // namespace
 
-        // A model loaded into plain CUDA storage (e.g. SOG / SPZ, which don't thread the
-        // allocator through their decoders) can't be bound by the Vulkan splat renderer — it
-        // refuses a full input-copy fallback. Re-home each parameter tensor into the loader's
-        // allocator (Vulkan-external interop) so every format is renderer-ready. No-op when the
-        // tensors are already allocator-backed (PLY / checkpoint) or no allocator is supplied.
-        [[nodiscard]] Result<void> migrateSplatTensorsToAllocator(lfs::core::SplatData& model,
-                                                                  const SplatTensorAllocator& allocator) {
-            if (!allocator) {
-                return {};
-            }
-            if (splat_tensor_renderer_ready(model.means_raw()) &&
-                splat_tensor_renderer_ready(model.sh0_raw()) &&
-                splat_tensor_renderer_ready(model.scaling_raw()) &&
-                splat_tensor_renderer_ready(model.rotation_raw()) &&
-                splat_tensor_renderer_ready(model.opacity_raw()) &&
-                splat_tensor_renderer_ready(model.shN_raw())) {
-                model.set_tensor_allocator(allocator);
-                return {};
-            }
-
-            try {
-                const auto copy_to_allocator =
-                    [&](const lfs::core::Tensor& source, const std::string_view name) -> lfs::core::Tensor {
-                    lfs::core::Tensor source_cuda =
-                        source.device() == lfs::core::Device::CUDA ? source : source.cuda();
-                    if (!source_cuda.is_contiguous()) {
-                        source_cuda = source_cuda.contiguous();
-                    }
-                    const auto& shape = source_cuda.shape();
-                    const size_t capacity = shape.rank() > 0 ? shape[0] : source_cuda.numel();
-                    lfs::core::Tensor dst = allocator(shape, capacity, source_cuda.dtype(), name);
-                    dst.set_name(std::string{name});
-                    dst.copy_from(source_cuda);
-                    return dst;
-                };
-
-                const int max_sh = model.get_max_sh_degree();
-                const int active_sh = model.get_active_sh_degree();
-                const float scene_scale = model.get_scene_scale();
-                lfs::core::Tensor deleted = model.has_deleted_mask() ? model.deleted() : lfs::core::Tensor{};
-
-                lfs::core::Tensor shN;
-                if (model.shN_raw().is_valid() && model.shN_raw().numel() > 0) {
-                    shN = copy_to_allocator(model.shN_raw(), "SplatData.shN");
-                }
-                lfs::core::SplatData migrated(max_sh,
-                                              copy_to_allocator(model.means_raw(), "SplatData.means"),
-                                              copy_to_allocator(model.sh0_raw(), "SplatData.sh0"),
-                                              std::move(shN),
-                                              copy_to_allocator(model.scaling_raw(), "SplatData.scaling"),
-                                              copy_to_allocator(model.rotation_raw(), "SplatData.rotation"),
-                                              copy_to_allocator(model.opacity_raw(), "SplatData.opacity"),
-                                              scene_scale,
-                                              lfs::core::SplatData::ShNLayout::Swizzled);
-                migrated.set_active_sh_degree(active_sh);
-                if (deleted.is_valid()) {
-                    migrated.deleted() = std::move(deleted);
-                }
-                model = std::move(migrated);
-                model.set_tensor_allocator(allocator);
-                lfs::core::Tensor::trim_memory_pool();
-            } catch (const std::exception& e) {
-                return make_error(ErrorCode::CORRUPTED_DATA,
-                                  std::format("Failed to migrate splat tensors to renderer storage: {}", e.what()));
-            }
+    // A model loaded into plain CUDA storage (e.g. SOG / SPZ, which don't thread the
+    // allocator through their decoders) can't be bound by the Vulkan splat renderer — it
+    // refuses a full input-copy fallback. Re-home each parameter tensor into the loader's
+    // allocator (Vulkan-external interop) so every format is renderer-ready. No-op when the
+    // tensors are already allocator-backed (PLY / checkpoint) or no allocator is supplied.
+    [[nodiscard]] Result<void> migrateSplatTensorsToAllocator(lfs::core::SplatData& model,
+                                                              const SplatTensorAllocator& allocator) {
+        if (!allocator) {
             return {};
         }
-    } // namespace
+        if (splat_tensor_renderer_ready(model.means_raw()) &&
+            splat_tensor_renderer_ready(model.sh0_raw()) &&
+            splat_tensor_renderer_ready(model.scaling_raw()) &&
+            splat_tensor_renderer_ready(model.rotation_raw()) &&
+            splat_tensor_renderer_ready(model.opacity_raw()) &&
+            splat_tensor_renderer_ready(model.shN_raw())) {
+            model.set_tensor_allocator(allocator);
+            return {};
+        }
+
+        try {
+            const auto copy_to_allocator =
+                [&](const lfs::core::Tensor& source, const std::string_view name) -> lfs::core::Tensor {
+                lfs::core::Tensor source_cuda =
+                    source.device() == lfs::core::Device::CUDA ? source : source.cuda();
+                if (!source_cuda.is_contiguous()) {
+                    source_cuda = source_cuda.contiguous();
+                }
+                const auto& shape = source_cuda.shape();
+                const size_t capacity = shape.rank() > 0 ? shape[0] : source_cuda.numel();
+                lfs::core::Tensor dst = allocator(shape, capacity, source_cuda.dtype(), name);
+                dst.set_name(std::string{name});
+                dst.copy_from(source_cuda);
+                return dst;
+            };
+
+            const int max_sh = model.get_max_sh_degree();
+            const int active_sh = model.get_active_sh_degree();
+            const float scene_scale = model.get_scene_scale();
+            lfs::core::Tensor deleted = model.has_deleted_mask() ? model.deleted() : lfs::core::Tensor{};
+
+            lfs::core::Tensor shN;
+            if (model.shN_raw().is_valid() && model.shN_raw().numel() > 0) {
+                shN = copy_to_allocator(model.shN_raw(), "SplatData.shN");
+            }
+            lfs::core::SplatData migrated(max_sh,
+                                          copy_to_allocator(model.means_raw(), "SplatData.means"),
+                                          copy_to_allocator(model.sh0_raw(), "SplatData.sh0"),
+                                          std::move(shN),
+                                          copy_to_allocator(model.scaling_raw(), "SplatData.scaling"),
+                                          copy_to_allocator(model.rotation_raw(), "SplatData.rotation"),
+                                          copy_to_allocator(model.opacity_raw(), "SplatData.opacity"),
+                                          scene_scale,
+                                          lfs::core::SplatData::ShNLayout::Swizzled);
+            migrated.set_active_sh_degree(active_sh);
+            if (deleted.is_valid()) {
+                migrated.deleted() = std::move(deleted);
+            }
+            model = std::move(migrated);
+            model.set_tensor_allocator(allocator);
+            lfs::core::Tensor::trim_memory_pool();
+        } catch (const std::exception& e) {
+            return make_error(ErrorCode::CORRUPTED_DATA,
+                              std::format("Failed to migrate splat tensors to renderer storage: {}", e.what()));
+        }
+        return {};
+    }
 
     Result<LoadResult> LoaderService::load(
         const std::filesystem::path& path,

--- a/src/python/lfs/py_scene.cpp
+++ b/src/python/lfs/py_scene.cpp
@@ -384,6 +384,18 @@ namespace lfs::python {
             opacity.tensor().clone(),
             scene_scale);
 
+        // The Vulkan splat renderer only binds tensors in Vulkan-external storage; the cloned
+        // tensors above land in plain CUDA storage, so without this the inserted splat won't
+        // render (the file loader performs the same migration on load). Re-home them before
+        // handing off to the scene.
+        if (auto* const scene_manager = get_scene_manager()) {
+            if (auto migrated = scene_manager->migrateSplatToRendererStorage(*splat); !migrated) {
+                LOG_WARN("add_splat: could not migrate '{}' to Vulkan-external storage; "
+                         "it may not render: {}",
+                         name, migrated.error());
+            }
+        }
+
         const size_t gaussian_count = splat->size();
         const int32_t node_id = scene_->addSplat(name, std::move(splat), parent);
 

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -247,6 +247,18 @@ namespace lfs::vis {
 
     using namespace lfs::core::events;
 
+    std::expected<void, std::string> SceneManager::migrateSplatToRendererStorage(lfs::core::SplatData& model) {
+        auto allocator = makeViewerSplatTensorAllocator();
+        if (!allocator) {
+            // No Vulkan-external interop available (e.g. headless) — nothing to migrate.
+            return {};
+        }
+        if (auto migrated = lfs::io::migrateSplatTensorsToAllocator(model, allocator); !migrated) {
+            return std::unexpected(migrated.error().message);
+        }
+        return {};
+    }
+
     SceneManager::SceneManager() {
         core::prop::set_undo_callback(
             [](const std::string& property_path,

--- a/src/visualizer/scene/scene_manager.hpp
+++ b/src/visualizer/scene/scene_manager.hpp
@@ -48,6 +48,12 @@ namespace lfs::vis {
         SceneManager(const SceneManager&) = delete;
         SceneManager& operator=(const SceneManager&) = delete;
 
+        // Re-home a plugin-inserted splat's tensors into Vulkan-external storage so the splat
+        // renderer can bind them. scene.add_splat otherwise lands in plain CUDA storage, which
+        // the Vulkan renderer rejects (refuses the input-copy fallback). No-op if external
+        // interop is unavailable. Returns true when the model is renderer-ready afterward.
+        [[nodiscard]] std::expected<void, std::string> migrateSplatToRendererStorage(lfs::core::SplatData& model);
+
         // Content queries - direct, no events
         ContentType getContentType() const {
             std::lock_guard<std::mutex> lock(state_mutex_);


### PR DESCRIPTION
## Summary

`scene.add_splat` clones its input tensors into plain CUDA storage, so the Vulkan splat renderer — which refuses the input-copy fallback and requires `vulkan_external_buffer` storage — can't bind them. A splat inserted by a Python plugin therefore renders nothing:

> `VkSplat refusing full input-copy fallback; model tensors must use Vulkan-external storage`

The file loader already guarantees renderer-ready models via `migrateSplatTensorsToAllocator`. This routes `PyScene::add_splat` through the same path:

- **io**: expose `migrateSplatTensorsToAllocator` (was file-local in `loader_service.cpp`)
- **`SceneManager::migrateSplatToRendererStorage`**: migrate a model through the viewer's Vulkan-external allocator (no-op when interop is unavailable / headless)
- **`PyScene::add_splat`**: migrate the cloned model before handing it to the scene

Un-breaks rendering for plugins that insert via `scene.add_splat` (TripoSplat, HY-World-Mirror, ml-sharp, …).

## Scope / notes

- **Single inserted model only.** A separate gap remains for the **combined model** of 2+ visible splats: `combined_model_allocator_` is only installed on file/dataset load, so plugin-built multi-splat scenes still fall back to plain storage. Intentionally left out of this PR.
- `loader_service.cpp`'s large diff is just the migrate helper moving out of the file-local anonymous namespace into `lfs::io` (clang-format re-indent); no logic change.

## Test plan

- [ ] Insert a splat from a Python plugin (`scene.add_splat`) → renders in the Vulkan viewport (was blank with the VkSplat error).
- [ ] Load a `.ply` / checkpoint → unchanged (migrate is a no-op for already-external models).
- [ ] Headless / no Vulkan-external interop → no crash (migration no-ops, logs a warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)