### PR TITLE
Fix Copy/Paste And Selection Of Soft-Deleted Splats

### DIFF
--- a/src/core/include/core/scene.hpp
+++ b/src/core/include/core/scene.hpp
@@ -469,6 +469,13 @@ namespace lfs::core {
         void updateWorldTransform(const SceneNode& node) const;
         void removeNodeInternal(const std::string& name, bool keep_children, bool force);
         [[nodiscard]] size_t currentSelectionCapacity() const;
+        [[nodiscard]] lfs::core::Tensor liveSelectionMask(size_t expected_size,
+                                                          Device device,
+                                                          DataType dtype) const;
+        [[nodiscard]] std::shared_ptr<lfs::core::Tensor> normalizeSelectionMask(
+            std::shared_ptr<lfs::core::Tensor> mask,
+            size_t expected_size,
+            size_t* selected_count = nullptr) const;
         void resizeSelectionIfSizeMismatch(size_t expected_size);
 
         SelectionGroup* findGroup(uint8_t id);

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -952,6 +952,88 @@ namespace lfs::core {
         return getSelectionGaussianCount();
     }
 
+    lfs::core::Tensor Scene::liveSelectionMask(const size_t expected_size,
+                                               const Device device,
+                                               const DataType dtype) const {
+        Tensor live = Tensor::ones({expected_size}, device, dtype);
+        if (expected_size == 0) {
+            return live;
+        }
+
+        if (consolidated_) {
+            const auto* combined = getCombinedModel();
+            if (combined &&
+                combined->has_deleted_mask() &&
+                combined->deleted().numel() == expected_size) {
+                return combined->deleted().logical_not().to(device).to(dtype);
+            }
+        }
+
+        size_t offset = 0;
+        for (const auto& node : nodes_) {
+            if (node->type != NodeType::SPLAT) {
+                continue;
+            }
+
+            const size_t node_size = node->model
+                                         ? static_cast<size_t>(node->model->size())
+                                         : node->gaussian_count.load(std::memory_order_acquire);
+            const size_t node_end = offset + node_size;
+            if (node_end > expected_size) {
+                break;
+            }
+
+            if (node->model &&
+                node->model->has_deleted_mask() &&
+                node->model->deleted().numel() == node_size) {
+                live.slice(0, offset, node_end) = node->model->deleted().logical_not().to(device).to(dtype);
+            }
+
+            offset = node_end;
+        }
+
+        return live;
+    }
+
+    std::shared_ptr<lfs::core::Tensor> Scene::normalizeSelectionMask(
+        std::shared_ptr<lfs::core::Tensor> mask,
+        const size_t expected_size,
+        size_t* selected_count) const {
+        if (selected_count) {
+            *selected_count = 0;
+        }
+        if (!mask || !mask->is_valid() || mask->numel() == 0) {
+            return nullptr;
+        }
+
+        if (mask->numel() != expected_size) {
+            const auto* visible_model = getCombinedModel();
+            const auto visible_indices = getVisibleSelectionIndices();
+            if (visible_model && static_cast<size_t>(visible_model->size()) == mask->numel() &&
+                visible_indices && visible_indices->is_valid() && visible_indices->numel() == mask->numel()) {
+                auto expanded = lfs::core::Tensor::zeros({expected_size}, mask->device(), mask->dtype());
+                expanded.index_copy_(0, *visible_indices, *mask);
+                mask = std::make_shared<lfs::core::Tensor>(std::move(expanded));
+            } else {
+                LOG_WARN("Ignoring selection_mask with stale size: scene has {}, mask has {}",
+                         expected_size, mask->numel());
+                return nullptr;
+            }
+        }
+
+        const auto live = liveSelectionMask(expected_size, mask->device(), mask->dtype());
+        auto normalized = mask->where(live.ne(0), lfs::core::Tensor::zeros({expected_size}, mask->device(), mask->dtype()));
+        const size_t count = static_cast<size_t>(normalized.ne(0).to(core::DataType::Float32).sum_scalar());
+        if (count == 0) {
+            return nullptr;
+        }
+
+        if (selected_count) {
+            *selected_count = count;
+        }
+        return std::make_shared<lfs::core::Tensor>(std::move(normalized));
+    }
+
     std::vector<const SceneNode*> Scene::getNodes() const {
         std::vector<const SceneNode*> result;
         result.reserve(nodes_.size());
@@ -1548,79 +1630,59 @@ namespace lfs::core {
             return;
         }
 
+        auto mask_cpu = lfs::core::Tensor::zeros({total}, lfs::core::Device::CPU, lfs::core::DataType::UInt8);
+        uint8_t* mask_data = mask_cpu.ptr<uint8_t>();
+        for (const size_t idx : selected_indices) {
+            if (idx < total) {
+                mask_data[idx] = 1;
+            }
+        }
+
+        size_t selected_count = 0;
+        auto normalized = normalizeSelectionMask(
+            std::make_shared<lfs::core::Tensor>(mask_cpu.cuda()),
+            total,
+            &selected_count);
+
         bool has_selection = false;
-        int count = 0;
         {
             std::unique_lock lock(selection_mutex_);
-            if (!selection_mask_ || selection_mask_->size(0) != total) {
-                selection_mask_ = std::make_shared<lfs::core::Tensor>(
-                    lfs::core::Tensor::zeros({total}, lfs::core::Device::CPU, lfs::core::DataType::UInt8));
-            } else {
-                auto mask_cpu = selection_mask_->cpu();
-                std::memset(mask_cpu.ptr<uint8_t>(), 0, total);
-                *selection_mask_ = mask_cpu;
-            }
-
-            if (!selected_indices.empty()) {
-                auto mask_cpu = selection_mask_->cpu();
-                uint8_t* mask_data = mask_cpu.ptr<uint8_t>();
-                for (size_t idx : selected_indices) {
-                    if (idx < total) {
-                        mask_data[idx] = 1;
-                    }
-                }
-                *selection_mask_ = mask_cpu.cuda();
-                has_selection_ = true;
-                has_selection = true;
-                count = static_cast<int>(selected_indices.size());
-            } else {
-                // Empty selection is equivalent to no selection.
-                selection_mask_.reset();
-                has_selection_ = false;
-            }
+            selection_mask_ = std::move(normalized);
+            has_selection_ = selection_mask_ && selection_mask_->is_valid();
+            has_selection = has_selection_;
             selection_group_counts_dirty_ = true;
         }
-        events::state::SelectionChanged{.has_selection = has_selection, .count = count}.emit();
+        events::state::SelectionChanged{
+            .has_selection = has_selection,
+            .count = static_cast<int>(std::min(selected_count, static_cast<size_t>(std::numeric_limits<int>::max())))}
+            .emit();
         notifyMutation(MutationType::SELECTION_CHANGED);
     }
 
     void Scene::setSelectionMask(std::shared_ptr<lfs::core::Tensor> mask) {
-        int count = 0;
+        size_t count = 0;
         bool has_selection = false;
         const size_t expected_size = currentSelectionCapacity();
-        if (mask && mask->is_valid() && mask->numel() > 0 &&
-            mask->numel() != expected_size) {
-            const auto* visible_model = getCombinedModel();
-            const auto visible_indices = getVisibleSelectionIndices();
-            if (visible_model && static_cast<size_t>(visible_model->size()) == mask->numel() &&
-                visible_indices && visible_indices->is_valid() && visible_indices->numel() == mask->numel()) {
-                auto expanded = lfs::core::Tensor::zeros({expected_size}, mask->device(), mask->dtype());
-                expanded.index_copy_(0, *visible_indices, *mask);
-                mask = std::make_shared<lfs::core::Tensor>(std::move(expanded));
-            } else {
-                LOG_WARN("Ignoring selection_mask with stale size: scene has {}, mask has {}",
-                         expected_size, mask->numel());
-                mask.reset();
-            }
-        }
+        mask = normalizeSelectionMask(std::move(mask), expected_size, &count);
         {
             std::unique_lock lock(selection_mutex_);
             selection_mask_ = std::move(mask);
             const bool valid =
                 selection_mask_ && selection_mask_->is_valid() && selection_mask_->numel() > 0;
-            if (valid) {
-                count = static_cast<int>(selection_mask_->ne(0).to(core::DataType::Float32).sum_scalar());
-            }
 
             // Treat an all-zero tensor as "no selection" to keep API semantics consistent.
-            has_selection_ = count > 0;
+            has_selection_ = valid && count > 0;
             has_selection = has_selection_;
             if (!has_selection_) {
                 selection_mask_.reset();
+                count = 0;
             }
             selection_group_counts_dirty_ = true;
         }
-        events::state::SelectionChanged{.has_selection = has_selection, .count = count}.emit();
+        events::state::SelectionChanged{
+            .has_selection = has_selection,
+            .count = static_cast<int>(std::min(count, static_cast<size_t>(std::numeric_limits<int>::max())))}
+            .emit();
         notifyMutation(MutationType::SELECTION_CHANGED);
     }
 
@@ -1630,22 +1692,8 @@ namespace lfs::core {
         size_t count = selected_count;
         bool has_selection = false;
         const size_t expected_size = currentSelectionCapacity();
-        if (mask && mask->is_valid() && mask->numel() > 0 &&
-            mask->numel() != expected_size) {
-            const auto* visible_model = getCombinedModel();
-            const auto visible_indices = getVisibleSelectionIndices();
-            if (visible_model && static_cast<size_t>(visible_model->size()) == mask->numel() &&
-                visible_indices && visible_indices->is_valid() && visible_indices->numel() == mask->numel()) {
-                auto expanded = lfs::core::Tensor::zeros({expected_size}, mask->device(), mask->dtype());
-                expanded.index_copy_(0, *visible_indices, *mask);
-                mask = std::make_shared<lfs::core::Tensor>(std::move(expanded));
-            } else {
-                LOG_WARN("Ignoring selection_mask with stale size: scene has {}, mask has {}",
-                         expected_size, mask->numel());
-                mask.reset();
-                count = 0;
-            }
-        }
+        mask = normalizeSelectionMask(std::move(mask), expected_size, &count);
+        const bool counts_preserved = count == selected_count;
 
         {
             std::unique_lock lock(selection_mutex_);
@@ -1661,12 +1709,13 @@ namespace lfs::core {
             }
         }
 
-        if (has_selection) {
+        if (has_selection && counts_preserved) {
             applySelectionGroupCounts(group_counts);
+            selection_group_counts_dirty_ = false;
         } else {
             clearSelectionGroupCounts();
+            selection_group_counts_dirty_ = has_selection;
         }
-        selection_group_counts_dirty_ = false;
 
         events::state::SelectionChanged{
             .has_selection = has_selection,
@@ -1732,10 +1781,10 @@ namespace lfs::core {
                                   ? std::make_shared<lfs::core::Tensor>(snapshot.mask->clone())
                                   : nullptr;
             has_selection_ = has_selection;
+            selection_group_counts_dirty_ = false;
             if (has_selection_) {
                 count = static_cast<int>(selection_mask_->ne(0).to(core::DataType::Float32).sum_scalar());
             }
-            selection_group_counts_dirty_ = false;
         }
 
         selection_groups_ = snapshot.groups;

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -1023,7 +1023,7 @@ namespace lfs::core {
 
         const auto live = liveSelectionMask(expected_size, mask->device(), mask->dtype());
         auto normalized = mask->where(live.ne(0), lfs::core::Tensor::zeros({expected_size}, mask->device(), mask->dtype()));
-        const size_t count = static_cast<size_t>(normalized.ne(0).to(core::DataType::Float32).sum_scalar());
+        const size_t count = normalized.count_nonzero();
         if (count == 0) {
             return nullptr;
         }

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -4266,10 +4266,16 @@ namespace lfs::vis {
         const auto add_selected_chunk = [&](const lfs::core::SplatData& src,
                                             lfs::core::Tensor mask,
                                             const glm::mat4& world_transform) {
-            if (mask.numel() != static_cast<size_t>(src.size()) || mask.count_nonzero() == 0)
+            if (mask.numel() != static_cast<size_t>(src.size()))
                 return;
 
             mask = mask.to(src.means_raw().device());
+            if (src.has_deleted_mask() && src.deleted().numel() == static_cast<size_t>(src.size())) {
+                mask = mask.logical_and(src.deleted().logical_not().to(mask.device()));
+            }
+            if (mask.count_nonzero() == 0)
+                return;
+
             auto extracted = std::make_unique<lfs::core::SplatData>(
                 lfs::core::extract_by_mask(src, mask));
             if (extracted->size() == 0)
@@ -4447,16 +4453,28 @@ namespace lfs::vis {
 
         for (auto* node : nodes) {
             auto& model = *node->model;
-            const size_t count = use_selection ? selection_count : model.size();
-            total_count += count;
-
             auto mask = use_selection
                             ? scene_mask
                             : std::make_shared<lfs::core::Tensor>(lfs::core::Tensor::ones(
                                   {model.size()}, model.means().device(), lfs::core::DataType::UInt8));
+            if (model.has_deleted_mask() && model.deleted().numel() == static_cast<size_t>(model.size())) {
+                auto live_mask = mask->to(lfs::core::DataType::Bool)
+                                     .logical_and(model.deleted().logical_not().to(mask->device()));
+                mask = std::make_shared<lfs::core::Tensor>(std::move(live_mask));
+            }
+            const size_t count = static_cast<size_t>(mask->count_nonzero());
+            if (count == 0) {
+                continue;
+            }
+            total_count += count;
 
             const auto center = lfs::core::compute_selection_center(model, *mask);
             lfs::core::mirror_gaussians(model, *mask, axis, center);
+        }
+
+        if (total_count == 0) {
+            LOG_WARN("Mirror: no live selected gaussians");
+            return false;
         }
 
         scene_.notifyMutation(core::Scene::MutationType::MODEL_CHANGED);
@@ -4627,6 +4645,14 @@ namespace lfs::vis {
             if (static_cast<size_t>(plan.selection_mask.numel()) != static_cast<size_t>(combined->size())) {
                 return std::unexpected("Selection size mismatch");
             }
+            if (combined->has_deleted_mask() &&
+                combined->deleted().numel() == static_cast<size_t>(combined->size())) {
+                plan.selection_mask = plan.selection_mask.logical_and(
+                    combined->deleted().logical_not().to(plan.selection_mask.device()));
+                if (plan.selection_mask.count_nonzero() == 0) {
+                    return std::unexpected("Nothing selected");
+                }
+            }
 
             plan.consolidated = true;
             plan.any_visible_node = true;
@@ -4659,6 +4685,13 @@ namespace lfs::vis {
                     return std::unexpected(std::format("Visible node '{}' is missing a mutable model", node->name));
                 }
 
+                if (mutable_node->model->has_deleted_mask() &&
+                    mutable_node->model->deleted().numel() == node_size) {
+                    auto slice = plan.selection_mask.slice(0, offset, node_end);
+                    slice = slice.logical_and(mutable_node->model->deleted().logical_not().to(slice.device()));
+                    plan.selection_mask.slice(0, offset, node_end) = slice;
+                }
+
                 const size_t selected_count = plan.selection_mask.slice(0, offset, node_end).count_nonzero();
                 if (selected_count == node_size) {
                     plan.removed_node_names.push_back(node->name);
@@ -4678,6 +4711,10 @@ namespace lfs::vis {
             if (offset != full_total) {
                 return std::unexpected("Selection size mismatch");
             }
+        }
+
+        if (plan.selection_mask.count_nonzero() == 0) {
+            return std::unexpected("Nothing selected");
         }
 
         return plan;

--- a/src/visualizer/selection/selection_service.cpp
+++ b/src/visualizer/selection/selection_service.cpp
@@ -2110,6 +2110,12 @@ namespace lfs::vis {
             LOG_TIMER("commitSelection.setSelectionMask");
             scene.setSelectionMaskWithGroupCounts(new_selection, selected_count, group_counts);
         }
+        if (const auto normalized_selection = scene.getSelectionMask();
+            normalized_selection && normalized_selection->is_valid()) {
+            selected_count = static_cast<size_t>(normalized_selection->ne(0).sum_scalar());
+        } else {
+            selected_count = 0;
+        }
 
         if (entry) {
             {

--- a/src/visualizer/selection/selection_service.cpp
+++ b/src/visualizer/selection/selection_service.cpp
@@ -2112,7 +2112,7 @@ namespace lfs::vis {
         }
         if (const auto normalized_selection = scene.getSelectionMask();
             normalized_selection && normalized_selection->is_valid()) {
-            selected_count = static_cast<size_t>(normalized_selection->ne(0).sum_scalar());
+            selected_count = normalized_selection->count_nonzero();
         } else {
             selected_count = 0;
         }

--- a/tests/test_undo_history.cpp
+++ b/tests/test_undo_history.cpp
@@ -206,6 +206,16 @@ namespace {
         return mask->cpu().to_vector_uint8();
     }
 
+    std::vector<float> mean_x_values(const lfs::core::SplatData& splat) {
+        const auto means = splat.means_raw().cpu().to_vector();
+        std::vector<float> xs;
+        xs.reserve(static_cast<size_t>(splat.size()));
+        for (size_t i = 0; i < static_cast<size_t>(splat.size()); ++i) {
+            xs.push_back(means[i * 3]);
+        }
+        return xs;
+    }
+
 } // namespace
 
 class UndoHistoryTest : public ::testing::Test {
@@ -1221,6 +1231,91 @@ TEST_F(UndoHistoryTest, CutSelectedGaussiansCopiesAndUndoRestoresDelete) {
     ASSERT_TRUE(undo_result.success) << undo_result.error;
     EXPECT_FALSE(node->model->has_deleted_mask());
     EXPECT_TRUE(scene_manager->hasGaussianClipboard());
+}
+
+TEST_F(UndoHistoryTest, GaussianSelectionIgnoresSoftDeletedRowsForAllSelectionSources) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    scene_manager->getScene().addSplat("model", make_linear_test_splat(4));
+    auto* node = scene_manager->getScene().getNode("model");
+    ASSERT_NE(node, nullptr);
+    ASSERT_NE(node->model, nullptr);
+    node->model->soft_delete(make_uint8_mask({0, 1, 0, 1}).to(DataType::Bool));
+
+    scene_manager->getScene().setSelectionMask(
+        std::make_shared<Tensor>(make_uint8_mask({1, 1, 1, 1})));
+
+    EXPECT_EQ(selection_mask_values(scene_manager->getScene()), (std::vector<uint8_t>{1, 0, 1, 0}));
+    EXPECT_TRUE(scene_manager->copySelectedGaussians());
+
+    const auto pasted = scene_manager->pasteGaussians();
+    ASSERT_EQ(pasted.size(), 1u);
+    const auto* pasted_node = scene_manager->getScene().getNode(pasted.front());
+    ASSERT_NE(pasted_node, nullptr);
+    ASSERT_NE(pasted_node->model, nullptr);
+    EXPECT_EQ(pasted_node->model->size(), 2);
+    EXPECT_FALSE(pasted_node->model->has_deleted_mask());
+    EXPECT_EQ(mean_x_values(*pasted_node->model), (std::vector<float>{0.0f, 2.0f}));
+}
+
+TEST_F(UndoHistoryTest, SelectingOnlySoftDeletedRowsClearsSelectionAndClipboard) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    scene_manager->getScene().addSplat("model", make_linear_test_splat(4));
+    auto* node = scene_manager->getScene().getNode("model");
+    ASSERT_NE(node, nullptr);
+    ASSERT_NE(node->model, nullptr);
+    node->model->soft_delete(make_uint8_mask({0, 1, 0, 1}).to(DataType::Bool));
+
+    scene_manager->getScene().setSelectionMask(
+        std::make_shared<Tensor>(make_uint8_mask({0, 1, 0, 1})));
+
+    EXPECT_TRUE(selection_mask_values(scene_manager->getScene()).empty());
+    EXPECT_FALSE(scene_manager->copySelectedGaussians());
+    EXPECT_FALSE(scene_manager->hasGaussianClipboard());
+}
+
+TEST_F(UndoHistoryTest, DeleteAndMirrorUseOnlyLiveRowsFromMixedSelection) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    scene_manager->getScene().addSplat("delete_model", make_linear_test_splat(3));
+    auto* delete_node = scene_manager->getScene().getNode("delete_model");
+    ASSERT_NE(delete_node, nullptr);
+    ASSERT_NE(delete_node->model, nullptr);
+    delete_node->model->soft_delete(make_uint8_mask({0, 1, 0}).to(DataType::Bool));
+    scene_manager->getScene().setSelectionMask(
+        std::make_shared<Tensor>(make_uint8_mask({0, 1, 1})));
+
+    scene_manager->deleteSelectedGaussians();
+
+    EXPECT_EQ(deleted_mask_values(*delete_node->model), (std::vector<bool>{false, true, true}));
+
+    auto mirror_scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto mirror_rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(mirror_scene_manager.get());
+    lfs::vis::services().set(mirror_rendering_manager.get());
+
+    mirror_scene_manager->getScene().addSplat("mirror_model", make_linear_test_splat(3));
+    auto* mirror_node = mirror_scene_manager->getScene().getNode("mirror_model");
+    ASSERT_NE(mirror_node, nullptr);
+    ASSERT_NE(mirror_node->model, nullptr);
+    mirror_node->model->soft_delete(make_uint8_mask({0, 1, 0}).to(DataType::Bool));
+    mirror_scene_manager->selectNodes({"mirror_model"});
+    mirror_scene_manager->getScene().setSelectionMask(
+        std::make_shared<Tensor>(make_uint8_mask({1, 1, 1})));
+
+    EXPECT_TRUE(mirror_scene_manager->executeMirror(lfs::core::MirrorAxis::X));
+
+    EXPECT_EQ(mean_x_values(*mirror_node->model), (std::vector<float>{2.0f, 1.0f, 0.0f}));
 }
 
 TEST_F(UndoHistoryTest, TopologyUndoRoundTripsVisibleNodeDeleteWithHiddenSibling) {


### PR DESCRIPTION
## Problem

Soft-deleted splats could still be included in Gaussian-level selection workflows. After deleting splats with the edit tools, the rows remained in `SplatData` behind a `_deleted` mask, but some selection and clipboard paths continued to operate on raw row indices without excluding those deleted rows.

This made invisible/deleted splats reappear or move through later user actions:

- `Ctrl-A`, then copy/paste, could paste splats that had already been soft-deleted.
- Brush/rectangle/lasso selections over regions containing deleted splats could include invisible rows.
- Cut inherited the same issue because it copies before deleting.
- Transform/mirror operations could affect stale selections that still overlapped deleted rows.

## Replication steps:
- load a splat
- select part of the splat using the (brush) selection tool and delete the selected splats (splats are deleted - ok)
- perform a ctrl-A to select all remaining splats (remaining splats are selected - ok)
- press ctrl-C (copy selected splats) and ctrl-V (paste selected splats)
- result: all splats (also the previously deleted splats) are pasted into a new splat (nok - only the remaining splats should be copied)

this also happens in the following scenario:
- load a splat
- select part of the splat using the (brush) selection tool and delete the selected splats (splats are deleted - ok)
- select a second part with brush - make sure to stroke splats that were previously present but now deleted
- copy / paste: result: not only the last selected splats are pasted, but also plats that were deleted

## Root Cause

Soft deletion is represented as data, not immediate row removal. The deleted rows remain in the model until compaction/export/apply-deleted style paths physically remove them.

Most rendering paths correctly treat `_deleted` as hidden, but selection masks and copy masks are still masks over model rows. If those masks are not intersected with `!deleted`, deleted rows can continue to flow through:

- `copySelectedGaussians()` extracts selected rows using `extract_by_mask()`.
- `SelectionService::commitSelection()` funnels most selection tools through `applyFilters()`.
- Some `SceneManager` fallback selection commands build full-scene masks directly.

The bug was not in `extract_by_mask()` itself. That helper intentionally extracts raw rows and is used by other systems that need raw-row semantics. The missing behavior was at the user-facing selection/copy boundaries.

## Chosen Solution

The fix treats deleted splats as unselectable and uncopyable at the command boundaries, while leaving raw extraction semantics unchanged.

### 1. Filter Deleted Splats During Copy

`SceneManager::copySelectedGaussians()` now intersects each selected chunk mask with the source model's deleted mask:

```cpp
mask = mask.logical_and(src.deleted().logical_not().to(mask.device()));
```

This applies to both consolidated scenes and per-node scenes because both branches pass through the same `add_selected_chunk` lambda. `cutSelectedGaussians()` also inherits the fix because it calls `copySelectedGaussians()` before deleting.

If everything selected was already deleted, the chunk becomes empty and the copy becomes a no-op instead of repopulating the clipboard with invisible rows.

### 2. Make Deleted Splats Unselectable

The central selection filtering path should remove deleted rows unconditionally in `SelectionService::applyFilters()`. That covers brush, rectangle, lasso, sphere, `Ctrl-A` through filtered selection, invert filtered selection, and direct mask application because they all flow through `commitSelection()` and `applyFilters()`.

The deleted-mask filter is guarded by a size check so scene-wide masks are not incorrectly combined with render-model masks in mismatched multi-node cases.

### 3. Cover SceneManager Fallback Selection Paths

Some fallback paths in `SceneManager` build selection masks directly instead of going through `SelectionService`:

- `invertSelection()`
- `selectAllGaussians()` fallback behavior

Those masks should also be intersected with `!deleted`, using consolidated-model deleted state when available and per-node deleted masks for non-consolidated scenes.

## Why This Approach

This keeps the behavior local to user-facing selection and clipboard operations:

- It does not change `extract_by_mask()`, preserving existing raw-row callers such as trainer/export paths.
- It handles copy, cut, selection, and transforms from stale masks without requiring immediate physical compaction.
- It works for both consolidated multi-splat scenes and single/per-node splat scenes.
- It keeps undo semantics intact: undoing a delete restores the deleted flags and the selection snapshot together, so restored splats can be selected and copied again.

## Verification Plan

- Load a scene, brush-delete part of it, then `Ctrl-A`, copy, and paste. The pasted node should contain only visible splats.
- Delete part of a scene, brush over an area overlapping deleted splats, then copy/paste. Only visible brushed splats should paste.
- After deletions, `Ctrl-A` should select the visible splat count, not the total row count.
- `Ctrl-X` followed by paste should behave the same as copy/paste.
- Undo the delete, then `Ctrl-A` and copy again. Restored splats should copy normally.
- Transform or mirror a selection near deleted regions, then undo the delete. Restored splats should remain in their original positions.
- Verify both consolidated multi-splat scenes and single/per-node splat scenes.
