### PR TITLE
Keep Set Pivot Available Across Editing Tools

### DIFF
--- a/src/visualizer/input/input_bindings.cpp
+++ b/src/visualizer/input/input_bindings.cpp
@@ -665,41 +665,46 @@ namespace lfs::vis::input {
 
     Action InputBindings::getActionForMouseButton(ToolMode mode, MouseButton button, int modifiers, bool is_double_click) const {
         const int mods = modifiers & MODIFIER_MASK;
-        const auto find_in_mode = [&](ToolMode query_mode) -> Action {
-            if (auto it = mouse_button_map_.find({query_mode, button, mods, is_double_click}); it != mouse_button_map_.end()) {
+        const auto find_in_mode = [&](ToolMode query_mode, const bool double_click) -> Action {
+            if (auto it = mouse_button_map_.find({query_mode, button, mods, double_click}); it != mouse_button_map_.end()) {
                 return it->second;
             }
             if (mods != MODIFIER_NONE) {
-                if (auto it = mouse_button_map_.find({query_mode, button, MODIFIER_NONE, is_double_click});
+                if (auto it = mouse_button_map_.find({query_mode, button, MODIFIER_NONE, double_click});
                     it != mouse_button_map_.end() &&
                     describe(it->second).allows_extra_modifiers) {
                     return it->second;
                 }
             }
-            // If double-click, also try a single-click binding in the same mode.
-            if (is_double_click) {
-                if (auto it = mouse_button_map_.find({query_mode, button, mods, false}); it != mouse_button_map_.end()) {
-                    return it->second;
-                }
-                if (mods != MODIFIER_NONE) {
-                    if (auto it = mouse_button_map_.find({query_mode, button, MODIFIER_NONE, false});
-                        it != mouse_button_map_.end() &&
-                        describe(it->second).allows_extra_modifiers) {
-                        return it->second;
-                    }
-                }
-            }
             return Action::NONE;
         };
 
-        if (const auto local_action = find_in_mode(mode); local_action != Action::NONE) {
+        if (const auto local_action = find_in_mode(mode, is_double_click); local_action != Action::NONE) {
             return local_action;
         }
         if (mode != ToolMode::GLOBAL) {
-            const auto global_action = find_in_mode(ToolMode::GLOBAL);
+            const auto global_action = find_in_mode(ToolMode::GLOBAL, is_double_click);
             if (global_action != Action::NONE &&
                 describe(global_action).inherits_from_global) {
                 return global_action;
+            }
+        }
+
+        // A double-click is its own gesture. Only fall back to single-click
+        // bindings after exact local and inherited global double-click bindings
+        // have both been considered. This keeps global viewport gestures such as
+        // Set Pivot available in every tool mode, even when that mode binds the
+        // same button to a single-click action.
+        if (is_double_click) {
+            if (const auto local_action = find_in_mode(mode, false); local_action != Action::NONE) {
+                return local_action;
+            }
+            if (mode != ToolMode::GLOBAL) {
+                const auto global_action = find_in_mode(ToolMode::GLOBAL, false);
+                if (global_action != Action::NONE &&
+                    describe(global_action).inherits_from_global) {
+                    return global_action;
+                }
             }
         }
         return Action::NONE;

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -760,8 +760,11 @@ namespace lfs::vis {
                 return;
             }
 
-            // Block if a transform gizmo is being used or hovered
-            if (over_transform_gizmo) {
+            // Pivot placement is a viewport-global double-click gesture and must
+            // remain available when an editing gizmo is merely hovered. Active
+            // gizmo manipulation still owns the pointer until the drag finishes.
+            if (isTransformGizmoUsing() ||
+                (over_transform_gizmo && bound_action != input::Action::CAMERA_SET_PIVOT)) {
                 return;
             }
 

--- a/tests/test_input_controller_focus.cpp
+++ b/tests/test_input_controller_focus.cpp
@@ -302,6 +302,41 @@ namespace lfs::vis {
                   input::Action::CAMERA_PAN);
     }
 
+    TEST_F(InputControllerFocusTest, GlobalSetPivotDoubleClickWorksInEveryToolMode) {
+        input::InputBindings bindings;
+
+        for (const auto mode : input::kAllToolModes) {
+            EXPECT_EQ(bindings.getActionForMouseButton(
+                          mode, input::MouseButton::RIGHT, input::MODIFIER_NONE, true),
+                      input::Action::CAMERA_SET_PIVOT)
+                << "tool mode " << static_cast<int>(mode);
+        }
+
+        // Selection deliberately owns an ordinary right-click for polygon undo;
+        // that single-click action must not shadow the global double-click.
+        EXPECT_EQ(bindings.getActionForMouseButton(
+                      input::ToolMode::SELECTION,
+                      input::MouseButton::RIGHT,
+                      input::MODIFIER_NONE,
+                      false),
+                  input::Action::UNDO_POLYGON_VERTEX);
+    }
+
+    TEST_F(InputControllerFocusTest, LocalDoubleClickOverridesGlobalSetPivot) {
+        input::InputBindings bindings;
+        bindings.setBinding(
+            input::ToolMode::SELECTION,
+            input::Action::CAMERA_ORBIT,
+            input::MouseButtonTrigger{input::MouseButton::RIGHT, input::MODIFIER_NONE, true});
+
+        EXPECT_EQ(bindings.getActionForMouseButton(
+                      input::ToolMode::SELECTION,
+                      input::MouseButton::RIGHT,
+                      input::MODIFIER_NONE,
+                      true),
+                  input::Action::CAMERA_ORBIT);
+    }
+
     TEST_F(InputControllerFocusTest, BindingConflictChecksInheritedGlobalBindings) {
         input::InputBindings bindings;
         const input::MouseDragTrigger right_drag{


### PR DESCRIPTION
## Summary

When editing splats, good navigation is important to move smoothly around the splat so that angles and viewpoints can be set easily for proper editing.
Currently, the right mouse double click for setting the pivot point is not always available. 

This change keeps the camera **Set Pivot** gesture available regardless of which editing tool is selected.

Right-button double-click already set the camera orbit pivot in the normal viewport. In editing modes, however, a tool-local single-click binding could take precedence over the inherited global double-click binding. Selection mode was the clearest example: its right-click action for undoing a polygon vertex shadowed the global Set Pivot gesture.

## Root Cause

Mouse-button bindings were resolved one tool mode at a time. During a double-click lookup, resolution checked both the tool-local double-click and its single-click fallback before checking inherited global bindings.

The effective priority was:

1. Tool-local double-click
2. Tool-local single-click fallback
3. Global double-click
4. Global single-click fallback

As a result, any tool-local single-click on the same mouse button could prevent an exact global double-click gesture from being reached.

Transform gizmo hover state also blocked all viewport mouse actions, including Set Pivot, even when the gizmo was not actively being manipulated.

## Changes

Mouse-button binding resolution now treats double-click as a distinct gesture and uses this priority:

1. Tool-local double-click
2. Inherited global double-click
3. Tool-local single-click fallback
4. Inherited global single-click fallback

This preserves explicit tool-local double-click overrides while ensuring that a tool-local single-click cannot shadow the global Set Pivot double-click.

Set Pivot is also allowed while a transform gizmo is merely hovered. Active gizmo manipulation continues to own the pointer, preventing an accidental pivot change during a drag.

Existing single-click behavior is unchanged. For example, an ordinary right-click in Selection mode still performs the polygon undo action.

