### PR TITLE
Add .webp to the image file picker filter

### DIFF
--- a/src/visualizer/gui/utils/native_file_dialog.cpp
+++ b/src/visualizer/gui/utils/native_file_dialog.cpp
@@ -419,7 +419,7 @@ namespace lfs::vis::gui {
 
         [[nodiscard]] std::vector<DialogFilter> imageFilters() {
             return {makeFilter("Image Files",
-                               {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".hdr", ".exr"})};
+                               {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tga", ".hdr", ".exr"})};
         }
 
         [[nodiscard]] std::vector<DialogFilter> environmentMapFilters() {


### PR DESCRIPTION
## What
Add `.webp` to the "Image Files" filter used by `open_image_dialog` / `OpenImageFileDialog` in `native_file_dialog.cpp`.

## Why
The image picker allowed `png/jpg/jpeg/bmp/tga/hdr/exr` but not `.webp`, so webp files were hidden in the Open Image dialog. webp is already a first-class format in the codebase — `src/io` links `WebP::webpdecoder` and `src/io/formats/sogs.cpp` decodes webp via `WebPDecodeRGBA` — so the decode capability exists; only the picker filter omitted it. This lets webp-capable consumers (e.g. Pillow-based plugins) select webp images.

## Change
One line in `imageFilters()`:
```diff
-            {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".hdr", ".exr"})};
+            {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tga", ".hdr", ".exr"})};
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)