### PR TITLE
feat(python): clipboard image read API for plugins

### DIFF
--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -583,6 +583,61 @@ namespace lfs::python {
             return {static_cast<uint64_t>(result.texture_id), result.width, result.height};
         }
 
+        // SDL returns clipboard payloads keyed by MIME type, chosen by the source app
+        // (browsers use image/png, native copies may use image/bmp, etc.), so scan every
+        // advertised image/* type rather than guessing a fixed set.
+        bool clipboard_has_image() {
+            size_t count = 0;
+            char** mimes = SDL_GetClipboardMimeTypes(&count);
+            if (!mimes)
+                return false;
+            bool found = false;
+            for (size_t i = 0; i < count; ++i) {
+                if (mimes[i] && std::string_view(mimes[i]).starts_with("image/")) {
+                    found = true;
+                    break;
+                }
+            }
+            SDL_free(mimes);
+            return found;
+        }
+
+        // Returns an owning RGB buffer (caller frees with lfs::core::free_image), or
+        // {nullptr, 0, 0, 0} when the clipboard holds no decodable image.
+        std::tuple<unsigned char*, int, int, int> decode_clipboard_image() {
+            size_t count = 0;
+            char** mimes = SDL_GetClipboardMimeTypes(&count);
+            if (!mimes)
+                return {nullptr, 0, 0, 0};
+
+            std::tuple<unsigned char*, int, int, int> image{nullptr, 0, 0, 0};
+            for (size_t i = 0; i < count; ++i) {
+                if (!mimes[i] || !std::string_view(mimes[i]).starts_with("image/"))
+                    continue;
+
+                size_t size = 0;
+                void* raw = SDL_GetClipboardData(mimes[i], &size);
+                if (!raw)
+                    continue;
+                if (size == 0) {
+                    SDL_free(raw);
+                    continue;
+                }
+
+                try {
+                    image = lfs::core::load_image_from_memory(
+                        static_cast<const uint8_t*>(raw), size);
+                } catch (const std::exception& e) {
+                    LOG_WARN("Clipboard image decode failed ({}): {}", mimes[i], e.what());
+                }
+                SDL_free(raw);
+                if (std::get<0>(image))
+                    break;
+            }
+            SDL_free(mimes);
+            return image;
+        }
+
         vis::op::OperatorResult parse_operator_result(nb::object result, nb::object instance = nb::none()) {
             if (nb::isinstance<nb::set>(result)) {
                 nb::set result_set = nb::cast<nb::set>(result);
@@ -5123,6 +5178,40 @@ namespace lfs::python {
             "set_clipboard_text",
             [](const std::string& text) { SDL_SetClipboardText(text.c_str()); },
             nb::arg("text"), "Copy text to the system clipboard");
+
+        m.def(
+            "has_clipboard_image",
+            []() { return clipboard_has_image(); },
+            "Return True if the system clipboard holds an image");
+
+        m.def(
+            "get_clipboard_image_texture",
+            []() -> nb::tuple {
+                auto [data, w, h, channels] = decode_clipboard_image();
+                if (!data)
+                    return nb::make_tuple(0, 0, 0);
+                const auto [tex_id, width, height] = create_ui_texture_from_data(data, w, h, channels);
+                lfs::core::free_image(data);
+                return nb::make_tuple(tex_id, width, height);
+            },
+            "Read an image from the clipboard as a UI texture, returns (texture_id, width, height)");
+
+        m.def(
+            "save_clipboard_image",
+            [](const std::string& path) {
+                const auto image = decode_clipboard_image();
+                if (!std::get<0>(image))
+                    return false;
+                bool saved = false;
+                try {
+                    saved = lfs::core::save_img_data(lfs::core::utf8_to_path(path), image);
+                } catch (const std::exception& e) {
+                    LOG_WARN("Failed to save clipboard image to {}: {}", path, e.what());
+                }
+                lfs::core::free_image(std::get<0>(image));
+                return saved;
+            },
+            nb::arg("path"), "Decode the clipboard image and write it to path; returns success");
 
         m.def(
             "set_mouse_cursor_hand",

--- a/src/python/stubs/lichtfeld/ui/__init__.pyi
+++ b/src/python/stubs/lichtfeld/ui/__init__.pyi
@@ -2523,6 +2523,15 @@ def get_ui_scale_preference() -> float:
 def set_clipboard_text(text: str) -> None:
     """Copy text to the system clipboard"""
 
+def has_clipboard_image() -> bool:
+    """Return True if the system clipboard holds an image"""
+
+def get_clipboard_image_texture() -> tuple:
+    """Read clipboard image as UI texture, returns (texture_id, width, height)"""
+
+def save_clipboard_image(path: str) -> bool:
+    """Decode the clipboard image and write it to path; returns success"""
+
 def set_mouse_cursor_hand() -> None:
     """Set mouse cursor to hand pointer for this frame"""
 


### PR DESCRIPTION
## What

Adds a Python clipboard **image read** API so plugins can pull an image straight off the system clipboard:

- `lf.ui.has_clipboard_image() -> bool`
- `lf.ui.get_clipboard_image_texture() -> (texture_id, w, h)`
- `lf.ui.save_clipboard_image(path) -> bool`

These complement the existing write-only `set_clipboard_text` (the only clipboard binding today).

## How

- Enumerates SDL's advertised clipboard MIME types and takes any `image/*`. Browsers expose `image/png`; native Windows copies expose `image/bmp` (SDL maps `CF_DIB`/`CF_DIBV5` → `image/bmp`), so it works across sources without hard-coding a list.
- Decodes the bytes through the existing `core::load_image_from_memory` (OpenImageIO).
- `get_clipboard_image_texture` uploads via the same `create_ui_texture_from_data` path as `load_image_texture`; `save_clipboard_image` writes the decoded image via `core::save_img_data`.
- Owning image buffers freed with `core::free_image`; SDL allocations with `SDL_free`.
- Helpers factored into the existing anonymous namespace alongside `create_ui_texture_from_data`; no new includes required.

## Notes

- Decoded as RGB (alpha dropped), matching `load_image_from_memory`.
- New stubs added to `lichtfeld/ui/__init__.pyi`.
- Verified: full build links (`lichtfeld.*.pyd` + `LichtFeld-Studio.exe`), and live end-to-end on Windows (clipboard image → `save_clipboard_image` wrote a valid PNG; `has_clipboard_image` gated the action correctly).

## Use case

Lets plugins offer a "Paste image" action (e.g. single-image 3D generators) instead of only a file dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
