### PR TITLE
VkSplat Delete Flash Fix

### DIFF
--- a/docs/plugins/api-reference.md
+++ b/docs/plugins/api-reference.md
@@ -1366,7 +1366,7 @@ Accessible via `scene.combined_model()` (all nodes merged) or `node.splat_data()
 | `active_sh_degree`    | `int`        | Current SH degree               |
 | `max_sh_degree`       | `int`        | Maximum SH degree               |
 | `scene_scale`         | `float`      | Scene scale factor              |
-| `soft_delete(mask)`   | `Tensor`     | Mark for deletion, returns prev state |
+| `soft_delete(mask)`   | `Tensor`     | Mark for deletion, returns newly deleted mask |
 | `undelete(mask)`      | `None`       | Restore deleted gaussians       |
 | `apply_deleted()`     | `int`        | Permanently remove, returns count|
 | `clear_deleted()`     | `None`       | Clear deletion mask             |

--- a/src/core/include/core/splat_data.hpp
+++ b/src/core/include/core/splat_data.hpp
@@ -302,6 +302,9 @@ namespace lfs::core {
         [[nodiscard]] std::size_t deleted_count() const {
             return _deleted_count.load(std::memory_order_relaxed);
         }
+        [[nodiscard]] std::uint64_t deleted_mask_version() const {
+            return _deleted_mask_version.load(std::memory_order_relaxed);
+        }
         void refresh_deleted_count();
 
         [[nodiscard]] const std::vector<FrozenRange>& frozen_ranges() const { return _frozen_ranges; }
@@ -367,6 +370,9 @@ namespace lfs::core {
         // Cached nonzero count of _deleted; see refresh_deleted_count(). Atomic so
         // the render thread can read it without a data race on the writer.
         std::atomic<std::size_t> _deleted_count{0};
+        // Monotonic content revision for the soft-delete mask. The renderer uses
+        // this to refresh per-ring opacity copies when the mask is updated in place.
+        std::atomic<std::uint64_t> _deleted_mask_version{0};
 
         // Backing allocator for parameter tensors (see set_tensor_allocator).
         SplatTensorAllocator _tensor_allocator;

--- a/src/core/include/core/splat_data.hpp
+++ b/src/core/include/core/splat_data.hpp
@@ -314,7 +314,7 @@ namespace lfs::core {
         void remap_frozen_ranges_after_keep(size_t old_size, const std::vector<int>& kept_old_indices);
         void remap_frozen_ranges_after_keep(size_t old_size, const std::vector<int64_t>& kept_old_indices);
 
-        // Mark gaussians as deleted, returns previous state for undo
+        // Mark gaussians as deleted, returns newly deleted mask for undo
         Tensor soft_delete(const Tensor& mask);
         void undelete(const Tensor& mask);
         void clear_deleted();

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -552,6 +552,7 @@ namespace lfs::core {
           _densification_info(std::move(other._densification_info)),
           _deleted(std::move(other._deleted)),
           _deleted_count(other._deleted_count.load(std::memory_order_relaxed)),
+          _deleted_mask_version(other._deleted_mask_version.load(std::memory_order_relaxed)),
           _tensor_allocator(std::move(other._tensor_allocator)),
           lod_tree(std::move(other.lod_tree)),
           _frozen_ranges(std::move(other._frozen_ranges)) {
@@ -560,6 +561,7 @@ namespace lfs::core {
         other._max_sh_degree = 0;
         other._scene_scale = 0.0f;
         other._deleted_count.store(0, std::memory_order_relaxed);
+        other._deleted_mask_version.store(0, std::memory_order_relaxed);
         other._frozen_ranges.clear();
     }
 
@@ -584,9 +586,12 @@ namespace lfs::core {
             lod_tree = std::move(other.lod_tree);
             _deleted_count.store(other._deleted_count.load(std::memory_order_relaxed),
                                  std::memory_order_relaxed);
+            _deleted_mask_version.store(other._deleted_mask_version.load(std::memory_order_relaxed),
+                                        std::memory_order_relaxed);
             _tensor_allocator = std::move(other._tensor_allocator);
             _frozen_ranges = std::move(other._frozen_ranges);
             other._deleted_count.store(0, std::memory_order_relaxed);
+            other._deleted_mask_version.store(0, std::memory_order_relaxed);
             other._frozen_ranges.clear();
         }
         return *this;
@@ -861,6 +866,7 @@ namespace lfs::core {
 
         const Tensor updated = _deleted || mask;
         _deleted.copy_from(updated);
+        _deleted_mask_version.fetch_add(1, std::memory_order_relaxed);
         return mask;
     }
 
@@ -877,13 +883,18 @@ namespace lfs::core {
 
         const Tensor updated = _deleted && mask.logical_not();
         _deleted.copy_from(updated);
+        _deleted_mask_version.fetch_add(1, std::memory_order_relaxed);
     }
 
     void SplatData::clear_deleted() {
+        const bool had_deleted = _deleted.is_valid();
         if (_deleted.is_valid()) {
             _deleted = Tensor();
         }
         _deleted_count.store(0, std::memory_order_relaxed);
+        if (had_deleted) {
+            _deleted_mask_version.fetch_add(1, std::memory_order_relaxed);
+        }
     }
 
     size_t SplatData::apply_deleted() {

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -859,7 +859,8 @@ namespace lfs::core {
             _deleted.set_name("splat.deleted_mask");
         }
 
-        _deleted = _deleted || mask;
+        const Tensor updated = _deleted || mask;
+        _deleted.copy_from(updated);
         return mask;
     }
 
@@ -874,7 +875,8 @@ namespace lfs::core {
             return;
         }
 
-        _deleted = _deleted && mask.logical_not();
+        const Tensor updated = _deleted && mask.logical_not();
+        _deleted.copy_from(updated);
     }
 
     void SplatData::clear_deleted() {

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -864,10 +864,11 @@ namespace lfs::core {
             _deleted.set_name("splat.deleted_mask");
         }
 
+        const Tensor newly_deleted = mask && _deleted.logical_not();
         const Tensor updated = _deleted || mask;
         _deleted.copy_from(updated);
         _deleted_mask_version.fetch_add(1, std::memory_order_relaxed);
-        return mask;
+        return newly_deleted;
     }
 
     void SplatData::undelete(const Tensor& mask) {

--- a/src/python/lfs/py_splat_data.cpp
+++ b/src/python/lfs/py_splat_data.cpp
@@ -88,8 +88,8 @@ namespace lfs::python {
     }
 
     PyTensor PySplatData::soft_delete(const PyTensor& mask) {
-        core::Tensor prev_state = data_->soft_delete(mask.tensor());
-        return PyTensor(std::move(prev_state), true);
+        core::Tensor newly_deleted = data_->soft_delete(mask.tensor());
+        return PyTensor(std::move(newly_deleted), true);
     }
 
     void PySplatData::undelete(const PyTensor& mask) {

--- a/src/python/stubs/lichtfeld/scene.pyi
+++ b/src/python/stubs/lichtfeld/scene.pyi
@@ -87,7 +87,7 @@ class SplatData:
         """Number of visible (non-deleted) Gaussians"""
 
     def soft_delete(self, mask: lichtfeld.Tensor) -> lichtfeld.Tensor:
-        """Mark Gaussians as deleted by mask, returns previous state for undo"""
+        """Mark Gaussians as deleted by mask, returns newly deleted mask for undo"""
 
     def undelete(self, mask: lichtfeld.Tensor) -> None:
         """Restore deleted Gaussians by mask"""

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -1206,6 +1206,27 @@ namespace lfs::vis {
             };
         }
 
+        [[nodiscard]] bool matchesExceptDeletedMask(
+            const VksplatViewportRenderer::ModelInputSnapshot& a,
+            const VksplatViewportRenderer::ModelInputSnapshot& b) {
+            return a.valid() && b.valid() &&
+                   a.model == b.model &&
+                   a.count == b.count &&
+                   a.max_sh_degree == b.max_sh_degree &&
+                   a.means == b.means &&
+                   a.scaling == b.scaling &&
+                   a.rotation == b.rotation &&
+                   a.opacity == b.opacity &&
+                   a.sh0 == b.sh0 &&
+                   a.shn == b.shn &&
+                   a.means_bytes == b.means_bytes &&
+                   a.scaling_bytes == b.scaling_bytes &&
+                   a.rotation_bytes == b.rotation_bytes &&
+                   a.opacity_bytes == b.opacity_bytes &&
+                   a.sh0_bytes == b.sh0_bytes &&
+                   a.shn_bytes == b.shn_bytes;
+        }
+
         [[nodiscard]] std::shared_ptr<VulkanExternalTensorStorage> vulkanExternalStorage(
             const Tensor& tensor) {
             if (!tensor.is_valid() || !tensor.is_external_storage() ||
@@ -4186,7 +4207,13 @@ namespace lfs::vis {
         if (!external_layout) {
             return std::unexpected(external_layout.error());
         }
-        const bool input_snapshot_changed = !inputsResident(splat_data, ring_slot);
+        const auto current_input_snapshot = makeModelInputSnapshot(splat_data);
+        const auto& uploaded_input_snapshot = ring_uploaded_[ring_slot];
+        const bool input_snapshot_changed =
+            !uploaded_input_snapshot.valid() || uploaded_input_snapshot != current_input_snapshot;
+        const bool deleted_mask_only_change =
+            input_snapshot_changed &&
+            matchesExceptDeletedMask(uploaded_input_snapshot, current_input_snapshot);
         const bool input_upload_requested = force_upload || input_snapshot_changed;
 
         std::shared_ptr<VulkanExternalTensorStorage> means_storage, sh0_storage, shN_storage,
@@ -4380,7 +4407,7 @@ namespace lfs::vis {
                 buffers_.page_frames.deviceBuffer = {};
                 buffers_.quant_pool = false;
                 buffers_.pool_page_splats = 0;
-                update_input_metadata(input_snapshot_changed);
+                update_input_metadata(input_snapshot_changed && !deleted_mask_only_change);
 
                 // Keep the borrowed storages alive until the frame that binds
                 // them retires: a trainer topology reallocation may drop its
@@ -4428,13 +4455,13 @@ namespace lfs::vis {
 
             {
                 LOG_TIMER("prepareInputs.snapshot");
-                ring_uploaded_[ring_slot] = makeModelInputSnapshot(splat_data);
+                ring_uploaded_[ring_slot] = current_input_snapshot;
             }
             current_input_sh_degree_ = shN_storage ? splat_data.get_max_sh_degree()
                                                    : effective_upload_sh_degree;
             return InputBindingResult{
                 .uses_temporary_upload_slot = false,
-                .model_snapshot_changed = input_snapshot_changed,
+                .model_snapshot_changed = input_snapshot_changed && !deleted_mask_only_change,
             };
         }
 

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -1196,6 +1196,7 @@ namespace lfs::vis {
                 .sh0 = tensor_ptr(sh0),
                 .shn = tensor_ptr(shn),
                 .deleted = deleted_ptr_src ? tensor_ptr(*deleted_ptr_src) : nullptr,
+                .deleted_version = splat_data.deleted_mask_version(),
                 .means_bytes = tensor_bytes(means),
                 .scaling_bytes = tensor_bytes(scaling),
                 .rotation_bytes = tensor_bytes(rotation),

--- a/src/visualizer/rendering/vksplat_viewport_renderer.hpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.hpp
@@ -65,11 +65,11 @@ namespace lfs::vis {
             const void* opacity = nullptr;
             const void* sh0 = nullptr;
             const void* shn = nullptr;
-            // Tracking the deleted mask pointer + byte count is enough to invalidate
-            // the resident-input cache when the user soft-deletes (or undoes a
-            // delete). The renderer then re-runs the copy path so the opacity
-            // upload applies the latest mask.
+            // The pointer/size catches mask allocation or removal; the version
+            // catches in-place content edits so every input ring opacity copy is
+            // refreshed without treating the edit as a full model change.
             const void* deleted = nullptr;
+            std::uint64_t deleted_version = 0;
             std::size_t means_bytes = 0;
             std::size_t scaling_bytes = 0;
             std::size_t rotation_bytes = 0;

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -4729,6 +4729,7 @@ namespace lfs::vis {
         scene_.notifyMutation(core::Scene::MutationType::MODEL_CHANGED);
 
         if (auto* rm = services().renderingOrNull()) {
+            rm->clearCursorPreviewState();
             rm->markDirty(DirtyFlag::SPLATS | DirtyFlag::SELECTION);
         }
 

--- a/tests/test_vksplat_input_packer.cpp
+++ b/tests/test_vksplat_input_packer.cpp
@@ -468,6 +468,7 @@ TEST(VksplatInputPackerTest, SoftDeleteAndUndeleteKeepDeletedMaskStorageStable) 
     constexpr std::size_t n = 5;
     SyntheticInputs in = makeInputs(n, /*max_sh_degree=*/1, /*seed=*/0x51AFu);
     auto splat = buildSplatData(in);
+    const std::uint64_t initial_version = splat->deleted_mask_version();
 
     const auto first_mask = Tensor::from_vector(
                                 std::vector<int>{0, 1, 0, 0, 0},
@@ -479,6 +480,8 @@ TEST(VksplatInputPackerTest, SoftDeleteAndUndeleteKeepDeletedMaskStorageStable) 
     ASSERT_TRUE(splat->has_deleted_mask());
     const void* const deleted_ptr = splat->deleted().data_ptr();
     ASSERT_NE(deleted_ptr, nullptr);
+    EXPECT_GT(splat->deleted_mask_version(), initial_version);
+    const std::uint64_t first_version = splat->deleted_mask_version();
     EXPECT_EQ(splat->deleted().cpu().to_vector_bool(),
               (std::vector<bool>{false, true, false, false, false}));
 
@@ -490,6 +493,8 @@ TEST(VksplatInputPackerTest, SoftDeleteAndUndeleteKeepDeletedMaskStorageStable) 
     splat->soft_delete(second_mask);
 
     EXPECT_EQ(splat->deleted().data_ptr(), deleted_ptr);
+    EXPECT_GT(splat->deleted_mask_version(), first_version);
+    const std::uint64_t second_version = splat->deleted_mask_version();
     EXPECT_EQ(splat->deleted().cpu().to_vector_bool(),
               (std::vector<bool>{false, true, true, false, true}));
 
@@ -501,6 +506,7 @@ TEST(VksplatInputPackerTest, SoftDeleteAndUndeleteKeepDeletedMaskStorageStable) 
     splat->undelete(undelete_mask);
 
     EXPECT_EQ(splat->deleted().data_ptr(), deleted_ptr);
+    EXPECT_GT(splat->deleted_mask_version(), second_version);
     EXPECT_EQ(splat->deleted().cpu().to_vector_bool(),
               (std::vector<bool>{false, false, true, false, false}));
 }

--- a/tests/test_vksplat_input_packer.cpp
+++ b/tests/test_vksplat_input_packer.cpp
@@ -475,26 +475,30 @@ TEST(VksplatInputPackerTest, SoftDeleteAndUndeleteKeepDeletedMaskStorageStable) 
                                 {n},
                                 Device::CUDA)
                                 .to(DataType::Bool);
-    splat->soft_delete(first_mask);
+    const Tensor first_newly_deleted = splat->soft_delete(first_mask);
 
     ASSERT_TRUE(splat->has_deleted_mask());
     const void* const deleted_ptr = splat->deleted().data_ptr();
     ASSERT_NE(deleted_ptr, nullptr);
     EXPECT_GT(splat->deleted_mask_version(), initial_version);
     const std::uint64_t first_version = splat->deleted_mask_version();
+    EXPECT_EQ(first_newly_deleted.cpu().to_vector_bool(),
+              (std::vector<bool>{false, true, false, false, false}));
     EXPECT_EQ(splat->deleted().cpu().to_vector_bool(),
               (std::vector<bool>{false, true, false, false, false}));
 
     const auto second_mask = Tensor::from_vector(
-                                 std::vector<int>{0, 0, 1, 0, 1},
+                                 std::vector<int>{0, 1, 1, 0, 1},
                                  {n},
                                  Device::CUDA)
                                  .to(DataType::Bool);
-    splat->soft_delete(second_mask);
+    const Tensor second_newly_deleted = splat->soft_delete(second_mask);
 
     EXPECT_EQ(splat->deleted().data_ptr(), deleted_ptr);
     EXPECT_GT(splat->deleted_mask_version(), first_version);
     const std::uint64_t second_version = splat->deleted_mask_version();
+    EXPECT_EQ(second_newly_deleted.cpu().to_vector_bool(),
+              (std::vector<bool>{false, false, true, false, true}));
     EXPECT_EQ(splat->deleted().cpu().to_vector_bool(),
               (std::vector<bool>{false, true, true, false, true}));
 

--- a/tests/test_vksplat_input_packer.cpp
+++ b/tests/test_vksplat_input_packer.cpp
@@ -463,3 +463,44 @@ TEST(VksplatInputPackerTest, RawOpacityCopyBakesDeletedMaskOnlyIntoOpacity) {
         }
     }
 }
+
+TEST(VksplatInputPackerTest, SoftDeleteAndUndeleteKeepDeletedMaskStorageStable) {
+    constexpr std::size_t n = 5;
+    SyntheticInputs in = makeInputs(n, /*max_sh_degree=*/1, /*seed=*/0x51AFu);
+    auto splat = buildSplatData(in);
+
+    const auto first_mask = Tensor::from_vector(
+                                std::vector<int>{0, 1, 0, 0, 0},
+                                {n},
+                                Device::CUDA)
+                                .to(DataType::Bool);
+    splat->soft_delete(first_mask);
+
+    ASSERT_TRUE(splat->has_deleted_mask());
+    const void* const deleted_ptr = splat->deleted().data_ptr();
+    ASSERT_NE(deleted_ptr, nullptr);
+    EXPECT_EQ(splat->deleted().cpu().to_vector_bool(),
+              (std::vector<bool>{false, true, false, false, false}));
+
+    const auto second_mask = Tensor::from_vector(
+                                 std::vector<int>{0, 0, 1, 0, 1},
+                                 {n},
+                                 Device::CUDA)
+                                 .to(DataType::Bool);
+    splat->soft_delete(second_mask);
+
+    EXPECT_EQ(splat->deleted().data_ptr(), deleted_ptr);
+    EXPECT_EQ(splat->deleted().cpu().to_vector_bool(),
+              (std::vector<bool>{false, true, true, false, true}));
+
+    const auto undelete_mask = Tensor::from_vector(
+                                   std::vector<int>{0, 1, 0, 0, 1},
+                                   {n},
+                                   Device::CUDA)
+                                   .to(DataType::Bool);
+    splat->undelete(undelete_mask);
+
+    EXPECT_EQ(splat->deleted().data_ptr(), deleted_ptr);
+    EXPECT_EQ(splat->deleted().cpu().to_vector_bool(),
+              (std::vector<bool>{false, false, true, false, false}));
+}


### PR DESCRIPTION
## Summary

Fixes #1362 

This change fixes a black viewport flash when deleting splats while using VkSplat with ring display mode and ring selection.

The original repro was a single PLY in edit mode, no training. Deleting the hovered/selected splat caused the whole viewport to go black for one or more frames, then recover. The original capture showed this on four consecutive deletes.

## Root Cause

Soft deletion updates the model's deleted mask without changing the model pointer or scene topology. The renderer should treat that as an input-content refresh, not as a full model change.

Two details made deletes visible as black frames:

- `SplatData::soft_delete()` and `undelete()` rebound `_deleted` to a newly allocated tensor result. That changed the deleted-mask data pointer on each delete/undo.
- VkSplat's resident-input snapshot includes the deleted-mask pointer so opacity-copy uploads can honor soft deletes. The pointer change made each ring slot look like a model-input change.

That snapshot change was then reported as `model_snapshot_changed`, which set `macro_chain_warmup_pending_`. The next render temporarily fell back from the HiGS macro-tile compose chain to the legacy chain, producing the observed blink.

After keeping the mask tensor stable, the first-ever delete still had a separate first-transition issue: the mask goes from absent to present, so the renderer must allocate and upload opacity-copy buffers for the input ring. The log showed the first post-delete HiGS frame had `tile_instances count=0` because `update_input_metadata(input_snapshot_changed)` reset cached raster state on a deleted-mask-only transition. The macro chain relies on deferred instance-count readback, so clearing that cached count created one empty frame.

Follow-up manual testing also showed that after making `_deleted` stable, some deleted splats could visually reappear when selecting later rings. That happened because pointer stability removed the cache signal for in-place mask content changes: one input ring slot could still hold an older opacity-copy buffer while another had the newest mask. The final fix adds a deleted-mask content version so every ring slot refreshes its opacity copy once per mask edit.

## What Changed

### Classify Deleted-Mask-Only Snapshot Changes

`VksplatViewportRenderer::prepareInputs()` now builds the current `ModelInputSnapshot` once and compares it with the resident ring-slot snapshot.

If model pointer, splat count, SH degree, geometry/color tensor pointers, and geometry/color byte sizes all match, and only deleted-mask pointer, size, or version changed, the change is classified as a deleted-mask-only refresh.

For deleted-mask-only refreshes:

- opacity-copy upload still runs when needed;
- ring-slot snapshots still update;
- input upload behavior remains intact;
- `model_snapshot_changed` is reported as false;
- HiGS macro-chain warmup is not triggered;
- cached raster metadata is not reset.

Real model, topology, geometry, color-storage, and size changes still behave as model-input changes.

### Keep Deleted Mask Storage Stable

`SplatData::soft_delete()` and `SplatData::undelete()` now update the existing deleted-mask tensor storage in place after the first allocation:

- `soft_delete`: compute `_deleted || mask`, then `copy_from()` into `_deleted`.
- `undelete`: compute `_deleted && mask.logical_not()`, then `copy_from()` into `_deleted`.
- both operations increment `deleted_mask_version()` so renderer ring slots refresh stale opacity copies even though the mask pointer is stable.

This prevents per-delete pointer churn across all input ring slots while preserving the first allocation and `set_name("splat.deleted_mask")`.

`clear_deleted()` also increments the version when it removes an existing mask. `apply_deleted()` is intentionally unchanged because it compacts model tensors and should remain a real model/input change.

### Clear Stale Cursor Preview On Delete

`SceneManager::applySelectedGaussianDeletionPlan()` now clears the cursor preview state before marking splats/selection dirty. This prevents a deleted focused splat or transient ring preview from lingering for the delete frame.

