### PR TITLE
Feature: Camera Frustum Visibility Shortcut

### DIFF
--- a/src/python/lfs/py_keymap.cpp
+++ b/src/python/lfs/py_keymap.cpp
@@ -171,7 +171,8 @@ namespace lfs::python {
             .value("TOOL_ALIGN", Action::TOOL_ALIGN)
             .value("PIE_MENU", Action::PIE_MENU)
             .value("DEPTH_ADJUST_NEAR", Action::DEPTH_ADJUST_NEAR)
-            .value("HISTOGRAM_ZOOM_MARKED", Action::HISTOGRAM_ZOOM_MARKED);
+            .value("HISTOGRAM_ZOOM_MARKED", Action::HISTOGRAM_ZOOM_MARKED)
+            .value("TOGGLE_CAMERA_FRUSTUMS", Action::TOGGLE_CAMERA_FRUSTUMS);
 
         // Expose ToolMode enum
         nb::enum_<ToolMode>(keymap, "ToolMode")

--- a/src/python/lfs_plugins/input_settings_panel.py
+++ b/src/python/lfs_plugins/input_settings_panel.py
@@ -100,6 +100,7 @@ class InputSettingsPanel(Panel):
             lf.keymap.Action.TOGGLE_SPLIT_VIEW,
             lf.keymap.Action.TOGGLE_INDEPENDENT_SPLIT_VIEW,
             lf.keymap.Action.TOGGLE_GT_COMPARISON,
+            lf.keymap.Action.TOGGLE_CAMERA_FRUSTUMS,
             lf.keymap.Action.CYCLE_PLY,
             lf.keymap.Action.CYCLE_SELECTION_VIS,
         ],

--- a/src/python/stubs/lichtfeld/keymap.pyi
+++ b/src/python/stubs/lichtfeld/keymap.pyi
@@ -143,6 +143,8 @@ class Action(enum.Enum):
 
     HISTOGRAM_ZOOM_MARKED = 71
 
+    TOGGLE_CAMERA_FRUSTUMS = 72
+
 class ToolMode(enum.Enum):
     GLOBAL = 0
 

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1181,6 +1181,7 @@
     "action.toggle_split_view": "Geteilte Ansicht umschalten",
     "action.toggle_independent_split_view": "Unabhängige geteilte Ansicht umschalten",
     "action.toggle_gt_comparison": "GT-Vergleich umschalten",
+    "action.toggle_camera_frustums": "Kamera-Frustums umschalten",
     "action.toggle_depth_mode": "Tiefenbox umschalten",
     "action.cycle_ply": "PLY durchschalten",
     "action.delete_selected": "Ausgewählte Gaussians löschen",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1206,6 +1206,7 @@
     "action.toggle_split_view": "Toggle Split View",
     "action.toggle_independent_split_view": "Toggle Independent Split View",
     "action.toggle_gt_comparison": "Toggle GT Comparison",
+    "action.toggle_camera_frustums": "Toggle Camera Frustums",
     "action.toggle_depth_mode": "Toggle Depth Box",
     "action.cycle_ply": "Cycle PLY",
     "action.delete_selected": "Delete Selected Gaussians",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -160,6 +160,7 @@
     "action.toggle_split_view": "Alternar vista dividida",
     "action.toggle_independent_split_view": "Alternar vista dividida independiente",
     "action.toggle_gt_comparison": "Alternar comparación GT",
+    "action.toggle_camera_frustums": "Alternar frustos de cámara",
     "action.toggle_depth_mode": "Alternar caja de profundidad",
     "action.cycle_ply": "Recorrer PLY",
     "action.delete_selected": "Eliminar gaussianas seleccionadas",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1181,6 +1181,7 @@
     "action.toggle_split_view": "Basculer la vue divisée",
     "action.toggle_independent_split_view": "Basculer la vue divisée indépendante",
     "action.toggle_gt_comparison": "Basculer la comparaison GT",
+    "action.toggle_camera_frustums": "Afficher/masquer les frustums de caméra",
     "action.toggle_depth_mode": "Basculer la boîte de profondeur",
     "action.cycle_ply": "Parcourir les PLY",
     "action.delete_selected": "Supprimer les gaussiennes sélectionnées",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1181,6 +1181,7 @@
     "action.toggle_split_view": "Attiva vista divisa",
     "action.toggle_independent_split_view": "Attiva vista divisa indipendente",
     "action.toggle_gt_comparison": "Attiva confronto GT",
+    "action.toggle_camera_frustums": "Attiva/disattiva frustum fotocamera",
     "action.toggle_depth_mode": "Attiva box di profondità",
     "action.cycle_ply": "Scorri PLY",
     "action.delete_selected": "Elimina gaussiane selezionate",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1181,6 +1181,7 @@
     "action.toggle_split_view": "分割ビュー切替",
     "action.toggle_independent_split_view": "独立分割ビュー切替",
     "action.toggle_gt_comparison": "GT比較切替",
+    "action.toggle_camera_frustums": "カメラ視錐台を切り替え",
     "action.toggle_depth_mode": "深度ボックス切替",
     "action.cycle_ply": "PLY切替",
     "action.delete_selected": "選択したガウシアンを削除",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1181,6 +1181,7 @@
     "action.toggle_split_view": "분할 보기 전환",
     "action.toggle_independent_split_view": "독립 분할 보기 전환",
     "action.toggle_gt_comparison": "GT 비교 전환",
+    "action.toggle_camera_frustums": "카메라 절두체 전환",
     "action.toggle_depth_mode": "깊이 상자 전환",
     "action.cycle_ply": "PLY 순환",
     "action.delete_selected": "선택한 가우시안 삭제",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1181,6 +1181,7 @@
     "action.toggle_split_view": "Gesplitste weergave omschakelen",
     "action.toggle_independent_split_view": "Onafhankelijke gesplitste weergave omschakelen",
     "action.toggle_gt_comparison": "GT-vergelijking omschakelen",
+    "action.toggle_camera_frustums": "Camerafrustums in-/uitschakelen",
     "action.toggle_depth_mode": "Diepteboog omschakelen",
     "action.cycle_ply": "PLY doorlopen",
     "action.delete_selected": "Geselecteerde gaussians verwijderen",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1181,6 +1181,7 @@
     "action.toggle_split_view": "Przełącz widok podzielony",
     "action.toggle_independent_split_view": "Przełącz niezależny widok podzielony",
     "action.toggle_gt_comparison": "Przełącz porównanie GT",
+    "action.toggle_camera_frustums": "Przełącz ostrosłupy kamery",
     "action.toggle_depth_mode": "Przełącz pudełko głębi",
     "action.cycle_ply": "Przełączaj PLY",
     "action.delete_selected": "Usuń wybrane gaussiany",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -1011,6 +1011,7 @@
     "action.toggle_split_view": "切换分屏视图",
     "action.toggle_independent_split_view": "切换独立分屏视图",
     "action.toggle_gt_comparison": "切换 GT 对比",
+    "action.toggle_camera_frustums": "切换相机视锥体",
     "action.toggle_depth_mode": "切换深度框",
     "action.cycle_ply": "循环 PLY",
     "action.delete_selected": "删除选中的高斯",

--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
@@ -521,7 +521,8 @@ namespace lfs::vis::gui {
                 }
             }
         }
-        syncVisibleRows(rebuilt_tree);
+        const bool frustum_visibility_changed = syncCameraFrustumVisibility();
+        syncVisibleRows(rebuilt_tree || frustum_visibility_changed);
     }
 
     void SceneGraphElement::RenameInputListener::ProcessEvent(Rml::Event& event) {
@@ -835,6 +836,18 @@ namespace lfs::vis::gui {
                 parent_it != snapshots.end() && parent_it->second.type == core::NodeType::DATASET;
             snapshot.draggable = canDrag(snapshot.type, parent_is_dataset);
             snapshot.deletable = isDeletable(snapshot.type, parent_is_dataset);
+            snapshot.camera_frustum_container =
+                (snapshot.type == core::NodeType::GROUP &&
+                 std::ranges::any_of(snapshot.children, [&](const core::NodeId child_id) {
+                     const auto child_it = snapshots.find(child_id);
+                     return child_it != snapshots.end() &&
+                            child_it->second.type == core::NodeType::CAMERA_GROUP;
+                 })) ||
+                (snapshot.type == core::NodeType::CAMERA_GROUP && (parent_it == snapshots.end() || parent_it->second.type != core::NodeType::GROUP));
+            if (snapshot.camera_frustum_container) {
+                if (const auto* rendering = services().renderingOrNull())
+                    snapshot.visible = rendering->getSettings().show_camera_frustums;
+            }
             if (!previous_ids.contains(id) &&
                 snapshot.type == core::NodeType::CAMERA_GROUP &&
                 static_cast<int>(snapshot.children.size()) >= kAutoCollapseCameraGroupThreshold) {
@@ -1078,6 +1091,30 @@ namespace lfs::vis::gui {
         return changed;
     }
 
+    bool SceneGraphElement::syncCameraFrustumVisibility() {
+        const auto* rendering = services().renderingOrNull();
+        if (!rendering)
+            return false;
+
+        const bool visible = rendering->getSettings().show_camera_frustums;
+        bool changed = false;
+        for (auto& [id, snapshot] : node_snapshots_) {
+            if (!snapshot.camera_frustum_container || snapshot.visible == visible)
+                continue;
+
+            snapshot.visible = visible;
+            if (const auto flat_it = flat_index_by_id_.find(id);
+                flat_it != flat_index_by_id_.end() && flat_it->second < flat_rows_.size()) {
+                flat_rows_[flat_it->second].visible = visible;
+            }
+            changed = true;
+        }
+
+        if (changed)
+            markStateDirty();
+        return changed;
+    }
+
     bool SceneGraphElement::syncFromScene(const PanelDrawContext& ctx) {
         claimRenameTextInputFocus();
 
@@ -1125,6 +1162,7 @@ namespace lfs::vis::gui {
             changed |= syncTrainingTopologyLabel(*scene, true);
             changed |= syncCameraLossIconColors(*scene, true);
         }
+        changed |= syncCameraFrustumVisibility();
 
         if (pending_reveal_node_id_ != core::NULL_NODE) {
             const auto target_it = node_snapshots_.find(pending_reveal_node_id_);
@@ -1521,6 +1559,16 @@ namespace lfs::vis::gui {
             return;
 
         if (action == "toggle-vis") {
+            if (const auto snapshot_it = node_snapshots_.find(node_id);
+                snapshot_it != node_snapshots_.end() && snapshot_it->second.camera_frustum_container) {
+                if (auto* rendering = services().renderingOrNull()) {
+                    auto settings = rendering->getSettings();
+                    settings.show_camera_frustums = !settings.show_camera_frustums;
+                    rendering->updateSettings(settings);
+                    syncCameraFrustumVisibility();
+                }
+                return;
+            }
             if (auto it = node_snapshots_.find(node_id); it != node_snapshots_.end()) {
                 it->second.visible = !static_cast<bool>(node->visible);
                 markStateDirty();

--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.hpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.hpp
@@ -68,6 +68,7 @@ namespace lfs::vis::gui {
             core::NodeType type = core::NodeType::GROUP;
             std::string name;
             bool visible = true;
+            bool camera_frustum_container = false;
             bool has_children = false;
             bool training_enabled = true;
             std::string label;
@@ -125,6 +126,7 @@ namespace lfs::vis::gui {
                                   std::vector<core::NodeId>& root_ids);
         bool syncTrainingTopologyLabel(const core::Scene& scene, bool update_cached_rows);
         bool syncCameraLossIconColors(const core::Scene& scene, bool update_cached_rows);
+        bool syncCameraFrustumVisibility();
         void appendSnapshotRows(core::NodeId node_id, int depth, std::vector<FlatRow>& rows,
                                 const std::string& filter_text_lower) const;
         void appendVisibleSubtreeRows(core::NodeId node_id, int depth,

--- a/src/visualizer/gui/scene_panel_native.cpp
+++ b/src/visualizer/gui/scene_panel_native.cpp
@@ -698,6 +698,7 @@ namespace lfs::vis::gui {
         if (active_tab_ == Tab::Scene) {
             stamp.scene_generation = store.scene_generation.get();
             stamp.selection_generation = store.selection_generation.get();
+            stamp.render_settings_generation = store.render_settings_generation.get();
             if (auto* params = services().paramsOrNull())
                 stamp.invert_masks = params->getActiveParams().invert_masks;
 

--- a/src/visualizer/gui/scene_panel_native.hpp
+++ b/src/visualizer/gui/scene_panel_native.hpp
@@ -76,6 +76,7 @@ namespace lfs::vis::gui {
             uint64_t log_generation = 0;
             lfs::core::LogLevel log_level = lfs::core::LogLevel::Off;
             uint64_t language_generation = 0;
+            uint64_t render_settings_generation = 0;
             int dp_ratio_milli = 1000;
             bool invert_masks = false;
 

--- a/src/visualizer/input/input_bindings.cpp
+++ b/src/visualizer/input/input_bindings.cpp
@@ -26,7 +26,7 @@ namespace lfs::vis::input {
 
     namespace {
 
-        constexpr int PROFILE_VERSION = 15; // Version 15 adds crop apply Enter bindings.
+        constexpr int PROFILE_VERSION = 16; // Version 16 adds the camera frustum visibility shortcut.
         constexpr int REMOVED_TOOL_MODE_2 = 2;
         constexpr int REMOVED_ACTION_39 = 39;
         constexpr int REMOVED_ACTION_66 = 66;
@@ -62,7 +62,7 @@ namespace lfs::vis::input {
         [[nodiscard]] std::optional<Action> findActionByDescription(std::string_view description) {
             static const auto* const table = [] {
                 auto* const m = new std::unordered_map<std::string, Action>();
-                constexpr int kActionCount = static_cast<int>(Action::HISTOGRAM_ZOOM_MARKED) + 1;
+                constexpr int kActionCount = static_cast<int>(Action::TOGGLE_CAMERA_FRUSTUMS) + 1;
                 for (int i = 0; i < kActionCount; ++i) {
                     const auto a = static_cast<Action>(i);
                     m->emplace(toLowerCopy(getActionName(a)), a);
@@ -494,7 +494,8 @@ namespace lfs::vis::input {
                 (version < 12 && brush_resize_shift_scroll) ||
                 (version < 13 && def.action == Action::CAMERA_SET_HOME) ||
                 (version < 14 && def.action == Action::HISTOGRAM_ZOOM_MARKED) ||
-                (version < 15 && def.action == Action::APPLY_CROP_BOX);
+                (version < 15 && def.action == Action::APPLY_CROP_BOX) ||
+                (version < 16 && def.action == Action::TOGGLE_CAMERA_FRUSTUMS);
             if (!should_add) {
                 continue;
             }
@@ -967,6 +968,7 @@ namespace lfs::vis::input {
             {KeyTrigger{KEY_V, MODIFIER_NONE}, Action::TOGGLE_SPLIT_VIEW, "Split view"},
             {KeyTrigger{KEY_V, MODIFIER_SHIFT}, Action::TOGGLE_INDEPENDENT_SPLIT_VIEW, "Independent split"},
             {KeyTrigger{KEY_G, MODIFIER_NONE}, Action::TOGGLE_GT_COMPARISON, "GT comparison"},
+            {KeyTrigger{KEY_C, MODIFIER_ALT}, Action::TOGGLE_CAMERA_FRUSTUMS, "Camera frustums"},
             {KeyTrigger{KEY_T, MODIFIER_NONE}, Action::CYCLE_PLY, "Cycle PLY"},
             // Editing (Delete is mode-specific, added below)
             {KeyTrigger{KEY_Z, MODIFIER_CTRL}, Action::UNDO, "Undo"},
@@ -1142,6 +1144,7 @@ namespace lfs::vis::input {
         case Action::TOOL_ALIGN: return "Align Tool";
         case Action::PIE_MENU: return "Pie Menu";
         case Action::HISTOGRAM_ZOOM_MARKED: return "Zoom Histogram at Cursor";
+        case Action::TOGGLE_CAMERA_FRUSTUMS: return "Toggle Camera Frustums";
         default: return "Unknown";
         }
     }
@@ -1218,6 +1221,7 @@ namespace lfs::vis::input {
         case Action::TOOL_ALIGN: return "tool_align";
         case Action::PIE_MENU: return "pie_menu";
         case Action::HISTOGRAM_ZOOM_MARKED: return "histogram_zoom_marked";
+        case Action::TOGGLE_CAMERA_FRUSTUMS: return "toggle_camera_frustums";
         default: return {};
         }
     }
@@ -1225,7 +1229,7 @@ namespace lfs::vis::input {
     std::optional<Action> actionFromName(std::string_view name) {
         static const auto table = [] {
             std::unordered_map<std::string, Action> m;
-            for (int i = 0; i <= static_cast<int>(Action::HISTOGRAM_ZOOM_MARKED); ++i) {
+            for (int i = 0; i <= static_cast<int>(Action::TOGGLE_CAMERA_FRUSTUMS); ++i) {
                 const auto action = static_cast<Action>(i);
                 const auto key = actionNameKey(action);
                 if (!key.empty())
@@ -1835,6 +1839,7 @@ namespace lfs::vis::input {
         case Action::TOGGLE_SPLIT_VIEW:
         case Action::TOGGLE_INDEPENDENT_SPLIT_VIEW:
         case Action::TOGGLE_GT_COMPARISON:
+        case Action::TOGGLE_CAMERA_FRUSTUMS:
         case Action::CYCLE_PLY:
         case Action::CYCLE_SELECTION_VIS:
             return d_view_global_key;
@@ -1967,6 +1972,7 @@ namespace lfs::vis::input {
         case Action::TOGGLE_SPLIT_VIEW:
         case Action::TOGGLE_INDEPENDENT_SPLIT_VIEW:
         case Action::TOGGLE_GT_COMPARISON:
+        case Action::TOGGLE_CAMERA_FRUSTUMS:
         case Action::CYCLE_SELECTION_VIS:
         case Action::PIE_MENU:
             return ShortcutScope::Viewport;

--- a/src/visualizer/input/input_bindings.hpp
+++ b/src/visualizer/input/input_bindings.hpp
@@ -125,6 +125,7 @@ namespace lfs::vis::input {
         DEPTH_ADJUST_NEAR, // Deprecated: migrated to DEPTH_ADJUST_FAR on load
         CAMERA_RESET_HOME,
         HISTOGRAM_ZOOM_MARKED,
+        TOGGLE_CAMERA_FRUSTUMS,
 
     };
 

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -1604,6 +1604,14 @@ namespace lfs::vis {
                 cmd::ToggleGTComparison{}.emit();
                 return;
 
+            case input::Action::TOGGLE_CAMERA_FRUSTUMS:
+                if (auto* rendering_manager = services().renderingOrNull()) {
+                    auto settings = rendering_manager->getSettings();
+                    settings.show_camera_frustums = !settings.show_camera_frustums;
+                    rendering_manager->updateSettings(settings);
+                }
+                return;
+
             case input::Action::CAMERA_NEXT_VIEW:
             case input::Action::CAMERA_PREV_VIEW: {
                 const auto* trainer = services().trainerOrNull();

--- a/tests/python/test_input_settings_panel.py
+++ b/tests/python/test_input_settings_panel.py
@@ -91,6 +91,7 @@ ACTION_NAMES = (
     "PIE_MENU",
     "DEPTH_ADJUST_NEAR",
     "HISTOGRAM_ZOOM_MARKED",
+    "TOGGLE_CAMERA_FRUSTUMS",
 )
 
 
@@ -518,4 +519,5 @@ def test_input_settings_global_mode_exposes_system_sections(input_settings_modul
     assert str(module.lf.keymap.Action.TOOL_TRANSLATE.value) in action_ids
     assert str(module.lf.keymap.Action.TOGGLE_UI.value) in action_ids
     assert str(module.lf.keymap.Action.HISTOGRAM_ZOOM_MARKED.value) in action_ids
+    assert str(module.lf.keymap.Action.TOGGLE_CAMERA_FRUSTUMS.value) in action_ids
     assert str(module.lf.keymap.Action.SEQUENCER_PLAY_PAUSE.value) in action_ids

--- a/tests/test_input_controller_focus.cpp
+++ b/tests/test_input_controller_focus.cpp
@@ -12,6 +12,7 @@
 #include "internal/viewport.hpp"
 #include "python/python_runtime.hpp"
 #include "rendering/coordinate_conventions.hpp"
+#include "rendering/rendering_manager.hpp"
 
 #include <cstdint>
 #include <cstdlib>
@@ -986,6 +987,89 @@ namespace lfs::vis {
         EXPECT_FALSE(scroll_trigger->chord_key.has_value());
         EXPECT_TRUE(input::describe(input::Action::HISTOGRAM_ZOOM_MARKED).allowed_kinds &
                     input::TRIGGER_KIND_MOUSE_SCROLL);
+    }
+
+    TEST_F(InputControllerFocusTest, CameraFrustumsDefaultToAltCAndToggleRenderSetting) {
+        RenderingManager rendering_manager;
+        services().set(&rendering_manager);
+
+        Viewport viewport(200, 200);
+        InputController controller(nullptr, viewport);
+        input::InputRouter router;
+        router.setInputController(&controller);
+        controller.setInputRouter(&router);
+        router.focusViewportKeyboard();
+
+        EXPECT_EQ(controller.getBindings().getActionForKey(input::ToolMode::GLOBAL,
+                                                           input::KEY_C,
+                                                           input::MODIFIER_ALT),
+                  input::Action::TOGGLE_CAMERA_FRUSTUMS);
+        EXPECT_EQ(input::shortcutScopeForAction(input::Action::TOGGLE_CAMERA_FRUSTUMS),
+                  input::ShortcutScope::Viewport);
+
+        EXPECT_FALSE(rendering_manager.getSettings().show_camera_frustums);
+        controller.handleKey(input::KEY_C, input::ACTION_PRESS, input::KEYMOD_ALT);
+        EXPECT_TRUE(rendering_manager.getSettings().show_camera_frustums);
+        controller.handleKey(input::KEY_C, input::ACTION_PRESS, input::KEYMOD_ALT);
+        EXPECT_FALSE(rendering_manager.getSettings().show_camera_frustums);
+    }
+
+    TEST_F(InputControllerFocusTest, VersionFifteenProfileMigratesCameraFrustumShortcutWhenFree) {
+        const auto profile_path = std::filesystem::temp_directory_path() / "lfs_input_bindings_legacy_v15.json";
+        std::filesystem::remove(profile_path);
+        {
+            std::ofstream file(profile_path);
+            ASSERT_TRUE(file.is_open());
+            file << R"({
+  "name": "LegacyV15",
+  "version": 15,
+  "bindings": []
+})";
+        }
+
+        input::InputBindings loaded;
+        ASSERT_TRUE(loaded.loadProfileFromFile(profile_path));
+        EXPECT_EQ(loaded.getActionForKey(input::ToolMode::GLOBAL,
+                                         input::KEY_C,
+                                         input::MODIFIER_ALT),
+                  input::Action::TOGGLE_CAMERA_FRUSTUMS);
+
+        std::filesystem::remove(profile_path);
+    }
+
+    TEST_F(InputControllerFocusTest, VersionFifteenProfilePreservesOccupiedAltC) {
+        const auto profile_path = std::filesystem::temp_directory_path() / "lfs_input_bindings_legacy_v15_alt_c.json";
+        std::filesystem::remove(profile_path);
+        {
+            std::ofstream file(profile_path);
+            ASSERT_TRUE(file.is_open());
+            file << R"({
+  "name": "LegacyV15AltC",
+  "version": 15,
+  "bindings": [
+    {
+      "mode": 0,
+      "action": 25,
+      "description": "Cycle PLY",
+      "trigger_type": "key",
+      "key": 67,
+      "modifiers": 4
+    }
+  ]
+})";
+        }
+
+        input::InputBindings loaded;
+        ASSERT_TRUE(loaded.loadProfileFromFile(profile_path));
+        EXPECT_EQ(loaded.getActionForKey(input::ToolMode::GLOBAL,
+                                         input::KEY_C,
+                                         input::MODIFIER_ALT),
+                  input::Action::CYCLE_PLY);
+        EXPECT_FALSE(loaded.getTriggerForAction(input::Action::TOGGLE_CAMERA_FRUSTUMS,
+                                                input::ToolMode::GLOBAL)
+                         .has_value());
+
+        std::filesystem::remove(profile_path);
     }
 
     TEST_F(InputControllerFocusTest, CropApplyDefaultsToEnterAndNumEnter) {


### PR DESCRIPTION
## Summary

This change adds a configurable shortcut for toggling dataset camera frustums. The default binding is **Alt+C**, and the action is available under the **View** section of Input Settings.

The camera-frustum master render setting is the single global source of truth. The shortcut, Rendering-panel checkbox, and top-level **Cameras** eye all operate on or reflect that same setting.

## Problem

Camera frustums are frequently toggled while training, but the scene tree was previously the only convenient place to control them. This required moving the pointer away from the viewport and expanding or locating the camera hierarchy.

An initial shortcut implementation exposed an important state mismatch: toggling the render setting hid the frustums without updating the scene-tree eye, while toggling ordinary scene-node visibility could not re-enable frustums when the master setting remained disabled.

## Behavior

- **Alt+C** toggles all camera-frustum rendering.
- The binding is configurable in **Input Settings > Global > View**.
- The top-level **Cameras** eye reflects the master camera-frustum setting:
  - Green when camera-frustum rendering is enabled.
  - Red when camera-frustum rendering is disabled.
- Clicking the top-level Cameras eye toggles the same master setting.
- The Rendering-panel **Camera Frustums** checkbox remains synchronized with the shortcut and Cameras eye.
- Training, Validation, and individual camera eyes continue to control their local scene-node visibility independently.

### Render-on-demand synchronization

The Scene panel uses render-on-demand caching. Its synchronization stamp now includes `render_settings_generation`, ensuring changes from the Rendering checkbox or `Alt+C` wake the cached panel and repaint the Cameras eye immediately.

