### PR TITLE
 Cross-Tool Activation Shortcuts

### DIFF
--- a/src/visualizer/input/input_bindings.cpp
+++ b/src/visualizer/input/input_bindings.cpp
@@ -30,15 +30,6 @@ namespace lfs::vis::input {
         constexpr int REMOVED_TOOL_MODE_2 = 2;
         constexpr int REMOVED_ACTION_39 = 39;
         constexpr int REMOVED_ACTION_66 = 66;
-        constexpr std::array<ToolMode, 7> ALL_MODES = {
-            ToolMode::GLOBAL,
-            ToolMode::SELECTION,
-            ToolMode::ALIGN,
-            ToolMode::CROP_BOX,
-            ToolMode::TRANSLATE,
-            ToolMode::ROTATE,
-            ToolMode::SCALE,
-        };
         constexpr std::array<ToolMode, 4> NODE_PICK_MODES = {
             ToolMode::GLOBAL,
             ToolMode::TRANSLATE,
@@ -206,7 +197,7 @@ namespace lfs::vis::input {
                     break;
                 default:
                     if (!describe(binding.action).inherits_from_global) {
-                        added += mirrorLegacyBindingToModes(bindings, binding, binding.action, ALL_MODES);
+                        added += mirrorLegacyBindingToModes(bindings, binding, binding.action, kAllToolModes);
                     }
                     break;
                 }

--- a/src/visualizer/input/input_bindings.hpp
+++ b/src/visualizer/input/input_bindings.hpp
@@ -6,6 +6,7 @@
 
 #include "core/export.hpp"
 #include "input/key_codes.hpp"
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -31,6 +32,15 @@ namespace lfs::vis::input {
 
     // Highest persisted ToolMode value plus one. Value 2 was the removed brush tool mode.
     inline constexpr size_t kToolModeCount = 8;
+    inline constexpr std::array<ToolMode, 7> kAllToolModes = {
+        ToolMode::GLOBAL,
+        ToolMode::SELECTION,
+        ToolMode::ALIGN,
+        ToolMode::CROP_BOX,
+        ToolMode::TRANSLATE,
+        ToolMode::ROTATE,
+        ToolMode::SCALE,
+    };
 
     enum class Action {
         NONE = 0,

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -35,6 +35,7 @@
 #include "visualizer/scene_coordinate_utils.hpp"
 #include <SDL3/SDL.h>
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <format>
 #include <limits>
@@ -237,7 +238,32 @@ namespace lfs::vis {
             return python::dispatch_modal_event(py_evt);
         }
 
-        bool handleSelectionModeShortcut(const input::Action action, gui::GuiManager* gui) {
+        std::optional<ToolType> ownerToolForActivationAction(const input::Action action) {
+            switch (action) {
+            case input::Action::TOOL_SELECT:
+            case input::Action::SELECT_MODE_CENTERS:
+            case input::Action::SELECT_MODE_RECTANGLE:
+            case input::Action::SELECT_MODE_POLYGON:
+            case input::Action::SELECT_MODE_LASSO:
+            case input::Action::SELECT_MODE_RINGS:
+            case input::Action::SELECT_MODE_COLOR:
+                return ToolType::Selection;
+            case input::Action::TOOL_TRANSLATE:
+                return ToolType::Translate;
+            case input::Action::TOOL_ROTATE:
+                return ToolType::Rotate;
+            case input::Action::TOOL_SCALE:
+                return ToolType::Scale;
+            case input::Action::TOOL_MIRROR:
+                return ToolType::Mirror;
+            case input::Action::TOOL_ALIGN:
+                return ToolType::Align;
+            default:
+                return std::nullopt;
+            }
+        }
+
+        bool applySelectionModeShortcut(const input::Action action, gui::GuiManager* gui) {
             if (!gui)
                 return false;
 
@@ -277,33 +303,41 @@ namespace lfs::vis {
             return true;
         }
 
-        bool handleToolbarToolShortcut(const input::Action action) {
-            ToolType tool = ToolType::None;
-            switch (action) {
-            case input::Action::TOOL_SELECT:
-                tool = ToolType::Selection;
-                break;
-            case input::Action::TOOL_TRANSLATE:
-                tool = ToolType::Translate;
-                break;
-            case input::Action::TOOL_ROTATE:
-                tool = ToolType::Rotate;
-                break;
-            case input::Action::TOOL_SCALE:
-                tool = ToolType::Scale;
-                break;
-            case input::Action::TOOL_MIRROR:
-                tool = ToolType::Mirror;
-                break;
-            case input::Action::TOOL_ALIGN:
-                tool = ToolType::Align;
-                break;
-            default:
+        bool handleToolControlActivationShortcut(const input::Action action, gui::GuiManager* gui) {
+            const auto tool = ownerToolForActivationAction(action);
+            if (!tool) {
                 return false;
             }
 
-            lfs::core::events::tools::SetToolbarTool{.tool_mode = static_cast<int>(tool)}.emit();
+            lfs::core::events::tools::SetToolbarTool{.tool_mode = static_cast<int>(*tool)}.emit();
+            (void)applySelectionModeShortcut(action, gui);
             return true;
+        }
+
+        input::Action resolveCrossToolActivationShortcut(const input::InputBindings& bindings,
+                                                         const input::ToolMode current_mode,
+                                                         const int key,
+                                                         const int mods) {
+            constexpr std::array modes = {
+                input::ToolMode::GLOBAL,
+                input::ToolMode::SELECTION,
+                input::ToolMode::ALIGN,
+                input::ToolMode::CROP_BOX,
+                input::ToolMode::TRANSLATE,
+                input::ToolMode::ROTATE,
+                input::ToolMode::SCALE,
+            };
+
+            for (const auto mode : modes) {
+                if (mode == current_mode) {
+                    continue;
+                }
+                const auto candidate = bindings.getActionForKey(mode, key, mods);
+                if (ownerToolForActivationAction(candidate).has_value()) {
+                    return candidate;
+                }
+            }
+            return input::Action::NONE;
         }
 
         [[nodiscard]] bool shouldDeferClickActionForDrag(const input::Action action) {
@@ -1493,7 +1527,10 @@ namespace lfs::vis {
         double mx = mx_f, my = my_f;
         const bool over_gui_hover = isPointerOverUiHover(mx, my);
         const auto tool_mode = getCurrentToolMode();
-        const auto bound_action = bindings_.getActionForKey(tool_mode, logical_key, mods);
+        auto bound_action = bindings_.getActionForKey(tool_mode, logical_key, mods);
+        if (bound_action == input::Action::NONE) {
+            bound_action = resolveCrossToolActivationShortcut(bindings_, tool_mode, logical_key, mods);
+        }
         if (action == input::ACTION_PRESS &&
             dispatchSelectionActionToModal(bound_action, mods, mx, my)) {
             return;
@@ -1559,10 +1596,7 @@ namespace lfs::vis {
         }
 
         if (action == input::ACTION_PRESS) {
-            if (handleSelectionModeShortcut(bound_action, gui))
-                return;
-
-            if (handleToolbarToolShortcut(bound_action))
+            if (handleToolControlActivationShortcut(bound_action, gui))
                 return;
         }
 

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -35,7 +35,6 @@
 #include "visualizer/scene_coordinate_utils.hpp"
 #include <SDL3/SDL.h>
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <format>
 #include <limits>
@@ -318,17 +317,7 @@ namespace lfs::vis {
                                                          const input::ToolMode current_mode,
                                                          const int key,
                                                          const int mods) {
-            constexpr std::array modes = {
-                input::ToolMode::GLOBAL,
-                input::ToolMode::SELECTION,
-                input::ToolMode::ALIGN,
-                input::ToolMode::CROP_BOX,
-                input::ToolMode::TRANSLATE,
-                input::ToolMode::ROTATE,
-                input::ToolMode::SCALE,
-            };
-
-            for (const auto mode : modes) {
+            for (const auto mode : input::kAllToolModes) {
                 if (mode == current_mode) {
                     continue;
                 }

--- a/tests/test_input_controller_focus.cpp
+++ b/tests/test_input_controller_focus.cpp
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/event_bridge/scoped_handler.hpp"
+#include "core/editor_context.hpp"
 #include "core/events.hpp"
 #include "core/services.hpp"
 #include "gui/gui_focus_state.hpp"
@@ -1034,6 +1035,56 @@ namespace lfs::vis {
                   input::Action::APPLY_CROP_BOX);
 
         std::filesystem::remove(profile_path);
+    }
+
+    TEST_F(InputControllerFocusTest, ToolControlActivationShortcutsResolveAcrossModesAtRuntime) {
+        Viewport viewport(200, 200);
+        InputController controller(nullptr, viewport);
+        input::InputRouter router;
+        router.setInputController(&controller);
+        controller.setInputRouter(&router);
+
+        controller.getBindings().setBinding(input::ToolMode::SELECTION,
+                                            input::Action::TOOL_MIRROR,
+                                            input::KeyTrigger{input::KEY_M, input::MODIFIER_CTRL});
+
+        lfs::event::ScopedHandler handlers;
+        int tool_mode = -1;
+        handlers.subscribe<core::events::tools::SetToolbarTool>(
+            [&](const auto& event) { tool_mode = event.tool_mode; });
+
+        controller.handleKey(input::KEY_M, input::ACTION_PRESS, input::MODIFIER_CTRL);
+
+        EXPECT_EQ(tool_mode, static_cast<int>(ToolType::Mirror));
+        EXPECT_TRUE(controller.getBindings()
+                        .getTriggerForAction(input::Action::TOOL_MIRROR,
+                                             input::ToolMode::SELECTION)
+                        .has_value());
+        EXPECT_FALSE(controller.getBindings()
+                         .getTriggerForAction(input::Action::TOOL_MIRROR,
+                                              input::ToolMode::GLOBAL)
+                         .has_value());
+    }
+
+    TEST_F(InputControllerFocusTest, ToolLocalOperationalShortcutsDoNotResolveAcrossModes) {
+        Viewport viewport(200, 200);
+        InputController controller(nullptr, viewport);
+        input::InputRouter router;
+        router.setInputController(&controller);
+        controller.setInputRouter(&router);
+
+        controller.getBindings().setBinding(input::ToolMode::SELECTION,
+                                            input::Action::DELETE_SELECTED,
+                                            input::KeyTrigger{input::KEY_B, input::MODIFIER_CTRL});
+
+        lfs::event::ScopedHandler handlers;
+        int delete_count = 0;
+        handlers.subscribe<core::events::cmd::DeleteSelected>(
+            [&](const auto&) { ++delete_count; });
+
+        controller.handleKey(input::KEY_B, input::ACTION_PRESS, input::MODIFIER_CTRL);
+
+        EXPECT_EQ(delete_count, 0);
     }
 
     TEST_F(InputControllerFocusTest, LegacyProfileMigrationAddsOnlyVersionedModalDefaults) {


### PR DESCRIPTION
## Summary

This change makes tool/control activation shortcuts usable regardless of the currently active left-toolbar tool, without moving those bindings into the Global keymap context.

Bindings remain owned by the context where users expect to configure them. For example, selection submode shortcuts can remain in the Selection context, but pressing them from another active tool still activates the Selection tool and applies the requested submode.

## Problem

Keyboard dispatch previously resolved a key only against the current `ToolMode`, plus eligible inherited Global bindings. That meant a shortcut defined under another tool context was invisible unless that tool was already active.

This is undesirable for activation-style shortcuts. A shortcut whose meaning is "switch to this tool/control" should be reachable from any tool, while still being defined and edited under its owning context.

The main visible case is selection submodes:

- `Ctrl+1` for Centers
- `Ctrl+2` for Rectangle
- `Ctrl+3` for Polygon
- `Ctrl+4` for Lasso
- `Ctrl+5` for Rings
- `Ctrl+6` for Color

The same routing model also supports future tool-control activation shortcuts without requiring them to be moved to Global.