### PR TITLE
fix(sequencer): gate on isTraining instead of isToolsDisabled

### DIFF
--- a/src/visualizer/gui/native_panels.cpp
+++ b/src/visualizer/gui/native_panels.cpp
@@ -114,8 +114,16 @@ namespace lfs::vis::gui::native_panels {
     }
 
     bool SequencerPanel::poll(const PanelDrawContext& ctx) {
+        // The sequencer is a camera/animation timeline, not a scene-editing
+        // tool, so it must not share the editing gizmos' isToolsDisabled() gate
+        // (true for TRAINING/PAUSED/FINISHED). The gizmos are disabled across all
+        // of those because the trainer owns the model tensors, but the sequencer
+        // has no such dependency. Disable it only while training is actively
+        // running; once training is paused/finished it should be usable without
+        // having to switch to Edit mode (which tears the trainer down).
+        const bool training_active = ctx.ui && ctx.ui->editor && ctx.ui->editor->isTraining();
         const bool is_enabled = !ctx.ui_hidden && ctx.ui && ctx.ui->editor &&
-                                !ctx.ui->editor->isToolsDisabled() && layout_->isShowSequencer();
+                                !training_active && layout_->isShowSequencer();
         if (!is_enabled && seq_)
             seq_->setSequencerEnabled(false);
         return is_enabled;


### PR DESCRIPTION
## Summary

Follow-up to #1327. That change disabled the sequencer toolbar button
during training but left the panel's render gate unchanged, so the sequencer
still couldn't be used after training **stops** — only after switching to Edit
mode. This corrects the actual gate.

## Root cause

`SequencerPanel::poll()` gated the panel on
`EditorContext::isToolsDisabled()`, which is true for TRAINING, PAUSED, and
FINISHED. After stopping training the editor is in FINISHED, so the panel stayed
gated off even though the toolbar button re-activated and `show_sequencer_`
toggled correctly. Switching to Edit mode "fixed" it only because
`SceneManager::switchToEditMode()` calls `clearTrainer()` and moves the scene to
VIEWING_SPLATS, where the gate is off.

`isToolsDisabled()` exists for the scene-editing gizmos, which can't run while
the trainer owns the model tensors. The sequencer is a camera/animation timeline
with no such dependency, so it shouldn't share that gate.

## Change

- `native_panels.cpp`: gate `poll()` on `isTraining()` (actively-running only)
  instead of `isToolsDisabled()`. The sequencer is now available when training is
  paused or finished, and disabled only during an active run.

## Testing

- Build from source (Release).
- Train, then stop → sequencer button live and panel toggles correctly **without**
  switching to Edit mode (the bug this fixes).
- During an active run → sequencer disabled (button greyed, panel gated).
- Paused → sequencer usable.
- No-scene / pre-training / edit mode → unchanged.