### PR TITLE
COLMAP Text Import Performance

### DIFF
--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -8,8 +8,11 @@
 #include "core/path_utils.hpp"
 #include "io/filesystem_utils.hpp"
 #include <algorithm>
+#include <charconv>
 #include <cctype>
+#include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <exception>
 #include <filesystem>
@@ -19,6 +22,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <system_error>
 #include <unordered_map>
 #include <vector>
 
@@ -38,6 +42,34 @@ namespace lfs::io {
 
         [[nodiscard]] bool should_poll_cancel(const size_t index) {
             return (index % CANCEL_POLL_INTERVAL) == 0;
+        }
+
+        [[nodiscard]] double elapsed_ms(const std::chrono::high_resolution_clock::time_point start) {
+            return std::chrono::duration<double, std::milli>(
+                       std::chrono::high_resolution_clock::now() - start)
+                .count();
+        }
+
+        void skip_ascii_spaces(const char*& cur, const char* end) {
+            while (cur < end && std::isspace(static_cast<unsigned char>(*cur))) {
+                ++cur;
+            }
+        }
+
+        template <typename T>
+        bool parse_next_number(const char*& cur, const char* end, T& value) {
+            skip_ascii_spaces(cur, end);
+            if (cur >= end) {
+                return false;
+            }
+
+            const auto parsed = std::from_chars(cur, end, value);
+            if (parsed.ec != std::errc{}) {
+                return false;
+            }
+
+            cur = parsed.ptr;
+            return true;
         }
     } // namespace
 
@@ -388,7 +420,11 @@ namespace lfs::io {
         const std::vector<ImageData>& images,
         const LoadOptions& options = {}) {
 
+        LOG_TIMER_DEBUG("COLMAP validate dataset layout");
         const fs::path images_path = base / lfs::core::utf8_to_path(images_folder);
+        LOG_INFO("[COLMAP_LOAD] validate_layout images={} images_path='{}'",
+                 images.size(),
+                 lfs::core::path_to_utf8(images_path));
         if (!safe_is_directory(images_path)) {
             return make_error(ErrorCode::PATH_NOT_FOUND, "Images folder does not exist", images_path);
         }
@@ -775,6 +811,9 @@ namespace lfs::io {
     std::vector<std::string> read_text_file(const std::filesystem::path& file_path,
                                             const LoadOptions& options = {}) {
         LOG_TRACE("Reading text file: {}", lfs::core::path_to_utf8(file_path));
+        const auto start = std::chrono::high_resolution_clock::now();
+        std::error_code file_size_ec;
+        const auto byte_size = fs::file_size(file_path, file_size_ec);
         std::ifstream file;
         if (!lfs::core::open_file_for_read(file_path, file)) {
             LOG_ERROR("Failed to open text file: {}", lfs::core::path_to_utf8(file_path));
@@ -806,6 +845,11 @@ namespace lfs::io {
             lines.pop_back();
 
         LOG_TRACE("Read {} lines from text file", lines.size());
+        LOG_INFO("[COLMAP_LOAD] read_text_file file='{}' bytes={} data_lines={} elapsed_ms={:.2f}",
+                 lfs::core::path_to_utf8(file_path),
+                 file_size_ec ? std::string("unknown") : std::format("{}", byte_size),
+                 lines.size(),
+                 elapsed_ms(start));
         return lines;
     }
 
@@ -869,12 +913,15 @@ namespace lfs::io {
     //  images.txt
     // -----------------------------------------------------------------------------
     std::vector<ImageData> read_images_text(const std::filesystem::path& file_path,
-                                            const LoadOptions& options = {}) {
+                                            const LoadOptions& options = {},
+                                            const bool parse_points2d = true) {
         LOG_TIMER_TRACE("Read images.txt");
         auto lines = read_text_file(file_path, options);
+        const auto parse_start = std::chrono::high_resolution_clock::now();
 
         std::vector<ImageData> images;
         images.reserve(lines.size());
+        size_t total_points2d = 0;
 
         for (size_t line_idx = 0; line_idx < lines.size(); ++line_idx) {
             if (should_poll_cancel(line_idx)) {
@@ -888,10 +935,15 @@ namespace lfs::io {
             }
 
             if (line_idx + 1 < lines.size()) {
-                ImageData maybe_next_image;
-                if (!parse_image_metadata_line(lines[line_idx + 1], maybe_next_image)) {
-                    img.points2D = parse_points2D_text_line(lines[line_idx + 1]);
+                if (!parse_points2d) {
                     ++line_idx;
+                } else {
+                    ImageData maybe_next_image;
+                    if (!parse_image_metadata_line(lines[line_idx + 1], maybe_next_image)) {
+                        img.points2D = parse_points2D_text_line(lines[line_idx + 1]);
+                        total_points2d += img.points2D.size();
+                        ++line_idx;
+                    }
                 }
             }
 
@@ -903,6 +955,68 @@ namespace lfs::io {
             throw std::runtime_error("No valid images in images.txt");
         }
 
+        LOG_INFO("[COLMAP_LOAD] parse images.txt images={} points2D={} parse_points2D={} source_lines={} elapsed_ms={:.2f}",
+                 images.size(),
+                 total_points2d,
+                 parse_points2d,
+                 lines.size(),
+                 elapsed_ms(parse_start));
+        LOG_DEBUG("Read {} images from text file", images.size());
+        return images;
+    }
+
+    std::vector<ImageData> read_images_text_camera_metadata_only(const std::filesystem::path& file_path,
+                                                                 const LoadOptions& options = {}) {
+        LOG_TIMER_TRACE("Read images.txt camera metadata");
+        const auto start = std::chrono::high_resolution_clock::now();
+        std::error_code file_size_ec;
+        const auto byte_size = fs::file_size(file_path, file_size_ec);
+
+        std::ifstream file;
+        if (!lfs::core::open_file_for_read(file_path, file)) {
+            LOG_ERROR("Failed to open text file: {}", lfs::core::path_to_utf8(file_path));
+            throw std::runtime_error("Failed to open " + lfs::core::path_to_utf8(file_path));
+        }
+
+        std::vector<ImageData> images;
+        std::string line;
+        size_t file_lines = 0;
+        while (std::getline(file, line)) {
+            if (should_poll_cancel(file_lines)) {
+                throw_if_load_cancel_requested(options, "COLMAP image metadata parse cancelled");
+            }
+            ++file_lines;
+
+            if (line.starts_with("#")) {
+                continue;
+            }
+            if (!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+            if (line.empty()) {
+                continue;
+            }
+
+            ImageData img;
+            if (!parse_image_metadata_line(line, img)) {
+                continue;
+            }
+
+            images.push_back(std::move(img));
+            file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            ++file_lines;
+        }
+
+        if (images.empty()) {
+            LOG_ERROR("No valid images found in {}", lfs::core::path_to_utf8(file_path));
+            throw std::runtime_error("No valid images in images.txt");
+        }
+
+        LOG_INFO("[COLMAP_LOAD] parse images.txt camera_metadata_fast images={} file_lines={} bytes={} elapsed_ms={:.2f}",
+                 images.size(),
+                 file_lines,
+                 file_size_ec ? std::string("unknown") : std::format("{}", byte_size),
+                 elapsed_ms(start));
         LOG_DEBUG("Read {} images from text file", images.size());
         return images;
     }
@@ -969,54 +1083,178 @@ namespace lfs::io {
     //  points3D.txt
     // -----------------------------------------------------------------------------
     std::vector<Point3DData> read_point3D_text_records(const std::filesystem::path& file_path,
-                                                       const LoadOptions& options = {}) {
+                                                       const LoadOptions& options = {},
+                                                       const bool parse_tracks = true) {
         LOG_TIMER_TRACE("Read points3D.txt");
         auto lines = read_text_file(file_path, options);
+        const auto parse_start = std::chrono::high_resolution_clock::now();
         uint64_t N = lines.size();
         LOG_DEBUG("Reading {} 3D points from text file", N);
 
         std::vector<Point3DData> points;
         points.reserve(N);
+        size_t total_track_elements = 0;
 
         for (uint64_t i = 0; i < N; ++i) {
             if (should_poll_cancel(static_cast<size_t>(i))) {
                 throw_if_load_cancel_requested(options, "COLMAP point cloud parse cancelled");
             }
             const auto& line = lines[i];
-            const auto tokens = split_string(line, ' ');
 
-            if (tokens.size() < 8) {
-                LOG_ERROR("Invalid format in points3D.txt: {}", line);
-                throw std::runtime_error("Invalid format in points3D.txt");
+            if (parse_tracks) {
+                const auto tokens = split_string(line, ' ');
+
+                if (tokens.size() < 8) {
+                    LOG_ERROR("Invalid format in points3D.txt: {}", line);
+                    throw std::runtime_error("Invalid format in points3D.txt");
+                }
+
+                Point3DData point;
+                point.point3D_id = std::stoull(tokens[0]);
+                point.xyz[0] = std::stod(tokens[1]);
+                point.xyz[1] = std::stod(tokens[2]);
+                point.xyz[2] = std::stod(tokens[3]);
+
+                point.color[0] = static_cast<uint8_t>(std::stoi(tokens[4]));
+                point.color[1] = static_cast<uint8_t>(std::stoi(tokens[5]));
+                point.color[2] = static_cast<uint8_t>(std::stoi(tokens[6]));
+                point.error = std::stod(tokens[7]);
+
+                for (size_t j = 8; j + 1 < tokens.size(); j += 2) {
+                    point.track.push_back(Point3DTrackElement{
+                        .image_id = static_cast<uint32_t>(std::stoul(tokens[j])),
+                        .point2D_idx = static_cast<uint32_t>(std::stoul(tokens[j + 1])),
+                    });
+                    ++total_track_elements;
+                }
+
+                points.push_back(std::move(point));
+            } else {
+                const char* cur = line.data();
+                const char* end = cur + line.size();
+
+                Point3DData point;
+                int red = 255;
+                int green = 255;
+                int blue = 255;
+                if (!parse_next_number(cur, end, point.point3D_id) ||
+                    !parse_next_number(cur, end, point.xyz[0]) ||
+                    !parse_next_number(cur, end, point.xyz[1]) ||
+                    !parse_next_number(cur, end, point.xyz[2]) ||
+                    !parse_next_number(cur, end, red) ||
+                    !parse_next_number(cur, end, green) ||
+                    !parse_next_number(cur, end, blue) ||
+                    !parse_next_number(cur, end, point.error)) {
+                    LOG_ERROR("Invalid format in points3D.txt: {}", line);
+                    throw std::runtime_error("Invalid format in points3D.txt");
+                }
+
+                point.color[0] = static_cast<uint8_t>(red);
+                point.color[1] = static_cast<uint8_t>(green);
+                point.color[2] = static_cast<uint8_t>(blue);
+                points.push_back(std::move(point));
             }
-
-            Point3DData point;
-            point.point3D_id = std::stoull(tokens[0]);
-            point.xyz[0] = std::stod(tokens[1]);
-            point.xyz[1] = std::stod(tokens[2]);
-            point.xyz[2] = std::stod(tokens[3]);
-
-            point.color[0] = static_cast<uint8_t>(std::stoi(tokens[4]));
-            point.color[1] = static_cast<uint8_t>(std::stoi(tokens[5]));
-            point.color[2] = static_cast<uint8_t>(std::stoi(tokens[6]));
-            point.error = std::stod(tokens[7]);
-
-            for (size_t j = 8; j + 1 < tokens.size(); j += 2) {
-                point.track.push_back(Point3DTrackElement{
-                    .image_id = static_cast<uint32_t>(std::stoul(tokens[j])),
-                    .point2D_idx = static_cast<uint32_t>(std::stoul(tokens[j + 1])),
-                });
-            }
-
-            points.push_back(std::move(point));
         }
 
+        LOG_INFO("[COLMAP_LOAD] parse points3D.txt points={} track_elements={} parse_tracks={} elapsed_ms={:.2f}",
+                 points.size(),
+                 total_track_elements,
+                 parse_tracks,
+                 elapsed_ms(parse_start));
         return points;
     }
 
     PointCloud read_point3D_text(const std::filesystem::path& file_path,
                                  const LoadOptions& options = {}) {
-        return point3D_records_to_point_cloud(read_point3D_text_records(file_path, options));
+        LOG_TIMER_TRACE("Read points3D.txt point cloud");
+        const auto start = std::chrono::high_resolution_clock::now();
+        std::error_code file_size_ec;
+        const auto byte_size = fs::file_size(file_path, file_size_ec);
+
+        std::ifstream file;
+        if (!lfs::core::open_file_for_read(file_path, file)) {
+            LOG_ERROR("Failed to open text file: {}", lfs::core::path_to_utf8(file_path));
+            throw std::runtime_error("Failed to open " + lfs::core::path_to_utf8(file_path));
+        }
+
+        std::vector<float> positions;
+        std::vector<uint8_t> colors;
+        if (!file_size_ec) {
+            const auto estimated_points = static_cast<size_t>(std::max<uintmax_t>(byte_size / 96, 1));
+            positions.reserve(estimated_points * 3);
+            colors.reserve(estimated_points * 3);
+        }
+
+        std::string line;
+        size_t line_count = 0;
+        size_t point_count = 0;
+        while (std::getline(file, line)) {
+            if (should_poll_cancel(line_count)) {
+                throw_if_load_cancel_requested(options, "COLMAP point cloud parse cancelled");
+            }
+            ++line_count;
+
+            if (line.starts_with("#")) {
+                continue;
+            }
+            if (!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+            if (line.empty()) {
+                continue;
+            }
+
+            const char* cur = line.data();
+            const char* end = cur + line.size();
+
+            uint64_t point_id = 0;
+            double x = 0.0;
+            double y = 0.0;
+            double z = 0.0;
+            int red = 255;
+            int green = 255;
+            int blue = 255;
+            double error = 0.0;
+            if (!parse_next_number(cur, end, point_id) ||
+                !parse_next_number(cur, end, x) ||
+                !parse_next_number(cur, end, y) ||
+                !parse_next_number(cur, end, z) ||
+                !parse_next_number(cur, end, red) ||
+                !parse_next_number(cur, end, green) ||
+                !parse_next_number(cur, end, blue) ||
+                !parse_next_number(cur, end, error)) {
+                LOG_ERROR("Invalid format in points3D.txt: {}", line);
+                throw std::runtime_error("Invalid format in points3D.txt");
+            }
+            (void)point_id;
+            (void)error;
+
+            positions.push_back(static_cast<float>(x));
+            positions.push_back(static_cast<float>(y));
+            positions.push_back(static_cast<float>(z));
+            colors.push_back(static_cast<uint8_t>(red));
+            colors.push_back(static_cast<uint8_t>(green));
+            colors.push_back(static_cast<uint8_t>(blue));
+            ++point_count;
+        }
+
+        if (point_count == 0) {
+            LOG_ERROR("No valid points found in {}", lfs::core::path_to_utf8(file_path));
+            throw std::runtime_error("No valid points in points3D.txt");
+        }
+
+        LOG_INFO("[COLMAP_LOAD] parse points3D.txt point_cloud_fast points={} file_lines={} bytes={} elapsed_ms={:.2f}",
+                 point_count,
+                 line_count,
+                 file_size_ec ? std::string("unknown") : std::format("{}", byte_size),
+                 elapsed_ms(start));
+
+        Tensor means = Tensor::from_vector(positions, {point_count, 3}, Device::CUDA);
+        Tensor colors_tensor = Tensor::from_blob(colors.data(), {point_count, 3}, Device::CPU, DataType::UInt8)
+                                   .to(Device::CUDA)
+                                   .contiguous();
+
+        return PointCloud(std::move(means), std::move(colors_tensor));
     }
 
     // -----------------------------------------------------------------------------
@@ -1950,7 +2188,7 @@ namespace lfs::io {
             if (has_binary_pair) {
                 images = read_images_binary(images_bin, options);
             } else {
-                images = read_images_text(images_txt, options);
+                images = read_images_text_camera_metadata_only(images_txt, options);
             }
 
             return validate_colmap_dataset_layout_impl(base, images_folder, images, options);
@@ -2007,7 +2245,7 @@ namespace lfs::io {
         fs::path images_file = get_sparse_file_path(base, "images.txt");
 
         auto cam_map = read_cameras_text(cams_file, scale_factor, options);
-        auto images = read_images_text(images_file, options);
+        auto images = read_images_text_camera_metadata_only(images_file, options);
 
         LOG_INFO("Read {} cameras and {} images from COLMAP text files", cam_map.size(), images.size());
 
@@ -2039,7 +2277,7 @@ namespace lfs::io {
             images = read_images_binary(sparse_path / "images.bin");
         } else {
             cam_map = read_cameras_text(sparse_path / "cameras.txt", scale_factor);
-            images = read_images_text(sparse_path / "images.txt");
+            images = read_images_text_camera_metadata_only(sparse_path / "images.txt");
         }
 
         LOG_INFO("Read {} cameras and {} images from COLMAP", cam_map.size(), images.size());

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -39,6 +39,7 @@ namespace lfs::io {
 
     namespace {
         constexpr size_t CANCEL_POLL_INTERVAL = 64;
+        constexpr size_t IMAGE_METADATA_PROBE_LIMIT = 8192;
 
         [[nodiscard]] bool should_poll_cancel(const size_t index) {
             return (index % CANCEL_POLL_INTERVAL) == 0;
@@ -886,6 +887,54 @@ namespace lfs::io {
         return std::isalpha(static_cast<unsigned char>(img.name[dot_pos + 1]));
     }
 
+    bool looks_like_image_metadata_line(const std::string& line) {
+        if (line.size() > IMAGE_METADATA_PROBE_LIMIT) {
+            return false;
+        }
+
+        ImageData img;
+        return parse_image_metadata_line(line, img);
+    }
+
+    bool read_next_short_metadata_line_or_skip(std::ifstream& file,
+                                               std::string& pending_line,
+                                               size_t& file_lines) {
+        pending_line.clear();
+
+        std::string probe;
+        probe.reserve(256);
+
+        char ch = '\0';
+        bool read_any = false;
+        while (file.get(ch)) {
+            read_any = true;
+            if (ch == '\n') {
+                break;
+            }
+            if (probe.size() >= IMAGE_METADATA_PROBE_LIMIT) {
+                file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+                break;
+            }
+            probe.push_back(ch);
+        }
+
+        if (!read_any) {
+            return false;
+        }
+
+        ++file_lines;
+        if (!probe.empty() && probe.back() == '\r') {
+            probe.pop_back();
+        }
+
+        if (probe.empty() || probe.starts_with("#") || !looks_like_image_metadata_line(probe)) {
+            return false;
+        }
+
+        pending_line = std::move(probe);
+        return true;
+    }
+
     uint64_t parse_point3D_id_token(const std::string& token) {
         if (token == "-1") {
             return INVALID_POINT3D_ID;
@@ -936,7 +985,9 @@ namespace lfs::io {
 
             if (line_idx + 1 < lines.size()) {
                 if (!parse_points2d) {
-                    ++line_idx;
+                    if (!looks_like_image_metadata_line(lines[line_idx + 1])) {
+                        ++line_idx;
+                    }
                 } else {
                     ImageData maybe_next_image;
                     if (!parse_image_metadata_line(lines[line_idx + 1], maybe_next_image)) {
@@ -980,12 +1031,30 @@ namespace lfs::io {
 
         std::vector<ImageData> images;
         std::string line;
+        std::string pending_line;
+        bool has_pending_line = false;
         size_t file_lines = 0;
-        while (std::getline(file, line)) {
+
+        auto read_next_line = [&]() {
+            if (has_pending_line) {
+                line = std::move(pending_line);
+                pending_line.clear();
+                has_pending_line = false;
+                return true;
+            }
+
+            if (!std::getline(file, line)) {
+                return false;
+            }
+
+            ++file_lines;
+            return true;
+        };
+
+        while (read_next_line()) {
             if (should_poll_cancel(file_lines)) {
                 throw_if_load_cancel_requested(options, "COLMAP image metadata parse cancelled");
             }
-            ++file_lines;
 
             if (line.starts_with("#")) {
                 continue;
@@ -1003,8 +1072,7 @@ namespace lfs::io {
             }
 
             images.push_back(std::move(img));
-            file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-            ++file_lines;
+            has_pending_line = read_next_short_metadata_line_or_skip(file, pending_line, file_lines);
         }
 
         if (images.empty()) {

--- a/src/io/loaders/colmap_loader.cpp
+++ b/src/io/loaders/colmap_loader.cpp
@@ -78,6 +78,16 @@ namespace lfs::io {
 
         bool has_points_ply = !points_ply.empty();
 
+        LOG_INFO("[COLMAP_LOAD] discovery path='{}' cameras_bin={} images_bin={} points_bin={} cameras_txt={} images_txt={} points_txt={} points_ply={}",
+                 lfs::core::path_to_utf8(path),
+                 has_cameras,
+                 has_images,
+                 has_points,
+                 has_cameras_text,
+                 has_images_text,
+                 has_points_text,
+                 has_points_ply);
+
         if ((has_cameras || has_images || has_points) &&
             (has_cameras_text || has_images_text || has_points_text)) {
             LOG_WARN("Found both binary and text COLMAP files. Prioritizing binary files.");
@@ -123,6 +133,7 @@ namespace lfs::io {
 
         // If specified folder doesn't exist, check for flat structure
         if (!std::filesystem::exists(image_dir)) {
+            LOG_TIMER_DEBUG("COLMAP resolve image directory");
             const auto cameras_txt_parent =
                 cameras_txt.empty() ? std::filesystem::path{} : cameras_txt.parent_path();
             const auto cameras_bin_parent =
@@ -163,12 +174,13 @@ namespace lfs::io {
 
             throw_if_load_cancel_requested(options, "COLMAP dataset validation cancelled");
 
-            if (auto validation_result = validate_colmap_dataset_layout(path, actual_images_folder, options); !validation_result) {
-                return std::unexpected(validation_result.error());
-            }
-
             // Validation only mode
             if (options.validate_only) {
+                LOG_TIMER_DEBUG("COLMAP validate_only dataset layout");
+                if (auto validation_result = validate_colmap_dataset_layout(path, actual_images_folder, options); !validation_result) {
+                    return std::unexpected(validation_result.error());
+                }
+
                 if (options.progress) {
                     options.progress(100.0f, "COLMAP validation complete");
                 }
@@ -196,6 +208,7 @@ namespace lfs::io {
 
             if (has_cameras && has_images) {
                 LOG_DEBUG("Reading binary COLMAP data");
+                LOG_TIMER_DEBUG("COLMAP read binary cameras and images");
                 auto result = read_colmap_cameras_and_images(path, actual_images_folder, options);
                 if (!result) {
                     return std::unexpected(result.error());
@@ -203,6 +216,7 @@ namespace lfs::io {
                 std::tie(cameras, scene_center) = std::move(*result);
             } else if (has_cameras_text && has_images_text) {
                 LOG_DEBUG("Reading text COLMAP data");
+                LOG_TIMER_DEBUG("COLMAP read text cameras and images");
                 auto result = read_colmap_cameras_and_images_text(path, actual_images_folder, options);
                 if (!result) {
                     return std::unexpected(result.error());
@@ -219,7 +233,11 @@ namespace lfs::io {
 
             LOG_DEBUG("Creating {} camera objects", cameras.size());
 
-            const bool images_have_alpha = detect_camera_alpha(cameras, options.cancel_requested);
+            bool images_have_alpha = false;
+            {
+                LOG_TIMER_DEBUG("COLMAP detect image alpha");
+                images_have_alpha = detect_camera_alpha(cameras, options.cancel_requested);
+            }
 
             if (options.progress) {
                 options.progress(60.0f, "Loading point cloud...");
@@ -231,6 +249,7 @@ namespace lfs::io {
             std::shared_ptr<PointCloud> point_cloud;
             if (has_points_ply) {
                 LOG_INFO("Loading custom point cloud from points3D.ply");
+                LOG_TIMER_DEBUG("COLMAP load points3D.ply");
                 auto pc_result = load_ply_point_cloud(points_ply, options);
                 if (pc_result) {
                     point_cloud = std::make_shared<PointCloud>(std::move(*pc_result));
@@ -244,11 +263,13 @@ namespace lfs::io {
             }
             if (!point_cloud && has_points) {
                 LOG_DEBUG("Loading binary point cloud");
+                LOG_TIMER_DEBUG("COLMAP load binary point cloud");
                 auto loaded_pc = read_colmap_point_cloud(path, options);
                 point_cloud = std::make_shared<PointCloud>(std::move(loaded_pc));
                 LOG_INFO("Loaded {} points from COLMAP", point_cloud->size());
             } else if (!point_cloud && has_points_text) {
                 LOG_DEBUG("Loading text point cloud");
+                LOG_TIMER_DEBUG("COLMAP load text point cloud");
                 auto loaded_pc = read_colmap_point_cloud_text(path, options);
                 point_cloud = std::make_shared<PointCloud>(std::move(loaded_pc));
                 LOG_INFO("Loaded {} points from COLMAP text file", point_cloud->size());
@@ -258,7 +279,10 @@ namespace lfs::io {
             }
 
             // Centralize scene
-            scene_center = centralize_scene(cameras, point_cloud, options.centralize, scene_center);
+            {
+                LOG_TIMER_DEBUG("COLMAP centralize scene");
+                scene_center = centralize_scene(cameras, point_cloud, options.centralize, scene_center);
+            }
 
             if (options.progress) {
                 options.progress(100.0f, "COLMAP loading complete");


### PR DESCRIPTION
## Problem

Loading large COLMAP text datasets was very slow in LichtFeld Studio. A text-only dataset with 986 cameras and 3,530,724 sparse points took about 147 seconds to import, with most of the time spent in COLMAP metadata and point cloud parsing before the scene became usable.

The issue was most visible for datasets that only contain:

- `cameras.txt`
- `images.txt`
- `points3D.txt`

We profiled 2 datasets for this improvement Results are:

Dataset 1:
```text
146876 ms -> 21715 ms
Saved: 125161 ms
Speedup: about 6.8x
Reduction: about 85%
```

Dataset 2:
```68149 ms -> 45758 ms -> 30312 ms -> 17172 ms -> 10604 ms```


## Observations

Initial logs showed two major bottlenecks:

- `images.txt` was parsed twice during a normal full import.
- Both image observations and point tracks were parsed and stored even though normal dataset import only needs camera metadata and point cloud `xyz/rgb`.

For the larger validation dataset `colmap_lcc_images`, the old import profile was:

```text
Read images.txt took 52614 ms
Read images.txt took 53351 ms
Read COLMAP cameras and images (text) took 53804 ms
Read points3D.txt took 40019 ms
Read COLMAP point cloud (text) took 40376 ms
COLMAP dataset loaded successfully in 146876 ms
```

Dataset consistency from the old run:

```text
Cameras: 986
Points: 3,530,724
Format: COLMAP text
```

## Analysis

The loader was paying for data that was not needed by the normal import path:

- `images.txt` contains two logical lines per image: camera/image metadata and a large 2D observation line.
- Normal import needs image id, pose, camera id, and image name, but it does not need `points2D`.
- `points3D.txt` contains `xyz/rgb/error` plus track pairs.
- Normal point cloud import needs only `xyz/rgb`, but it was parsing and storing all track elements.

The first optimization removed redundant work. Later optimizations separated the full reconstruction-preserving parse path from the fast normal-import path.

## Root Cause

The COLMAP text loader used one general-purpose parser for multiple use cases:

- validating/importing a dataset for viewing/training
- preserving COLMAP observations/tracks for reconstruction export

That general parser eagerly loaded observation and track data for all imports. For large reconstructions, this meant millions of unnecessary `points2D` and track entries were parsed, allocated, and copied. In addition, a top-level validation pass caused `images.txt` to be read before the actual import, duplicating one of the most expensive steps.

## Changes

The import path was split into fast import-only readers while preserving the existing full readers for export/reconstruction workflows.

Implemented changes:

- Removed the duplicate full validation parse from normal COLMAP loads.
- Kept validation behavior for `validate_only`.
- Added targeted `[COLMAP_LOAD]` timing logs for discovery, camera metadata, validation, alpha probing, point cloud loading, and centralization.
- Added `read_images_text_camera_metadata_only(...)` for normal imports.
- Made normal text image import skip 2D observation lines instead of parsing them.
- Added fast numeric parsing helpers using `std::from_chars`.
- Added a direct `points3D.txt` point-cloud reader that parses `xyz/rgb` straight into tensor source arrays.
- Avoided building intermediate `Point3DData` records for normal text point cloud import.
- Kept full observation/track-preserving text parsers available for COLMAP reconstruction/export paths.

## Iterations

### Iteration 1: Identify duplicate image parsing

The original log showed `images.txt` parsed twice. The first parse came from validation, then the actual import parsed the same file again.

Result on first test dataset:

```text
Before: 68149 ms
After removing duplicate validation parse: 45758 ms
```

### Iteration 2: Skip observations and tracks during normal import

The next logs showed that `images.txt` and `points3D.txt` still spent most time parsing unused data:

```text
images.txt parse: 17570 ms, points2D=5,261,907
points3D.txt parse: 12733 ms, track_elements=5,261,907
```

Normal import was changed to use `parse_points2D=false` and `parse_tracks=false`.

Result on first test dataset:

```text
45758 ms -> 30312 ms
```

### Iteration 3: Directly skip image observation lines

Even with `parse_points2D=false`, the image parser still probed large observation lines as possible metadata. The import path was changed to skip the documented COLMAP observation line directly.

Result after rebuild:

```text
images.txt parse dropped to about 4 ms
```

### Iteration 4: Fast point cloud text import

The point cloud path still parsed `points3D.txt` into `Point3DData` records, then copied the useful data into tensors. A direct point-cloud reader was added for normal import.

Result on first test dataset:

```text
30312 ms -> 17172 ms
```

### Iteration 5: Streaming camera metadata reader

The `images.txt` path still read the full file into strings even though only 437 or 986 metadata lines were needed. A streaming metadata-only reader was added.

Result on first test dataset:

```text
17172 ms -> 10604 ms
```

### Iteration 6: Preserve one-line `images.txt` compatibility

Copilot review identified that the direct observation-line skip assumed every COLMAP text image record had a following `points2D` line. That is the normal COLMAP layout, but some minimal text datasets and tests use one metadata line per image with no observation line.

The fast path now uses a bounded lookahead:

- If the next physical line is another image metadata record, keep it for the next loop iteration.
- If the next physical line is an observation line, skip it without storing the full line.
- Keep the full parsers unchanged for reconstruction/export workflows that need observations.

Latest run after this safety fix:

```text
camera_metadata_fast: 2233 ms
Read COLMAP cameras and images (text): 2655 ms
point_cloud_fast: 18783 ms
Read COLMAP point cloud (text): 18835 ms
COLMAP dataset loaded successfully in 21505 ms
```

This added about 0.5 s to camera metadata parsing versus the previous fast run, while keeping the full import time effectively unchanged because `points3D.txt` parsing remains dominant.


## Final Results

### Validation Dataset: `colmap_lcc_images`

Old import:

```text
COLMAP dataset loaded successfully in 146876 ms
986 cameras
3,530,724 points
```

New import:

```text
COLMAP dataset loaded successfully in 21715 ms
986 cameras
3,530,724 points
```

After the final streaming metadata change, the relevant phase timings were:

```text
camera_metadata_fast: 1706 ms
Read COLMAP cameras and images (text): 2106 ms
point_cloud_fast: 19539 ms
Read COLMAP point cloud (text): 19593 ms
COLMAP dataset loaded successfully in 21715 ms
```

Overall improvement on this dataset:

```text
146876 ms -> 21715 ms
Saved: 125161 ms
Speedup: about 6.8x
Reduction: about 85%
```

### First Test Dataset

The smaller initial test dataset improved across the investigation as follows:

```text
68149 ms -> 45758 ms -> 30312 ms -> 17172 ms -> 10604 ms
```

The final profile showed:

```text
camera_metadata_fast: 803 ms
Read COLMAP cameras and images (text): 1073 ms
point_cloud_fast: 9489 ms
COLMAP dataset loaded successfully in 10604 ms
```

## Remaining Bottleneck

After these changes, the remaining cost is almost entirely `points3D.txt` text parsing. This is expected for very large text point clouds:

```text
3,530,724 points
points3D.txt size: 380 MB
point_cloud_fast: about 19.5 s
```

## Compatibility Notes

The normal import path now avoids observations and tracks by default, but the full parsers remain available. This keeps the optimization compatible with future track-based filtering if track loading is made explicit, for example:

```text
TrackLoadMode::None
TrackLoadMode::TrackLengthOnly
TrackLoadMode::FullTracks
```

The important invariant is that normal import stays on the fast path, while workflows that need tracks opt into the extra parsing cost.


## Validation Behavior

The duplicate top-level validation parse was removed, but normal imports still validate the dataset layout. Validation now happens inside the camera/image read path after the fast metadata-only image reader has loaded the COLMAP image records.

Validation still covers the important data used by normal import:

- required COLMAP camera/image metadata files
- image folder existence
- missing image files referenced by COLMAP metadata
- ambiguous image basename references
- ambiguous mask/depth references
- missing `camera_id` references from images
- invalid or unsupported camera models during camera assembly
- malformed required camera/image/point fields that are consumed by the fast readers

Additional checks still happen during camera assembly, including image lookup fallback and camera id/model validation.

What changed intentionally:

- Normal import no longer parses `images.txt` `points2D` observations.
- Normal import no longer parses `points3D.txt` track pairs.
- Therefore normal import no longer validates corruption that exists only in unused observation or track data.

This is acceptable for viewing/training import because that data is not consumed. Workflows that need observations or tracks, such as reconstruction-preserving export or future track-based filtering, should opt into the full parser or a dedicated track-loading mode. In those modes, the existing full observation/track-preserving parsers remain available and can perform the stricter validation.


