### PR TITLE
Global Tool-Control Shortcuts

### DIFF
--- a/src/visualizer/input/input_bindings.cpp
+++ b/src/visualizer/input/input_bindings.cpp
@@ -26,7 +26,7 @@ namespace lfs::vis::input {
 
     namespace {
 
-        constexpr int PROFILE_VERSION = 15; // Version 15 adds crop apply Enter bindings.
+        constexpr int PROFILE_VERSION = 16; // Version 16 promotes tool/control activation bindings to global.
         constexpr int REMOVED_TOOL_MODE_2 = 2;
         constexpr int REMOVED_ACTION_39 = 39;
         constexpr int REMOVED_ACTION_66 = 66;
@@ -93,6 +93,26 @@ namespace lfs::vis::input {
             case Action::DEPTH_ADJUST_SIDE:
             case Action::TOGGLE_SELECTION_DEPTH_FILTER:
             case Action::TOGGLE_SELECTION_CROP_FILTER:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        [[nodiscard]] bool isToolControlActivationAction(const Action action) {
+            switch (action) {
+            case Action::TOOL_SELECT:
+            case Action::TOOL_TRANSLATE:
+            case Action::TOOL_ROTATE:
+            case Action::TOOL_SCALE:
+            case Action::TOOL_MIRROR:
+            case Action::TOOL_ALIGN:
+            case Action::SELECT_MODE_CENTERS:
+            case Action::SELECT_MODE_RECTANGLE:
+            case Action::SELECT_MODE_POLYGON:
+            case Action::SELECT_MODE_LASSO:
+            case Action::SELECT_MODE_RINGS:
+            case Action::SELECT_MODE_COLOR:
                 return true;
             default:
                 return false;
@@ -212,6 +232,55 @@ namespace lfs::vis::input {
                 }
             }
             return added;
+        }
+
+        size_t promoteToolControlActivationBindings(std::vector<Binding>& bindings,
+                                                    const int version,
+                                                    std::string_view profile_name) {
+            if (version >= 16) {
+                return 0;
+            }
+
+            size_t changed = 0;
+            for (auto it = bindings.begin(); it != bindings.end();) {
+                if (it->mode == ToolMode::GLOBAL || !isToolControlActivationAction(it->action)) {
+                    ++it;
+                    continue;
+                }
+
+                const bool duplicate_global_action_trigger = std::ranges::any_of(
+                    bindings,
+                    [&](const Binding& current) {
+                        return current.mode == ToolMode::GLOBAL &&
+                               current.action == it->action &&
+                               triggersOverlap(current.trigger, it->trigger);
+                    });
+                if (duplicate_global_action_trigger) {
+                    it = bindings.erase(it);
+                    ++changed;
+                    continue;
+                }
+
+                const bool trigger_conflicts_global = std::ranges::any_of(
+                    bindings,
+                    [&](const Binding& current) {
+                        return current.mode == ToolMode::GLOBAL &&
+                               triggersOverlap(current.trigger, it->trigger);
+                    });
+                if (trigger_conflicts_global) {
+                    LOG_WARN("Profile '{}' keeps tool/control shortcut '{}' in mode {} because its trigger conflicts globally",
+                             profile_name, getActionName(it->action), static_cast<int>(it->mode));
+                    ++it;
+                    continue;
+                }
+
+                LOG_INFO("Promoting profile '{}' tool/control shortcut '{}' from mode {} to Global mode",
+                         profile_name, getActionName(it->action), static_cast<int>(it->mode));
+                it->mode = ToolMode::GLOBAL;
+                ++changed;
+                ++it;
+            }
+            return changed;
         }
 
     } // namespace
@@ -449,8 +518,9 @@ namespace lfs::vis::input {
                          added_bindings, current_profile_name_);
             }
 
+            const size_t promoted = promoteToolControlActivationBindings(bindings_, version, current_profile_name_);
             const size_t collapsed = collapseRedundantModeBindings(version);
-            const size_t migrated = collapsed + migrateLoadedProfile(version);
+            const size_t migrated = promoted + collapsed + migrateLoadedProfile(version);
 
             rebuildLookupMaps();
             LOG_INFO("Loaded profile '{}' ({} bindings) from {}", current_profile_name_, bindings_.size(), lfs::core::path_to_utf8(path));

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -35,6 +35,7 @@
 #include "visualizer/scene_coordinate_utils.hpp"
 #include <SDL3/SDL.h>
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <format>
 #include <limits>
@@ -237,7 +238,32 @@ namespace lfs::vis {
             return python::dispatch_modal_event(py_evt);
         }
 
-        bool handleSelectionModeShortcut(const input::Action action, gui::GuiManager* gui) {
+        std::optional<ToolType> ownerToolForActivationAction(const input::Action action) {
+            switch (action) {
+            case input::Action::TOOL_SELECT:
+            case input::Action::SELECT_MODE_CENTERS:
+            case input::Action::SELECT_MODE_RECTANGLE:
+            case input::Action::SELECT_MODE_POLYGON:
+            case input::Action::SELECT_MODE_LASSO:
+            case input::Action::SELECT_MODE_RINGS:
+            case input::Action::SELECT_MODE_COLOR:
+                return ToolType::Selection;
+            case input::Action::TOOL_TRANSLATE:
+                return ToolType::Translate;
+            case input::Action::TOOL_ROTATE:
+                return ToolType::Rotate;
+            case input::Action::TOOL_SCALE:
+                return ToolType::Scale;
+            case input::Action::TOOL_MIRROR:
+                return ToolType::Mirror;
+            case input::Action::TOOL_ALIGN:
+                return ToolType::Align;
+            default:
+                return std::nullopt;
+            }
+        }
+
+        bool applySelectionModeShortcut(const input::Action action, gui::GuiManager* gui) {
             if (!gui)
                 return false;
 
@@ -277,33 +303,41 @@ namespace lfs::vis {
             return true;
         }
 
-        bool handleToolbarToolShortcut(const input::Action action) {
-            ToolType tool = ToolType::None;
-            switch (action) {
-            case input::Action::TOOL_SELECT:
-                tool = ToolType::Selection;
-                break;
-            case input::Action::TOOL_TRANSLATE:
-                tool = ToolType::Translate;
-                break;
-            case input::Action::TOOL_ROTATE:
-                tool = ToolType::Rotate;
-                break;
-            case input::Action::TOOL_SCALE:
-                tool = ToolType::Scale;
-                break;
-            case input::Action::TOOL_MIRROR:
-                tool = ToolType::Mirror;
-                break;
-            case input::Action::TOOL_ALIGN:
-                tool = ToolType::Align;
-                break;
-            default:
+        bool handleToolControlActivationShortcut(const input::Action action, gui::GuiManager* gui) {
+            const auto tool = ownerToolForActivationAction(action);
+            if (!tool) {
                 return false;
             }
 
-            lfs::core::events::tools::SetToolbarTool{.tool_mode = static_cast<int>(tool)}.emit();
+            lfs::core::events::tools::SetToolbarTool{.tool_mode = static_cast<int>(*tool)}.emit();
+            (void)applySelectionModeShortcut(action, gui);
             return true;
+        }
+
+        input::Action resolveCrossToolActivationShortcut(const input::InputBindings& bindings,
+                                                         const input::ToolMode current_mode,
+                                                         const int key,
+                                                         const int mods) {
+            constexpr std::array modes = {
+                input::ToolMode::GLOBAL,
+                input::ToolMode::SELECTION,
+                input::ToolMode::ALIGN,
+                input::ToolMode::CROP_BOX,
+                input::ToolMode::TRANSLATE,
+                input::ToolMode::ROTATE,
+                input::ToolMode::SCALE,
+            };
+
+            for (const auto mode : modes) {
+                if (mode == current_mode) {
+                    continue;
+                }
+                const auto candidate = bindings.getActionForKey(mode, key, mods);
+                if (ownerToolForActivationAction(candidate).has_value()) {
+                    return candidate;
+                }
+            }
+            return input::Action::NONE;
         }
 
         [[nodiscard]] bool shouldDeferClickActionForDrag(const input::Action action) {
@@ -1493,7 +1527,10 @@ namespace lfs::vis {
         double mx = mx_f, my = my_f;
         const bool over_gui_hover = isPointerOverUiHover(mx, my);
         const auto tool_mode = getCurrentToolMode();
-        const auto bound_action = bindings_.getActionForKey(tool_mode, logical_key, mods);
+        auto bound_action = bindings_.getActionForKey(tool_mode, logical_key, mods);
+        if (bound_action == input::Action::NONE) {
+            bound_action = resolveCrossToolActivationShortcut(bindings_, tool_mode, logical_key, mods);
+        }
         if (action == input::ACTION_PRESS &&
             dispatchSelectionActionToModal(bound_action, mods, mx, my)) {
             return;
@@ -1559,10 +1596,7 @@ namespace lfs::vis {
         }
 
         if (action == input::ACTION_PRESS) {
-            if (handleSelectionModeShortcut(bound_action, gui))
-                return;
-
-            if (handleToolbarToolShortcut(bound_action))
+            if (handleToolControlActivationShortcut(bound_action, gui))
                 return;
         }
 

--- a/tests/test_input_controller_focus.cpp
+++ b/tests/test_input_controller_focus.cpp
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/event_bridge/scoped_handler.hpp"
+#include "core/editor_context.hpp"
 #include "core/events.hpp"
 #include "core/services.hpp"
 #include "gui/gui_focus_state.hpp"
@@ -1034,6 +1035,85 @@ namespace lfs::vis {
                   input::Action::APPLY_CROP_BOX);
 
         std::filesystem::remove(profile_path);
+    }
+
+    TEST_F(InputControllerFocusTest, VersionFifteenProfilePromotesToolControlActivationBindingsToGlobal) {
+        const auto profile_path =
+            std::filesystem::temp_directory_path() / "lfs_input_bindings_legacy_v15_tool_controls.json";
+        std::filesystem::remove(profile_path);
+        {
+            std::ofstream file(profile_path);
+            ASSERT_TRUE(file.is_open());
+            file << R"({
+  "name": "LegacyToolControls",
+  "version": 15,
+  "bindings": [
+    {
+      "mode": )" << static_cast<int>(input::ToolMode::SELECTION) << R"(,
+      "action": )" << static_cast<int>(input::Action::SELECT_MODE_RECTANGLE) << R"(,
+      "description": "Selection: Rectangle",
+      "trigger_type": "key",
+      "key": )" << input::KEY_2 << R"(,
+      "modifiers": )" << input::MODIFIER_CTRL << R"(
+    },
+    {
+      "mode": )" << static_cast<int>(input::ToolMode::ROTATE) << R"(,
+      "action": )" << static_cast<int>(input::Action::TOOL_MIRROR) << R"(,
+      "description": "Mirror Tool",
+      "trigger_type": "key",
+      "key": )" << input::KEY_M << R"(,
+      "modifiers": )" << input::MODIFIER_CTRL << R"(
+    }
+  ]
+})";
+        }
+
+        input::InputBindings loaded;
+        ASSERT_TRUE(loaded.loadProfileFromFile(profile_path));
+
+        EXPECT_EQ(loaded.getActionForKey(input::ToolMode::TRANSLATE,
+                                         input::KEY_2,
+                                         input::MODIFIER_CTRL),
+                  input::Action::SELECT_MODE_RECTANGLE);
+        EXPECT_TRUE(loaded.getTriggerForAction(input::Action::SELECT_MODE_RECTANGLE,
+                                               input::ToolMode::GLOBAL)
+                        .has_value());
+        EXPECT_FALSE(loaded.getTriggerForAction(input::Action::SELECT_MODE_RECTANGLE,
+                                                input::ToolMode::SELECTION)
+                         .has_value());
+        EXPECT_EQ(loaded.getActionForKey(input::ToolMode::SELECTION,
+                                         input::KEY_M,
+                                         input::MODIFIER_CTRL),
+                  input::Action::TOOL_MIRROR);
+        EXPECT_TRUE(loaded.getTriggerForAction(input::Action::TOOL_MIRROR,
+                                               input::ToolMode::GLOBAL)
+                        .has_value());
+        EXPECT_FALSE(loaded.getTriggerForAction(input::Action::TOOL_MIRROR,
+                                                input::ToolMode::ROTATE)
+                         .has_value());
+
+        std::filesystem::remove(profile_path);
+    }
+
+    TEST_F(InputControllerFocusTest, ToolControlActivationShortcutsResolveAcrossModesAtRuntime) {
+        Viewport viewport(200, 200);
+        InputController controller(nullptr, viewport);
+        input::InputRouter router;
+        router.setInputController(&controller);
+        controller.setInputRouter(&router);
+
+        controller.getBindings().setBinding(input::ToolMode::SELECTION,
+                                            input::Action::TOOL_MIRROR,
+                                            input::KeyTrigger{input::KEY_M, input::MODIFIER_CTRL});
+
+        lfs::event::ScopedHandler handlers;
+        int tool_mode = -1;
+        handlers.subscribe<core::events::tools::SetToolbarTool>(
+            [&](const auto& event) { tool_mode = event.tool_mode; });
+
+        controller.handleKey(input::KEY_M, input::ACTION_PRESS, input::MODIFIER_CTRL);
+
+        EXPECT_EQ(tool_mode, static_cast<int>(ToolType::Mirror));
     }
 
     TEST_F(InputControllerFocusTest, LegacyProfileMigrationAddsOnlyVersionedModalDefaults) {


### PR DESCRIPTION
## Summary

This change makes tool/control activation shortcuts work regardless of the currently active left-toolbar tool, while keeping tool-local operational shortcuts scoped to their owning tool.

Before this change, shortcuts such as selection submode keys could be bound to a tool mode and therefore only resolved when that tool was already active. This made shortcuts like `Ctrl+1` / `Ctrl+2` for selection modes fail from other toolbar tools, even though their purpose is to activate a control mode rather than perform an operation inside the active tool.

## Problem

The input dispatcher resolved keyboard shortcuts only against the current `ToolMode`, then inherited eligible global bindings. If a shortcut was stored under another tool mode, it was invisible unless that tool was active.

This especially affected activation-style shortcuts:

- Main toolbar shortcuts, such as `1`, `2`, `3`, etc.
- Selection submode shortcuts, such as `Ctrl+1`, `Ctrl+2`, etc.
- Future tool-control activation shortcuts that should switch to their owning tool first.

The old behavior also diverged from toolbar clicks. Clicking a selection submode first activates the selection tool and then applies the submode. The keyboard path only applied the submode when the action was already resolved.

## Design

The fix introduces a distinction between:

- **Tool/control activation shortcuts**: shortcuts that select a tool or control mode and should be reachable from any active tool.
- **Tool-local operational shortcuts**: shortcuts that perform work inside a tool and should remain scoped, such as selection drags, crop apply, polygon confirmation, brush resize, node picking, and delete behavior.

Runtime routing now does this:

1. Resolve the key in the current tool mode as before.
2. If nothing is found, search the other tool modes only for whitelisted tool/control activation actions.
3. If such an action is found, activate its owning toolbar tool.
4. Apply any extra control state, such as selection submode.

This keeps the behavior intentionally narrow around activation actions, while avoiding a selection-only special case.

## Profile Migration

Input profile version was bumped to `16`.

When loading older profiles, tool/control activation bindings stored in a non-global mode are promoted to `ToolMode::GLOBAL` when safe:

- Exact duplicate global bindings are removed from the local mode.
- Alternate user triggers for the same action are preserved by promoting them.
- Bindings are left local if their trigger conflicts with an existing global trigger.

This migration makes existing user profiles behave consistently with the new runtime routing without broadly globalizing operational shortcuts.

