### PR TITLE
New mask mode combining Ignore and Segment [Volinga]

### DIFF
--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -273,12 +273,13 @@ namespace {
             ::args::Group mask_sep(parser, " ");
             ::args::Group mask_group(parser, "MASK / DEPTH OPTIONS:");
             ::args::MapFlag<std::string, lfs::core::param::MaskMode> mask_mode(mask_group, "mask_mode",
-                                                                               "Mask mode: none, segment, ignore, alpha_consistent (default: none)",
+                                                                               "Mask mode: none, segment, ignore, segment_and_ignore, alpha_consistent (default: none)",
                                                                                {"mask-mode"},
                                                                                std::unordered_map<std::string, lfs::core::param::MaskMode>{
                                                                                    {"none", lfs::core::param::MaskMode::None},
                                                                                    {"segment", lfs::core::param::MaskMode::Segment},
                                                                                    {"ignore", lfs::core::param::MaskMode::Ignore},
+                                                                                   {"segment_and_ignore", lfs::core::param::MaskMode::SegmentAndIgnore},
                                                                                    {"alpha_consistent", lfs::core::param::MaskMode::AlphaConsistent}});
             ::args::Flag invert_masks(mask_group, "invert_masks", "Invert mask values (swap object/background)", {"invert-masks"});
             ::args::Flag no_alpha_as_mask(mask_group, "no_alpha_as_mask", "Disable automatic alpha-as-mask for RGBA images", {"no-alpha-as-mask"});

--- a/src/core/camera.cpp
+++ b/src/core/camera.cpp
@@ -384,7 +384,8 @@ namespace lfs::core {
     }
 
     Tensor Camera::load_and_get_mask(const int resize_factor, const int max_width,
-                                     const bool invert_mask, const float mask_threshold) {
+                                     const bool invert_mask, const float mask_threshold,
+                                     const bool binarize) {
         if (_mask_loaded && _cached_mask.is_valid()) {
             return _cached_mask;
         }
@@ -446,7 +447,7 @@ namespace lfs::core {
         }
 
         // Threshold before undistort; final binarization happens after geometric resampling.
-        if (mask_threshold > 0.0f && mask_threshold < 1.0f) {
+        if (binarize && mask_threshold > 0.0f && mask_threshold < 1.0f) {
             mask = mask.ge(mask_threshold).to(DataType::Float32);
         }
 
@@ -458,7 +459,11 @@ namespace lfs::core {
             mask = undistort_mask(mask, scaled, _stream);
         }
 
-        mask = mask.ge(0.5f).to(DataType::UInt8).contiguous();
+        if (binarize) {
+            mask = mask.ge(0.5f).to(DataType::UInt8).contiguous();
+        } else {
+            mask = (mask * 255.f).to(DataType::UInt8).contiguous();
+        }
         _cached_mask = mask;
         _mask_loaded = true;
 

--- a/src/core/include/core/camera.hpp
+++ b/src/core/include/core/camera.hpp
@@ -60,7 +60,7 @@ namespace lfs::core {
 
         // Load mask from disk, process it, and return it (cached)
         Tensor load_and_get_mask(int resize_factor = -1, int max_width = 0,
-                                 bool invert_mask = false, float mask_threshold = 0.5f);
+                                 bool invert_mask = false, float mask_threshold = 0.5f, bool binarize = true);
 
         // Load depth map from disk, convert to [H,W] float32 [0,1], and return it (cached)
         Tensor load_and_get_depth(int resize_factor = -1, int max_width = 0);

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -25,6 +25,7 @@ namespace lfs::core {
             None,           // No masking applied
             Segment,        // Soft penalty to enforce alpha→0 in masked areas
             Ignore,         // Completely ignore masked regions in loss
+            SegmentAndIgnore, // 3-band mask (0-255): value<128 ignore, 128<=value<=250 segment, value>250 keep
             AlphaConsistent // Enforce exact alpha values from mask
         };
 

--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -166,7 +166,7 @@ namespace lfs::core {
             }
 
             // Mask parameters
-            static constexpr const char* MASK_MODE_NAMES[] = {"none", "segment", "ignore", "alpha_consistent"};
+            static constexpr const char* MASK_MODE_NAMES[] = {"none", "segment", "ignore", "segment_and_ignore", "alpha_consistent"};
             opt_json["mask_mode"] = MASK_MODE_NAMES[static_cast<int>(mask_mode)];
             opt_json["invert_masks"] = invert_masks;
             opt_json["mask_opacity_penalty_weight"] = mask_opacity_penalty_weight;
@@ -495,6 +495,8 @@ namespace lfs::core {
                     params.mask_mode = MaskMode::Segment;
                 } else if (mode == "ignore") {
                     params.mask_mode = MaskMode::Ignore;
+                } else if (mode == "segment_and_ignore") {
+                    params.mask_mode = MaskMode::SegmentAndIgnore;
                 } else if (mode == "alpha_consistent") {
                     params.mask_mode = MaskMode::AlphaConsistent;
                 }

--- a/src/io/pipelined_image_loader.cpp
+++ b/src/io/pipelined_image_loader.cpp
@@ -200,12 +200,13 @@ namespace lfs::io {
             }
         }
 
-        lfs::core::Tensor binarize_mask(lfs::core::Tensor mask) {
+        lfs::core::Tensor process_mask(lfs::core::Tensor mask, bool binarize) {
             if (!mask.is_valid())
                 return {};
             if (mask.dtype() == lfs::core::DataType::UInt8 || mask.dtype() == lfs::core::DataType::Bool)
                 return mask.contiguous();
-            return mask.ge(0.5f).to(lfs::core::DataType::UInt8).contiguous();
+            mask = binarize ? mask.ge(0.5f) : mask * 255.f;
+            return mask.to(lfs::core::DataType::UInt8).contiguous();
         }
 
         [[nodiscard]] bool is_jpeg_file_signature(const std::filesystem::path& path) {
@@ -1192,7 +1193,7 @@ namespace lfs::io {
                                 throw std::runtime_error("Invalid mask tensor");
                             }
 
-                            mask_tensor = binarize_mask(std::move(mask_tensor));
+                            mask_tensor = process_mask(std::move(mask_tensor), batch[i].mask_params.threshold > 0);
                             try_complete_pair(batch[i].sequence_id, std::nullopt, std::move(mask_tensor), nullptr);
 
                         } else {
@@ -1397,7 +1398,7 @@ namespace lfs::io {
                         }
                     }
 
-                    alpha = binarize_mask(std::move(alpha));
+                    alpha = process_mask(std::move(alpha), item.alpha_mask_params.threshold > 0);
                     if (const cudaError_t err = cudaStreamSynchronize(nullptr); err != cudaSuccess) {
                         throw std::runtime_error(std::string("CUDA sync failed: ") + cudaGetErrorString(err));
                     }
@@ -1489,7 +1490,7 @@ namespace lfs::io {
                     }
 
                     if (item.is_mask) {
-                        aux_tensor = binarize_mask(std::move(aux_tensor));
+                        aux_tensor = process_mask(std::move(aux_tensor), item.mask_params.threshold > 0);
                     } else {
                         aux_tensor = aux_tensor.contiguous();
                     }

--- a/src/python/lfs/py_params.cpp
+++ b/src/python/lfs/py_params.cpp
@@ -115,6 +115,7 @@ namespace lfs::python {
                        {{"None", MaskMode::None},
                         {"Segment", MaskMode::Segment},
                         {"Ignore", MaskMode::Ignore},
+                        {"SegmentAndIgnore", MaskMode::SegmentAndIgnore},
                         {"AlphaConsistent", MaskMode::AlphaConsistent}},
                        "Attention mask behavior during training")
             .bool_prop(&OptimizationParameters::invert_masks,
@@ -999,6 +1000,7 @@ namespace lfs::python {
             .value("NONE", MaskMode::None)
             .value("SEGMENT", MaskMode::Segment)
             .value("IGNORE", MaskMode::Ignore)
+            .value("SEGMENT_AND_IGNORE", MaskMode::SegmentAndIgnore)
             .value("ALPHA_CONSISTENT", MaskMode::AlphaConsistent);
 
         nb::enum_<BackgroundMode>(m, "BackgroundMode")

--- a/src/python/lfs_plugins/training_panel.py
+++ b/src/python/lfs_plugins/training_panel.py
@@ -186,6 +186,7 @@ LOCALE_KEYS = {
     "mask_none": "training.options.mask.none",
     "mask_segment": "training.options.mask.segment",
     "mask_ignore": "training.options.mask.ignore",
+    "mask_segment_and_ignore": "training.options.mask.segment_and_ignore",
     "mask_alpha_consistent": "training.options.mask.alpha_consistent",
     "depth_loss_pearson": "training.options.depth_loss.pearson",
     "depth_loss_adaptive_warped_l1": "training.options.depth_loss.adaptive_warped_l1",
@@ -560,7 +561,11 @@ class TrainingPanel(Panel):
         )
         model.bind_func(
             "dep_mask_segment",
-            lambda: p() is not None and p().has_params() and p().mask_mode.value == 1,
+            lambda: p() is not None and p().has_params() and (p().mask_mode.value == 1 or p().mask_mode.value == 3),
+        )
+        model.bind_func(
+            "dep_mask_threshold",
+            lambda: p() is not None and p().has_params() and p().mask_mode.value != 3,
         )
         model.bind_func(
             "dep_depth_loss",
@@ -2413,6 +2418,7 @@ class TrainingPanel(Panel):
                 tr("training.options.mask.none"),
                 tr("training.options.mask.segment"),
                 tr("training.options.mask.ignore"),
+                tr("training.options.mask.segment_and_ignore"),
                 tr("training.options.mask.alpha_consistent"),
             ]
             changed, new_idx = layout.combo("##py_mask_mode", mask_idx, mask_mode_items)

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -1771,7 +1771,9 @@ class MaskMode(enum.Enum):
 
     IGNORE = 2
 
-    ALPHA_CONSISTENT = 3
+    SEGMENT_AND_IGNORE = 3
+
+    ALPHA_CONSISTENT = 4
 
 class BackgroundMode(enum.Enum):
     SOLID_COLOR = 0

--- a/src/training/dataset.hpp
+++ b/src/training/dataset.hpp
@@ -579,11 +579,13 @@ namespace lfs::training {
                     // Direct-scene plugins attach masks as in-memory tensors
                     // via Camera::set_mask_tensor — load_and_get_mask returns
                     // the processed-and-cached tensor (skips file I/O).
+                    bool segment_and_ignore = aux_config_.mask_threshold <= 0.f;
                     auto m = cam->load_and_get_mask(
                         dataset_->get_resize_factor(),
                         dataset_->get_max_width(),
                         aux_config_.invert_masks,
-                        aux_config_.mask_threshold);
+                        aux_config_.mask_threshold,
+                        !segment_and_ignore);
                     if (m.is_valid()) {
                         example.mask = std::move(m);
                     }

--- a/src/training/metrics/metrics.cpp
+++ b/src/training/metrics/metrics.cpp
@@ -356,11 +356,17 @@ namespace lfs::training {
                                                        lfs::core::Tensor& gt_image,
                                                        const bool alpha_as_mask) const {
         if (cam->has_mask()) {
-            return cam->load_and_get_mask(
+            bool is_segment_and_ignore = _params.optimization.mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore;
+            auto m = cam->load_and_get_mask(
                 _params.dataset.resize_factor,
                 _params.dataset.max_width,
                 _params.optimization.invert_masks,
-                _params.optimization.mask_threshold);
+                _params.optimization.mask_threshold,
+                !is_segment_and_ignore);
+            if (is_segment_and_ignore) {
+                m = m.gt(250).to(lfs::core::DataType::UInt8).contiguous();
+            }
+            return m;
         }
 
         if (!alpha_as_mask)
@@ -461,7 +467,10 @@ namespace lfs::training {
         size_t evaluated_images = 0;
 
         const auto mask_mode = _params.optimization.mask_mode;
-        const bool use_masking = mask_mode == lfs::core::param::MaskMode::Segment || mask_mode == lfs::core::param::MaskMode::Ignore;
+        const bool use_masking = \
+            mask_mode == lfs::core::param::MaskMode::Segment ||
+            mask_mode == lfs::core::param::MaskMode::Ignore  ||
+            mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore;
 
         while (auto batch_opt = val_dataloader->next()) {
             auto& batch = *batch_opt;

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -326,7 +326,8 @@ namespace lfs::training {
             const auto mask_mode = opt_params.mask_mode;
             const bool use_masking =
                 mask_mode == lfs::core::param::MaskMode::Segment ||
-                mask_mode == lfs::core::param::MaskMode::Ignore;
+                mask_mode == lfs::core::param::MaskMode::Ignore  ||
+                mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore;
 
             // Sidecar mask file wins when present; alpha-as-mask is only used as fallback
             // (some datasets ship RGBA images with a degenerate constant alpha alongside
@@ -1387,6 +1388,12 @@ namespace lfs::training {
             return {};
         }
 
+        // Segment and ignore does not support mask invert
+        if (opt.mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore && opt.invert_masks) {
+            LOG_WARN("invert_masks is ignored in SegmentAndIgnore mode (would scramble the mask bands)");
+            params_.optimization.invert_masks = false;
+        }
+
         size_t alpha_count = 0;
         size_t masks_found = 0;
         for (const auto& cam : train_dataset_->get_cameras()) {
@@ -1434,10 +1441,16 @@ namespace lfs::training {
 
         const auto mode = opt_params.mask_mode;
         const Tensor mask_2d = mask.ndim() == 3 ? mask.squeeze(0) : mask;
-        const auto mask_as_float = [&]() -> Tensor {
-            return (mask_2d.dtype() == DataType::UInt8 || mask_2d.dtype() == DataType::Bool)
-                       ? mask_2d.to(DataType::Float32)
-                       : mask_2d;
+        Tensor mask_2d_th = mask_2d;
+        if (mode == param::MaskMode::SegmentAndIgnore) {
+            mask_2d_th = mask_2d_th.masked_fill(mask_2d_th <= 250, 0);   // Set all Ignore and Segment to 0
+            mask_2d_th = mask_2d_th.masked_fill(mask_2d_th > 250, 255);  // Keep everything > 250
+        }
+
+        const auto mask_as_float = [](const Tensor t) -> Tensor {
+            return (t.dtype() == DataType::UInt8 || t.dtype() == DataType::Bool)
+                       ? t.gt(0).to(DataType::Float32)
+                       : t;
         };
 
         Tensor loss, grad_corrected, grad_raw, grad_alpha;
@@ -1446,10 +1459,10 @@ namespace lfs::training {
             raw_rendered.numel() > 0 &&
             opt_params.lambda_dssim > 0.0f;
 
-        if (mode == param::MaskMode::Segment || mode == param::MaskMode::Ignore) {
+        if (mode == param::MaskMode::Segment || mode == param::MaskMode::Ignore || mode == param::MaskMode::SegmentAndIgnore) {
             if (use_decoupled_appearance_loss) {
                 auto [loss_tensor, ctx] = lfs::training::kernels::masked_decoupled_fused_l1_ssim_forward(
-                    corrected, raw_rendered, gt_image, mask_2d, opt_params.lambda_dssim,
+                    corrected, raw_rendered, gt_image, mask_2d_th, opt_params.lambda_dssim,
                     masked_decoupled_fused_workspace_);
                 auto grads = lfs::training::kernels::masked_decoupled_fused_l1_ssim_backward(
                     ctx, masked_decoupled_fused_workspace_);
@@ -1466,7 +1479,7 @@ namespace lfs::training {
                 }
             } else {
                 auto [loss_tensor, ctx] = lfs::training::kernels::masked_fused_l1_ssim_forward(
-                    corrected, gt_image, mask_2d, opt_params.lambda_dssim, masked_fused_workspace_);
+                    corrected, gt_image, mask_2d_th, opt_params.lambda_dssim, masked_fused_workspace_);
 
                 grad_corrected = lfs::training::kernels::masked_fused_l1_ssim_backward(ctx, masked_fused_workspace_);
                 loss = loss_tensor;
@@ -1477,10 +1490,19 @@ namespace lfs::training {
             }
 
             // Segment: opacity penalty for background
-            if (mode == param::MaskMode::Segment && alpha.is_valid()) {
+            if ((mode == param::MaskMode::Segment || mode == param::MaskMode::SegmentAndIgnore) && alpha.is_valid()) {
+                Tensor mask_2d_th_segment = mask_2d;
+                if (mode == param::MaskMode::SegmentAndIgnore) {
+                    // Values used for ignore (<128) do not contribute to opacity penalty
+                    // Values in the range 128<=x<=250 contribute to the opacity penalty
+                    // Values > 250 are kept
+                    mask_2d_th_segment = mask_2d_th_segment.masked_fill(mask_2d_th_segment < 128, 255);
+                    mask_2d_th_segment = mask_2d_th_segment.masked_fill(mask_2d_th_segment >= 128 && mask_2d_th_segment <= 250, 0);
+                    mask_2d_th_segment = mask_2d_th_segment.masked_fill(mask_2d_th_segment > 250, 255);
+                }
+                const Tensor mask_2d_th_segment_f = mask_as_float(mask_2d_th_segment);
                 const Tensor alpha_2d = alpha.ndim() == 3 ? alpha.squeeze(0) : alpha;
-                const Tensor mask_f = mask_as_float();
-                const Tensor bg_mask = Tensor::full(mask_f.shape(), 1.0f, mask_f.device()) - mask_f;
+                const Tensor bg_mask = Tensor::full(mask_2d_th_segment_f.shape(), 1.0f, mask_2d_th_segment_f.device()) - mask_2d_th_segment_f;
                 const Tensor penalty_weights = bg_mask.pow(opt_params.mask_opacity_penalty_power);
                 const Tensor penalty = (alpha_2d * penalty_weights).mean() * opt_params.mask_opacity_penalty_weight;
 
@@ -1502,7 +1524,7 @@ namespace lfs::training {
             // Alpha should match mask
             if (alpha.is_valid()) {
                 const Tensor alpha_2d = alpha.ndim() == 3 ? alpha.squeeze(0) : alpha;
-                const Tensor mask_f = mask_as_float();
+                const Tensor mask_f = mask_as_float(mask_2d_th);
                 const Tensor alpha_loss = (alpha_2d - mask_f).abs().mean() * ALPHA_CONSISTENCY_WEIGHT;
                 loss = loss + alpha_loss;
                 grad_alpha = (alpha_2d - mask_f).sign() * (ALPHA_CONSISTENCY_WEIGHT / static_cast<float>(alpha_2d.numel()));
@@ -2184,7 +2206,7 @@ namespace lfs::training {
             LOG_INFO("Visualization: {}", params.optimization.headless ? "disabled" : "enabled");
             LOG_INFO("Strategy: {}", params.optimization.strategy);
             if (params.optimization.mask_mode != lfs::core::param::MaskMode::None) {
-                static constexpr const char* MASK_MODE_NAMES[] = {"none", "segment", "ignore", "alpha_consistent"};
+                static constexpr const char* MASK_MODE_NAMES[] = {"none", "segment", "ignore", "segment_and_ignore", "alpha_consistent"};
                 LOG_INFO("Mask mode: {}", MASK_MODE_NAMES[static_cast<int>(params.optimization.mask_mode)]);
             }
             if (current_iteration_ > 0) {
@@ -3114,7 +3136,8 @@ namespace lfs::training {
                                     params_.dataset.resize_factor,
                                     params_.dataset.max_width,
                                     params_.optimization.invert_masks,
-                                    params_.optimization.mask_threshold);
+                                    params_.optimization.mask_threshold,
+                                    params_.optimization.mask_mode != lfs::core::param::MaskMode::SegmentAndIgnore);
                             }
 
                             lfs::core::Tensor mask_tile = mask;
@@ -3219,7 +3242,8 @@ namespace lfs::training {
                     const bool used_masked_fused =
                         use_mask &&
                         (params_.optimization.mask_mode == lfs::core::param::MaskMode::Segment ||
-                         params_.optimization.mask_mode == lfs::core::param::MaskMode::Ignore) &&
+                         params_.optimization.mask_mode == lfs::core::param::MaskMode::Ignore  ||
+                         params_.optimization.mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore) &&
                         params_.optimization.lambda_dssim > 0.0f;
                     {
                         LFS_VRAM_SCOPE("train.photometric_loss");
@@ -3233,7 +3257,8 @@ namespace lfs::training {
                                     params_.dataset.resize_factor,
                                     params_.dataset.max_width,
                                     params_.optimization.invert_masks,
-                                    params_.optimization.mask_threshold);
+                                    params_.optimization.mask_threshold,
+                                    params_.optimization.mask_mode != lfs::core::param::MaskMode::SegmentAndIgnore);
                             }
 
                             mask_tile = mask;
@@ -3456,6 +3481,12 @@ namespace lfs::training {
                                 tile_error_map = abs_diff;
                             }
                             tile_error_map = tile_error_map.contiguous();
+                        }
+
+                        if (use_mask &&
+                            params_.optimization.mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore) {
+                            const auto mask_for_error = mask_tile.gt(250).to(lfs::core::DataType::Float32);
+                            tile_error_map.mul_(mask_for_error);
                         }
 
                         if (use_mask &&
@@ -4095,6 +4126,9 @@ namespace lfs::training {
             if (params_.optimization.mask_mode != lfs::core::param::MaskMode::None) {
                 aux_pipeline_config.invert_masks = params_.optimization.invert_masks;
                 aux_pipeline_config.mask_threshold = params_.optimization.mask_threshold;
+                if (params_.optimization.mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore) {
+                    aux_pipeline_config.mask_threshold = 0.0f;
+                }
                 if (params_.optimization.use_alpha_as_mask && alpha_available) {
                     aux_pipeline_config.use_alpha_as_mask = true;
                     aux_pipeline_config.load_masks = true;

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -436,6 +436,7 @@
     "options.mask.none": "Keine",
     "options.mask.segment": "Segment",
     "options.mask.ignore": "Ignorieren",
+    "options.mask.segment_and_ignore": "Segment + Ignorieren",
     "options.mask.alpha_consistent": "Alpha-konsistent",
     "options.bg.color": "Farbe",
     "options.bg.modulation": "Modulation",
@@ -486,6 +487,7 @@
           "none": "Auf dem gesamten Bild trainieren, keine Maskierung",
           "segment": "Segmentierungsmaske für den Vordergrund verwenden",
           "ignore": "Maskierte Pixel im Verlust ignorieren",
+          "segment_and_ignore": "Kombination aus Segmentierung und Ignorieren",
           "alpha_consistent": "Alpha-Konsistenz mit der Maske erzwingen"
         },
         "bg_mode": {

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -433,6 +433,7 @@
     "options.mask.none": "None",
     "options.mask.segment": "Segment",
     "options.mask.ignore": "Ignore",
+    "options.mask.segment_and_ignore": "Segment + Ignore",
     "options.mask.alpha_consistent": "Alpha Consistent",
     "options.depth_loss.pearson": "Pearson Correlation",
     "options.depth_loss.adaptive_warped_l1": "Adaptive Warped L1",
@@ -495,6 +496,7 @@
           "none": "Train on the entire image, no masking",
           "segment": "Use the segmentation mask for foreground",
           "ignore": "Ignore masked pixels in the loss",
+          "segment_and_ignore": "Combination of Segment and Ignore",
           "alpha_consistent": "Enforce alpha consistency with the mask"
         },
         "bg_mode": {

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -436,6 +436,7 @@
     "options.mask.none": "Aucun",
     "options.mask.segment": "Segment",
     "options.mask.ignore": "Ignorer",
+    "options.mask.segment_and_ignore": "Segment + Ignorer",
     "options.mask.alpha_consistent": "Coh erent alpha",
     "options.bg.color": "Couleur",
     "options.bg.modulation": "Modulation",
@@ -486,6 +487,7 @@
           "none": "Entraîner sur toute l'image, sans masque",
           "segment": "Utiliser le masque de segmentation pour l'avant-plan",
           "ignore": "Ignorer les pixels masqués dans la perte",
+          "segment_and_ignore": "Combinaison de Segment et Ignorer",
           "alpha_consistent": "Forcer la cohérence alpha avec le masque"
         },
         "bg_mode": {

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -436,6 +436,7 @@
     "options.mask.none": "Nessuno",
     "options.mask.segment": "Segmento",
     "options.mask.ignore": "Ignora",
+    "options.mask.segment_and_ignore": "Segmento + Ignora",
     "options.mask.alpha_consistent": "Coerente con alpha",
     "options.bg.color": "Colore",
     "options.bg.modulation": "Modulazione",
@@ -486,6 +487,7 @@
           "none": "Allena su tutta l'immagine, nessuna maschera",
           "segment": "Usa la maschera di segmentazione per il primo piano",
           "ignore": "Ignora i pixel mascherati nella loss",
+          "segment_and_ignore": "Combinazione di Segment e Ignore",
           "alpha_consistent": "Imponi consistenza alpha con la maschera"
         },
         "bg_mode": {

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -436,6 +436,7 @@
     "options.mask.none": "なし",
     "options.mask.segment": "セグメント",
     "options.mask.ignore": "無視",
+    "options.mask.segment_and_ignore": "セグメント + 無視",
     "options.mask.alpha_consistent": "アルファ整合",
     "options.bg.color": "色",
     "options.bg.modulation": "変調",
@@ -486,6 +487,7 @@
           "none": "画像全体で学習、マスクなし",
           "segment": "前景にセグメンテーションマスクを使用",
           "ignore": "損失でマスクされたピクセルを無視",
+          "segment_and_ignore": "セグメントと無視の組み合わせ",
           "alpha_consistent": "マスクとのアルファ一貫性を強制"
         },
         "bg_mode": {

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -436,6 +436,7 @@
     "options.mask.none": "없음",
     "options.mask.segment": "세그먼트",
     "options.mask.ignore": "무시",
+    "options.mask.segment_and_ignore": "세그먼트 + 무시",
     "options.mask.alpha_consistent": "알파 일관",
     "options.bg.color": "색상",
     "options.bg.modulation": "변조",
@@ -486,6 +487,7 @@
           "none": "전체 이미지로 훈련, 마스크 없음",
           "segment": "전경에 세그먼테이션 마스크 사용",
           "ignore": "손실에서 마스크된 픽셀 무시",
+          "segment_and_ignore": "세그먼트와 무시의 조합",
           "alpha_consistent": "마스크와의 알파 일관성 적용"
         },
         "bg_mode": {

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -436,6 +436,7 @@
     "options.mask.none": "Geen",
     "options.mask.segment": "Segment",
     "options.mask.ignore": "Negeren",
+    "options.mask.segment_and_ignore": "Segmenteren + Negeren",
     "options.mask.alpha_consistent": "Alpha-consistent",
     "options.bg.color": "Kleur",
     "options.bg.modulation": "Modulatie",
@@ -486,6 +487,7 @@
           "none": "Train op de hele afbeelding, geen masker",
           "segment": "Gebruik segmentatiemasker voor voorgrond",
           "ignore": "Negeer gemaskeerde pixels in de loss",
+          "segment_and_ignore": "Combinatie van Segmenteren en Negeren",
           "alpha_consistent": "Alpha-consistentie met masker afdwingen"
         },
         "bg_mode": {

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -436,6 +436,7 @@
     "options.mask.none": "Brak",
     "options.mask.segment": "Segment",
     "options.mask.ignore": "Ignoruj",
+    "options.mask.segment_and_ignore": "Segment + Ignoruj",
     "options.mask.alpha_consistent": "Spojne z alfa",
     "options.bg.color": "Kolor",
     "options.bg.modulation": "Modulacja",
@@ -486,6 +487,7 @@
           "none": "Trenuj na całym obrazie, bez maskowania",
           "segment": "Użyj maski segmentacji dla pierwszego planu",
           "ignore": "Ignoruj zamaskowane piksele w stracie",
+          "segment_and_ignore": "Kombinacja Segmentu i Ignorowania",
           "alpha_consistent": "Wymuś spójność alfa z maską"
         },
         "bg_mode": {

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -266,6 +266,7 @@
     "options.mask.none": "无",
     "options.mask.segment": "分割",
     "options.mask.ignore": "忽略",
+    "options.mask.segment_and_ignore": "分割 + 忽略",
     "options.mask.alpha_consistent": "与 Alpha 一致",
     "options.bg.color": "颜色",
     "options.bg.modulation": "调制",
@@ -316,6 +317,7 @@
           "none": "在整张图像上训练，无掩码",
           "segment": "使用分割掩码作为前景",
           "ignore": "在损失中忽略被掩码的像素",
+          "segment_and_ignore": "分割与忽略的组合",
           "alpha_consistent": "强制 alpha 与掩码一致"
         },
         "bg_mode": {

--- a/src/visualizer/gui/rmlui/resources/training.rml
+++ b/src/visualizer/gui/rmlui/resources/training.rml
@@ -109,7 +109,8 @@
           <option value="0" data-tooltip="training.tooltip.opt.mask_mode.none">{{label_mask_none}}</option>
           <option value="1" data-tooltip="training.tooltip.opt.mask_mode.segment">{{label_mask_segment}}</option>
           <option value="2" data-tooltip="training.tooltip.opt.mask_mode.ignore">{{label_mask_ignore}}</option>
-          <option value="3" data-tooltip="training.tooltip.opt.mask_mode.alpha_consistent">{{label_mask_alpha_consistent}}</option>
+          <option value="3" data-tooltip="training.tooltip.opt.mask_mode.segment_and_ignore">{{label_mask_segment_and_ignore}}</option>
+          <option value="4" data-tooltip="training.tooltip.opt.mask_mode.alpha_consistent">{{label_mask_alpha_consistent}}</option>
         </select>
       </div>
       <div class="setting-row" data-tooltip="training.tooltip.use_depth_loss">
@@ -134,7 +135,7 @@
           <span class="prop-label">{{label_invert_masks}}</span>
           <input type="checkbox" data-checked="invert_masks" />
         </div>
-        <div class="setting-row" data-tooltip="training.tooltip.mask_threshold">
+        <div class="setting-row" data-if="dep_mask_threshold" data-tooltip="training.tooltip.mask_threshold">
           <span class="prop-label">{{label_mask_threshold}}</span>
           <input type="text" class="number-input" data-value="mask_threshold_str" />
           <button class="num-step-btn" data-event-mousedown="num_step('mask_threshold', -1)">-</button>


### PR DESCRIPTION
We have found ourselves in the need of an extra masking mode that combines both the segment (e.g. for the sky) and ignore (for specific components of the scene) in a single training.

An attempt to add this mode is proposed in this PR, called `SegmentAndIgnore`. One caveat is that this mode does not permit a user configurable threshold since the masks are expected to be single files and are split in 3 bands. Each band is made big enough so JPEG compression won't scramble them together. We went through the single file approach since it seemed to be a much faster implementation.

```
0 -> 128 elements to ignore
128 -> 250 elements to segment
250 -> 255 elements to keep
```

> Interface
>
> <img width="326" height="558" alt="UI" src="https://github.com/user-attachments/assets/39035d37-2c99-45d0-866d-2ca2fe52f76b" />

Below there is an example of the same 10K training.

> Original image (no alpha channel) + mask
> 
> <img width="1080" height="297" alt="original" src="https://github.com/user-attachments/assets/a599aecf-2f84-43dd-86a8-800a1d400058" />

> Different masking modes (10K iter MCMC)
>
> <img width="1080" height="651" alt="changes" src="https://github.com/user-attachments/assets/23dd2cf8-6c6f-4d1b-a992-321c217eda1c" />



