### PR TITLE
feat: add sam-segmentation plugin to curated marketplace list

### DIFF
--- a/src/python/lfs_plugins/marketplace.py
+++ b/src/python/lfs_plugins/marketplace.py
@@ -45,6 +45,7 @@ CURATED_PLUGIN_URLS: Tuple[str, ...] = (
     "https://github.com/jacobvanbeets/lichtfeld-depthmap-plugin",
     "https://github.com/jacobvanbeets/splat-vr-viewer",
     "https://github.com/jacobvanbeets/lichtfeld-measurement-plugin",
+    "https://github.com/iCarlosVega/sam-segmentation",
 )
 
 


### PR DESCRIPTION
Adds `iCarlosVega/sam-segmentation` to `CURATED_PLUGIN_URLS` in `marketplace.py`.

Text-prompted Grounded SAM 2 segmentation plugin generates per-frame binary masks
for mask aware Gaussian Splatting training. Users type a prompt ("person", "red car"),
the plugin writes `masks/<stem>.png` for every frame, and LichtFeld picks them up
automatically at training time.

- Plugin API: `>=1,<2`
- LichtFeld version: `>=0.5.2`
- License: GPL-3.0-or-later
- Tested on Windows 11, RTX 5070, LichtFeld 0.5.2

  Closes #1345