### PR TITLE
Fix Plugin Marketplace Confirm Overlay Hover Glitch

### DIFF
--- a/src/visualizer/gui/rmlui/resources/plugin_marketplace.rcss
+++ b/src/visualizer/gui/rmlui/resources/plugin_marketplace.rcss
@@ -471,7 +471,6 @@
     left: 0;
     right: 0;
     bottom: 0;
-    backdrop-filter: blur(3dp);
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/visualizer/gui/rmlui/resources/plugin_marketplace.theme.rcss
+++ b/src/visualizer/gui/rmlui/resources/plugin_marketplace.theme.rcss
@@ -76,3 +76,7 @@
     background-color: @{surface};
     border-color: @{border};
 }
+
+.confirm-buttons .btn--secondary:hover {
+    background-color: @{surface_bright};
+}


### PR DESCRIPTION
closes #1338

- Removed the unsupported `backdrop-filter` from the Plugin Marketplace uninstall confirmation overlay.
- Added a scoped hover color override for the confirmation dialog's secondary "No" button so its hover state remains visible.

## Why

Issue #1338 reports background glitches when hovering the "Yes" or "No" buttons in the uninstall confirmation dialog. The overlay used `backdrop-filter`, but the Vulkan RmlUI backend does not support layer filters, causing warnings and visual artifacts during hover repaints.

## Verification

- Confirmed `backdrop-filter` is no longer used in RmlUI resources.
- Reviewed the final diff to ensure the fix is limited to Plugin Marketplace styles.
