### PR TITLE
Add viewport splat low-pass setting

### DIFF
--- a/src/python/lfs/py_rendering.cpp
+++ b/src/python/lfs/py_rendering.cpp
@@ -808,6 +808,8 @@ namespace lfs::python {
                       {"3DGUT", "3dgut", 3}},
                      2);
         add_bool(&Proxy::mip_filter, "mip_filter", "Mip Filter", "Enable mip-map filtering", false);
+        add_float(&Proxy::low_pass_filter_eps, "low_pass_filter_eps", "Splat Low Pass",
+                  "Additional screen-space covariance blur for Gaussian splats", 0.0, 0.0, 0.1);
         add_float(&Proxy::render_scale, "render_scale", "Render Scale", "Render resolution scale", 1.0, 0.25, 1.0);
         add_float(&Proxy::depth_view_min, "depth_view_min", "Depth Near", "Depth-map visualization near range",
                   lfs::rendering::DEFAULT_DEPTH_VIEW_MIN, 0.0, lfs::rendering::MAX_DEPTH_VIEW_DISTANCE);

--- a/src/python/lfs_plugins/rendering_panel.py
+++ b/src/python/lfs_plugins/rendering_panel.py
@@ -67,7 +67,7 @@ BOOL_PROPS = [
 
 SLIDER_PROPS = [
     "axes_size", "grid_opacity", "camera_frustum_scale", "voxel_size",
-    "focal_length_mm", "render_scale", "environment_exposure", "environment_rotation_degrees",
+    "focal_length_mm", "low_pass_filter_eps", "render_scale", "environment_exposure", "environment_rotation_degrees",
     "mesh_wireframe_width", "mesh_light_intensity", "mesh_ambient",
     "ppisp_exposure", "ppisp_vignette_strength", "ppisp_gamma_multiplier",
     "ppisp_gamma_red", "ppisp_gamma_green", "ppisp_gamma_blue",
@@ -82,6 +82,7 @@ SCRUB_FIELD_DEFS = {
     "camera_frustum_scale": ScrubFieldSpec(0.01, 10.0, 0.01, "%.3f"),
     "voxel_size": ScrubFieldSpec(0.001, 0.1, 0.001, "%.3f"),
     "focal_length_mm": ScrubFieldSpec(10.0, 200.0, 0.1, "%.1f"),
+    "low_pass_filter_eps": ScrubFieldSpec(0.0, 0.1, 0.001, "%.4f"),
     "render_scale": ScrubFieldSpec(0.25, 1.0, 0.01, "%.2f"),
     "environment_exposure": ScrubFieldSpec(-6.0, 6.0, 0.01, "%.2f"),
     "environment_rotation_degrees": ScrubFieldSpec(-180.0, 180.0, 0.1, "%.1f"),
@@ -165,6 +166,7 @@ LOCALE_KEY = {
     "equirectangular": "main_panel.equirectangular",
     "raster_backend": "main_panel.raster_backend",
     "mip_filter": "main_panel.mip_filter",
+    "low_pass_filter_eps": "main_panel.low_pass_filter_eps",
     "axes_size": "main_panel.axes_size",
     "grid_opacity": "main_panel.grid_opacity",
     "focal_length_mm": "main_panel.focal_length",

--- a/src/rendering/include/rendering/rendering.hpp
+++ b/src/rendering/include/rendering/rendering.hpp
@@ -183,6 +183,7 @@ namespace lfs::rendering {
         float scaling_modifier = 1.0f;
         bool antialiasing = false;
         bool mip_filter = false;
+        float low_pass_filter_eps = 0.0f;
         int sh_degree = 3;
         GaussianRasterBackend raster_backend = GaussianRasterBackend::ThreeDgs;
         bool gut = false;
@@ -289,6 +290,7 @@ namespace lfs::rendering {
         float scaling_modifier = 1.0f;
         bool antialiasing = false;
         bool mip_filter = false;
+        float low_pass_filter_eps = 0.0f;
         int sh_degree = 3;
         GaussianRasterBackend raster_backend = GaussianRasterBackend::ThreeDgs;
         bool gut = false;

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/utils.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/utils.slang
@@ -608,19 +608,26 @@ float3 clamp_covariance_2d_extent(float3 cov_vs, float opacity_after_compensatio
 
 [ForceInline]
 [Differentiable]
-float4 add_blur_to_covariance2d(float3 cov_vs, no_diff bool mip_filter, no_diff bool compensate_non_mip) {
+float4 add_blur_to_covariance2d(
+    float3 cov_vs,
+    no_diff bool mip_filter,
+    no_diff bool compensate_non_mip,
+    no_diff float low_pass_filter_eps) {
     float4 result = float4(cov_vs, 1.0);
+    const float extra_blur = max(0.0f, low_pass_filter_eps);
 
     if (mip_filter) {
         float old_det = compute_det(result.xyz);
-        result.x += DILATION_MIP_FILTER;
-        result.z += DILATION_MIP_FILTER;
+        const float blur = DILATION_MIP_FILTER + extra_blur;
+        result.x += blur;
+        result.z += blur;
         float new_det = compute_det(result.xyz);
         result.w = sqrt(max(0.f, old_det / new_det));
     } else {
         float old_det = compute_det(result.xyz);
-        result.x += DILATION_3DGS;
-        result.z += DILATION_3DGS;
+        const float blur = DILATION_3DGS + extra_blur;
+        result.x += blur;
+        result.z += blur;
         if (compensate_non_mip) {
             float new_det = compute_det(result.xyz);
             result.w = sqrt(max(0.f, old_det / new_det));
@@ -654,7 +661,8 @@ float4 covariance_3d_to_2d(
     float3 xyz_ws,
     float3x3 cov_ws,
     no_diff bool mip_filter,
-    no_diff bool compensate_non_mip) {
+    no_diff bool compensate_non_mip,
+    no_diff float low_pass_filter_eps) {
     float3x3 R = (float3x3)cam.world_view_transform;
     float3x3 J = compute_jacobian(xyz_ws, cam);
     float3x3 cov_vs = mul(J, mul(R, mul(cov_ws, mul(transpose(R), transpose(J)))));
@@ -662,7 +670,8 @@ float4 covariance_3d_to_2d(
     return add_blur_to_covariance2d(
         float3(cov_vs[0][0], cov_vs[0][1], cov_vs[1][1]),
         mip_filter,
-        compensate_non_mip);
+        compensate_non_mip,
+        low_pass_filter_eps);
 }
 
 
@@ -1129,10 +1138,9 @@ struct Uniforms {
     float fy;
     float cx;
     float cy;
-    // HiGS raster/compose wave window start (batch index); occupies what was
-    // implicit alignment padding before dist_coeffs, so the layout is unchanged.
+    // HiGS raster/compose wave window start (batch index).
     uint wave_base;
-    uint higs_pad0;
+    float low_pass_filter_eps;
     float4 dist_coeffs;
     float4x4 world_view_transform;
 }

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/vertex_shader.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/vertex_shader.slang
@@ -263,7 +263,7 @@ Splat_2D_Vertex project_gaussian_to_camera(Gaussian_3D g, Camera cam, uint activ
     float3x3 cov_ws = get_covariance_from_quat_scales(
         safe_quat_normalize(g.rotations), g.scales
     );
-    float4 cov_vs = covariance_3d_to_2d(cam, g.xyz_ws, cov_ws, false, false);
+    float4 cov_vs = covariance_3d_to_2d(cam, g.xyz_ws, cov_ws, false, false, 0.0f);
 
     float det = compute_det(cov_vs.xyz);
     float3 inv_cov_vs = compute_inverse(cov_vs.xyz);
@@ -281,6 +281,7 @@ Splat_2D_Vertex project_gaussian_to_camera_model(
     uint model_transform_base,
     bool model_transform_enabled,
     bool mip_filter,
+    float low_pass_filter_eps,
     bool spark_rad_opacity_path) {
     float3 xyz_vs = project_point(mean_ws, cam);
     // Reject behind-camera, non-finite, and far off-screen means. The EWA
@@ -309,7 +310,7 @@ Splat_2D_Vertex project_gaussian_to_camera_model(
     if (model_transform_enabled) {
         cov_ws = transform_covariance_rows(model_transform_rows, model_transform_base, cov_ws);
     }
-    float4 cov_vs = covariance_3d_to_2d(cam, mean_ws, cov_ws, mip_filter, spark_rad_opacity_path);
+    float4 cov_vs = covariance_3d_to_2d(cam, mean_ws, cov_ws, mip_filter, spark_rad_opacity_path, low_pass_filter_eps);
     float opac = g.opacities * cov_vs.w;
     float3 cov_projected = clamp_covariance_2d_extent(cov_vs.xyz, opac);
     float det = compute_det(cov_projected);
@@ -342,7 +343,8 @@ Splat_2D_Vertex project_gaussian_to_camera_gut(
     StructuredBuffer<float4> model_transform_rows,
     uint model_transform_base,
     bool model_transform_enabled,
-    bool mip_filter) {
+    bool mip_filter,
+    float low_pass_filter_eps) {
     float3 mean_vs = project_point(mean_ws, cam);
     if (mean_vs.z <= NEAR_CLIP || !isfinite(dot(mean_vs, mean_vs))) {
         return { float3(0.0), float3(0.0), float3(0.0), float4(0.0), 0.0 };
@@ -405,7 +407,7 @@ Splat_2D_Vertex project_gaussian_to_camera_gut(
         cov2d += weight * float3(d.x * d.x, d.x * d.y, d.y * d.y);
     }
 
-    float4 cov_vs = add_blur_to_covariance2d(cov2d, mip_filter, false);
+    float4 cov_vs = add_blur_to_covariance2d(cov2d, mip_filter, false, low_pass_filter_eps);
     float det = compute_det(cov_vs.xyz);
     if (!isfinite(det) || det <= 0.0f) {
         return { float3(0.0), float3(0.0), float3(0.0), float4(0.0), 0.0 };
@@ -749,7 +751,8 @@ void main(
         model_transforms,
         model_transform_base,
         model_transform_enabled,
-        uniforms.mip_filter != 0u);
+        uniforms.mip_filter != 0u,
+        uniforms.low_pass_filter_eps);
   #else
     Splat_2D_Vertex splat = project_gaussian_to_camera_model(
         gauss,
@@ -760,6 +763,7 @@ void main(
         model_transform_base,
         model_transform_enabled,
         uniforms.mip_filter != 0u,
+        uniforms.low_pass_filter_eps,
         spark_rad_opacity_path);
   #endif
   #else

--- a/src/rendering/rasterizer/vulkan/src/gs_renderer.h
+++ b/src/rendering/rasterizer/vulkan/src/gs_renderer.h
@@ -30,10 +30,9 @@ PACK_STRUCT(struct VulkanGSRendererUniforms {
     float fy;
     float cx;
     float cy;
-    // HiGS raster/compose wave window start; occupies the former alignment
-    // padding before dist_coeffs (match shader).
+    // Match shader layout before dist_coeffs.
     uint32_t wave_base;
-    uint32_t higs_pad0;
+    float low_pass_filter_eps;
     float dist_coeffs[4];
     float world_view_transform[16];
 });

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -704,6 +704,7 @@
     "raster_backend": "Raster Backend",
     "gut_mode": "GUT (3DGUT)",
     "mip_filter": "Mip Filter",
+    "low_pass_filter_eps": "Splat Low Pass",
     "camera_metrics": "Camera Metrics",
     "appearance_correction": "PPISP Correction",
     "ppisp_mode": "Mode",
@@ -875,6 +876,7 @@
   "tooltip": {
     "gut_mode": "For fisheye/distorted/equirect cameras",
     "mip_filter": "Reduce aliasing for sub-pixel Gaussians",
+    "low_pass_filter_eps": "Additional screen-space covariance blur for Gaussian splats",
     "appearance_correction": "Apply learned exposure/color correction",
     "ppisp_mode": "Auto uses the trained controller, Manual allows slider adjustments",
     "ppisp_exposure": "Adjust exposure in EV stops",

--- a/src/visualizer/gui/rmlui/resources/rendering.rml
+++ b/src/visualizer/gui/rmlui/resources/rendering.rml
@@ -186,6 +186,13 @@
         <input type="checkbox" data-checked="mip_filter" />
       </label>
     </div>
+    <div class="setting-row setting-row--aligned" data-tooltip="tooltip.low_pass_filter_eps">
+      <span class="setting-row__label-col">{{label_low_pass_filter_eps}}</span>
+      <div class="setting-row__control-col setting-row__control-col--fill">
+        <input type="range" class="setting-slider" data-value="low_pass_filter_eps" min="0" max="0.1" step="0.001" />
+        <span class="slider-value">{{low_pass_filter_eps | format_float(4)}}</span>
+      </div>
+    </div>
     <div class="setting-row setting-row--aligned" data-tooltip="tooltip.camera_metrics_mode">
       <span class="setting-row__label-col">{{label_camera_metrics_mode}}</span>
       <div class="setting-row__control-col setting-row__control-col--fill">

--- a/src/visualizer/ipc/render_settings_convert.hpp
+++ b/src/visualizer/ipc/render_settings_convert.hpp
@@ -21,6 +21,7 @@ namespace lfs::vis {
         p.scaling_modifier = s.scaling_modifier;
         p.antialiasing = s.antialiasing;
         p.mip_filter = s.mip_filter;
+        p.low_pass_filter_eps = s.low_pass_filter_eps > 0.0f ? s.low_pass_filter_eps : 0.0f;
         p.sh_degree = s.sh_degree;
         p.render_scale = s.render_scale;
         p.camera_metrics_mode = static_cast<int>(s.camera_metrics_mode);
@@ -101,6 +102,7 @@ namespace lfs::vis {
         s.scaling_modifier = p.scaling_modifier;
         s.antialiasing = p.antialiasing;
         s.mip_filter = p.mip_filter;
+        s.low_pass_filter_eps = p.low_pass_filter_eps > 0.0f ? p.low_pass_filter_eps : 0.0f;
         s.sh_degree = p.sh_degree;
         s.render_scale = p.render_scale;
         s.camera_metrics_mode = static_cast<RenderSettings::CameraMetricsMode>(p.camera_metrics_mode);

--- a/src/visualizer/ipc/view_context.hpp
+++ b/src/visualizer/ipc/view_context.hpp
@@ -69,6 +69,7 @@ namespace lfs::vis {
         float scaling_modifier = 1.0f;
         bool antialiasing = false;
         bool mip_filter = false;
+        float low_pass_filter_eps = 0.0f;
         int sh_degree = 3;
         float render_scale = 1.0f;
         int camera_metrics_mode = 0;

--- a/src/visualizer/rendering/rendering_manager.cpp
+++ b/src/visualizer/rendering/rendering_manager.cpp
@@ -378,6 +378,7 @@ namespace lfs::vis {
                                            ? lfs::rendering::viewerRasterBackendForGutMode(settings_.gut)
                                            : lfs::rendering::normalizeViewerRasterBackend(
                                                  settings_.raster_backend, settings_.gut);
+            settings_.low_pass_filter_eps = std::max(0.0f, settings_.low_pass_filter_eps);
             settings_.gut = lfs::rendering::isGutBackend(settings_.raster_backend);
             enforceProjectionBackend(settings_);
             sanitizeDepthViewSettings(settings_);

--- a/src/visualizer/rendering/rendering_types.hpp
+++ b/src/visualizer/rendering/rendering_types.hpp
@@ -169,6 +169,7 @@ namespace lfs::vis {
         float scaling_modifier = 1.0f;
         bool antialiasing = false;
         bool mip_filter = false;
+        float low_pass_filter_eps = 0.0f;
         int sh_degree = 3;
         float render_scale = 1.0f; // Viewer resolution scale (0.25-1.0), does not affect training
         CameraMetricsMode camera_metrics_mode = CameraMetricsMode::Off;

--- a/src/visualizer/rendering/viewport_request_builder.cpp
+++ b/src/visualizer/rendering/viewport_request_builder.cpp
@@ -171,6 +171,7 @@ namespace lfs::vis {
             .scaling_modifier = ctx.settings.scaling_modifier,
             .antialiasing = ctx.settings.antialiasing,
             .mip_filter = ctx.settings.mip_filter,
+            .low_pass_filter_eps = ctx.settings.low_pass_filter_eps,
             .sh_degree = ctx.settings.sh_degree,
             .raster_backend = ctx.settings.raster_backend,
             .gut = ctx.settings.gut ||
@@ -240,6 +241,7 @@ namespace lfs::vis {
             .scaling_modifier = request.scaling_modifier,
             .antialiasing = request.antialiasing,
             .mip_filter = request.mip_filter,
+            .low_pass_filter_eps = request.low_pass_filter_eps,
             .sh_degree = request.sh_degree,
             .raster_backend = request.raster_backend,
             .gut = request.gut,

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -1263,7 +1263,8 @@ namespace lfs::vis {
             const std::size_t model_num_splats,
             const bool equirectangular,
             const bool gut,
-            const bool mip_filter) {
+            const bool mip_filter,
+            const float low_pass_filter_eps) {
             (void)scene;
             uniforms = {};
             uniforms.image_width = static_cast<std::uint32_t>(frame_view.size.x);
@@ -1285,6 +1286,9 @@ namespace lfs::vis {
             uniforms.shN_layout_slots = shN_layout_slots;
             uniforms.camera_model = packedVksplatCameraModel(frame_view, equirectangular, gut);
             uniforms.mip_filter = mip_filter ? 1u : 0u;
+            uniforms.low_pass_filter_eps = std::isfinite(low_pass_filter_eps)
+                                               ? std::max(0.0f, low_pass_filter_eps)
+                                               : 0.0f;
 
             if (frame_view.orthographic) {
                 const float ortho_scale =
@@ -5561,7 +5565,8 @@ namespace lfs::vis {
                                       num_splats,
                                       request.equirectangular,
                                       request.gut,
-                                      false);
+                                      false,
+                                      0.0f);
         VulkanGSSelectionMaskUniforms selection_uniforms{};
         selection_uniforms.num_splats = static_cast<std::uint32_t>(num_splats);
         selection_uniforms.primitive_count = static_cast<std::uint32_t>(request.primitives.size());
@@ -5752,7 +5757,8 @@ namespace lfs::vis {
                                           buffers_.num_splats,
                                           request.equirectangular,
                                           request.gut,
-                                          request.mip_filter);
+                                          request.mip_filter,
+                                          request.low_pass_filter_eps);
             uniforms.step = static_cast<std::uint32_t>(modelTransformCount(request.scene.model_transforms));
             uniforms.sort_capacity = static_cast<uint32_t>(
                 std::min<std::size_t>(buffers_.num_indices,
@@ -6277,7 +6283,8 @@ namespace lfs::vis {
                                           buffers_.num_splats,
                                           request.equirectangular,
                                           request.gut,
-                                          request.mip_filter);
+                                          request.mip_filter,
+                                          request.low_pass_filter_eps);
             uniforms.step = static_cast<std::uint32_t>(modelTransformCount(request.scene.model_transforms));
             uniforms.lod_enabled = (lod_indices_present || gpu_lod_render_active) ? 1u : 0u;
             if (lod_logical_indices_present || gpu_lod_render_active) {

--- a/tests/test_render_settings_defaults.cpp
+++ b/tests/test_render_settings_defaults.cpp
@@ -17,6 +17,24 @@ TEST(RenderSettingsDefaults, CameraFrustumsAreDisabledByDefault) {
     EXPECT_FALSE(proxy_settings.show_camera_frustums);
     EXPECT_FLOAT_EQ(render_settings.camera_frustum_scale, 0.25f);
     EXPECT_FLOAT_EQ(proxy_settings.camera_frustum_scale, 0.25f);
+    EXPECT_FLOAT_EQ(render_settings.low_pass_filter_eps, 0.0f);
+    EXPECT_FLOAT_EQ(proxy_settings.low_pass_filter_eps, 0.0f);
+}
+
+TEST(RenderSettingsProxy, LowPassFilterEpsRoundTripsAndClamps) {
+    lfs::vis::RenderSettings render_settings;
+    render_settings.low_pass_filter_eps = 0.025f;
+
+    const auto proxy = lfs::vis::to_proxy(render_settings);
+
+    lfs::vis::RenderSettings roundtrip;
+    lfs::vis::apply_proxy(roundtrip, proxy);
+    EXPECT_FLOAT_EQ(roundtrip.low_pass_filter_eps, 0.025f);
+
+    auto negative_proxy = proxy;
+    negative_proxy.low_pass_filter_eps = -1.0f;
+    lfs::vis::apply_proxy(roundtrip, negative_proxy);
+    EXPECT_FLOAT_EQ(roundtrip.low_pass_filter_eps, 0.0f);
 }
 
 TEST(RenderSettingsProxy, DepthFilterTransformRoundTrips) {


### PR DESCRIPTION
## Summary
- Add a default-zero low_pass_filter_eps render setting for viewport Gaussian splats.
- Thread it through render requests, VkSplat uniforms, and the 3DGS/3DGUT projection shaders as additive screen-space covariance blur.
- Expose the setting in Python render metadata and the Rendering panel as Splat Low Pass.

## Tests
- python -m pytest tests\python\test_rendering_panel_regressions.py tests\python\test_rendering_panel_localization_regressions.py tests\python\test_rendering_panel_simplify.py (17 passed)
- Parsed locale JSON files with Python json.loads
- cmake --build build-codex --target lfs_vulkan_rasterizer_shaders lfs_visualizer --parallel 8

Note: I added a focused C++ render-settings regression test, but did not run it locally because enabling BUILD_TESTS in this temporary clean worktree failed to locate TorchConfig.cmake.