### PR TITLE
GT 16 bits image support + lossless 16bits cache for HDR training [VOLINGA]

### DIFF
--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -209,7 +209,6 @@ namespace {
             ::args::ValueFlag<std::string> init_path(paths_group, "path", "Initialize from splat file (.ply, .sog, .spz, .usd, .usda, .usdc, .usdz, .resume)", {"init"});
             ::args::ValueFlagList<std::string> add_splats(paths_group, "path", "Append trained splat file(s) to the training model before optimizer initialization", {"add-splat"});
             ::args::CounterFlag freeze(paths_group, "freeze", "Freeze the immediately preceding --add-splat rows from optimizer gradients and densification", {"freeze"});
-            ::args::Flag exclude_export(paths_group, "exclude_export", "Exclude frozen --add-splat rows from PLY exports", {"exclude-export"});
 
             ::args::ValueFlag<std::string> import_cameras(paths_group, "path", "Import COLMAP cameras from sparse folder (no images required)", {"import-cameras"});
 
@@ -259,6 +258,7 @@ namespace {
             ::args::ValueFlag<int> max_width(dataset_group, "max_width", "Max width of images in px; 0 disables the cap (default: 3840)", {"max-width"});
             ::args::Flag no_cpu_cache(dataset_group, "no_cpu_cache", "Disable CPU memory caching (default: enabled)", {"no-cpu-cache"});
             ::args::Flag no_fs_cache(dataset_group, "no_fs_cache", "Disable filesystem caching (default: enabled)", {"no-fs-cache"});
+            ::args::ValueFlag<bool> use_8bit_color(parser, "use_8bit_color", "if true - train with 8bit depth color images, else 16bits for HDR (default: true)", {"use_8bit_color"});
             ::args::Flag undistort(dataset_group, "undistort", "Undistort images on-the-fly before training", {"undistort"});
             ::args::MapFlag<std::string, std::string> centralize(dataset_group, "mode",
                                                                  "Centralize dataset origin: off, by_pointcloud, by_cameras (default: off)",
@@ -685,6 +685,7 @@ namespace {
                                         max_width_val = max_width ? std::optional<int>(::args::get(max_width)) : std::optional<int>(3840),
                                         no_cpu_cache_flag = static_cast<bool>(no_cpu_cache),
                                         no_fs_cache_flag = static_cast<bool>(no_fs_cache),
+                                        use_8bit_color_val = use_8bit_color ? std::optional<bool>(::args::get(use_8bit_color)) : std::optional<bool>(),
                                         tcp_server_connection_port_val = tcp_server_connection_port ? std::optional<int>(::args::get(tcp_server_connection_port)) : std::optional<int>(),
                                         tcp_broadcast_connection_port_val = tcp_broadcast_connection_port ? std::optional<int>(::args::get(tcp_broadcast_connection_port)) : std::optional<int>(),
                                         tcp_connection_flag = bool(tcp_connection),
@@ -742,7 +743,6 @@ namespace {
                                         use_depth_loss_flag = bool(use_depth_loss),
                                         no_error_map_flag = bool(no_error_map),
                                         no_edge_map_flag = bool(no_edge_map),
-                                        exclude_export_flag = bool(exclude_export),
                                         output_name_val = cli_option_present({"--output-name"}) ? std::optional<std::string>(::args::get(output_name)) : std::optional<std::string>()]() {
                 auto& opt = params.optimization;
                 auto& svs = params.server;
@@ -767,6 +767,7 @@ namespace {
                     ds.loading_params.use_cpu_memory = false;
                 if (no_fs_cache_flag)
                     ds.loading_params.use_fs_cache = false;
+                setVal(use_8bit_color_val, ds.loading_params.use_8bit_color);
                 setVal(max_cap_val, opt.max_cap);
                 setVal(tcp_server_connection_port_val, svs.tcp_server_connection_port);
                 setVal(tcp_broadcast_connection_port_val, svs.tcp_broadcast_connection_port);
@@ -828,7 +829,6 @@ namespace {
                     opt.use_error_map = false;
                 if (no_edge_map_flag)
                     opt.use_edge_map = false;
-                setFlag(exclude_export_flag, params.exclude_frozen_add_splats_from_export);
 
                 // Mask parameters
                 setVal(mask_mode_val, opt.mask_mode);
@@ -1038,8 +1038,6 @@ namespace {
         ::args::ValueFlag<int> sog_iter(parser, "iterations", "K-means iterations for SOG (default: 10)", {"sog-iterations"});
         ::args::ValueFlag<std::string> tiles(parser, "AxB", "Replicate a PLY source across an AxB ground-plane grid (RAD output only)", {"tiles"});
         ::args::ValueFlag<std::string> lod_builder(parser, "builder", "PLY->RAD LOD tree builder: bhatt (default) or octree (hybrid: octree fine levels + similarity-ordered bhatt top, much faster)", {"lod-builder"});
-        ::args::Flag rad_stream(parser, "stream", "RAD output: streamable Spark-compatible chunks (default)", {"stream"});
-        ::args::Flag rad_none_stream(parser, "none-stream", "RAD output: native LichtFeld chunks", {"none-stream"});
         ::args::Flag overwrite(parser, "overwrite", "Overwrite existing files without prompting", {'y', "overwrite"});
 
         std::vector<std::string> args_vec(argv + 1, argv + argc);
@@ -1127,15 +1125,6 @@ namespace {
                 return std::unexpected("--lod-builder requires RAD output (--format rad)");
             }
         }
-
-        if (rad_stream && rad_none_stream) {
-            return std::unexpected("--stream and --none-stream are mutually exclusive");
-        }
-        if ((rad_stream || rad_none_stream) && params.format != param::OutputFormat::RAD) {
-            return std::unexpected("--stream/--none-stream require RAD output (--format rad)");
-        }
-        params.rad_export_mode = rad_none_stream ? param::RadExportMode::NonStream
-                                                 : param::RadExportMode::Stream;
 
         return core_args::ConvertMode{params};
     }

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -209,6 +209,7 @@ namespace {
             ::args::ValueFlag<std::string> init_path(paths_group, "path", "Initialize from splat file (.ply, .sog, .spz, .usd, .usda, .usdc, .usdz, .resume)", {"init"});
             ::args::ValueFlagList<std::string> add_splats(paths_group, "path", "Append trained splat file(s) to the training model before optimizer initialization", {"add-splat"});
             ::args::CounterFlag freeze(paths_group, "freeze", "Freeze the immediately preceding --add-splat rows from optimizer gradients and densification", {"freeze"});
+            ::args::Flag exclude_export(paths_group, "exclude_export", "Exclude frozen --add-splat rows from PLY exports", {"exclude-export"});
 
             ::args::ValueFlag<std::string> import_cameras(paths_group, "path", "Import COLMAP cameras from sparse folder (no images required)", {"import-cameras"});
 
@@ -743,6 +744,7 @@ namespace {
                                         use_depth_loss_flag = bool(use_depth_loss),
                                         no_error_map_flag = bool(no_error_map),
                                         no_edge_map_flag = bool(no_edge_map),
+                                        exclude_export_flag = bool(exclude_export),
                                         output_name_val = cli_option_present({"--output-name"}) ? std::optional<std::string>(::args::get(output_name)) : std::optional<std::string>()]() {
                 auto& opt = params.optimization;
                 auto& svs = params.server;
@@ -829,6 +831,7 @@ namespace {
                     opt.use_error_map = false;
                 if (no_edge_map_flag)
                     opt.use_edge_map = false;
+                setFlag(exclude_export_flag, params.exclude_frozen_add_splats_from_export);
 
                 // Mask parameters
                 setVal(mask_mode_val, opt.mask_mode);
@@ -1038,6 +1041,8 @@ namespace {
         ::args::ValueFlag<int> sog_iter(parser, "iterations", "K-means iterations for SOG (default: 10)", {"sog-iterations"});
         ::args::ValueFlag<std::string> tiles(parser, "AxB", "Replicate a PLY source across an AxB ground-plane grid (RAD output only)", {"tiles"});
         ::args::ValueFlag<std::string> lod_builder(parser, "builder", "PLY->RAD LOD tree builder: bhatt (default) or octree (hybrid: octree fine levels + similarity-ordered bhatt top, much faster)", {"lod-builder"});
+        ::args::Flag rad_stream(parser, "stream", "RAD output: streamable Spark-compatible chunks (default)", {"stream"});
+        ::args::Flag rad_none_stream(parser, "none-stream", "RAD output: native LichtFeld chunks", {"none-stream"});
         ::args::Flag overwrite(parser, "overwrite", "Overwrite existing files without prompting", {'y', "overwrite"});
 
         std::vector<std::string> args_vec(argv + 1, argv + argc);
@@ -1125,6 +1130,15 @@ namespace {
                 return std::unexpected("--lod-builder requires RAD output (--format rad)");
             }
         }
+
+        if (rad_stream && rad_none_stream) {
+            return std::unexpected("--stream and --none-stream are mutually exclusive");
+        }
+        if ((rad_stream || rad_none_stream) && params.format != param::OutputFormat::RAD) {
+            return std::unexpected("--stream/--none-stream require RAD output (--format rad)");
+        }
+        params.rad_export_mode = rad_none_stream ? param::RadExportMode::NonStream
+                                                 : param::RadExportMode::Stream;
 
         return core_args::ConvertMode{params};
     }

--- a/src/core/cuda/lanczos_resize/lanczos_resize.cu
+++ b/src/core/cuda/lanczos_resize/lanczos_resize.cu
@@ -278,8 +278,6 @@ namespace lfs::core {
             return Tensor();
         }
 
-         LOG_INFO("lanczos_resize RUNNING");
-
         if (input.dtype() == DataType::UInt8) {
             return detail::lanczos_resize_impl<uint8_t>(
                 input, output_h, output_w, kernel_size, cuda_stream);

--- a/src/core/cuda/lanczos_resize/lanczos_resize.cu
+++ b/src/core/cuda/lanczos_resize/lanczos_resize.cu
@@ -31,13 +31,6 @@ namespace {
         }
     };
 
-    //template <>
-    //struct PixelTraits<uint16_t> {
-    //    __device__ __forceinline__ static float load_and_normalize(const uint16_t* ptr, int idx) {
-    //        return static_cast<float>(ptr[idx]) / 65535.f;
-    //    }
-    //};
-
     template <>
     struct PixelTraits<float> {
         __device__ __forceinline__ static float load_and_normalize(const float* ptr, int idx) {

--- a/src/core/cuda/lanczos_resize/lanczos_resize.cu
+++ b/src/core/cuda/lanczos_resize/lanczos_resize.cu
@@ -20,6 +20,33 @@
 
 namespace cg = cooperative_groups;
 
+namespace {
+    template <typename T>
+    struct PixelTraits;
+
+    template <>
+    struct PixelTraits<uint8_t> {
+        __device__ __forceinline__ static float load_and_normalize(const uint8_t* ptr, int idx) {
+            return static_cast<float>(ptr[idx]) / 255.0f;
+        }
+    };
+
+    //template <>
+    //struct PixelTraits<uint16_t> {
+    //    __device__ __forceinline__ static float load_and_normalize(const uint16_t* ptr, int idx) {
+    //        return static_cast<float>(ptr[idx]) / 65535.f;
+    //    }
+    //};
+
+    template <>
+    struct PixelTraits<float> {
+        __device__ __forceinline__ static float load_and_normalize(const float* ptr, int idx) {
+            return ptr[idx];
+        }
+    };
+
+} // namespace
+
 namespace lfs::core {
     namespace detail {
 
@@ -68,7 +95,7 @@ namespace lfs::core {
             }
         }
 
-        template <uint32_t CHANNELS>
+        template <uint32_t CHANNELS, typename T>
         __global__ void __launch_bounds__(BLOCK_X* BLOCK_Y)
             LanczosResampleCUDA(
                 const int input_h, const int input_w,
@@ -76,7 +103,7 @@ namespace lfs::core {
                 const int kernel_size,
                 const float* __restrict__ pre_coef_x,
                 const float* __restrict__ pre_coef_y,
-                const uint8_t* __restrict__ input, // [H, W, C] uint8
+                const T* __restrict__ input, // [H, W, C] T
                 float* __restrict__ output         // [C, H, W] float32
             ) {
             const auto block = cg::this_thread_block();
@@ -115,8 +142,7 @@ namespace lfs::core {
                     const float kernel_value = kernel_value_y * kernel_value_x;
 
                     for (int ch = 0; ch < CHANNELS; ch++) {
-                        const float pixel_value = (float)input[input_pix_id * 3 + ch] / 255.0f;
-                        accumulator[ch] += pixel_value * kernel_value;
+                        accumulator[ch] += PixelTraits<T>::load_and_normalize(input, input_pix_id * 3 + ch) * kernel_value;
                     }
                 }
             }
@@ -180,6 +206,60 @@ namespace lfs::core {
             output[pix.y * output_w + pix.x] = accumulator;
         }
 
+        template <typename T>
+        static Tensor lanczos_resize_impl(
+            const Tensor& input,
+            int output_h,
+            int output_w,
+            int kernel_size,
+            cudaStream_t cuda_stream) {
+            const int input_h = static_cast<int>(input.size(0));
+            const int input_w = static_cast<int>(input.size(1));
+            const int channels = static_cast<int>(input.size(2));
+
+            if (channels != 3) {
+                LOG_ERROR("lanczos_resize: Only 3-channel (RGB) images supported, got {}", channels);
+                return Tensor();
+            }
+
+            auto output = Tensor::empty(
+                TensorShape({static_cast<size_t>(channels),
+                             static_cast<size_t>(output_h),
+                             static_cast<size_t>(output_w)}),
+                Device::CUDA, DataType::Float32);
+
+            cudaMemsetAsync(output.data_ptr(), 0, output.bytes(), cuda_stream);
+
+            const uint32_t offset_step_x =
+                (uint32_t)(kernel_size * (1.0 * input_w / output_w) * 2 + 1 + 0.5f);
+            const uint32_t offset_step_y =
+                (uint32_t)(kernel_size * (1.0 * input_h / output_h) * 2 + 1 + 0.5f);
+
+            float *coef_x, *coef_y;
+            cudaMalloc(&coef_x, sizeof(float) * output_w * offset_step_x);
+            cudaMalloc(&coef_y, sizeof(float) * output_h * offset_step_y);
+
+            const int threads = BLOCK_X * BLOCK_Y;
+            detail::PreComputeCoef<<<(output_w + threads - 1) / threads, threads, 0, cuda_stream>>>(
+                input_w, output_w, kernel_size, coef_x);
+            detail::PreComputeCoef<<<(output_h + threads - 1) / threads, threads, 0, cuda_stream>>>(
+                input_h, output_h, kernel_size, coef_y);
+
+            const dim3 tile_grid((output_w + BLOCK_X - 1) / BLOCK_X,
+                                 (output_h + BLOCK_Y - 1) / BLOCK_Y);
+            const dim3 block(BLOCK_X, BLOCK_Y, 1);
+
+            detail::LanczosResampleCUDA<NUM_CHANNELS, T>
+                <<<tile_grid, block, 0, cuda_stream>>>(
+                    input_h, input_w, output_h, output_w, kernel_size,
+                    coef_x, coef_y,
+                    input.ptr<T>(), output.ptr<float>());
+
+            cudaFree(coef_x);
+            cudaFree(coef_y);
+            return output;
+        }
+
     } // namespace detail
 
     Tensor lanczos_resize(
@@ -193,63 +273,24 @@ namespace lfs::core {
             LOG_ERROR("lanczos_resize: Input must be a valid CUDA tensor");
             return Tensor();
         }
-
-        if (input.dtype() != DataType::UInt8) {
-            LOG_ERROR("lanczos_resize: Input must be UInt8 dtype");
-            return Tensor();
-        }
-
         if (input.ndim() != 3) {
             LOG_ERROR("lanczos_resize: Input must be 3D tensor [H, W, C]");
             return Tensor();
         }
 
-        const int input_h = static_cast<int>(input.size(0));
-        const int input_w = static_cast<int>(input.size(1));
-        const int channels = static_cast<int>(input.size(2));
+         LOG_INFO("lanczos_resize RUNNING");
 
-        if (channels != 3) {
-            LOG_ERROR("lanczos_resize: Only 3-channel (RGB) images supported, got {}", channels);
+        if (input.dtype() == DataType::UInt8) {
+            return detail::lanczos_resize_impl<uint8_t>(
+                input, output_h, output_w, kernel_size, cuda_stream);
+        } else if (input.dtype() == DataType::Float32) {
+            return detail::lanczos_resize_impl<float>(
+                input, output_h, output_w, kernel_size, cuda_stream);
+        } else {
+            LOG_ERROR("lanczos_resize: Unsupported dtype: {}",
+                      dtype_name(input.dtype()));
             return Tensor();
         }
-
-        auto output = Tensor::empty(
-            TensorShape({static_cast<size_t>(channels), static_cast<size_t>(output_h), static_cast<size_t>(output_w)}),
-            Device::CUDA,
-            DataType::Float32);
-
-        cudaMemsetAsync(output.data_ptr(), 0, output.bytes(), cuda_stream);
-
-        const uint32_t offset_step_x = (uint32_t)(kernel_size * (1.0 * input_w / output_w) * 2 + 1 + 0.5f);
-        const uint32_t offset_step_y = (uint32_t)(kernel_size * (1.0 * input_h / output_h) * 2 + 1 + 0.5f);
-
-        float* coef_x;
-        float* coef_y;
-        cudaMalloc(&coef_x, sizeof(float) * output_w * offset_step_x);
-        cudaMalloc(&coef_y, sizeof(float) * output_h * offset_step_y);
-
-        detail::PreComputeCoef<<<(output_w + BLOCK_X * BLOCK_Y - 1) / (BLOCK_X * BLOCK_Y), BLOCK_X * BLOCK_Y, 0, cuda_stream>>>(
-            input_w, output_w, kernel_size, coef_x);
-
-        detail::PreComputeCoef<<<(output_h + BLOCK_X * BLOCK_Y - 1) / (BLOCK_X * BLOCK_Y), BLOCK_X * BLOCK_Y, 0, cuda_stream>>>(
-            input_h, output_h, kernel_size, coef_y);
-
-        const dim3 tile_grid((output_w + BLOCK_X - 1) / BLOCK_X, (output_h + BLOCK_Y - 1) / BLOCK_Y);
-        const dim3 block(BLOCK_X, BLOCK_Y, 1);
-
-        detail::LanczosResampleCUDA<NUM_CHANNELS><<<tile_grid, block, 0, cuda_stream>>>(
-            input_h, input_w,
-            output_h, output_w,
-            kernel_size,
-            coef_x,
-            coef_y,
-            input.ptr<uint8_t>(),
-            output.ptr<float>());
-
-        cudaFree(coef_x);
-        cudaFree(coef_y);
-
-        return output;
     }
 
     Tensor lanczos_resize_grayscale(

--- a/src/core/image_io.cpp
+++ b/src/core/image_io.cpp
@@ -596,8 +596,6 @@ namespace lfs::core {
 
     void free_image(void* img) { std::free(img); }
 
-    void free_image(void* img) { std::free(img); }
-
     bool save_img_data(const std::filesystem::path& p, const std::tuple<unsigned char*, int, int, int>& image_data) {
         init_oiio(); // Assuming this initializes OIIO like in your load_image
 

--- a/src/core/image_io.cpp
+++ b/src/core/image_io.cpp
@@ -596,6 +596,8 @@ namespace lfs::core {
 
     void free_image(void* img) { std::free(img); }
 
+    void free_image(void* img) { std::free(img); }
+
     bool save_img_data(const std::filesystem::path& p, const std::tuple<unsigned char*, int, int, int>& image_data) {
         init_oiio(); // Assuming this initializes OIIO like in your load_image
 

--- a/src/core/image_io.cpp
+++ b/src/core/image_io.cpp
@@ -26,6 +26,34 @@ namespace {
 
     constexpr int DEFAULT_JPEG_QUALITY = 95;
 
+    template <typename T>
+    struct PixelTypeTrait;
+
+    template <>
+    struct PixelTypeTrait<uint8_t> {
+        static constexpr OIIO::TypeDesc value = OIIO::TypeDesc::UINT8;
+    };
+
+    template <>
+    struct PixelTypeTrait<uint16_t> {
+        static constexpr OIIO::TypeDesc value = OIIO::TypeDesc::UINT16;
+    };
+
+    template <>
+    struct PixelTypeTrait<float> {
+        static constexpr OIIO::TypeDesc value = OIIO::TypeDesc::FLOAT;
+    };
+
+    template <typename T>
+    struct PixelTypeTrait {
+        static_assert(!sizeof(T), "Unsupported pixel type");
+    };
+
+    template <typename T>
+    constexpr OIIO::TypeDesc pixel_type_of() {
+        return PixelTypeTrait<T>::value;
+    }
+
     // Run once: set global OIIO attributes (threading, etc.)
     std::once_flag g_oiio_once;
     inline void init_oiio() {
@@ -72,18 +100,20 @@ namespace {
         return ImageOutputPtr(OIIO::ImageOutput::create(path_utf8).release());
     }
 
-    static inline unsigned char* downscale_resample_nch(const unsigned char* src,
-                                                        int w, int h, int nw, int nh,
-                                                        int channels,
-                                                        int nthreads /* 0=auto, 1=single */) {
-        size_t outbytes = (size_t)nw * nh * channels;
-        auto* out = static_cast<unsigned char*>(std::malloc(outbytes));
+    template <typename T>
+    T* downscale_resample_nch(const T* src,
+                              int w, int h, int nw, int nh,
+                              int channels,
+                              int nthreads /* 0=auto, 1=single */) {
+        size_t outbytes = (size_t)nw * nh * channels * sizeof(T);
+        auto* out = static_cast<T*>(std::malloc(outbytes));
         if (!out)
             throw std::bad_alloc();
 
-        OIIO::ImageBuf srcbuf(OIIO::ImageSpec(w, h, channels, OIIO::TypeDesc::UINT8),
-                              const_cast<unsigned char*>(src));
-        OIIO::ImageBuf dstbuf(OIIO::ImageSpec(nw, nh, channels, OIIO::TypeDesc::UINT8), out);
+        // Wrap src & dst without extra allocations/copies
+        OIIO::ImageBuf srcbuf(OIIO::ImageSpec(w, h, channels, pixel_type_of<T>()),
+                              const_cast<T*>(src));
+        OIIO::ImageBuf dstbuf(OIIO::ImageSpec(nw, nh, channels, pixel_type_of<T>()), out);
 
         OIIO::ROI roi(0, nw, 0, nh, 0, 1, 0, channels);
         if (!OIIO::ImageBufAlgo::resample(dstbuf, srcbuf, /*interpolate=*/true, roi, nthreads)) {
@@ -94,10 +124,11 @@ namespace {
         return out;
     }
 
-    static inline unsigned char* downscale_resample_direct(const unsigned char* src_rgb,
-                                                           int w, int h, int nw, int nh,
-                                                           int nthreads /* 0=auto, 1=single */) {
-        return downscale_resample_nch(src_rgb, w, h, nw, nh, 3, nthreads);
+    template <typename T>
+    T* downscale_resample_direct(const T* src_rgb,
+                                            int w, int h, int nw, int nh,
+                                            int nthreads /* 0=auto, 1=single */) {
+        return downscale_resample_nch<T>(src_rgb, w, h, nw, nh, 3, nthreads);
     }
 
     lfs::core::Tensor normalize_image_for_save(lfs::core::Tensor image) {
@@ -193,6 +224,228 @@ namespace {
         out.reset();
     }
 
+    template <typename T>
+    std::tuple<T*, int, int, int>
+    load_image_t(std::filesystem::path p, int res_div, int max_width) {
+        LOG_TIMER("load_image total");
+
+        {
+            LOG_TIMER("init_oiio");
+            init_oiio();
+        }
+
+        const std::string path_utf8 = lfs::core::path_to_utf8(p);
+        ImageInputPtr in;
+        {
+            LOG_TIMER("OIIO::ImageInput::open");
+            in = open_image_input(path_utf8);
+            if (!in)
+                throw std::runtime_error("Load failed: " + path_utf8 + " : " + OIIO::geterror());
+        }
+
+        const OIIO::ImageSpec& spec = in->spec();
+        int w = spec.width, h = spec.height, file_c = spec.nchannels;
+
+        // Decide threading for the resample (see notes below)
+        const int nthreads = 0; // set to 1 if you call this from multiple worker threads
+
+        // Fast path: read 3 channels directly (drop alpha if present)
+        if (file_c >= 3) {
+            if (res_div <= 1) {
+                LOG_PERF("Fast path: reading 3 channels directly");
+                // allocate and read directly into final RGB buffer
+                auto* out = [&]() {
+                    LOG_TIMER("malloc RGB buffer");
+                    return static_cast<T*>(std::malloc((size_t)w * h * 3 * sizeof(T)));
+                }();
+                if (!out) {
+                    throw std::bad_alloc();
+                }
+
+                {
+                    LOG_TIMER("OIIO read_image");
+                    if (!in->read_image(/*subimage*/ 0, /*miplevel*/ 0,
+                                        /*chbegin*/ 0, /*chend*/ 3,
+                                        pixel_type_of<T>(), out)) {
+                        std::string e = in->geterror();
+                        std::free(out);
+                        throw std::runtime_error("Read failed: " + path_utf8 + (e.empty() ? "" : (" : " + e)));
+                    }
+                }
+
+                {
+                    in.reset();
+                }
+
+                if (max_width > 0 && (w > max_width || h > max_width)) {
+                    LOG_PERF("Need downscaling: {}x{} -> max_width {}", w, h, max_width);
+                    int scale_w;
+                    int scale_h;
+                    if (w > h) {
+                        scale_h = std::max(1, max_width * h / w);
+                        scale_w = std::max(1, max_width);
+                    } else {
+                        scale_w = std::max(1, max_width * w / h);
+                        scale_h = std::max(1, max_width);
+                    }
+                    T* ret = nullptr;
+                    try {
+                        LOG_TIMER("downscale_resample_direct");
+                        ret = downscale_resample_direct<T>(out, w, h, scale_w, scale_h, nthreads);
+                    } catch (...) {
+                        std::free(out);
+                        throw;
+                    }
+                    std::free(out);
+                    LOG_PERF("Downscaled to {}x{}", scale_w, scale_h);
+                    return {ret, scale_w, scale_h, 3};
+                } else {
+                    return {out, w, h, 3};
+                }
+
+            } else if (res_div == 2 || res_div == 4 || res_div == 8) {
+                LOG_PERF("res_div path: res_div={}", res_div);
+                // read full, then downscale in-place into a new buffer without extra copy
+                auto* full = [&]() {
+                    LOG_TIMER("malloc full buffer for res_div");
+                    return static_cast<T*>(std::malloc((size_t)w * h * 3 * sizeof(T)));
+                }();
+                if (!full) {
+                    throw std::bad_alloc();
+                }
+
+                {
+                    LOG_TIMER("OIIO read_image (res_div)");
+                    if (!in->read_image(0, 0, 0, 3, pixel_type_of<T>(), full)) {
+                        std::string e = in->geterror();
+                        std::free(full);
+                        throw std::runtime_error("Read failed: " + path_utf8 + (e.empty() ? "" : (" : " + e)));
+                    }
+                }
+
+                {
+                    LOG_TIMER("OIIO close (res_div)");
+                    in.reset();
+                }
+
+                const int nw = std::max(1, w / res_div);
+                const int nh = std::max(1, h / res_div);
+                LOG_PERF("Target size after res_div: {}x{}", nw, nh);
+                int scale_w = nw;
+                int scale_h = nh;
+                if (max_width > 0 && (nw > max_width || nh > max_width)) {
+                    if (nw > nh) {
+                        scale_h = std::max(1, max_width * nh / nw);
+                        scale_w = std::max(1, max_width);
+                    } else {
+                        scale_w = std::max(1, max_width * nw / nh);
+                        scale_h = std::max(1, max_width);
+                    }
+                }
+
+                T* out = nullptr;
+                try {
+                    LOG_TIMER("downscale_resample_direct (res_div)");
+                    out = downscale_resample_direct<T>(full, w, h, scale_w, scale_h, nthreads);
+                } catch (...) {
+                    std::free(full);
+                    throw;
+                }
+                std::free(full);
+                LOG_PERF("Final size: {}x{}", scale_w, scale_h);
+                return {out, scale_w, scale_h, 3};
+            } else {
+                LOG_ERROR("load_image: unsupported resize factor {}", res_div);
+                // fall through
+            }
+        }
+
+        // 1–2 channel inputs -> read native, then expand to RGB
+        {
+            LOG_PERF("Grayscale/2-channel path: file_c={}", file_c);
+            const int in_c = std::min(2, std::max(1, file_c));
+            std::vector<T> tmp;
+            {
+                LOG_TIMER("allocate temp buffer");
+                tmp.resize((size_t)w * h * in_c);
+            }
+
+            {
+                LOG_TIMER("OIIO read_image (grayscale)");
+                if (!in->read_image(0, 0, 0, in_c, pixel_type_of<T>(), tmp.data())) {
+                    auto e = in->geterror();
+                    throw std::runtime_error("Read failed: " + path_utf8 + (e.empty() ? "" : (" : " + e)));
+                }
+            }
+
+            {
+                LOG_TIMER("OIIO close (grayscale)");
+                in.reset();
+            }
+
+            auto* base = [&]() {
+                LOG_TIMER("malloc RGB base buffer");
+                return static_cast<T*>(std::malloc((size_t)w * h * 3 * sizeof(T)));
+            }();
+            if (!base)
+                throw std::bad_alloc();
+
+            {
+                LOG_TIMER("expand to RGB");
+                if (in_c == 1) {
+                    const T* g = tmp.data();
+                    for (size_t i = 0, N = (size_t)w * h; i < N; ++i) {
+                        T v = g[i];
+                        base[3 * i + 0] = v;
+                        base[3 * i + 1] = v;
+                        base[3 * i + 2] = v;
+                    }
+                } else { // 2 channels -> (R,G,avg)
+                    const T* src = tmp.data();
+                    for (size_t i = 0, N = (size_t)w * h; i < N; ++i) {
+                        T r = src[2 * i + 0];
+                        T g = src[2 * i + 1];
+                        base[3 * i + 0] = r;
+                        base[3 * i + 1] = g;
+                        base[3 * i + 2] = (T)((r + g) / 2);
+                    }
+                }
+            }
+
+            // Calculate target dimensions after res_div
+            int nw = (res_div == 2 || res_div == 4 || res_div == 8) ? std::max(1, w / res_div) : w;
+            int nh = (res_div == 2 || res_div == 4 || res_div == 8) ? std::max(1, h / res_div) : h;
+
+            // Apply max_width if needed
+            int scale_w = nw;
+            int scale_h = nh;
+            if (max_width > 0 && (nw > max_width || nh > max_width)) {
+                if (nw > nh) {
+                    scale_h = std::max(1, max_width * nh / nw);
+                    scale_w = std::max(1, max_width);
+                } else {
+                    scale_w = std::max(1, max_width * nw / nh);
+                    scale_h = std::max(1, max_width);
+                }
+            }
+
+            // Resize if dimensions changed
+            if (scale_w != w || scale_h != h) {
+                T* out = nullptr;
+                try {
+                    out = downscale_resample_direct<T>(base, w, h, scale_w, scale_h, nthreads);
+                } catch (...) {
+                    std::free(base);
+                    throw;
+                }
+                std::free(base);
+                return {out, scale_w, scale_h, 3};
+            }
+
+            return {base, w, h, 3};
+        }
+    }
+
 } // namespace
 
 namespace lfs::core {
@@ -259,7 +512,7 @@ namespace lfs::core {
         if (nw != w || nh != h) {
             unsigned char* resized = nullptr;
             try {
-                resized = downscale_resample_nch(out, w, h, nw, nh, 4, 0);
+                resized = downscale_resample_nch<unsigned char>(out, w, h, nw, nh, 4, 0);
             } catch (...) {
                 std::free(out);
                 throw;
@@ -298,223 +551,19 @@ namespace lfs::core {
 
     std::tuple<unsigned char*, int, int, int>
     load_image(std::filesystem::path p, int res_div, int max_width) {
-        LOG_TIMER("load_image total");
+        return ::load_image_t<unsigned char>(p, res_div, max_width);
+    }
 
-        {
-            LOG_TIMER("init_oiio");
-            init_oiio();
-        }
+    std::tuple<uint16_t*, int, int, int>
+    load_image_u16(std::filesystem::path p, int res_div, int max_width)
+    {
+        return ::load_image_t<uint16_t>(p, res_div, max_width);
+    }
 
-        const std::string path_utf8 = lfs::core::path_to_utf8(p);
-        ImageInputPtr in;
-        {
-            LOG_TIMER("OIIO::ImageInput::open");
-            in = open_image_input(path_utf8);
-            if (!in)
-                throw std::runtime_error("Load failed: " + path_utf8 + " : " + OIIO::geterror());
-        }
-
-        const OIIO::ImageSpec& spec = in->spec();
-        int w = spec.width, h = spec.height, file_c = spec.nchannels;
-
-        // Decide threading for the resample (see notes below)
-        const int nthreads = 0; // set to 1 if you call this from multiple worker threads
-
-        // Fast path: read 3 channels directly (drop alpha if present)
-        if (file_c >= 3) {
-            if (res_div <= 1) {
-                LOG_PERF("Fast path: reading 3 channels directly");
-                // allocate and read directly into final RGB buffer
-                auto* out = [&]() {
-                    LOG_TIMER("malloc RGB buffer");
-                    return static_cast<unsigned char*>(std::malloc((size_t)w * h * 3));
-                }();
-                if (!out) {
-                    throw std::bad_alloc();
-                }
-
-                {
-                    LOG_TIMER("OIIO read_image");
-                    if (!in->read_image(/*subimage*/ 0, /*miplevel*/ 0,
-                                        /*chbegin*/ 0, /*chend*/ 3,
-                                        OIIO::TypeDesc::UINT8, out)) {
-                        std::string e = in->geterror();
-                        std::free(out);
-                        throw std::runtime_error("Read failed: " + path_utf8 + (e.empty() ? "" : (" : " + e)));
-                    }
-                }
-
-                {
-                    in.reset();
-                }
-
-                if (max_width > 0 && (w > max_width || h > max_width)) {
-                    LOG_PERF("Need downscaling: {}x{} -> max_width {}", w, h, max_width);
-                    int scale_w;
-                    int scale_h;
-                    if (w > h) {
-                        scale_h = std::max(1, max_width * h / w);
-                        scale_w = std::max(1, max_width);
-                    } else {
-                        scale_w = std::max(1, max_width * w / h);
-                        scale_h = std::max(1, max_width);
-                    }
-                    unsigned char* ret = nullptr;
-                    try {
-                        LOG_TIMER("downscale_resample_direct");
-                        ret = downscale_resample_direct(out, w, h, scale_w, scale_h, nthreads);
-                    } catch (...) {
-                        std::free(out);
-                        throw;
-                    }
-                    std::free(out);
-                    LOG_PERF("Downscaled to {}x{}", scale_w, scale_h);
-                    return {ret, scale_w, scale_h, 3};
-                } else {
-                    return {out, w, h, 3};
-                }
-
-            } else if (res_div == 2 || res_div == 4 || res_div == 8) {
-                LOG_PERF("res_div path: res_div={}", res_div);
-                // read full, then downscale in-place into a new buffer without extra copy
-                auto* full = [&]() {
-                    LOG_TIMER("malloc full buffer for res_div");
-                    return static_cast<unsigned char*>(std::malloc((size_t)w * h * 3));
-                }();
-                if (!full) {
-                    throw std::bad_alloc();
-                }
-
-                {
-                    LOG_TIMER("OIIO read_image (res_div)");
-                    if (!in->read_image(0, 0, 0, 3, OIIO::TypeDesc::UINT8, full)) {
-                        std::string e = in->geterror();
-                        std::free(full);
-                        throw std::runtime_error("Read failed: " + path_utf8 + (e.empty() ? "" : (" : " + e)));
-                    }
-                }
-
-                {
-                    LOG_TIMER("OIIO close (res_div)");
-                    in.reset();
-                }
-
-                const int nw = std::max(1, w / res_div);
-                const int nh = std::max(1, h / res_div);
-                LOG_PERF("Target size after res_div: {}x{}", nw, nh);
-                int scale_w = nw;
-                int scale_h = nh;
-                if (max_width > 0 && (nw > max_width || nh > max_width)) {
-                    if (nw > nh) {
-                        scale_h = std::max(1, max_width * nh / nw);
-                        scale_w = std::max(1, max_width);
-                    } else {
-                        scale_w = std::max(1, max_width * nw / nh);
-                        scale_h = std::max(1, max_width);
-                    }
-                }
-
-                unsigned char* out = nullptr;
-                try {
-                    LOG_TIMER("downscale_resample_direct (res_div)");
-                    out = downscale_resample_direct(full, w, h, scale_w, scale_h, nthreads);
-                } catch (...) {
-                    std::free(full);
-                    throw;
-                }
-                std::free(full);
-                LOG_PERF("Final size: {}x{}", scale_w, scale_h);
-                return {out, scale_w, scale_h, 3};
-            } else {
-                LOG_ERROR("load_image: unsupported resize factor {}", res_div);
-                // fall through
-            }
-        }
-
-        // 1–2 channel inputs -> read native, then expand to RGB
-        {
-            LOG_PERF("Grayscale/2-channel path: file_c={}", file_c);
-            const int in_c = std::min(2, std::max(1, file_c));
-            std::vector<unsigned char> tmp;
-            {
-                LOG_TIMER("allocate temp buffer");
-                tmp.resize((size_t)w * h * in_c);
-            }
-
-            {
-                LOG_TIMER("OIIO read_image (grayscale)");
-                if (!in->read_image(0, 0, 0, in_c, OIIO::TypeDesc::UINT8, tmp.data())) {
-                    auto e = in->geterror();
-                    throw std::runtime_error("Read failed: " + path_utf8 + (e.empty() ? "" : (" : " + e)));
-                }
-            }
-
-            {
-                LOG_TIMER("OIIO close (grayscale)");
-                in.reset();
-            }
-
-            auto* base = [&]() {
-                LOG_TIMER("malloc RGB base buffer");
-                return static_cast<unsigned char*>(std::malloc((size_t)w * h * 3));
-            }();
-            if (!base)
-                throw std::bad_alloc();
-
-            {
-                LOG_TIMER("expand to RGB");
-                if (in_c == 1) {
-                    const unsigned char* g = tmp.data();
-                    for (size_t i = 0, N = (size_t)w * h; i < N; ++i) {
-                        unsigned char v = g[i];
-                        base[3 * i + 0] = v;
-                        base[3 * i + 1] = v;
-                        base[3 * i + 2] = v;
-                    }
-                } else { // 2 channels -> (R,G,avg)
-                    const unsigned char* src = tmp.data();
-                    for (size_t i = 0, N = (size_t)w * h; i < N; ++i) {
-                        unsigned char r = src[2 * i + 0];
-                        unsigned char g = src[2 * i + 1];
-                        base[3 * i + 0] = r;
-                        base[3 * i + 1] = g;
-                        base[3 * i + 2] = (unsigned char)(((int)r + (int)g) / 2);
-                    }
-                }
-            }
-
-            // Calculate target dimensions after res_div
-            int nw = (res_div == 2 || res_div == 4 || res_div == 8) ? std::max(1, w / res_div) : w;
-            int nh = (res_div == 2 || res_div == 4 || res_div == 8) ? std::max(1, h / res_div) : h;
-
-            // Apply max_width if needed
-            int scale_w = nw;
-            int scale_h = nh;
-            if (max_width > 0 && (nw > max_width || nh > max_width)) {
-                if (nw > nh) {
-                    scale_h = std::max(1, max_width * nh / nw);
-                    scale_w = std::max(1, max_width);
-                } else {
-                    scale_w = std::max(1, max_width * nw / nh);
-                    scale_h = std::max(1, max_width);
-                }
-            }
-
-            // Resize if dimensions changed
-            if (scale_w != w || scale_h != h) {
-                unsigned char* out = nullptr;
-                try {
-                    out = downscale_resample_direct(base, w, h, scale_w, scale_h, nthreads);
-                } catch (...) {
-                    std::free(base);
-                    throw;
-                }
-                std::free(base);
-                return {out, scale_w, scale_h, 3};
-            }
-
-            return {base, w, h, 3};
-        }
+    std::tuple<float*, int, int, int>
+    load_image_fp32(std::filesystem::path p, int res_div, int max_width)
+    {
+        return ::load_image_t<float>(p, res_div, max_width);
     }
 
     void save_image(const std::filesystem::path& path, lfs::core::Tensor image) {
@@ -545,7 +594,7 @@ namespace lfs::core {
                              DEFAULT_JPEG_QUALITY);
     }
 
-    void free_image(unsigned char* img) { std::free(img); }
+    void free_image(void* img) { std::free(img); }
 
     bool save_img_data(const std::filesystem::path& p, const std::tuple<unsigned char*, int, int, int>& image_data) {
         init_oiio(); // Assuming this initializes OIIO like in your load_image

--- a/src/core/include/core/image_io.hpp
+++ b/src/core/include/core/image_io.hpp
@@ -15,6 +15,7 @@
 #include <queue>
 #include <thread>
 #include <vector>
+#include <stdfloat>
 
 namespace lfs::core {
 
@@ -25,18 +26,26 @@ namespace lfs::core {
     LFS_CORE_API std::tuple<unsigned char*, int, int, int>
     load_image_from_memory(const uint8_t* data, size_t size);
 
+    // Existing functions
     LFS_CORE_API std::tuple<unsigned char*, int, int, int>
     load_image(std::filesystem::path p, int res_div = -1, int max_width = 0);
+
+    LFS_CORE_API std::tuple<uint16_t*, int, int, int>
+    load_image_u16(std::filesystem::path p, int res_div = -1, int max_width = 0);
+
+    LFS_CORE_API std::tuple<float*, int, int, int>
+    load_image_fp32(std::filesystem::path p, int res_div = -1, int max_width = 0);
+
     LFS_CORE_API void save_image(const std::filesystem::path& path, Tensor image);
     LFS_CORE_API void save_image_u8(const std::filesystem::path& path, Tensor image, int jpeg_quality = 95);
     LFS_CORE_API void save_image(const std::filesystem::path& path,
-                                 const std::vector<Tensor>& images,
-                                 bool horizontal = true,
-                                 int separator_width = 2);
+                                const std::vector<Tensor>& images,
+                                bool horizontal = true,
+                                int separator_width = 2);
 
     LFS_CORE_API bool save_img_data(const std::filesystem::path& p, const std::tuple<unsigned char*, int, int, int>& image_data);
 
-    LFS_CORE_API void free_image(unsigned char* image);
+    LFS_CORE_API void free_image(void* image);
 
 } // namespace lfs::core
 

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -221,7 +221,7 @@ namespace lfs::core {
             bool use_fs_cache = true;
             bool print_cache_status = true;
             int print_status_freq_num = 500; // every print_status_freq_num calls for load print cache status
-
+            bool use_8bit_color = true;
             nlohmann::json to_json() const;
             static LoadingParams from_json(const nlohmann::json& j);
         };

--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -630,6 +630,9 @@ namespace lfs::core {
             if (j.contains("print_status_freq_num")) {
                 params.print_status_freq_num = j["print_status_freq_num"];
             }
+            if (j.contains("use_8bit_color")) {
+                params.use_8bit_color = j["use_8bit_color"];
+            }
 
             return params;
         }
@@ -642,6 +645,7 @@ namespace lfs::core {
             loading_json["use_fs_cache"] = use_fs_cache;
             loading_json["print_cache_status"] = print_cache_status;
             loading_json["print_status_freq_num"] = print_status_freq_num;
+            loading_json["use_8bit_color"] = use_8bit_color;
 
             return loading_json;
         }

--- a/src/io/cuda/image_format_kernels.cu
+++ b/src/io/cuda/image_format_kernels.cu
@@ -8,7 +8,9 @@ namespace lfs::io::cuda {
 
     namespace {
         constexpr int BLOCK_SIZE = 256;
-        constexpr float NORMALIZE_SCALE = 1.0f / 255.0f;
+        constexpr float NORMALIZE_SCALE_U8 = 1.0f / 255.0f;
+        constexpr float NORMALIZE_SCALE_U16 = 1.0f / 65535.f;
+        ;
     } // namespace
 
     __global__ void uint8_hwc_to_float32_chw_kernel(
@@ -29,7 +31,99 @@ namespace lfs::io::cuda {
         const size_t h = tmp / W;
 
         const size_t out_idx = c * (H * W) + h * W + w;
-        output[out_idx] = static_cast<float>(input[idx]) * NORMALIZE_SCALE;
+        output[out_idx] = static_cast<float>(input[idx]) * NORMALIZE_SCALE_U8;
+    }
+
+    __global__ void uint16_hwc_to_float32_chw_kernel(
+        const uint16_t* __restrict__ input,
+        float* __restrict__ output,
+        const size_t H,
+        const size_t W,
+        const size_t C) {
+
+        const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+        const size_t total = H * W * C;
+        if (idx >= total)
+            return;
+
+        const size_t c = idx % C;
+        const size_t tmp = idx / C;
+        const size_t w = tmp % W;
+        const size_t h = tmp / W;
+
+        const size_t out_idx = c * (H * W) + h * W + w;
+        output[out_idx] = static_cast<float>(input[idx]) * NORMALIZE_SCALE_U16;
+    }
+
+    __global__ void float32_chw_to_uint16_hwc_kernel(
+        const float* __restrict__ input, // CHW float32 input
+        uint16_t* __restrict__ output,   // HWC uint16 output
+        const size_t H,
+        const size_t W,
+        const size_t C) {
+
+        const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+        const size_t total = H * W * C;
+        if (idx >= total)
+            return;
+
+        // Decompose linear CHW index -> (c, h, w)
+        const size_t c = idx / (H * W);
+        const size_t h = (idx / W) % H;
+        const size_t w = idx % W;
+
+        // Recompose as HWC index
+        const size_t out_idx = h * (W * C) + w * C + c;
+
+        // Scale [0, 1] -> [0, 65535] and clamp before cast
+        const float scaled = fminf(fmaxf(input[idx] * 65535.0f, 0.0f), 65535.0f);
+        output[out_idx] = static_cast<uint16_t>(scaled);
+    }
+
+    __global__ void float32_hwc_to_uint16_hwc_kernel(
+        const float* __restrict__ input,
+        uint16_t* __restrict__ output,
+        const size_t total) {
+
+        const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+        if (idx >= total)
+            return;
+
+        const float scaled = fminf(fmaxf(input[idx] * 65535.0f, 0.0f), 65535.0f);
+        output[idx] = static_cast<uint16_t>(scaled);
+    }
+
+    __global__ void uint16_hwc_to_float_hwc_kernel(
+        const uint16_t* __restrict__ input,
+        float* __restrict__ output,
+        const size_t total) {
+
+        const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+        if (idx >= total)
+            return;
+        output[idx] = static_cast<float>(input[idx]) * NORMALIZE_SCALE_U16;
+    }
+
+
+    __global__ void float32_hwc_to_float32_chw_kernel(
+        const float* __restrict__ input,
+        float* __restrict__ output,
+        const size_t H,
+        const size_t W,
+        const size_t C) {
+
+        const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+        const size_t total = H * W * C;
+        if (idx >= total)
+            return;
+
+        const size_t c = idx % C;
+        const size_t tmp = idx / C;
+        const size_t w = tmp % W;
+        const size_t h = tmp / W;
+
+        const size_t out_idx = c * (H * W) + h * W + w;
+        output[out_idx] = input[idx];
     }
 
     __global__ void uint8_hwc_to_uint8_chw_kernel(
@@ -51,6 +145,27 @@ namespace lfs::io::cuda {
 
         const size_t out_idx = c * (H * W) + h * W + w;
         output[out_idx] = input[idx];
+    }
+
+    __global__ void uint16_hwc_to_uint8_chw_kernel(
+        const uint16_t* __restrict__ input,
+        uint8_t* __restrict__ output,
+        const size_t H,
+        const size_t W,
+        const size_t C) {
+
+        const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+        const size_t total = H * W * C;
+        if (idx >= total)
+            return;
+
+        const size_t c = idx % C;
+        const size_t tmp = idx / C;
+        const size_t w = tmp % W;
+        const size_t h = tmp / W;
+
+        const size_t out_idx = c * (H * W) + h * W + w;
+        output[out_idx] = input[idx] >> 8;
     }
 
     __device__ __forceinline__ uint8_t float_to_u8(const float v) {
@@ -85,6 +200,83 @@ namespace lfs::io::cuda {
             input, output, height, width, channels);
     }
 
+    void launch_uint16_hwc_to_float32_chw(
+        const uint16_t* input,
+        float* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream) {
+
+        const size_t total = height * width * channels;
+        const int num_blocks = static_cast<int>((total + BLOCK_SIZE - 1) / BLOCK_SIZE);
+
+        uint16_hwc_to_float32_chw_kernel<<<num_blocks, BLOCK_SIZE, 0, stream>>>(
+            input, output, height, width, channels);
+
+    }
+
+    void launch_float32_chw_to_uint16_hwc(
+        const float* input,
+        uint16_t* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream) {
+
+        const size_t total = height * width * channels;
+        const int num_blocks = static_cast<int>((total + BLOCK_SIZE - 1) / BLOCK_SIZE);
+
+        float32_chw_to_uint16_hwc_kernel<<<num_blocks, BLOCK_SIZE, 0, stream>>>(
+            input, output, height, width, channels);
+    }
+
+    void launch_float32_hwc_to_uint16_hwc(
+        const float* input,
+        uint16_t* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream) {
+
+        const size_t total = height * width * channels;
+        const int num_blocks = static_cast<int>((total + BLOCK_SIZE - 1) / BLOCK_SIZE);
+
+        float32_hwc_to_uint16_hwc_kernel<<<num_blocks, BLOCK_SIZE, 0, stream>>>(
+            input, output, total);
+    }
+
+    void launch_uint16_hwc_to_float32_hwc(
+        const uint16_t* input,
+        float* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream) {
+
+        const size_t total = height * width * channels;
+        const int num_blocks = static_cast<int>((total + BLOCK_SIZE - 1) / BLOCK_SIZE);
+
+        uint16_hwc_to_float_hwc_kernel<<<num_blocks, BLOCK_SIZE, 0, stream>>>(
+            input, output, total);
+
+    }
+
+    void launch_float32_hwc_to_float32_chw(
+        const float* input,
+        float* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream) {
+
+        const size_t total = height * width * channels;
+        const int num_blocks = static_cast<int>((total + BLOCK_SIZE - 1) / BLOCK_SIZE);
+
+        float32_hwc_to_float32_chw_kernel<<<num_blocks, BLOCK_SIZE, 0, stream>>>(
+                input, output, height, width, channels);
+    }
+
     void launch_uint8_hwc_to_uint8_chw(
         const uint8_t* input,
         uint8_t* output,
@@ -97,6 +289,21 @@ namespace lfs::io::cuda {
         const int num_blocks = static_cast<int>((total + BLOCK_SIZE - 1) / BLOCK_SIZE);
 
         uint8_hwc_to_uint8_chw_kernel<<<num_blocks, BLOCK_SIZE, 0, stream>>>(
+            input, output, height, width, channels);
+    }
+
+    void launch_uint16_hwc_to_uint8_chw(
+        const uint16_t* input,
+        uint8_t* output,
+        const size_t height,
+        const size_t width,
+        const size_t channels,
+        cudaStream_t stream) {
+
+        const size_t total = height * width * channels;
+        const int num_blocks = static_cast<int>((total + BLOCK_SIZE - 1) / BLOCK_SIZE);
+
+        uint16_hwc_to_uint8_chw_kernel<<<num_blocks, BLOCK_SIZE, 0, stream>>>(
             input, output, height, width, channels);
     }
 
@@ -124,7 +331,7 @@ namespace lfs::io::cuda {
         if (idx >= total)
             return;
 
-        output[idx] = static_cast<float>(input[idx]) * NORMALIZE_SCALE;
+        output[idx] = static_cast<float>(input[idx]) * NORMALIZE_SCALE_U8;
     }
 
     void launch_uint8_hw_to_float32_hw(
@@ -152,10 +359,10 @@ namespace lfs::io::cuda {
             return;
 
         const size_t src = idx * 4;
-        const float r = static_cast<float>(input[src + 0]) * NORMALIZE_SCALE;
-        const float g = static_cast<float>(input[src + 1]) * NORMALIZE_SCALE;
-        const float b = static_cast<float>(input[src + 2]) * NORMALIZE_SCALE;
-        const float a = static_cast<float>(input[src + 3]) * NORMALIZE_SCALE;
+        const float r = static_cast<float>(input[src + 0]) * NORMALIZE_SCALE_U8;
+        const float g = static_cast<float>(input[src + 1]) * NORMALIZE_SCALE_U8;
+        const float b = static_cast<float>(input[src + 2]) * NORMALIZE_SCALE_U8;
+        const float a = static_cast<float>(input[src + 3]) * NORMALIZE_SCALE_U8;
 
         rgb_output[idx] = r;
         rgb_output[total + idx] = g;
@@ -177,7 +384,7 @@ namespace lfs::io::cuda {
         rgb_output[idx] = input[src + 0];
         rgb_output[total + idx] = input[src + 1];
         rgb_output[2 * total + idx] = input[src + 2];
-        alpha_output[idx] = static_cast<float>(input[src + 3]) * NORMALIZE_SCALE;
+        alpha_output[idx] = static_cast<float>(input[src + 3]) * NORMALIZE_SCALE_U8;
     }
 
     void launch_uint8_rgba_split_to_float32_rgb_and_alpha(

--- a/src/io/cuda/image_format_kernels.cuh
+++ b/src/io/cuda/image_format_kernels.cuh
@@ -17,9 +17,63 @@ namespace lfs::io::cuda {
         size_t channels,
         cudaStream_t stream = nullptr);
 
+    // Fused kernel: uint16 HWC -> float32 CHW normalized [0,1]
+    void launch_uint16_hwc_to_float32_chw(
+        const uint16_t* input,
+        float* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream = nullptr);
+
+    // Fused kernel: float32 CHW [0,1] -> uint16 HWC [0, 65535]
+    void launch_float32_chw_to_uint16_hwc(
+        const float* input,
+        uint16_t* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream = nullptr);
+
+    // Fused kernel: float32 HWC [0,1] -> uint16 HWC [0, 65535]
+    void launch_float32_hwc_to_uint16_hwc(
+        const float* input,
+        uint16_t* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream = nullptr);
+
+     // Fused kernel: uint16 HWC [0, 65535] -> float32 HWC [0,1]
+    void launch_uint16_hwc_to_float32_hwc(
+        const uint16_t* input,
+        float* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream = nullptr);
+
+    // float32 HWC -> float32 CHW
+    void launch_float32_hwc_to_float32_chw(
+        const float* input,
+        float* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream = nullptr);
+
     // Fused kernel: uint8 HWC -> uint8 CHW
     void launch_uint8_hwc_to_uint8_chw(
         const uint8_t* input,
+        uint8_t* output,
+        size_t height,
+        size_t width,
+        size_t channels,
+        cudaStream_t stream = nullptr);
+
+    // Fused kernel: uint16 HWC -> uint8 CHW
+    void launch_uint16_hwc_to_uint8_chw(
+        const uint16_t* input,
         uint8_t* output,
         size_t height,
         size_t width,

--- a/src/io/include/io/pipelined_image_loader.hpp
+++ b/src/io/include/io/pipelined_image_loader.hpp
@@ -51,6 +51,7 @@ namespace lfs::io {
         int cache_jpeg_quality = config::DEFAULT_JPEG_QUALITY;
         std::chrono::milliseconds batch_collect_timeout{config::DEFAULT_BATCH_TIMEOUT_MS};
         std::chrono::milliseconds output_wait_timeout{config::DEFAULT_OUTPUT_TIMEOUT_MS};
+        bool use_16bits_pixel_depth = false;
     };
 
     /**

--- a/src/io/nvcodec_image_loader.cpp
+++ b/src/io/nvcodec_image_loader.cpp
@@ -20,9 +20,9 @@
 #include <cuda.h> // For CUcontext, cuCtxGetCurrent, cuCtxSetCurrent
 #include <cuda_runtime.h>
 #include <fstream>
+#include <iostream>
 #include <mutex>
 #include <nvimgcodec.h>
-
 #include <sstream>
 #include <stdexcept>
 #include <unordered_map>
@@ -889,27 +889,38 @@ namespace lfs::io {
         }
         const bool needs_resize = (target_width != src_width || target_height != src_height);
 
+        auto source_image_sample_type = image_info.plane_info[0].sample_type;
+        bool decode_u8_data_path = source_image_sample_type == NVIMGCODEC_SAMPLE_DATA_TYPE_UINT8;
+        bool decode_u16_data_path = source_image_sample_type == NVIMGCODEC_SAMPLE_DATA_TYPE_UINT16;
+
+        if (!(decode_u8_data_path || decode_u16_data_path)) {
+            LOG_ERROR("[NvCodecImageLoader] Image decode failed: source sample_type no supported -> {}", static_cast<int>(image_info.plane_info[0].sample_type));
+        };
+
+        auto tensor_datatype = (decode_u8_data_path) ? lfs::core::DataType::UInt8 : lfs::core::DataType::Float16;
+
         LOG_DEBUG("Image info: {}x{} -> {}x{} (resize_factor={}, max_width={})",
                   src_width, src_height, target_width, target_height, resize_factor, max_width);
 
         cudaSetDevice(impl_->device_id);
 
         using namespace lfs::core;
-        Tensor uint8_tensor;
+        Tensor image_tensor_aux;
         if (is_grayscale) {
-            uint8_tensor = Tensor::empty(
+            image_tensor_aux = Tensor::empty(
                 TensorShape({static_cast<size_t>(src_height), static_cast<size_t>(src_width)}),
                 Device::CUDA,
                 DataType::UInt8);
         } else {
-            uint8_tensor = Tensor::empty(
+            image_tensor_aux = Tensor::empty(
                 TensorShape({static_cast<size_t>(src_height), static_cast<size_t>(src_width), 3}),
                 Device::CUDA,
-                DataType::UInt8);
+                tensor_datatype);
         }
 
-        void* const gpu_uint8_buffer = uint8_tensor.data_ptr();
-        const size_t decoded_size = static_cast<size_t>(src_width) * src_height * num_channels;
+        void* const gpu_image_buffer = image_tensor_aux.data_ptr();
+        const size_t num_bytes_per_channel = decode_u8_data_path ? 1 : 2;
+        const size_t decoded_size = static_cast<size_t>(src_width) * src_height * num_channels * num_bytes_per_channel;
 
         nvimgcodecImage_t nv_image;
         nvimgcodecImageInfo_t output_info{};
@@ -928,12 +939,12 @@ namespace lfs::io {
         output_info.num_planes = 1;
         output_info.plane_info[0].height = src_height;
         output_info.plane_info[0].width = src_width;
-        output_info.plane_info[0].row_stride = src_width * num_channels;
+        output_info.plane_info[0].row_stride = src_width * num_channels * num_bytes_per_channel;
         output_info.plane_info[0].num_channels = num_channels;
-        output_info.plane_info[0].sample_type = NVIMGCODEC_SAMPLE_DATA_TYPE_UINT8;
+        output_info.plane_info[0].sample_type = source_image_sample_type;
 
         output_info.buffer_kind = NVIMGCODEC_IMAGE_BUFFER_KIND_STRIDED_DEVICE;
-        output_info.buffer = gpu_uint8_buffer;
+        output_info.buffer = gpu_image_buffer;
         output_info.buffer_size = decoded_size;
         output_info.cuda_stream = static_cast<cudaStream_t>(cuda_stream);
 
@@ -993,13 +1004,33 @@ namespace lfs::io {
             throw std::runtime_error(std::string("Decode failed: ") + status_str);
         }
 
+        //// when decoding u16 images, transform to normalized float prior to resize
+        std::optional<Tensor> u16_converted;
+
+        if (decode_u16_data_path && needs_resize) {
+             u16_converted.emplace(Tensor::empty(
+                TensorShape({static_cast<size_t>(src_height), static_cast<size_t>(src_width), static_cast<size_t>(3)}),
+                Device::CUDA,
+                DataType::Float32));
+
+            cuda::launch_uint16_hwc_to_float32_hwc(
+                reinterpret_cast<const uint16_t*>(image_tensor_aux.data_ptr()),
+                reinterpret_cast<float*>(u16_converted.value().data_ptr()),
+                src_height, src_width, 3, static_cast<cudaStream_t>(cuda_stream));
+
+        }
+
+        const Tensor& resize_input_image = u16_converted.has_value()
+                                               ? *u16_converted
+                                               : image_tensor_aux;
+
         Tensor output_tensor;
         if (needs_resize) {
             if (is_grayscale) {
-                output_tensor = lanczos_resize_grayscale(uint8_tensor, target_height, target_width,
+                output_tensor = lanczos_resize_grayscale(resize_input_image, target_height, target_width,
                                                          LANCZOS_KERNEL_SIZE, static_cast<cudaStream_t>(cuda_stream));
             } else {
-                output_tensor = lanczos_resize(uint8_tensor, target_height, target_width,
+                output_tensor = lanczos_resize(resize_input_image, target_height, target_width,
                                                LANCZOS_KERNEL_SIZE, static_cast<cudaStream_t>(cuda_stream));
                 if (output_uint8) {
                     auto output_uint8_tensor = Tensor::empty(output_tensor.shape(), Device::CUDA, DataType::UInt8);
@@ -1015,44 +1046,50 @@ namespace lfs::io {
             }
         } else {
             if (is_grayscale) {
-                const auto shape = uint8_tensor.shape();
+                const auto shape = image_tensor_aux.shape();
                 const size_t H = shape[0], W = shape[1];
-                output_tensor = Tensor::empty(TensorShape({H, W}), Device::CUDA, DataType::Float32);
+                output_tensor = Tensor::zeros(TensorShape({H, W}), Device::CUDA, DataType::Float32);
                 cuda::launch_uint8_hw_to_float32_hw(
-                    reinterpret_cast<const uint8_t*>(uint8_tensor.data_ptr()),
+                    reinterpret_cast<const uint8_t*>(image_tensor_aux.data_ptr()),
                     reinterpret_cast<float*>(output_tensor.data_ptr()),
                     H, W, static_cast<cudaStream_t>(cuda_stream));
             } else {
-                const auto shape = uint8_tensor.shape();
+                const auto shape = image_tensor_aux.shape();
                 const size_t H = shape[0], W = shape[1], C = shape[2];
                 if (output_uint8) {
                     output_tensor = Tensor::empty(TensorShape({C, H, W}), Device::CUDA, DataType::UInt8);
-                    cuda::launch_uint8_hwc_to_uint8_chw(
-                        reinterpret_cast<const uint8_t*>(uint8_tensor.data_ptr()),
-                        reinterpret_cast<uint8_t*>(output_tensor.data_ptr()),
-                        H, W, C, static_cast<cudaStream_t>(cuda_stream));
+                    if (decode_u8_data_path) {
+                        cuda::launch_uint8_hwc_to_uint8_chw(
+                            reinterpret_cast<const uint8_t*>(image_tensor_aux.data_ptr()),
+                            reinterpret_cast<uint8_t*>(output_tensor.data_ptr()),
+                            H, W, C, static_cast<cudaStream_t>(cuda_stream));
+                    } else if (decode_u16_data_path) {
+                        cuda::launch_uint16_hwc_to_uint8_chw(
+                            reinterpret_cast<const uint16_t*>(image_tensor_aux.data_ptr()),
+                            reinterpret_cast<uint8_t*>(output_tensor.data_ptr()),
+                            H, W, C, static_cast<cudaStream_t>(cuda_stream));
+                    }
                 } else {
-                    output_tensor = Tensor::empty(TensorShape({C, H, W}), Device::CUDA, DataType::Float32);
-                    cuda::launch_uint8_hwc_to_float32_chw(
-                        reinterpret_cast<const uint8_t*>(uint8_tensor.data_ptr()),
-                        reinterpret_cast<float*>(output_tensor.data_ptr()),
-                        H, W, C, static_cast<cudaStream_t>(cuda_stream));
+                    output_tensor = Tensor::zeros(TensorShape({C, H, W}), Device::CUDA, DataType::Float32);
+                    if (decode_u8_data_path) {
+                        cuda::launch_uint8_hwc_to_float32_chw(
+                            reinterpret_cast<const uint8_t*>(image_tensor_aux.data_ptr()),
+                            reinterpret_cast<float*>(output_tensor.data_ptr()),
+                            H, W, C, static_cast<cudaStream_t>(cuda_stream));
+                    } else if (decode_u16_data_path) {
+                        cuda::launch_uint16_hwc_to_float32_chw(
+                            reinterpret_cast<const uint16_t*>(image_tensor_aux.data_ptr()),
+                            reinterpret_cast<float*>(output_tensor.data_ptr()),
+                            H, W, C, static_cast<cudaStream_t>(cuda_stream));
+                    }
                 }
             }
         }
 
-        // Materialize before handoff. With a caller stream, sync only it — a
-        // device-wide sync would couple image availability to in-flight
-        // training kernels on other streams.
-        if (cuda_stream) {
-            if (const cudaError_t err = cudaStreamSynchronize(static_cast<cudaStream_t>(cuda_stream));
-                err != cudaSuccess) {
-                throw std::runtime_error(std::string("CUDA sync failed: ") + cudaGetErrorString(err));
-            }
-        } else if (const cudaError_t err = cudaDeviceSynchronize(); err != cudaSuccess) {
+        if (const cudaError_t err = cudaDeviceSynchronize(); err != cudaSuccess) {
             throw std::runtime_error(std::string("CUDA sync failed: ") + cudaGetErrorString(err));
         }
-        uint8_tensor = Tensor();
+        image_tensor_aux = Tensor();
 
         return output_tensor;
     }
@@ -1527,216 +1564,6 @@ namespace lfs::io {
         return output_buffer;
     }
 
-
-//std::vector<uint8_t> encode_jpeg2k_from_gpu_u16(
-//        const uint16_t* d_image,
-//        uint32_t height,
-//        uint32_t width,
-//        uint32_t channels,
-//        cudaStream_t stream) {
-//        if (channels != 3) {
-//            throw std::runtime_error("Only RGB interleaved supported");
-//        }
-//
-//        // -----------------------------
-//        // 1. Create instance
-//        // -----------------------------
-//        nvimgcodecInstance_t instance{};
-//
-//        nvimgcodecInstanceCreateInfo_t instance_info{};
-//        instance_info.struct_type = NVIMGCODEC_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-//        instance_info.struct_size = sizeof(instance_info);
-//
-//        // CRITICAL on Windows
-//        instance_info.load_builtin_modules = 1;
-//        instance_info.load_extension_modules = 1;
-//
-//        auto status = nvimgcodecInstanceCreate(&instance, &instance_info);
-//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
-//            throw std::runtime_error("Failed to create instance");
-//        }
-//
-//        // -----------------------------
-//        // 2. Describe input image (GPU interleaved uint16)
-//        // -----------------------------
-//        nvimgcodecImageInfo_t image_info{};
-//        image_info.struct_type = NVIMGCODEC_STRUCTURE_TYPE_IMAGE_INFO;
-//        image_info.struct_size = sizeof(image_info);
-//
-//        image_info.sample_format = NVIMGCODEC_SAMPLEFORMAT_I_RGB;
-//        image_info.color_spec = NVIMGCODEC_COLORSPEC_SRGB;
-//        image_info.chroma_subsampling = NVIMGCODEC_SAMPLING_444;
-//
-//        image_info.num_planes = 1;
-//        image_info.plane_info[0].height = height;
-//        image_info.plane_info[0].width = width;
-//        image_info.plane_info[0].num_channels = 3;
-//        image_info.plane_info[0].row_stride = width * channels * sizeof(uint16_t);
-//        image_info.plane_info[0].sample_type = NVIMGCODEC_SAMPLE_DATA_TYPE_UINT16;
-//
-//        image_info.buffer_kind = NVIMGCODEC_IMAGE_BUFFER_KIND_STRIDED_DEVICE;
-//        image_info.buffer = const_cast<uint16_t*>(d_image);
-//        image_info.buffer_size = static_cast<size_t>(height) * width * channels * sizeof(uint16_t);
-//        image_info.cuda_stream = stream;
-//
-//        nvimgcodecImage_t image{};
-//        status = nvimgcodecImageCreate(instance, &image, &image_info);
-//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
-//            nvimgcodecInstanceDestroy(instance);
-//            throw std::runtime_error("Failed to create image");
-//        }
-//
-//        // -----------------------------
-//        // 3. Output codestream (to memory)
-//        // -----------------------------
-//        std::vector<uint8_t> output;
-//
-//        nvimgcodecImageInfo_t out_info{};
-//        out_info.struct_type = NVIMGCODEC_STRUCTURE_TYPE_IMAGE_INFO;
-//        out_info.struct_size = sizeof(out_info);
-//
-//        // IMPORTANT: this is the working name in your setup
-//        std::snprintf(out_info.codec_name, sizeof(out_info.codec_name), "%s", "jpeg2k");
-//
-//        nvimgcodecCodeStream_t code_stream{};
-//
-//        status = nvimgcodecCodeStreamCreateToHostMem(
-//            instance,
-//            &code_stream,
-//            &output,
-//            [](void* ctx, size_t size) -> unsigned char* {
-//                auto* v = reinterpret_cast<std::vector<uint8_t>*>(ctx);
-//                v->resize(size);
-//                return v->data();
-//            },
-//            &out_info);
-//
-//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
-//            nvimgcodecImageDestroy(image);
-//            nvimgcodecInstanceDestroy(instance);
-//            throw std::runtime_error("Failed to create codestream");
-//        }
-//
-//        // -----------------------------
-//        // 4. Encode params (JPEG2000 lossless)
-//        // -----------------------------
-//        nvimgcodecEncodeParams_t encode_params{};
-//        encode_params.struct_type = NVIMGCODEC_STRUCTURE_TYPE_ENCODE_PARAMS;
-//        encode_params.struct_size = sizeof(encode_params);
-//        encode_params.quality_type = NVIMGCODEC_QUALITY_TYPE_LOSSLESS;
-//        encode_params.quality_value = 0.0f;
-//
-//        nvimgcodecJpeg2kEncodeParams_t j2k_params{};
-//        j2k_params.struct_type = NVIMGCODEC_STRUCTURE_TYPE_JPEG2K_ENCODE_PARAMS;
-//        j2k_params.struct_size = sizeof(j2k_params);
-//
-//        // CRITICAL: lossless
-//        //j2k_params.reversible = 1;
-//
-//        // sane defaults (from sample)
-//        j2k_params.code_block_w = 64;
-//        j2k_params.code_block_h = 64;
-//        j2k_params.num_resolutions = 6;
-//        j2k_params.prog_order = NVIMGCODEC_JPEG2K_PROG_ORDER_RPCL;
-//
-//        encode_params.struct_next = &j2k_params;
-//
-//        // -----------------------------
-//        // 5. Create encoder
-//        // -----------------------------
-//        nvimgcodecEncoder_t encoder{};
-//
-//        nvimgcodecExecutionParams_t exec_params{};
-//        exec_params.struct_type = NVIMGCODEC_STRUCTURE_TYPE_EXECUTION_PARAMS;
-//        exec_params.struct_size = sizeof(exec_params);
-//        exec_params.device_id = NVIMGCODEC_DEVICE_CURRENT;
-//
-//        status = nvimgcodecEncoderCreate(instance, &encoder, &exec_params, nullptr);
-//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
-//            nvimgcodecCodeStreamDestroy(code_stream);
-//            nvimgcodecImageDestroy(image);
-//            nvimgcodecInstanceDestroy(instance);
-//            throw std::runtime_error("Failed to create encoder");
-//        }
-//
-//
-//        // ------------------------
-//        // -----------------------------
-//        // Check if encoder can encode
-//        // -----------------------------
-//        nvimgcodecProcessingStatus_t can_encode_status{};
-//        std::memset(&can_encode_status, 0, sizeof(can_encode_status));
-//
-//        status = nvimgcodecEncoderCanEncode(
-//            encoder,
-//            &image,       // pointer to input image
-//            &code_stream, // pointer to output stream
-//            1,            // batch size
-//            &encode_params,
-//            &can_encode_status,
-//            1 // force_format = 1 (allow fallback)
-//        );
-//
-//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
-//            throw std::runtime_error("nvimgcodecEncoderCanEncode call failed");
-//        }
-//
-//        // -----------------------------
-//        // Interpret result
-//        // -----------------------------
-//        if (can_encode_status != NVIMGCODEC_PROCESSING_STATUS_SUCCESS) {
-//            std::ostringstream oss;
-//            oss << "Encoder cannot encode input. Status = " << can_encode_status;
-//            throw std::runtime_error(oss.str());
-//        }
-//
-//        // -----------------------------
-//        // 6. Encode
-//        // -----------------------------
-//        nvimgcodecFuture_t future{};
-//
-//        status = nvimgcodecEncoderEncode(
-//            encoder,
-//            &image,
-//            &code_stream,
-//            1,
-//            &encode_params,
-//            &future);
-//
-//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
-//            nvimgcodecEncoderDestroy(encoder);
-//            nvimgcodecCodeStreamDestroy(code_stream);
-//            nvimgcodecImageDestroy(image);
-//            nvimgcodecInstanceDestroy(instance);
-//            throw std::runtime_error("Encode launch failed");
-//        }
-//
-//        nvimgcodecFutureWaitForAll(future);
-//
-//        // -----------------------------
-//        // 7. Check status
-//        // -----------------------------
-//        nvimgcodecProcessingStatus_t proc_status{};
-//        size_t status_size = 0;
-//
-//        nvimgcodecFutureGetProcessingStatus(future, &proc_status, &status_size);
-//
-//        // -----------------------------
-//        // 8. Cleanup
-//        // -----------------------------
-//        nvimgcodecFutureDestroy(future);
-//        nvimgcodecEncoderDestroy(encoder);
-//        nvimgcodecCodeStreamDestroy(code_stream);
-//        nvimgcodecImageDestroy(image);
-//        nvimgcodecInstanceDestroy(instance);
-//
-//        if (proc_status != NVIMGCODEC_PROCESSING_STATUS_SUCCESS) {
-//            throw std::runtime_error("JPEG2000 encoding failed (likely missing encoder plugin)");
-//        }
-//
-//        return output;
-//    }
-
     std::vector<uint8_t> NvCodecImageLoader::encode_to_jpeg2k(
         const lfs::core::Tensor& image,
         void* cuda_stream) {
@@ -1756,7 +1583,7 @@ namespace lfs::io {
 
         const bool is_hwc = (shape[2] == 3);
         const bool is_chw = !is_hwc && (shape[0] == 3 && shape[1] > 3 && shape[2] > 3);
-        const uint32_t height = (is_chw ? shape[1] : shape[0]);
+        const uint32_t height = static_cast<uint32_t>(is_chw ? shape[1] : shape[0]);
         const uint32_t width = static_cast<uint32_t>(is_chw ? shape[2] : shape[1]);
         const uint32_t channels = 3;
 

--- a/src/io/nvcodec_image_loader.cpp
+++ b/src/io/nvcodec_image_loader.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <mutex>
 #include <nvimgcodec.h>
+
 #include <sstream>
 #include <stdexcept>
 #include <unordered_map>
@@ -1523,6 +1524,358 @@ namespace lfs::io {
             throw std::runtime_error("JPEG encoding failed: " +
                                      std::string(processing_status_to_string(encode_status)));
         }
+        return output_buffer;
+    }
+
+
+//std::vector<uint8_t> encode_jpeg2k_from_gpu_u16(
+//        const uint16_t* d_image,
+//        uint32_t height,
+//        uint32_t width,
+//        uint32_t channels,
+//        cudaStream_t stream) {
+//        if (channels != 3) {
+//            throw std::runtime_error("Only RGB interleaved supported");
+//        }
+//
+//        // -----------------------------
+//        // 1. Create instance
+//        // -----------------------------
+//        nvimgcodecInstance_t instance{};
+//
+//        nvimgcodecInstanceCreateInfo_t instance_info{};
+//        instance_info.struct_type = NVIMGCODEC_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+//        instance_info.struct_size = sizeof(instance_info);
+//
+//        // CRITICAL on Windows
+//        instance_info.load_builtin_modules = 1;
+//        instance_info.load_extension_modules = 1;
+//
+//        auto status = nvimgcodecInstanceCreate(&instance, &instance_info);
+//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
+//            throw std::runtime_error("Failed to create instance");
+//        }
+//
+//        // -----------------------------
+//        // 2. Describe input image (GPU interleaved uint16)
+//        // -----------------------------
+//        nvimgcodecImageInfo_t image_info{};
+//        image_info.struct_type = NVIMGCODEC_STRUCTURE_TYPE_IMAGE_INFO;
+//        image_info.struct_size = sizeof(image_info);
+//
+//        image_info.sample_format = NVIMGCODEC_SAMPLEFORMAT_I_RGB;
+//        image_info.color_spec = NVIMGCODEC_COLORSPEC_SRGB;
+//        image_info.chroma_subsampling = NVIMGCODEC_SAMPLING_444;
+//
+//        image_info.num_planes = 1;
+//        image_info.plane_info[0].height = height;
+//        image_info.plane_info[0].width = width;
+//        image_info.plane_info[0].num_channels = 3;
+//        image_info.plane_info[0].row_stride = width * channels * sizeof(uint16_t);
+//        image_info.plane_info[0].sample_type = NVIMGCODEC_SAMPLE_DATA_TYPE_UINT16;
+//
+//        image_info.buffer_kind = NVIMGCODEC_IMAGE_BUFFER_KIND_STRIDED_DEVICE;
+//        image_info.buffer = const_cast<uint16_t*>(d_image);
+//        image_info.buffer_size = static_cast<size_t>(height) * width * channels * sizeof(uint16_t);
+//        image_info.cuda_stream = stream;
+//
+//        nvimgcodecImage_t image{};
+//        status = nvimgcodecImageCreate(instance, &image, &image_info);
+//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
+//            nvimgcodecInstanceDestroy(instance);
+//            throw std::runtime_error("Failed to create image");
+//        }
+//
+//        // -----------------------------
+//        // 3. Output codestream (to memory)
+//        // -----------------------------
+//        std::vector<uint8_t> output;
+//
+//        nvimgcodecImageInfo_t out_info{};
+//        out_info.struct_type = NVIMGCODEC_STRUCTURE_TYPE_IMAGE_INFO;
+//        out_info.struct_size = sizeof(out_info);
+//
+//        // IMPORTANT: this is the working name in your setup
+//        std::snprintf(out_info.codec_name, sizeof(out_info.codec_name), "%s", "jpeg2k");
+//
+//        nvimgcodecCodeStream_t code_stream{};
+//
+//        status = nvimgcodecCodeStreamCreateToHostMem(
+//            instance,
+//            &code_stream,
+//            &output,
+//            [](void* ctx, size_t size) -> unsigned char* {
+//                auto* v = reinterpret_cast<std::vector<uint8_t>*>(ctx);
+//                v->resize(size);
+//                return v->data();
+//            },
+//            &out_info);
+//
+//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
+//            nvimgcodecImageDestroy(image);
+//            nvimgcodecInstanceDestroy(instance);
+//            throw std::runtime_error("Failed to create codestream");
+//        }
+//
+//        // -----------------------------
+//        // 4. Encode params (JPEG2000 lossless)
+//        // -----------------------------
+//        nvimgcodecEncodeParams_t encode_params{};
+//        encode_params.struct_type = NVIMGCODEC_STRUCTURE_TYPE_ENCODE_PARAMS;
+//        encode_params.struct_size = sizeof(encode_params);
+//        encode_params.quality_type = NVIMGCODEC_QUALITY_TYPE_LOSSLESS;
+//        encode_params.quality_value = 0.0f;
+//
+//        nvimgcodecJpeg2kEncodeParams_t j2k_params{};
+//        j2k_params.struct_type = NVIMGCODEC_STRUCTURE_TYPE_JPEG2K_ENCODE_PARAMS;
+//        j2k_params.struct_size = sizeof(j2k_params);
+//
+//        // CRITICAL: lossless
+//        //j2k_params.reversible = 1;
+//
+//        // sane defaults (from sample)
+//        j2k_params.code_block_w = 64;
+//        j2k_params.code_block_h = 64;
+//        j2k_params.num_resolutions = 6;
+//        j2k_params.prog_order = NVIMGCODEC_JPEG2K_PROG_ORDER_RPCL;
+//
+//        encode_params.struct_next = &j2k_params;
+//
+//        // -----------------------------
+//        // 5. Create encoder
+//        // -----------------------------
+//        nvimgcodecEncoder_t encoder{};
+//
+//        nvimgcodecExecutionParams_t exec_params{};
+//        exec_params.struct_type = NVIMGCODEC_STRUCTURE_TYPE_EXECUTION_PARAMS;
+//        exec_params.struct_size = sizeof(exec_params);
+//        exec_params.device_id = NVIMGCODEC_DEVICE_CURRENT;
+//
+//        status = nvimgcodecEncoderCreate(instance, &encoder, &exec_params, nullptr);
+//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
+//            nvimgcodecCodeStreamDestroy(code_stream);
+//            nvimgcodecImageDestroy(image);
+//            nvimgcodecInstanceDestroy(instance);
+//            throw std::runtime_error("Failed to create encoder");
+//        }
+//
+//
+//        // ------------------------
+//        // -----------------------------
+//        // Check if encoder can encode
+//        // -----------------------------
+//        nvimgcodecProcessingStatus_t can_encode_status{};
+//        std::memset(&can_encode_status, 0, sizeof(can_encode_status));
+//
+//        status = nvimgcodecEncoderCanEncode(
+//            encoder,
+//            &image,       // pointer to input image
+//            &code_stream, // pointer to output stream
+//            1,            // batch size
+//            &encode_params,
+//            &can_encode_status,
+//            1 // force_format = 1 (allow fallback)
+//        );
+//
+//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
+//            throw std::runtime_error("nvimgcodecEncoderCanEncode call failed");
+//        }
+//
+//        // -----------------------------
+//        // Interpret result
+//        // -----------------------------
+//        if (can_encode_status != NVIMGCODEC_PROCESSING_STATUS_SUCCESS) {
+//            std::ostringstream oss;
+//            oss << "Encoder cannot encode input. Status = " << can_encode_status;
+//            throw std::runtime_error(oss.str());
+//        }
+//
+//        // -----------------------------
+//        // 6. Encode
+//        // -----------------------------
+//        nvimgcodecFuture_t future{};
+//
+//        status = nvimgcodecEncoderEncode(
+//            encoder,
+//            &image,
+//            &code_stream,
+//            1,
+//            &encode_params,
+//            &future);
+//
+//        if (status != NVIMGCODEC_STATUS_SUCCESS) {
+//            nvimgcodecEncoderDestroy(encoder);
+//            nvimgcodecCodeStreamDestroy(code_stream);
+//            nvimgcodecImageDestroy(image);
+//            nvimgcodecInstanceDestroy(instance);
+//            throw std::runtime_error("Encode launch failed");
+//        }
+//
+//        nvimgcodecFutureWaitForAll(future);
+//
+//        // -----------------------------
+//        // 7. Check status
+//        // -----------------------------
+//        nvimgcodecProcessingStatus_t proc_status{};
+//        size_t status_size = 0;
+//
+//        nvimgcodecFutureGetProcessingStatus(future, &proc_status, &status_size);
+//
+//        // -----------------------------
+//        // 8. Cleanup
+//        // -----------------------------
+//        nvimgcodecFutureDestroy(future);
+//        nvimgcodecEncoderDestroy(encoder);
+//        nvimgcodecCodeStreamDestroy(code_stream);
+//        nvimgcodecImageDestroy(image);
+//        nvimgcodecInstanceDestroy(instance);
+//
+//        if (proc_status != NVIMGCODEC_PROCESSING_STATUS_SUCCESS) {
+//            throw std::runtime_error("JPEG2000 encoding failed (likely missing encoder plugin)");
+//        }
+//
+//        return output;
+//    }
+
+    std::vector<uint8_t> NvCodecImageLoader::encode_to_jpeg2k(
+        const lfs::core::Tensor& image,
+        void* cuda_stream) {
+
+        using namespace lfs::core;
+
+        if (!impl_->encoder) {
+            throw std::runtime_error("JPEG2000 encoder not available");
+        }
+
+        std::lock_guard<std::mutex> lock(impl_->encoder_mutex);
+
+        const auto& shape = image.shape();
+        if (shape.rank() != 3) {
+            throw std::runtime_error("Expected 3D tensor, got " + std::to_string(shape.rank()) + "D");
+        }
+
+        const bool is_hwc = (shape[2] == 3);
+        const bool is_chw = !is_hwc && (shape[0] == 3 && shape[1] > 3 && shape[2] > 3);
+        const uint32_t height = (is_chw ? shape[1] : shape[0]);
+        const uint32_t width = static_cast<uint32_t>(is_chw ? shape[2] : shape[1]);
+        const uint32_t channels = 3;
+
+        // 1. Convert to uint16: scale float [0,1] -> [0, 65535], transpose CHW->HWC if needed
+        // Using float16 as uint16 container
+        Tensor hwc_uint16 = lfs::core::Tensor::zeros(
+            lfs::core::TensorShape({height, width, channels}),
+            lfs::core::Device::CUDA, lfs::core::DataType::Float16);
+
+        auto convert_to_uint16 = [height, width, channels](const Tensor& in, Tensor& out){
+            cuda::launch_float32_hwc_to_uint16_hwc(
+                    reinterpret_cast<const float*>(in.data_ptr()),
+                    reinterpret_cast<uint16_t*>(out.data_ptr()),
+                    height, width, channels, nullptr);
+        };
+
+        if (is_chw) {
+            convert_to_uint16(image.to(DataType::Float32).permute({1, 2, 0}).contiguous(), hwc_uint16);
+        } else {
+            convert_to_uint16(image.to(DataType::Float32), hwc_uint16);
+        }
+
+        // 2. Ensure the tensor is on CUDA and contiguous
+        if (hwc_uint16.device() != Device::CUDA) {
+            hwc_uint16 = hwc_uint16.to(Device::CUDA);
+        }
+        hwc_uint16 = hwc_uint16.contiguous();
+
+        // 3. Fill image descriptor: uint16, stride doubled vs uint8
+        nvimgcodecImageInfo_t image_info{};
+        image_info.struct_type = NVIMGCODEC_STRUCTURE_TYPE_IMAGE_INFO;
+        image_info.struct_size = sizeof(nvimgcodecImageInfo_t);
+        image_info.sample_format = NVIMGCODEC_SAMPLEFORMAT_I_RGB;
+        image_info.color_spec = NVIMGCODEC_COLORSPEC_SRGB;
+        image_info.chroma_subsampling = NVIMGCODEC_SAMPLING_444;
+        image_info.num_planes = 1;
+        image_info.plane_info[0].height = height;
+        image_info.plane_info[0].width = width;
+        image_info.plane_info[0].num_channels = 3;
+        image_info.plane_info[0].row_stride = static_cast<size_t>(width) * 3 * sizeof(uint16_t);
+        image_info.plane_info[0].sample_type = NVIMGCODEC_SAMPLE_DATA_TYPE_UINT16;
+        image_info.buffer_kind = NVIMGCODEC_IMAGE_BUFFER_KIND_STRIDED_DEVICE;
+        image_info.buffer = hwc_uint16.data_ptr();
+        image_info.buffer_size = static_cast<size_t>(height) * width * 3 * sizeof(uint16_t);
+        image_info.cuda_stream = static_cast<cudaStream_t>(cuda_stream);
+
+        nvimgcodecImage_t nv_image;
+        auto status = nvimgcodecImageCreate(impl_->instance, &nv_image, &image_info);
+        if (status != NVIMGCODEC_STATUS_SUCCESS) {
+            throw std::runtime_error("Failed to create image for encoding: " +
+                                     std::string(nvimgcodec_status_to_string(status)));
+        }
+
+        // 4. Output stream: select jpeg2k codec
+        std::vector<uint8_t> output_buffer;
+
+        nvimgcodecImageInfo_t output_info{};
+        output_info.struct_type = NVIMGCODEC_STRUCTURE_TYPE_IMAGE_INFO;
+        output_info.struct_size = sizeof(nvimgcodecImageInfo_t);
+        std::snprintf(output_info.codec_name, sizeof(output_info.codec_name), "%s", "jpeg2k");
+
+        nvimgcodecCodeStream_t code_stream;
+        status = nvimgcodecCodeStreamCreateToHostMem(
+            impl_->instance, &code_stream, &output_buffer,
+            [](void* ctx, size_t req_size) -> unsigned char* {
+                auto* vec = static_cast<std::vector<uint8_t>*>(ctx);
+                vec->resize(req_size);
+                return vec->data();
+            },
+            &output_info);
+
+        if (status != NVIMGCODEC_STATUS_SUCCESS) {
+            nvimgcodecImageDestroy(nv_image);
+            throw std::runtime_error("Failed to create output code stream for JPEG2000");
+        }
+
+        // 5. JPEG2000 lossless params: reversible DWT 5/3, chained via struct_next
+        nvimgcodecJpeg2kEncodeParams_t j2k_params{};
+        j2k_params.struct_type = NVIMGCODEC_STRUCTURE_TYPE_JPEG2K_ENCODE_PARAMS;
+        j2k_params.struct_size = sizeof(nvimgcodecJpeg2kEncodeParams_t);
+        j2k_params.struct_next = nullptr;
+        j2k_params.num_resolutions = 6;
+        j2k_params.code_block_w = 64;
+        j2k_params.code_block_h = 64;
+        j2k_params.prog_order = NVIMGCODEC_JPEG2K_PROG_ORDER_RPCL;
+
+        nvimgcodecEncodeParams_t encode_params{};
+        encode_params.struct_type = NVIMGCODEC_STRUCTURE_TYPE_ENCODE_PARAMS;
+        encode_params.struct_size = sizeof(nvimgcodecEncodeParams_t);
+        encode_params.struct_next = &j2k_params; // chain JPEG2000-specific params
+        encode_params.quality_value = 0.0f;      // unused in lossless mode
+        encode_params.quality_type = NVIMGCODEC_QUALITY_TYPE_LOSSLESS;
+
+        // 6. Launch async encode and wait
+        nvimgcodecFuture_t encode_future;
+        status = nvimgcodecEncoderEncode(
+            impl_->encoder, &nv_image, &code_stream, 1, &encode_params, &encode_future);
+
+        if (status != NVIMGCODEC_STATUS_SUCCESS) {
+            nvimgcodecCodeStreamDestroy(code_stream);
+            nvimgcodecImageDestroy(nv_image);
+            throw std::runtime_error("JPEG2000 encode launch failed");
+        }
+
+        nvimgcodecFutureWaitForAll(encode_future);
+
+        // 7. Check result and release all resources
+        nvimgcodecProcessingStatus_t encode_status;
+        size_t status_size;
+        nvimgcodecFutureGetProcessingStatus(encode_future, &encode_status, &status_size);
+        nvimgcodecFutureDestroy(encode_future);
+        nvimgcodecCodeStreamDestroy(code_stream);
+        nvimgcodecImageDestroy(nv_image);
+
+        if (encode_status != NVIMGCODEC_PROCESSING_STATUS_SUCCESS) {
+            throw std::runtime_error("JPEG2000 encoding failed: " +
+                                     std::string(processing_status_to_string(encode_status)));
+        }
+
         return output_buffer;
     }
 

--- a/src/io/nvcodec_image_loader.hpp
+++ b/src/io/nvcodec_image_loader.hpp
@@ -106,6 +106,11 @@ namespace lfs::io {
             int quality = 100,
             void* cuda_stream = nullptr);
 
+        // Encode GPU tensor to JPEG2k bytes (RGB 16bits)
+        std::vector<uint8_t> encode_to_jpeg2k(
+            const lfs::core::Tensor& image,
+            void* cuda_stream);
+
         /**
          * @brief Encode grayscale GPU tensor to JPEG bytes
          *

--- a/src/io/nvcodec_image_loader.hpp
+++ b/src/io/nvcodec_image_loader.hpp
@@ -109,7 +109,7 @@ namespace lfs::io {
         // Encode GPU tensor to JPEG2k bytes (RGB 16bits)
         std::vector<uint8_t> encode_to_jpeg2k(
             const lfs::core::Tensor& image,
-            void* cuda_stream);
+            void* cuda_stream = nullptr);
 
         /**
          * @brief Encode grayscale GPU tensor to JPEG bytes

--- a/src/io/pipelined_image_loader.cpp
+++ b/src/io/pipelined_image_loader.cpp
@@ -1217,8 +1217,12 @@ namespace lfs::io {
                                 apply_requested_undistort(tensor, batch[i].params);
 
                                 try {
-                                    auto jpeg_bytes = nvcodec->encode_to_jpeg(
-                                        tensor, config_.cache_jpeg_quality, batch[i].params.cuda_stream);
+                                    std::vector<uint8_t> jpeg_bytes;
+                                    if (config_.use_16bits_pixel_depth) {
+                                        jpeg_bytes = nvcodec->encode_to_jpeg2k(tensor, nullptr);
+                                    } else {
+                                        jpeg_bytes = nvcodec->encode_to_jpeg(tensor, config_.cache_jpeg_quality, nullptr);
+                                    }
                                     save_to_fs_cache(batch[i].cache_key, jpeg_bytes);
                                     put_in_jpeg_cache(
                                         batch[i].cache_key,
@@ -1623,12 +1627,10 @@ namespace lfs::io {
 
                             if (config_.use_16bits_pixel_depth) {
                                 jpeg_bytes = nvcodec->encode_to_jpeg2k(decoded, nullptr);
-                                save_to_fs_cache(item.cache_key, jpeg_bytes);
                             } else {
-                                jpeg_bytes = nvcodec->encode_to_jpeg(
-                                    decoded, config_.cache_jpeg_quality, nullptr);
-                                save_to_fs_cache(item.cache_key, jpeg_bytes);
+                                jpeg_bytes = nvcodec->encode_to_jpeg(decoded, config_.cache_jpeg_quality, nullptr);
                             }
+                            save_to_fs_cache(item.cache_key, jpeg_bytes);
                             put_in_jpeg_cache(item.cache_key,
                                               std::make_shared<std::vector<uint8_t>>(std::move(jpeg_bytes)));
                         } catch (...) {

--- a/src/io/pipelined_image_loader.cpp
+++ b/src/io/pipelined_image_loader.cpp
@@ -7,8 +7,6 @@
 #include "core/image_io.hpp"
 #include "core/logger.hpp"
 #include "core/path_utils.hpp"
-#include "core/tensor/internal/cuda_stream_context.hpp"
-#include "core/tensor/internal/memory_pool.hpp"
 #include "cuda/image_format_kernels.cuh"
 #include "diagnostics/vram_profiler.hpp"
 #include "io/nvcodec_image_loader.hpp"
@@ -281,12 +279,13 @@ namespace lfs::io {
         : config_(std::move(config)),
           output_queue_(std::max<size_t>(1, config_.output_queue_size)) {
 
-        LOG_INFO("[PipelinedImageLoader] batch_size={}, prefetch={}, output_queue={}, io_threads={}, cold_threads={}",
+        LOG_INFO("[PipelinedImageLoader] batch_size={}, prefetch={}, output_queue={}, io_threads={}, cold_threads={}, 16bit_pixel_depth={}",
                  config_.jpeg_batch_size,
                  config_.prefetch_count,
                  config_.output_queue_size,
                  config_.io_threads,
-                 config_.cold_process_threads);
+                 config_.cold_process_threads,
+                 config_.use_16bits_pixel_depth);
 
         const bool nvcodec_available = is_nvcodec_available();
 
@@ -309,11 +308,6 @@ namespace lfs::io {
         }
 
         if (nvcodec_available) {
-            // On failure fall back to the default stream rather than a bad handle.
-            if (const cudaError_t err = cudaStreamCreateWithFlags(&decode_stream_, cudaStreamNonBlocking); err != cudaSuccess) {
-                LOG_WARN("[PipelinedImageLoader] cudaStreamCreateWithFlags failed ({}), GPU decode falls back to default stream", cudaGetErrorString(err));
-                decode_stream_ = nullptr;
-            }
             gpu_decode_thread_ = std::thread([this] { gpu_batch_decode_thread_func(); });
         }
 
@@ -357,11 +351,6 @@ namespace lfs::io {
         }
 
         cudaDeviceSynchronize();
-        if (decode_stream_) {
-            lfs::core::CudaMemoryPool::instance().release_stream(decode_stream_);
-            cudaStreamDestroy(decode_stream_);
-            decode_stream_ = nullptr;
-        }
         release_nvcodec_loader_cache(config_.decoder_pool_size);
         if (config_.use_filesystem_cache && !fs_cache_folder_.empty()) {
             std::error_code ec;
@@ -1160,9 +1149,6 @@ namespace lfs::io {
 
     void PipelinedImageLoader::gpu_batch_decode_thread_func() {
         LFS_VRAM_SCOPE("io.image_loader");
-        // Tensor ops on this thread (decode targets, format conversion) home
-        // onto the decode stream so they order with the explicit-stream kernels.
-        const lfs::core::CUDAStreamGuard stream_guard(decode_stream_);
         std::vector<PrefetchedImage> batch;
         batch.reserve(config_.jpeg_batch_size);
 
@@ -1198,10 +1184,9 @@ namespace lfs::io {
 
                 for (size_t i = 0; i < batch.size(); ++i) {
                     try {
-                        batch[i].params.cuda_stream = decode_stream_;
                         if (batch[i].is_mask) {
                             auto mask_tensor = nvcodec->load_image_from_memory_gpu(
-                                *batch[i].jpeg_data, 1, 0, decode_stream_, DecodeFormat::Grayscale);
+                                *batch[i].jpeg_data, 1, 0, nullptr, DecodeFormat::Grayscale);
 
                             if (!mask_tensor.is_valid() || mask_tensor.numel() == 0) {
                                 LOG_WARN("[PipelinedImageLoader] GPU mask decode failed for {}",
@@ -1535,29 +1520,63 @@ namespace lfs::io {
                     }
 
                     if (!used_gpu) {
-                        auto [img_data, width, height, channels] = lfs::core::load_image(
-                            item.path, item.params.resize_factor, item.params.max_width);
 
-                        if (!img_data)
-                            throw std::runtime_error("Failed to decode image");
+                        if (config_.use_16bits_pixel_depth)
+                        {
+                            auto [img_data, width, height, channels] = lfs::core::load_image_u16(
+                                item.path, item.params.resize_factor, item.params.max_width);
 
-                        const size_t H = static_cast<size_t>(height);
-                        const size_t W = static_cast<size_t>(width);
-                        const size_t C = static_cast<size_t>(channels);
+                            if (!img_data)
+                                throw std::runtime_error("Failed to decode image");
 
-                        auto cpu_tensor = lfs::core::Tensor::from_blob(
-                            img_data, lfs::core::TensorShape({H, W, C}),
-                            lfs::core::Device::CPU, lfs::core::DataType::UInt8);
+                            const size_t H = static_cast<size_t>(height);
+                            const size_t W = static_cast<size_t>(width);
+                            const size_t C = static_cast<size_t>(channels);
 
-                        auto gpu_uint8 = cpu_tensor.to(lfs::core::Device::CUDA);
-                        lfs::core::free_image(img_data);
+                            auto cpu_tensor = lfs::core::Tensor::from_blob(
+                                img_data, lfs::core::TensorShape({H, W, C}),
+                                lfs::core::Device::CPU, lfs::core::DataType::Float16);
+
+                            auto gpu_u16 = cpu_tensor.to(lfs::core::Device::CUDA);
+                            lfs::core::free_image(img_data);
+
+                            decoded = lfs::core::Tensor::zeros(
+                                lfs::core::TensorShape({C, H, W}),
+                                lfs::core::Device::CUDA, lfs::core::DataType::Float32);
+
+                            cuda::launch_uint16_hwc_to_float32_chw(
+                                reinterpret_cast<const uint16_t*>(gpu_u16.data_ptr()),
+                                reinterpret_cast<float*>(decoded.data_ptr()),
+                                H, W, C, nullptr);
+
+                            if (const cudaError_t err = cudaDeviceSynchronize(); err != cudaSuccess) {
+                                throw std::runtime_error(std::string("CUDA sync failed: ") + cudaGetErrorString(err));
+                            }
+                            gpu_u16 = lfs::core::Tensor();
+                        } else {
+                            auto [img_data, width, height, channels] = lfs::core::load_image(
+                                item.path, item.params.resize_factor, item.params.max_width);
+
+                            if (!img_data)
+                                throw std::runtime_error("Failed to decode image");
+
+                            const size_t H = static_cast<size_t>(height);
+                            const size_t W = static_cast<size_t>(width);
+                            const size_t C = static_cast<size_t>(channels);
+
+                            auto cpu_tensor = lfs::core::Tensor::from_blob(
+                                img_data, lfs::core::TensorShape({H, W, C}),
+                                lfs::core::Device::CPU, lfs::core::DataType::UInt8);
+
+                            auto gpu_u8 = cpu_tensor.to(lfs::core::Device::CUDA);
+                            lfs::core::free_image(img_data);
 
                         if (item.params.output_uint8) {
                             decoded = lfs::core::Tensor::empty(
                                 lfs::core::TensorShape({C, H, W}),
                                 lfs::core::Device::CUDA, lfs::core::DataType::UInt8);
                             cuda::launch_uint8_hwc_to_uint8_chw(
-                                reinterpret_cast<const uint8_t*>(gpu_uint8.data_ptr()),
+                                reinterpret_cast<const uint8_t*>(gpu_u8.data_ptr()),
                                 reinterpret_cast<uint8_t*>(decoded.data_ptr()),
                                 H, W, C, nullptr);
                         } else {
@@ -1565,15 +1584,17 @@ namespace lfs::io {
                                 lfs::core::TensorShape({C, H, W}),
                                 lfs::core::Device::CUDA, lfs::core::DataType::Float32);
                             cuda::launch_uint8_hwc_to_float32_chw(
-                                reinterpret_cast<const uint8_t*>(gpu_uint8.data_ptr()),
+                                reinterpret_cast<const uint8_t*>(gpu_u8.data_ptr()),
                                 reinterpret_cast<float*>(decoded.data_ptr()),
                                 H, W, C, nullptr);
                         }
 
-                        if (const cudaError_t err = cudaDeviceSynchronize(); err != cudaSuccess) {
-                            throw std::runtime_error(std::string("CUDA sync failed: ") + cudaGetErrorString(err));
+                            if (const cudaError_t err = cudaDeviceSynchronize(); err != cudaSuccess) {
+                                throw std::runtime_error(std::string("CUDA sync failed: ") + cudaGetErrorString(err));
+                            }
+                            gpu_u8 = lfs::core::Tensor();
                         }
-                        gpu_uint8 = lfs::core::Tensor();
+
                     }
 
                     if (item.undistort) {
@@ -1598,9 +1619,16 @@ namespace lfs::io {
 
                     if (is_nvcodec_available()) {
                         try {
-                            auto jpeg_bytes = nvcodec->encode_to_jpeg(
-                                decoded, config_.cache_jpeg_quality, nullptr);
-                            save_to_fs_cache(item.cache_key, jpeg_bytes);
+                            std::vector<uint8_t> jpeg_bytes;
+
+                            if (config_.use_16bits_pixel_depth) {
+                                jpeg_bytes = nvcodec->encode_to_jpeg2k(decoded, nullptr);
+                                save_to_fs_cache(item.cache_key, jpeg_bytes);
+                            } else {
+                                jpeg_bytes = nvcodec->encode_to_jpeg(
+                                    decoded, config_.cache_jpeg_quality, nullptr);
+                                save_to_fs_cache(item.cache_key, jpeg_bytes);
+                            }
                             put_in_jpeg_cache(item.cache_key,
                                               std::make_shared<std::vector<uint8_t>>(std::move(jpeg_bytes)));
                         } catch (...) {

--- a/src/io/pipelined_image_loader.cpp
+++ b/src/io/pipelined_image_loader.cpp
@@ -7,6 +7,8 @@
 #include "core/image_io.hpp"
 #include "core/logger.hpp"
 #include "core/path_utils.hpp"
+#include "core/tensor/internal/cuda_stream_context.hpp"
+#include "core/tensor/internal/memory_pool.hpp"
 #include "cuda/image_format_kernels.cuh"
 #include "diagnostics/vram_profiler.hpp"
 #include "io/nvcodec_image_loader.hpp"
@@ -308,6 +310,11 @@ namespace lfs::io {
         }
 
         if (nvcodec_available) {
+            // On failure fall back to the default stream rather than a bad handle.
+            if (const cudaError_t err = cudaStreamCreateWithFlags(&decode_stream_, cudaStreamNonBlocking); err != cudaSuccess) {
+                LOG_WARN("[PipelinedImageLoader] cudaStreamCreateWithFlags failed ({}), GPU decode falls back to default stream", cudaGetErrorString(err));
+                decode_stream_ = nullptr;
+            }
             gpu_decode_thread_ = std::thread([this] { gpu_batch_decode_thread_func(); });
         }
 
@@ -351,6 +358,11 @@ namespace lfs::io {
         }
 
         cudaDeviceSynchronize();
+        if (decode_stream_) {
+            lfs::core::CudaMemoryPool::instance().release_stream(decode_stream_);
+            cudaStreamDestroy(decode_stream_);
+            decode_stream_ = nullptr;
+        }
         release_nvcodec_loader_cache(config_.decoder_pool_size);
         if (config_.use_filesystem_cache && !fs_cache_folder_.empty()) {
             std::error_code ec;
@@ -1149,6 +1161,9 @@ namespace lfs::io {
 
     void PipelinedImageLoader::gpu_batch_decode_thread_func() {
         LFS_VRAM_SCOPE("io.image_loader");
+        // Tensor ops on this thread (decode targets, format conversion) home
+        // onto the decode stream so they order with the explicit-stream kernels.
+        const lfs::core::CUDAStreamGuard stream_guard(decode_stream_);
         std::vector<PrefetchedImage> batch;
         batch.reserve(config_.jpeg_batch_size);
 
@@ -1184,9 +1199,10 @@ namespace lfs::io {
 
                 for (size_t i = 0; i < batch.size(); ++i) {
                     try {
+                        batch[i].params.cuda_stream = decode_stream_;
                         if (batch[i].is_mask) {
                             auto mask_tensor = nvcodec->load_image_from_memory_gpu(
-                                *batch[i].jpeg_data, 1, 0, nullptr, DecodeFormat::Grayscale);
+                                *batch[i].jpeg_data, 1, 0, decode_stream_, DecodeFormat::Grayscale);
 
                             if (!mask_tensor.is_valid() || mask_tensor.numel() == 0) {
                                 LOG_WARN("[PipelinedImageLoader] GPU mask decode failed for {}",

--- a/src/training/dataset.hpp
+++ b/src/training/dataset.hpp
@@ -647,6 +647,9 @@ namespace lfs::training {
                 request.params.resize_factor = dataset_->get_resize_factor();
                 request.params.max_width = dataset_->get_max_width();
                 request.params.output_uint8 = true;
+                if (config_.use_16bits_pixel_depth) {
+                    request.params.output_uint8 = false;
+                }
                 if (cam->is_undistort_prepared()) {
                     request.undistort = &cam->undistort_params();
                     request.params.undistort = request.undistort;

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -4448,6 +4448,7 @@ namespace lfs::training {
             pipelined_config.prefetch_count = 8;
             pipelined_config.output_queue_size = 4;
             pipelined_config.io_threads = 2;
+            pipelined_config.use_16bits_pixel_depth = !params_.dataset.loading_params.use_8bit_color;
 
             // Non-JPEG images (PNG, WebP) need CPU decoding - use more threads until cache warms
             constexpr float NON_JPEG_THRESHOLD = 0.1f;


### PR DESCRIPTION
This set of commits introduces support for 16-bit and FP32 image workflows, making the image pipeline more flexible and better prepared for HDR and high-precision image inputs.

The loading path has been improved to support u16 and FP32 images, with internal templating added to load_image_t to make the implementation cleaner and easier to extend. A new CUDA kernel was also added to convert FP32 images from HWC to CHW layout directly on the GPU.

JPEG2000 support has been added for lossless encoding, with the correct encoding selected depending on the active configuration. The decoding path has also been advanced, including work on 16-bit decoding and support for float tensors during Lanczos resize.

A new --use_8bit_color flag has been introduced to easily switch between standard 8-bit input and HDR 16-bit image input by disabling it with 0.

To build and compile these changes correctly, JPEG2000 development support needs to be installed on the target machine, including the required libraries and headers.

We merged this based on an old commit, please doble check that we are not breaking any new functionality added in between.