### PR TITLE
Issue 1208: Viewport Shortcut Focus Fix

### DIFF
--- a/src/visualizer/gui/rml_viewport_overlay.cpp
+++ b/src/visualizer/gui/rml_viewport_overlay.cpp
@@ -651,9 +651,12 @@ namespace lfs::vis::gui {
                                rml_my >= 0 && rml_my < static_cast<int>(vp_size_.y);
         const bool mouse_moved =
             !mouse_pos_valid_ || rml_mx != last_mouse_x_ || rml_my != last_mouse_y_;
+        const bool mouse_clicked =
+            input.mouse_clicked[0] || input.mouse_clicked[1] || input.mouse_clicked[2];
         const bool pointer_event =
             input.mouse_clicked[0] || input.mouse_released[0] ||
             input.mouse_clicked[1] || input.mouse_released[1] ||
+            input.mouse_clicked[2] || input.mouse_released[2] ||
             input.mouse_wheel != 0.0f;
         const bool pointer_drag =
             input.mouse_down[0] || input.mouse_down[1] || input.mouse_down[2];
@@ -691,7 +694,7 @@ namespace lfs::vis::gui {
         const bool point_interactive = viewportOverlayHoverRoot(point_element) != nullptr;
         const bool hover_target_changed = point_element != last_hover_element_;
         if (focused_text_target &&
-            (input.mouse_clicked[0] || input.mouse_clicked[1]) &&
+            mouse_clicked &&
             is_inside &&
             !isElementOrDescendantOf(point_element, focused_before)) {
             focused_before->Blur();
@@ -723,7 +726,8 @@ namespace lfs::vis::gui {
                 if (input.mouse_wheel != 0.0f)
                     markRenderNeeded(RenderReason::PointerWheel);
                 if (input.mouse_clicked[0] || input.mouse_released[0] ||
-                    input.mouse_clicked[1] || input.mouse_released[1])
+                    input.mouse_clicked[1] || input.mouse_released[1] ||
+                    input.mouse_clicked[2] || input.mouse_released[2])
                     markRenderNeeded(RenderReason::PointerButton);
                 if (pointer_drag || vram_drag_capture)
                     markRenderNeeded(RenderReason::PointerDrag);

--- a/src/visualizer/gui/rml_viewport_overlay.cpp
+++ b/src/visualizer/gui/rml_viewport_overlay.cpp
@@ -61,6 +61,15 @@ namespace lfs::vis::gui {
             return isInteractiveViewportOverlayElement(element) ? element : nullptr;
         }
 
+        [[nodiscard]] bool isElementOrDescendantOf(const Rml::Element* element,
+                                                   const Rml::Element* ancestor) {
+            for (auto* node = element; node; node = node->GetParentNode()) {
+                if (node == ancestor)
+                    return true;
+            }
+            return false;
+        }
+
     } // namespace
 
     RmlViewportOverlay::RmlViewportOverlay()
@@ -681,6 +690,13 @@ namespace lfs::vis::gui {
                                         : nullptr;
         const bool point_interactive = viewportOverlayHoverRoot(point_element) != nullptr;
         const bool hover_target_changed = point_element != last_hover_element_;
+        if (focused_text_target &&
+            (input.mouse_clicked[0] || input.mouse_clicked[1]) &&
+            is_inside &&
+            !isElementOrDescendantOf(point_element, focused_before)) {
+            focused_before->Blur();
+            markRenderNeeded(RenderReason::Keyboard);
+        }
         if (external_mouse_capture && !point_interactive && !hovered_interactive_ &&
             !vram_drag_capture) {
             tooltip_.setHover({}, nullptr);

--- a/src/visualizer/input/input_bindings.cpp
+++ b/src/visualizer/input/input_bindings.cpp
@@ -1982,6 +1982,11 @@ namespace lfs::vis::input {
         case Action::SEQUENCER_ADD_KEYFRAME:
         case Action::SEQUENCER_UPDATE_KEYFRAME:
         case Action::SEQUENCER_PLAY_PAUSE:
+        case Action::TOGGLE_SPLIT_VIEW:
+        case Action::TOGGLE_INDEPENDENT_SPLIT_VIEW:
+        case Action::TOGGLE_GT_COMPARISON:
+        case Action::TOGGLE_CAMERA_FRUSTUMS:
+        case Action::CYCLE_SELECTION_VIS:
             return ShortcutScope::GlobalWhenNotTextEditing;
 
         case Action::CAMERA_MOVE_FORWARD:
@@ -2000,11 +2005,6 @@ namespace lfs::vis::input {
         case Action::CAMERA_SPEED_DOWN:
         case Action::ZOOM_SPEED_UP:
         case Action::ZOOM_SPEED_DOWN:
-        case Action::TOGGLE_SPLIT_VIEW:
-        case Action::TOGGLE_INDEPENDENT_SPLIT_VIEW:
-        case Action::TOGGLE_GT_COMPARISON:
-        case Action::TOGGLE_CAMERA_FRUSTUMS:
-        case Action::CYCLE_SELECTION_VIS:
         case Action::PIE_MENU:
             return ShortcutScope::Viewport;
 

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -640,6 +640,17 @@ namespace lfs::vis {
             return;
         }
 
+        const bool wants_text_input = input_router_
+                                          ? input_router_->isTextInputActive()
+                                          : gui::guiFocusState().want_text_input;
+        if (action == input::ACTION_PRESS &&
+            wants_text_input &&
+            !over_gui &&
+            isInViewport(x, y)) {
+            text_input_viewport_click_button_ = button;
+            return;
+        }
+
         if (action == input::ACTION_PRESS) {
             const auto mouse_btn = static_cast<input::MouseButton>(button);
             const auto tool_mode = getCurrentToolMode();
@@ -654,17 +665,6 @@ namespace lfs::vis {
 
         // Dispatch to modal operators first - if consumed, don't continue
         if (dispatchMouseButtonToModals(button, action, mods, x, y, over_gui_hover)) {
-            return;
-        }
-
-        const bool wants_text_input = input_router_
-                                          ? input_router_->isTextInputActive()
-                                          : gui::guiFocusState().want_text_input;
-        if (action == input::ACTION_PRESS &&
-            wants_text_input &&
-            !over_gui &&
-            isInViewport(x, y)) {
-            text_input_viewport_click_button_ = button;
             return;
         }
 

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -513,6 +513,7 @@ namespace lfs::vis {
         held_keys_.clear();
         pending_click_drag_ = {};
         forced_mouse_press_action_ = input::Action::NONE;
+        text_input_viewport_click_button_ = -1;
         is_node_rect_dragging_ = false;
         node_rect_button_ = -1;
         node_point_pick_enabled_ = false;
@@ -611,6 +612,12 @@ namespace lfs::vis {
         const bool over_transform_gizmo = isTransformGizmoOverOrUsing();
         const int mods = getModifierKeys();
 
+        if (text_input_viewport_click_button_ == button &&
+            action == input::ACTION_RELEASE) {
+            text_input_viewport_click_button_ = -1;
+            return;
+        }
+
         // Consume all mouse events while pie menu is open
         if (gui && gui->gizmo().isPieMenuOpen()) {
             if (action == input::ACTION_PRESS && button == static_cast<int>(input::AppMouseButton::LEFT)) {
@@ -647,6 +654,17 @@ namespace lfs::vis {
 
         // Dispatch to modal operators first - if consumed, don't continue
         if (dispatchMouseButtonToModals(button, action, mods, x, y, over_gui_hover)) {
+            return;
+        }
+
+        const bool wants_text_input = input_router_
+                                          ? input_router_->isTextInputActive()
+                                          : gui::guiFocusState().want_text_input;
+        if (action == input::ACTION_PRESS &&
+            wants_text_input &&
+            !over_gui &&
+            isInViewport(x, y)) {
+            text_input_viewport_click_button_ = button;
             return;
         }
 

--- a/src/visualizer/input/input_controller.hpp
+++ b/src/visualizer/input/input_controller.hpp
@@ -253,6 +253,7 @@ namespace lfs::vis {
         };
         PendingClickDragGesture pending_click_drag_;
         input::Action forced_mouse_press_action_ = input::Action::NONE;
+        int text_input_viewport_click_button_ = -1;
         struct PendingCameraContextMenuGesture {
             bool active = false;
             bool released = false;

--- a/tests/test_input_controller_focus.cpp
+++ b/tests/test_input_controller_focus.cpp
@@ -120,7 +120,7 @@ namespace lfs::vis {
         EXPECT_FALSE(controller.getBindings().isCapturing());
     }
 
-    TEST_F(InputControllerFocusTest, ViewportViewHotkeysDoNotBypassGuiKeyboardFocus) {
+    TEST_F(InputControllerFocusTest, ViewportViewHotkeysBypassGuiKeyboardFocusWhenNotTextEditing) {
         Viewport viewport(200, 200);
         InputController controller(nullptr, viewport);
         input::InputRouter router;
@@ -142,8 +142,8 @@ namespace lfs::vis {
         controller.handleKey(input::KEY_G, input::ACTION_PRESS, input::KEYMOD_NONE);
         controller.handleKey(input::KEY_V, input::ACTION_PRESS, input::KEYMOD_NONE);
 
-        EXPECT_EQ(toggle_gt_count, 0);
-        EXPECT_EQ(toggle_split_count, 0);
+        EXPECT_EQ(toggle_gt_count, 1);
+        EXPECT_EQ(toggle_split_count, 1);
     }
 
     TEST_F(InputControllerFocusTest, ViewportViewHotkeysWorkAfterViewportFocus) {
@@ -221,6 +221,28 @@ namespace lfs::vis {
 
         EXPECT_EQ(toggle_gt_count, 0);
         EXPECT_EQ(toggle_split_count, 0);
+    }
+
+    TEST_F(InputControllerFocusTest, ViewportClickDuringTextEntryDoesNotStartCameraGesture) {
+        Viewport viewport(200, 200);
+        InputController controller(nullptr, viewport);
+        input::InputRouter router;
+        router.setInputController(&controller);
+        controller.setInputRouter(&router);
+
+        auto& focus = gui::guiFocusState();
+        focus.want_capture_keyboard = true;
+        focus.want_text_input = true;
+        focus.any_item_active = true;
+
+        router.beginMouseButton(input::ACTION_PRESS, 40.0, 50.0);
+        controller.handleMouseButton(static_cast<int>(input::AppMouseButton::MIDDLE),
+                                     input::ACTION_PRESS, 40.0, 50.0);
+        controller.handleMouseButton(static_cast<int>(input::AppMouseButton::MIDDLE),
+                                     input::ACTION_RELEASE, 40.0, 50.0);
+        router.endMouseButton(input::ACTION_RELEASE);
+
+        EXPECT_FALSE(controller.isContinuousInputActive());
     }
 
     TEST_F(InputControllerFocusTest, GlobalShortcutsUseLogicalKeyWhileMovementUsesPhysicalKey) {
@@ -1040,7 +1062,7 @@ namespace lfs::vis {
                                                            input::MODIFIER_ALT),
                   input::Action::TOGGLE_CAMERA_FRUSTUMS);
         EXPECT_EQ(input::shortcutScopeForAction(input::Action::TOGGLE_CAMERA_FRUSTUMS),
-                  input::ShortcutScope::Viewport);
+                  input::ShortcutScope::GlobalWhenNotTextEditing);
 
         EXPECT_FALSE(rendering_manager.getSettings().show_camera_frustums);
         controller.handleKey(input::KEY_C, input::ACTION_PRESS, input::KEYMOD_ALT);


### PR DESCRIPTION
## Problem

Issue #1208 reports that the split view shortcut only works after the viewport has focus. The same focus behavior also affects editing workflows: after changing a numeric transform field in the viewport overlay, clicking the viewport can leave the app in an awkward state where WASD and tool switching feel stuck.

## Root Cause

The shortcut scope table treated view commands such as split view, GT comparison, camera frustums, and selection visibility as viewport-only actions. That meant they were blocked whenever keyboard focus was owned by GUI controls, even if the user was not typing.

Separately, RML text inputs in the viewport overlay kept text focus until blurred. Clicking the viewport after editing a transform field could both blur/commit the field and continue into translate-tool viewport handling. In translate mode, that click can become node picking; clicking empty space can clear the selected node, collapsing the transform panel.

## Chosen Fix

View command shortcuts are now `GlobalWhenNotTextEditing` instead of viewport-only. Camera movement and direct viewport controls remain viewport-scoped.

The RML viewport overlay now blurs a focused text field when the user clicks elsewhere in the overlay or viewport. The input controller consumes the matching viewport press/release while text input is active, so the click only exits text editing and does not also perform node picking, deselection, or camera interaction.

Closes #1208 