### PR TITLE
Brush Selection Commit Uses Preview Mask

### DIFF
--- a/src/visualizer/operator/ops/selection_ops.cpp
+++ b/src/visualizer/operator/ops/selection_ops.cpp
@@ -166,6 +166,7 @@ namespace lfs::vis::op {
             }
 
             if (is_stroke_button && mb->action == input::ACTION_RELEASE) {
+                service->updateInteractiveSelection(glm::vec2(mb->position));
                 const auto result = service->finishInteractiveSelection();
                 return result.success ? OperatorResult::FINISHED : OperatorResult::CANCELLED;
             }

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -6017,6 +6017,15 @@ namespace lfs::vis {
                                                    selection_query_timeline_.cuda_semaphore.lastError()));
             }
         }
+        {
+            LOG_TIMER("VksplatViewportRenderer::buildSelectionMask.dispatch.cuda_sync");
+            if (const cudaError_t status = cudaStreamSynchronize(selection_query_stream);
+                status != cudaSuccess) {
+                return std::unexpected(std::format("VkSplat selection query sync failed: {} ({})",
+                                                   cudaGetErrorName(status),
+                                                   cudaGetErrorString(status)));
+            }
+        }
 
         if (ring_mode) {
             LOG_TIMER("VksplatViewportRenderer::buildSelectionMask.ring_pick");

--- a/src/visualizer/selection/selection_service.cpp
+++ b/src/visualizer/selection/selection_service.cpp
@@ -2422,8 +2422,8 @@ namespace lfs::vis {
         switch (session.shape) {
         case SelectionShape::Brush:
             success = buildInteractiveBrushPreviewIncremental();
-            success = success && session.working_selection.is_valid() &&
-                      session.working_selection.numel() == total;
+            success = success && session.preview_brush_point_count == session.points.size() &&
+                      session.working_selection.is_valid() && session.working_selection.numel() == total;
             if (success) {
                 selection_out = session.working_selection;
             }

--- a/src/visualizer/selection/selection_service.cpp
+++ b/src/visualizer/selection/selection_service.cpp
@@ -2418,17 +2418,22 @@ namespace lfs::vis {
             return false;
         }
 
-        selection_out = resetBoolScratchBuffer(session.working_selection, total);
-
         bool success = false;
         switch (session.shape) {
         case SelectionShape::Brush:
-            success = buildBrushSelection(session.points, session.brush_radius, selection_out);
+            success = buildInteractiveBrushPreviewIncremental();
+            success = success && session.working_selection.is_valid() &&
+                      session.working_selection.numel() == total;
+            if (success) {
+                selection_out = session.working_selection;
+            }
             break;
         case SelectionShape::Rectangle:
+            selection_out = resetBoolScratchBuffer(session.working_selection, total);
             success = buildRectangleSelection(session.start_pos, session.cursor_pos, selection_out);
             break;
         case SelectionShape::Polygon: {
+            selection_out = resetBoolScratchBuffer(session.working_selection, total);
             if (!session.polygon_world_points.empty()) {
                 success = buildWorldPolygonSelection(session.polygon_world_points, selection_out);
             } else {
@@ -2438,14 +2443,17 @@ namespace lfs::vis {
             break;
         }
         case SelectionShape::Lasso:
+            selection_out = resetBoolScratchBuffer(session.working_selection, total);
             success = buildPolygonSelection(session.points, selection_out);
             break;
         case SelectionShape::Rings:
+            selection_out = resetBoolScratchBuffer(session.working_selection, total);
             success = buildRingSelection(
                 session.cursor_pos, selection_out, true, !include_polygon_cursor, picked_ring_id_out);
             break;
         case SelectionShape::Box:
         case SelectionShape::Sphere:
+            selection_out = resetBoolScratchBuffer(session.working_selection, total);
             if (const auto geometry = buildInteractiveVolumeGeometry()) {
                 success = buildVolumeSelection(*geometry, selection_out);
             }


### PR DESCRIPTION
## Problem

Some users reported that brush-selecting splats could show the expected green preview while dragging, but only a small part of the stroke became committed as the red selection on mouse release.

The issue was most visible when the mouse was still moving at the moment the button was released. If the user stopped moving first and then released, the selection usually committed correctly.

One reported recording also showed the previous stroke's green preview briefly reappearing during the next stroke. That points at stale or late GPU-side selection/preview state, but the most important user-visible mismatch was:

- preview mask while dragging: correct
- committed mask on release: partial

## Suspected Cause

Brush selection had two different paths:

1. During dragging, `buildInteractiveBrushPreviewIncremental()` builds only the new brush segments and merges them into `session.working_selection`.
2. On release, `buildSelectionMaskForInteractiveSession()` rebuilt the whole brush stroke from `session.points` with `buildBrushSelection(...)`.

That means the final committed mask did not come from the same mask the user saw as the green preview.

This became more suspicious after the CUDA streams work in `d568fd3fcc5b1f48371c2b5669fcacb84e0f99b9`, which moved VkSplat selection query and upload work onto dedicated stream/timeline synchronization. If the final full-stroke query races or observes stale/partial GPU state, the preview can still look right while the release-time rebuild commits only part of the stroke.

An affected-user test of the first patch showed that the previously missing part of the stroke became selected, but the part that used to be selected then appeared in the next brush stroke. That indicates the VkSplat selection query output can be one brush delta late: a result from stroke N may only become visible when stroke N+1 starts.

## Change

Brush commit now reuses the accumulated interactive brush preview mask.

On finish, the brush path calls `buildInteractiveBrushPreviewIncremental()` one last time to catch up any unprocessed points, then passes `session.working_selection` into the existing `commitSelection(...)` path.

This preserves selection modes:

- Replace still replaces with the brush hit mask.
- Shift/add still adds the brush hit mask.
- Ctrl/remove still removes the brush hit mask.
- Alt/intersect still intersects with the brush hit mask.

The change only replaces how the brush hit mask is constructed. It does not bypass the normal commit logic.

Other interactive shapes still rebuild from scratch into a cleared scratch mask:

- rectangle
- polygon
- lasso
- rings
- box
- sphere

Brush is intentionally different because it is incremental. Its `working_selection` is the accumulated stroke mask, not just temporary scratch.

The mouse release handler also now sends the release position through `updateInteractiveSelection(...)` before finishing the stroke, so a final cursor position carried by the button-up event is not dropped.

The VkSplat selection query path now also synchronizes `selection_query_stream` after waiting for the Vulkan completion timeline and before returning `slot.output_tensor`. This is intentionally conservative: it prevents callers from accepting a reusable external output tensor before the CUDA stream has actually observed the query result.

## Validation

Manual validation should focus on:

- one continuous brush stroke while releasing during motion
- brush replace/add/remove/intersect modes
- releasing after stopping, to confirm existing behavior is unchanged
- repeated brush strokes, to check whether stale green preview still appears
