### PR TITLE
fix(visualizer): match Vulkan physical device to CUDA device on multi-GPU systems

### DIFF
--- a/src/visualizer/window/vulkan_context.cpp
+++ b/src/visualizer/window/vulkan_context.cpp
@@ -91,6 +91,27 @@ namespace lfs::vis {
             return false;
         }
 
+        // True when the given Vulkan physical device is the same physical GPU as
+        // the CUDA device the trainer will use (cuda_device, the current CUDA
+        // ordering's device 0 by default). On multi-GPU machines with identical
+        // cards, Vulkan's enumeration order can differ from CUDA's; matching by
+        // UUID lets pickPhysicalDevice keep the viewer on the same card as the
+        // trainer so CUDA<->Vulkan external-memory interop can import the block.
+        [[nodiscard]] bool vulkanDeviceMatchesCudaDevice(const VkPhysicalDevice device, const int cuda_device) {
+            cudaDeviceProp cuda_props{};
+            if (cudaGetDeviceProperties(&cuda_props, cuda_device) != cudaSuccess) {
+                return false;
+            }
+            VkPhysicalDeviceIDProperties vk_id{};
+            vk_id.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+            VkPhysicalDeviceProperties2 vk_props2{};
+            vk_props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+            vk_props2.pNext = &vk_id;
+            vkGetPhysicalDeviceProperties2(device, &vk_props2);
+            static_assert(sizeof(cuda_props.uuid.bytes) == VK_UUID_SIZE);
+            return std::memcmp(cuda_props.uuid.bytes, vk_id.deviceUUID, VK_UUID_SIZE) == 0;
+        }
+
         [[nodiscard]] std::string vulkanApiVersionString(const uint32_t api_version) {
             return std::format("{}.{}.{}",
                                VK_API_VERSION_MAJOR(api_version),
@@ -1185,6 +1206,7 @@ namespace lfs::vis {
         vkEnumeratePhysicalDevices(instance_, &count, devices.data());
 
         VkPhysicalDevice fallback = VK_NULL_HANDLE;
+        VkPhysicalDevice first_discrete = VK_NULL_HANDLE;
         for (const auto device : devices) {
             const QueueFamilies families = findQueueFamilies(device);
             if (!families.complete() || !deviceSupportsSwapchain(device)) {
@@ -1217,11 +1239,27 @@ namespace lfs::vis {
                 fallback = device;
             }
             if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
-                physical_device_ = device;
-                break;
+                // Prefer the discrete GPU that matches CUDA's device 0. Picking
+                // the first discrete GPU in Vulkan's enumeration order can land
+                // the viewer on a different physical card than the CUDA trainer
+                // on multi-GPU systems; CUDA<->Vulkan external-memory import then
+                // fails (VK_ERROR_OUT_OF_DEVICE_MEMORY) and corrupts the CUDA
+                // context, surfacing as a spurious "out of GPU memory".
+                if (first_discrete == VK_NULL_HANDLE) {
+                    first_discrete = device;
+                }
+                if (vulkanDeviceMatchesCudaDevice(device, 0)) {
+                    physical_device_ = device;
+                    break;
+                }
             }
         }
 
+        // No CUDA-matched discrete GPU: keep the legacy "first discrete" choice,
+        // then any presentable device.
+        if (physical_device_ == VK_NULL_HANDLE) {
+            physical_device_ = first_discrete;
+        }
         if (physical_device_ == VK_NULL_HANDLE) {
             physical_device_ = fallback;
         }


### PR DESCRIPTION
## Summary

On multi-GPU systems, starting GUI training crashes immediately with a misleading
"CUDA out of memory" error - even with tens of GB of VRAM free. The root cause is
that the Vulkan viewer and the CUDA trainer can end up on **different physical GPUs**,
which breaks the CUDA↔Vulkan zero-copy interop.

## Root cause

`VulkanContext::pickPhysicalDevice()` selects the **first discrete GPU in Vulkan's
enumeration order** and never reconciles it with the GPU CUDA uses (device 0). On
machines with two GPUs - especially two identical cards - Vulkan's enumeration order
does not necessarily match CUDA's, so the viewer initializes on one card and the
trainer on the other.

When training starts, the exportable-interop allocator exports a CUDA VMM block on the
CUDA device and tries to import it into Vulkan on the *other* card:

exportable_storage.cpp  Exportable CUDA block: device_ptr=0x... committed=1184 MiB
vulkan_context.cpp      Vulkan: vkAllocateMemory(import) failed: VK_ERROR_OUT_OF_DEVICE_MEMORY
training_manager.cpp    Exportable-interop allocator failed (...); falling back to legacy Vulkan-external allocator
pinned_memory_allocator.cpp  cudaEventQuery failed: an illegal memory access was encountered
tensor.cpp              cudaErrorIllegalAddress: an illegal memory access was encountered
training_manager.cpp    Failed to initialize SplatData: CUDA out of memory: failed to allocate 21033300 bytes (0.02 GB).



The import fails with `VK_ERROR_OUT_OF_DEVICE_MEMORY`; the legacy fallback then performs
cross-device CUDA work that raises `cudaErrorIllegalAddress`, which poisons the CUDA
context so every subsequent allocation fails. The allocator surfaces those failures as
"out of memory" — hence the misleading message on a nearly empty GPU.

Notably, `verifyCudaMatchesVulkanDevice()` in `cuda_vulkan_interop.cpp` already *detects*
this exact mismatch and suggests setting `CUDA_VISIBLE_DEVICES`, confirming the two APIs
can diverge — this PR makes the selection align automatically.

## Fix

In `pickPhysicalDevice()`, prefer the discrete GPU whose UUID matches CUDA device 0
(via `VkPhysicalDeviceIDProperties::deviceUUID` vs `cudaDeviceProp::uuid`). If no match
is found, fall back to the previous "first discrete GPU" behavior, so **single-GPU
systems are completely unaffected**.

## Reproduction

- Hardware: 2× identical NVIDIA GPUs (reproduced on 2× RTX 4090, driver 572.61, CUDA 12.8).
- Load any COLMAP/transforms dataset and start training in the GUI → instant
  "CUDA out of memory" crash.
- Workaround without this patch: `set CUDA_VISIBLE_DEVICES=<index matching the Vulkan card>`.

## Testing

- **Before:** GUI training crashes at model init with the log above (GPU ~0.5 GB used of 24 GB).
- **After:** Vulkan selects the CUDA-matched 4090, interop succeeds
  (`Training tensors share one CUDA-exportable VMM block imported into Vulkan — zero-copy
  viewer interop`), and training runs normally with no env var.
- Single-GPU path unchanged (fallback preserves prior behavior).
