### PR TITLE
Fix logging panel action layout

### DIFF
--- a/src/visualizer/gui/rmlui/resources/scene_tree.rcss
+++ b/src/visualizer/gui/rmlui/resources/scene_tree.rcss
@@ -227,7 +227,7 @@ scene-graph,
 
 .logging-toolbar {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: flex-end;
     gap: 8dp;
 }
@@ -236,8 +236,9 @@ scene-graph,
     display: flex;
     flex-direction: column;
     gap: 4dp;
-    min-width: 132dp;
-    flex: 1 1 132dp;
+    min-width: 96dp;
+    width: 120dp;
+    flex: 0 1 120dp;
 }
 
 .logging-field-label {
@@ -248,13 +249,29 @@ scene-graph,
 }
 
 .logging-level-select {
+    width: 100%;
     min-height: 26dp;
 }
 
 .logging-actions {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 6dp;
+    flex: 0 0 auto;
+}
+
+.logging-actions .history-action {
+    display: inline-block;
+    width: 78dp;
+    min-width: 78dp;
+    height: 26dp;
+    min-height: 26dp;
+    line-height: 20dp;
+    padding: 2dp 8dp;
+    box-sizing: border-box;
+    text-align: center;
+    white-space: nowrap;
+    flex: 0 0 auto;
 }
 
 .logging-feedback {

--- a/src/visualizer/gui/rmlui/resources/scene_tree.rml
+++ b/src/visualizer/gui/rmlui/resources/scene_tree.rml
@@ -112,7 +112,7 @@
                         class="btn btn--secondary history-action"
                         type="button">Export .txt</button>
                 <button id="logging-copy-btn"
-                        class="btn btn--ghost history-action"
+                        class="btn btn--secondary history-action"
                         type="button">Copy</button>
             </div>
         </div>


### PR DESCRIPTION
The logging panel shows some bad positioning and size:

This fix now reserve stable button dimensions and disable wrapping for the controls in that row.

Before:
<img width="734" height="134" alt="image" src="https://github.com/user-attachments/assets/a5b6ec6d-ca48-4f0c-bb45-4bc5e9b9933c" />

After:

<img width="591" height="119" alt="image" src="https://github.com/user-attachments/assets/af9ce7d4-d69e-4086-8781-26443769fc75" />

