### PR TITLE
fix(l10n): sync missing keys, reorder, add --lang filter to validate_localization

### DIFF
--- a/scripts/validate_localization.py
+++ b/scripts/validate_localization.py
@@ -9,19 +9,25 @@ Features:
 - Finds missing translations
 - Finds unused translations
 - Validates JSON syntax
-- Compares with string_keys.hpp for consistency
+- Compares with string_keys.hpp and C++ LOC() calls
+- --fix: auto-adds missing keys and reorders to match en.json key order
+- --lang: scope to specific language(s)
 
 Usage:
-    python scripts/validate_localization.py
-    python scripts/validate_localization.py --fix  # Auto-add missing keys with TODO markers
+    python scripts/validate_localization.py                          # Check all
+    python scripts/validate_localization.py --fix                    # Fix all
+    python scripts/validate_localization.py --lang zh                # Check only zh
+    python scripts/validate_localization.py --lang zh --lang ja      # Check zh & ja
+    python scripts/validate_localization.py --lang zh,ja --fix       # Fix zh & ja
 """
 
 import json
 import sys
 import re
+from collections import OrderedDict
+from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Set
-from collections import defaultdict
+from typing import Dict, Set, Tuple
 
 
 class Colors:
@@ -46,11 +52,11 @@ def find_project_root() -> Path:
     raise RuntimeError("Could not find project root")
 
 
-def load_json_file(filepath: Path) -> Dict:
-    """Load and parse a JSON file"""
+def load_json_file(filepath: Path) -> OrderedDict:
+    """Load and parse a JSON file, preserving key order."""
     try:
         with open(filepath, 'r', encoding='utf-8') as f:
-            return json.load(f)
+            return json.load(f, object_pairs_hook=OrderedDict)
     except json.JSONDecodeError as e:
         print(f"{Colors.RED}✗ JSON syntax error in {filepath.name}:{Colors.END}")
         print(f"  {e}")
@@ -61,8 +67,15 @@ def load_json_file(filepath: Path) -> Dict:
         return None
 
 
+def save_json_file(data: OrderedDict, filepath: Path) -> None:
+    """Write JSON with 2-space indent, trailing newline."""
+    with open(filepath, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write('\n')
+
+
 def flatten_dict(d: Dict, prefix: str = '') -> Dict[str, str]:
-    """Flatten nested dictionary into dot-notation keys"""
+    """Flatten nested dictionary into dot-notation keys (for reporting only)."""
     result = {}
     for key, value in d.items():
         if key.startswith('_'):  # Skip metadata keys
@@ -72,6 +85,22 @@ def flatten_dict(d: Dict, prefix: str = '') -> Dict[str, str]:
             result.update(flatten_dict(value, full_key))
         elif isinstance(value, str):
             result[full_key] = value
+    return result
+
+
+def sync_dict(en_dict: OrderedDict, target_dict: OrderedDict) -> OrderedDict:
+    """Recursively align target_dict keys and order with en_dict.
+
+    Missing keys are filled from en_dict. Target-only keys are dropped.
+    """
+    result = OrderedDict()
+    for key in en_dict:
+        if key not in target_dict:
+            result[key] = deepcopy(en_dict[key])
+        elif isinstance(en_dict[key], dict) and isinstance(target_dict[key], dict):
+            result[key] = sync_dict(en_dict[key], target_dict[key])
+        else:
+            result[key] = target_dict[key]
     return result
 
 
@@ -107,9 +136,14 @@ def extract_keys_from_code(code_dir: Path) -> Set[str]:
     return keys
 
 
-def validate_localization(project_root: Path, fix: bool = False) -> int:
+def validate_localization(project_root: Path, fix: bool = False, langs: list|None = None) -> int:
     """
-    Validate all localization files
+    Validate localization files.
+
+    Args:
+        fix: If True, add missing keys and reorder to match en.json.
+        langs: Optional list of language codes to check (e.g. ['zh', 'ja']).
+               If None, all non-en languages are checked.
 
     Returns:
         0 if validation passed, 1 if errors found
@@ -149,15 +183,26 @@ def validate_localization(project_root: Path, fix: bool = False) -> int:
         print(f"{Colors.RED}✗ English (en.json) not found - cannot validate{Colors.END}")
         return 1
 
+    en_data = locales['en']['data']
     reference_keys = set(locales['en']['flat'].keys())
-    print(f"{Colors.CYAN}Reference (English): {len(reference_keys)} keys{Colors.END}\n")
+    print(f"{Colors.CYAN}Reference (English): {len(reference_keys)} keys{Colors.END}")
+
+    # Filter target languages
+    target_langs = [lc for lc in sorted(locales.keys()) if lc != 'en']
+    if langs:
+        unknown = [lc for lc in langs if lc not in target_langs]
+        if unknown:
+            print(f"\n{Colors.RED}✗ Unknown language code(s): {', '.join(unknown)}. "
+                  f"Available: {', '.join(target_langs)}{Colors.END}\n")
+            return 1
+        target_langs = [lc for lc in target_langs if lc in langs]
+    print()
 
     # Validate each language
     has_errors = False
 
-    for lang_code, locale_data in locales.items():
-        if lang_code == 'en':
-            continue
+    for lang_code in target_langs:
+        locale_data = locales[lang_code]
 
         lang_keys = set(locale_data['flat'].keys())
         lang_name = locale_data['data'].get('_language_name', lang_code)
@@ -176,14 +221,16 @@ def validate_localization(project_root: Path, fix: bool = False) -> int:
                 print(f"    ... and {len(missing) - 10} more")
 
             if fix:
-                print(f"  {Colors.YELLOW}→ Adding missing keys with TODO markers...{Colors.END}")
-                # Add missing keys
-                for key in missing:
-                    locale_data['flat'][key] = f"TODO: {locales['en']['flat'][key]}"
+                print(f"  {Colors.YELLOW}→ Syncing: adding missing keys + reordering to en.json order...{Colors.END}")
+                synced = sync_dict(en_data, locale_data['data'])
+                save_json_file(synced, locale_data['file'])
+                # Rebuild flat dict from synced data for accurate reporting
+                locale_data['data'] = synced
+                locale_data['flat'] = flatten_dict(synced)
 
         if extra:
             has_errors = True
-            print(f"  {Colors.YELLOW}⚠ Extra {len(extra)} unused key(s):{Colors.END}")
+            print(f"  {Colors.YELLOW}⚠ Extra {len(extra)} unused key(s) (dropped if --fix was used):{Colors.END}")
             for key in sorted(extra)[:5]:
                 print(f"    - {key}")
             if len(extra) > 5:
@@ -195,6 +242,7 @@ def validate_localization(project_root: Path, fix: bool = False) -> int:
         print()
 
     # Check string_keys.hpp consistency
+    header_keys = set()
     if header_path.exists():
         print(f"{Colors.BOLD}Checking string_keys.hpp consistency:{Colors.END}")
         header_keys = extract_keys_from_cpp_header(header_path)
@@ -228,23 +276,26 @@ def validate_localization(project_root: Path, fix: bool = False) -> int:
     # Check for keys used in code
     print(f"{Colors.BOLD}Checking code usage:{Colors.END}")
     code_keys = extract_keys_from_code(code_dir)
-    if code_keys:
-        print(f"{Colors.CYAN}Found {len(code_keys)} LOC() calls in code{Colors.END}")
+    all_used_keys = code_keys | header_keys  # LOC("...") + LOC(Strings::X) via string_keys.hpp
+    if all_used_keys:
+        print(f"  {Colors.CYAN}{len(code_keys)} LOC(\"...\") + {len(header_keys)} header = "
+              f"{len(all_used_keys)} referenced keys{Colors.END}")
 
-        unused = reference_keys - code_keys
-        undefined = code_keys - reference_keys
+        unused = reference_keys - all_used_keys
+        undefined = all_used_keys - reference_keys
 
         if undefined:
             has_errors = True
-            print(f"{Colors.RED}✗ Undefined keys used in code:{Colors.END}")
-            for key in sorted(undefined):
-                print(f"  - {key}")
+            print(f"  {Colors.RED}✗ {len(undefined)} undefined key(s) in code:{Colors.END}")
+            for key in sorted(undefined)[:10]:
+                print(f"    - {key}")
+            if len(undefined) > 10:
+                print(f"    ... and {len(undefined) - 10} more")
+        else:
+            print(f"  {Colors.GREEN}✓ All code references are defined{Colors.END}")
 
         if unused:
-            print(f"{Colors.YELLOW}⚠ {len(unused)} defined but unused keys{Colors.END}")
-
-        if not undefined:
-            print(f"{Colors.GREEN}✓ All code references are defined{Colors.END}")
+            print(f"  {Colors.YELLOW}⚠ {len(unused)} keys in en.json not referenced in code{Colors.END}")
     print()
 
     # Summary
@@ -252,7 +303,7 @@ def validate_localization(project_root: Path, fix: bool = False) -> int:
     if has_errors:
         print(f"{Colors.RED}✗ Validation FAILED - please fix the issues above{Colors.END}")
         if not fix:
-            print(f"\n{Colors.CYAN}Tip: Run with --fix to auto-add missing keys{Colors.END}")
+            print(f"\n{Colors.CYAN}Tip: Run with --fix to auto-add missing keys and reorder{Colors.END}")
         return 1
     else:
         print(f"{Colors.GREEN}✓ Validation PASSED - all localizations are complete{Colors.END}")
@@ -264,12 +315,22 @@ def main():
 
     parser = argparse.ArgumentParser(description='Validate LichtFeld Studio localization files')
     parser.add_argument('--fix', action='store_true',
-                       help='Automatically add missing keys with TODO markers')
+                       help='Automatically add missing keys and reorder to match en.json')
+    parser.add_argument('--lang', action='append', default=None,
+                       help='Language code(s) to check (e.g. --lang zh --lang ja). '
+                            'Repeatable or comma-separated. If omitted, checks all.')
     args = parser.parse_args()
+
+    # Flatten --lang values and split comma-separated entries
+    langs = None
+    if args.lang:
+        langs = []
+        for entry in args.lang:
+            langs.extend(s.strip() for s in entry.split(',') if s.strip())
 
     try:
         project_root = find_project_root()
-        exit_code = validate_localization(project_root, fix=args.fix)
+        exit_code = validate_localization(project_root, fix=args.fix, langs=langs)
         sys.exit(exit_code)
     except Exception as e:
         print(f"{Colors.RED}Error: {e}{Colors.END}")


### PR DESCRIPTION
## Summary

The `--fix` flag in `scripts/validate_localization.py` `line 178` was broken:

```python
if fix:
  print(f"  {Colors.YELLOW}→ Adding missing keys with TODO markers...{Colors.END}")
  # Add missing keys
  for key in missing:
      locale_data['flat'][key] = f"TODO: {locales['en']['flat'][key]}"
````

It modified a flattened in-memory dict and never wrote the result back to disk.  
This PR replaces the flat comparison with recursive `OrderedDict` sync, adds key reordering to match en.json, and introduces a `--lang` filter for scoped validation.

## Changes

### Bug fixes
- `--fix` now actually writes synced data back to the target JSON file
- "unused keys" count now combines `string_keys.hpp` constants  
  with raw `LOC("...")` calls instead of counting only the latter

### New features
- `sync_dict()` recursively aligns a target locale file with en.json:
  fills missing keys from the English baseline and reorders all keys
  to the canonical en.json order
- `--lang zh,ja,fr` flag to scope validation/fix to one or more
  languages; unknown codes produce a hard error

## Usage

```bash
python scripts/validate_localization.py                         # Check all
python scripts/validate_localization.py --fix                   # Fix all
python scripts/validate_localization.py --lang zh --fix         # Fix only zh
```

<img width="596" height="571" alt="image" src="https://github.com/user-attachments/assets/c0e44fc0-0ef7-4b58-b432-075404fd404b" />
