### PR TITLE
Resize Training Pause Bugfix

### DIFF
--- a/src/core/include/core/events.hpp
+++ b/src/core/include/core/events.hpp
@@ -252,6 +252,7 @@ namespace lfs::core {
         namespace ui {
             EVENT(FileDropReceived, ); // Emitted when files are dropped onto the window
             EVENT(WindowResized, int width; int height;);
+            EVENT(WindowResizeInteraction, bool active;);
             EVENT(CameraMove, glm::mat3 rotation; glm::vec3 translation;);
             EVENT(SpeedChanged, float current_speed; float max_speed;);
             EVENT(ZoomSpeedChanged, float zoom_speed; float max_zoom_speed;);

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -5993,6 +5993,12 @@ namespace lfs::vis::gui {
         if (!hasMouseButtonDown(sdl_input))
             left_dock_pointer_live_capture_ = false;
 
+        const bool dock_resize_interaction_active = panel_layout_.isResizeInteractionActive();
+        if (dock_resize_interaction_active != dock_resize_interaction_active_) {
+            viewer_->getRenderingManager()->setViewportResizeActive(dock_resize_interaction_active);
+            dock_resize_interaction_active_ = dock_resize_interaction_active;
+        }
+
         if (has_side_panel_plugins || has_floating_panels || has_status_bar_panels ||
             right_panel_requires_live_layout || bottom_dock_requires_live_layout ||
             left_dock_requires_live_layout ||

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -419,6 +419,7 @@ namespace lfs::vis {
                 RightPanelPointerRegion::None;
             bool bottom_dock_pointer_live_capture_ = false;
             bool left_dock_pointer_live_capture_ = false;
+            bool dock_resize_interaction_active_ = false;
             std::string last_ui_layout_active_tab_;
             std::uint64_t last_pre_scene_panel_sync_generation_ = 0;
 

--- a/src/visualizer/gui/panel_layout.hpp
+++ b/src/visualizer/gui/panel_layout.hpp
@@ -111,6 +111,10 @@ namespace lfs::vis::gui {
                    left_dock_resizing_ || left_dock_hovering_edge_;
         }
 
+        bool isResizeInteractionActive() const {
+            return python_console_resizing_ || bottom_dock_resizing_ || left_dock_resizing_;
+        }
+
         CursorRequest getCursorRequest() const { return cursor_request_; }
 
         void applyResizeDelta(float dx, const ScreenState& screen);

--- a/src/visualizer/rendering/rendering_manager.cpp
+++ b/src/visualizer/rendering/rendering_manager.cpp
@@ -185,7 +185,37 @@ namespace lfs::vis {
     void RenderingManager::setViewportResizeActive(bool active) {
         if (const DirtyMask dirty = frame_lifecycle_service_.setViewportResizeActive(active); dirty) {
             markDirty(dirty);
+            std::function<void()> wake_callback;
+            {
+                std::scoped_lock lock(wake_callback_mutex_);
+                wake_callback = wake_callback_;
+            }
+            if (wake_callback) {
+                wake_callback();
+            }
         }
+    }
+
+    void RenderingManager::requestResizeTrainingPause(TrainerManager* const trainer_manager) {
+        if (resize_training_pause_active_ || !trainer_manager || !trainer_manager->isRunning()) {
+            return;
+        }
+
+        trainer_manager->pauseTrainingTemporary();
+        resize_training_pause_trainer_ = trainer_manager;
+        resize_training_pause_active_ = true;
+    }
+
+    void RenderingManager::releaseResizeTrainingPause() {
+        if (!resize_training_pause_active_) {
+            return;
+        }
+
+        if (resize_training_pause_trainer_ && resize_training_pause_trainer_->isRunning()) {
+            resize_training_pause_trainer_->resumeTrainingTemporary();
+        }
+        resize_training_pause_trainer_ = nullptr;
+        resize_training_pause_active_ = false;
     }
 
     void RenderingManager::setLodAvailable(bool available) {

--- a/src/visualizer/rendering/rendering_manager.cpp
+++ b/src/visualizer/rendering/rendering_manager.cpp
@@ -211,7 +211,7 @@ namespace lfs::vis {
             return;
         }
 
-        if (resize_training_pause_trainer_ && resize_training_pause_trainer_->isRunning()) {
+        if (resize_training_pause_trainer_) {
             resize_training_pause_trainer_->resumeTrainingTemporary();
         }
         resize_training_pause_trainer_ = nullptr;

--- a/src/visualizer/rendering/rendering_manager.hpp
+++ b/src/visualizer/rendering/rendering_manager.hpp
@@ -624,6 +624,8 @@ namespace lfs::vis {
         void queueCameraMetricsRefreshIfStale(SceneManager* scene_manager);
         void invalidateCameraMetricsRequests(bool clear_latest = false);
         void notifyAsyncLodResultsReady();
+        void requestResizeTrainingPause(TrainerManager* trainer_manager);
+        void releaseResizeTrainingPause();
         void cameraMetricsWorkerLoop(std::stop_token stop_token);
         void releaseSceneModelResources();
         void releaseSceneRenderResources();
@@ -683,6 +685,8 @@ namespace lfs::vis {
         glm::ivec2 vulkan_viewport_image_size_{0, 0};
         bool vulkan_viewport_image_flip_y_ = false;
         glm::ivec2 vulkan_gt_comparison_content_size_{0, 0};
+        TrainerManager* resize_training_pause_trainer_ = nullptr;
+        bool resize_training_pause_active_ = false;
 
         // Granular dirty tracking
         std::atomic<uint32_t> dirty_mask_{DirtyFlag::ALL};

--- a/src/visualizer/rendering/rendering_manager_events.cpp
+++ b/src/visualizer/rendering/rendering_manager_events.cpp
@@ -55,6 +55,7 @@ namespace lfs::vis {
         ui::SplitPositionChanged::when([this](const auto& event) { handleSplitPositionChanged(event.position); });
         ui::RenderSettingsChanged::when([this](const auto& event) { handleRenderSettingsChanged(event); });
         ui::WindowResized::when([this](const auto&) { handleWindowResized(); });
+        ui::WindowResizeInteraction::when([this](const auto& event) { setViewportResizeActive(event.active); });
         ui::GridSettingsChanged::when([this](const auto& event) { handleGridSettingsChanged(event); });
         ui::NodeSelected::when([this](const auto&) { triggerSelectionFlash(); });
         state::TrainingStarted::when([this](const auto&) { handleTrainingStarted(); });

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -35,7 +35,6 @@
 namespace lfs::vis {
 
     namespace {
-        constexpr auto kVulkanViewportResizeTrainingPauseWait = std::chrono::milliseconds(300);
         constexpr bool kEnableLodTransitionWeights = true;
         constexpr double kGpuLodRenderCapacityOverhead = 1.20;
         constexpr float kInteractiveResizeRenderScale = 0.33f;
@@ -96,38 +95,6 @@ namespace lfs::vis {
             state.orthographic = params.orthographic;
             return state;
         }
-
-        class ScopedTemporaryTrainingPause {
-        public:
-            ScopedTemporaryTrainingPause(TrainerManager* const trainer_manager,
-                                         const std::chrono::milliseconds timeout)
-                : trainer_manager_(trainer_manager) {
-                if (!trainer_manager_ || !trainer_manager_->isRunning()) {
-                    return;
-                }
-
-                const auto pause_result = trainer_manager_->pauseTrainingTemporaryAndWait(timeout);
-                synchronized_ = pause_result.synchronized;
-                resume_required_ = pause_result.resume_required;
-            }
-
-            ScopedTemporaryTrainingPause(const ScopedTemporaryTrainingPause&) = delete;
-            ScopedTemporaryTrainingPause& operator=(const ScopedTemporaryTrainingPause&) = delete;
-
-            ~ScopedTemporaryTrainingPause() {
-                if (resume_required_ && trainer_manager_ && trainer_manager_->isRunning()) {
-                    trainer_manager_->resumeTrainingTemporary();
-                    LOG_TRACE("Training resumed after Vulkan viewport resize");
-                }
-            }
-
-            [[nodiscard]] bool synchronized() const { return synchronized_; }
-
-        private:
-            TrainerManager* trainer_manager_ = nullptr;
-            bool synchronized_ = false;
-            bool resume_required_ = false;
-        };
 
         [[nodiscard]] std::optional<std::shared_lock<std::shared_mutex>> acquireLiveModelRenderLock(
             const SceneManager* const scene_manager) {
@@ -760,12 +727,23 @@ namespace lfs::vis {
             update_cached_split_position(!only_split_position_pending)) {
             dirty_mask_.fetch_and(~DirtyFlag::SPLIT_POSITION, std::memory_order_relaxed);
             LOG_PERF("renderVulkanFrame: split-position early cache HIT (returning cached image)");
+            if (!resize_deferring) {
+                releaseResizeTrainingPause();
+            }
             return cached_frame_result();
         }
 
         auto* const trainer_manager = scene_manager ? scene_manager->getTrainerManager() : nullptr;
         const bool is_training = scene_manager && scene_manager->hasDataset() &&
                                  trainer_manager && trainer_manager->isRunning();
+        if (resize_deferring && is_training) {
+            requestResizeTrainingPause(trainer_manager);
+        }
+        const auto release_resize_pause_if_idle = [this, resize_deferring]() {
+            if (!resize_deferring) {
+                releaseResizeTrainingPause();
+            }
+        };
 
         auto render_lock = acquireLiveModelRenderLock(scene_manager);
 
@@ -959,6 +937,7 @@ namespace lfs::vis {
             viewport_artifact_service_.clearViewportOutput();
             clearVulkanMeshFrame();
             render_lock.reset();
+            release_resize_pause_if_idle();
             return {};
         }
 
@@ -973,6 +952,7 @@ namespace lfs::vis {
             LOG_PERF("renderVulkanFrame: split-position cache HIT (returning cached image, deferred_dirty=0x{:x})",
                      deferred_dirty);
             render_lock.reset();
+            release_resize_pause_if_idle();
             return cached_frame_result();
         }
 
@@ -991,13 +971,6 @@ namespace lfs::vis {
             return cached_frame_result();
         }
 
-        if (frame_dirty == 0 && has_cached_viewport_output) {
-            LOG_PERF("renderVulkanFrame: cache HIT (returning cached image)");
-            render_lock.reset();
-            return cached_frame_result();
-        }
-
-        std::optional<ScopedTemporaryTrainingPause> viewport_resize_training_pause;
         const bool vksplat_viewport_resize =
             is_training &&
             context.vulkan_context != nullptr &&
@@ -1007,18 +980,47 @@ namespace lfs::vis {
                 VksplatViewportRenderer::OutputSlot::Main) &&
             lfs::rendering::isVkSplatBackend(settings_.raster_backend);
         if (vksplat_viewport_resize) {
-            viewport_resize_training_pause.emplace(trainer_manager,
-                                                   kVulkanViewportResizeTrainingPauseWait);
-            if (!viewport_resize_training_pause->synchronized()) {
+            const auto* const trainer = trainer_manager ? trainer_manager->getTrainer() : nullptr;
+            if (!trainer || !trainer->is_paused()) {
+                requestResizeTrainingPause(trainer_manager);
                 dirty_mask_.fetch_or(vksplatOutputResizeRetryDirty(frame_dirty),
                                      std::memory_order_relaxed);
-                LOG_WARN("Skipping Vulkan viewport resize because training did not pause in time");
+                LOG_PERF("renderVulkanFrame: deferring VkSplat output resize until training pause takes effect");
                 render_lock.reset();
                 return cached_frame_result();
             }
-            LOG_DEBUG("Training paused around VkSplat output resize to {}x{}",
-                      render_size.x,
-                      render_size.y);
+            const cudaError_t sync_status = cudaDeviceSynchronize();
+            if (sync_status != cudaSuccess) {
+                dirty_mask_.fetch_or(vksplatOutputResizeRetryDirty(frame_dirty),
+                                     std::memory_order_relaxed);
+                LOG_WARN("Skipping Vulkan viewport resize because CUDA sync after resize pause failed: {}",
+                         cudaGetErrorString(sync_status));
+                render_lock.reset();
+                release_resize_pause_if_idle();
+                return cached_frame_result();
+            }
+            LOG_DEBUG("Training paused for VkSplat output resize to {}x{}", render_size.x, render_size.y);
+        }
+        const auto release_resize_pause_on_return = [this, resize_deferring]() {
+            if (!resize_deferring) {
+                releaseResizeTrainingPause();
+            }
+        };
+        struct ResizePauseReleaseOnReturn {
+            const decltype(release_resize_pause_on_return)& release;
+            bool active = false;
+            ~ResizePauseReleaseOnReturn() {
+                if (active) {
+                    release();
+                }
+            }
+        } resize_pause_release_on_return{release_resize_pause_on_return,
+                                         resize_training_pause_active_ && !resize_deferring};
+
+        if (frame_dirty == 0 && has_cached_viewport_output) {
+            LOG_PERF("renderVulkanFrame: cache HIT (returning cached image)");
+            render_lock.reset();
+            return cached_frame_result();
         }
 
         framerate_controller_.beginFrame();

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -1017,7 +1017,7 @@ namespace lfs::vis {
         } resize_pause_release_on_return{release_resize_pause_on_return,
                                          resize_training_pause_active_ && !resize_deferring};
 
-        if (frame_dirty == 0 && has_cached_viewport_output) {
+        if (!vksplat_viewport_resize && frame_dirty == 0 && has_cached_viewport_output) {
             LOG_PERF("renderVulkanFrame: cache HIT (returning cached image)");
             render_lock.reset();
             return cached_frame_result();

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -530,6 +530,9 @@ namespace lfs::vis {
                 frame_input_.processEvent(event, main_window_id);
             processEvent(event);
         }
+        if (isManualResizeActive()) {
+            updateManualResize();
+        }
         finishTitlebarDragIfReleased();
         frame_input_.finalize(window_);
         suppressFrameInputForManualResize();
@@ -549,6 +552,9 @@ namespace lfs::vis {
                                            ? std::max(kPendingResizeMinWaitSeconds, resize_wait)
                                            : 0.0);
         }
+        if (isManualResizeActive()) {
+            timeout_seconds = std::min(timeout_seconds, 1.0 / 60.0);
+        }
         const int timeout_ms = static_cast<int>(timeout_seconds * 1000.0);
         if (SDL_WaitEventTimeout(&event, timeout_ms)) {
             bool suppress_gui_route = shouldSuppressGuiRoutingForResize(event, main_window_id);
@@ -565,6 +571,9 @@ namespace lfs::vis {
                     frame_input_.processEvent(event, main_window_id);
                 processEvent(event);
             }
+        }
+        if (isManualResizeActive()) {
+            updateManualResize();
         }
         finishTitlebarDragIfReleased();
         frame_input_.finalize(window_);
@@ -710,17 +719,18 @@ namespace lfs::vis {
 
         case SDL_EVENT_MOUSE_BUTTON_DOWN:
         case SDL_EVENT_MOUSE_BUTTON_UP: {
+            if (event.type == SDL_EVENT_MOUSE_BUTTON_UP &&
+                event.button.button == SDL_BUTTON_LEFT &&
+                isManualResizeActive()) {
+                finishManualResize();
+                break;
+            }
             if (!eventTargetsWindow(event, main_window_id))
                 break;
             const int mouse_x = static_cast<int>(std::round(event.button.x));
             const int mouse_y = static_cast<int>(std::round(event.button.y));
             const bool titlebar_point = isTitlebarDragPoint(mouse_x, mouse_y);
             if (event.button.button == SDL_BUTTON_LEFT) {
-                if (event.type == SDL_EVENT_MOUSE_BUTTON_UP && isManualResizeActive()) {
-                    finishManualResize();
-                    break;
-                }
-
                 if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
                     const ResizeEdge resize_edge = resizeEdgeAt(mouse_x, mouse_y);
                     if (resize_edge != ResizeEdge::NoEdge) {
@@ -761,12 +771,12 @@ namespace lfs::vis {
         }
 
         case SDL_EVENT_MOUSE_MOTION:
-            if (!eventTargetsWindow(event, main_window_id))
-                break;
             if (isManualResizeActive()) {
                 updateManualResize();
                 break;
             }
+            if (!eventTargetsWindow(event, main_window_id))
+                break;
             if (titlebar_drag_active_) {
                 updateTitlebarDrag();
                 break;
@@ -1048,6 +1058,7 @@ namespace lfs::vis {
         SDL_GetWindowSize(window_, &manual_resize_start_size_.x, &manual_resize_start_size_.y);
         saveBorderlessRestoreGeometry();
         SDL_CaptureMouse(true);
+        lfs::core::events::ui::WindowResizeInteraction{.active = true}.emit();
     }
 
     void WindowManager::updateManualResize() {
@@ -1089,13 +1100,28 @@ namespace lfs::vis {
             next_h = std::max(next_h, kMinWindowHeight);
         }
 
-        if (next_x != manual_resize_start_pos_.x || next_y != manual_resize_start_pos_.y) {
+        int current_x = 0;
+        int current_y = 0;
+        int current_w = 0;
+        int current_h = 0;
+        SDL_GetWindowPosition(window_, &current_x, &current_y);
+        SDL_GetWindowSize(window_, &current_w, &current_h);
+
+        const bool position_changed = next_x != current_x || next_y != current_y;
+        const bool size_changed = next_w != current_w || next_h != current_h;
+        if (!position_changed && !size_changed) {
+            setResizeCursorForEdge(manual_resize_edge_);
+            return;
+        }
+
+        if (position_changed) {
             SDL_SetWindowPosition(window_, next_x, next_y);
         }
-        SDL_SetWindowSize(window_, next_w, next_h);
+        if (size_changed) {
+            SDL_SetWindowSize(window_, next_w, next_h);
+        }
         updateWindowSize("manual-resize-drag", ResizeIntent::Interactive);
         setResizeCursorForEdge(manual_resize_edge_);
-        wakeEventLoop();
     }
 
     void WindowManager::finishManualResize() {
@@ -1106,6 +1132,7 @@ namespace lfs::vis {
         SDL_CaptureMouse(false);
         SDL_SetCursor(SDL_GetDefaultCursor());
         updateWindowSize("manual-resize-end", ResizeIntent::Exact);
+        lfs::core::events::ui::WindowResizeInteraction{.active = false}.emit();
         wakeEventLoop();
     }
 


### PR DESCRIPTION
## Symptoms

While training was active, resizing UI surfaces could make the viewport resize path unstable and slow. The issue was reproducible with both top-level window resizing and internal panel resizing.

Observed behavior included:

- Repeated warnings during resize:

  ```text
  Timed out waiting for temporary training pause
  Skipping Vulkan viewport resize because training did not pause in time
  ```

- Training became very slow during resize and sometimes did not recover until the user interacted with the 3D viewport again.
- Resizing an internal panel could pause training and leave it paused until another UI event woke the render loop.
- Double-click maximize/restore on the top application bar could fail to resume training correctly.
- Window resizing could repeatedly pause/resume training while dragging, especially when changing drag direction.
- During manual borderless resize, holding the mouse still and then reversing direction could stop live window updates.
- Plugin panels and docked panels used different resize paths, so fixes that only handled one path did not solve all resize scenarios.

## Analysis

The resize pipeline had two separate concerns that were coupled too tightly:

1. The UI resize interaction lifecycle.
2. The Vulkan viewport image resize that must not race training writes.

The Vulkan path used `pauseTrainingTemporaryAndWait(300ms)` immediately before resizing VkSplat output images. During resize, the viewport size changes frequently. Each change could re-enter this blocking pause path, wait up to 300 ms, fail to observe a paused trainer in time, mark the frame dirty, and retry on the next frame.

That produced a feedback loop:

- Resize changes viewport size.
- VkSplat output image needs a new size.
- Renderer asks training to pause and waits synchronously.
- Training may not reach a pause point within the 300 ms timeout.
- Renderer skips the resize, marks dirty, and tries again.
- The repeated retries slow the UI and training loop.

Earlier attempts that held or released the pause from narrow render paths were fragile because not every resize scenario entered the same code path. Some UI resizes were driven by RmlUi right-panel callbacks, others by ImGui dock layout code, and manual borderless window resize had its own SDL event handling. This made it possible to pause training in one path and only resume it after an unrelated later event.

## Root Cause

The root cause was that resize was treated as a sequence of independent render-frame resize attempts instead of a single resize interaction with a clear begin/end lifecycle.

More specifically:

- VkSplat output resize used a synchronous temporary pause wait inside the render frame.
- Active resizing could trigger many output-size changes before training had time to pause.
- The render path retried immediately after timeout, causing repeated warnings and stalls.
- Internal panel resize state was used for cursor/live-layout behavior, but not consistently forwarded into the rendering resize lifecycle.
- Manual borderless window resizing depended too much on incoming SDL motion events. If events stopped or were routed differently, the active resize could stop updating.
- Manual resize updates also woke the event loop on every update, which risked unnecessary self-wake churn.

## Changes

### Explicit Resize Interaction Tracking

Added `ui::WindowResizeInteraction` with an `active` flag. Manual borderless window resize now emits:

- `active = true` when manual resize starts.
- `active = false` when manual resize finishes.

`RenderingManager` listens for this event and forwards it into `setViewportResizeActive()`.

### Dock Resize Lifecycle Forwarding

Added `PanelLayoutManager::isResizeInteractionActive()` to distinguish actual active drag resizing from simple hover state.

`GuiManager` now tracks dock resize transitions and calls:

```cpp
viewer_->getRenderingManager()->setViewportResizeActive(active);
```

when bottom dock, left dock, or python console resizing starts or ends.

The existing RmlUi right-panel resize callbacks already called `setViewportResizeActive()`, so the render lifecycle now covers:

- Main window manual resize.
- Right panel width resize.
- Right panel vertical splitter resize.
- Bottom dock resize.
- Left dock / asset manager resize.
- Python console resize.

### Held Resize Training Pause

Added resize pause ownership to `RenderingManager`:

- `requestResizeTrainingPause(TrainerManager*)`
- `releaseResizeTrainingPause()`

During resize deferral, the renderer requests one temporary training pause and holds that lease across the resize interaction. It does not repeatedly pause/resume while the mouse is still dragging.

Training is resumed only when the resize is no longer deferring and the final resize work has been handled or no longer needs to be handled.

### Non-blocking VkSplat Output Resize

Removed the synchronous `ScopedTemporaryTrainingPause` / `pauseTrainingTemporaryAndWait(300ms)` path from `rendering_manager_vulkan.cpp`.

When VkSplat output images need resizing during active training:

- If training is not paused yet, the renderer requests the resize pause, marks resize-related dirty state, returns the cached viewport image, and retries later.
- If training is paused, the renderer performs a CUDA synchronization and proceeds with the output resize.
- No 300 ms wait is performed inside the render frame.

This avoids the repeated timeout warning loop and prevents render frames from blocking while training reaches a pause point.

### Safe Pause Release

The Vulkan render path now releases the held resize pause on idle return paths after resize deferral is over. It also avoids releasing the pause too early when the final VkSplat resize still needs one more frame for the pause request to take effect.

This addresses cases where training previously remained paused until another user interaction woke the renderer.

### Manual Window Resize Updates

Manual borderless window resize now updates outside SDL motion events:

- `pollEvents()` calls `updateManualResize()` once per loop while resize is active.
- `waitEvents()` caps its wait to roughly 60 FPS while resize is active and then calls `updateManualResize()`.
- Mouse-up finishing is handled before checking whether the event targets the current window, so captured resize can finish reliably.
- Mouse motion updates active resize before normal event targeting.

`updateManualResize()` now checks whether position or size actually changed before calling SDL setters. It no longer wakes the event loop on every drag update, avoiding a self-sustaining wake/event loop.

## Result

Resize is now modeled as a single interaction instead of many independent pause attempts. Training pauses once for the resize lifecycle and resumes after the resize settles. Vulkan output resizing no longer blocks repeatedly on a 300 ms pause wait, and internal dock/panel resize paths participate in the same lifecycle as top-level window resizing.

The fix covers the reported scenarios:

- Main window resize while training.
- Right panel resize while training.
- Internal dock/panel resize while training.
- Left asset manager dock resize while training.
- Double-click maximize/restore.
- Holding the mouse during resize and then changing direction.
- Avoiding intermediate pause/resume churn during active drag.
