### PR TITLE
VkSplat Training Viewport Stability

### DIFF
--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -2951,7 +2951,8 @@ namespace lfs::vis {
                 cmd::ToggleGTComparison{}.emit();
             }
 
-            if (auto* trainer = services().trainerOrNull(); trainer && trainer->isRunning()) {
+            if (auto* trainer = services().trainerOrNull();
+                trainer && trainer->isRunning() && !trainer->isTrainerPaused()) {
                 trainer->pauseTrainingTemporary();
                 training_was_paused_by_camera_ = true;
             }

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -2952,8 +2952,7 @@ namespace lfs::vis {
             }
 
             if (auto* trainer_mgr = services().trainerOrNull();
-                trainer_mgr && trainer_mgr->isRunning() && !trainer_mgr->isTrainerPaused()) {
-                trainer_mgr->pauseTrainingTemporary();
+                trainer_mgr && trainer_mgr->pauseTrainingTemporaryIfActive()) {
                 training_was_paused_by_camera_ = true;
             }
         } else {

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -2951,9 +2951,9 @@ namespace lfs::vis {
                 cmd::ToggleGTComparison{}.emit();
             }
 
-            if (auto* trainer = services().trainerOrNull();
-                trainer && trainer->isRunning() && !trainer->isTrainerPaused()) {
-                trainer->pauseTrainingTemporary();
+            if (auto* trainer_mgr = services().trainerOrNull();
+                trainer_mgr && trainer_mgr->isRunning() && !trainer_mgr->isTrainerPaused()) {
+                trainer_mgr->pauseTrainingTemporary();
                 training_was_paused_by_camera_ = true;
             }
         } else {
@@ -2979,7 +2979,7 @@ namespace lfs::vis {
             if (training_was_paused_by_camera_ && services().trainerOrNull() && services().trainerOrNull()->isRunning()) {
                 services().trainerOrNull()->resumeTrainingTemporary();
                 training_was_paused_by_camera_ = false;
-                LOG_INFO("Camera movement stopped - resuming training temporarily");
+                LOG_DEBUG("Camera movement stopped - resumed temporary training pause");
             }
         }
     }

--- a/src/visualizer/rendering/rendering_manager.hpp
+++ b/src/visualizer/rendering/rendering_manager.hpp
@@ -112,6 +112,10 @@ namespace lfs::vis {
         // Main render function
         void renderFrame(const RenderContext& context);
         VulkanFrameResult renderVulkanFrame(const RenderContext& context);
+        [[nodiscard]] std::expected<void, std::string> ensureVksplatTrainingSharedScratchReady(
+            VulkanContext& context,
+            const lfs::core::SplatData& model,
+            glm::ivec2 viewport_size);
 
         enum class VksplatSelectionMaskShape : std::uint32_t {
             Brush = 0,

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -777,18 +777,22 @@ namespace lfs::vis {
             vulkan_viewport_image_size_ = {0, 0};
             vulkan_viewport_image_flip_y_ = false;
             if (vksplat_viewport_renderer_) {
-                // The trainer must drop the fence handle before reset destroys
-                // the CUDA import it points at.
-                if (trainer_manager) {
-                    if (auto* trainer = trainer_manager->getTrainer()) {
-                        trainer->setViewerReleaseFence(nullptr);
+                if (is_training && lfs::rendering::isVkSplatBackend(settings_.raster_backend)) {
+                    LOG_DEBUG("Preserving VkSplat renderer across training model change");
+                } else {
+                    // The trainer must drop the fence handle before reset destroys
+                    // the CUDA import it points at.
+                    if (trainer_manager) {
+                        if (auto* trainer = trainer_manager->getTrainer()) {
+                            trainer->setViewerReleaseFence(nullptr);
+                        }
                     }
+                    // reset() destroys render_stream_; drop it from the TLS current
+                    // stream first so the rest of the frame doesn't enqueue work on a
+                    // stale handle. Re-installed after the handshake re-init below.
+                    frame_stream_guard.reset();
+                    vksplat_viewport_renderer_->reset();
                 }
-                // reset() destroys render_stream_; drop it from the TLS current
-                // stream first so the rest of the frame doesn't enqueue work on a
-                // stale handle. Re-installed after the handshake re-init below.
-                frame_stream_guard.reset();
-                vksplat_viewport_renderer_->reset();
             }
             viewport_artifact_service_.clearViewportOutput();
             markDirty(DirtyFlag::ALL);
@@ -2569,6 +2573,31 @@ namespace lfs::vis {
                 .image_generation = vulkan_viewport_image_generation_,
                 .size = vulkan_viewport_image_size_,
                 .flip_y = vulkan_viewport_image_flip_y_};
+    }
+
+    std::expected<void, std::string> RenderingManager::ensureVksplatTrainingSharedScratchReady(
+        VulkanContext& context,
+        const lfs::core::SplatData& model,
+        glm::ivec2 viewport_size) {
+        if (!lfs::rendering::isVkSplatBackend(settings_.raster_backend) || model.size() <= 0) {
+            return {};
+        }
+        if (viewport_size.x <= 0 || viewport_size.y <= 0) {
+            viewport_size = getRenderedSize();
+        }
+        if (viewport_size.x <= 0 || viewport_size.y <= 0) {
+            viewport_size = {1280, 720};
+        }
+        if (!vksplat_viewport_renderer_) {
+            vksplat_viewport_renderer_ = std::make_unique<VksplatViewportRenderer>();
+        }
+        if (auto ok = vksplat_viewport_renderer_->ensureHandshakeReady(context); !ok) {
+            return std::unexpected(ok.error());
+        }
+        return vksplat_viewport_renderer_->ensureTrainingSharedScratchReady(
+            context,
+            static_cast<std::size_t>(model.size()),
+            viewport_size);
     }
 
     lfs::io::SplatTensorAllocator RenderingManager::makeSplatTensorAllocator() const {

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -6607,19 +6607,6 @@ namespace lfs::vis {
             splat_data.lod_tree->rad_source.valid();
         static const bool kDisableSharedScratch = (std::getenv("LFS_NO_SHARED_SCRATCH") != nullptr);
         std::optional<RasterizerArenaRenderGuard> shared_arena_guard;
-        if (synchronize_input_upload && !kDisableSharedScratch) {
-            if (!shared_scratch_.installed_in_training_arena || !shared_scratch_.block) {
-                return std::unexpected(
-                    "VkSplat shared scratch is not installed for training render (prime shared scratch before training starts)");
-            }
-            try {
-                shared_arena_guard.emplace();
-            } catch (const std::exception& e) {
-                return std::unexpected(std::format(
-                    "VkSplat shared scratch training rasterizer arena is busy; reason={}",
-                    e.what()));
-            }
-        }
         std::vector<LodPageCache::PendingUpload> lod_page_uploads;
         std::vector<std::uint32_t> protected_lod_chunks;
         bool lod_page_inputs_active = false;

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -3170,10 +3170,16 @@ namespace lfs::vis {
 
         const std::size_t width = static_cast<std::size_t>(viewport_size.x);
         const std::size_t height = static_cast<std::size_t>(viewport_size.y);
+        if (height != 0 && width > (std::numeric_limits<std::size_t>::max() / height)) {
+            return std::unexpected("VkSplat training shared-scratch prime viewport size overflows size_t");
+        }
         const std::size_t num_pixels = width * height;
-        const std::size_t num_tiles =
-            ((width + TILE_WIDTH - 1) / TILE_WIDTH) *
-            ((height + TILE_HEIGHT - 1) / TILE_HEIGHT);
+        const std::size_t tiles_x = (width + TILE_WIDTH - 1) / TILE_WIDTH;
+        const std::size_t tiles_y = (height + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        if (tiles_y != 0 && tiles_x > (std::numeric_limits<std::size_t>::max() / tiles_y)) {
+            return std::unexpected("VkSplat training shared-scratch prime tile count overflows size_t");
+        }
+        const std::size_t num_tiles = tiles_x * tiles_y;
         const std::size_t sort_capacity =
             num_splats > (std::numeric_limits<std::size_t>::max() / 4u)
                 ? num_splats
@@ -6604,7 +6610,7 @@ namespace lfs::vis {
         if (synchronize_input_upload && !kDisableSharedScratch) {
             if (!shared_scratch_.installed_in_training_arena || !shared_scratch_.block) {
                 return std::unexpected(
-                    "VkSplat shared scratch training rasterizer arena is busy; reason=shared scratch is not installed before training render");
+                    "VkSplat shared scratch is not installed for training render (prime shared scratch before training starts)");
             }
             try {
                 shared_arena_guard.emplace();

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -3157,6 +3157,39 @@ namespace lfs::vis {
         return {};
     }
 
+    std::expected<void, std::string> VksplatViewportRenderer::ensureTrainingSharedScratchReady(
+        VulkanContext& context,
+        const std::size_t num_splats,
+        const glm::ivec2 viewport_size) {
+        if (num_splats == 0 || viewport_size.x <= 0 || viewport_size.y <= 0) {
+            return {};
+        }
+        if (auto ok = ensureInitialized(context); !ok) {
+            return std::unexpected(ok.error());
+        }
+
+        const std::size_t width = static_cast<std::size_t>(viewport_size.x);
+        const std::size_t height = static_cast<std::size_t>(viewport_size.y);
+        const std::size_t num_pixels = width * height;
+        const std::size_t num_tiles =
+            ((width + TILE_WIDTH - 1) / TILE_WIDTH) *
+            ((height + TILE_HEIGHT - 1) / TILE_HEIGHT);
+        const std::size_t sort_capacity =
+            num_splats > (std::numeric_limits<std::size_t>::max() / 4u)
+                ? num_splats
+                : num_splats * 4u;
+        const std::size_t required_shared_scratch =
+            estimateSharedScratchBytes(num_splats,
+                                       num_splats,
+                                       false,
+                                       sort_capacity,
+                                       num_pixels,
+                                       num_tiles);
+
+        releasePrivateScratchBuffers();
+        return ensureSharedScratchArena(context, required_shared_scratch);
+    }
+
     void VksplatViewportRenderer::bindSharedScratchBuffers(
         const std::size_t num_splats,
         const std::size_t visible_capacity,
@@ -6566,6 +6599,21 @@ namespace lfs::vis {
             lod_request_active &&
             splat_data.lod_tree &&
             splat_data.lod_tree->rad_source.valid();
+        static const bool kDisableSharedScratch = (std::getenv("LFS_NO_SHARED_SCRATCH") != nullptr);
+        std::optional<RasterizerArenaRenderGuard> shared_arena_guard;
+        if (synchronize_input_upload && !kDisableSharedScratch) {
+            if (!shared_scratch_.installed_in_training_arena || !shared_scratch_.block) {
+                return std::unexpected(
+                    "VkSplat shared scratch training rasterizer arena is busy; reason=shared scratch is not installed before training render");
+            }
+            try {
+                shared_arena_guard.emplace();
+            } catch (const std::exception& e) {
+                return std::unexpected(std::format(
+                    "VkSplat shared scratch training rasterizer arena is busy; reason={}",
+                    e.what()));
+            }
+        }
         std::vector<LodPageCache::PendingUpload> lod_page_uploads;
         std::vector<std::uint32_t> protected_lod_chunks;
         bool lod_page_inputs_active = false;
@@ -7001,7 +7049,6 @@ namespace lfs::vis {
         const std::size_t num_tiles =
             static_cast<std::size_t>(uniforms.grid_width) * static_cast<std::size_t>(uniforms.grid_height);
         bool shared_scratch_bound = false;
-        std::optional<RasterizerArenaRenderGuard> shared_arena_guard;
         std::uint64_t shared_scratch_attempt_id = 0;
         const auto shared_scratch_context = [&]() {
             return std::format(
@@ -7024,7 +7071,6 @@ namespace lfs::vis {
                 render_complete_value_ + 1);
         };
 
-        static const bool kDisableSharedScratch = (std::getenv("LFS_NO_SHARED_SCRATCH") != nullptr);
         if (synchronize_input_upload && !kDisableSharedScratch) {
             // A busy training arena makes this frame fall back to the cached viewport.
             // Do not resize output images until this render is guaranteed to proceed.
@@ -7035,7 +7081,9 @@ namespace lfs::vis {
             shared_scratch_attempt_id = ++shared_scratch_attempt_serial_;
             if (auto ok = ensureSharedScratchArena(context, required_shared_scratch); ok) {
                 try {
-                    shared_arena_guard.emplace();
+                    if (!shared_arena_guard) {
+                        shared_arena_guard.emplace();
+                    }
                     // Now that the render owns the arena frame (training is
                     // excluded), it is safe to re-import the block if training grew
                     // it in place since the last frame — the handle/size are stable.

--- a/src/visualizer/rendering/vksplat_viewport_renderer.hpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.hpp
@@ -159,6 +159,10 @@ namespace lfs::vis {
         [[nodiscard]] std::expected<void, std::string> ensureHandshakeReady(VulkanContext& context) {
             return ensureInitialized(context);
         }
+        [[nodiscard]] std::expected<void, std::string> ensureTrainingSharedScratchReady(
+            VulkanContext& context,
+            std::size_t num_splats,
+            glm::ivec2 viewport_size);
 
         // Invoked with the completion value immediately after each live-model
         // submit, BEFORE the shared arena frame is released — the trainer's

--- a/src/visualizer/training/training_manager.cpp
+++ b/src/visualizer/training/training_manager.cpp
@@ -256,6 +256,10 @@ namespace lfs::vis {
         return trainer_ != nullptr;
     }
 
+    bool TrainerManager::isTrainerPaused() const {
+        return trainer_ && trainer_->is_paused();
+    }
+
     void TrainerManager::clearTrainer() {
         LOG_DEBUG("Clearing trainer");
 
@@ -417,6 +421,26 @@ namespace lfs::vis {
             // Match headless mode: release init-time cached pool allocations before the
             // first training batch spins up image decoders and render workspaces.
             lfs::core::Tensor::trim_memory_pool();
+        }
+
+        if (viewer_) {
+            auto* const rendering_manager = viewer_->getRenderingManager();
+            auto* const window_manager = viewer_->getWindowManager();
+            auto* const vulkan_context = window_manager ? window_manager->getVulkanContext() : nullptr;
+            auto* const model = scene_ ? scene_->getTrainingModel() : nullptr;
+            if (rendering_manager && vulkan_context && model) {
+                glm::ivec2 prime_size = rendering_manager->getRenderedSize();
+                if (prime_size.x <= 0 || prime_size.y <= 0) {
+                    prime_size = window_manager ? window_manager->getWindowSize() : glm::ivec2{1280, 720};
+                }
+                if (auto ok = rendering_manager->ensureVksplatTrainingSharedScratchReady(
+                        *vulkan_context,
+                        *model,
+                        prime_size);
+                    !ok) {
+                    LOG_WARN("VkSplat training shared-scratch pre-start prime skipped: {}", ok.error());
+                }
+            }
         }
 
         {

--- a/src/visualizer/training/training_manager.cpp
+++ b/src/visualizer/training/training_manager.cpp
@@ -256,10 +256,6 @@ namespace lfs::vis {
         return trainer_ != nullptr;
     }
 
-    bool TrainerManager::isTrainerPaused() const {
-        return trainer_ && trainer_->is_paused();
-    }
-
     void TrainerManager::clearTrainer() {
         LOG_DEBUG("Clearing trainer");
 
@@ -537,6 +533,15 @@ namespace lfs::vis {
 
         trainer_->request_pause();
         LOG_TRACE("Training temporary pause requested at iteration {}", iteration);
+    }
+
+    bool TrainerManager::pauseTrainingTemporaryIfActive() {
+        if (!isRunning() || !trainer_ || trainer_->is_paused()) {
+            return false;
+        }
+
+        pauseTrainingTemporary();
+        return true;
     }
 
     TrainerManager::TemporaryPauseResult

--- a/src/visualizer/training/training_manager.hpp
+++ b/src/visualizer/training/training_manager.hpp
@@ -74,6 +74,7 @@ namespace lfs::vis {
         };
 
         void pauseTrainingTemporary();
+        [[nodiscard]] bool pauseTrainingTemporaryIfActive();
         [[nodiscard]] TemporaryPauseResult pauseTrainingTemporaryAndWait(std::chrono::milliseconds timeout);
         void resumeTrainingTemporary();
 
@@ -90,7 +91,6 @@ namespace lfs::vis {
         [[nodiscard]] bool isPaused() const { return state_machine_.isInState(TrainingState::Paused); }
         [[nodiscard]] bool isFinished() const { return state_machine_.isInState(TrainingState::Finished); }
         [[nodiscard]] bool isTrainingActive() const { return state_machine_.isActive(); }
-        [[nodiscard]] bool isTrainerPaused() const;
         [[nodiscard]] bool canStart() const { return canPerform(TrainingAction::Start); }
         [[nodiscard]] bool canPause() const { return canPerform(TrainingAction::Pause); }
         [[nodiscard]] bool canResume() const { return canPerform(TrainingAction::Resume); }

--- a/src/visualizer/training/training_manager.hpp
+++ b/src/visualizer/training/training_manager.hpp
@@ -90,6 +90,7 @@ namespace lfs::vis {
         [[nodiscard]] bool isPaused() const { return state_machine_.isInState(TrainingState::Paused); }
         [[nodiscard]] bool isFinished() const { return state_machine_.isInState(TrainingState::Finished); }
         [[nodiscard]] bool isTrainingActive() const { return state_machine_.isActive(); }
+        [[nodiscard]] bool isTrainerPaused() const;
         [[nodiscard]] bool canStart() const { return canPerform(TrainingAction::Start); }
         [[nodiscard]] bool canPause() const { return canPerform(TrainingAction::Pause); }
         [[nodiscard]] bool canResume() const { return canPerform(TrainingAction::Resume); }


### PR DESCRIPTION
## Summary

This change fixes an intermittent CUDA illegal-address failure seen on a 2080 Ti when training starts while the VkSplat viewport is active, especially when dragging or moving the viewport around training startup.

The fix keeps hardware decoding and the Vulkan viewport enabled. It does not exclude specific GPUs, disable nvImageCodec, or increase the VkSplat shared-scratch allocation estimate.

## Root Cause

The failure was initially reported as nvImageCodec decode failures, but the detailed logs showed those errors were often downstream of an already-poisoned CUDA context. The first CUDA illegal address usually came from FastGS rasterization or related training work, while nvImageCodec later observed the same CUDA error during decode or sync.

The useful signal came from the Vulkan/VkSplat path:

- VkSplat creates/imports a shared rasterizer scratch arena for viewport rendering.
- Training also uses the CUDA rasterizer arena.
- At training start, the render model pointer changes from the pre-training model to the training model.
- The old render path treated that model change as a full scene switch and reset `VksplatViewportRenderer`.
- That reset dropped the renderer state and shared-scratch import right as the training thread was starting.
- The first interactive viewport frames then tried to recreate or bind VkSplat shared scratch while FastGS training work was active.
- On the affected setup this could corrupt CUDA state and surface as `cudaErrorIllegalAddress` in FastGS, tensor ops, nvImageCodec, or Vulkan interop.

So the core issue was not "hardware decode is bad" and not "the 2080 Ti must be disabled". The crash came from unsafe lifecycle/ownership around the VkSplat shared scratch during training startup and interactive viewport work.

## What Changed

### Preserve VkSplat Renderer During Training Model Swap

When `renderVulkanFrame()` detects a model pointer change while training with the VkSplat backend, it now preserves the existing `VksplatViewportRenderer` instead of resetting it.

This keeps the already-created handshake and shared-scratch state alive across the normal training-start model transition.

For non-training model changes, the previous reset behavior is kept.

### Prime VkSplat Shared Scratch Before Training Starts

Training startup now asks the rendering manager to prepare VkSplat training shared scratch before the training thread begins.

This happens after trainer initialization and memory-pool trimming, but before `training_complete_` is cleared and before the training thread starts. The goal is to have the renderer's shared scratch installed before FastGS starts using the CUDA arena.

### Fail Viewport Contention Safely

During training renders, VkSplat now checks that shared scratch is already installed and tries to acquire the rasterizer arena guard before doing input upload or other CUDA/Vulkan render preparation.

If the arena is busy, the viewport returns the existing retryable "shared scratch unavailable" path. The rendering manager can keep or return the cached viewport image and retry later, instead of performing late scratch setup while training owns the arena.

### Prevent Camera Pause Lease Stacking

A second issue appeared after the crash was fixed: training sometimes did not resume after viewport/camera movement.

Logs showed repeated temporary camera pause requests at the same iteration while the underlying trainer was already paused. Those requests stacked temporary pause leases, so a later camera timeout could log "resuming" without actually reaching a zero pause depth.

Camera movement now only requests a temporary training pause when the trainer manager is running and the underlying trainer is not already paused.

## Files Changed

- `src/visualizer/rendering/rendering_manager.hpp`
- `src/visualizer/rendering/rendering_manager_vulkan.cpp`
- `src/visualizer/rendering/vksplat_viewport_renderer.hpp`
- `src/visualizer/rendering/vksplat_viewport_renderer.cpp`
- `src/visualizer/training/training_manager.hpp`
- `src/visualizer/training/training_manager.cpp`
- `src/visualizer/input/input_controller.cpp`

## Validation

Tested manually on the affected Windows/2080 Ti setup with:

```bat
build\LichtFeld-Studio.exe -o D:\temp\gs_tests\dual_camera\colmap\output -d D:\temp\gs_tests\dual_camera\colmap --log-file output.txt
```

Observed results after the patch:

- No CUDA illegal-address crashes while dragging/moving the viewport during training startup.
- nvImageCodec remains enabled.
- Vulkan viewport remains enabled.
- Training resumes correctly after camera/viewport movement.
- No GPU-specific exclusion was added.
- No larger shared-scratch capacity multiplier was kept.

Build validation:

```bat
cmake --build build -j 8
```

The build completed successfully.

## Notes For Reviewers

The key behavioral change is that training-start model pointer changes are not treated the same as ordinary scene switches for VkSplat renderer lifetime. In training, preserving the renderer is intentional because the renderer owns CUDA/Vulkan interop state that must remain stable across the handoff into live training.

The retry path for busy shared scratch is also intentional. A missed viewport frame is acceptable; racing the trainer for shared rasterizer arena ownership is not.
