### PR TITLE
Window Resize Behavior

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -5538,6 +5538,13 @@ namespace lfs::vis::gui {
             const auto* mvp = ImGui::GetMainViewport();
             const float status_bar_h = PanelLayoutManager::STATUS_BAR_HEIGHT * current_ui_scale_;
             const float panel_h = mvp->WorkSize.y - status_bar_h;
+            panel_layout_.enforceWidthConstraints(show_main_panel_, ui_hidden_,
+                                                  {
+                                                      .work_pos = {mvp->WorkPos.x, mvp->WorkPos.y},
+                                                      .work_size = {mvp->WorkSize.x, mvp->WorkSize.y},
+                                                      .any_item_active = ImGui::IsAnyItemActive() ||
+                                                                         rmlui_manager_.anyItemActive(),
+                                                  });
 
             ShellRegions shell_regions;
             shell_regions.screen = {mvp->Pos.x, mvp->Pos.y, mvp->Size.x, mvp->Size.y};
@@ -5651,6 +5658,7 @@ namespace lfs::vis::gui {
             screen.work_size = {mvp_input->WorkSize.x, mvp_input->WorkSize.y};
             screen.any_item_active = ImGui::IsAnyItemActive() || rmlui_manager_.anyItemActive();
         }
+        panel_layout_.enforceWidthConstraints(show_main_panel_, ui_hidden_, screen);
 
         constexpr uint8_t kUiLayoutSettleFrames = 3;
         const bool python_console_visible = window_states_["python_console"];

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -63,6 +63,7 @@
 #include "tools/selection_tool.hpp"
 #include "training/trainer.hpp"
 #include "training/training_manager.hpp"
+#include "window/window_manager.hpp"
 #include "visualizer/app_store.hpp"
 #include "visualizer/scene_coordinate_utils.hpp"
 #include "visualizer_impl.hpp"
@@ -6268,14 +6269,22 @@ namespace lfs::vis::gui {
             LOG_TIMER_THRESHOLD("gui_render.rml_modal_processInput", 0.25);
             rml_modal_overlay_->processInput(raw_panel_input);
         }
-        if (ImGui::GetMouseCursor() == ImGuiMouseCursor_Arrow)
-            applyRmlCursorRequest(rmlui_manager_.consumeCursorRequest());
-        apply_cursor(rml_right_panel_.getCursorRequest());
-        apply_cursor(panel_layout_.getCursorRequest());
-        if (SDL_Cursor* const cursor = systemCursorForImGuiCursor(ImGui::GetMouseCursor()))
-            SDL_SetCursor(cursor);
-        if (auto* input_controller = viewer_->getInputController())
-            input_controller->applySplitterCursorOverride();
+        const bool window_resize_active =
+            viewer_ &&
+            viewer_->getWindowManager() &&
+            viewer_->getWindowManager()->manualResizeEdgeMask() != 0;
+        if (!window_resize_active) {
+            if (ImGui::GetMouseCursor() == ImGuiMouseCursor_Arrow)
+                applyRmlCursorRequest(rmlui_manager_.consumeCursorRequest());
+            apply_cursor(rml_right_panel_.getCursorRequest());
+            apply_cursor(panel_layout_.getCursorRequest());
+            if (SDL_Cursor* const cursor = systemCursorForImGuiCursor(ImGui::GetMouseCursor()))
+                SDL_SetCursor(cursor);
+            if (auto* input_controller = viewer_->getInputController())
+                input_controller->applySplitterCursorOverride();
+        } else if (auto* const wm = viewer_->getWindowManager()) {
+            wm->refreshResizeCursor();
+        }
         syncWindowTextInput(viewer_->getWindow());
 
         if (vulkan_gui_) {

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -5226,6 +5226,13 @@ namespace lfs::vis::gui {
     bool GuiManager::shouldUseCachedImGuiResizeFrame(
         const WindowManager* const window_manager,
         const VulkanContext* const vulkan_context) const {
+#if defined(__linux__)
+        // The cached platform frame is a Windows manual-resize optimization. On
+        // X11, SDL's live platform frame keeps ImGui in sync with exposed pixels.
+        (void)window_manager;
+        (void)vulkan_context;
+        return false;
+#else
         if (!window_manager || !vulkan_context) {
             return false;
         }
@@ -5238,6 +5245,7 @@ namespace lfs::vis::gui {
         return active_window_resize &&
                window_size.x > 0 && window_size.y > 0 &&
                framebuffer_size.x > 0 && framebuffer_size.y > 0;
+#endif
     }
 
     void GuiManager::beginImGuiPlatformFrame(WindowManager* const window_manager,

--- a/src/visualizer/gui/panel_layout.cpp
+++ b/src/visualizer/gui/panel_layout.cpp
@@ -11,6 +11,27 @@
 #include <algorithm>
 
 namespace lfs::vis::gui {
+    namespace {
+        void drawLeftDockResizeIndicator(const PanelInputState& input,
+                                         const float edge_x,
+                                         const float top_y,
+                                         const float bottom_y,
+                                         const float dpi,
+                                         const bool active) {
+            auto* draw_list = static_cast<ImDrawList*>(input.fg_draw_list ? input.fg_draw_list : input.bg_draw_list);
+            if (!draw_list || bottom_y <= top_y)
+                return;
+
+            ImVec4 color = lfs::vis::theme().palette.info;
+            color.w = active ? 0.50f : 0.30f;
+
+            const float thickness = std::max(active ? 3.0f : 2.0f, (active ? 3.0f : 2.0f) * dpi);
+            const float half_thickness = thickness * 0.5f;
+            draw_list->AddRectFilled(ImVec2(edge_x - half_thickness, top_y),
+                                     ImVec2(edge_x + half_thickness, bottom_y),
+                                     ImGui::ColorConvertFloat4ToU32(color));
+        }
+    } // namespace
 
     PanelLayoutManager::PanelLayoutManager() = default;
 
@@ -85,8 +106,8 @@ namespace lfs::vis::gui {
         const float dpi = lfs::python::get_shared_dpi_scale();
         const float panel_h = screen.work_size.y - STATUS_BAR_HEIGHT * dpi;
         const float bottom_dock_h = computeBottomDockReservedHeight(show_main_panel, ui_hidden, screen);
-        const float min_w = screen.work_size.x * RIGHT_PANEL_MIN_RATIO;
-        const float max_w = screen.work_size.x * RIGHT_PANEL_MAX_RATIO;
+        const float max_w = maxRightPanelWidth(show_main_panel, ui_hidden, screen);
+        const float min_w = std::min(RIGHT_PANEL_MIN_VISIBLE_WIDTH * dpi, max_w);
 
         right_panel_width_ = std::clamp(right_panel_width_, min_w, max_w);
 
@@ -277,8 +298,8 @@ namespace lfs::vis::gui {
         const float dpi = lfs::python::get_shared_dpi_scale();
         const float panel_h = screen.work_size.y - STATUS_BAR_HEIGHT * dpi;
         const float bottom_dock_h = computeBottomDockReservedHeight(show_main_panel, ui_hidden, screen);
-        const float min_w = screen.work_size.x * RIGHT_PANEL_MIN_RATIO;
-        const float max_w = screen.work_size.x * RIGHT_PANEL_MAX_RATIO;
+        const float max_w = maxRightPanelWidth(show_main_panel, ui_hidden, screen);
+        const float min_w = std::min(RIGHT_PANEL_MIN_VISIBLE_WIDTH * dpi, max_w);
 
         right_panel_width_ = std::clamp(right_panel_width_, min_w, max_w);
 
@@ -556,7 +577,7 @@ namespace lfs::vis::gui {
         const float icon_bar_w = ICON_BAR_WIDTH * dpi;
         const float status_bar_h = STATUS_BAR_HEIGHT * dpi;
         const float panel_h = screen.work_size.y - status_bar_h;
-        const float max_panel_w = std::max(0.0f, screen.work_size.x - icon_bar_w);
+        const float max_panel_w = maxLeftDockPanelWidth(show_main_panel, ui_hidden, screen);
 
         if (max_panel_w <= 0.0f) {
             left_dock_hovering_edge_ = false;
@@ -645,6 +666,15 @@ namespace lfs::vis::gui {
                                    draw_ctx,
                                    &dock_input);
         }
+
+        if (left_dock_hovering_edge_ || left_dock_resizing_) {
+            drawLeftDockResizeIndicator(input,
+                                        panel_right_x,
+                                        screen.work_pos.y,
+                                        screen.work_pos.y + panel_h,
+                                        dpi,
+                                        left_dock_resizing_);
+        }
     }
 
     void PanelLayoutManager::renderLeftDockCached(const PanelDrawContext& draw_ctx,
@@ -668,7 +698,7 @@ namespace lfs::vis::gui {
         const float icon_bar_w = ICON_BAR_WIDTH * dpi;
         const float status_bar_h = STATUS_BAR_HEIGHT * dpi;
         const float panel_h = screen.work_size.y - status_bar_h;
-        const float max_panel_w = std::max(0.0f, screen.work_size.x - icon_bar_w);
+        const float max_panel_w = maxLeftDockPanelWidth(show_main_panel, ui_hidden, screen);
 
         if (max_panel_w <= 0.0f) {
             left_dock_hovering_edge_ = false;
@@ -709,9 +739,88 @@ namespace lfs::vis::gui {
     }
 
     void PanelLayoutManager::applyResizeDelta(float dx, const ScreenState& screen) {
-        const float min_w = screen.work_size.x * RIGHT_PANEL_MIN_RATIO;
-        const float max_w = screen.work_size.x * RIGHT_PANEL_MAX_RATIO;
+        const float max_w = maxRightPanelWidth(true, false, screen);
+        const float min_w = std::min(RIGHT_PANEL_MIN_VISIBLE_WIDTH * lfs::python::get_shared_dpi_scale(), max_w);
         right_panel_width_ = std::clamp(right_panel_width_ - dx, min_w, max_w);
+    }
+
+    float PanelLayoutManager::maxRightPanelWidth(const bool show_main_panel,
+                                                 const bool ui_hidden,
+                                                 const ScreenState& screen) const {
+        if (!(show_main_panel && !ui_hidden))
+            return screen.work_size.x;
+
+        const float dpi = lfs::python::get_shared_dpi_scale();
+        const float icon_bar_w = ICON_BAR_WIDTH * dpi;
+        const float viewport_min_w = MIN_VIEWPORT_WIDTH * dpi;
+        const float right_min_w = RIGHT_PANEL_MIN_VISIBLE_WIDTH * dpi;
+        const float panel_budget = std::max(0.0f, screen.work_size.x - icon_bar_w - viewport_min_w - PANEL_GAP);
+        const float left_w = left_dock_visible_
+                                 ? std::min(std::max(0.0f, left_dock_width_),
+                                            std::max(0.0f, panel_budget - right_min_w))
+                                 : 0.0f;
+        const float reserved_w = icon_bar_w + left_w + viewport_min_w + PANEL_GAP;
+        const float effective_min_w = std::min(right_min_w, panel_budget);
+        return std::max(effective_min_w,
+                        std::min(screen.work_size.x * RIGHT_PANEL_MAX_RATIO,
+                                 screen.work_size.x - reserved_w));
+    }
+
+    float PanelLayoutManager::maxLeftDockPanelWidth(const bool show_main_panel,
+                                                    const bool ui_hidden,
+                                                    const ScreenState& screen) const {
+        if (!(show_main_panel && !ui_hidden))
+            return 0.0f;
+
+        const float dpi = lfs::python::get_shared_dpi_scale();
+        const float icon_bar_w = ICON_BAR_WIDTH * dpi;
+        const float viewport_min_w = MIN_VIEWPORT_WIDTH * dpi;
+        const float panel_budget = std::max(0.0f, screen.work_size.x - icon_bar_w - viewport_min_w - PANEL_GAP);
+        const float right_min_w = std::min(RIGHT_PANEL_MIN_VISIBLE_WIDTH * dpi, panel_budget);
+        const float right_w = std::clamp(right_panel_width_,
+                                         right_min_w,
+                                         std::max(right_min_w, panel_budget));
+        return std::max(0.0f, panel_budget - right_w);
+    }
+
+    void PanelLayoutManager::enforceWidthConstraints(const bool show_main_panel,
+                                                     const bool ui_hidden,
+                                                     const ScreenState& screen) {
+        if (!(show_main_panel && !ui_hidden) || screen.work_size.x <= 0.0f)
+            return;
+
+        const float dpi = lfs::python::get_shared_dpi_scale();
+        const float icon_bar_w = ICON_BAR_WIDTH * dpi;
+        const float viewport_min_w = MIN_VIEWPORT_WIDTH * dpi;
+        const float panel_budget = std::max(0.0f, screen.work_size.x - icon_bar_w - viewport_min_w - PANEL_GAP);
+        const float right_min_w = std::min(RIGHT_PANEL_MIN_VISIBLE_WIDTH * dpi, panel_budget);
+        const float right_pref_w = std::max(right_panel_width_, right_min_w);
+
+        if (left_dock_visible_) {
+            const float left_pref_w = std::max(0.0f, left_dock_width_);
+            const float left_soft_min_w = std::min(LEFT_DOCK_MIN_VISIBLE_WIDTH * dpi,
+                                                   std::max(0.0f, panel_budget - right_min_w));
+            float left_max_w = std::max(0.0f, panel_budget - right_min_w);
+            if (right_pref_w + left_pref_w <= panel_budget) {
+                left_dock_width_ = left_pref_w;
+                right_panel_width_ = right_pref_w;
+            } else {
+                left_dock_width_ = std::clamp(left_pref_w, 0.0f, left_max_w);
+                if (left_dock_width_ < left_soft_min_w &&
+                    panel_budget - left_soft_min_w >= right_min_w) {
+                    left_dock_width_ = left_soft_min_w;
+                }
+                right_panel_width_ = std::clamp(right_pref_w,
+                                                right_min_w,
+                                                std::max(right_min_w, panel_budget - left_dock_width_));
+                left_max_w = std::max(0.0f, panel_budget - right_panel_width_);
+                left_dock_width_ = std::min(left_dock_width_, left_max_w);
+            }
+        } else {
+            right_panel_width_ = std::clamp(right_pref_w,
+                                            right_min_w,
+                                            std::max(right_min_w, panel_budget));
+        }
     }
 
     float PanelLayoutManager::computeViewportWidth(const bool show_main_panel,
@@ -774,7 +883,7 @@ namespace lfs::vis::gui {
         if (!left_dock_visible_)
             return icon_bar_w;
 
-        const float max_panel_w = std::max(0.0f, screen.work_size.x - icon_bar_w);
+        const float max_panel_w = maxLeftDockPanelWidth(show_main_panel, ui_hidden, screen);
         if (max_panel_w <= 0.0f)
             return icon_bar_w;
 

--- a/src/visualizer/gui/panel_layout.cpp
+++ b/src/visualizer/gui/panel_layout.cpp
@@ -755,7 +755,7 @@ namespace lfs::vis::gui {
         const float viewport_min_w = MIN_VIEWPORT_WIDTH * dpi;
         const float right_min_w = RIGHT_PANEL_MIN_VISIBLE_WIDTH * dpi;
         const float panel_budget = std::max(0.0f, screen.work_size.x - icon_bar_w - viewport_min_w - PANEL_GAP);
-        const float left_w = left_dock_visible_
+        const float left_w = shouldReserveLeftDockWidth()
                                  ? std::min(std::max(0.0f, left_dock_width_),
                                             std::max(0.0f, panel_budget - right_min_w))
                                  : 0.0f;
@@ -796,7 +796,7 @@ namespace lfs::vis::gui {
         const float right_min_w = std::min(RIGHT_PANEL_MIN_VISIBLE_WIDTH * dpi, panel_budget);
         const float right_pref_w = std::max(right_panel_width_, right_min_w);
 
-        if (left_dock_visible_) {
+        if (shouldReserveLeftDockWidth()) {
             const float left_pref_w = std::max(0.0f, left_dock_width_);
             const float left_soft_min_w = std::min(LEFT_DOCK_MIN_VISIBLE_WIDTH * dpi,
                                                    std::max(0.0f, panel_budget - right_min_w));
@@ -821,6 +821,10 @@ namespace lfs::vis::gui {
                                             right_min_w,
                                             std::max(right_min_w, panel_budget));
         }
+    }
+
+    bool PanelLayoutManager::shouldReserveLeftDockWidth() const {
+        return PanelRegistry::instance().has_panels(PanelSpace::LeftDock);
     }
 
     float PanelLayoutManager::computeViewportWidth(const bool show_main_panel,

--- a/src/visualizer/gui/panel_layout.hpp
+++ b/src/visualizer/gui/panel_layout.hpp
@@ -114,6 +114,8 @@ namespace lfs::vis::gui {
         CursorRequest getCursorRequest() const { return cursor_request_; }
 
         void applyResizeDelta(float dx, const ScreenState& screen);
+        void enforceWidthConstraints(bool show_main_panel, bool ui_hidden,
+                                     const ScreenState& screen);
 
         float getRightPanelWidth() const { return right_panel_width_; }
         float getScenePanelRatio() const { return scene_panel_ratio_; }
@@ -151,6 +153,10 @@ namespace lfs::vis::gui {
                                               const ScreenState& screen) const;
         float computeLeftDockReservedWidth(bool show_main_panel, bool ui_hidden,
                                            const ScreenState& screen) const;
+        [[nodiscard]] float maxLeftDockPanelWidth(bool show_main_panel, bool ui_hidden,
+                                                  const ScreenState& screen) const;
+        [[nodiscard]] float maxRightPanelWidth(bool show_main_panel, bool ui_hidden,
+                                               const ScreenState& screen) const;
 
         float right_panel_width_ = 340.0f;
         float scene_panel_ratio_ = 0.4f;
@@ -182,13 +188,16 @@ namespace lfs::vis::gui {
 
         static constexpr float RIGHT_PANEL_MIN_RATIO = 0.01f;
         static constexpr float RIGHT_PANEL_MAX_RATIO = 0.99f;
+        static constexpr float RIGHT_PANEL_MIN_VISIBLE_WIDTH = 260.0f;
         static constexpr float PYTHON_CONSOLE_MIN_WIDTH = 200.0f;
         static constexpr float PYTHON_CONSOLE_MAX_RATIO = 0.5f;
         static constexpr float BOTTOM_DOCK_MIN_HEIGHT = 180.0f;
         static constexpr float BOTTOM_DOCK_DEFAULT_HEIGHT = 440.0f;
         static constexpr float BOTTOM_DOCK_MAX_RATIO = 0.65f;
         static constexpr float MIN_VIEWPORT_HEIGHT = 140.0f;
+        static constexpr float MIN_VIEWPORT_WIDTH = 180.0f;
         static constexpr float LEFT_DOCK_MIN_WIDTH = 180.0f;
+        static constexpr float LEFT_DOCK_MIN_VISIBLE_WIDTH = 220.0f;
         static constexpr float LEFT_DOCK_DEFAULT_WIDTH = 320.0f;
         static constexpr float ICON_BAR_WIDTH = 40.0f;
     };

--- a/src/visualizer/gui/panel_layout.hpp
+++ b/src/visualizer/gui/panel_layout.hpp
@@ -153,6 +153,7 @@ namespace lfs::vis::gui {
                                               const ScreenState& screen) const;
         float computeLeftDockReservedWidth(bool show_main_panel, bool ui_hidden,
                                            const ScreenState& screen) const;
+        [[nodiscard]] bool shouldReserveLeftDockWidth() const;
         [[nodiscard]] float maxLeftDockPanelWidth(bool show_main_panel, bool ui_hidden,
                                                   const ScreenState& screen) const;
         [[nodiscard]] float maxRightPanelWidth(bool show_main_panel, bool ui_hidden,

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -54,6 +54,9 @@ namespace lfs::vis {
         }
 
         constexpr double kResizeSettleMinWaitSeconds = 0.001;
+#if defined(__linux__)
+        constexpr auto kWindowResizePaintDemandWindow = std::chrono::milliseconds(160);
+#endif
 
         std::optional<glm::mat3> buildValidatedViewRotation(const glm::vec3& eye,
                                                             const glm::vec3& target,
@@ -1243,6 +1246,12 @@ namespace lfs::vis {
             demand.swapchain_resize_ready = demand.swapchain_resize_pending &&
                                             vulkan_context->pendingSwapchainResizeReady();
         }
+#if defined(__linux__)
+        if (window_manager_) {
+            demand.window_resize_paint_pending =
+                window_manager_->hasRecentWindowSizeChange(kWindowResizePaintDemandWindow);
+        }
+#endif
         demand.viewport_resize_deferring = rendering_manager_ &&
                                            rendering_manager_->isViewportResizeDeferring();
         demand.viewport_resize_settle_ready = rendering_manager_ &&
@@ -1363,7 +1372,7 @@ namespace lfs::vis {
         const bool is_training = trainer_manager_ && trainer_manager_->isRunning();
         const FrameDemand frame_demand = collectFrameDemand(viewport_export_locked, store_dirty);
         if (gui_frame_rendered_ && !frame_demand.shouldRenderFrame()) {
-            LOG_PERF("loop_idle skip_gui_render=true needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} viewport_resize_deferring={} viewport_resize_settle_ready={}",
+            LOG_PERF("loop_idle skip_gui_render=true needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} window_resize_paint_pending={} viewport_resize_deferring={} viewport_resize_settle_ready={}",
                      frame_demand.scene_dirty,
                      frame_demand.continuous_input,
                      frame_demand.python_animation,
@@ -1376,6 +1385,7 @@ namespace lfs::vis {
                      frame_demand.store_dirty,
                      frame_demand.swapchain_resize_pending,
                      frame_demand.swapchain_resize_ready,
+                     frame_demand.window_resize_paint_pending,
                      frame_demand.viewport_resize_deferring,
                      frame_demand.viewport_resize_settle_ready);
             python::flush_signals();
@@ -1455,7 +1465,7 @@ namespace lfs::vis {
         // Render-on-demand: VSync handles frame pacing, waitEvents saves CPU when idle
         const FrameDemand next_demand = collectFrameDemand(viewport_export_locked);
 
-        LOG_PERF("loop_end needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} viewport_resize_deferring={} viewport_resize_settle_ready={}",
+        LOG_PERF("loop_end needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} window_resize_paint_pending={} viewport_resize_deferring={} viewport_resize_settle_ready={}",
                  next_demand.scene_dirty,
                  next_demand.continuous_input,
                  next_demand.python_animation,
@@ -1468,6 +1478,7 @@ namespace lfs::vis {
                  next_demand.store_dirty,
                  next_demand.swapchain_resize_pending,
                  next_demand.swapchain_resize_ready,
+                 next_demand.window_resize_paint_pending,
                  next_demand.viewport_resize_deferring,
                  next_demand.viewport_resize_settle_ready);
 

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -1443,6 +1443,7 @@ namespace lfs::vis {
             LOG_TIMER("VisualizerImpl::render.gui_frame_total_with_swapchain_wait");
             window_manager_->updateWindowSize("pre_gui_render");
             gui_manager_->render();
+            window_manager_->refreshResizeCursor();
         } else {
             processRenderWorkQueue();
         }

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -190,6 +190,7 @@ namespace lfs::vis {
             bool store_dirty = false;
             bool swapchain_resize_pending = false;
             bool swapchain_resize_ready = false;
+            bool window_resize_paint_pending = false;
             bool viewport_resize_deferring = false;
             bool viewport_resize_settle_ready = false;
 
@@ -197,7 +198,8 @@ namespace lfs::vis {
                 return viewport_export_locked || scene_dirty || continuous_input ||
                        python_animation || python_overlay || python_redraw ||
                        gui_animation || input_event || posted_work || render_work ||
-                       store_dirty || swapchain_resize_ready || viewport_resize_settle_ready;
+                       store_dirty || swapchain_resize_ready || window_resize_paint_pending ||
+                       viewport_resize_settle_ready;
             }
 
             [[nodiscard]] bool needsContinuousLoop() const {
@@ -208,7 +210,8 @@ namespace lfs::vis {
                        python_overlay || python_redraw ||
                        (gui_animation && !resize_deferral_throttles_animation) ||
                        render_work || viewport_export_locked || store_dirty ||
-                       swapchain_resize_ready || viewport_resize_settle_ready;
+                       swapchain_resize_ready || window_resize_paint_pending ||
+                       viewport_resize_settle_ready;
             }
         };
 

--- a/src/visualizer/window/vulkan_context.cpp
+++ b/src/visualizer/window/vulkan_context.cpp
@@ -43,11 +43,21 @@ namespace lfs::vis {
             VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
 #endif
         constexpr std::uint64_t kExternalTimelineWaitTimeoutNs = 2'000'000'000ull;
-        // Window-resize events can arrive every mouse delta. Shrinks can wait
-        // for a quiet period because no new pixels are exposed. Growth needs
-        // periodic swapchain updates so the newly exposed area paints during
-        // the drag, but vkCreateSwapchainKHR is expensive enough that doing it
-        // for every tiny delta makes the resize stutter.
+#if defined(__linux__)
+        constexpr bool kPromoteExposedResizeGrowthImmediately = true;
+        constexpr bool kUseResizeHeadroom = false;
+        constexpr bool kRecreateExactAfterInteractiveResize = true;
+        constexpr bool kRecreateExactAfterResizeHeadroom = false;
+#else
+        constexpr bool kPromoteExposedResizeGrowthImmediately = false;
+        constexpr bool kUseResizeHeadroom = true;
+        constexpr bool kRecreateExactAfterInteractiveResize = false;
+        constexpr bool kRecreateExactAfterResizeHeadroom = true;
+#endif
+        // Shrinks can settle because no new pixels are exposed. Windows manual
+        // borderless resize tolerates padded, throttled grow recreates. X11
+        // exposes grown client pixels immediately and must return to exact
+        // swapchain extents after shrink/restore to avoid compositor scaling blur.
         constexpr auto kSwapchainResizeQuietDelay = std::chrono::milliseconds(33);
         constexpr auto kSwapchainResizeGrowInterval = std::chrono::milliseconds(33);
         constexpr auto kSwapchainResizeGrowQuietDelay = std::chrono::milliseconds(48);
@@ -548,7 +558,7 @@ namespace lfs::vis {
     bool VulkanContext::pendingSwapchainResizeReady() const {
         const auto now = std::chrono::steady_clock::now();
         if (!framebuffer_resize_deferred_) {
-            if (!framebuffer_resize_exact_after_headroom_) {
+            if (!framebuffer_resize_exact_after_interactive_) {
                 return true;
             }
             return now - framebuffer_resize_last_change_ >= kSwapchainResizeQuietDelay;
@@ -563,6 +573,9 @@ namespace lfs::vis {
                                                    swapchain_extent_);
         if (grow_delta <= 0) {
             return now - framebuffer_resize_last_change_ >= kSwapchainResizeQuietDelay;
+        }
+        if (kPromoteExposedResizeGrowthImmediately) {
+            return true;
         }
 
         if (framebuffer_resize_last_recreate_ == std::chrono::steady_clock::time_point{}) {
@@ -580,7 +593,7 @@ namespace lfs::vis {
     double VulkanContext::secondsUntilPendingSwapchainResizeReady() const {
         const auto now = std::chrono::steady_clock::now();
         if (!framebuffer_resize_deferred_) {
-            if (!framebuffer_resize_exact_after_headroom_) {
+            if (!framebuffer_resize_exact_after_interactive_) {
                 return 0.0;
             }
             const auto since_last_change = now - framebuffer_resize_last_change_;
@@ -606,6 +619,9 @@ namespace lfs::vis {
             }
             const auto until_quiet = kSwapchainResizeQuietDelay - since_last_change;
             return std::chrono::duration<double>(until_quiet).count();
+        }
+        if (kPromoteExposedResizeGrowthImmediately) {
+            return 0.0;
         }
 
         if (framebuffer_resize_last_recreate_ == std::chrono::steady_clock::time_point{}) {
@@ -643,7 +659,11 @@ namespace lfs::vis {
 
         if (!pendingSwapchainResizeReady()) {
             last_error_.clear();
+#if defined(__linux__)
+            return framebufferFitsSwapchainExtent();
+#else
             return false;
+#endif
         }
 
         const bool requires_recreate = framebuffer_resize_requires_recreate_;
@@ -670,17 +690,20 @@ namespace lfs::vis {
         }
         framebuffer_width_ = width;
         framebuffer_height_ = height;
-        framebuffer_resize_allow_headroom_ = !exact_resize;
+        framebuffer_resize_allow_headroom_ = !exact_resize && kUseResizeHeadroom;
         if (width <= 0 || height <= 0) {
             framebuffer_resize_deferred_ = false;
             framebuffer_resize_requires_recreate_ = false;
             framebuffer_resize_allow_headroom_ = false;
-            framebuffer_resize_exact_after_headroom_ = false;
+            framebuffer_resize_exact_after_interactive_ = false;
             framebuffer_resized_ = true;
             return;
         }
 
-        framebuffer_resize_exact_after_headroom_ = !exact_resize;
+        framebuffer_resize_exact_after_interactive_ =
+            !exact_resize &&
+            (kRecreateExactAfterInteractiveResize ||
+             (framebuffer_resize_allow_headroom_ && kRecreateExactAfterResizeHeadroom));
         const bool requires_recreate =
             framebufferResizeRequiresSwapchainRecreate() || exact_extent_mismatch;
         if (requires_recreate) {
@@ -715,15 +738,15 @@ namespace lfs::vis {
             return false;
         }
 
-        if (framebuffer_resize_exact_after_headroom_ && !framebuffer_resize_deferred_) {
+        if (framebuffer_resize_exact_after_interactive_ && !framebuffer_resize_deferred_) {
             const bool extent_matches_framebuffer =
                 swapchain_ != VK_NULL_HANDLE &&
                 static_cast<std::uint32_t>(framebuffer_width_) == swapchain_extent_.width &&
                 static_cast<std::uint32_t>(framebuffer_height_) == swapchain_extent_.height;
             if (extent_matches_framebuffer) {
-                framebuffer_resize_exact_after_headroom_ = false;
+                framebuffer_resize_exact_after_interactive_ = false;
             } else if (pendingSwapchainResizeReady()) {
-                framebuffer_resize_exact_after_headroom_ = false;
+                framebuffer_resize_exact_after_interactive_ = false;
                 framebuffer_resize_allow_headroom_ = false;
                 framebuffer_resized_ = true;
             }
@@ -802,7 +825,7 @@ namespace lfs::vis {
                       framebuffer_height_,
                       swapchain_extent_.width,
                       swapchain_extent_.height);
-            framebuffer_resize_exact_after_headroom_ = false;
+            framebuffer_resize_exact_after_interactive_ = false;
             deferSwapchainResizeRecreate(true, false);
             return false;
         }
@@ -1053,7 +1076,7 @@ namespace lfs::vis {
                       swapchain_extent_.width,
                       swapchain_extent_.height);
             frame_suboptimal_ = false;
-            framebuffer_resize_exact_after_headroom_ = false;
+            framebuffer_resize_exact_after_interactive_ = false;
             deferSwapchainResizeRecreate(true, false);
             return true;
         }

--- a/src/visualizer/window/vulkan_context.hpp
+++ b/src/visualizer/window/vulkan_context.hpp
@@ -48,7 +48,7 @@ namespace lfs::vis {
         void shutdown();
         void notifyFramebufferResized(int width, int height, ResizeIntent intent = ResizeIntent::Exact);
         [[nodiscard]] bool hasPendingSwapchainResize() const {
-            return framebuffer_resize_deferred_ || framebuffer_resize_exact_after_headroom_;
+            return framebuffer_resize_deferred_ || framebuffer_resize_exact_after_interactive_;
         }
         [[nodiscard]] bool pendingSwapchainResizeReady() const;
         [[nodiscard]] double secondsUntilPendingSwapchainResizeReady() const;
@@ -368,7 +368,7 @@ namespace lfs::vis {
         bool framebuffer_resize_deferred_ = false;
         bool framebuffer_resize_requires_recreate_ = false;
         bool framebuffer_resize_allow_headroom_ = false;
-        bool framebuffer_resize_exact_after_headroom_ = false;
+        bool framebuffer_resize_exact_after_interactive_ = false;
         bool swapchain_extent_fixed_to_surface_ = false;
         std::chrono::steady_clock::time_point framebuffer_resize_last_change_{};
         std::chrono::steady_clock::time_point framebuffer_resize_last_recreate_{};

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -580,7 +580,7 @@ namespace lfs::vis {
 
         const int mouse_x = static_cast<int>(std::round(event.button.x));
         const int mouse_y = static_cast<int>(std::round(event.button.y));
-        return resizeEdgeAt(mouse_x, mouse_y) != ResizeEdge::None;
+        return resizeEdgeAt(mouse_x, mouse_y) != ResizeEdge::NoEdge;
     }
 
     void WindowManager::processEvent(const SDL_Event& event) {
@@ -685,7 +685,7 @@ namespace lfs::vis {
 
                 if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
                     const ResizeEdge resize_edge = resizeEdgeAt(mouse_x, mouse_y);
-                    if (resize_edge != ResizeEdge::None) {
+                    if (resize_edge != ResizeEdge::NoEdge) {
                         beginManualResize(resize_edge);
                         break;
                     }
@@ -906,11 +906,11 @@ namespace lfs::vis {
 
     WindowManager::ResizeEdge WindowManager::resizeEdgeAt(const int x, const int y) const {
         if (!window_ || is_fullscreen_ || isMaximized())
-            return ResizeEdge::None;
+            return ResizeEdge::NoEdge;
 
         const glm::ivec2 size = getWindowSize();
         if (size.x <= 0 || size.y <= 0)
-            return ResizeEdge::None;
+            return ResizeEdge::NoEdge;
 
         const bool left = x >= 0 && x < kResizeBorder;
         const bool right = x >= size.x - kResizeBorder && x < size.x;
@@ -931,7 +931,7 @@ namespace lfs::vis {
     }
 
     void WindowManager::setResizeCursorForEdge(const ResizeEdge edge) {
-        if (edge == ResizeEdge::None)
+        if (edge == ResizeEdge::NoEdge)
             return;
 
         const auto has_edge = [edge](const ResizeEdge flag) {
@@ -985,7 +985,7 @@ namespace lfs::vis {
     }
 
     void WindowManager::beginManualResize(const ResizeEdge edge) {
-        if (!window_ || edge == ResizeEdge::None || is_fullscreen_ || isMaximized())
+        if (!window_ || edge == ResizeEdge::NoEdge || is_fullscreen_ || isMaximized())
             return;
 
         manual_resize_edge_ = edge;
@@ -1046,7 +1046,7 @@ namespace lfs::vis {
         if (!isManualResizeActive())
             return;
 
-        manual_resize_edge_ = ResizeEdge::None;
+        manual_resize_edge_ = ResizeEdge::NoEdge;
         SDL_CaptureMouse(false);
         SDL_SetCursor(SDL_GetDefaultCursor());
         updateWindowSize("manual-resize-end", ResizeIntent::Exact);

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -488,13 +488,16 @@ namespace lfs::vis {
         const SDL_WindowID main_window_id = window_ ? SDL_GetWindowID(window_) : 0;
         SDL_Event event;
         while (SDL_PollEvent(&event)) {
-            if (imgui_ready)
+            const bool suppress_gui_route = shouldSuppressGuiRoutingForResize(event, main_window_id);
+            if (imgui_ready && !suppress_gui_route)
                 ImGui_ImplSDL3_ProcessEvent(&event);
-            frame_input_.processEvent(event, main_window_id);
+            if (!suppress_gui_route)
+                frame_input_.processEvent(event, main_window_id);
             processEvent(event);
         }
         finishTitlebarDragIfReleased();
         frame_input_.finalize(window_);
+        suppressFrameInputForManualResize();
         flushPendingTitlebarDoubleClick();
     }
 
@@ -513,19 +516,24 @@ namespace lfs::vis {
         }
         const int timeout_ms = static_cast<int>(timeout_seconds * 1000.0);
         if (SDL_WaitEventTimeout(&event, timeout_ms)) {
-            if (imgui_ready)
+            bool suppress_gui_route = shouldSuppressGuiRoutingForResize(event, main_window_id);
+            if (imgui_ready && !suppress_gui_route)
                 ImGui_ImplSDL3_ProcessEvent(&event);
-            frame_input_.processEvent(event, main_window_id);
+            if (!suppress_gui_route)
+                frame_input_.processEvent(event, main_window_id);
             processEvent(event);
             while (SDL_PollEvent(&event)) {
-                if (imgui_ready)
+                suppress_gui_route = shouldSuppressGuiRoutingForResize(event, main_window_id);
+                if (imgui_ready && !suppress_gui_route)
                     ImGui_ImplSDL3_ProcessEvent(&event);
-                frame_input_.processEvent(event, main_window_id);
+                if (!suppress_gui_route)
+                    frame_input_.processEvent(event, main_window_id);
                 processEvent(event);
             }
         }
         finishTitlebarDragIfReleased();
         frame_input_.finalize(window_);
+        suppressFrameInputForManualResize();
         flushPendingTitlebarDoubleClick();
     }
 
@@ -546,6 +554,33 @@ namespace lfs::vis {
         SDL_Event event{};
         event.type = SDL_EVENT_USER;
         SDL_PushEvent(&event);
+    }
+
+    bool WindowManager::shouldSuppressGuiRoutingForResize(const SDL_Event& event,
+                                                          const unsigned int main_window_id) const {
+        switch (event.type) {
+        case SDL_EVENT_MOUSE_BUTTON_DOWN:
+        case SDL_EVENT_MOUSE_BUTTON_UP:
+        case SDL_EVENT_MOUSE_MOTION:
+        case SDL_EVENT_MOUSE_WHEEL:
+            if (!eventTargetsWindow(event, main_window_id))
+                return false;
+            break;
+        default:
+            return false;
+        }
+
+        if (isManualResizeActive())
+            return true;
+
+        if (event.type != SDL_EVENT_MOUSE_BUTTON_DOWN ||
+            event.button.button != SDL_BUTTON_LEFT) {
+            return false;
+        }
+
+        const int mouse_x = static_cast<int>(std::round(event.button.x));
+        const int mouse_y = static_cast<int>(std::round(event.button.y));
+        return resizeEdgeAt(mouse_x, mouse_y) != ResizeEdge::None;
     }
 
     void WindowManager::processEvent(const SDL_Event& event) {
@@ -1016,6 +1051,25 @@ namespace lfs::vis {
         SDL_SetCursor(SDL_GetDefaultCursor());
         updateWindowSize("manual-resize-end", ResizeIntent::Exact);
         wakeEventLoop();
+    }
+
+    void WindowManager::suppressFrameInputForManualResize() {
+        if (!isManualResizeActive())
+            return;
+
+        frame_input_.mouse_x = -100000.0f;
+        frame_input_.mouse_y = -100000.0f;
+        frame_input_.mouse_down[0] = false;
+        frame_input_.mouse_down[1] = false;
+        frame_input_.mouse_down[2] = false;
+        frame_input_.mouse_clicked[0] = false;
+        frame_input_.mouse_clicked[1] = false;
+        frame_input_.mouse_clicked[2] = false;
+        frame_input_.mouse_released[0] = false;
+        frame_input_.mouse_released[1] = false;
+        frame_input_.mouse_released[2] = false;
+        frame_input_.mouse_wheel = 0.0f;
+        frame_input_.mouse_moved = false;
     }
 
     void WindowManager::beginTitlebarDrag(const int local_x, const int local_y) {

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -30,8 +30,17 @@ namespace lfs::vis {
     namespace {
         constexpr double kPendingResizeMinWaitSeconds = 0.001;
         constexpr int kResizeBorder = 6;
-        constexpr int kMinManualResizeWidth = 640;
-        constexpr int kMinManualResizeHeight = 360;
+        constexpr int kMinWindowWidth = 640;
+        constexpr int kMinWindowHeight = 360;
+#if defined(_WIN32)
+        constexpr bool kUseManualBorderlessResize = true;
+#else
+        constexpr bool kUseManualBorderlessResize = false;
+#endif
+        constexpr unsigned kResizeLeft = 1u << 0;
+        constexpr unsigned kResizeRight = 1u << 1;
+        constexpr unsigned kResizeTop = 1u << 2;
+        constexpr unsigned kResizeBottom = 1u << 3;
 
         const char* windowEventName(const Uint32 event_type) {
             switch (event_type) {
@@ -199,6 +208,31 @@ namespace lfs::vis {
         }
 #endif
 
+        SDL_HitTestResult resizeHitTestResult(const unsigned edge_mask) {
+            const bool left = (edge_mask & kResizeLeft) != 0;
+            const bool right = (edge_mask & kResizeRight) != 0;
+            const bool top = (edge_mask & kResizeTop) != 0;
+            const bool bottom = (edge_mask & kResizeBottom) != 0;
+
+            if (top && left)
+                return SDL_HITTEST_RESIZE_TOPLEFT;
+            if (top && right)
+                return SDL_HITTEST_RESIZE_TOPRIGHT;
+            if (bottom && left)
+                return SDL_HITTEST_RESIZE_BOTTOMLEFT;
+            if (bottom && right)
+                return SDL_HITTEST_RESIZE_BOTTOMRIGHT;
+            if (left)
+                return SDL_HITTEST_RESIZE_LEFT;
+            if (right)
+                return SDL_HITTEST_RESIZE_RIGHT;
+            if (top)
+                return SDL_HITTEST_RESIZE_TOP;
+            if (bottom)
+                return SDL_HITTEST_RESIZE_BOTTOM;
+            return SDL_HITTEST_NORMAL;
+        }
+
         SDL_HitTestResult SDLCALL borderlessWindowHitTest(SDL_Window* window, const SDL_Point* const area, void* data) {
             auto* const self = static_cast<WindowManager*>(data);
             if (!self || !area)
@@ -206,28 +240,10 @@ namespace lfs::vis {
             if (self->isFullscreen())
                 return SDL_HITTEST_NORMAL;
 
-            const unsigned active_resize_edge = self->manualResizeEdgeMask();
-            if (active_resize_edge != 0) {
-                const bool left = (active_resize_edge & 1u) != 0;
-                const bool right = (active_resize_edge & 2u) != 0;
-                const bool top = (active_resize_edge & 4u) != 0;
-                const bool bottom = (active_resize_edge & 8u) != 0;
-                if (top && left)
-                    return SDL_HITTEST_RESIZE_TOPLEFT;
-                if (top && right)
-                    return SDL_HITTEST_RESIZE_TOPRIGHT;
-                if (bottom && left)
-                    return SDL_HITTEST_RESIZE_BOTTOMLEFT;
-                if (bottom && right)
-                    return SDL_HITTEST_RESIZE_BOTTOMRIGHT;
-                if (left)
-                    return SDL_HITTEST_RESIZE_LEFT;
-                if (right)
-                    return SDL_HITTEST_RESIZE_RIGHT;
-                if (top)
-                    return SDL_HITTEST_RESIZE_TOP;
-                if (bottom)
-                    return SDL_HITTEST_RESIZE_BOTTOM;
+            if constexpr (kUseManualBorderlessResize) {
+                const unsigned active_resize_edge = self->manualResizeEdgeMask();
+                if (active_resize_edge != 0)
+                    return resizeHitTestResult(active_resize_edge);
             }
 
             glm::ivec2 size = self->getWindowSize();
@@ -241,8 +257,24 @@ namespace lfs::vis {
             const bool titlebar_point = self->isTitlebarDragPoint(area->x, area->y);
 
             if (!self->isMaximized()) {
-                if (left || right || (top && !titlebar_point) || bottom)
-                    return SDL_HITTEST_NORMAL;
+                unsigned edge_mask = 0;
+                if (left)
+                    edge_mask |= kResizeLeft;
+                if (right)
+                    edge_mask |= kResizeRight;
+                if (top && !titlebar_point)
+                    edge_mask |= kResizeTop;
+                if (bottom)
+                    edge_mask |= kResizeBottom;
+
+                if constexpr (kUseManualBorderlessResize) {
+                    if (edge_mask != 0)
+                        return SDL_HITTEST_NORMAL;
+                } else {
+                    const SDL_HitTestResult resize_result = resizeHitTestResult(edge_mask);
+                    if (resize_result != SDL_HITTEST_NORMAL)
+                        return resize_result;
+                }
             }
 
             if (titlebar_point) {
@@ -356,6 +388,9 @@ namespace lfs::vis {
             std::cerr << "Failed to create SDL window: " << SDL_GetError() << std::endl;
             SDL_Quit();
             return false;
+        }
+        if (!SDL_SetWindowMinimumSize(window_, kMinWindowWidth, kMinWindowHeight)) {
+            LOG_DEBUG("Failed to set window minimum size: {}", SDL_GetError());
         }
 
         native_titlebar_move_available_ = hasX11NativeMoveSupport(window_);
@@ -558,6 +593,9 @@ namespace lfs::vis {
 
     bool WindowManager::shouldSuppressGuiRoutingForResize(const SDL_Event& event,
                                                           const unsigned int main_window_id) const {
+        if constexpr (!kUseManualBorderlessResize)
+            return false;
+
         switch (event.type) {
         case SDL_EVENT_MOUSE_BUTTON_DOWN:
         case SDL_EVENT_MOUSE_BUTTON_UP:
@@ -686,7 +724,10 @@ namespace lfs::vis {
                 if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
                     const ResizeEdge resize_edge = resizeEdgeAt(mouse_x, mouse_y);
                     if (resize_edge != ResizeEdge::NoEdge) {
-                        beginManualResize(resize_edge);
+                        if constexpr (kUseManualBorderlessResize) {
+                            beginManualResize(resize_edge);
+                            break;
+                        }
                         break;
                     }
                 }
@@ -908,7 +949,8 @@ namespace lfs::vis {
         if (!window_ || is_fullscreen_ || isMaximized())
             return ResizeEdge::NoEdge;
 
-        const glm::ivec2 size = getWindowSize();
+        glm::ivec2 size = getWindowSize();
+        SDL_GetWindowSize(window_, &size.x, &size.y);
         if (size.x <= 0 || size.y <= 0)
             return ResizeEdge::NoEdge;
 
@@ -931,6 +973,9 @@ namespace lfs::vis {
     }
 
     void WindowManager::setResizeCursorForEdge(const ResizeEdge edge) {
+        if constexpr (!kUseManualBorderlessResize)
+            return;
+
         if (edge == ResizeEdge::NoEdge)
             return;
 
@@ -959,6 +1004,9 @@ namespace lfs::vis {
     }
 
     void WindowManager::refreshResizeCursor() {
+        if constexpr (!kUseManualBorderlessResize)
+            return;
+
         if (!window_ || is_fullscreen_ || isMaximized())
             return;
 
@@ -978,6 +1026,9 @@ namespace lfs::vis {
     }
 
     void WindowManager::updateResizeCursor(const int x, const int y) {
+        if constexpr (!kUseManualBorderlessResize)
+            return;
+
         if (!window_ || isManualResizeActive() || is_fullscreen_ || isMaximized())
             return;
 
@@ -985,6 +1036,9 @@ namespace lfs::vis {
     }
 
     void WindowManager::beginManualResize(const ResizeEdge edge) {
+        if constexpr (!kUseManualBorderlessResize)
+            return;
+
         if (!window_ || edge == ResizeEdge::NoEdge || is_fullscreen_ || isMaximized())
             return;
 
@@ -1014,28 +1068,30 @@ namespace lfs::vis {
         if (has_edge(ResizeEdge::Left)) {
             next_w = manual_resize_start_size_.x - delta.x;
             next_x = manual_resize_start_pos_.x + delta.x;
-            if (next_w < kMinManualResizeWidth) {
-                next_w = kMinManualResizeWidth;
+            if (next_w < kMinWindowWidth) {
+                next_w = kMinWindowWidth;
                 next_x = manual_resize_start_pos_.x + manual_resize_start_size_.x - next_w;
             }
         } else if (has_edge(ResizeEdge::Right)) {
             next_w = manual_resize_start_size_.x + delta.x;
-            next_w = std::max(next_w, kMinManualResizeWidth);
+            next_w = std::max(next_w, kMinWindowWidth);
         }
 
         if (has_edge(ResizeEdge::Top)) {
             next_h = manual_resize_start_size_.y - delta.y;
             next_y = manual_resize_start_pos_.y + delta.y;
-            if (next_h < kMinManualResizeHeight) {
-                next_h = kMinManualResizeHeight;
+            if (next_h < kMinWindowHeight) {
+                next_h = kMinWindowHeight;
                 next_y = manual_resize_start_pos_.y + manual_resize_start_size_.y - next_h;
             }
         } else if (has_edge(ResizeEdge::Bottom)) {
             next_h = manual_resize_start_size_.y + delta.y;
-            next_h = std::max(next_h, kMinManualResizeHeight);
+            next_h = std::max(next_h, kMinWindowHeight);
         }
 
-        SDL_SetWindowPosition(window_, next_x, next_y);
+        if (next_x != manual_resize_start_pos_.x || next_y != manual_resize_start_pos_.y) {
+            SDL_SetWindowPosition(window_, next_x, next_y);
+        }
         SDL_SetWindowSize(window_, next_w, next_h);
         updateWindowSize("manual-resize-drag", ResizeIntent::Interactive);
         setResizeCursorForEdge(manual_resize_edge_);

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -29,6 +29,9 @@ namespace lfs::vis {
 
     namespace {
         constexpr double kPendingResizeMinWaitSeconds = 0.001;
+        constexpr int kResizeBorder = 6;
+        constexpr int kMinManualResizeWidth = 640;
+        constexpr int kMinManualResizeHeight = 360;
 
         const char* windowEventName(const Uint32 event_type) {
             switch (event_type) {
@@ -203,18 +206,12 @@ namespace lfs::vis {
             if (self->isFullscreen())
                 return SDL_HITTEST_NORMAL;
 
-            glm::ivec2 size = self->getWindowSize();
-            if (window)
-                SDL_GetWindowSize(window, &size.x, &size.y);
-            constexpr int kResizeBorder = 6;
-
-            const bool left = area->x >= 0 && area->x < kResizeBorder;
-            const bool right = area->x >= size.x - kResizeBorder && area->x < size.x;
-            const bool top = area->y >= 0 && area->y < kResizeBorder;
-            const bool bottom = area->y >= size.y - kResizeBorder && area->y < size.y;
-            const bool titlebar_point = self->isTitlebarDragPoint(area->x, area->y);
-
-            if (!self->isMaximized()) {
+            const unsigned active_resize_edge = self->manualResizeEdgeMask();
+            if (active_resize_edge != 0) {
+                const bool left = (active_resize_edge & 1u) != 0;
+                const bool right = (active_resize_edge & 2u) != 0;
+                const bool top = (active_resize_edge & 4u) != 0;
+                const bool bottom = (active_resize_edge & 8u) != 0;
                 if (top && left)
                     return SDL_HITTEST_RESIZE_TOPLEFT;
                 if (top && right)
@@ -227,10 +224,25 @@ namespace lfs::vis {
                     return SDL_HITTEST_RESIZE_LEFT;
                 if (right)
                     return SDL_HITTEST_RESIZE_RIGHT;
-                if (top && !titlebar_point)
+                if (top)
                     return SDL_HITTEST_RESIZE_TOP;
                 if (bottom)
                     return SDL_HITTEST_RESIZE_BOTTOM;
+            }
+
+            glm::ivec2 size = self->getWindowSize();
+            if (window)
+                SDL_GetWindowSize(window, &size.x, &size.y);
+
+            const bool left = area->x >= 0 && area->x < kResizeBorder;
+            const bool right = area->x >= size.x - kResizeBorder && area->x < size.x;
+            const bool top = area->y >= 0 && area->y < kResizeBorder;
+            const bool bottom = area->y >= size.y - kResizeBorder && area->y < size.y;
+            const bool titlebar_point = self->isTitlebarDragPoint(area->x, area->y);
+
+            if (!self->isMaximized()) {
+                if (left || right || (top && !titlebar_point) || bottom)
+                    return SDL_HITTEST_NORMAL;
             }
 
             if (titlebar_point) {
@@ -559,6 +571,7 @@ namespace lfs::vis {
                 input_controller_->onWindowFocusLost();
             }
             titlebar_drag_active_ = false;
+            finishManualResize();
             break;
 
         case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
@@ -630,6 +643,19 @@ namespace lfs::vis {
             const int mouse_y = static_cast<int>(std::round(event.button.y));
             const bool titlebar_point = isTitlebarDragPoint(mouse_x, mouse_y);
             if (event.button.button == SDL_BUTTON_LEFT) {
+                if (event.type == SDL_EVENT_MOUSE_BUTTON_UP && isManualResizeActive()) {
+                    finishManualResize();
+                    break;
+                }
+
+                if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
+                    const ResizeEdge resize_edge = resizeEdgeAt(mouse_x, mouse_y);
+                    if (resize_edge != ResizeEdge::None) {
+                        beginManualResize(resize_edge);
+                        break;
+                    }
+                }
+
                 if (event.type == SDL_EVENT_MOUSE_BUTTON_UP && titlebar_drag_active_) {
                     finishTitlebarDrag();
                     break;
@@ -661,6 +687,10 @@ namespace lfs::vis {
         case SDL_EVENT_MOUSE_MOTION:
             if (!eventTargetsWindow(event, main_window_id))
                 break;
+            if (isManualResizeActive()) {
+                updateManualResize();
+                break;
+            }
             if (titlebar_drag_active_) {
                 updateTitlebarDrag();
                 break;
@@ -668,6 +698,8 @@ namespace lfs::vis {
             if (input_controller_) {
                 input_controller_->handleMouseMove(event.motion.x, event.motion.y);
             }
+            updateResizeCursor(static_cast<int>(std::round(event.motion.x)),
+                               static_cast<int>(std::round(event.motion.y)));
             break;
 
         case SDL_EVENT_MOUSE_WHEEL:
@@ -833,6 +865,159 @@ namespace lfs::vis {
         }
     }
 
+    unsigned WindowManager::manualResizeEdgeMask() const {
+        return static_cast<unsigned>(manual_resize_edge_);
+    }
+
+    WindowManager::ResizeEdge WindowManager::resizeEdgeAt(const int x, const int y) const {
+        if (!window_ || is_fullscreen_ || isMaximized())
+            return ResizeEdge::None;
+
+        const glm::ivec2 size = getWindowSize();
+        if (size.x <= 0 || size.y <= 0)
+            return ResizeEdge::None;
+
+        const bool left = x >= 0 && x < kResizeBorder;
+        const bool right = x >= size.x - kResizeBorder && x < size.x;
+        const bool top = y >= 0 && y < kResizeBorder;
+        const bool bottom = y >= size.y - kResizeBorder && y < size.y;
+
+        unsigned edge = 0;
+        if (left)
+            edge |= static_cast<unsigned>(ResizeEdge::Left);
+        if (right)
+            edge |= static_cast<unsigned>(ResizeEdge::Right);
+        if (top && !isTitlebarDragPoint(x, y))
+            edge |= static_cast<unsigned>(ResizeEdge::Top);
+        if (bottom)
+            edge |= static_cast<unsigned>(ResizeEdge::Bottom);
+
+        return static_cast<ResizeEdge>(edge);
+    }
+
+    void WindowManager::setResizeCursorForEdge(const ResizeEdge edge) {
+        if (edge == ResizeEdge::None)
+            return;
+
+        const auto has_edge = [edge](const ResizeEdge flag) {
+            return (static_cast<unsigned>(edge) & static_cast<unsigned>(flag)) != 0;
+        };
+        SDL_Cursor* cursor = nullptr;
+        static SDL_Cursor* ew_cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_EW_RESIZE);
+        static SDL_Cursor* ns_cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NS_RESIZE);
+        static SDL_Cursor* nwse_cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NWSE_RESIZE);
+        static SDL_Cursor* nesw_cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NESW_RESIZE);
+
+        if ((has_edge(ResizeEdge::Left) && has_edge(ResizeEdge::Top)) ||
+            (has_edge(ResizeEdge::Right) && has_edge(ResizeEdge::Bottom))) {
+            cursor = nwse_cursor;
+        } else if ((has_edge(ResizeEdge::Right) && has_edge(ResizeEdge::Top)) ||
+                   (has_edge(ResizeEdge::Left) && has_edge(ResizeEdge::Bottom))) {
+            cursor = nesw_cursor;
+        } else if (has_edge(ResizeEdge::Left) || has_edge(ResizeEdge::Right)) {
+            cursor = ew_cursor;
+        } else if (has_edge(ResizeEdge::Top) || has_edge(ResizeEdge::Bottom)) {
+            cursor = ns_cursor;
+        }
+        if (cursor)
+            SDL_SetCursor(cursor);
+    }
+
+    void WindowManager::refreshResizeCursor() {
+        if (!window_ || is_fullscreen_ || isMaximized())
+            return;
+
+        if (isManualResizeActive()) {
+            setResizeCursorForEdge(manual_resize_edge_);
+            return;
+        }
+
+        if ((SDL_GetWindowFlags(window_) & SDL_WINDOW_MOUSE_FOCUS) == 0)
+            return;
+
+        float mouse_x = 0.0f;
+        float mouse_y = 0.0f;
+        SDL_GetMouseState(&mouse_x, &mouse_y);
+        setResizeCursorForEdge(resizeEdgeAt(static_cast<int>(std::round(mouse_x)),
+                                            static_cast<int>(std::round(mouse_y))));
+    }
+
+    void WindowManager::updateResizeCursor(const int x, const int y) {
+        if (!window_ || isManualResizeActive() || is_fullscreen_ || isMaximized())
+            return;
+
+        setResizeCursorForEdge(resizeEdgeAt(x, y));
+    }
+
+    void WindowManager::beginManualResize(const ResizeEdge edge) {
+        if (!window_ || edge == ResizeEdge::None || is_fullscreen_ || isMaximized())
+            return;
+
+        manual_resize_edge_ = edge;
+        manual_resize_start_global_ = globalMousePosition();
+        SDL_GetWindowPosition(window_, &manual_resize_start_pos_.x, &manual_resize_start_pos_.y);
+        SDL_GetWindowSize(window_, &manual_resize_start_size_.x, &manual_resize_start_size_.y);
+        saveBorderlessRestoreGeometry();
+        SDL_CaptureMouse(true);
+    }
+
+    void WindowManager::updateManualResize() {
+        if (!window_ || !isManualResizeActive())
+            return;
+
+        const auto has_edge = [this](const ResizeEdge flag) {
+            return (static_cast<unsigned>(manual_resize_edge_) & static_cast<unsigned>(flag)) != 0;
+        };
+        const glm::ivec2 current_global = globalMousePosition();
+        const glm::ivec2 delta = current_global - manual_resize_start_global_;
+
+        int next_x = manual_resize_start_pos_.x;
+        int next_y = manual_resize_start_pos_.y;
+        int next_w = manual_resize_start_size_.x;
+        int next_h = manual_resize_start_size_.y;
+
+        if (has_edge(ResizeEdge::Left)) {
+            next_w = manual_resize_start_size_.x - delta.x;
+            next_x = manual_resize_start_pos_.x + delta.x;
+            if (next_w < kMinManualResizeWidth) {
+                next_w = kMinManualResizeWidth;
+                next_x = manual_resize_start_pos_.x + manual_resize_start_size_.x - next_w;
+            }
+        } else if (has_edge(ResizeEdge::Right)) {
+            next_w = manual_resize_start_size_.x + delta.x;
+            next_w = std::max(next_w, kMinManualResizeWidth);
+        }
+
+        if (has_edge(ResizeEdge::Top)) {
+            next_h = manual_resize_start_size_.y - delta.y;
+            next_y = manual_resize_start_pos_.y + delta.y;
+            if (next_h < kMinManualResizeHeight) {
+                next_h = kMinManualResizeHeight;
+                next_y = manual_resize_start_pos_.y + manual_resize_start_size_.y - next_h;
+            }
+        } else if (has_edge(ResizeEdge::Bottom)) {
+            next_h = manual_resize_start_size_.y + delta.y;
+            next_h = std::max(next_h, kMinManualResizeHeight);
+        }
+
+        SDL_SetWindowPosition(window_, next_x, next_y);
+        SDL_SetWindowSize(window_, next_w, next_h);
+        updateWindowSize("manual-resize-drag", ResizeIntent::Interactive);
+        setResizeCursorForEdge(manual_resize_edge_);
+        wakeEventLoop();
+    }
+
+    void WindowManager::finishManualResize() {
+        if (!isManualResizeActive())
+            return;
+
+        manual_resize_edge_ = ResizeEdge::None;
+        SDL_CaptureMouse(false);
+        SDL_SetCursor(SDL_GetDefaultCursor());
+        updateWindowSize("manual-resize-end", ResizeIntent::Exact);
+        wakeEventLoop();
+    }
+
     void WindowManager::beginTitlebarDrag(const int local_x, const int local_y) {
         if (!window_ || is_fullscreen_)
             return;
@@ -885,14 +1070,17 @@ namespace lfs::vis {
     }
 
     void WindowManager::finishTitlebarDragIfReleased() {
-        if (!titlebar_drag_active_)
+        if (!titlebar_drag_active_ && !isManualResizeActive())
             return;
 
         const SDL_MouseButtonFlags buttons = SDL_GetGlobalMouseState(nullptr, nullptr);
         if ((buttons & SDL_BUTTON_LMASK) != 0)
             return;
 
-        finishTitlebarDrag();
+        if (isManualResizeActive())
+            finishManualResize();
+        if (titlebar_drag_active_)
+            finishTitlebarDrag();
     }
 
     bool WindowManager::isSdlMaximized() const {

--- a/src/visualizer/window/window_manager.hpp
+++ b/src/visualizer/window/window_manager.hpp
@@ -84,6 +84,8 @@ namespace lfs::vis {
 
     private:
         void processEvent(const ::SDL_Event& event);
+        [[nodiscard]] bool shouldSuppressGuiRoutingForResize(const ::SDL_Event& event,
+                                                             unsigned int main_window_id) const;
 
         enum class ResizeEdge : unsigned {
             None = 0,
@@ -138,6 +140,7 @@ namespace lfs::vis {
         void beginManualResize(ResizeEdge edge);
         void updateManualResize();
         void finishManualResize();
+        void suppressFrameInputForManualResize();
         [[nodiscard]] bool isManualResizeActive() const { return manual_resize_edge_ != ResizeEdge::None; }
         void beginTitlebarDrag(int local_x, int local_y);
         void updateTitlebarDrag();

--- a/src/visualizer/window/window_manager.hpp
+++ b/src/visualizer/window/window_manager.hpp
@@ -88,7 +88,7 @@ namespace lfs::vis {
                                                              unsigned int main_window_id) const;
 
         enum class ResizeEdge : unsigned {
-            None = 0,
+            NoEdge = 0,
             Left = 1u << 0,
             Right = 1u << 1,
             Top = 1u << 2,
@@ -118,7 +118,7 @@ namespace lfs::vis {
         glm::ivec2 titlebar_drag_start_global_{0, 0};
         glm::ivec2 titlebar_drag_start_local_{0, 0};
         glm::ivec2 titlebar_drag_window_offset_{0, 0};
-        ResizeEdge manual_resize_edge_ = ResizeEdge::None;
+        ResizeEdge manual_resize_edge_ = ResizeEdge::NoEdge;
         glm::ivec2 manual_resize_start_global_{0, 0};
         glm::ivec2 manual_resize_start_pos_{0, 0};
         glm::ivec2 manual_resize_start_size_{0, 0};
@@ -141,7 +141,7 @@ namespace lfs::vis {
         void updateManualResize();
         void finishManualResize();
         void suppressFrameInputForManualResize();
-        [[nodiscard]] bool isManualResizeActive() const { return manual_resize_edge_ != ResizeEdge::None; }
+        [[nodiscard]] bool isManualResizeActive() const { return manual_resize_edge_ != ResizeEdge::NoEdge; }
         void beginTitlebarDrag(int local_x, int local_y);
         void updateTitlebarDrag();
         void finishTitlebarDrag();

--- a/src/visualizer/window/window_manager.hpp
+++ b/src/visualizer/window/window_manager.hpp
@@ -57,6 +57,8 @@ namespace lfs::vis {
         void requestClose() { should_close_ = true; }
         void cancelClose();
         void wakeEventLoop();
+        void refreshResizeCursor();
+        [[nodiscard]] unsigned manualResizeEdgeMask() const;
 
         SDL_Window* getWindow() const { return window_; }
         VulkanContext* getVulkanContext() const { return vulkan_context_.get(); }
@@ -83,6 +85,14 @@ namespace lfs::vis {
     private:
         void processEvent(const ::SDL_Event& event);
 
+        enum class ResizeEdge : unsigned {
+            None = 0,
+            Left = 1u << 0,
+            Right = 1u << 1,
+            Top = 1u << 2,
+            Bottom = 1u << 3,
+        };
+
         SDL_Window* window_ = nullptr;
         std::unique_ptr<VulkanContext> vulkan_context_;
         GraphicsBackend graphics_backend_ = GraphicsBackend::Vulkan;
@@ -106,6 +116,10 @@ namespace lfs::vis {
         glm::ivec2 titlebar_drag_start_global_{0, 0};
         glm::ivec2 titlebar_drag_start_local_{0, 0};
         glm::ivec2 titlebar_drag_window_offset_{0, 0};
+        ResizeEdge manual_resize_edge_ = ResizeEdge::None;
+        glm::ivec2 manual_resize_start_global_{0, 0};
+        glm::ivec2 manual_resize_start_pos_{0, 0};
+        glm::ivec2 manual_resize_start_size_{0, 0};
         bool is_borderless_maximized_ = false;
         glm::ivec2 borderless_restore_pos_{0, 0};
         glm::ivec2 borderless_restore_size_{1280, 720};
@@ -118,6 +132,13 @@ namespace lfs::vis {
         std::vector<std::string> pending_drop_files_;
 
         void beginTitlebarNativeMove();
+        [[nodiscard]] ResizeEdge resizeEdgeAt(int x, int y) const;
+        void setResizeCursorForEdge(ResizeEdge edge);
+        void updateResizeCursor(int x, int y);
+        void beginManualResize(ResizeEdge edge);
+        void updateManualResize();
+        void finishManualResize();
+        [[nodiscard]] bool isManualResizeActive() const { return manual_resize_edge_ != ResizeEdge::None; }
         void beginTitlebarDrag(int local_x, int local_y);
         void updateTitlebarDrag();
         void finishTitlebarDrag();


### PR DESCRIPTION
## Problem

LichtFeld Studio uses a borderless custom window with its own title bar and docked UI layout. The previous resize path depended on the platform/native resize interaction for the window frame. That made resize behavior feel disconnected from the application render loop.

The visible symptoms were:

- Dragging the side or bottom resize handles did not update the visible layout while the drag was in progress.
- Making the window larger showed no immediate visible change until the resize was released.
- Making the window smaller clipped the existing content during the drag, then redrew the panels only after release.
- The resize cursor could revert to the normal pointer while hovering over or actively dragging resize edges.
- During active resize drags, top toolbar and window-control buttons could still receive hover state, so buttons appeared to light up under the cursor even though the user was resizing the window.
- When the asset manager or right panels were wider than the available window width, the layout could enter a constrained state where the left toolbar disappeared or panel resize/recovery became difficult.

<img width="651" height="720" alt="image" src="https://github.com/user-attachments/assets/7b28f5bf-5306-405c-a223-9df2255d63a1" />


Together these issues made window resizing visually unstable.

## Analysis

The core issue was that native borderless resize handling did not provide the application with a continuously usable resize flow. The OS/windowing system resized the outer window, but the UI layout and viewport were not being recomputed and redrawn in a way that matched the drag motion.

There were several secondary issues layered on top of that:

- Cursor state was being influenced by both window-edge resize handling and normal GUI cursor requests.
- Mouse input continued to route through the regular ImGui/UI path during resize drags.
- Hover detection for toolbar and title-bar controls had no concept of "the current mouse drag belongs to window resizing".
- Panel layout constraints were local to individual panels, so the combined width of the left dock, right panel, icon toolbar, and viewport could exceed the available window width.
- The asset manager left dock and the right panel could each independently keep a large width, causing the central viewport and left icon toolbar to be squeezed out visually.

The solution therefore needed to address both resize mechanics and layout recovery, not only redraw timing.

## Implementation

### Dynamic Layout Updates During Resize

`GuiManager` now applies panel width constraints before layout/render decisions are made. This keeps layout state synchronized with the current window size during resize, instead of letting stale panel widths survive until after the drag ends.

This is important because live resizing only feels correct if the visual layout is recomputed on every resize step.

### Manual Borderless Resize Handling

Window resizing was moved into `WindowManager` so the application owns the resize drag lifecycle.

The manual resize path tracks:

- which edge or corner is being resized,
- whether a resize drag is active,
- the initial mouse position,
- the initial window position and size,
- the updated size and position during mouse motion.

This allows the application to update the SDL window size continuously during the drag instead of waiting for a native resize release event. Because the window dimensions now change through the normal application path, the viewport and docked panels can be recalculated every frame while resizing.

### Stable Resize Cursor Ownership

Resize cursor behavior was centralized around explicit resize-edge state. The cursor now remains a horizontal, vertical, or diagonal resize cursor when:

- hovering over a window resize zone,
- pressing on a resize zone,
- dragging after the pointer has moved away from the original edge.

This avoids cursor flicker caused by normal GUI widgets overwriting the resize cursor during an active resize operation.

### GUI Input Suppression During Window Resize

Active resize drags now suppress normal GUI routing for the resize-owned mouse events.

This prevents resize interactions from being interpreted as regular UI hover/click input. In practice this fixes the issue where top toolbar buttons, minimize/restore/maximize/close controls, or other widgets could enter hover state while the user was dragging the window edge.

The resize path still receives the mouse motion it needs, but the rest of the UI does not treat that same drag as a normal pointer interaction.

### Width Constraint Handling

Panel width constraints were added to `PanelLayoutManager` so the combined layout remains recoverable at narrow window sizes.

The constraint logic accounts for:

- the fixed left icon toolbar width,
- a minimum visible viewport width,
- a minimum visible right panel width,
- a minimum visible left dock width when the asset manager is open,
- the current left dock width,
- the current right panel width,
- the available work area after status/title bars.

The right panel and left dock are clamped against the shared available width budget. This prevents either side from consuming all space and hiding critical UI.

### Left Toolbar Preservation

The left icon toolbar is treated as reserved layout space. Even when the asset manager is open and the window is narrowed, the layout should not let the asset manager or right panels cover or push away the icon toolbar.

This keeps the primary tool access and panel recovery path visible.

### Recovery From Over-Constrained States

The resize constraints are enforced continuously, including after panels have previously been made large. This means the application can recover when:

- the asset manager is expanded and the window is then narrowed,
- the right panel is expanded and the window is then narrowed,
- both left and right docked areas compete for space,
- the user re-expands the window after entering a narrow state.

The goal is not only to avoid bad layout states, but also to make sure the user can resize back out of them.

## Problems Tackled

### No Visible Live Resize Feedback

The old path allowed the outer window size to change without forcing the application layout to track each intermediate size. Manual resizing gives the application per-frame control, so layout and rendering update during the drag.

### Content Clipping While Shrinking

Panel sizes are now clamped against the current available work area during resize. This reduces stale widths that would otherwise draw outside the visible region until the resize ends.

### Resize Cursor Flicker

Cursor selection now respects active resize ownership. Once a resize drag starts, normal GUI cursor requests no longer immediately replace the resize cursor.

### Toolbar Hover During Resize

Resize-owned mouse events are withheld from regular GUI routing. This prevents accidental hover feedback on title-bar and toolbar controls while resizing.

### Left Toolbar Disappearing

The left toolbar is included as reserved space in panel width calculations. Left and right panels are constrained around it rather than being allowed to consume that area.

### Asset Manager / Right Panel Width Conflicts

The left dock and right panel now share a constrained width budget with a reserved minimum viewport width. When space is tight, panel widths are reduced instead of allowing one panel to hide the other or remove the resize recovery path.

## Files And Areas Involved

- `WindowManager`
  - Manual borderless resize state and resize-edge detection.
  - Dynamic window size/position updates during resize drags.
  - Resize cursor refresh behavior.

- `VisualizerImpl`
  - Event routing updates so resize-owned events are handled by the resize path.
  - Suppression of regular frame input for resize interactions.

- `GuiManager`
  - Suppression of GUI hover/click routing while a window resize is active.
  - Early enforcement of panel width constraints before layout rendering.

- `PanelLayoutManager`
  - Shared width budget calculations.
  - Left dock and right panel min/max width clamping.
  - Recovery behavior for constrained layouts.


