### PR TITLE
Fix Issue 1301: Tooltip Cache Invalidation Fix

### DIFF
--- a/src/visualizer/gui/rmlui/rml_panel_host.cpp
+++ b/src/visualizer/gui/rmlui/rml_panel_host.cpp
@@ -663,6 +663,35 @@ namespace lfs::vis::gui {
         if (ph <= 0 || display_h <= 0.0f || ph > last_fbo_h_)
             return false;
 
+        if (tooltip_.hasActiveState() && input_) {
+            const float local_x = input_->mouse_x - x;
+            const float local_y = input_->mouse_y - y;
+            bool hovered = hitTestPanelShape(local_x, local_y,
+                                             static_cast<float>(last_fbo_w_),
+                                             static_cast<float>(last_fbo_h_));
+
+            if (hovered && clip_y_min_ >= 0.0f && clip_y_max_ > clip_y_min_) {
+                if (input_->mouse_y < clip_y_min_ || input_->mouse_y > clip_y_max_)
+                    hovered = false;
+            }
+
+            const bool any_capture = mouse_captured_[0] || mouse_captured_[1] || mouse_captured_[2];
+            const bool effective_hovered = hovered || any_capture;
+            const int rml_mx = static_cast<int>(local_x);
+            const int rml_my = static_cast<int>(local_y);
+            const bool pointer_event =
+                input_->mouse_clicked[0] || input_->mouse_released[0] ||
+                input_->mouse_clicked[1] || input_->mouse_released[1] ||
+                input_->mouse_wheel != 0.0f;
+
+            if (pointer_event ||
+                effective_hovered != last_hovered_ ||
+                (effective_hovered &&
+                 (rml_mx != last_forwarded_mx_ || rml_my != last_forwarded_my_))) {
+                return false;
+            }
+        }
+
         compositeDirectToScreen(x, y, w, display_h);
         return true;
     }


### PR DESCRIPTION
## Problem

Issue #1301 reports stale tooltip behavior in the RML UI, most visibly in the
Rendering > Viewport panel. The tooltip can remain visible after the cursor
moves away from the original control, and clicking in the panel causes the
tooltip to disappear or update.

The important detail is that this is not specific to checkboxes. Any RML panel
element with a tooltip can hit the same path.

## Root Cause

RML panels are rendered on demand and cached into Vulkan textures for
performance. `RmlPanelHost::drawDirectCached()` can reuse the cached texture
without running the live input path.

The live path, `drawDirect()`, calls:

- `forwardInput()`, which updates RML hover state and tooltip target state.
- `applyHoverTooltip()`, which shows, moves, updates, or hides the tooltip.

Clicks already force a render frame, so clicking naturally runs the live path
and refreshes the tooltip. Hover-only movement can keep using the cached path,
leaving the old tooltip texture visible.

## Options Considered

### 1. Always redraw while a tooltip is visible

This would be simple, but it would turn visible tooltips into a continuous
animation source. That risks undoing the render-on-demand optimization that
keeps idle UI performance acceptable.

### 2. Mark all mouse movement over RML panels as live

This would also fix stale hover state, but it is broader than necessary. It
would increase cache refreshes for ordinary mouse movement even when no tooltip
is active.

### 3. Move or remove specific tooltips in the Rendering panel

This would only address the most visible instance. It would not fix the shared
RML tooltip lifecycle bug and would leave other panels vulnerable to the same
stale-cache behavior.

### 4. Reject cached drawing only when active tooltip state could change

This keeps the existing render-on-demand model intact. Cached drawing remains
available unless a tooltip is active and the current pointer state indicates
that the tooltip may need to move, update, or hide.

## Chosen Fix

The selected approach is option 4.

`RmlPanelHost::drawDirectCached()` now checks active tooltip state before
reusing the cached texture. If a tooltip is active and pointer state differs
from the last forwarded RML mouse state, the cached path returns `false`. The
existing caller then falls back to `drawDirect()`, which runs the normal input
and tooltip update flow.

This is intentionally minimal:

- No changes to tooltip styling.
- No changes to Rendering panel layout.
- No rebuild-time behavior changes.
- No continuous redraw while a tooltip is visible.

## Performance Impact

The fix is edge-triggered rather than frame-triggered. It does not make active
tooltips request animation frames. It only prevents cache reuse on frames that
already reached the panel and where the active tooltip may be stale.

In idle cases, cached drawing still works as before. In hover-transition cases,
one live panel refresh is allowed so the tooltip can be hidden, moved, or
updated.

closes #1301 