### PR TITLE
#1316 Fix Borderless Maximize After Titlebar Double-Click

### DIFF
--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -867,21 +867,31 @@ namespace lfs::vis {
     }
 
     void WindowManager::normalizeNativeMaximize(const char* const reason) {
-        if (!window_ || is_fullscreen_ || is_borderless_maximized_) {
+        if (!window_ || is_fullscreen_) {
             updateWindowSize(reason);
             return;
         }
 
+        bool restored_sdl_maximize = false;
         if (isSdlMaximized()) {
             if (!SDL_RestoreWindow(window_)) {
                 LOG_WARN("Failed to restore SDL-maximized window before normalizing maximize: {}", SDL_GetError());
                 updateWindowSize(reason);
                 return;
             }
+            restored_sdl_maximize = true;
+        }
+
+        if (is_borderless_maximized_) {
+            updateWindowSize(reason);
+            return;
+        }
+
+        if (restored_sdl_maximize) {
             saveBorderlessRestoreGeometry();
         }
 
-        maximizeBorderless(reason, false);
+        maximizeBorderless(reason, !restored_sdl_maximize);
     }
 
     void WindowManager::maximizeBorderless(const char* const reason, const bool save_restore_geometry) {

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -204,6 +204,7 @@ namespace lfs::vis {
             const bool right = area->x >= size.x - kResizeBorder && area->x < size.x;
             const bool top = area->y >= 0 && area->y < kResizeBorder;
             const bool bottom = area->y >= size.y - kResizeBorder && area->y < size.y;
+            const bool titlebar_point = self->isTitlebarDragPoint(area->x, area->y);
 
             if (!self->isMaximized()) {
                 if (top && left)
@@ -218,13 +219,15 @@ namespace lfs::vis {
                     return SDL_HITTEST_RESIZE_LEFT;
                 if (right)
                     return SDL_HITTEST_RESIZE_RIGHT;
-                if (top)
+                if (top && !titlebar_point)
                     return SDL_HITTEST_RESIZE_TOP;
                 if (bottom)
                     return SDL_HITTEST_RESIZE_BOTTOM;
             }
 
-            if (self->isTitlebarDragPoint(area->x, area->y)) {
+            if (titlebar_point) {
+                if (self->isMaximized())
+                    return SDL_HITTEST_NORMAL;
                 if (self->usesEventDrivenTitlebarDrag())
                     return SDL_HITTEST_NORMAL;
                 return SDL_HITTEST_DRAGGABLE;
@@ -551,10 +554,20 @@ namespace lfs::vis {
             }
             break;
 
+        case SDL_EVENT_WINDOW_MAXIMIZED:
+            if (!eventTargetsWindow(event, main_window_id))
+                break;
+            LOG_DEBUG("SDL window event: {} data1={} data2={} fullscreen={}",
+                      windowEventName(event.type),
+                      event.window.data1,
+                      event.window.data2,
+                      is_fullscreen_);
+            normalizeNativeMaximize("native-window-maximized");
+            break;
+
         case SDL_EVENT_WINDOW_RESIZED:
         case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
         case SDL_EVENT_WINDOW_MINIMIZED:
-        case SDL_EVENT_WINDOW_MAXIMIZED:
         case SDL_EVENT_WINDOW_RESTORED:
             if (!eventTargetsWindow(event, main_window_id))
                 break;
@@ -851,6 +864,24 @@ namespace lfs::vis {
 
         SDL_GetWindowPosition(window_, &borderless_restore_pos_.x, &borderless_restore_pos_.y);
         SDL_GetWindowSize(window_, &borderless_restore_size_.x, &borderless_restore_size_.y);
+    }
+
+    void WindowManager::normalizeNativeMaximize(const char* const reason) {
+        if (!window_ || is_fullscreen_ || is_borderless_maximized_) {
+            updateWindowSize(reason);
+            return;
+        }
+
+        if (isSdlMaximized()) {
+            if (!SDL_RestoreWindow(window_)) {
+                LOG_WARN("Failed to restore SDL-maximized window before normalizing maximize: {}", SDL_GetError());
+                updateWindowSize(reason);
+                return;
+            }
+            saveBorderlessRestoreGeometry();
+        }
+
+        maximizeBorderless(reason, false);
     }
 
     void WindowManager::maximizeBorderless(const char* const reason, const bool save_restore_geometry) {

--- a/src/visualizer/window/window_manager.hpp
+++ b/src/visualizer/window/window_manager.hpp
@@ -114,6 +114,7 @@ namespace lfs::vis {
         void finishTitlebarDragIfReleased();
         [[nodiscard]] bool isSdlMaximized() const;
         void saveBorderlessRestoreGeometry();
+        void normalizeNativeMaximize(const char* reason);
         void maximizeBorderless(const char* reason, bool save_restore_geometry);
         void restoreMaximized(const char* reason);
         [[nodiscard]] bool titlebarDragMovedEnough() const;


### PR DESCRIPTION
## Summary

Fixes GitHub issue #1316, where double-clicking the custom titlebar could make the borderless window extend into the Windows taskbar area after a maximize/restore cycle.

## Reproduction

On Windows 11:

1. Launch LichtFeld Studio.
2. Double-click the top/titlebar area to maximize.
3. Double-click the top/titlebar area again to restore.
4. Double-click the top/titlebar area a third time to maximize again.

Before this change, the third maximize could leave the outer borderless window at full monitor height while the client/work area remained taskbar-aware. This produced a black strip at the bottom and could obscure the taskbar.

## Root Cause

LichtFeld Studio uses an SDL borderless, resizable window with custom titlebar handling.

The top resize hit-test region could still let SDL/Windows perform a native maximize on the borderless window. That created mixed state:

- SDL/Windows considered the window natively maximized.
- The app also had its own borderless maximize/restore state.
- After a native maximize/restore cycle, the outer HWND could become full monitor height while the client area stayed at the monitor work-area height.

That mismatch caused the visible black bottom strip and taskbar overlap.

## Fix

The fix routes titlebar maximize behavior consistently through the app-managed borderless maximize path:

- Top-edge hit testing now preserves native resize only outside the custom titlebar region.
- Titlebar hit-test points on a maximized window return normal mouse events, allowing the app double-click path to restore via `toggleMaximized()`.
- Native `SDL_EVENT_WINDOW_MAXIMIZED` events are normalized immediately: if SDL/Windows maximizes the borderless window, the app restores that native state and reapplies `maximizeBorderless()`.

This keeps maximize/restore behavior in one code path and prevents stale mixed native/custom maximize state.

## Validation

The repeated sequence now works:

1. Launch application.
2. Double-click top bar: maximizes correctly.
3. Double-click top bar: restores correctly.
4. Double-click top bar again: maximizes correctly without the black bottom strip or taskbar overlap.