### PR TITLE
fix(build): make lfs_py build with the new add_splat → external-storage path

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -272,6 +272,9 @@ target_link_libraries(lfs_py PRIVATE
     imgui::imgui
     implot::implot
     $<IF:$<PLATFORM_ID:Windows>,RmlUi::RmlUi,lfs_rmlui>
+    # py_scene.cpp now includes vulkan_external_tensor.hpp -> vulkan_context.hpp -> <vk_mem_alloc.h>.
+    # lfs_visualizer links VMA privately, so lfs_py needs the include interface directly.
+    GPUOpen::VulkanMemoryAllocator
 )
 
 target_include_directories(lfs_py PRIVATE

--- a/src/visualizer/rendering/vulkan_external_tensor.hpp
+++ b/src/visualizer/rendering/vulkan_external_tensor.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include "core/splat_data.hpp"
 #include "core/splat_exportable_storage.hpp"
 #include "core/tensor.hpp"
@@ -82,6 +83,6 @@ namespace lfs::vis {
     // One-tensor-per-VkBuffer allocator bound to the active window's Vulkan context, matching
     // what the splat renderer binds. Empty when interop is unavailable (headless). Shared by the
     // file loader and in-memory inserts (Python API).
-    [[nodiscard]] lfs::core::SplatTensorAllocator makeViewerSplatTensorAllocator();
+    [[nodiscard]] LFS_VIS_API lfs::core::SplatTensorAllocator makeViewerSplatTensorAllocator();
 
 } // namespace lfs::vis


### PR DESCRIPTION
Follow-up to **dceb8f8d** ("Fix ply loading via api").

That commit made `py_scene.cpp` include `visualizer/rendering/vulkan_external_tensor.hpp` and call `lfs::vis::makeViewerSplatTensorAllocator()`. This breaks the `lfs_py` build for any configuration that **compiles the Python bindings from source** (i.e. not the Windows CI's `-DLFS_DEV_IMPORT_SOURCE_PYTHON=OFF`):

1. `vulkan_external_tensor.hpp` → `window/vulkan_context.hpp` → `<vk_mem_alloc.h>`, but `lfs_visualizer` links `VulkanMemoryAllocator` **privately**, so `lfs_py` can't find the header:
   ```
   fatal error C1083: Cannot open include file: 'vk_mem_alloc.h'
   ```
2. `makeViewerSplatTensorAllocator` isn't exported, so `lfs_py` can't resolve it across the `lfs_visualizer` DLL boundary:
   ```
   LNK2019: unresolved external symbol ... makeViewerSplatTensorAllocator ... LNK1120
   ```

## Fix
- Add `GPUOpen::VulkanMemoryAllocator` to `lfs_py`'s link libraries (provides the VMA include interface).
- Mark `makeViewerSplatTensorAllocator` `LFS_VIS_API` (and include `core/export.hpp`) so it's exported from `lfs_visualizer`.

## Test plan
- [ ] Configure + build with Python bindings compiled from source (default local build) → `lichtfeld.cp312-win_amd64.pyd` links.
- [ ] Insert a splat via the Python API (`scene.add_splat`) → renders (exercises the dceb8f8d path end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)