### PR TITLE
Add SPHERICAL (equirectangular) camera model to the COLMAP loader

### DIFF
--- a/src/core/camera.cpp
+++ b/src/core/camera.cpp
@@ -589,6 +589,11 @@ namespace lfs::core {
             return true;
         if (_tangential_distortion.is_valid() && _tangential_distortion.numel() > 0)
             return true;
+        // Equirectangular is a complete projection model handled natively by the
+        // rasterizer; there is no pinhole image to "undistort" to, so it must not
+        // be routed through the undistortion path.
+        if (_camera_model_type == CameraModelType::EQUIRECTANGULAR)
+            return false;
         if (_camera_model_type != CameraModelType::PINHOLE)
             return true;
         return false;

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -167,7 +167,12 @@ namespace lfs::io {
         SIMPLE_RADIAL_FISHEYE = 8,
         RADIAL_FISHEYE = 9,
         THIN_PRISM_FISHEYE = 10,
-        UNDEFINED = 11
+        UNDEFINED = 11,
+        // Equirectangular / spherical 360 panorama model. The id matches the
+        // SPHERICAL model id written by the equirectangular COLMAP fork
+        // (params: [width, height], no intrinsics). Mapped to
+        // CameraModelType::EQUIRECTANGULAR, which the rasterizer handles natively.
+        SPHERICAL = 17
     };
 
     static const std::unordered_map<int, std::pair<CAMERA_MODEL, int32_t>> camera_model_ids = {
@@ -182,7 +187,8 @@ namespace lfs::io {
         {8, {CAMERA_MODEL::SIMPLE_RADIAL_FISHEYE, 4}},
         {9, {CAMERA_MODEL::RADIAL_FISHEYE, 5}},
         {10, {CAMERA_MODEL::THIN_PRISM_FISHEYE, 12}},
-        {11, {CAMERA_MODEL::UNDEFINED, -1}}};
+        {11, {CAMERA_MODEL::UNDEFINED, -1}},
+        {17, {CAMERA_MODEL::SPHERICAL, 2}}};
 
     static const std::unordered_map<std::string, CAMERA_MODEL> camera_model_names = {
         {"SIMPLE_PINHOLE", CAMERA_MODEL::SIMPLE_PINHOLE},
@@ -195,7 +201,17 @@ namespace lfs::io {
         {"FOV", CAMERA_MODEL::FOV},
         {"SIMPLE_RADIAL_FISHEYE", CAMERA_MODEL::SIMPLE_RADIAL_FISHEYE},
         {"RADIAL_FISHEYE", CAMERA_MODEL::RADIAL_FISHEYE},
-        {"THIN_PRISM_FISHEYE", CAMERA_MODEL::THIN_PRISM_FISHEYE}};
+        {"THIN_PRISM_FISHEYE", CAMERA_MODEL::THIN_PRISM_FISHEYE},
+        {"SPHERICAL", CAMERA_MODEL::SPHERICAL},
+        // Accept EQUIRECTANGULAR as an alias for the same 360 panorama model.
+        {"EQUIRECTANGULAR", CAMERA_MODEL::SPHERICAL}};
+
+    // Placeholder focal length for equirectangular/spherical cameras. They carry
+    // no real intrinsics; the rasterizer reinterprets K for EQUIRECTANGULAR
+    // (focal := full image dimensions, principal point := tile offsets). This
+    // value only keeps the FoV/intrinsics bookkeeping non-degenerate and mirrors
+    // the convention used by the transforms.json loader.
+    static constexpr float EQUIRECTANGULAR_DUMMY_FOCAL = 20.0f;
 
     static const char* camera_model_name(const int model_id) {
         switch (static_cast<CAMERA_MODEL>(model_id)) {
@@ -210,6 +226,7 @@ namespace lfs::io {
         case CAMERA_MODEL::SIMPLE_RADIAL_FISHEYE: return "SIMPLE_RADIAL_FISHEYE";
         case CAMERA_MODEL::RADIAL_FISHEYE: return "RADIAL_FISHEYE";
         case CAMERA_MODEL::THIN_PRISM_FISHEYE: return "THIN_PRISM_FISHEYE";
+        case CAMERA_MODEL::SPHERICAL: return "SPHERICAL";
         default: return "UNDEFINED";
         }
     }
@@ -515,6 +532,11 @@ namespace lfs::io {
             params[1] /= factor; // fy
             params[2] /= factor; // cx
             params[3] /= factor; // cy
+            break;
+
+        case CAMERA_MODEL::SPHERICAL:
+            params[0] /= factor; // width
+            params[1] /= factor; // height
             break;
 
         default:
@@ -1204,6 +1226,18 @@ namespace lfs::io {
                 return make_error(ErrorCode::UNSUPPORTED_FORMAT,
                                   std::format("FOV camera model not supported for image '{}'", img.name),
                                   image_path);
+
+            case CAMERA_MODEL::SPHERICAL:
+                // Equirectangular 360 panorama. params = [width, height]; no real
+                // intrinsics. The EQUIRECTANGULAR rasterizer derives projection
+                // from the image dimensions, so we only set placeholder focal/center.
+                focal_x = focal_y = EQUIRECTANGULAR_DUMMY_FOCAL;
+                center_x = 0.5f * static_cast<float>(cam_data.width);
+                center_y = 0.5f * static_cast<float>(cam_data.height);
+                radial_dist = Tensor::empty({0}, Device::CPU);
+                tangential_dist = Tensor::empty({0}, Device::CPU);
+                camera_model_type = lfs::core::CameraModelType::EQUIRECTANGULAR;
+                break;
 
             default:
                 return make_error(ErrorCode::UNSUPPORTED_FORMAT,
@@ -2159,6 +2193,18 @@ namespace lfs::io {
                 return make_error(ErrorCode::UNSUPPORTED_FORMAT,
                                   std::format("FOV camera model not supported for image '{}'", img.name),
                                   sparse_path);
+
+            case CAMERA_MODEL::SPHERICAL:
+                // Equirectangular 360 panorama. params = [width, height]; no real
+                // intrinsics. The EQUIRECTANGULAR rasterizer derives projection
+                // from the image dimensions, so we only set placeholder focal/center.
+                focal_x = focal_y = EQUIRECTANGULAR_DUMMY_FOCAL;
+                center_x = 0.5f * static_cast<float>(cam_data.width);
+                center_y = 0.5f * static_cast<float>(cam_data.height);
+                radial_dist = Tensor::empty({0}, Device::CPU);
+                tangential_dist = Tensor::empty({0}, Device::CPU);
+                camera_model_type = lfs::core::CameraModelType::EQUIRECTANGULAR;
+                break;
 
             default:
                 return make_error(ErrorCode::UNSUPPORTED_FORMAT,


### PR DESCRIPTION
Dependent on https://github.com/colmap/colmap/pull/4441

LichtFeld already supports the EQUIRECTANGULAR camera model natively in the CUDA/Vulkan rasterizers, UI, and the transforms.json loader, but the COLMAP loader did not recognize the SPHERICAL model emitted by equirectangular COLMAP forks (e.g. colmap/colmap#4441), so 360 panorama reconstructions could not be loaded from COLMAP output.

src/io/formats/colmap.cpp:
- Register SPHERICAL (COLMAP model id 17, params [width, height]) in the CAMERA_MODEL enum, id/name maps, name lookup, and intrinsic scaling.
- Handle it in both the binary and text camera parse paths, mapping it to CameraModelType::EQUIRECTANGULAR. "EQUIRECTANGULAR" is accepted as an alias name. A placeholder focal length is set (the EQUIRECTANGULAR rasterizer derives the projection from the image dimensions), mirroring the transforms.json convention.

src/core/camera.cpp:
- Exclude EQUIRECTANGULAR from has_distortion(): it is a complete projection model handled natively by the rasterizer, with no pinhole image to undistort to.

Equirectangular COLMAP reconstructions train with --gut (3DGUT).