### PR TITLE
#1327 fix(sequencer): disable toolbar button while training is active

### DIFF
--- a/src/python/lfs_plugins/toolbar.py
+++ b/src/python/lfs_plugins/toolbar.py
@@ -836,6 +836,11 @@ class _UtilityToolbarController:
         utility_bottom_buttons = []
         if has_render_manager:
             seq_visible = lf.ui.is_sequencer_visible()
+            # The sequencer is disabled while training is active (the native
+            # SequencerPanel gates on EditorContext::isToolsDisabled). Reflect
+            # that in the button so it greys out instead of appearing live but
+            # doing nothing on press, matching the editing-tool buttons.
+            seq_enabled = RuntimeState.trainer_state.value not in _TOOLBAR_HIDDEN_STATES
             utility_extra_buttons.append(
                 _button_record(
                     "util-sequencer",
@@ -845,6 +850,7 @@ class _UtilityToolbarController:
                     tooltip_key="toolbar.sequencer",
                     tooltip_text="Sequencer",
                     selected=seq_visible,
+                    enabled=seq_enabled,
                 )
             )
 
@@ -881,6 +887,8 @@ class _UtilityToolbarController:
             lf.focus_selection()
             return
         if action == "toggle_sequencer":
+            if RuntimeState.trainer_state.value in _TOOLBAR_HIDDEN_STATES:
+                return
             lf.ui.set_sequencer_visible(not lf.ui.is_sequencer_visible())
             return
         if action == "toggle_panel":


### PR DESCRIPTION
fixes #1327

## Summary

The Sequencer sidebar button stays fully active during training even though the
panel itself is disabled then (the native `SequencerPanel::poll()` gates on
`EditorContext::isToolsDisabled()`, true for `TRAINING`/`PAUSED`/`FINISHED`).
The button therefore looks live but does nothing on press, and clicking it could
leave the panel's visibility flag set while the panel stays gated off — the
cause of the "opens for one frame then closes" behavior after a checkpoint load.

## Change

Make the sequencer button reflect training state, the same way the editing-tool
buttons already do. Tool buttons render with
`enabled=tool_def.can_activate(context)`; the sequencer button is hardcoded and
never had an equivalent. This passes `enabled=` on it, computed from the same
`_TOOLBAR_HIDDEN_STATES` trainer-state set the toolbar already uses elsewhere, so
the button greys out during training. The `toggle_sequencer` dispatch also
no-ops in those states as a guard.

Single file, no C++ changes; the `poll()` gate is untouched.

## Testing

- Built from source (Release).
- During training (and with a checkpoint loaded): sequencer button is greyed out;
  clicking it does nothing; the one-frame-flash behavior no longer occurs.
- Before training / not gated: button active, sequencer opens and works normally.
- Editing tools unaffected.
