### PR TITLE
Window Resize Plugin Panel Bugfix

### DIFF
--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -1097,13 +1097,28 @@ namespace lfs::vis {
             next_h = std::max(next_h, kMinWindowHeight);
         }
 
-        if (next_x != manual_resize_start_pos_.x || next_y != manual_resize_start_pos_.y) {
+        int current_x = 0;
+        int current_y = 0;
+        int current_w = 0;
+        int current_h = 0;
+        SDL_GetWindowPosition(window_, &current_x, &current_y);
+        SDL_GetWindowSize(window_, &current_w, &current_h);
+
+        const bool position_changed = next_x != current_x || next_y != current_y;
+        const bool size_changed = next_w != current_w || next_h != current_h;
+        if (!position_changed && !size_changed) {
+            setResizeCursorForEdge(manual_resize_edge_);
+            return;
+        }
+
+        if (position_changed) {
             SDL_SetWindowPosition(window_, next_x, next_y);
         }
-        SDL_SetWindowSize(window_, next_w, next_h);
+        if (size_changed) {
+            SDL_SetWindowSize(window_, next_w, next_h);
+        }
         updateWindowSize("manual-resize-drag", ResizeIntent::Interactive);
         setResizeCursorForEdge(manual_resize_edge_);
-        wakeEventLoop();
     }
 
     void WindowManager::finishManualResize() {

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -530,6 +530,8 @@ namespace lfs::vis {
                 frame_input_.processEvent(event, main_window_id);
             processEvent(event);
         }
+        if (isManualResizeActive())
+            updateManualResize();
         finishTitlebarDragIfReleased();
         frame_input_.finalize(window_);
         suppressFrameInputForManualResize();
@@ -549,6 +551,8 @@ namespace lfs::vis {
                                            ? std::max(kPendingResizeMinWaitSeconds, resize_wait)
                                            : 0.0);
         }
+        if (isManualResizeActive())
+            timeout_seconds = std::min(timeout_seconds, 1.0 / 60.0);
         const int timeout_ms = static_cast<int>(timeout_seconds * 1000.0);
         if (SDL_WaitEventTimeout(&event, timeout_ms)) {
             bool suppress_gui_route = shouldSuppressGuiRoutingForResize(event, main_window_id);
@@ -566,6 +570,8 @@ namespace lfs::vis {
                 processEvent(event);
             }
         }
+        if (isManualResizeActive())
+            updateManualResize();
         finishTitlebarDragIfReleased();
         frame_input_.finalize(window_);
         suppressFrameInputForManualResize();
@@ -710,17 +716,19 @@ namespace lfs::vis {
 
         case SDL_EVENT_MOUSE_BUTTON_DOWN:
         case SDL_EVENT_MOUSE_BUTTON_UP: {
+            if (event.type == SDL_EVENT_MOUSE_BUTTON_UP &&
+                event.button.button == SDL_BUTTON_LEFT &&
+                isManualResizeActive()) {
+                finishManualResize();
+                break;
+            }
+
             if (!eventTargetsWindow(event, main_window_id))
                 break;
             const int mouse_x = static_cast<int>(std::round(event.button.x));
             const int mouse_y = static_cast<int>(std::round(event.button.y));
             const bool titlebar_point = isTitlebarDragPoint(mouse_x, mouse_y);
             if (event.button.button == SDL_BUTTON_LEFT) {
-                if (event.type == SDL_EVENT_MOUSE_BUTTON_UP && isManualResizeActive()) {
-                    finishManualResize();
-                    break;
-                }
-
                 if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
                     const ResizeEdge resize_edge = resizeEdgeAt(mouse_x, mouse_y);
                     if (resize_edge != ResizeEdge::NoEdge) {
@@ -761,12 +769,12 @@ namespace lfs::vis {
         }
 
         case SDL_EVENT_MOUSE_MOTION:
-            if (!eventTargetsWindow(event, main_window_id))
-                break;
             if (isManualResizeActive()) {
                 updateManualResize();
                 break;
             }
+            if (!eventTargetsWindow(event, main_window_id))
+                break;
             if (titlebar_drag_active_) {
                 updateTitlebarDrag();
                 break;


### PR DESCRIPTION
## Problem

After the window resize behavior changes, borderless window resizing worked in normal UI states but could fail when some plugin panels were visible, as well as the Plugin Marketplace panel.

The observed behavior was:

- Hovering the window edge correctly changed the cursor to the resize cursor.
- Pressing and dragging the edge started a resize interaction.
- While dragging, the window size did not change.
- Releasing the mouse ended the resize interaction with the original window size unchanged.
- The same resize path worked correctly when other panels, such as Input Settings, were visible.

This made the issue appear panel-specific, even though the initial edge hit test and resize start logic were working correctly.

## Investigation

Temporary info-level tracing was added around the manual resize path in `WindowManager`.

The failing Plugin Marketplace case produced this important pattern:

- `shouldSuppressGuiRoutingForResize()` detected the resize edge and suppressed normal GUI routing.
- `processEvent()` received the left mouse button down event.
- `beginManualResize()` ran successfully with valid window position and size.
- No `updateManualResize()` calls occurred during the drag.
- `finishManualResize()` eventually ran and reported the same size as the start size.

The working case produced the same initial resize start logs, followed by multiple `updateManualResize()` calls while dragging.

That comparison ruled out:

- incorrect resize-edge detection,
- incorrect minimum-size clamping,
- panel layout width constraints,
- resize math problems,
- failure to enter manual resize mode.

The actual failure was that SDL mouse motion events were not always delivered to the window-manager resize path while certain plugin/RmlUI panels were active. Since `updateManualResize()` was only called from `SDL_EVENT_MOUSE_MOTION`, the resize could become stuck even though manual resize state was active.

## Root Cause

Manual resize depended too strongly on SDL motion event delivery.

The resize implementation already used `globalMousePosition()` to compute drag deltas, so it did not actually need the motion event coordinates. However, the update was triggered only when a motion event passed through `processEvent()`.

When Plugin Marketplace was visible, the application could enter this sequence:

1. Mouse down on a resize edge starts manual resize.
2. SDL motion events do not reach the resize update branch.
3. The event loop waits for events instead of continuously updating the resize.
4. Mouse release is detected later.
5. Resize ends with no intermediate size changes.

The release fallback made the interaction terminate cleanly, but it could not compensate for the missing drag updates.

## Fix

The fix makes active manual resize independent from SDL motion event delivery.

`WindowManager::pollEvents()` now calls `updateManualResize()` once after draining the event queue when manual resize is active. This lets the resize use the current global mouse position even if no `SDL_EVENT_MOUSE_MOTION` event was received.

`WindowManager::waitEvents()` now caps the wait timeout to approximately 60 FPS while manual resize is active. This prevents the idle event loop from sleeping for the normal longer timeout during a drag, giving the polling update path regular opportunities to resize the window smoothly.

The mouse event ordering was also adjusted so active manual resize owns its terminal events before normal window-id filtering:

- left-button release finishes active manual resize before checking `eventTargetsWindow()`;
- mouse motion updates active manual resize before checking `eventTargetsWindow()`.

This is appropriate because the manual resize path uses global mouse position and `SDL_CaptureMouse(true)`, so the drag should remain owned by the window resize operation once it has started.

## Files Changed

- `src/visualizer/window/window_manager.cpp`

## Behavioral Impact

The fix keeps the existing resize behavior for normal cases while making the resize path robust when plugin panels or RmlUI content interfere with SDL motion delivery.

Expected behavior after the fix:

- Window edge hover still shows the resize cursor.
- Pressing a resize edge starts manual resize.
- Dragging resizes the window continuously, even with Plugin Marketplace visible.
- Releasing the mouse finishes resize cleanly.
- No temporary diagnostic logging remains in the production patch.

## Platform Notes

The current manual borderless resize path is enabled only on Windows through `kUseManualBorderlessResize`.

On Linux, this change should compile and remain effectively inert unless manual borderless resize is enabled there in the future. The Linux/native resize path is not changed by this patch.

If Linux later uses the same manual resize mode, this fix should be beneficial there too because it removes the dependency on every drag update arriving as an SDL mouse motion event.

