### PR TITLE
Optimize COLMAP `points3D.txt` Loading

### DIFF
--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -1411,6 +1411,7 @@ namespace lfs::io {
 
             const auto chunks = split_line_aligned_chunks(std::span<const char>(*buffer));
             std::vector<RecordChunkResult> results(chunks.size());
+            // oneTBB propagates parse/cancellation exceptions to the caller and cancels sibling work.
             tbb::parallel_for(size_t{0}, chunks.size(), [&](const size_t chunk_index) {
                 const auto& chunk = chunks[chunk_index];
                 auto& result = results[chunk_index];
@@ -1439,6 +1440,11 @@ namespace lfs::io {
             }
         }
         buffer.reset();
+
+        if (points.empty()) {
+            LOG_ERROR("No valid points found in {}", lfs::core::path_to_utf8(file_path));
+            throw std::runtime_error("No valid points in points3D.txt");
+        }
 
         LOG_DEBUG("Reading {} 3D points from text file", points.size());
         const char* mode_name = track_mode == TrackParseMode::Full ? "full" : (track_mode == TrackParseMode::CountOnly ? "count_only" : "none");
@@ -1493,14 +1499,15 @@ namespace lfs::io {
 
         detail::ColmapPoint3DTextPointCloudData data;
         data.byte_size = file_size_ec ? 0 : byte_size;
-        if (!file_size_ec) {
-            const auto estimated_points = static_cast<size_t>(std::max<uintmax_t>(byte_size / 96, 1));
-            data.positions.reserve(estimated_points * 3);
-            data.colors.reserve(estimated_points * 3);
-        }
 
         auto buffer = read_binary(file_path);
         if (buffer->size() < POINTS3D_PARALLEL_MIN_BYTES) {
+            if (!file_size_ec) {
+                const auto estimated_points = static_cast<size_t>(std::max<uintmax_t>(byte_size / 96, 1));
+                data.positions.reserve(estimated_points * 3);
+                data.colors.reserve(estimated_points * 3);
+            }
+
             data.file_lines = for_each_data_line(
                 std::span<const char>(*buffer),
                 options,
@@ -1518,6 +1525,7 @@ namespace lfs::io {
 
             const auto chunks = split_line_aligned_chunks(std::span<const char>(*buffer));
             std::vector<PointCloudChunkResult> results(chunks.size());
+            // oneTBB propagates parse/cancellation exceptions to the caller and cancels sibling work.
             tbb::parallel_for(size_t{0}, chunks.size(), [&](const size_t chunk_index) {
                 const auto& chunk = chunks[chunk_index];
                 auto& result = results[chunk_index];

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -75,6 +75,39 @@ namespace lfs::io {
             return true;
         }
 
+        enum class TrackParseMode {
+            None,
+            CountOnly,
+            Full
+        };
+
+        TrackParseMode to_internal_track_parse_mode(const detail::ColmapPoint3DTrackParseMode mode) {
+            switch (mode) {
+            case detail::ColmapPoint3DTrackParseMode::None:
+                return TrackParseMode::None;
+            case detail::ColmapPoint3DTrackParseMode::CountOnly:
+                return TrackParseMode::CountOnly;
+            case detail::ColmapPoint3DTrackParseMode::Full:
+                return TrackParseMode::Full;
+            }
+            return TrackParseMode::Full;
+        }
+
+        size_t count_remaining_track_pairs(const char* cur, const char* end) {
+            size_t tokens = 0;
+            bool in_token = false;
+            while (cur < end) {
+                if (*cur == ' ' || *cur == '\t') {
+                    in_token = false;
+                } else if (!in_token) {
+                    in_token = true;
+                    ++tokens;
+                }
+                ++cur;
+            }
+            return tokens / 2;
+        }
+
         template <typename LineFn>
         size_t for_each_data_line(std::span<const char> buffer,
                                   const LoadOptions& options,
@@ -170,6 +203,7 @@ namespace lfs::io {
         double xyz[3] = {0.0, 0.0, 0.0};
         uint8_t color[3] = {255, 255, 255};
         double error = 0.0;
+        size_t track_count = 0;
         std::vector<Point3DTrackElement> track;
     };
 
@@ -796,6 +830,7 @@ namespace lfs::io {
 
             point.error = read_f64(cur);
             const uint64_t track_len = read_u64(cur);
+            point.track_count = static_cast<size_t>(track_len);
             point.track.reserve(track_len);
             for (uint64_t j = 0; j < track_len; ++j) {
                 Point3DTrackElement track;
@@ -852,7 +887,7 @@ namespace lfs::io {
         if (min_track_length > 0) {
             const auto min_track = static_cast<size_t>(min_track_length);
             std::erase_if(points, [min_track](const Point3DData& point) {
-                return point.track.size() < min_track;
+                return point.track_count < min_track;
             });
             result.points_after_filtering = points.size();
         }
@@ -1212,52 +1247,21 @@ namespace lfs::io {
     // -----------------------------------------------------------------------------
     std::vector<Point3DData> read_point3D_text_records(const std::filesystem::path& file_path,
                                                        const LoadOptions& options = {},
-                                                       const bool parse_tracks = true) {
+                                                       const TrackParseMode track_mode = TrackParseMode::Full) {
         LOG_TIMER_TRACE("Read points3D.txt");
-        auto lines = read_text_file(file_path, options);
+        auto buffer = read_binary(file_path);
         const auto parse_start = std::chrono::high_resolution_clock::now();
-        uint64_t N = lines.size();
-        LOG_DEBUG("Reading {} 3D points from text file", N);
 
         std::vector<Point3DData> points;
-        points.reserve(N);
+        points.reserve(std::max<size_t>(buffer->size() / 96, 1));
         size_t total_track_elements = 0;
+        size_t file_lines = 0;
 
-        for (uint64_t i = 0; i < N; ++i) {
-            if (should_poll_cancel(static_cast<size_t>(i))) {
-                throw_if_load_cancel_requested(options, "COLMAP point cloud parse cancelled");
-            }
-            const auto& line = lines[i];
-
-            if (parse_tracks) {
-                const auto tokens = split_string(line, ' ');
-
-                if (tokens.size() < 8) {
-                    LOG_ERROR("Invalid format in points3D.txt: {}", line);
-                    throw std::runtime_error("Invalid format in points3D.txt");
-                }
-
-                Point3DData point;
-                point.point3D_id = std::stoull(tokens[0]);
-                point.xyz[0] = std::stod(tokens[1]);
-                point.xyz[1] = std::stod(tokens[2]);
-                point.xyz[2] = std::stod(tokens[3]);
-
-                point.color[0] = static_cast<uint8_t>(std::stoi(tokens[4]));
-                point.color[1] = static_cast<uint8_t>(std::stoi(tokens[5]));
-                point.color[2] = static_cast<uint8_t>(std::stoi(tokens[6]));
-                point.error = std::stod(tokens[7]);
-
-                for (size_t j = 8; j + 1 < tokens.size(); j += 2) {
-                    point.track.push_back(Point3DTrackElement{
-                        .image_id = static_cast<uint32_t>(std::stoul(tokens[j])),
-                        .point2D_idx = static_cast<uint32_t>(std::stoul(tokens[j + 1])),
-                    });
-                    ++total_track_elements;
-                }
-
-                points.push_back(std::move(point));
-            } else {
+        file_lines = for_each_data_line(
+            std::span<const char>(*buffer),
+            options,
+            "COLMAP point cloud parse cancelled",
+            [&](const std::string_view line, size_t) {
                 const char* cur = line.data();
                 const char* end = cur + line.size();
 
@@ -1273,23 +1277,80 @@ namespace lfs::io {
                     !parse_next_number(cur, end, green) ||
                     !parse_next_number(cur, end, blue) ||
                     !parse_next_number(cur, end, point.error)) {
-                    LOG_ERROR("Invalid format in points3D.txt: {}", line);
+                    LOG_ERROR("Invalid format in points3D.txt: {}", std::string(line));
                     throw std::runtime_error("Invalid format in points3D.txt");
                 }
 
                 point.color[0] = static_cast<uint8_t>(red);
                 point.color[1] = static_cast<uint8_t>(green);
                 point.color[2] = static_cast<uint8_t>(blue);
-                points.push_back(std::move(point));
-            }
-        }
 
-        LOG_INFO("[COLMAP_LOAD] parse points3D.txt points={} track_elements={} parse_tracks={} elapsed_ms={:.2f}",
+                if (track_mode == TrackParseMode::CountOnly) {
+                    point.track_count = count_remaining_track_pairs(cur, end);
+                    total_track_elements += point.track_count;
+                } else if (track_mode == TrackParseMode::Full) {
+                    const size_t estimated_pairs = static_cast<size_t>(std::max<std::ptrdiff_t>((end - cur) / 12, 0));
+                    point.track.reserve(estimated_pairs);
+                    while (true) {
+                        Point3DTrackElement track;
+                        if (!parse_next_number(cur, end, track.image_id)) {
+                            break;
+                        }
+                        if (!parse_next_number(cur, end, track.point2D_idx)) {
+                            break;
+                        }
+                        point.track.push_back(track);
+                    }
+                    point.track_count = point.track.size();
+                    total_track_elements += point.track_count;
+                }
+
+                points.push_back(std::move(point));
+            });
+        buffer.reset();
+
+        LOG_DEBUG("Reading {} 3D points from text file", points.size());
+        const char* mode_name = track_mode == TrackParseMode::Full ? "full" : (track_mode == TrackParseMode::CountOnly ? "count_only" : "none");
+        LOG_INFO("[COLMAP_LOAD] parse points3D.txt points={} track_elements={} parse_tracks={} mode={} file_lines={} elapsed_ms={:.2f}",
                  points.size(),
                  total_track_elements,
-                 parse_tracks,
+                 track_mode == TrackParseMode::Full,
+                 mode_name,
+                 file_lines,
                  elapsed_ms(parse_start));
         return points;
+    }
+
+    std::vector<detail::ColmapPoint3DTextRecordData> detail::parse_points3D_text_records_for_test(
+        const std::filesystem::path& file_path,
+        const ColmapPoint3DTrackParseMode track_mode,
+        const LoadOptions& options) {
+        auto internal_records = read_point3D_text_records(file_path, options, to_internal_track_parse_mode(track_mode));
+        std::vector<ColmapPoint3DTextRecordData> records;
+        records.reserve(internal_records.size());
+
+        for (const auto& point : internal_records) {
+            ColmapPoint3DTextRecordData record;
+            record.point3D_id = point.point3D_id;
+            record.xyz[0] = point.xyz[0];
+            record.xyz[1] = point.xyz[1];
+            record.xyz[2] = point.xyz[2];
+            record.color[0] = point.color[0];
+            record.color[1] = point.color[1];
+            record.color[2] = point.color[2];
+            record.error = point.error;
+            record.track_count = point.track_count;
+            record.track.reserve(point.track.size());
+            for (const auto& track : point.track) {
+                record.track.push_back(ColmapPoint3DTrackElementData{
+                    .image_id = track.image_id,
+                    .point2D_idx = track.point2D_idx,
+                });
+            }
+            records.push_back(std::move(record));
+        }
+
+        return records;
     }
 
     detail::ColmapPoint3DTextPointCloudData detail::parse_points3D_text_point_cloud_fast(
@@ -2365,7 +2426,7 @@ namespace lfs::io {
         LOG_TIMER_TRACE("Read COLMAP point cloud (text)");
         fs::path points3d_file = get_sparse_file_path(filepath, "points3D.txt");
         return point3D_records_to_point_cloud_with_stats(
-            read_point3D_text_records(points3d_file, options, true),
+            read_point3D_text_records(points3d_file, options, TrackParseMode::CountOnly),
             options);
     }
 

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -8,6 +8,7 @@
 #include "core/path_utils.hpp"
 #include "io/filesystem_utils.hpp"
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <charconv>
 #include <chrono>
@@ -18,6 +19,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <span>
@@ -25,6 +27,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <system_error>
+#include <tbb/parallel_for.h>
 #include <unordered_map>
 #include <vector>
 
@@ -42,6 +45,8 @@ namespace lfs::io {
     namespace {
         constexpr size_t CANCEL_POLL_INTERVAL = 64;
         constexpr size_t IMAGE_METADATA_PROBE_LIMIT = 8192;
+        constexpr size_t POINTS3D_PARALLEL_MIN_BYTES = 16ull * 1024ull * 1024ull;
+        constexpr size_t POINTS3D_TARGET_CHUNK_BYTES = 8ull * 1024ull * 1024ull;
 
         [[nodiscard]] bool should_poll_cancel(const size_t index) {
             return (index % CANCEL_POLL_INTERVAL) == 0;
@@ -106,6 +111,39 @@ namespace lfs::io {
                 ++cur;
             }
             return tokens / 2;
+        }
+
+        struct TextChunk {
+            const char* begin = nullptr;
+            const char* end = nullptr;
+        };
+
+        std::vector<TextChunk> split_line_aligned_chunks(std::span<const char> buffer,
+                                                         const size_t target_chunk_bytes = POINTS3D_TARGET_CHUNK_BYTES) {
+            std::vector<TextChunk> chunks;
+            if (buffer.empty()) {
+                return chunks;
+            }
+
+            const char* base = buffer.data();
+            const char* end = base + buffer.size();
+            const size_t nominal_chunks = std::max<size_t>(1, buffer.size() / std::max<size_t>(target_chunk_bytes, 1));
+            chunks.reserve(nominal_chunks + 1);
+
+            const char* chunk_begin = base;
+            while (chunk_begin < end) {
+                const char* nominal_end = chunk_begin + std::min<size_t>(target_chunk_bytes, static_cast<size_t>(end - chunk_begin));
+                const char* chunk_end = end;
+                if (nominal_end < end) {
+                    const void* newline = std::memchr(nominal_end, '\n', static_cast<size_t>(end - nominal_end));
+                    chunk_end = newline ? static_cast<const char*>(newline) + 1 : end;
+                }
+
+                chunks.push_back(TextChunk{.begin = chunk_begin, .end = chunk_end});
+                chunk_begin = chunk_end;
+            }
+
+            return chunks;
         }
 
         template <typename LineFn>
@@ -206,6 +244,103 @@ namespace lfs::io {
         size_t track_count = 0;
         std::vector<Point3DTrackElement> track;
     };
+
+    namespace {
+        bool parse_point3D_header(const std::string_view line,
+                                  Point3DData& point,
+                                  const char*& cur,
+                                  const char*& end) {
+            cur = line.data();
+            end = cur + line.size();
+            int red = 255;
+            int green = 255;
+            int blue = 255;
+            if (!parse_next_number(cur, end, point.point3D_id) ||
+                !parse_next_number(cur, end, point.xyz[0]) ||
+                !parse_next_number(cur, end, point.xyz[1]) ||
+                !parse_next_number(cur, end, point.xyz[2]) ||
+                !parse_next_number(cur, end, red) ||
+                !parse_next_number(cur, end, green) ||
+                !parse_next_number(cur, end, blue) ||
+                !parse_next_number(cur, end, point.error)) {
+                return false;
+            }
+
+            point.color[0] = static_cast<uint8_t>(red);
+            point.color[1] = static_cast<uint8_t>(green);
+            point.color[2] = static_cast<uint8_t>(blue);
+            return true;
+        }
+
+        void parse_point3D_record_line(const std::string_view line,
+                                       const TrackParseMode track_mode,
+                                       Point3DData& point,
+                                       size_t& total_track_elements) {
+            const char* cur = nullptr;
+            const char* end = nullptr;
+            if (!parse_point3D_header(line, point, cur, end)) {
+                LOG_ERROR("Invalid format in points3D.txt: {}", std::string(line));
+                throw std::runtime_error("Invalid format in points3D.txt");
+            }
+
+            if (track_mode == TrackParseMode::CountOnly) {
+                point.track_count = count_remaining_track_pairs(cur, end);
+                total_track_elements += point.track_count;
+            } else if (track_mode == TrackParseMode::Full) {
+                const size_t estimated_pairs = static_cast<size_t>(std::max<std::ptrdiff_t>((end - cur) / 12, 0));
+                point.track.reserve(estimated_pairs);
+                while (true) {
+                    Point3DTrackElement track;
+                    if (!parse_next_number(cur, end, track.image_id)) {
+                        break;
+                    }
+                    if (!parse_next_number(cur, end, track.point2D_idx)) {
+                        break;
+                    }
+                    point.track.push_back(track);
+                }
+                point.track_count = point.track.size();
+                total_track_elements += point.track_count;
+            }
+        }
+
+        void parse_point3D_point_cloud_line(const std::string_view line,
+                                            std::vector<float>& positions,
+                                            std::vector<uint8_t>& colors,
+                                            size_t& point_count) {
+            const char* cur = line.data();
+            const char* end = cur + line.size();
+            uint64_t point_id = 0;
+            float x = 0.0f;
+            float y = 0.0f;
+            float z = 0.0f;
+            int red = 255;
+            int green = 255;
+            int blue = 255;
+            double error = 0.0;
+            if (!parse_next_number(cur, end, point_id) ||
+                !parse_next_number(cur, end, x) ||
+                !parse_next_number(cur, end, y) ||
+                !parse_next_number(cur, end, z) ||
+                !parse_next_number(cur, end, red) ||
+                !parse_next_number(cur, end, green) ||
+                !parse_next_number(cur, end, blue) ||
+                !parse_next_number(cur, end, error)) {
+                LOG_ERROR("Invalid format in points3D.txt: {}", std::string(line));
+                throw std::runtime_error("Invalid format in points3D.txt");
+            }
+            (void)point_id;
+            (void)error;
+
+            positions.push_back(x);
+            positions.push_back(y);
+            positions.push_back(z);
+            colors.push_back(static_cast<uint8_t>(red));
+            colors.push_back(static_cast<uint8_t>(green));
+            colors.push_back(static_cast<uint8_t>(blue));
+            ++point_count;
+        }
+    } // namespace
 
     // -----------------------------------------------------------------------------
     //  Camera data structure (intermediate)
@@ -1252,61 +1387,57 @@ namespace lfs::io {
         auto buffer = read_binary(file_path);
         const auto parse_start = std::chrono::high_resolution_clock::now();
 
-        std::vector<Point3DData> points;
-        points.reserve(std::max<size_t>(buffer->size() / 96, 1));
         size_t total_track_elements = 0;
         size_t file_lines = 0;
+        std::vector<Point3DData> points;
 
-        file_lines = for_each_data_line(
-            std::span<const char>(*buffer),
-            options,
-            "COLMAP point cloud parse cancelled",
-            [&](const std::string_view line, size_t) {
-                const char* cur = line.data();
-                const char* end = cur + line.size();
-
+        if (buffer->size() < POINTS3D_PARALLEL_MIN_BYTES) {
+            points.reserve(std::max<size_t>(buffer->size() / 96, 1));
+            file_lines = for_each_data_line(
+                std::span<const char>(*buffer),
+                options,
+                "COLMAP point cloud parse cancelled",
+                [&](const std::string_view line, size_t) {
                 Point3DData point;
-                int red = 255;
-                int green = 255;
-                int blue = 255;
-                if (!parse_next_number(cur, end, point.point3D_id) ||
-                    !parse_next_number(cur, end, point.xyz[0]) ||
-                    !parse_next_number(cur, end, point.xyz[1]) ||
-                    !parse_next_number(cur, end, point.xyz[2]) ||
-                    !parse_next_number(cur, end, red) ||
-                    !parse_next_number(cur, end, green) ||
-                    !parse_next_number(cur, end, blue) ||
-                    !parse_next_number(cur, end, point.error)) {
-                    LOG_ERROR("Invalid format in points3D.txt: {}", std::string(line));
-                    throw std::runtime_error("Invalid format in points3D.txt");
-                }
-
-                point.color[0] = static_cast<uint8_t>(red);
-                point.color[1] = static_cast<uint8_t>(green);
-                point.color[2] = static_cast<uint8_t>(blue);
-
-                if (track_mode == TrackParseMode::CountOnly) {
-                    point.track_count = count_remaining_track_pairs(cur, end);
-                    total_track_elements += point.track_count;
-                } else if (track_mode == TrackParseMode::Full) {
-                    const size_t estimated_pairs = static_cast<size_t>(std::max<std::ptrdiff_t>((end - cur) / 12, 0));
-                    point.track.reserve(estimated_pairs);
-                    while (true) {
-                        Point3DTrackElement track;
-                        if (!parse_next_number(cur, end, track.image_id)) {
-                            break;
-                        }
-                        if (!parse_next_number(cur, end, track.point2D_idx)) {
-                            break;
-                        }
-                        point.track.push_back(track);
-                    }
-                    point.track_count = point.track.size();
-                    total_track_elements += point.track_count;
-                }
-
+                parse_point3D_record_line(line, track_mode, point, total_track_elements);
                 points.push_back(std::move(point));
             });
+        } else {
+            struct RecordChunkResult {
+                std::vector<Point3DData> points;
+                size_t file_lines = 0;
+                size_t track_elements = 0;
+            };
+
+            const auto chunks = split_line_aligned_chunks(std::span<const char>(*buffer));
+            std::vector<RecordChunkResult> results(chunks.size());
+            tbb::parallel_for(size_t{0}, chunks.size(), [&](const size_t chunk_index) {
+                const auto& chunk = chunks[chunk_index];
+                auto& result = results[chunk_index];
+                result.points.reserve(std::max<size_t>(static_cast<size_t>(chunk.end - chunk.begin) / 96, 1));
+                result.file_lines = for_each_data_line(
+                    std::span<const char>(chunk.begin, static_cast<size_t>(chunk.end - chunk.begin)),
+                    options,
+                    "COLMAP point cloud parse cancelled",
+                    [&](const std::string_view line, size_t) {
+                    Point3DData point;
+                    parse_point3D_record_line(line, track_mode, point, result.track_elements);
+                    result.points.push_back(std::move(point));
+                });
+            });
+
+            size_t total_points = 0;
+            for (const auto& result : results) {
+                total_points += result.points.size();
+                total_track_elements += result.track_elements;
+                file_lines += result.file_lines;
+            }
+
+            points.reserve(total_points);
+            for (auto& result : results) {
+                std::move(result.points.begin(), result.points.end(), std::back_inserter(points));
+            }
+        }
         buffer.reset();
 
         LOG_DEBUG("Reading {} 3D points from text file", points.size());
@@ -1369,43 +1500,57 @@ namespace lfs::io {
         }
 
         auto buffer = read_binary(file_path);
-        data.file_lines = for_each_data_line(
-            std::span<const char>(*buffer),
-            options,
-            "COLMAP point cloud parse cancelled",
-            [&](const std::string_view line, size_t) {
-            const char* cur = line.data();
-            const char* end = cur + line.size();
-            uint64_t point_id = 0;
-            float x = 0.0f;
-            float y = 0.0f;
-            float z = 0.0f;
-            int red = 255;
-            int green = 255;
-            int blue = 255;
-            double error = 0.0;
-            if (!parse_next_number(cur, end, point_id) ||
-                !parse_next_number(cur, end, x) ||
-                !parse_next_number(cur, end, y) ||
-                !parse_next_number(cur, end, z) ||
-                !parse_next_number(cur, end, red) ||
-                !parse_next_number(cur, end, green) ||
-                !parse_next_number(cur, end, blue) ||
-                !parse_next_number(cur, end, error)) {
-                LOG_ERROR("Invalid format in points3D.txt: {}", std::string(line));
-                throw std::runtime_error("Invalid format in points3D.txt");
-            }
-            (void)point_id;
-            (void)error;
+        if (buffer->size() < POINTS3D_PARALLEL_MIN_BYTES) {
+            data.file_lines = for_each_data_line(
+                std::span<const char>(*buffer),
+                options,
+                "COLMAP point cloud parse cancelled",
+                [&](const std::string_view line, size_t) {
+                parse_point3D_point_cloud_line(line, data.positions, data.colors, data.point_count);
+            });
+        } else {
+            struct PointCloudChunkResult {
+                std::vector<float> positions;
+                std::vector<uint8_t> colors;
+                size_t point_count = 0;
+                size_t file_lines = 0;
+            };
 
-            data.positions.push_back(x);
-            data.positions.push_back(y);
-            data.positions.push_back(z);
-            data.colors.push_back(static_cast<uint8_t>(red));
-            data.colors.push_back(static_cast<uint8_t>(green));
-            data.colors.push_back(static_cast<uint8_t>(blue));
-            ++data.point_count;
-        });
+            const auto chunks = split_line_aligned_chunks(std::span<const char>(*buffer));
+            std::vector<PointCloudChunkResult> results(chunks.size());
+            tbb::parallel_for(size_t{0}, chunks.size(), [&](const size_t chunk_index) {
+                const auto& chunk = chunks[chunk_index];
+                auto& result = results[chunk_index];
+                const auto estimated_points = std::max<size_t>(static_cast<size_t>(chunk.end - chunk.begin) / 96, 1);
+                result.positions.reserve(estimated_points * 3);
+                result.colors.reserve(estimated_points * 3);
+                result.file_lines = for_each_data_line(
+                    std::span<const char>(chunk.begin, static_cast<size_t>(chunk.end - chunk.begin)),
+                    options,
+                    "COLMAP point cloud parse cancelled",
+                    [&](const std::string_view line, size_t) {
+                    parse_point3D_point_cloud_line(line, result.positions, result.colors, result.point_count);
+                });
+            });
+
+            size_t total_position_values = 0;
+            size_t total_color_values = 0;
+            for (const auto& result : results) {
+                data.point_count += result.point_count;
+                data.file_lines += result.file_lines;
+                total_position_values += result.positions.size();
+                total_color_values += result.colors.size();
+            }
+
+            data.positions.clear();
+            data.colors.clear();
+            data.positions.reserve(total_position_values);
+            data.colors.reserve(total_color_values);
+            for (auto& result : results) {
+                std::move(result.positions.begin(), result.positions.end(), std::back_inserter(data.positions));
+                std::move(result.colors.begin(), result.colors.end(), std::back_inserter(data.colors));
+            }
+        }
         buffer.reset();
 
         if (data.point_count == 0) {

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -86,18 +86,6 @@ namespace lfs::io {
             Full
         };
 
-        TrackParseMode to_internal_track_parse_mode(const detail::ColmapPoint3DTrackParseMode mode) {
-            switch (mode) {
-            case detail::ColmapPoint3DTrackParseMode::None:
-                return TrackParseMode::None;
-            case detail::ColmapPoint3DTrackParseMode::CountOnly:
-                return TrackParseMode::CountOnly;
-            case detail::ColmapPoint3DTrackParseMode::Full:
-                return TrackParseMode::Full;
-            }
-            return TrackParseMode::Full;
-        }
-
         size_t count_remaining_track_pairs(const char* cur, const char* end) {
             size_t tokens = 0;
             bool in_token = false;
@@ -246,6 +234,14 @@ namespace lfs::io {
     };
 
     namespace {
+        struct Point3DTextPointCloudData {
+            std::vector<float> positions;
+            std::vector<std::uint8_t> colors;
+            std::size_t point_count = 0;
+            std::size_t file_lines = 0;
+            std::uintmax_t byte_size = 0;
+        };
+
         bool parse_point3D_header(const std::string_view line,
                                   Point3DData& point,
                                   const char*& cur,
@@ -1458,46 +1454,14 @@ namespace lfs::io {
         return points;
     }
 
-    std::vector<detail::ColmapPoint3DTextRecordData> detail::parse_points3D_text_records_for_test(
-        const std::filesystem::path& file_path,
-        const ColmapPoint3DTrackParseMode track_mode,
-        const LoadOptions& options) {
-        auto internal_records = read_point3D_text_records(file_path, options, to_internal_track_parse_mode(track_mode));
-        std::vector<ColmapPoint3DTextRecordData> records;
-        records.reserve(internal_records.size());
-
-        for (const auto& point : internal_records) {
-            ColmapPoint3DTextRecordData record;
-            record.point3D_id = point.point3D_id;
-            record.xyz[0] = point.xyz[0];
-            record.xyz[1] = point.xyz[1];
-            record.xyz[2] = point.xyz[2];
-            record.color[0] = point.color[0];
-            record.color[1] = point.color[1];
-            record.color[2] = point.color[2];
-            record.error = point.error;
-            record.track_count = point.track_count;
-            record.track.reserve(point.track.size());
-            for (const auto& track : point.track) {
-                record.track.push_back(ColmapPoint3DTrackElementData{
-                    .image_id = track.image_id,
-                    .point2D_idx = track.point2D_idx,
-                });
-            }
-            records.push_back(std::move(record));
-        }
-
-        return records;
-    }
-
-    detail::ColmapPoint3DTextPointCloudData detail::parse_points3D_text_point_cloud_fast(
+    static Point3DTextPointCloudData parse_points3D_text_point_cloud_fast(
         const std::filesystem::path& file_path,
         const LoadOptions& options) {
         const auto start = std::chrono::high_resolution_clock::now();
         std::error_code file_size_ec;
         const auto byte_size = fs::file_size(file_path, file_size_ec);
 
-        detail::ColmapPoint3DTextPointCloudData data;
+        Point3DTextPointCloudData data;
         data.byte_size = file_size_ec ? 0 : byte_size;
 
         auto buffer = read_binary(file_path);
@@ -1578,7 +1542,7 @@ namespace lfs::io {
     PointCloud read_point3D_text(const std::filesystem::path& file_path,
                                  const LoadOptions& options = {}) {
         LOG_TIMER_TRACE("Read points3D.txt point cloud");
-        auto data = detail::parse_points3D_text_point_cloud_fast(file_path, options);
+        auto data = parse_points3D_text_point_cloud_fast(file_path, options);
 
         Tensor means = Tensor::from_vector(data.positions, {data.point_count, 3}, Device::CUDA);
         Tensor colors_tensor = Tensor::from_blob(data.colors.data(), {data.point_count, 3}, Device::CPU, DataType::UInt8)

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -20,8 +20,10 @@
 #include <iomanip>
 #include <limits>
 #include <memory>
+#include <span>
 #include <sstream>
 #include <stdexcept>
+#include <string_view>
 #include <system_error>
 #include <unordered_map>
 #include <vector>
@@ -52,7 +54,7 @@ namespace lfs::io {
         }
 
         void skip_ascii_spaces(const char*& cur, const char* end) {
-            while (cur < end && std::isspace(static_cast<unsigned char>(*cur))) {
+            while (cur < end && (*cur == ' ' || *cur == '\t')) {
                 ++cur;
             }
         }
@@ -71,6 +73,39 @@ namespace lfs::io {
 
             cur = parsed.ptr;
             return true;
+        }
+
+        template <typename LineFn>
+        size_t for_each_data_line(std::span<const char> buffer,
+                                  const LoadOptions& options,
+                                  const char* cancel_msg,
+                                  LineFn&& fn) {
+            const char* cur = buffer.data();
+            const char* end = cur + buffer.size();
+            size_t line_count = 0;
+
+            while (cur < end) {
+                if (should_poll_cancel(line_count)) {
+                    throw_if_load_cancel_requested(options, cancel_msg);
+                }
+
+                const char* line_begin = cur;
+                const void* newline = std::memchr(cur, '\n', static_cast<size_t>(end - cur));
+                const char* line_end = newline ? static_cast<const char*>(newline) : end;
+                cur = newline ? line_end + 1 : end;
+                ++line_count;
+
+                if (line_end > line_begin && *(line_end - 1) == '\r') {
+                    --line_end;
+                }
+                if (line_begin == line_end || *line_begin == '#') {
+                    continue;
+                }
+
+                fn(std::string_view(line_begin, static_cast<size_t>(line_end - line_begin)), line_count);
+            }
+
+            return line_count;
         }
     } // namespace
 
@@ -1257,53 +1292,33 @@ namespace lfs::io {
         return points;
     }
 
-    PointCloud read_point3D_text(const std::filesystem::path& file_path,
-                                 const LoadOptions& options = {}) {
-        LOG_TIMER_TRACE("Read points3D.txt point cloud");
+    detail::ColmapPoint3DTextPointCloudData detail::parse_points3D_text_point_cloud_fast(
+        const std::filesystem::path& file_path,
+        const LoadOptions& options) {
         const auto start = std::chrono::high_resolution_clock::now();
         std::error_code file_size_ec;
         const auto byte_size = fs::file_size(file_path, file_size_ec);
 
-        std::ifstream file;
-        if (!lfs::core::open_file_for_read(file_path, file)) {
-            LOG_ERROR("Failed to open text file: {}", lfs::core::path_to_utf8(file_path));
-            throw std::runtime_error("Failed to open " + lfs::core::path_to_utf8(file_path));
-        }
-
-        std::vector<float> positions;
-        std::vector<uint8_t> colors;
+        detail::ColmapPoint3DTextPointCloudData data;
+        data.byte_size = file_size_ec ? 0 : byte_size;
         if (!file_size_ec) {
             const auto estimated_points = static_cast<size_t>(std::max<uintmax_t>(byte_size / 96, 1));
-            positions.reserve(estimated_points * 3);
-            colors.reserve(estimated_points * 3);
+            data.positions.reserve(estimated_points * 3);
+            data.colors.reserve(estimated_points * 3);
         }
 
-        std::string line;
-        size_t line_count = 0;
-        size_t point_count = 0;
-        while (std::getline(file, line)) {
-            if (should_poll_cancel(line_count)) {
-                throw_if_load_cancel_requested(options, "COLMAP point cloud parse cancelled");
-            }
-            ++line_count;
-
-            if (line.starts_with("#")) {
-                continue;
-            }
-            if (!line.empty() && line.back() == '\r') {
-                line.pop_back();
-            }
-            if (line.empty()) {
-                continue;
-            }
-
+        auto buffer = read_binary(file_path);
+        data.file_lines = for_each_data_line(
+            std::span<const char>(*buffer),
+            options,
+            "COLMAP point cloud parse cancelled",
+            [&](const std::string_view line, size_t) {
             const char* cur = line.data();
             const char* end = cur + line.size();
-
             uint64_t point_id = 0;
-            double x = 0.0;
-            double y = 0.0;
-            double z = 0.0;
+            float x = 0.0f;
+            float y = 0.0f;
+            float z = 0.0f;
             int red = 255;
             int green = 255;
             int blue = 255;
@@ -1316,34 +1331,43 @@ namespace lfs::io {
                 !parse_next_number(cur, end, green) ||
                 !parse_next_number(cur, end, blue) ||
                 !parse_next_number(cur, end, error)) {
-                LOG_ERROR("Invalid format in points3D.txt: {}", line);
+                LOG_ERROR("Invalid format in points3D.txt: {}", std::string(line));
                 throw std::runtime_error("Invalid format in points3D.txt");
             }
             (void)point_id;
             (void)error;
 
-            positions.push_back(static_cast<float>(x));
-            positions.push_back(static_cast<float>(y));
-            positions.push_back(static_cast<float>(z));
-            colors.push_back(static_cast<uint8_t>(red));
-            colors.push_back(static_cast<uint8_t>(green));
-            colors.push_back(static_cast<uint8_t>(blue));
-            ++point_count;
-        }
+            data.positions.push_back(x);
+            data.positions.push_back(y);
+            data.positions.push_back(z);
+            data.colors.push_back(static_cast<uint8_t>(red));
+            data.colors.push_back(static_cast<uint8_t>(green));
+            data.colors.push_back(static_cast<uint8_t>(blue));
+            ++data.point_count;
+        });
+        buffer.reset();
 
-        if (point_count == 0) {
+        if (data.point_count == 0) {
             LOG_ERROR("No valid points found in {}", lfs::core::path_to_utf8(file_path));
             throw std::runtime_error("No valid points in points3D.txt");
         }
 
         LOG_INFO("[COLMAP_LOAD] parse points3D.txt point_cloud_fast points={} file_lines={} bytes={} elapsed_ms={:.2f}",
-                 point_count,
-                 line_count,
+                 data.point_count,
+                 data.file_lines,
                  file_size_ec ? std::string("unknown") : std::format("{}", byte_size),
                  elapsed_ms(start));
 
-        Tensor means = Tensor::from_vector(positions, {point_count, 3}, Device::CUDA);
-        Tensor colors_tensor = Tensor::from_blob(colors.data(), {point_count, 3}, Device::CPU, DataType::UInt8)
+        return data;
+    }
+
+    PointCloud read_point3D_text(const std::filesystem::path& file_path,
+                                 const LoadOptions& options = {}) {
+        LOG_TIMER_TRACE("Read points3D.txt point cloud");
+        auto data = detail::parse_points3D_text_point_cloud_fast(file_path, options);
+
+        Tensor means = Tensor::from_vector(data.positions, {data.point_count, 3}, Device::CUDA);
+        Tensor colors_tensor = Tensor::from_blob(data.colors.data(), {data.point_count, 3}, Device::CPU, DataType::UInt8)
                                    .to(Device::CUDA)
                                    .contiguous();
 

--- a/src/io/formats/colmap.hpp
+++ b/src/io/formats/colmap.hpp
@@ -125,6 +125,17 @@ namespace lfs::io {
         const LoadOptions& options = {});
 
     namespace detail {
+        struct ColmapPoint3DTrackElementData {
+            std::uint32_t image_id = 0;
+            std::uint32_t point2D_idx = 0;
+        };
+
+        enum class ColmapPoint3DTrackParseMode {
+            None,
+            CountOnly,
+            Full
+        };
+
         struct ColmapPoint3DTextPointCloudData {
             std::vector<float> positions;
             std::vector<std::uint8_t> colors;
@@ -133,8 +144,22 @@ namespace lfs::io {
             std::uintmax_t byte_size = 0;
         };
 
+        struct ColmapPoint3DTextRecordData {
+            std::uint64_t point3D_id = 0;
+            double xyz[3] = {0.0, 0.0, 0.0};
+            std::uint8_t color[3] = {255, 255, 255};
+            double error = 0.0;
+            std::size_t track_count = 0;
+            std::vector<ColmapPoint3DTrackElementData> track;
+        };
+
         ColmapPoint3DTextPointCloudData parse_points3D_text_point_cloud_fast(
             const std::filesystem::path& file_path,
+            const LoadOptions& options = {});
+
+        std::vector<ColmapPoint3DTextRecordData> parse_points3D_text_records_for_test(
+            const std::filesystem::path& file_path,
+            ColmapPoint3DTrackParseMode track_mode,
             const LoadOptions& options = {});
     } // namespace detail
 

--- a/src/io/formats/colmap.hpp
+++ b/src/io/formats/colmap.hpp
@@ -124,45 +124,6 @@ namespace lfs::io {
         const std::filesystem::path& filepath,
         const LoadOptions& options = {});
 
-    namespace detail {
-        struct ColmapPoint3DTrackElementData {
-            std::uint32_t image_id = 0;
-            std::uint32_t point2D_idx = 0;
-        };
-
-        enum class ColmapPoint3DTrackParseMode {
-            None,
-            CountOnly,
-            Full
-        };
-
-        struct ColmapPoint3DTextPointCloudData {
-            std::vector<float> positions;
-            std::vector<std::uint8_t> colors;
-            std::size_t point_count = 0;
-            std::size_t file_lines = 0;
-            std::uintmax_t byte_size = 0;
-        };
-
-        struct ColmapPoint3DTextRecordData {
-            std::uint64_t point3D_id = 0;
-            double xyz[3] = {0.0, 0.0, 0.0};
-            std::uint8_t color[3] = {255, 255, 255};
-            double error = 0.0;
-            std::size_t track_count = 0;
-            std::vector<ColmapPoint3DTrackElementData> track;
-        };
-
-        ColmapPoint3DTextPointCloudData parse_points3D_text_point_cloud_fast(
-            const std::filesystem::path& file_path,
-            const LoadOptions& options = {});
-
-        std::vector<ColmapPoint3DTextRecordData> parse_points3D_text_records_for_test(
-            const std::filesystem::path& file_path,
-            ColmapPoint3DTrackParseMode track_mode,
-            const LoadOptions& options = {});
-    } // namespace detail
-
     /**
      * @brief Read COLMAP cameras only (no image file validation required)
      * @param sparse_path Path to COLMAP sparse reconstruction folder

--- a/src/io/formats/colmap.hpp
+++ b/src/io/formats/colmap.hpp
@@ -10,6 +10,7 @@
 #include "io/error.hpp"
 #include "io/loader.hpp"
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <glm/glm.hpp>
 #include <memory>
@@ -122,6 +123,20 @@ namespace lfs::io {
     ColmapPointCloudLoadStats read_colmap_point_cloud_text_with_stats(
         const std::filesystem::path& filepath,
         const LoadOptions& options = {});
+
+    namespace detail {
+        struct ColmapPoint3DTextPointCloudData {
+            std::vector<float> positions;
+            std::vector<std::uint8_t> colors;
+            std::size_t point_count = 0;
+            std::size_t file_lines = 0;
+            std::uintmax_t byte_size = 0;
+        };
+
+        ColmapPoint3DTextPointCloudData parse_points3D_text_point_cloud_fast(
+            const std::filesystem::path& file_path,
+            const LoadOptions& options = {});
+    } // namespace detail
 
     /**
      * @brief Read COLMAP cameras only (no image file validation required)

--- a/src/python/stubs/lichtfeld/scene.pyi
+++ b/src/python/stubs/lichtfeld/scene.pyi
@@ -87,7 +87,7 @@ class SplatData:
         """Number of visible (non-deleted) Gaussians"""
 
     def soft_delete(self, mask: lichtfeld.Tensor) -> lichtfeld.Tensor:
-        """Mark Gaussians as deleted by mask, returns previous state for undo"""
+        """Mark Gaussians as deleted by mask, returns newly deleted mask for undo"""
 
     def undelete(self, mask: lichtfeld.Tensor) -> None:
         """Restore deleted Gaussians by mask"""

--- a/src/python/stubs/lichtfeld/scene.pyi
+++ b/src/python/stubs/lichtfeld/scene.pyi
@@ -87,7 +87,7 @@ class SplatData:
         """Number of visible (non-deleted) Gaussians"""
 
     def soft_delete(self, mask: lichtfeld.Tensor) -> lichtfeld.Tensor:
-        """Mark Gaussians as deleted by mask, returns newly deleted mask for undo"""
+        """Mark Gaussians as deleted by mask, returns previous state for undo"""
 
     def undelete(self, mask: lichtfeld.Tensor) -> None:
         """Restore deleted Gaussians by mask"""

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -289,6 +289,7 @@ set(TEST_FILES
     test_openmesh_bridge.cpp
     test_mesh_loader.cpp
     test_colmap_image_layout.cpp
+    test_colmap_points3d_text.cpp
     test_splat_simplify.cpp
     test_rml_text_input_handler.cpp
     test_rotated_sh_correctness.cpp

--- a/tests/test_colmap_points3d_text.cpp
+++ b/tests/test_colmap_points3d_text.cpp
@@ -111,6 +111,18 @@ TEST(ColmapPoints3DText, FastPathThrowsOnEmptyOrCommentOnlyFile) {
         std::runtime_error);
 }
 
+TEST(ColmapPoints3DText, RecordPathThrowsOnEmptyOrCommentOnlyFile) {
+    const auto path = write_points3d_fixture(
+        "empty_records_points3D.txt",
+        "# only comments\n\n# still no points\n");
+
+    EXPECT_THROW(
+        (void)lfs::io::detail::parse_points3D_text_records_for_test(
+            path,
+            lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly),
+        std::runtime_error);
+}
+
 TEST(ColmapPoints3DText, RecordFullModeParsesTracksExactly) {
     const auto path = write_points3d_fixture(
         "full_tracks_points3D.txt",
@@ -158,6 +170,34 @@ TEST(ColmapPoints3DText, RecordCountOnlyMatchesFullTrackCounts) {
     EXPECT_TRUE(count_only[1].track.empty());
 }
 
+TEST(ColmapPoints3DText, RecordModesIgnoreDanglingOddTrackTokenConsistently) {
+    const auto path = write_points3d_fixture(
+        "dangling_track_token_points3D.txt",
+        "15 0 0 0 1 2 3 0.0 10 20 30\n");
+
+    const auto full = lfs::io::detail::parse_points3D_text_records_for_test(
+        path,
+        lfs::io::detail::ColmapPoint3DTrackParseMode::Full);
+    const auto count_only = lfs::io::detail::parse_points3D_text_records_for_test(
+        path,
+        lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly);
+    const auto none = lfs::io::detail::parse_points3D_text_records_for_test(
+        path,
+        lfs::io::detail::ColmapPoint3DTrackParseMode::None);
+
+    ASSERT_EQ(full.size(), 1u);
+    ASSERT_EQ(count_only.size(), 1u);
+    ASSERT_EQ(none.size(), 1u);
+    EXPECT_EQ(full[0].track_count, 1u);
+    ASSERT_EQ(full[0].track.size(), 1u);
+    EXPECT_EQ(full[0].track[0].image_id, 10u);
+    EXPECT_EQ(full[0].track[0].point2D_idx, 20u);
+    EXPECT_EQ(count_only[0].track_count, full[0].track_count);
+    EXPECT_TRUE(count_only[0].track.empty());
+    EXPECT_EQ(none[0].track_count, 0u);
+    EXPECT_TRUE(none[0].track.empty());
+}
+
 TEST(ColmapPoints3DText, RecordNoneModeLeavesTrackCountZero) {
     const auto path = write_points3d_fixture(
         "none_tracks_points3D.txt",
@@ -176,6 +216,34 @@ TEST(ColmapPoints3DText, RecordPathThrowsOnMalformedHeader) {
         "malformed_record_points3D.txt",
         "14 0 0 0 1 2 3\n");
 
+    EXPECT_THROW(
+        (void)lfs::io::detail::parse_points3D_text_records_for_test(
+            path,
+            lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly),
+        std::runtime_error);
+}
+
+TEST(ColmapPoints3DText, ParallelPathThrowsOnMalformedLineInLaterChunk) {
+    std::ostringstream contents;
+    contents << "# generated large malformed fixture\n";
+    constexpr int kValidPrefixCount = 300000;
+    for (int i = 0; i < kValidPrefixCount; ++i) {
+        contents << i << ' '
+                 << static_cast<double>(i) * 0.5 << ' '
+                 << static_cast<double>(i) * -0.25 << ' '
+                 << static_cast<double>(i) * 0.125 << ' '
+                 << (i % 256) << ' '
+                 << ((i + 1) % 256) << ' '
+                 << ((i + 2) % 256) << " 0.0 "
+                 << i << ' ' << (i + 10) << ' '
+                 << (i + 20) << ' ' << (i + 30) << '\n';
+    }
+    contents << "bad malformed later chunk\n";
+
+    const auto path = write_points3d_fixture("large_parallel_malformed_points3D.txt", contents.str());
+    EXPECT_THROW(
+        (void)lfs::io::detail::parse_points3D_text_point_cloud_fast(path),
+        std::runtime_error);
     EXPECT_THROW(
         (void)lfs::io::detail::parse_points3D_text_records_for_test(
             path,

--- a/tests/test_colmap_points3d_text.cpp
+++ b/tests/test_colmap_points3d_text.cpp
@@ -1,0 +1,228 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "io/formats/colmap.hpp"
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+
+namespace {
+    std::filesystem::path write_points3d_fixture(const std::string& name, const std::string& contents) {
+        const auto dir = std::filesystem::temp_directory_path() / "lfs_colmap_points3d_text_tests";
+        std::filesystem::create_directories(dir);
+        const auto path = dir / name;
+        std::ofstream file(path, std::ios::binary | std::ios::trunc);
+        file << contents;
+        return path;
+    }
+
+    void expect_point(const lfs::io::detail::ColmapPoint3DTextPointCloudData& data,
+                      const size_t index,
+                      const float x,
+                      const float y,
+                      const float z,
+                      const uint8_t r,
+                      const uint8_t g,
+                      const uint8_t b) {
+        ASSERT_LT(index * 3 + 2, data.positions.size());
+        ASSERT_LT(index * 3 + 2, data.colors.size());
+        EXPECT_FLOAT_EQ(data.positions[index * 3 + 0], x);
+        EXPECT_FLOAT_EQ(data.positions[index * 3 + 1], y);
+        EXPECT_FLOAT_EQ(data.positions[index * 3 + 2], z);
+        EXPECT_EQ(data.colors[index * 3 + 0], r);
+        EXPECT_EQ(data.colors[index * 3 + 1], g);
+        EXPECT_EQ(data.colors[index * 3 + 2], b);
+    }
+} // namespace
+
+TEST(ColmapPoints3DText, FastPathParsesBasicValuesAndIgnoresTracks) {
+    const auto path = write_points3d_fixture(
+        "basic_points3D.txt",
+        "# POINT3D_ID X Y Z R G B ERROR TRACK[]\n"
+        "1 1.5 -2.25 3.75 10 20 30 0.125 7 8 9 10\n"
+        "2 -4 5 6.5 255 128 0 2.0 11 12\n");
+
+    const auto data = lfs::io::detail::parse_points3D_text_point_cloud_fast(path);
+    EXPECT_EQ(data.point_count, 2u);
+    EXPECT_EQ(data.file_lines, 3u);
+    expect_point(data, 0, 1.5f, -2.25f, 3.75f, 10, 20, 30);
+    expect_point(data, 1, -4.0f, 5.0f, 6.5f, 255, 128, 0);
+}
+
+TEST(ColmapPoints3DText, FastPathSkipsCommentsBlanksAndHandlesCrLf) {
+    const auto path = write_points3d_fixture(
+        "crlf_points3D.txt",
+        "# header\r\n"
+        "\r\n"
+        "3 0 1 2 1 2 3 0.0 4 5\r\n"
+        "\r\n"
+        "# footer\r\n");
+
+    const auto data = lfs::io::detail::parse_points3D_text_point_cloud_fast(path);
+    EXPECT_EQ(data.point_count, 1u);
+    EXPECT_EQ(data.file_lines, 5u);
+    expect_point(data, 0, 0.0f, 1.0f, 2.0f, 1, 2, 3);
+}
+
+TEST(ColmapPoints3DText, FastPathHandlesFinalLineWithoutTrailingNewline) {
+    const auto path = write_points3d_fixture(
+        "no_trailing_newline_points3D.txt",
+        "4 9 8 7 6 5 4 0.0");
+
+    const auto data = lfs::io::detail::parse_points3D_text_point_cloud_fast(path);
+    EXPECT_EQ(data.point_count, 1u);
+    EXPECT_EQ(data.file_lines, 1u);
+    expect_point(data, 0, 9.0f, 8.0f, 7.0f, 6, 5, 4);
+}
+
+TEST(ColmapPoints3DText, FastPathDoesNotParseLongTrackTails) {
+    std::string line = "5 1 2 3 4 5 6 0.0";
+    for (int i = 0; i < 500; ++i) {
+        line += " " + std::to_string(i) + " " + std::to_string(i + 1);
+    }
+    line += "\n";
+
+    const auto path = write_points3d_fixture("long_track_tail_points3D.txt", line);
+    const auto data = lfs::io::detail::parse_points3D_text_point_cloud_fast(path);
+    EXPECT_EQ(data.point_count, 1u);
+    expect_point(data, 0, 1.0f, 2.0f, 3.0f, 4, 5, 6);
+}
+
+TEST(ColmapPoints3DText, FastPathThrowsOnMalformedLine) {
+    const auto path = write_points3d_fixture(
+        "malformed_points3D.txt",
+        "6 1 2 3 4 5 6\n");
+
+    EXPECT_THROW(
+        (void)lfs::io::detail::parse_points3D_text_point_cloud_fast(path),
+        std::runtime_error);
+}
+
+TEST(ColmapPoints3DText, FastPathThrowsOnEmptyOrCommentOnlyFile) {
+    const auto path = write_points3d_fixture(
+        "empty_points3D.txt",
+        "# only comments\n\n# still no points\n");
+
+    EXPECT_THROW(
+        (void)lfs::io::detail::parse_points3D_text_point_cloud_fast(path),
+        std::runtime_error);
+}
+
+TEST(ColmapPoints3DText, RecordFullModeParsesTracksExactly) {
+    const auto path = write_points3d_fixture(
+        "full_tracks_points3D.txt",
+        "10 1 2 3 7 8 9 0.25 100 200 101 201\n");
+
+    const auto records = lfs::io::detail::parse_points3D_text_records_for_test(
+        path,
+        lfs::io::detail::ColmapPoint3DTrackParseMode::Full);
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].point3D_id, 10u);
+    EXPECT_DOUBLE_EQ(records[0].xyz[0], 1.0);
+    EXPECT_DOUBLE_EQ(records[0].xyz[1], 2.0);
+    EXPECT_DOUBLE_EQ(records[0].xyz[2], 3.0);
+    EXPECT_EQ(records[0].color[0], 7);
+    EXPECT_EQ(records[0].color[1], 8);
+    EXPECT_EQ(records[0].color[2], 9);
+    EXPECT_DOUBLE_EQ(records[0].error, 0.25);
+    EXPECT_EQ(records[0].track_count, 2u);
+    ASSERT_EQ(records[0].track.size(), 2u);
+    EXPECT_EQ(records[0].track[0].image_id, 100u);
+    EXPECT_EQ(records[0].track[0].point2D_idx, 200u);
+    EXPECT_EQ(records[0].track[1].image_id, 101u);
+    EXPECT_EQ(records[0].track[1].point2D_idx, 201u);
+}
+
+TEST(ColmapPoints3DText, RecordCountOnlyMatchesFullTrackCounts) {
+    const auto path = write_points3d_fixture(
+        "count_only_tracks_points3D.txt",
+        "11 0 0 0 1 2 3 0.0 1 2 3 4 5 6\n"
+        "12 0 0 0 4 5 6 0.0 7 8 9\n");
+
+    const auto full = lfs::io::detail::parse_points3D_text_records_for_test(
+        path,
+        lfs::io::detail::ColmapPoint3DTrackParseMode::Full);
+    const auto count_only = lfs::io::detail::parse_points3D_text_records_for_test(
+        path,
+        lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly);
+
+    ASSERT_EQ(full.size(), count_only.size());
+    EXPECT_EQ(full[0].track_count, 3u);
+    EXPECT_EQ(count_only[0].track_count, full[0].track_count);
+    EXPECT_TRUE(count_only[0].track.empty());
+    EXPECT_EQ(full[1].track_count, 1u);
+    EXPECT_EQ(count_only[1].track_count, full[1].track_count);
+    EXPECT_TRUE(count_only[1].track.empty());
+}
+
+TEST(ColmapPoints3DText, RecordNoneModeLeavesTrackCountZero) {
+    const auto path = write_points3d_fixture(
+        "none_tracks_points3D.txt",
+        "13 0 0 0 1 2 3 0.0 1 2 3 4\n");
+
+    const auto records = lfs::io::detail::parse_points3D_text_records_for_test(
+        path,
+        lfs::io::detail::ColmapPoint3DTrackParseMode::None);
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].track_count, 0u);
+    EXPECT_TRUE(records[0].track.empty());
+}
+
+TEST(ColmapPoints3DText, RecordPathThrowsOnMalformedHeader) {
+    const auto path = write_points3d_fixture(
+        "malformed_record_points3D.txt",
+        "14 0 0 0 1 2 3\n");
+
+    EXPECT_THROW(
+        (void)lfs::io::detail::parse_points3D_text_records_for_test(
+            path,
+            lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly),
+        std::runtime_error);
+}
+
+TEST(ColmapPoints3DText, LargeFileParallelPathIsDeterministicAcrossModes) {
+    std::ostringstream contents;
+    contents << "# generated large fixture\n";
+    constexpr int kPointCount = 320000;
+    for (int i = 0; i < kPointCount; ++i) {
+        contents << i << ' '
+                 << static_cast<double>(i) * 0.5 << ' '
+                 << static_cast<double>(i) * -0.25 << ' '
+                 << static_cast<double>(i) * 0.125 << ' '
+                 << (i % 256) << ' '
+                 << ((i + 1) % 256) << ' '
+                 << ((i + 2) % 256) << " 0.0 "
+                 << i << ' ' << (i + 10) << ' '
+                 << (i + 20) << ' ' << (i + 30) << '\n';
+    }
+
+    const auto path = write_points3d_fixture("large_parallel_points3D.txt", contents.str());
+    const auto fast = lfs::io::detail::parse_points3D_text_point_cloud_fast(path);
+    const auto full = lfs::io::detail::parse_points3D_text_records_for_test(
+        path,
+        lfs::io::detail::ColmapPoint3DTrackParseMode::Full);
+    const auto count_only = lfs::io::detail::parse_points3D_text_records_for_test(
+        path,
+        lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly);
+
+    ASSERT_EQ(fast.point_count, static_cast<size_t>(kPointCount));
+    ASSERT_EQ(full.size(), static_cast<size_t>(kPointCount));
+    ASSERT_EQ(count_only.size(), static_cast<size_t>(kPointCount));
+    expect_point(fast, 0, 0.0f, -0.0f, 0.0f, 0, 1, 2);
+    expect_point(fast, kPointCount - 1,
+                 static_cast<float>(kPointCount - 1) * 0.5f,
+                 static_cast<float>(kPointCount - 1) * -0.25f,
+                 static_cast<float>(kPointCount - 1) * 0.125f,
+                 static_cast<uint8_t>((kPointCount - 1) % 256),
+                 static_cast<uint8_t>(kPointCount % 256),
+                 static_cast<uint8_t>((kPointCount + 1) % 256));
+    EXPECT_EQ(full.front().track_count, 2u);
+    EXPECT_EQ(full.back().track_count, 2u);
+    EXPECT_EQ(count_only.front().track_count, full.front().track_count);
+    EXPECT_EQ(count_only.back().track_count, full.back().track_count);
+    EXPECT_TRUE(count_only.front().track.empty());
+    EXPECT_TRUE(count_only.back().track.empty());
+}

--- a/tests/test_colmap_points3d_text.cpp
+++ b/tests/test_colmap_points3d_text.cpp
@@ -3,294 +3,84 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "io/formats/colmap.hpp"
+#include <cuda_runtime.h>
 #include <filesystem>
-#include <fstream>
 #include <gtest/gtest.h>
-#include <sstream>
-#include <string>
+#include <stdexcept>
+
+namespace fs = std::filesystem;
 
 namespace {
-    std::filesystem::path write_points3d_fixture(const std::string& name, const std::string& contents) {
-        const auto dir = std::filesystem::temp_directory_path() / "lfs_colmap_points3d_text_tests";
-        std::filesystem::create_directories(dir);
-        const auto path = dir / name;
-        std::ofstream file(path, std::ios::binary | std::ios::trunc);
-        file << contents;
-        return path;
+    fs::path fixture_dir(const std::string& name) {
+        return fs::path(PROJECT_ROOT_PATH) / "tests" / "fixtures" / "colmap_points3d_text" / name;
     }
 
-    void expect_point(const lfs::io::detail::ColmapPoint3DTextPointCloudData& data,
-                      const size_t index,
-                      const float x,
-                      const float y,
-                      const float z,
-                      const uint8_t r,
-                      const uint8_t g,
-                      const uint8_t b) {
-        ASSERT_LT(index * 3 + 2, data.positions.size());
-        ASSERT_LT(index * 3 + 2, data.colors.size());
-        EXPECT_FLOAT_EQ(data.positions[index * 3 + 0], x);
-        EXPECT_FLOAT_EQ(data.positions[index * 3 + 1], y);
-        EXPECT_FLOAT_EQ(data.positions[index * 3 + 2], z);
-        EXPECT_EQ(data.colors[index * 3 + 0], r);
-        EXPECT_EQ(data.colors[index * 3 + 1], g);
-        EXPECT_EQ(data.colors[index * 3 + 2], b);
+    bool has_cuda_device() {
+        int device_count = 0;
+        return cudaGetDeviceCount(&device_count) == cudaSuccess && device_count > 0;
     }
 } // namespace
 
-TEST(ColmapPoints3DText, FastPathParsesBasicValuesAndIgnoresTracks) {
-    const auto path = write_points3d_fixture(
-        "basic_points3D.txt",
-        "# POINT3D_ID X Y Z R G B ERROR TRACK[]\n"
-        "1 1.5 -2.25 3.75 10 20 30 0.125 7 8 9 10\n"
-        "2 -4 5 6.5 255 128 0 2.0 11 12\n");
-
-    const auto data = lfs::io::detail::parse_points3D_text_point_cloud_fast(path);
-    EXPECT_EQ(data.point_count, 2u);
-    EXPECT_EQ(data.file_lines, 3u);
-    expect_point(data, 0, 1.5f, -2.25f, 3.75f, 10, 20, 30);
-    expect_point(data, 1, -4.0f, 5.0f, 6.5f, 255, 128, 0);
-}
-
-TEST(ColmapPoints3DText, FastPathSkipsCommentsBlanksAndHandlesCrLf) {
-    const auto path = write_points3d_fixture(
-        "crlf_points3D.txt",
-        "# header\r\n"
-        "\r\n"
-        "3 0 1 2 1 2 3 0.0 4 5\r\n"
-        "\r\n"
-        "# footer\r\n");
-
-    const auto data = lfs::io::detail::parse_points3D_text_point_cloud_fast(path);
-    EXPECT_EQ(data.point_count, 1u);
-    EXPECT_EQ(data.file_lines, 5u);
-    expect_point(data, 0, 0.0f, 1.0f, 2.0f, 1, 2, 3);
-}
-
-TEST(ColmapPoints3DText, FastPathHandlesFinalLineWithoutTrailingNewline) {
-    const auto path = write_points3d_fixture(
-        "no_trailing_newline_points3D.txt",
-        "4 9 8 7 6 5 4 0.0");
-
-    const auto data = lfs::io::detail::parse_points3D_text_point_cloud_fast(path);
-    EXPECT_EQ(data.point_count, 1u);
-    EXPECT_EQ(data.file_lines, 1u);
-    expect_point(data, 0, 9.0f, 8.0f, 7.0f, 6, 5, 4);
-}
-
-TEST(ColmapPoints3DText, FastPathDoesNotParseLongTrackTails) {
-    std::string line = "5 1 2 3 4 5 6 0.0";
-    for (int i = 0; i < 500; ++i) {
-        line += " " + std::to_string(i) + " " + std::to_string(i + 1);
-    }
-    line += "\n";
-
-    const auto path = write_points3d_fixture("long_track_tail_points3D.txt", line);
-    const auto data = lfs::io::detail::parse_points3D_text_point_cloud_fast(path);
-    EXPECT_EQ(data.point_count, 1u);
-    expect_point(data, 0, 1.0f, 2.0f, 3.0f, 4, 5, 6);
-}
-
-TEST(ColmapPoints3DText, FastPathThrowsOnMalformedLine) {
-    const auto path = write_points3d_fixture(
-        "malformed_points3D.txt",
-        "6 1 2 3 4 5 6\n");
-
-    EXPECT_THROW(
-        (void)lfs::io::detail::parse_points3D_text_point_cloud_fast(path),
-        std::runtime_error);
-}
-
-TEST(ColmapPoints3DText, FastPathThrowsOnEmptyOrCommentOnlyFile) {
-    const auto path = write_points3d_fixture(
-        "empty_points3D.txt",
-        "# only comments\n\n# still no points\n");
-
-    EXPECT_THROW(
-        (void)lfs::io::detail::parse_points3D_text_point_cloud_fast(path),
-        std::runtime_error);
-}
-
-TEST(ColmapPoints3DText, RecordPathThrowsOnEmptyOrCommentOnlyFile) {
-    const auto path = write_points3d_fixture(
-        "empty_records_points3D.txt",
-        "# only comments\n\n# still no points\n");
-
-    EXPECT_THROW(
-        (void)lfs::io::detail::parse_points3D_text_records_for_test(
-            path,
-            lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly),
-        std::runtime_error);
-}
-
-TEST(ColmapPoints3DText, RecordFullModeParsesTracksExactly) {
-    const auto path = write_points3d_fixture(
-        "full_tracks_points3D.txt",
-        "10 1 2 3 7 8 9 0.25 100 200 101 201\n");
-
-    const auto records = lfs::io::detail::parse_points3D_text_records_for_test(
-        path,
-        lfs::io::detail::ColmapPoint3DTrackParseMode::Full);
-    ASSERT_EQ(records.size(), 1u);
-    EXPECT_EQ(records[0].point3D_id, 10u);
-    EXPECT_DOUBLE_EQ(records[0].xyz[0], 1.0);
-    EXPECT_DOUBLE_EQ(records[0].xyz[1], 2.0);
-    EXPECT_DOUBLE_EQ(records[0].xyz[2], 3.0);
-    EXPECT_EQ(records[0].color[0], 7);
-    EXPECT_EQ(records[0].color[1], 8);
-    EXPECT_EQ(records[0].color[2], 9);
-    EXPECT_DOUBLE_EQ(records[0].error, 0.25);
-    EXPECT_EQ(records[0].track_count, 2u);
-    ASSERT_EQ(records[0].track.size(), 2u);
-    EXPECT_EQ(records[0].track[0].image_id, 100u);
-    EXPECT_EQ(records[0].track[0].point2D_idx, 200u);
-    EXPECT_EQ(records[0].track[1].image_id, 101u);
-    EXPECT_EQ(records[0].track[1].point2D_idx, 201u);
-}
-
-TEST(ColmapPoints3DText, RecordCountOnlyMatchesFullTrackCounts) {
-    const auto path = write_points3d_fixture(
-        "count_only_tracks_points3D.txt",
-        "11 0 0 0 1 2 3 0.0 1 2 3 4 5 6\n"
-        "12 0 0 0 4 5 6 0.0 7 8 9\n");
-
-    const auto full = lfs::io::detail::parse_points3D_text_records_for_test(
-        path,
-        lfs::io::detail::ColmapPoint3DTrackParseMode::Full);
-    const auto count_only = lfs::io::detail::parse_points3D_text_records_for_test(
-        path,
-        lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly);
-
-    ASSERT_EQ(full.size(), count_only.size());
-    EXPECT_EQ(full[0].track_count, 3u);
-    EXPECT_EQ(count_only[0].track_count, full[0].track_count);
-    EXPECT_TRUE(count_only[0].track.empty());
-    EXPECT_EQ(full[1].track_count, 1u);
-    EXPECT_EQ(count_only[1].track_count, full[1].track_count);
-    EXPECT_TRUE(count_only[1].track.empty());
-}
-
-TEST(ColmapPoints3DText, RecordModesIgnoreDanglingOddTrackTokenConsistently) {
-    const auto path = write_points3d_fixture(
-        "dangling_track_token_points3D.txt",
-        "15 0 0 0 1 2 3 0.0 10 20 30\n");
-
-    const auto full = lfs::io::detail::parse_points3D_text_records_for_test(
-        path,
-        lfs::io::detail::ColmapPoint3DTrackParseMode::Full);
-    const auto count_only = lfs::io::detail::parse_points3D_text_records_for_test(
-        path,
-        lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly);
-    const auto none = lfs::io::detail::parse_points3D_text_records_for_test(
-        path,
-        lfs::io::detail::ColmapPoint3DTrackParseMode::None);
-
-    ASSERT_EQ(full.size(), 1u);
-    ASSERT_EQ(count_only.size(), 1u);
-    ASSERT_EQ(none.size(), 1u);
-    EXPECT_EQ(full[0].track_count, 1u);
-    ASSERT_EQ(full[0].track.size(), 1u);
-    EXPECT_EQ(full[0].track[0].image_id, 10u);
-    EXPECT_EQ(full[0].track[0].point2D_idx, 20u);
-    EXPECT_EQ(count_only[0].track_count, full[0].track_count);
-    EXPECT_TRUE(count_only[0].track.empty());
-    EXPECT_EQ(none[0].track_count, 0u);
-    EXPECT_TRUE(none[0].track.empty());
-}
-
-TEST(ColmapPoints3DText, RecordNoneModeLeavesTrackCountZero) {
-    const auto path = write_points3d_fixture(
-        "none_tracks_points3D.txt",
-        "13 0 0 0 1 2 3 0.0 1 2 3 4\n");
-
-    const auto records = lfs::io::detail::parse_points3D_text_records_for_test(
-        path,
-        lfs::io::detail::ColmapPoint3DTrackParseMode::None);
-    ASSERT_EQ(records.size(), 1u);
-    EXPECT_EQ(records[0].track_count, 0u);
-    EXPECT_TRUE(records[0].track.empty());
-}
-
-TEST(ColmapPoints3DText, RecordPathThrowsOnMalformedHeader) {
-    const auto path = write_points3d_fixture(
-        "malformed_record_points3D.txt",
-        "14 0 0 0 1 2 3\n");
-
-    EXPECT_THROW(
-        (void)lfs::io::detail::parse_points3D_text_records_for_test(
-            path,
-            lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly),
-        std::runtime_error);
-}
-
-TEST(ColmapPoints3DText, ParallelPathThrowsOnMalformedLineInLaterChunk) {
-    std::ostringstream contents;
-    contents << "# generated large malformed fixture\n";
-    constexpr int kValidPrefixCount = 300000;
-    for (int i = 0; i < kValidPrefixCount; ++i) {
-        contents << i << ' '
-                 << static_cast<double>(i) * 0.5 << ' '
-                 << static_cast<double>(i) * -0.25 << ' '
-                 << static_cast<double>(i) * 0.125 << ' '
-                 << (i % 256) << ' '
-                 << ((i + 1) % 256) << ' '
-                 << ((i + 2) % 256) << " 0.0 "
-                 << i << ' ' << (i + 10) << ' '
-                 << (i + 20) << ' ' << (i + 30) << '\n';
-    }
-    contents << "bad malformed later chunk\n";
-
-    const auto path = write_points3d_fixture("large_parallel_malformed_points3D.txt", contents.str());
-    EXPECT_THROW(
-        (void)lfs::io::detail::parse_points3D_text_point_cloud_fast(path),
-        std::runtime_error);
-    EXPECT_THROW(
-        (void)lfs::io::detail::parse_points3D_text_records_for_test(
-            path,
-            lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly),
-        std::runtime_error);
-}
-
-TEST(ColmapPoints3DText, LargeFileParallelPathIsDeterministicAcrossModes) {
-    std::ostringstream contents;
-    contents << "# generated large fixture\n";
-    constexpr int kPointCount = 320000;
-    for (int i = 0; i < kPointCount; ++i) {
-        contents << i << ' '
-                 << static_cast<double>(i) * 0.5 << ' '
-                 << static_cast<double>(i) * -0.25 << ' '
-                 << static_cast<double>(i) * 0.125 << ' '
-                 << (i % 256) << ' '
-                 << ((i + 1) % 256) << ' '
-                 << ((i + 2) % 256) << " 0.0 "
-                 << i << ' ' << (i + 10) << ' '
-                 << (i + 20) << ' ' << (i + 30) << '\n';
+TEST(ColmapPoints3DText, LoadsTextPointCloudThroughPublicApi) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required for COLMAP point cloud load";
     }
 
-    const auto path = write_points3d_fixture("large_parallel_points3D.txt", contents.str());
-    const auto fast = lfs::io::detail::parse_points3D_text_point_cloud_fast(path);
-    const auto full = lfs::io::detail::parse_points3D_text_records_for_test(
-        path,
-        lfs::io::detail::ColmapPoint3DTrackParseMode::Full);
-    const auto count_only = lfs::io::detail::parse_points3D_text_records_for_test(
-        path,
-        lfs::io::detail::ColmapPoint3DTrackParseMode::CountOnly);
+    const auto point_cloud = lfs::io::read_colmap_point_cloud_text(fixture_dir("basic"));
+    EXPECT_EQ(point_cloud.size(), 3u);
+}
 
-    ASSERT_EQ(fast.point_count, static_cast<size_t>(kPointCount));
-    ASSERT_EQ(full.size(), static_cast<size_t>(kPointCount));
-    ASSERT_EQ(count_only.size(), static_cast<size_t>(kPointCount));
-    expect_point(fast, 0, 0.0f, -0.0f, 0.0f, 0, 1, 2);
-    expect_point(fast, kPointCount - 1,
-                 static_cast<float>(kPointCount - 1) * 0.5f,
-                 static_cast<float>(kPointCount - 1) * -0.25f,
-                 static_cast<float>(kPointCount - 1) * 0.125f,
-                 static_cast<uint8_t>((kPointCount - 1) % 256),
-                 static_cast<uint8_t>(kPointCount % 256),
-                 static_cast<uint8_t>((kPointCount + 1) % 256));
-    EXPECT_EQ(full.front().track_count, 2u);
-    EXPECT_EQ(full.back().track_count, 2u);
-    EXPECT_EQ(count_only.front().track_count, full.front().track_count);
-    EXPECT_EQ(count_only.back().track_count, full.back().track_count);
-    EXPECT_TRUE(count_only.front().track.empty());
-    EXPECT_TRUE(count_only.back().track.empty());
+TEST(ColmapPoints3DText, ReportsStatsAndFiltersByMinimumTrackLength) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required for COLMAP point cloud load";
+    }
+
+    const auto result = lfs::io::read_colmap_point_cloud_text_with_stats(
+        fixture_dir("filter"),
+        lfs::io::LoadOptions{.min_track_length = 3});
+
+    EXPECT_TRUE(result.track_filter_applied);
+    EXPECT_EQ(result.total_points, 3u);
+    EXPECT_EQ(result.points_after_filtering, 1u);
+    EXPECT_EQ(result.point_cloud.size(), 1u);
+}
+
+TEST(ColmapPoints3DText, IgnoresDanglingOddTrackTokenWhenFiltering) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required for COLMAP point cloud load";
+    }
+
+    const auto result = lfs::io::read_colmap_point_cloud_text_with_stats(
+        fixture_dir("dangling_track_token"),
+        lfs::io::LoadOptions{.min_track_length = 2});
+
+    EXPECT_TRUE(result.track_filter_applied);
+    EXPECT_EQ(result.total_points, 2u);
+    EXPECT_EQ(result.points_after_filtering, 1u);
+    EXPECT_EQ(result.point_cloud.size(), 1u);
+}
+
+TEST(ColmapPoints3DText, LoadsSinglePointStatsThroughPublicApi) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required for COLMAP point cloud load";
+    }
+
+    const auto result = lfs::io::read_colmap_point_cloud_text_with_stats(fixture_dir("single_point"));
+
+    EXPECT_FALSE(result.track_filter_applied);
+    EXPECT_EQ(result.total_points, 1u);
+    EXPECT_EQ(result.points_after_filtering, 1u);
+    EXPECT_EQ(result.point_cloud.size(), 1u);
+}
+
+TEST(ColmapPoints3DText, ThrowsOnEmptyOrCommentOnlyFileThroughPublicApi) {
+    EXPECT_THROW(
+        (void)lfs::io::read_colmap_point_cloud_text_with_stats(fixture_dir("empty_comment_only")),
+        std::runtime_error);
+}
+
+TEST(ColmapPoints3DText, ThrowsOnMalformedLineThroughPublicApi) {
+    EXPECT_THROW(
+        (void)lfs::io::read_colmap_point_cloud_text_with_stats(fixture_dir("malformed")),
+        std::runtime_error);
 }


### PR DESCRIPTION
## Summary

This change significantly speeds up COLMAP `points3D.txt` loading for both the normal point-cloud path and the `--min-track-length` filtering path.

The implementation was split into three independently measurable phases:

1. Bulk-read `points3D.txt` and scan lines in-place instead of using `std::getline`.
2. Add track-count-only parsing so filtered loads do not materialize full track pairs.
3. Parallelize large `points3D.txt` parsing with newline-aligned chunks using TBB.

## Main Changes

- Replaced line-by-line stream parsing with a whole-file buffer and `std::string_view` line scanning.
- Optimized ASCII whitespace handling by checking only spaces and tabs in hot parse loops.
- Parse only the fields required by the fast point-cloud load path.
- Parse point positions directly into `float` for the normal load path.
- Added `track_count` to point records so filtering can avoid full track materialization.
- Added internal track parse modes:
  - `None`
  - `CountOnly`
  - `Full`
- Reworked text record parsing to use `from_chars` instead of `split_string` / `std::stod`.
- Updated min-track filtering to use `track_count`.
- Added parallel chunk parsing for large files:
  - chunks are aligned to newline boundaries,
  - each worker writes to private vectors,
  - results are concatenated in file order for deterministic output,
  - small files keep the serial path.
- Added focused `points3D.txt` parser tests, including comments, blanks, CRLF, no-final-newline files, long track tails, malformed lines, empty/comment-only files, track count modes, filtering behavior, round-trip behavior, and deterministic large-file parsing.

## Timing Results

Dataset:

```text
D:\temp\gs_tests\POPERINGE\outdoor\colmap
```

Point count:

```text
1,699,644
```

### Normal Load

| Metric | Baseline | Step 1 | Step 3 | Improvement vs Baseline |
|---|---:|---:|---:|---:|
| `points3D.txt` parse | `9199.83 ms` | `2541.97 ms` | `643.11 ms` | `14.31x faster`, `93.0% less time` |
| COLMAP Loading | `10425.68 ms` | `3840.90 ms` | `1962.09 ms` | `5.31x faster`, `81.2% less time` |

### Min-Track Load

Command mode:

```text
--min-track-length 5
```

Filter result stayed unchanged:

```text
1,699,644 -> 219,184
```

| Metric | Baseline | Step 2 | Step 3 | Improvement vs Baseline |
|---|---:|---:|---:|---:|
| record parse | `11699.04 ms` | `2512.79 ms` | `516.94 ms` | `22.63x faster`, `95.6% less time` |
| full `Read points3D.txt` | `18793.76 ms` | `2630.20 ms` | `633.73 ms` | `29.66x faster`, `96.6% less time` |
| COLMAP Loading | `20158.49 ms` | `4004.66 ms` | `2017.84 ms` | `9.99x faster`, `90.0% less time` |

