### PR TITLE
Fix numpad keys acting as navigation in viewport overlay text inputs

### DIFF
--- a/src/visualizer/gui/rml_viewport_overlay.cpp
+++ b/src/visualizer/gui/rml_viewport_overlay.cpp
@@ -672,7 +672,19 @@ namespace lfs::vis::gui {
             if (is_text_target) {
                 wants_input_ = true;
                 guiFocusState().want_capture_keyboard = true;
+                // Numpad digit and period scancodes must be suppressed from
+                // ProcessKeyDown / ProcessKeyUp when a text input is focused,
+                // otherwise RmlUi treats them as navigation keys (Home, End,
+                // arrows, etc.). The actual digit text arrives via
+                // ProcessTextInput below. This mirrors the fix in
+                // rml_panel_host.cpp for the sidebar text inputs.
+                auto isNumpadTextKey = [](int sc) {
+                    return (sc >= SDL_SCANCODE_KP_1 && sc <= SDL_SCANCODE_KP_0) ||
+                           sc == SDL_SCANCODE_KP_PERIOD;
+                };
                 for (const int sc : input.keys_pressed) {
+                    if (isNumpadTextKey(sc))
+                        continue;
                     const auto rml_key = sdlScancodeToRml(static_cast<SDL_Scancode>(sc));
                     if (rml_key != Rml::Input::KI_UNKNOWN) {
                         markRenderNeeded(RenderReason::Keyboard);
@@ -680,6 +692,8 @@ namespace lfs::vis::gui {
                     }
                 }
                 for (const int sc : input.keys_released) {
+                    if (isNumpadTextKey(sc))
+                        continue;
                     const auto rml_key = sdlScancodeToRml(static_cast<SDL_Scancode>(sc));
                     if (rml_key != Rml::Input::KI_UNKNOWN) {
                         markRenderNeeded(RenderReason::Keyboard);


### PR DESCRIPTION
## Problem

Numpad keys (0–9 and decimal) always act as navigation keys (Home, End, PgUp, PgDn, Left, Right, etc.) when typing in the viewport overlay transform controls (X/Y/Z input fields for Translate, Rotate, Scale). This happens regardless of NumLock state.

## Cause

The viewport overlay forwards numpad scancodes directly to RmlUi's \ProcessKeyDown\/\ProcessKeyUp\ when a text input has focus. RmlUi interprets \KI_NUMPAD0\–\KI_NUMPAD9\ as their navigation-key equivalents rather than digits.

## Fix

Skip numpad digit and period scancodes from \ProcessKeyDown\/\ProcessKeyUp\ when a text input element is focused in \ml_viewport_overlay.cpp\. The actual digit characters still arrive through \ProcessTextInput\ via SDL's \SDL_EVENT_TEXT_INPUT\ events (when NumLock is on).

This mirrors the existing fix in \ml_panel_host.cpp\ (lines 1023–1069) that was applied for the sidebar text inputs.

## Changes

- \src/visualizer/gui/rml_viewport_overlay.cpp\: Added \isNumpadTextKey\ filter in the keyboard forwarding block for focused text inputs, identical to the one in \ml_panel_host.cpp\.

---
