### PR TITLE
fix: add LFS_VIS_API export to makeViewerSplatTensorAllocator

### DIFF
--- a/src/visualizer/rendering/vulkan_external_tensor.hpp
+++ b/src/visualizer/rendering/vulkan_external_tensor.hpp
@@ -82,6 +82,6 @@ namespace lfs::vis {
     // One-tensor-per-VkBuffer allocator bound to the active window's Vulkan context, matching
     // what the splat renderer binds. Empty when interop is unavailable (headless). Shared by the
     // file loader and in-memory inserts (Python API).
-    [[nodiscard]] lfs::core::SplatTensorAllocator makeViewerSplatTensorAllocator();
+    [[nodiscard]] LFS_VIS_API lfs::core::SplatTensorAllocator makeViewerSplatTensorAllocator();
 
 } // namespace lfs::vis


### PR DESCRIPTION
## Problem

\makeViewerSplatTensorAllocator()\ is defined in \lfs_visualizer\ (SHARED on Windows) but called from \lfs_py\ (\py_scene.cpp\). Without the \LFS_VIS_API\ (\__declspec(dllexport)\) decorator, the symbol is not exported from the DLL, causing \LNK2019: unresolved external symbol\ when linking the Python extension module on Windows.

## Fix

Add the \LFS_VIS_API\ macro to the \makeViewerSplatTensorAllocator()\ declaration in \ulkan_external_tensor.hpp\, consistent with other cross-DLL-boundary functions in the codebase.