### PR TITLE
COLMAP Minimum Track Length Filter

### DIFF
--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -257,7 +257,7 @@ namespace {
                                                                 {"4", 4},
                                                                 {"8", 8}});
             ::args::ValueFlag<int> max_width(dataset_group, "max_width", "Max width of images in px; 0 disables the cap (default: 3840)", {"max-width"});
-            ::args::ValueFlag<int> min_colmap_track_length(dataset_group, "min_colmap_track_length", "Minimum COLMAP point track length; 0 disables sparse point filtering", {"min-colmap-track-length"});
+            ::args::ValueFlag<int> min_track_length(dataset_group, "min_track_length", "Minimum point track length for COLMAP sparse point import; 0 disables filtering", {"min-track-length"});
             ::args::Flag no_cpu_cache(dataset_group, "no_cpu_cache", "Disable CPU memory caching (default: enabled)", {"no-cpu-cache"});
             ::args::Flag no_fs_cache(dataset_group, "no_fs_cache", "Disable filesystem caching (default: enabled)", {"no-fs-cache"});
             ::args::Flag undistort(dataset_group, "undistort", "Undistort images on-the-fly before training", {"undistort"});
@@ -606,10 +606,10 @@ namespace {
                     return std::unexpected("ERROR: --max-width must be 0 or greater");
                 }
             }
-            if (min_colmap_track_length) {
-                int min_track = ::args::get(min_colmap_track_length);
+            if (min_track_length) {
+                int min_track = ::args::get(min_track_length);
                 if (min_track < 0) {
-                    return std::unexpected("ERROR: --min-colmap-track-length must be 0 or greater");
+                    return std::unexpected("ERROR: --min-track-length must be 0 or greater");
                 }
             }
 
@@ -690,7 +690,7 @@ namespace {
                                         iterations_val = cli_option_present({"-i", "--iter"}) ? std::optional<uint32_t>(::args::get(iterations)) : std::optional<uint32_t>(),
                                         resize_factor_val = resize_factor ? std::optional<int>(::args::get(resize_factor)) : std::optional<int>(1), // default 1
                                         max_width_val = max_width ? std::optional<int>(::args::get(max_width)) : std::optional<int>(3840),
-                                        min_colmap_track_length_val = cli_option_present({"--min-colmap-track-length"}) ? std::optional<int>(::args::get(min_colmap_track_length)) : std::optional<int>(),
+                                        min_track_length_val = cli_option_present({"--min-track-length"}) ? std::optional<int>(::args::get(min_track_length)) : std::optional<int>(),
                                         no_cpu_cache_flag = static_cast<bool>(no_cpu_cache),
                                         no_fs_cache_flag = static_cast<bool>(no_fs_cache),
                                         tcp_server_connection_port_val = tcp_server_connection_port ? std::optional<int>(::args::get(tcp_server_connection_port)) : std::optional<int>(),
@@ -771,7 +771,7 @@ namespace {
                 setVal(iterations_val, opt.iterations);
                 setVal(resize_factor_val, ds.resize_factor);
                 setVal(max_width_val, ds.max_width);
-                setVal(min_colmap_track_length_val, ds.min_colmap_track_length);
+                setVal(min_track_length_val, ds.min_track_length);
                 if (no_cpu_cache_flag)
                     ds.loading_params.use_cpu_memory = false;
                 if (no_fs_cache_flag)

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -257,6 +257,7 @@ namespace {
                                                                 {"4", 4},
                                                                 {"8", 8}});
             ::args::ValueFlag<int> max_width(dataset_group, "max_width", "Max width of images in px; 0 disables the cap (default: 3840)", {"max-width"});
+            ::args::ValueFlag<int> min_colmap_track_length(dataset_group, "min_colmap_track_length", "Minimum COLMAP point track length; 0 disables sparse point filtering", {"min-colmap-track-length"});
             ::args::Flag no_cpu_cache(dataset_group, "no_cpu_cache", "Disable CPU memory caching (default: enabled)", {"no-cpu-cache"});
             ::args::Flag no_fs_cache(dataset_group, "no_fs_cache", "Disable filesystem caching (default: enabled)", {"no-fs-cache"});
             ::args::Flag undistort(dataset_group, "undistort", "Undistort images on-the-fly before training", {"undistort"});
@@ -605,6 +606,12 @@ namespace {
                     return std::unexpected("ERROR: --max-width must be 0 or greater");
                 }
             }
+            if (min_colmap_track_length) {
+                int min_track = ::args::get(min_colmap_track_length);
+                if (min_track < 0) {
+                    return std::unexpected("ERROR: --min-colmap-track-length must be 0 or greater");
+                }
+            }
 
             // Validate sh_degree (0-3)
             if (sh_degree) {
@@ -683,6 +690,7 @@ namespace {
                                         iterations_val = cli_option_present({"-i", "--iter"}) ? std::optional<uint32_t>(::args::get(iterations)) : std::optional<uint32_t>(),
                                         resize_factor_val = resize_factor ? std::optional<int>(::args::get(resize_factor)) : std::optional<int>(1), // default 1
                                         max_width_val = max_width ? std::optional<int>(::args::get(max_width)) : std::optional<int>(3840),
+                                        min_colmap_track_length_val = cli_option_present({"--min-colmap-track-length"}) ? std::optional<int>(::args::get(min_colmap_track_length)) : std::optional<int>(),
                                         no_cpu_cache_flag = static_cast<bool>(no_cpu_cache),
                                         no_fs_cache_flag = static_cast<bool>(no_fs_cache),
                                         tcp_server_connection_port_val = tcp_server_connection_port ? std::optional<int>(::args::get(tcp_server_connection_port)) : std::optional<int>(),
@@ -763,6 +771,7 @@ namespace {
                 setVal(iterations_val, opt.iterations);
                 setVal(resize_factor_val, ds.resize_factor);
                 setVal(max_width_val, ds.max_width);
+                setVal(min_colmap_track_length_val, ds.min_colmap_track_length);
                 if (no_cpu_cache_flag)
                     ds.loading_params.use_cpu_memory = false;
                 if (no_fs_cache_flag)

--- a/src/core/include/core/events.hpp
+++ b/src/core/include/core/events.hpp
@@ -58,7 +58,7 @@ namespace lfs::core {
             EVENT(ResetTraining, );
             EVENT(SwitchToLatestCheckpoint, );
             EVENT(SaveCheckpoint, std::optional<int> iteration;);
-            EVENT(LoadFile, std::filesystem::path path; bool is_dataset; std::filesystem::path output_path; std::filesystem::path init_path; std::string centralize_dataset; std::optional<int> max_width; std::optional<int> min_colmap_track_length; bool apply_auto_crop = false;);
+            EVENT(LoadFile, std::filesystem::path path; bool is_dataset; std::filesystem::path output_path; std::filesystem::path init_path; std::string centralize_dataset; std::optional<int> max_width; std::optional<int> min_track_length; bool apply_auto_crop = false;);
             EVENT(LoadCheckpointForTraining, std::filesystem::path checkpoint_path; std::filesystem::path dataset_path; std::filesystem::path output_path;);
             EVENT(ImportColmapCameras, std::filesystem::path sparse_path;);
             EVENT(LoadConfigFile, std::filesystem::path path;);

--- a/src/core/include/core/events.hpp
+++ b/src/core/include/core/events.hpp
@@ -58,7 +58,7 @@ namespace lfs::core {
             EVENT(ResetTraining, );
             EVENT(SwitchToLatestCheckpoint, );
             EVENT(SaveCheckpoint, std::optional<int> iteration;);
-            EVENT(LoadFile, std::filesystem::path path; bool is_dataset; std::filesystem::path output_path; std::filesystem::path init_path; std::string centralize_dataset; std::optional<int> max_width; bool apply_auto_crop = false;);
+            EVENT(LoadFile, std::filesystem::path path; bool is_dataset; std::filesystem::path output_path; std::filesystem::path init_path; std::string centralize_dataset; std::optional<int> max_width; std::optional<int> min_colmap_track_length; bool apply_auto_crop = false;);
             EVENT(LoadCheckpointForTraining, std::filesystem::path checkpoint_path; std::filesystem::path dataset_path; std::filesystem::path output_path;);
             EVENT(ImportColmapCameras, std::filesystem::path sparse_path;);
             EVENT(LoadConfigFile, std::filesystem::path path;);

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -236,6 +236,7 @@ namespace lfs::core {
             std::vector<std::string> timelapse_images = {};
             int timelapse_every = 50;
             int max_width = 3840;
+            int min_colmap_track_length = 0;
             LoadingParams loading_params;
 
             // Mask loading parameters (copied from optimization params)

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -236,7 +236,7 @@ namespace lfs::core {
             std::vector<std::string> timelapse_images = {};
             int timelapse_every = 50;
             int max_width = 3840;
-            int min_colmap_track_length = 0;
+            int min_track_length = 0;
             LoadingParams loading_params;
 
             // Mask loading parameters (copied from optimization params)

--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -680,6 +680,7 @@ namespace lfs::core {
             json["resize_factor"] = resize_factor;
             json["test_every"] = test_every;
             json["max_width"] = max_width;
+            json["min_colmap_track_length"] = min_colmap_track_length;
             json["loading_params"] = loading_params.to_json();
             json["invert_masks"] = invert_masks;
             json["mask_threshold"] = mask_threshold;
@@ -697,6 +698,9 @@ namespace lfs::core {
             dataset.images = j["images"].get<std::string>();
             dataset.resize_factor = j["resize_factor"].get<int>();
             dataset.max_width = j["max_width"].get<int>();
+            if (j.contains("min_colmap_track_length")) {
+                dataset.min_colmap_track_length = j["min_colmap_track_length"].get<int>();
+            }
             dataset.test_every = j["test_every"].get<int>();
             dataset.output_path = utf8_to_path(j["output_folder"].get<std::string>());
 

--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -680,7 +680,7 @@ namespace lfs::core {
             json["resize_factor"] = resize_factor;
             json["test_every"] = test_every;
             json["max_width"] = max_width;
-            json["min_colmap_track_length"] = min_colmap_track_length;
+            json["min_track_length"] = min_track_length;
             json["loading_params"] = loading_params.to_json();
             json["invert_masks"] = invert_masks;
             json["mask_threshold"] = mask_threshold;
@@ -698,8 +698,8 @@ namespace lfs::core {
             dataset.images = j["images"].get<std::string>();
             dataset.resize_factor = j["resize_factor"].get<int>();
             dataset.max_width = j["max_width"].get<int>();
-            if (j.contains("min_colmap_track_length")) {
-                dataset.min_colmap_track_length = j["min_colmap_track_length"].get<int>();
+            if (j.contains("min_track_length")) {
+                dataset.min_track_length = j["min_track_length"].get<int>();
             }
             dataset.test_every = j["test_every"].get<int>();
             dataset.output_path = utf8_to_path(j["output_folder"].get<std::string>());

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -781,6 +781,9 @@ namespace lfs::io {
 
     PointCloud point3D_records_to_point_cloud(const std::vector<Point3DData>& points) {
         const uint64_t N = points.size();
+        if (N == 0)
+            return PointCloud();
+
         std::vector<float> positions(N * 3);
         std::vector<uint8_t> colors(N * 3);
 
@@ -799,6 +802,28 @@ namespace lfs::io {
                                    .contiguous();
 
         return PointCloud(std::move(means), std::move(colors_tensor));
+    }
+
+    ColmapPointCloudLoadStats point3D_records_to_point_cloud_with_stats(
+        std::vector<Point3DData> points,
+        const LoadOptions& options) {
+        ColmapPointCloudLoadStats result{
+            .total_points = points.size(),
+            .points_after_filtering = points.size(),
+            .track_filter_applied = options.min_colmap_track_length > 0,
+        };
+
+        const int min_track_length = options.min_colmap_track_length;
+        if (min_track_length > 0) {
+            const auto min_track = static_cast<size_t>(min_track_length);
+            std::erase_if(points, [min_track](const Point3DData& point) {
+                return point.track.size() < min_track;
+            });
+            result.points_after_filtering = points.size();
+        }
+
+        result.point_cloud = point3D_records_to_point_cloud(points);
+        return result;
     }
 
     PointCloud read_point3D_binary(const std::filesystem::path& file_path,
@@ -2233,6 +2258,16 @@ namespace lfs::io {
         return read_point3D_binary(points3d_file, options);
     }
 
+    ColmapPointCloudLoadStats read_colmap_point_cloud_with_stats(
+        const std::filesystem::path& filepath,
+        const LoadOptions& options) {
+        LOG_TIMER_TRACE("Read COLMAP point cloud");
+        fs::path points3d_file = get_sparse_file_path(filepath, "points3D.bin");
+        return point3D_records_to_point_cloud_with_stats(
+            read_point3D_binary_records(points3d_file, options),
+            options);
+    }
+
     Result<void> validate_colmap_dataset_layout(const std::filesystem::path& base,
                                                 const std::string& images_folder,
                                                 const LoadOptions& options) {
@@ -2298,6 +2333,16 @@ namespace lfs::io {
         LOG_TIMER_TRACE("Read COLMAP point cloud (text)");
         fs::path points3d_file = get_sparse_file_path(filepath, "points3D.txt");
         return read_point3D_text(points3d_file, options);
+    }
+
+    ColmapPointCloudLoadStats read_colmap_point_cloud_text_with_stats(
+        const std::filesystem::path& filepath,
+        const LoadOptions& options) {
+        LOG_TIMER_TRACE("Read COLMAP point cloud (text)");
+        fs::path points3d_file = get_sparse_file_path(filepath, "points3D.txt");
+        return point3D_records_to_point_cloud_with_stats(
+            read_point3D_text_records(points3d_file, options, true),
+            options);
     }
 
     Result<std::tuple<std::vector<std::shared_ptr<Camera>>, Tensor>>

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -810,10 +810,10 @@ namespace lfs::io {
         ColmapPointCloudLoadStats result{
             .total_points = points.size(),
             .points_after_filtering = points.size(),
-            .track_filter_applied = options.min_colmap_track_length > 0,
+            .track_filter_applied = options.min_track_length > 0,
         };
 
-        const int min_track_length = options.min_colmap_track_length;
+        const int min_track_length = options.min_track_length;
         if (min_track_length > 0) {
             const auto min_track = static_cast<size_t>(min_track_length);
             std::erase_if(points, [min_track](const Point3DData& point) {

--- a/src/io/formats/colmap.hpp
+++ b/src/io/formats/colmap.hpp
@@ -9,6 +9,7 @@
 #include "core/tensor.hpp"
 #include "io/error.hpp"
 #include "io/loader.hpp"
+#include <cstddef>
 #include <filesystem>
 #include <glm/glm.hpp>
 #include <memory>
@@ -22,6 +23,13 @@ namespace lfs::io {
     using lfs::core::Device;
     using lfs::core::PointCloud;
     using lfs::core::Tensor;
+
+    struct ColmapPointCloudLoadStats {
+        PointCloud point_cloud;
+        std::size_t total_points = 0;
+        std::size_t points_after_filtering = 0;
+        bool track_filter_applied = false;
+    };
 
     // Camera data structure used for intermediate loading before Camera creation
     struct CameraData {
@@ -71,6 +79,10 @@ namespace lfs::io {
     PointCloud read_colmap_point_cloud(const std::filesystem::path& filepath,
                                        const LoadOptions& options = {});
 
+    ColmapPointCloudLoadStats read_colmap_point_cloud_with_stats(
+        const std::filesystem::path& filepath,
+        const LoadOptions& options = {});
+
     /**
      * @brief Read COLMAP cameras and images from text files
      * @param base Base directory containing COLMAP data
@@ -106,6 +118,10 @@ namespace lfs::io {
      */
     PointCloud read_colmap_point_cloud_text(const std::filesystem::path& filepath,
                                             const LoadOptions& options = {});
+
+    ColmapPointCloudLoadStats read_colmap_point_cloud_text_with_stats(
+        const std::filesystem::path& filepath,
+        const LoadOptions& options = {});
 
     /**
      * @brief Read COLMAP cameras only (no image file validation required)

--- a/src/io/include/io/loader.hpp
+++ b/src/io/include/io/loader.hpp
@@ -61,6 +61,7 @@ namespace lfs::io {
         int resize_factor = -1;
         int max_width = 0;
         std::string images_folder = "images";
+        int min_colmap_track_length = 0;
         bool validate_only = false;
         CentralizeDataset centralize = CentralizeDataset::Off;
         ProgressCallback progress = nullptr;

--- a/src/io/include/io/loader.hpp
+++ b/src/io/include/io/loader.hpp
@@ -61,7 +61,7 @@ namespace lfs::io {
         int resize_factor = -1;
         int max_width = 0;
         std::string images_folder = "images";
-        int min_colmap_track_length = 0;
+        int min_track_length = 0;
         bool validate_only = false;
         CentralizeDataset centralize = CentralizeDataset::Off;
         ProgressCallback progress = nullptr;

--- a/src/io/loaders/colmap_loader.cpp
+++ b/src/io/loaders/colmap_loader.cpp
@@ -249,7 +249,7 @@ namespace lfs::io {
             // Track filtering requires COLMAP sparse records, so prefer .bin/.txt when enabled.
             std::shared_ptr<PointCloud> point_cloud;
             std::vector<std::string> warnings;
-            const bool use_colmap_track_filter = options.min_colmap_track_length > 0;
+            const bool use_colmap_track_filter = options.min_track_length > 0;
             if (has_points_ply && !use_colmap_track_filter) {
                 LOG_INFO("Loading custom point cloud from points3D.ply");
                 LOG_TIMER_DEBUG("COLMAP load points3D.ply");
@@ -289,7 +289,7 @@ namespace lfs::io {
                     point_cloud = std::make_shared<PointCloud>(std::move(loaded_pc.point_cloud));
                     const std::string message = std::format(
                         "COLMAP min track length filter: min track length {}, total points {}, after filtering {}",
-                        options.min_colmap_track_length,
+                        options.min_track_length,
                         loaded_pc.total_points,
                         loaded_pc.points_after_filtering);
                     LOG_INFO("{}", message);
@@ -307,7 +307,7 @@ namespace lfs::io {
                     point_cloud = std::make_shared<PointCloud>(std::move(loaded_pc.point_cloud));
                     const std::string message = std::format(
                         "COLMAP min track length filter: min track length {}, total points {}, after filtering {}",
-                        options.min_colmap_track_length,
+                        options.min_track_length,
                         loaded_pc.total_points,
                         loaded_pc.points_after_filtering);
                     LOG_INFO("{}", message);

--- a/src/io/loaders/colmap_loader.cpp
+++ b/src/io/loaders/colmap_loader.cpp
@@ -245,9 +245,12 @@ namespace lfs::io {
 
             throw_if_load_cancel_requested(options, "COLMAP point cloud load cancelled");
 
-            // Load point cloud: points3D.ply > points3D.bin > points3D.txt
+            // Load point cloud: points3D.ply > points3D.bin > points3D.txt.
+            // Track filtering requires COLMAP sparse records, so prefer .bin/.txt when enabled.
             std::shared_ptr<PointCloud> point_cloud;
-            if (has_points_ply) {
+            std::vector<std::string> warnings;
+            const bool use_colmap_track_filter = options.min_colmap_track_length > 0;
+            if (has_points_ply && !use_colmap_track_filter) {
                 LOG_INFO("Loading custom point cloud from points3D.ply");
                 LOG_TIMER_DEBUG("COLMAP load points3D.ply");
                 auto pc_result = load_ply_point_cloud(points_ply, options);
@@ -260,18 +263,59 @@ namespace lfs::io {
                     }
                     LOG_WARN("Failed to load points3D.ply: {}, falling back", pc_result.error());
                 }
+            } else if (has_points_ply && use_colmap_track_filter) {
+                if (has_points || has_points_text) {
+                    LOG_INFO("Skipping points3D.ply because COLMAP min track length filter is enabled");
+                } else {
+                    LOG_WARN("COLMAP min track length filter requested, but only points3D.ply is available; loading unfiltered PLY");
+                    LOG_TIMER_DEBUG("COLMAP load points3D.ply");
+                    auto pc_result = load_ply_point_cloud(points_ply, options);
+                    if (pc_result) {
+                        point_cloud = std::make_shared<PointCloud>(std::move(*pc_result));
+                        LOG_INFO("Loaded {} points from points3D.ply", point_cloud->size());
+                    } else {
+                        if (is_load_cancel_requested(options)) {
+                            return std::unexpected(make_error(ErrorCode::CANCELLED, pc_result.error(), points_ply));
+                        }
+                        LOG_WARN("Failed to load points3D.ply: {}, falling back", pc_result.error());
+                    }
+                }
             }
             if (!point_cloud && has_points) {
                 LOG_DEBUG("Loading binary point cloud");
                 LOG_TIMER_DEBUG("COLMAP load binary point cloud");
-                auto loaded_pc = read_colmap_point_cloud(path, options);
-                point_cloud = std::make_shared<PointCloud>(std::move(loaded_pc));
+                if (use_colmap_track_filter) {
+                    auto loaded_pc = read_colmap_point_cloud_with_stats(path, options);
+                    point_cloud = std::make_shared<PointCloud>(std::move(loaded_pc.point_cloud));
+                    const std::string message = std::format(
+                        "COLMAP min track length filter: min track length {}, total points {}, after filtering {}",
+                        options.min_colmap_track_length,
+                        loaded_pc.total_points,
+                        loaded_pc.points_after_filtering);
+                    LOG_INFO("{}", message);
+                    warnings.push_back(message);
+                } else {
+                    auto loaded_pc = read_colmap_point_cloud(path, options);
+                    point_cloud = std::make_shared<PointCloud>(std::move(loaded_pc));
+                }
                 LOG_INFO("Loaded {} points from COLMAP", point_cloud->size());
             } else if (!point_cloud && has_points_text) {
                 LOG_DEBUG("Loading text point cloud");
                 LOG_TIMER_DEBUG("COLMAP load text point cloud");
-                auto loaded_pc = read_colmap_point_cloud_text(path, options);
-                point_cloud = std::make_shared<PointCloud>(std::move(loaded_pc));
+                if (use_colmap_track_filter) {
+                    auto loaded_pc = read_colmap_point_cloud_text_with_stats(path, options);
+                    point_cloud = std::make_shared<PointCloud>(std::move(loaded_pc.point_cloud));
+                    const std::string message = std::format(
+                        "COLMAP min track length filter: min track length {}, total points {}, after filtering {}",
+                        options.min_colmap_track_length,
+                        loaded_pc.total_points,
+                        loaded_pc.points_after_filtering);
+                    LOG_INFO("{}", message);
+                    warnings.push_back(message);
+                } else {
+                    auto loaded_pc = read_colmap_point_cloud_text(path, options);
+                    point_cloud = std::make_shared<PointCloud>(std::move(loaded_pc));
+                }
                 LOG_INFO("Loaded {} points from COLMAP text file", point_cloud->size());
             } else if (!point_cloud) {
                 LOG_WARN("No point cloud found - will use random initialization");
@@ -304,7 +348,11 @@ namespace lfs::io {
                 .images_have_alpha = images_have_alpha,
                 .loader_used = name(),
                 .load_time = load_time,
-                .warnings = (has_points || has_points_text || has_points_ply) ? std::vector<std::string>{} : std::vector<std::string>{"No sparse point cloud found - using random initialization"}};
+                .warnings = std::move(warnings)};
+
+            if (!has_points && !has_points_text && !has_points_ply) {
+                result.warnings.push_back("No sparse point cloud found - using random initialization");
+            }
 
             LOG_INFO("COLMAP dataset loaded successfully in {}ms", load_time.count());
             LOG_INFO("  - {} cameras", num_cameras);

--- a/src/mcp/shared_scene_tools.cpp
+++ b/src/mcp/shared_scene_tools.cpp
@@ -50,6 +50,12 @@ namespace lfs::mcp {
                 params.optimization.iterations = args["max_iterations"].get<size_t>();
             if (args.contains("output_path"))
                 params.dataset.output_path = args["output_path"].get<std::string>();
+            if (args.contains("min_colmap_track_length")) {
+                const int min_track = args["min_colmap_track_length"].get<int>();
+                if (min_track < 0)
+                    return std::unexpected("min_colmap_track_length must be 0 or greater");
+                params.dataset.min_colmap_track_length = min_track;
+            }
             if (params.dataset.output_path.empty())
                 params.dataset.output_path = core::param::default_dataset_output_path(params.dataset.data_path);
 
@@ -86,6 +92,7 @@ namespace lfs::mcp {
                         {"path", json{{"type", "string"}, {"description", "Path to COLMAP dataset directory"}}},
                         {"images_folder", json{{"type", "string"}, {"description", "Images subfolder (default: images)"}}},
                         {"output_path", json{{"type", "string"}, {"description", "Optional output directory for checkpoints and exports (default: <dataset>/output)"}}},
+                        {"min_colmap_track_length", json{{"type", "integer"}, {"minimum", 0}, {"description", "Minimum COLMAP track length for sparse point import; 0 disables filtering"}}},
                         {"max_iterations", json{{"type", "integer"}, {"description", "Maximum training iterations (default: 30000)"}}},
                         {"strategy", json{{"type", "string"}, {"enum", json::array({"default", "mcmc", "mrnf", "igs+"})}, {"description", "Training strategy or 'default' to keep the built-in default"}}}},
                     .required = {"path"}},
@@ -107,6 +114,7 @@ namespace lfs::mcp {
                     {"success", true},
                     {"path", core::path_to_utf8(path)},
                     {"output_path", core::path_to_utf8(params.dataset.output_path)},
+                    {"min_colmap_track_length", params.dataset.min_colmap_track_length},
                     {"strategy", params.optimization.strategy},
                 };
                 if (backend.gaussian_count) {

--- a/src/mcp/shared_scene_tools.cpp
+++ b/src/mcp/shared_scene_tools.cpp
@@ -50,11 +50,11 @@ namespace lfs::mcp {
                 params.optimization.iterations = args["max_iterations"].get<size_t>();
             if (args.contains("output_path"))
                 params.dataset.output_path = args["output_path"].get<std::string>();
-            if (args.contains("min_colmap_track_length")) {
-                const int min_track = args["min_colmap_track_length"].get<int>();
+            if (args.contains("min_track_length")) {
+                const int min_track = args["min_track_length"].get<int>();
                 if (min_track < 0)
-                    return std::unexpected("min_colmap_track_length must be 0 or greater");
-                params.dataset.min_colmap_track_length = min_track;
+                    return std::unexpected("min_track_length must be 0 or greater");
+                params.dataset.min_track_length = min_track;
             }
             if (params.dataset.output_path.empty())
                 params.dataset.output_path = core::param::default_dataset_output_path(params.dataset.data_path);
@@ -92,7 +92,7 @@ namespace lfs::mcp {
                         {"path", json{{"type", "string"}, {"description", "Path to COLMAP dataset directory"}}},
                         {"images_folder", json{{"type", "string"}, {"description", "Images subfolder (default: images)"}}},
                         {"output_path", json{{"type", "string"}, {"description", "Optional output directory for checkpoints and exports (default: <dataset>/output)"}}},
-                        {"min_colmap_track_length", json{{"type", "integer"}, {"minimum", 0}, {"description", "Minimum COLMAP track length for sparse point import; 0 disables filtering"}}},
+                        {"min_track_length", json{{"type", "integer"}, {"minimum", 0}, {"description", "Minimum COLMAP track length for sparse point import; 0 disables filtering"}}},
                         {"max_iterations", json{{"type", "integer"}, {"description", "Maximum training iterations (default: 30000)"}}},
                         {"strategy", json{{"type", "string"}, {"enum", json::array({"default", "mcmc", "mrnf", "igs+"})}, {"description", "Training strategy or 'default' to keep the built-in default"}}}},
                     .required = {"path"}},
@@ -114,7 +114,7 @@ namespace lfs::mcp {
                     {"success", true},
                     {"path", core::path_to_utf8(path)},
                     {"output_path", core::path_to_utf8(params.dataset.output_path)},
-                    {"min_colmap_track_length", params.dataset.min_colmap_track_length},
+                    {"min_track_length", params.dataset.min_track_length},
                     {"strategy", params.optimization.strategy},
                 };
                 if (backend.gaussian_count) {

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -791,7 +791,8 @@ NB_MODULE(lichtfeld, m) {
            const std::string& output_path, const std::string& init_path,
            const std::string& centralize_dataset,
            std::optional<int> max_width,
-           bool apply_auto_crop) {
+           bool apply_auto_crop,
+           std::optional<int> min_colmap_track_length) {
             nb::gil_scoped_release release;
             lfs::core::events::cmd::LoadFile{
                 .path = python_utf8_path(path),
@@ -800,6 +801,7 @@ NB_MODULE(lichtfeld, m) {
                 .init_path = python_utf8_path(init_path),
                 .centralize_dataset = centralize_dataset,
                 .max_width = max_width,
+                .min_colmap_track_length = min_colmap_track_length,
                 .apply_auto_crop = apply_auto_crop}
                 .emit();
         },
@@ -808,6 +810,7 @@ NB_MODULE(lichtfeld, m) {
         nb::arg("centralize_dataset") = "off",
         nb::arg("max_width") = nb::none(),
         nb::arg("apply_auto_crop") = false,
+        nb::arg("min_colmap_track_length") = nb::none(),
         "Load a file (PLY, checkpoint) or dataset into the scene.");
 
     m.def(

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -792,7 +792,7 @@ NB_MODULE(lichtfeld, m) {
            const std::string& centralize_dataset,
            std::optional<int> max_width,
            bool apply_auto_crop,
-           std::optional<int> min_colmap_track_length) {
+           std::optional<int> min_track_length) {
             nb::gil_scoped_release release;
             lfs::core::events::cmd::LoadFile{
                 .path = python_utf8_path(path),
@@ -801,7 +801,7 @@ NB_MODULE(lichtfeld, m) {
                 .init_path = python_utf8_path(init_path),
                 .centralize_dataset = centralize_dataset,
                 .max_width = max_width,
-                .min_colmap_track_length = min_colmap_track_length,
+                .min_track_length = min_track_length,
                 .apply_auto_crop = apply_auto_crop}
                 .emit();
         },
@@ -810,7 +810,7 @@ NB_MODULE(lichtfeld, m) {
         nb::arg("centralize_dataset") = "off",
         nb::arg("max_width") = nb::none(),
         nb::arg("apply_auto_crop") = false,
-        nb::arg("min_colmap_track_length") = nb::none(),
+        nb::arg("min_track_length") = nb::none(),
         "Load a file (PLY, checkpoint) or dataset into the scene.");
 
     m.def(

--- a/src/python/lfs/py_io.cpp
+++ b/src/python/lfs/py_io.cpp
@@ -183,7 +183,8 @@ namespace lfs::python {
             "load",
             [](const std::filesystem::path& path, std::optional<std::string> format,
                std::optional<int> resize_factor, std::optional<int> max_width,
-               std::optional<std::string> images_folder, nb::object progress) -> PyLoadResult {
+               std::optional<std::string> images_folder, nb::object progress,
+               std::optional<int> min_colmap_track_length) -> PyLoadResult {
                 auto loader = io::Loader::create();
 
                 io::LoadOptions options;
@@ -193,6 +194,8 @@ namespace lfs::python {
                     options.max_width = *max_width;
                 if (images_folder)
                     options.images_folder = *images_folder;
+                if (min_colmap_track_length)
+                    options.min_colmap_track_length = *min_colmap_track_length;
 
                 if (progress && !progress.is_none()) {
                     PyProgressCallback py_progress{nb::cast<nb::object>(progress)};
@@ -226,6 +229,7 @@ namespace lfs::python {
             nb::arg("path"), nb::arg("format") = nb::none(), nb::arg("resize_factor") = nb::none(),
             nb::arg("max_width") = nb::none(), nb::arg("images_folder") = nb::none(),
             nb::arg("progress") = nb::none(),
+            nb::arg("min_colmap_track_length") = nb::none(),
             "Load a scene or splat file from path");
 
         m.def(

--- a/src/python/lfs/py_io.cpp
+++ b/src/python/lfs/py_io.cpp
@@ -184,7 +184,7 @@ namespace lfs::python {
             [](const std::filesystem::path& path, std::optional<std::string> format,
                std::optional<int> resize_factor, std::optional<int> max_width,
                std::optional<std::string> images_folder, nb::object progress,
-               std::optional<int> min_colmap_track_length) -> PyLoadResult {
+               std::optional<int> min_track_length) -> PyLoadResult {
                 auto loader = io::Loader::create();
 
                 io::LoadOptions options;
@@ -194,8 +194,8 @@ namespace lfs::python {
                     options.max_width = *max_width;
                 if (images_folder)
                     options.images_folder = *images_folder;
-                if (min_colmap_track_length)
-                    options.min_colmap_track_length = *min_colmap_track_length;
+                if (min_track_length)
+                    options.min_track_length = *min_track_length;
 
                 if (progress && !progress.is_none()) {
                     PyProgressCallback py_progress{nb::cast<nb::object>(progress)};
@@ -229,7 +229,7 @@ namespace lfs::python {
             nb::arg("path"), nb::arg("format") = nb::none(), nb::arg("resize_factor") = nb::none(),
             nb::arg("max_width") = nb::none(), nb::arg("images_folder") = nb::none(),
             nb::arg("progress") = nb::none(),
-            nb::arg("min_colmap_track_length") = nb::none(),
+            nb::arg("min_track_length") = nb::none(),
             "Load a scene or splat file from path");
 
         m.def(

--- a/src/python/lfs/py_params.cpp
+++ b/src/python/lfs/py_params.cpp
@@ -414,6 +414,12 @@ namespace lfs::python {
             [](const DatasetConfig& c) { return c.max_width; },
             [](DatasetConfig& c, int v) { c.max_width = v; });
 
+        add_int(
+            "min_colmap_track_length", "Min COLMAP Track Length", 0, 0, 65535,
+            "Minimum COLMAP sparse point track length; 0 disables filtering", false,
+            [](const DatasetConfig& c) { return c.min_colmap_track_length; },
+            [](DatasetConfig& c, int v) { c.min_colmap_track_length = v; });
+
         add_bool(
             "use_cpu_cache", "CPU Cache", true, "Cache images in CPU memory", false,
             [](const DatasetConfig& c) { return c.loading_params.use_cpu_memory; },
@@ -1389,6 +1395,17 @@ namespace lfs::python {
                     self.params().max_width = v;
                 },
                 "Maximum image width in pixels; 0 disables the cap")
+            .def_prop_rw(
+                "min_colmap_track_length",
+                [](const PyDatasetConfig& self) { return self.params().min_colmap_track_length; },
+                [](PyDatasetConfig& self, int v) {
+                    if (!self.can_edit())
+                        throw std::runtime_error("Cannot edit dataset params during training");
+                    if (v < 0)
+                        throw std::invalid_argument("min_colmap_track_length must be non-negative; 0 disables filtering");
+                    self.params().min_colmap_track_length = v;
+                },
+                "Minimum COLMAP sparse point track length; 0 disables filtering")
             .def_prop_rw(
                 "use_cpu_cache",
                 [](const PyDatasetConfig& self) { return self.params().loading_params.use_cpu_memory; },

--- a/src/python/lfs/py_params.cpp
+++ b/src/python/lfs/py_params.cpp
@@ -415,10 +415,10 @@ namespace lfs::python {
             [](DatasetConfig& c, int v) { c.max_width = v; });
 
         add_int(
-            "min_colmap_track_length", "Min COLMAP Track Length", 0, 0, 65535,
+            "min_track_length", "Minimum Track Length", 0, 0, 65535,
             "Minimum COLMAP sparse point track length; 0 disables filtering", false,
-            [](const DatasetConfig& c) { return c.min_colmap_track_length; },
-            [](DatasetConfig& c, int v) { c.min_colmap_track_length = v; });
+            [](const DatasetConfig& c) { return c.min_track_length; },
+            [](DatasetConfig& c, int v) { c.min_track_length = v; });
 
         add_bool(
             "use_cpu_cache", "CPU Cache", true, "Cache images in CPU memory", false,
@@ -1396,14 +1396,14 @@ namespace lfs::python {
                 },
                 "Maximum image width in pixels; 0 disables the cap")
             .def_prop_rw(
-                "min_colmap_track_length",
-                [](const PyDatasetConfig& self) { return self.params().min_colmap_track_length; },
+                "min_track_length",
+                [](const PyDatasetConfig& self) { return self.params().min_track_length; },
                 [](PyDatasetConfig& self, int v) {
                     if (!self.can_edit())
                         throw std::runtime_error("Cannot edit dataset params during training");
                     if (v < 0)
-                        throw std::invalid_argument("min_colmap_track_length must be non-negative; 0 disables filtering");
-                    self.params().min_colmap_track_length = v;
+                        throw std::invalid_argument("min_track_length must be non-negative; 0 disables filtering");
+                    self.params().min_track_length = v;
                 },
                 "Minimum COLMAP sparse point track length; 0 disables filtering")
             .def_prop_rw(

--- a/src/python/lfs_plugins/import_panels.py
+++ b/src/python/lfs_plugins/import_panels.py
@@ -888,8 +888,8 @@ class DatasetImportPanel(_ImportDialogPanel):
         self._centralize_dataset = "off"
         self._max_width = self.DEFAULT_MAX_WIDTH
         self._max_width_str = str(self.DEFAULT_MAX_WIDTH)
-        self._min_colmap_track_length = 0
-        self._min_colmap_track_length_str = "0"
+        self._min_track_length = 0
+        self._min_track_length_str = "0"
         self._apply_auto_crop = False
         self._clear_scene_on_load = False
         self._last_lang = ""
@@ -907,7 +907,8 @@ class DatasetImportPanel(_ImportDialogPanel):
         model.bind_func("images_count_text", self._images_count_text)
         model.bind_func("mask_count_text", self._mask_count_text)
         model.bind_func("show_masks", lambda: bool(self._dataset_info and getattr(self._dataset_info, "has_masks", False)))
-        model.bind_func("show_min_colmap_track_length", self._show_min_colmap_track_length)
+        model.bind_func("show_min_track_length", self._show_min_track_length)
+        model.bind_func("show_min_track_length_warning", self._show_min_track_length_warning)
         model.bind_func("can_load", lambda: bool(self._dataset_valid and self._output_path.strip()))
 
         model.bind("dataset_path", lambda: self._dataset_path, self._set_dataset_path)
@@ -917,14 +918,14 @@ class DatasetImportPanel(_ImportDialogPanel):
         model.bind("centralize_dataset", lambda: self._centralize_dataset, self._set_centralize_dataset)
         model.bind("max_width_str", lambda: self._max_width_str, self._set_max_width_str)
         model.bind("max_width_disabled", lambda: self._max_width == 0, self._set_max_width_disabled)
-        model.bind("min_colmap_track_length_str", lambda: self._min_colmap_track_length_str, self._set_min_colmap_track_length_str)
+        model.bind("min_track_length_str", lambda: self._min_track_length_str, self._set_min_track_length_str)
         model.bind("apply_auto_crop", lambda: self._apply_auto_crop, self._set_apply_auto_crop)
 
         model.bind_event("browse_dataset", self._on_browse_dataset)
         model.bind_event("browse_output", self._on_browse_output)
         model.bind_event("browse_init", self._on_browse_init)
         model.bind_event("browse_ppisp_sidecar", self._on_browse_ppisp_sidecar)
-        model.bind_event("min_colmap_track_length_step", self._on_min_colmap_track_length_step)
+        model.bind_event("min_track_length_step", self._on_min_track_length_step)
         model.bind_event("do_load", self._on_do_load)
         model.bind_event("do_cancel", self._on_do_cancel)
 
@@ -949,8 +950,8 @@ class DatasetImportPanel(_ImportDialogPanel):
         self._centralize_dataset = "off"
         self._max_width = self.DEFAULT_MAX_WIDTH
         self._max_width_str = str(self.DEFAULT_MAX_WIDTH)
-        self._min_colmap_track_length = 0
-        self._min_colmap_track_length_str = "0"
+        self._min_track_length = 0
+        self._min_track_length_str = "0"
         self._apply_auto_crop = False
         params = lf.optimization_params()
         self._ppisp_sidecar_path = (
@@ -1000,12 +1001,13 @@ class DatasetImportPanel(_ImportDialogPanel):
             "images_count_text",
             "mask_count_text",
             "show_masks",
-            "show_min_colmap_track_length",
+            "show_min_track_length",
+            "show_min_track_length_warning",
             "output_path",
             "init_path",
             "ppisp_sidecar_path",
             "can_load",
-            "min_colmap_track_length_str",
+            "min_track_length_str",
         )
         return self._dataset_valid
 
@@ -1034,13 +1036,20 @@ class DatasetImportPanel(_ImportDialogPanel):
             return ""
         return f"({int(getattr(self._dataset_info, 'mask_count', 0))} masks)"
 
-    def _show_min_colmap_track_length(self) -> bool:
+    def _show_min_track_length(self) -> bool:
         if self._dataset_info is None:
             return False
         sparse_path = getattr(self._dataset_info, "sparse_path", "")
         if not sparse_path:
             return False
         return _directory_has_colmap_file(str(sparse_path))
+
+    def _show_min_track_length_warning(self) -> bool:
+        return (
+            self._show_min_track_length()
+            and bool(self._init_path.strip())
+            and self._min_track_length > 0
+        )
 
     def _set_output_path(self, value):
         next_value = str(value)
@@ -1060,7 +1069,7 @@ class DatasetImportPanel(_ImportDialogPanel):
         if next_value == self._init_path:
             return
         self._init_path = next_value
-        self._dirty_model("init_path")
+        self._dirty_model("init_path", "show_min_track_length_warning")
 
     def _set_ppisp_sidecar_path(self, value):
         next_value = str(value)
@@ -1103,31 +1112,31 @@ class DatasetImportPanel(_ImportDialogPanel):
             self._max_width_str = str(self.DEFAULT_MAX_WIDTH)
         self._dirty_model("max_width_str", "max_width_disabled")
 
-    def _set_min_colmap_track_length_str(self, value):
+    def _set_min_track_length_str(self, value):
         text = str(value).strip().replace(",", "")
         try:
             parsed = int(text) if text else 0
         except ValueError:
-            self._dirty_model("min_colmap_track_length_str")
+            self._dirty_model("min_track_length_str")
             return
-        self._set_min_colmap_track_length(parsed)
+        self._set_min_track_length(parsed)
 
-    def _set_min_colmap_track_length(self, value):
+    def _set_min_track_length(self, value):
         parsed = max(0, min(99, int(value)))
-        if parsed == self._min_colmap_track_length and self._min_colmap_track_length_str == str(parsed):
+        if parsed == self._min_track_length and self._min_track_length_str == str(parsed):
             return
-        self._min_colmap_track_length = parsed
-        self._min_colmap_track_length_str = str(parsed)
-        self._dirty_model("min_colmap_track_length_str")
+        self._min_track_length = parsed
+        self._min_track_length_str = str(parsed)
+        self._dirty_model("min_track_length_str", "show_min_track_length_warning")
 
-    def _on_min_colmap_track_length_step(self, _handle=None, _ev=None, args=None):
+    def _on_min_track_length_step(self, _handle=None, _ev=None, args=None):
         delta = 0
         if args:
             try:
                 delta = int(args[0])
             except (TypeError, ValueError, IndexError):
                 delta = 0
-        self._set_min_colmap_track_length(self._min_colmap_track_length + delta)
+        self._set_min_track_length(self._min_track_length + delta)
 
     def _set_apply_auto_crop(self, value):
         enabled = bool(value)
@@ -1191,7 +1200,7 @@ class DatasetImportPanel(_ImportDialogPanel):
             centralize_dataset=centralize_dataset,
             max_width=self._max_width,
             apply_auto_crop=self._apply_auto_crop,
-            min_colmap_track_length=self._min_colmap_track_length,
+            min_track_length=self._min_track_length,
         )
 
     def _on_do_cancel(self, _handle=None, _ev=None, _args=None):

--- a/src/python/lfs_plugins/import_panels.py
+++ b/src/python/lfs_plugins/import_panels.py
@@ -907,6 +907,7 @@ class DatasetImportPanel(_ImportDialogPanel):
         model.bind_func("images_count_text", self._images_count_text)
         model.bind_func("mask_count_text", self._mask_count_text)
         model.bind_func("show_masks", lambda: bool(self._dataset_info and getattr(self._dataset_info, "has_masks", False)))
+        model.bind_func("show_min_colmap_track_length", self._show_min_colmap_track_length)
         model.bind_func("can_load", lambda: bool(self._dataset_valid and self._output_path.strip()))
 
         model.bind("dataset_path", lambda: self._dataset_path, self._set_dataset_path)
@@ -999,6 +1000,7 @@ class DatasetImportPanel(_ImportDialogPanel):
             "images_count_text",
             "mask_count_text",
             "show_masks",
+            "show_min_colmap_track_length",
             "output_path",
             "init_path",
             "ppisp_sidecar_path",
@@ -1031,6 +1033,14 @@ class DatasetImportPanel(_ImportDialogPanel):
         if self._dataset_info is None or not getattr(self._dataset_info, "has_masks", False):
             return ""
         return f"({int(getattr(self._dataset_info, 'mask_count', 0))} masks)"
+
+    def _show_min_colmap_track_length(self) -> bool:
+        if self._dataset_info is None:
+            return False
+        sparse_path = getattr(self._dataset_info, "sparse_path", "")
+        if not sparse_path:
+            return False
+        return _directory_has_colmap_file(str(sparse_path))
 
     def _set_output_path(self, value):
         next_value = str(value)

--- a/src/python/lfs_plugins/import_panels.py
+++ b/src/python/lfs_plugins/import_panels.py
@@ -888,6 +888,8 @@ class DatasetImportPanel(_ImportDialogPanel):
         self._centralize_dataset = "off"
         self._max_width = self.DEFAULT_MAX_WIDTH
         self._max_width_str = str(self.DEFAULT_MAX_WIDTH)
+        self._min_colmap_track_length = 0
+        self._min_colmap_track_length_str = "0"
         self._apply_auto_crop = False
         self._clear_scene_on_load = False
         self._last_lang = ""
@@ -914,12 +916,14 @@ class DatasetImportPanel(_ImportDialogPanel):
         model.bind("centralize_dataset", lambda: self._centralize_dataset, self._set_centralize_dataset)
         model.bind("max_width_str", lambda: self._max_width_str, self._set_max_width_str)
         model.bind("max_width_disabled", lambda: self._max_width == 0, self._set_max_width_disabled)
+        model.bind("min_colmap_track_length_str", lambda: self._min_colmap_track_length_str, self._set_min_colmap_track_length_str)
         model.bind("apply_auto_crop", lambda: self._apply_auto_crop, self._set_apply_auto_crop)
 
         model.bind_event("browse_dataset", self._on_browse_dataset)
         model.bind_event("browse_output", self._on_browse_output)
         model.bind_event("browse_init", self._on_browse_init)
         model.bind_event("browse_ppisp_sidecar", self._on_browse_ppisp_sidecar)
+        model.bind_event("min_colmap_track_length_step", self._on_min_colmap_track_length_step)
         model.bind_event("do_load", self._on_do_load)
         model.bind_event("do_cancel", self._on_do_cancel)
 
@@ -944,6 +948,8 @@ class DatasetImportPanel(_ImportDialogPanel):
         self._centralize_dataset = "off"
         self._max_width = self.DEFAULT_MAX_WIDTH
         self._max_width_str = str(self.DEFAULT_MAX_WIDTH)
+        self._min_colmap_track_length = 0
+        self._min_colmap_track_length_str = "0"
         self._apply_auto_crop = False
         params = lf.optimization_params()
         self._ppisp_sidecar_path = (
@@ -997,6 +1003,7 @@ class DatasetImportPanel(_ImportDialogPanel):
             "init_path",
             "ppisp_sidecar_path",
             "can_load",
+            "min_colmap_track_length_str",
         )
         return self._dataset_valid
 
@@ -1086,6 +1093,32 @@ class DatasetImportPanel(_ImportDialogPanel):
             self._max_width_str = str(self.DEFAULT_MAX_WIDTH)
         self._dirty_model("max_width_str", "max_width_disabled")
 
+    def _set_min_colmap_track_length_str(self, value):
+        text = str(value).strip().replace(",", "")
+        try:
+            parsed = int(text) if text else 0
+        except ValueError:
+            self._dirty_model("min_colmap_track_length_str")
+            return
+        self._set_min_colmap_track_length(parsed)
+
+    def _set_min_colmap_track_length(self, value):
+        parsed = max(0, min(99, int(value)))
+        if parsed == self._min_colmap_track_length and self._min_colmap_track_length_str == str(parsed):
+            return
+        self._min_colmap_track_length = parsed
+        self._min_colmap_track_length_str = str(parsed)
+        self._dirty_model("min_colmap_track_length_str")
+
+    def _on_min_colmap_track_length_step(self, _handle=None, _ev=None, args=None):
+        delta = 0
+        if args:
+            try:
+                delta = int(args[0])
+            except (TypeError, ValueError, IndexError):
+                delta = 0
+        self._set_min_colmap_track_length(self._min_colmap_track_length + delta)
+
     def _set_apply_auto_crop(self, value):
         enabled = bool(value)
         if enabled == self._apply_auto_crop:
@@ -1148,6 +1181,7 @@ class DatasetImportPanel(_ImportDialogPanel):
             centralize_dataset=centralize_dataset,
             max_width=self._max_width,
             apply_auto_crop=self._apply_auto_crop,
+            min_colmap_track_length=self._min_colmap_track_length,
         )
 
     def _on_do_cancel(self, _handle=None, _ev=None, _args=None):

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -244,7 +244,7 @@ def clear_scene() -> None:
 def switch_to_edit_mode() -> None:
     """Switch from training to edit mode"""
 
-def load_file(path: str, is_dataset: bool = False, output_path: str = '', init_path: str = '', centralize_dataset: str = 'off', max_width: int | None = None, apply_auto_crop: bool = False, min_colmap_track_length: int | None = None) -> None:
+def load_file(path: str, is_dataset: bool = False, output_path: str = '', init_path: str = '', centralize_dataset: str = 'off', max_width: int | None = None, apply_auto_crop: bool = False, min_track_length: int | None = None) -> None:
     """Load a file (PLY, checkpoint) or dataset into the scene."""
 
 def load_config_file(path: str) -> None:
@@ -2180,11 +2180,11 @@ class DatasetParams:
     def max_width(self, arg: int, /) -> None: ...
 
     @property
-    def min_colmap_track_length(self) -> int:
+    def min_track_length(self) -> int:
         """Minimum COLMAP sparse point track length; 0 disables filtering"""
 
-    @min_colmap_track_length.setter
-    def min_colmap_track_length(self, arg: int, /) -> None: ...
+    @min_track_length.setter
+    def min_track_length(self, arg: int, /) -> None: ...
 
     @property
     def use_cpu_cache(self) -> bool:

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -244,7 +244,7 @@ def clear_scene() -> None:
 def switch_to_edit_mode() -> None:
     """Switch from training to edit mode"""
 
-def load_file(path: str, is_dataset: bool = False, output_path: str = '', init_path: str = '', centralize_dataset: str = 'off', max_width: int | None = None, apply_auto_crop: bool = False) -> None:
+def load_file(path: str, is_dataset: bool = False, output_path: str = '', init_path: str = '', centralize_dataset: str = 'off', max_width: int | None = None, apply_auto_crop: bool = False, min_colmap_track_length: int | None = None) -> None:
     """Load a file (PLY, checkpoint) or dataset into the scene."""
 
 def load_config_file(path: str) -> None:
@@ -2178,6 +2178,13 @@ class DatasetParams:
 
     @max_width.setter
     def max_width(self, arg: int, /) -> None: ...
+
+    @property
+    def min_colmap_track_length(self) -> int:
+        """Minimum COLMAP sparse point track length; 0 disables filtering"""
+
+    @min_colmap_track_length.setter
+    def min_colmap_track_length(self, arg: int, /) -> None: ...
 
     @property
     def use_cpu_cache(self) -> bool:

--- a/src/python/stubs/lichtfeld/io.pyi
+++ b/src/python/stubs/lichtfeld/io.pyi
@@ -39,7 +39,7 @@ class LoadResult:
     def is_dataset(self) -> bool:
         """Whether loaded data is a dataset with cameras"""
 
-def load(path: str | os.PathLike, format: str | None = None, resize_factor: int | None = None, max_width: int | None = None, images_folder: str | None = None, progress: object | None = None, min_colmap_track_length: int | None = None) -> LoadResult:
+def load(path: str | os.PathLike, format: str | None = None, resize_factor: int | None = None, max_width: int | None = None, images_folder: str | None = None, progress: object | None = None, min_track_length: int | None = None) -> LoadResult:
     """Load a scene or splat file from path"""
 
 def load_point_cloud(path: str | os.PathLike) -> tuple:

--- a/src/python/stubs/lichtfeld/io.pyi
+++ b/src/python/stubs/lichtfeld/io.pyi
@@ -39,7 +39,7 @@ class LoadResult:
     def is_dataset(self) -> bool:
         """Whether loaded data is a dataset with cameras"""
 
-def load(path: str | os.PathLike, format: str | None = None, resize_factor: int | None = None, max_width: int | None = None, images_folder: str | None = None, progress: object | None = None) -> LoadResult:
+def load(path: str | os.PathLike, format: str | None = None, resize_factor: int | None = None, max_width: int | None = None, images_folder: str | None = None, progress: object | None = None, min_colmap_track_length: int | None = None) -> LoadResult:
     """Load a scene or splat file from path"""
 
 def load_point_cloud(path: str | os.PathLike) -> tuple:

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -383,6 +383,7 @@ namespace lfs::training {
             .resize_factor = params.dataset.resize_factor,
             .max_width = params.dataset.max_width,
             .images_folder = params.dataset.images,
+            .min_colmap_track_length = params.dataset.min_colmap_track_length,
             .validate_only = false,
             .centralize = parse_centralize(params.dataset.centralize_dataset),
             .progress = [&data_path](float percentage, const std::string& message) {
@@ -766,6 +767,7 @@ namespace lfs::training {
             .resize_factor = params.dataset.resize_factor,
             .max_width = params.dataset.max_width,
             .images_folder = params.dataset.images,
+            .min_colmap_track_length = params.dataset.min_colmap_track_length,
             .validate_only = true};
 
         auto result = data_loader->load(params.dataset.data_path, load_options);

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -32,6 +32,18 @@ namespace lfs::training {
             return std::make_shared<lfs::core::PointCloud>(positions, colors);
         }
 
+        int effectiveMinTrackLengthForLoad(const lfs::core::param::TrainingParameters& params) {
+            if (params.dataset.min_track_length > 0 &&
+                params.init_path.has_value() &&
+                !params.init_path->empty()) {
+                LOG_WARN(
+                    "min-track-length cannot be used with --init-ply; COLMAP sparse point filtering will not be applied because initialization uses '{}'",
+                    *params.init_path);
+                return 0;
+            }
+            return params.dataset.min_track_length;
+        }
+
         void randomChoosePointCloud(lfs::core::PointCloud& point_cloud,
                                     const int target_count,
                                     const int seed = 0) {
@@ -383,7 +395,7 @@ namespace lfs::training {
             .resize_factor = params.dataset.resize_factor,
             .max_width = params.dataset.max_width,
             .images_folder = params.dataset.images,
-            .min_colmap_track_length = params.dataset.min_colmap_track_length,
+            .min_track_length = effectiveMinTrackLengthForLoad(params),
             .validate_only = false,
             .centralize = parse_centralize(params.dataset.centralize_dataset),
             .progress = [&data_path](float percentage, const std::string& message) {
@@ -767,7 +779,7 @@ namespace lfs::training {
             .resize_factor = params.dataset.resize_factor,
             .max_width = params.dataset.max_width,
             .images_folder = params.dataset.images,
-            .min_colmap_track_length = params.dataset.min_colmap_track_length,
+            .min_track_length = params.dataset.min_track_length,
             .validate_only = true};
 
         auto result = data_loader->load(params.dataset.data_path, load_options);

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -656,6 +656,8 @@ namespace lfs::vis::gui {
                 params.dataset.centralize_dataset = cmd.centralize_dataset;
             if (cmd.max_width.has_value() && *cmd.max_width >= 0)
                 params.dataset.max_width = *cmd.max_width;
+            if (cmd.min_colmap_track_length.has_value() && *cmd.min_colmap_track_length >= 0)
+                params.dataset.min_colmap_track_length = *cmd.min_colmap_track_length;
             import_state_.apply_auto_crop.store(cmd.apply_auto_crop);
             startAsyncImport(cmd.path, params);
         });
@@ -1432,6 +1434,7 @@ namespace lfs::vis::gui {
                     .resize_factor = local_params.dataset.resize_factor,
                     .max_width = local_params.dataset.max_width,
                     .images_folder = local_params.dataset.images,
+                    .min_colmap_track_length = local_params.dataset.min_colmap_track_length,
                     .validate_only = false,
                     .centralize = parse_centralize(local_params.dataset.centralize_dataset),
                     .progress = [this, &stop_token](const float pct, const std::string& msg) {

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -656,8 +656,8 @@ namespace lfs::vis::gui {
                 params.dataset.centralize_dataset = cmd.centralize_dataset;
             if (cmd.max_width.has_value() && *cmd.max_width >= 0)
                 params.dataset.max_width = *cmd.max_width;
-            if (cmd.min_colmap_track_length.has_value() && *cmd.min_colmap_track_length >= 0)
-                params.dataset.min_colmap_track_length = *cmd.min_colmap_track_length;
+            if (cmd.min_track_length.has_value() && *cmd.min_track_length >= 0)
+                params.dataset.min_track_length = *cmd.min_track_length;
             import_state_.apply_auto_crop.store(cmd.apply_auto_crop);
             startAsyncImport(cmd.path, params);
         });
@@ -1430,11 +1430,20 @@ namespace lfs::vis::gui {
                         return lfs::io::CentralizeDataset::ByCameras;
                     return lfs::io::CentralizeDataset::Off;
                 };
+                int effective_min_track_length = local_params.dataset.min_track_length;
+                if (effective_min_track_length > 0 &&
+                    local_params.init_path.has_value() &&
+                    !local_params.init_path->empty()) {
+                    LOG_WARN(
+                        "min-track-length cannot be used with --init; COLMAP sparse point filtering will not be applied because initialization uses '{}'",
+                        *local_params.init_path);
+                    effective_min_track_length = 0;
+                }
                 const lfs::io::LoadOptions load_options{
                     .resize_factor = local_params.dataset.resize_factor,
                     .max_width = local_params.dataset.max_width,
                     .images_folder = local_params.dataset.images,
-                    .min_colmap_track_length = local_params.dataset.min_colmap_track_length,
+                    .min_track_length = effective_min_track_length,
                     .validate_only = false,
                     .centralize = parse_centralize(local_params.dataset.centralize_dataset),
                     .progress = [this, &stop_token](const float pct, const std::string& msg) {

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1068,8 +1068,9 @@
     "max_width": "Max. Breite (px)",
     "max_width_disable": "Herunterskalierung deaktivieren",
     "max_width_hint": "Breitere Bilder werden herunterskaliert. 0 deaktiviert die Begrenzung.",
-    "min_colmap_track_length": "Min COLMAP Track Length",
-    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length": "Minimum Track Length",
+    "min_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length_init_warning": "Ignored while Init PLY is set.",
     "apply_auto_crop": "Auto-Zuschnitt anwenden"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1068,6 +1068,8 @@
     "max_width": "Max. Breite (px)",
     "max_width_disable": "Herunterskalierung deaktivieren",
     "max_width_hint": "Breitere Bilder werden herunterskaliert. 0 deaktiviert die Begrenzung.",
+    "min_colmap_track_length": "Min COLMAP Track Length",
+    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
     "apply_auto_crop": "Auto-Zuschnitt anwenden"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1093,6 +1093,8 @@
     "max_width": "Max Width (px)",
     "max_width_disable": "Disable downscaling",
     "max_width_hint": "Images wider than this are downscaled. 0 disables the cap.",
+    "min_colmap_track_length": "Min COLMAP Track Length",
+    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
     "apply_auto_crop": "Apply Auto Crop"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1093,8 +1093,9 @@
     "max_width": "Max Width (px)",
     "max_width_disable": "Disable downscaling",
     "max_width_hint": "Images wider than this are downscaled. 0 disables the cap.",
-    "min_colmap_track_length": "Min COLMAP Track Length",
-    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length": "Minimum Track Length",
+    "min_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length_init_warning": "Ignored while Init PLY is set.",
     "apply_auto_crop": "Apply Auto Crop"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1068,6 +1068,8 @@
     "max_width": "Largeur max. (px)",
     "max_width_disable": "Désactiver la réduction",
     "max_width_hint": "Les images plus larges sont réduites. 0 désactive la limite.",
+    "min_colmap_track_length": "Min COLMAP Track Length",
+    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
     "apply_auto_crop": "Appliquer le recadrage automatique"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1068,8 +1068,9 @@
     "max_width": "Largeur max. (px)",
     "max_width_disable": "Désactiver la réduction",
     "max_width_hint": "Les images plus larges sont réduites. 0 désactive la limite.",
-    "min_colmap_track_length": "Min COLMAP Track Length",
-    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length": "Minimum Track Length",
+    "min_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length_init_warning": "Ignored while Init PLY is set.",
     "apply_auto_crop": "Appliquer le recadrage automatique"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1068,8 +1068,9 @@
     "max_width": "Larghezza max. (px)",
     "max_width_disable": "Disattiva ridimensionamento",
     "max_width_hint": "Le immagini più larghe vengono ridimensionate. 0 disattiva il limite.",
-    "min_colmap_track_length": "Min COLMAP Track Length",
-    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length": "Minimum Track Length",
+    "min_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length_init_warning": "Ignored while Init PLY is set.",
     "apply_auto_crop": "Applica ritaglio automatico"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1068,6 +1068,8 @@
     "max_width": "Larghezza max. (px)",
     "max_width_disable": "Disattiva ridimensionamento",
     "max_width_hint": "Le immagini più larghe vengono ridimensionate. 0 disattiva il limite.",
+    "min_colmap_track_length": "Min COLMAP Track Length",
+    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
     "apply_auto_crop": "Applica ritaglio automatico"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1068,6 +1068,8 @@
     "max_width": "最大幅 (px)",
     "max_width_disable": "ダウンスケーリングを無効化",
     "max_width_hint": "これより幅の大きい画像は縮小されます。0で制限なし。",
+    "min_colmap_track_length": "Min COLMAP Track Length",
+    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
     "apply_auto_crop": "自動クロップを適用"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1068,8 +1068,9 @@
     "max_width": "最大幅 (px)",
     "max_width_disable": "ダウンスケーリングを無効化",
     "max_width_hint": "これより幅の大きい画像は縮小されます。0で制限なし。",
-    "min_colmap_track_length": "Min COLMAP Track Length",
-    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length": "Minimum Track Length",
+    "min_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length_init_warning": "Ignored while Init PLY is set.",
     "apply_auto_crop": "自動クロップを適用"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1068,6 +1068,8 @@
     "max_width": "최대 너비 (px)",
     "max_width_disable": "다운스케일링 비활성화",
     "max_width_hint": "이보다 넓은 이미지는 축소됩니다. 0이면 제한 없음.",
+    "min_colmap_track_length": "Min COLMAP Track Length",
+    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
     "apply_auto_crop": "자동 자르기 적용"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1068,8 +1068,9 @@
     "max_width": "최대 너비 (px)",
     "max_width_disable": "다운스케일링 비활성화",
     "max_width_hint": "이보다 넓은 이미지는 축소됩니다. 0이면 제한 없음.",
-    "min_colmap_track_length": "Min COLMAP Track Length",
-    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length": "Minimum Track Length",
+    "min_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length_init_warning": "Ignored while Init PLY is set.",
     "apply_auto_crop": "자동 자르기 적용"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1068,6 +1068,8 @@
     "max_width": "Max. breedte (px)",
     "max_width_disable": "Verkleinen uitschakelen",
     "max_width_hint": "Bredere afbeeldingen worden verkleind. 0 schakelt de limiet uit.",
+    "min_colmap_track_length": "Min COLMAP Track Length",
+    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
     "apply_auto_crop": "Automatisch bijsnijden toepassen"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1068,8 +1068,9 @@
     "max_width": "Max. breedte (px)",
     "max_width_disable": "Verkleinen uitschakelen",
     "max_width_hint": "Bredere afbeeldingen worden verkleind. 0 schakelt de limiet uit.",
-    "min_colmap_track_length": "Min COLMAP Track Length",
-    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length": "Minimum Track Length",
+    "min_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length_init_warning": "Ignored while Init PLY is set.",
     "apply_auto_crop": "Automatisch bijsnijden toepassen"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1068,6 +1068,8 @@
     "max_width": "Maks. szerokość (px)",
     "max_width_disable": "Wyłącz skalowanie",
     "max_width_hint": "Szersze obrazy są zmniejszane. 0 wyłącza limit.",
+    "min_colmap_track_length": "Min COLMAP Track Length",
+    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
     "apply_auto_crop": "Zastosuj automatyczne kadrowanie"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1068,8 +1068,9 @@
     "max_width": "Maks. szerokość (px)",
     "max_width_disable": "Wyłącz skalowanie",
     "max_width_hint": "Szersze obrazy są zmniejszane. 0 wyłącza limit.",
-    "min_colmap_track_length": "Min COLMAP Track Length",
-    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length": "Minimum Track Length",
+    "min_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length_init_warning": "Ignored while Init PLY is set.",
     "apply_auto_crop": "Zastosuj automatyczne kadrowanie"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -898,8 +898,9 @@
     "max_width": "最大宽度 (px)",
     "max_width_disable": "禁用降采样",
     "max_width_hint": "更宽的图像将被缩小。0 表示不限制。",
-    "min_colmap_track_length": "Min COLMAP Track Length",
-    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length": "Minimum Track Length",
+    "min_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
+    "min_track_length_init_warning": "Ignored while Init PLY is set.",
     "apply_auto_crop": "应用自动裁剪"
   },
   "notification": {

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -898,6 +898,8 @@
     "max_width": "最大宽度 (px)",
     "max_width_disable": "禁用降采样",
     "max_width_hint": "更宽的图像将被缩小。0 表示不限制。",
+    "min_colmap_track_length": "Min COLMAP Track Length",
+    "min_colmap_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
     "apply_auto_crop": "应用自动裁剪"
   },
   "notification": {

--- a/src/visualizer/gui/rmlui/resources/dataset_import_panel.rml
+++ b/src/visualizer/gui/rmlui/resources/dataset_import_panel.rml
@@ -109,7 +109,7 @@
       </div>
     </div>
 
-    <div class="impdlg-control-group">
+    <div class="impdlg-control-group" data-if="show_min_colmap_track_length">
       <span class="impdlg-field-label text-muted">@tr:load_dataset_popup.min_colmap_track_length</span>
       <div class="impdlg-control-main">
         <div class="impdlg-control-row">

--- a/src/visualizer/gui/rmlui/resources/dataset_import_panel.rml
+++ b/src/visualizer/gui/rmlui/resources/dataset_import_panel.rml
@@ -109,6 +109,18 @@
       </div>
     </div>
 
+    <div class="impdlg-control-group">
+      <span class="impdlg-field-label text-muted">@tr:load_dataset_popup.min_colmap_track_length</span>
+      <div class="impdlg-control-main">
+        <div class="impdlg-control-row">
+          <input type="text" class="impdlg-input impdlg-track-length-input" data-value="min_colmap_track_length_str" />
+          <button class="num-step-btn" data-event-click="min_colmap_track_length_step(-1)">-</button>
+          <button class="num-step-btn" data-event-click="min_colmap_track_length_step(1)">+</button>
+        </div>
+        <span class="impdlg-meta text-muted">@tr:load_dataset_popup.min_colmap_track_length_hint</span>
+      </div>
+    </div>
+
     <span class="impdlg-note text-muted">@tr:load_dataset_popup.help_text</span>
 
     <div class="impdlg-buttons">

--- a/src/visualizer/gui/rmlui/resources/dataset_import_panel.rml
+++ b/src/visualizer/gui/rmlui/resources/dataset_import_panel.rml
@@ -109,15 +109,16 @@
       </div>
     </div>
 
-    <div class="impdlg-control-group" data-if="show_min_colmap_track_length">
-      <span class="impdlg-field-label text-muted">@tr:load_dataset_popup.min_colmap_track_length</span>
+    <div class="impdlg-control-group" data-if="show_min_track_length">
+      <span class="impdlg-field-label text-muted">@tr:load_dataset_popup.min_track_length</span>
       <div class="impdlg-control-main">
         <div class="impdlg-control-row">
-          <input type="text" class="impdlg-input impdlg-track-length-input" data-value="min_colmap_track_length_str" />
-          <button class="num-step-btn" data-event-click="min_colmap_track_length_step(-1)">-</button>
-          <button class="num-step-btn" data-event-click="min_colmap_track_length_step(1)">+</button>
+          <input type="text" class="impdlg-input impdlg-track-length-input" data-value="min_track_length_str" />
+          <button class="num-step-btn" data-event-click="min_track_length_step(-1)">-</button>
+          <button class="num-step-btn" data-event-click="min_track_length_step(1)">+</button>
         </div>
-        <span class="impdlg-meta text-muted">@tr:load_dataset_popup.min_colmap_track_length_hint</span>
+        <span class="impdlg-meta text-muted">@tr:load_dataset_popup.min_track_length_hint</span>
+        <span class="impdlg-meta status-warning" data-if="show_min_track_length_warning">@tr:load_dataset_popup.min_track_length_init_warning</span>
       </div>
     </div>
 

--- a/src/visualizer/gui/rmlui/resources/import_dialog.rcss
+++ b/src/visualizer/gui/rmlui/resources/import_dialog.rcss
@@ -90,6 +90,13 @@
     min-width: 220dp;
 }
 
+.impdlg-track-length-input {
+    flex: 0 0 42dp;
+    width: 42dp;
+    min-width: 42dp;
+    text-align: center;
+}
+
 .impdlg-browse-btn {
     min-width: 88dp;
     text-align: center;

--- a/tests/python/test_import_dialog_panels.py
+++ b/tests/python/test_import_dialog_panels.py
@@ -296,6 +296,30 @@ def test_dataset_import_panel_steps_min_colmap_track_length(import_dialog_module
     assert panel._min_colmap_track_length_str == "0"
 
 
+def test_dataset_import_panel_shows_track_length_for_colmap(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+
+    sparse_zero = Path(state.dataset_info.sparse_path) / "0"
+    sparse_zero.mkdir(parents=True)
+    (sparse_zero / "points3D.txt").write_text("", encoding="utf-8")
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+
+    assert panel._show_min_colmap_track_length() is True
+
+
+def test_dataset_import_panel_hides_track_length_for_non_colmap(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+
+    assert panel._show_min_colmap_track_length() is False
+
+
 def test_dataset_import_panel_preserves_unicode_paths(import_dialog_module):
     module, state = import_dialog_module
     panel = module.DatasetImportPanel()

--- a/tests/python/test_import_dialog_panels.py
+++ b/tests/python/test_import_dialog_panels.py
@@ -42,6 +42,7 @@ def _install_lf_stub(monkeypatch, tmp_path):
     state = SimpleNamespace(
         language=["en"],
         panel_enabled_calls=[],
+        log_warnings=[],
         load_file_calls=[],
         load_checkpoint_calls=[],
         clear_scene_calls=0,
@@ -65,7 +66,7 @@ def _install_lf_stub(monkeypatch, tmp_path):
         init_path="",
         centralize_dataset="off",
         max_width=None,
-        min_colmap_track_length=None,
+        min_track_length=None,
         **_kwargs,
     ):
         state.load_file_calls.append(
@@ -76,11 +77,14 @@ def _install_lf_stub(monkeypatch, tmp_path):
                 "init_path": init_path,
                 "centralize_dataset": centralize_dataset,
                 "max_width": max_width,
-                "min_colmap_track_length": min_colmap_track_length,
+                "min_track_length": min_track_length,
             }
         )
 
     lf_stub = ModuleType("lichtfeld")
+    lf_stub.log = SimpleNamespace(
+        warn=lambda message: state.log_warnings.append(message),
+    )
     lf_stub.ui = SimpleNamespace(
         PanelSpace=panel_space,
         PanelHeightMode=panel_height_mode,
@@ -235,7 +239,7 @@ def test_dataset_import_panel_show_and_load(import_dialog_module):
             "init_path": "/tmp/seed_points.ply",
             "centralize_dataset": "off",
             "max_width": 3840,
-            "min_colmap_track_length": 0,
+            "min_track_length": 0,
         }
     ]
     assert state.panel_enabled_calls[-1] == ("lfs.dataset_import", False)
@@ -257,43 +261,43 @@ def test_dataset_import_panel_can_clear_scene_on_confirm(import_dialog_module):
     assert state.load_file_calls[0]["path"] == str(state.dataset_info.base_path)
 
 
-def test_dataset_import_panel_forwards_min_colmap_track_length(import_dialog_module):
+def test_dataset_import_panel_forwards_min_track_length(import_dialog_module):
     module, state = import_dialog_module
     panel = module.DatasetImportPanel()
     panel._handle = _HandleStub()
 
     assert panel.show(str(state.dataset_info.base_path)) is True
 
-    panel._set_min_colmap_track_length_str("4")
+    panel._set_min_track_length_str("4")
     panel._on_do_load()
 
-    assert state.load_file_calls[0]["min_colmap_track_length"] == 4
+    assert state.load_file_calls[0]["min_track_length"] == 4
 
 
-def test_dataset_import_panel_steps_min_colmap_track_length(import_dialog_module):
+def test_dataset_import_panel_steps_min_track_length(import_dialog_module):
     module, state = import_dialog_module
     panel = module.DatasetImportPanel()
     panel._handle = _HandleStub()
 
     assert panel.show(str(state.dataset_info.base_path)) is True
 
-    panel._set_min_colmap_track_length_str("1")
-    panel._on_min_colmap_track_length_step(args=["1"])
-    assert panel._min_colmap_track_length == 2
-    assert panel._min_colmap_track_length_str == "2"
+    panel._set_min_track_length_str("1")
+    panel._on_min_track_length_step(args=["1"])
+    assert panel._min_track_length == 2
+    assert panel._min_track_length_str == "2"
 
-    panel._on_min_colmap_track_length_step(args=["-1"])
-    assert panel._min_colmap_track_length == 1
-    assert panel._min_colmap_track_length_str == "1"
+    panel._on_min_track_length_step(args=["-1"])
+    assert panel._min_track_length == 1
+    assert panel._min_track_length_str == "1"
 
-    panel._set_min_colmap_track_length_str("120")
-    assert panel._min_colmap_track_length == 99
-    assert panel._min_colmap_track_length_str == "99"
+    panel._set_min_track_length_str("120")
+    assert panel._min_track_length == 99
+    assert panel._min_track_length_str == "99"
 
-    panel._set_min_colmap_track_length_str("0")
-    panel._on_min_colmap_track_length_step(args=["-1"])
-    assert panel._min_colmap_track_length == 0
-    assert panel._min_colmap_track_length_str == "0"
+    panel._set_min_track_length_str("0")
+    panel._on_min_track_length_step(args=["-1"])
+    assert panel._min_track_length == 0
+    assert panel._min_track_length_str == "0"
 
 
 def test_dataset_import_panel_shows_track_length_for_colmap(import_dialog_module):
@@ -307,7 +311,42 @@ def test_dataset_import_panel_shows_track_length_for_colmap(import_dialog_module
 
     assert panel.show(str(state.dataset_info.base_path)) is True
 
-    assert panel._show_min_colmap_track_length() is True
+    assert panel._show_min_track_length() is True
+
+
+def test_dataset_import_panel_warns_track_length_ignored_with_init(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+
+    sparse_zero = Path(state.dataset_info.sparse_path) / "0"
+    sparse_zero.mkdir(parents=True)
+    (sparse_zero / "points3D.txt").write_text("", encoding="utf-8")
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+
+    panel._set_min_track_length_str("4")
+    assert panel._show_min_track_length_warning() is False
+
+    panel._set_init_path("/tmp/seed_points.ply")
+    assert panel._show_min_track_length_warning() is True
+
+    panel._set_min_track_length_str("0")
+    assert panel._show_min_track_length_warning() is False
+
+
+def test_dataset_import_panel_does_not_duplicate_track_length_init_warning(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+
+    panel._set_min_track_length_str("4")
+    panel._set_init_path("/tmp/seed_points.ply")
+    panel._on_do_load()
+
+    assert state.log_warnings == []
 
 
 def test_dataset_import_panel_hides_track_length_for_non_colmap(import_dialog_module):
@@ -317,7 +356,7 @@ def test_dataset_import_panel_hides_track_length_for_non_colmap(import_dialog_mo
 
     assert panel.show(str(state.dataset_info.base_path)) is True
 
-    assert panel._show_min_colmap_track_length() is False
+    assert panel._show_min_track_length() is False
 
 
 def test_dataset_import_panel_preserves_unicode_paths(import_dialog_module):
@@ -348,7 +387,7 @@ def test_dataset_import_panel_preserves_unicode_paths(import_dialog_module):
             "init_path": "/tmp/初期化ポイント.ply",
             "centralize_dataset": "off",
             "max_width": 3840,
-            "min_colmap_track_length": 0,
+            "min_track_length": 0,
         }
     ]
     assert state.panel_enabled_calls[-1] == ("lfs.dataset_import", False)
@@ -384,7 +423,7 @@ def test_dataset_import_panel_loads_updated_dataset_path(import_dialog_module, t
             "init_path": "",
             "centralize_dataset": "off",
             "max_width": 3840,
-            "min_colmap_track_length": 0,
+            "min_track_length": 0,
         }
     ]
 
@@ -602,7 +641,7 @@ def test_dataset_import_panel_clears_init_and_sidecar_on_dataset_change(import_d
             "init_path": "",
             "centralize_dataset": "off",
             "max_width": 3840,
-            "min_colmap_track_length": 0,
+            "min_track_length": 0,
         }
     ]
 
@@ -721,7 +760,7 @@ def test_dataset_import_panel_binds_enter_and_escape(import_dialog_module):
             "init_path": "",
             "centralize_dataset": "off",
             "max_width": 3840,
-            "min_colmap_track_length": 0,
+            "min_track_length": 0,
         }
     ]
     assert enter_event.propagation_stopped is True

--- a/tests/python/test_import_dialog_panels.py
+++ b/tests/python/test_import_dialog_panels.py
@@ -65,6 +65,7 @@ def _install_lf_stub(monkeypatch, tmp_path):
         init_path="",
         centralize_dataset="off",
         max_width=None,
+        min_colmap_track_length=None,
         **_kwargs,
     ):
         state.load_file_calls.append(
@@ -75,6 +76,7 @@ def _install_lf_stub(monkeypatch, tmp_path):
                 "init_path": init_path,
                 "centralize_dataset": centralize_dataset,
                 "max_width": max_width,
+                "min_colmap_track_length": min_colmap_track_length,
             }
         )
 
@@ -233,6 +235,7 @@ def test_dataset_import_panel_show_and_load(import_dialog_module):
             "init_path": "/tmp/seed_points.ply",
             "centralize_dataset": "off",
             "max_width": 3840,
+            "min_colmap_track_length": 0,
         }
     ]
     assert state.panel_enabled_calls[-1] == ("lfs.dataset_import", False)
@@ -252,6 +255,45 @@ def test_dataset_import_panel_can_clear_scene_on_confirm(import_dialog_module):
 
     assert state.clear_scene_calls == 1
     assert state.load_file_calls[0]["path"] == str(state.dataset_info.base_path)
+
+
+def test_dataset_import_panel_forwards_min_colmap_track_length(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+
+    panel._set_min_colmap_track_length_str("4")
+    panel._on_do_load()
+
+    assert state.load_file_calls[0]["min_colmap_track_length"] == 4
+
+
+def test_dataset_import_panel_steps_min_colmap_track_length(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+
+    panel._set_min_colmap_track_length_str("1")
+    panel._on_min_colmap_track_length_step(args=["1"])
+    assert panel._min_colmap_track_length == 2
+    assert panel._min_colmap_track_length_str == "2"
+
+    panel._on_min_colmap_track_length_step(args=["-1"])
+    assert panel._min_colmap_track_length == 1
+    assert panel._min_colmap_track_length_str == "1"
+
+    panel._set_min_colmap_track_length_str("120")
+    assert panel._min_colmap_track_length == 99
+    assert panel._min_colmap_track_length_str == "99"
+
+    panel._set_min_colmap_track_length_str("0")
+    panel._on_min_colmap_track_length_step(args=["-1"])
+    assert panel._min_colmap_track_length == 0
+    assert panel._min_colmap_track_length_str == "0"
 
 
 def test_dataset_import_panel_preserves_unicode_paths(import_dialog_module):
@@ -282,6 +324,7 @@ def test_dataset_import_panel_preserves_unicode_paths(import_dialog_module):
             "init_path": "/tmp/初期化ポイント.ply",
             "centralize_dataset": "off",
             "max_width": 3840,
+            "min_colmap_track_length": 0,
         }
     ]
     assert state.panel_enabled_calls[-1] == ("lfs.dataset_import", False)
@@ -317,6 +360,7 @@ def test_dataset_import_panel_loads_updated_dataset_path(import_dialog_module, t
             "init_path": "",
             "centralize_dataset": "off",
             "max_width": 3840,
+            "min_colmap_track_length": 0,
         }
     ]
 
@@ -534,6 +578,7 @@ def test_dataset_import_panel_clears_init_and_sidecar_on_dataset_change(import_d
             "init_path": "",
             "centralize_dataset": "off",
             "max_width": 3840,
+            "min_colmap_track_length": 0,
         }
     ]
 
@@ -652,6 +697,7 @@ def test_dataset_import_panel_binds_enter_and_escape(import_dialog_module):
             "init_path": "",
             "centralize_dataset": "off",
             "max_width": 3840,
+            "min_colmap_track_length": 0,
         }
     ]
     assert enter_event.propagation_stopped is True

--- a/tests/test_colmap_image_layout.cpp
+++ b/tests/test_colmap_image_layout.cpp
@@ -205,7 +205,7 @@ TEST_F(ColmapImageLayoutTest, FiltersTextPointCloudByMinimumTrackLength) {
 
     const auto result = lfs::io::read_colmap_point_cloud_text_with_stats(
         dataset_dir,
-        lfs::io::LoadOptions{.min_colmap_track_length = 3});
+        lfs::io::LoadOptions{.min_track_length = 3});
 
     EXPECT_TRUE(result.track_filter_applied);
     EXPECT_EQ(result.total_points, 3u);

--- a/tests/test_colmap_image_layout.cpp
+++ b/tests/test_colmap_image_layout.cpp
@@ -192,6 +192,27 @@ TEST_F(ColmapImageLayoutTest, ResolvesNestedImagesByBasename) {
     EXPECT_TRUE(fs::equivalent(cameras[0]->mask_path(), nested_mask));
 }
 
+TEST_F(ColmapImageLayoutTest, FiltersTextPointCloudByMinimumTrackLength) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required for COLMAP point cloud load";
+    }
+
+    const fs::path dataset_dir = temp_dir_ / "dataset";
+    write_text_file(dataset_dir / "points3D.txt",
+                    "1 0 0 0 255 0 0 0.1 1 0\n"
+                    "2 1 0 0 0 255 0 0.2 1 0 2 0 3 0\n"
+                    "3 2 0 0 0 0 255 0.3 1 0 2 0\n");
+
+    const auto result = lfs::io::read_colmap_point_cloud_text_with_stats(
+        dataset_dir,
+        lfs::io::LoadOptions{.min_colmap_track_length = 3});
+
+    EXPECT_TRUE(result.track_filter_applied);
+    EXPECT_EQ(result.total_points, 3u);
+    EXPECT_EQ(result.points_after_filtering, 1u);
+    EXPECT_EQ(result.point_cloud.size(), 1u);
+}
+
 TEST_F(ColmapImageLayoutTest, ResolvesDepthMapsByImageName) {
     const fs::path dataset_dir = temp_dir_ / "dataset";
     const fs::path image_path = dataset_dir / "images" / "frame_0000.png";


### PR DESCRIPTION
This change adds an optional sparse-point reliability filter for COLMAP imports. A COLMAP point track is the list of image observations that support a reconstructed 3D point. Higher track lengths generally indicate points that were seen from more views and are therefore more reliable.

## User-Facing Behavior

The filter is disabled by default.

Set a minimum track length greater than `0` to keep only COLMAP sparse points observed in at least that many images. For example, a value of `5` keeps points with track length `5` or higher and removes points with track length `1` through `4`.

Command-line usage:

```powershell
build\LichtFeld-Studio.exe --min-colmap-track-length 5 -d D:\temp\gs_tests\tutorial\colmap -o D:\temp\gs_tests\tutorial\output
```

The command-line flag uses hyphens:

```text
--min-colmap-track-length
```

The persisted/settings/API property uses underscores:

```text
min_colmap_track_length
```

## Load Dataset Panel

The Load Dataset panel now exposes a `Min COLMAP Track Length` field.

<img width="557" height="508" alt="image" src="https://github.com/user-attachments/assets/e9dbf9d2-6b99-4a5d-a059-b30d561be8ca" />


- `0` disables filtering.
- The input accepts typed values.
- The `+` and `-` buttons step the value up or down.
- The UI clamps the value to two digits, `0..99`.

## Logging

When the filter is applied, the COLMAP loader logs the configured threshold, the number of sparse points before filtering, and the number of points kept after filtering:

```text
COLMAP min track length filter: min track length 5, total points 1699644, after filtering 35893
```

This makes it visible how aggressively the setting reduced the sparse initialization point cloud.

## Import Path Details

The optimized unfiltered text import path is preserved.

- When `min_colmap_track_length == 0`, text `points3D.txt` loading continues to use the fast text reader.
- When `min_colmap_track_length > 0`, the loader reads COLMAP point records with track metadata and filters them before building the point cloud.
- Binary `points3D.bin` imports also support filtering.
- Existing `points3D.ply` files do not contain COLMAP track metadata. If filtering is enabled and `points3D.bin` or `points3D.txt` is available, the loader skips `points3D.ply` and reads the COLMAP file with tracks instead.
- If filtering is enabled but only `points3D.ply` exists, the loader falls back to loading the PLY unfiltered and emits a warning.

