### PR TITLE
HDRI Background Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,6 +671,7 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory "${RESOURCE_DIR}/assets/icon/scene"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${RESOURCE_DIR}/assets/fonts"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${RESOURCE_DIR}/assets/themes"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${RESOURCE_DIR}/assets/environments"
     COMMENT "Creating resource directory structure"
 )
 
@@ -725,6 +726,14 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         "${CMAKE_SOURCE_DIR}/src/visualizer/gui/assets/themes"
         "${RESOURCE_DIR}/assets/themes"
     COMMENT "Copying themes"
+)
+
+# Copy bundled environment maps
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+        "${CMAKE_SOURCE_DIR}/src/visualizer/gui/assets/environments"
+        "${RESOURCE_DIR}/assets/environments"
+    COMMENT "Copying environment maps"
 )
 
 # Copy additional assets (logo, splash images, etc.)

--- a/src/python/lfs/py_rendering.cpp
+++ b/src/python/lfs/py_rendering.cpp
@@ -24,6 +24,7 @@
 #include "visualizer/internal/viewport.hpp"
 #include "visualizer/ipc/view_context.hpp"
 #include "visualizer/rendering/rendering_manager.hpp"
+#include "visualizer/rendering/viewport_appearance_correction.hpp"
 #include "visualizer/visualizer.hpp"
 
 #include <algorithm>
@@ -1322,11 +1323,19 @@ namespace lfs::python {
 
                 std::optional<lfs::rendering::GpuFrame> primary_frame;
                 if (preview_image && preview_image->is_valid()) {
+                    auto normalized_preview =
+                        (preview_image->to(core::DataType::Float32) * (1.0f / 255.0f)).contiguous();
+                    preview_image = std::make_shared<core::Tensor>(std::move(normalized_preview));
+                    preview_image = vis::applyViewportAppearanceCorrection(
+                        std::move(preview_image),
+                        scene_manager,
+                        settings,
+                        rendering_manager->getCurrentCameraId());
                     auto frame = *preview_image;
                     if (frame.dtype() != core::DataType::Float32) {
                         frame = frame.to(core::DataType::Float32);
                     }
-                    frame = (frame * (1.0f / 255.0f)).permute({2, 0, 1}).contiguous();
+                    frame = frame.permute({2, 0, 1}).contiguous();
                     if (frame.device() != core::Device::CUDA) {
                         frame = frame.cuda();
                     }

--- a/src/python/lfs/py_rendering.cpp
+++ b/src/python/lfs/py_rendering.cpp
@@ -1225,7 +1225,7 @@ namespace lfs::python {
                 throw std::runtime_error("viewport export expected a 3D image tensor");
             }
             if (image.shape()[0] <= 4 && image.shape()[2] > 4) {
-                image = image.permute({1, 2, 0});
+                image = image.permute({1, 2, 0}).contiguous();
             }
             image = image.to(core::Device::CPU);
             if (image.dtype() != core::DataType::UInt8) {
@@ -1276,6 +1276,152 @@ namespace lfs::python {
                 throw std::runtime_error("transparent viewport export render failed");
             }
             return toU8Hwc(std::move(*image));
+        }
+
+        [[nodiscard]] std::optional<core::Tensor> renderCurrentViewHdrComposite8(
+            const vis::ViewInfo& view_info,
+            const int width,
+            const int height) {
+            auto invoke_render = [&]() -> std::optional<core::Tensor> {
+                auto* const viewer = get_visualizer();
+                auto* const rendering_manager = viewer ? viewer->getRenderingManager() : nullptr;
+                auto* const scene_manager = viewer ? viewer->getSceneManager() : nullptr;
+                if (!rendering_manager || !scene_manager) {
+                    return std::nullopt;
+                }
+
+                const auto settings = rendering_manager->getSettings();
+                if (!vis::environmentBackgroundEnabled(settings)) {
+                    return std::nullopt;
+                }
+
+                auto* const engine = rendering_manager->getRenderingEngine();
+                if (!engine) {
+                    return std::nullopt;
+                }
+
+                const auto rotation = viewInfoRotationMatrix(view_info);
+                const glm::vec3 translation{
+                    view_info.translation[0],
+                    view_info.translation[1],
+                    view_info.translation[2]};
+                const float focal_length_mm = lfs::rendering::vFovToFocalLength(view_info.fov);
+                const auto ortho_scale_override = scaledViewInfoOrthoScale(view_info, height);
+                const float ortho_scale = ortho_scale_override.value_or(view_info.ortho_scale);
+
+                auto preview_image = rendering_manager->renderPreviewImageRgba8(
+                    scene_manager,
+                    rotation,
+                    translation,
+                    focal_length_mm,
+                    width,
+                    height,
+                    view_info.orthographic,
+                    ortho_scale_override);
+                rendering_manager->releasePreviewImageResources();
+
+                std::optional<lfs::rendering::GpuFrame> primary_frame;
+                if (preview_image && preview_image->is_valid()) {
+                    auto frame = *preview_image;
+                    if (frame.dtype() != core::DataType::Float32) {
+                        frame = frame.to(core::DataType::Float32);
+                    }
+                    frame = (frame * (1.0f / 255.0f)).permute({2, 0, 1}).contiguous();
+                    if (frame.device() != core::Device::CUDA) {
+                        frame = frame.cuda();
+                    }
+                    auto frame_image = std::make_shared<core::Tensor>(std::move(frame));
+                    lfs::rendering::FrameMetadata metadata{
+                        .valid = true,
+                        .far_plane = settings.depth_clip_enabled
+                                          ? settings.depth_clip_far
+                                          : lfs::rendering::DEFAULT_FAR_PLANE,
+                        .orthographic = view_info.orthographic,
+                        .color_has_alpha = true};
+                    auto materialized = engine->materializeGpuFrame(
+                        frame_image,
+                        metadata,
+                        {width, height});
+                    if (!materialized || !materialized->valid()) {
+                        LOG_ERROR("Viewport export HDRI composite failed to materialize Gaussian frame: {}",
+                                  materialized ? "invalid frame" : materialized.error());
+                        return std::nullopt;
+                    }
+                    primary_frame = std::move(*materialized);
+                }
+
+                lfs::rendering::FrameView frame_view{
+                    .rotation = rotation,
+                    .translation = translation,
+                    .size = {width, height},
+                    .focal_length_mm = focal_length_mm,
+                    .near_plane = lfs::rendering::DEFAULT_NEAR_PLANE,
+                    .far_plane = settings.depth_clip_enabled
+                                      ? settings.depth_clip_far
+                                      : lfs::rendering::DEFAULT_FAR_PLANE,
+                    .orthographic = view_info.orthographic,
+                    .ortho_scale = ortho_scale,
+                    .background_color = settings.background_color};
+                lfs::rendering::ViewportData viewport{
+                    .rotation = frame_view.rotation,
+                    .translation = frame_view.translation,
+                    .size = frame_view.size,
+                    .focal_length_mm = frame_view.focal_length_mm,
+                    .orthographic = frame_view.orthographic,
+                    .ortho_scale = frame_view.ortho_scale};
+                lfs::rendering::VideoCompositeFrameRequest composite_request{
+                    .viewport = viewport,
+                    .frame_view = frame_view,
+                    .background_color = settings.background_color,
+                    .environment =
+                        {.enabled = true,
+                         .map_path = settings.environment_map_path,
+                         .exposure = settings.environment_exposure,
+                         .rotation_degrees = settings.environment_rotation_degrees,
+                         .equirectangular = settings.equirectangular},
+                    .meshes = {}};
+
+                auto composited = engine->renderVideoCompositeFrame(primary_frame, composite_request);
+                if (!composited) {
+                    LOG_ERROR("Viewport export HDRI composite failed: {}", composited.error());
+                    return std::nullopt;
+                }
+                return toU8Hwc(std::move(*composited));
+            };
+
+            auto* const viewer = get_visualizer();
+            if (!viewer || viewer->isOnViewerThread()) {
+                return invoke_render();
+            }
+            if (!viewer->acceptsPostedWork()) {
+                return std::nullopt;
+            }
+
+            auto promise = std::make_shared<std::promise<std::optional<core::Tensor>>>();
+            auto future = promise->get_future();
+            auto completed = std::make_shared<std::atomic_bool>(false);
+
+            auto finish = [promise, completed](std::optional<core::Tensor> result) mutable {
+                if (!completed->exchange(true)) {
+                    promise->set_value(std::move(result));
+                }
+            };
+
+            const bool posted = viewer->postWork(vis::Visualizer::WorkItem{
+                .run =
+                    [invoke_render, finish]() mutable {
+                        finish(invoke_render());
+                    },
+                .cancel =
+                    [finish]() mutable {
+                        finish(std::nullopt);
+                    }});
+            if (!posted) {
+                return std::nullopt;
+            }
+
+            nb::gil_scoped_release release;
+            return future.get();
         }
 
         [[nodiscard]] core::Tensor recoverAlphaRgba(core::Tensor black_rgb, core::Tensor white_rgb) {
@@ -1656,7 +1802,24 @@ namespace lfs::python {
                     image = recoverAlphaRgba(std::move(black), std::move(white));
                 }
             } else {
-                image = renderCurrentViewRgb8(*view_info, target_width, target_height, std::nullopt);
+                const auto render_settings = vis::get_render_settings();
+                const bool export_hdr_environment =
+                    render_settings &&
+                    render_settings->environment_mode ==
+                        static_cast<int>(vis::EnvironmentBackgroundMode::Equirectangular) &&
+                    !render_settings->environment_map_path.empty();
+                if (export_hdr_environment) {
+                    auto composited = renderCurrentViewHdrComposite8(
+                        *view_info,
+                        target_width,
+                        target_height);
+                    if (!composited || !composited->is_valid()) {
+                        throw std::runtime_error("viewport HDRI export render failed");
+                    }
+                    image = std::move(*composited);
+                } else {
+                    image = renderCurrentViewRgb8(*view_info, target_width, target_height, std::nullopt);
+                }
             }
         }
 

--- a/src/python/lfs/py_rendering.cpp
+++ b/src/python/lfs/py_rendering.cpp
@@ -65,7 +65,6 @@ namespace lfs::python {
             const auto layout = rendering::detectImageLayout(image);
             if (layout == rendering::ImageLayout::Unknown)
                 return std::nullopt;
-            image = rendering::flipImageVertical(image, layout);
             if (layout == rendering::ImageLayout::CHW) {
                 image = image.permute({1, 2, 0});
             } else {

--- a/src/python/stubs/lichtfeld/scene.pyi
+++ b/src/python/stubs/lichtfeld/scene.pyi
@@ -87,7 +87,7 @@ class SplatData:
         """Number of visible (non-deleted) Gaussians"""
 
     def soft_delete(self, mask: lichtfeld.Tensor) -> lichtfeld.Tensor:
-        """Mark Gaussians as deleted by mask, returns newly deleted mask for undo"""
+        """Mark Gaussians as deleted by mask, returns previous state for undo"""
 
     def undelete(self, mask: lichtfeld.Tensor) -> None:
         """Restore deleted Gaussians by mask"""

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -411,13 +411,18 @@ namespace lfs::vis::gui {
         if (!image || !image->is_valid() || image->ndim() != 3) {
             return std::unexpected("Rendered Gaussian frame is invalid");
         }
-        if (image->size(0) <= 0 || image->size(1) <= 0 || image->size(2) != 3) {
-            return std::unexpected("Rendered Gaussian frame must have shape [H, W, 3]");
+        if (image->size(0) <= 0 || image->size(1) <= 0 ||
+            (image->size(2) != 3 && image->size(2) != 4)) {
+            return std::unexpected("Rendered Gaussian frame must have shape [H, W, 3] or [H, W, 4]");
         }
 
         auto frame = *image;
+        const bool normalize_uint8 = frame.dtype() == lfs::core::DataType::UInt8;
         if (frame.dtype() != lfs::core::DataType::Float32) {
             frame = frame.to(lfs::core::DataType::Float32);
+        }
+        if (normalize_uint8) {
+            frame = frame / 255.0f;
         }
         frame = frame.permute({2, 0, 1}).contiguous();
         if (frame.device() != lfs::core::Device::CUDA) {
@@ -485,14 +490,24 @@ namespace lfs::vis::gui {
                 primary_frame = std::move(*render_result);
             } else {
                 auto scene_state = makeVideoExportGaussianSceneState(snapshot);
-                auto preview_image = rendering_manager.renderPreviewImage(
-                    *snapshot.combined_model,
-                    std::move(scene_state),
-                    glm::mat3_cast(cam_state.rotation),
-                    cam_state.position,
-                    cam_state.focal_length_mm,
-                    width,
-                    height);
+                const auto camera_rotation = glm::mat3_cast(cam_state.rotation);
+                auto preview_image = render_environment
+                                         ? rendering_manager.renderPreviewImageRgba8(
+                                               *snapshot.combined_model,
+                                               std::move(scene_state),
+                                               camera_rotation,
+                                               cam_state.position,
+                                               cam_state.focal_length_mm,
+                                               width,
+                                               height)
+                                         : rendering_manager.renderPreviewImage(
+                                               *snapshot.combined_model,
+                                               std::move(scene_state),
+                                               camera_rotation,
+                                               cam_state.position,
+                                               cam_state.focal_length_mm,
+                                               width,
+                                               height);
                 auto video_frame = makeGaussianPreviewVideoFrame(preview_image);
                 if (!video_frame) {
                     return std::unexpected(video_frame.error());
@@ -505,7 +520,7 @@ namespace lfs::vis::gui {
                 auto frame_image = std::make_shared<lfs::core::Tensor>(std::move(*video_frame));
                 auto materialized = engine.materializeGpuFrame(
                     frame_image,
-                    makeVideoExportFrameMetadata(frame_view, false),
+                    makeVideoExportFrameMetadata(frame_view, render_environment),
                     {width, height});
                 if (!materialized || !materialized->valid()) {
                     return std::unexpected(materialized ? "Rendered Gaussian frame is invalid"

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -417,6 +417,8 @@ namespace lfs::vis::gui {
         }
 
         auto frame = *image;
+        // Preview readbacks currently arrive as uint8 HWC and need normalization;
+        // float preview tensors are expected to already be in normalized color space.
         const bool normalize_uint8 = frame.dtype() == lfs::core::DataType::UInt8;
         if (frame.dtype() != lfs::core::DataType::Float32) {
             frame = frame.to(lfs::core::DataType::Float32);

--- a/src/visualizer/rendering/passes/vulkan_environment_pass.cpp
+++ b/src/visualizer/rendering/passes/vulkan_environment_pass.cpp
@@ -564,22 +564,20 @@ namespace lfs::vis {
             loaded_path = params.map_path;
         }
 
-        void record(VkCommandBuffer cb, VkExtent2D extent, const VulkanEnvironmentParams& params) {
+        void record(VkCommandBuffer cb, VkRect2D rect, const VulkanEnvironmentParams& params) {
             if (!params.enabled || pipeline == VK_NULL_HANDLE || image_view == VK_NULL_HANDLE ||
                 screen_quad_buffer == VK_NULL_HANDLE) {
                 return;
             }
             VkViewport vp{};
-            vp.x = 0.0f;
-            vp.y = 0.0f;
-            vp.width = static_cast<float>(extent.width);
-            vp.height = static_cast<float>(extent.height);
+            vp.x = static_cast<float>(rect.offset.x);
+            vp.y = static_cast<float>(rect.offset.y);
+            vp.width = static_cast<float>(rect.extent.width);
+            vp.height = static_cast<float>(rect.extent.height);
             vp.minDepth = 0.0f;
             vp.maxDepth = 1.0f;
-            VkRect2D sc{};
-            sc.extent = extent;
             vkCmdSetViewport(cb, 0, 1, &vp);
-            vkCmdSetScissor(cb, 0, 1, &sc);
+            vkCmdSetScissor(cb, 0, 1, &rect);
 
             vkCmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
             vkCmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout,
@@ -628,10 +626,10 @@ namespace lfs::vis {
             impl_->prepare(params);
     }
 
-    void VulkanEnvironmentPass::record(VkCommandBuffer cb, VkExtent2D extent,
+    void VulkanEnvironmentPass::record(VkCommandBuffer cb, VkRect2D rect,
                                        const VulkanEnvironmentParams& params) {
         if (impl_)
-            impl_->record(cb, extent, params);
+            impl_->record(cb, rect, params);
     }
 
     void VulkanEnvironmentPass::shutdown() {

--- a/src/visualizer/rendering/passes/vulkan_environment_pass.hpp
+++ b/src/visualizer/rendering/passes/vulkan_environment_pass.hpp
@@ -44,10 +44,10 @@ namespace lfs::vis {
         // is unchanged.
         void prepare(const VulkanEnvironmentParams& params);
 
-        // Records a full-screen quad draw that fills the color attachment with the
+        // Records a quad draw that fills the viewport rect with the
         // ACES-tonemapped equirect background. Caller is mid-render.
         void record(VkCommandBuffer command_buffer,
-                    VkExtent2D framebuffer_extent,
+                    VkRect2D framebuffer_rect,
                     const VulkanEnvironmentParams& params);
 
         void shutdown();

--- a/src/visualizer/rendering/passes/vulkan_viewport_pass.cpp
+++ b/src/visualizer/rendering/passes/vulkan_viewport_pass.cpp
@@ -1592,8 +1592,10 @@ namespace lfs::vis {
                                    const VulkanViewportPassParams& params) {
             assert(params.environment.enabled && environment_pass.hasTexture());
             environment_pass.record(command_buffer,
-                                    {static_cast<std::uint32_t>(rect.width),
-                                     static_cast<std::uint32_t>(rect.height)},
+                                    VkRect2D{
+                                        .offset = {rect.x, rect.y},
+                                        .extent = {static_cast<std::uint32_t>(rect.width),
+                                                   static_cast<std::uint32_t>(rect.height)}},
                                     params.environment);
         }
 

--- a/src/visualizer/rendering/rendering_manager_viewport.cpp
+++ b/src/visualizer/rendering/rendering_manager_viewport.cpp
@@ -280,12 +280,12 @@ namespace lfs::vis {
     }
 
     std::shared_ptr<lfs::core::Tensor> RenderingManager::captureViewportImage() {
-        if (auto image = getViewportImageIfAvailable()) {
-            return image;
-        }
-
         if (viewport_artifact_service_.hasLazyCapture()) {
             return viewport_artifact_service_.resolveLazyCapture();
+        }
+
+        if (auto image = getViewportImageIfAvailable()) {
+            return image;
         }
 
         if (!engine_ || !viewport_artifact_service_.hasGpuFrame()) {

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <cstdint>
 #include <expected>
+#include <filesystem>
 #include <format>
 #include <optional>
 #include <shared_mutex>
@@ -360,6 +361,19 @@ namespace lfs::vis {
                  static_cast<std::size_t>(width)},
                 lfs::core::Device::CPU);
             return std::make_shared<lfs::core::Tensor>(std::move(tensor));
+        }
+
+        [[nodiscard]] std::shared_ptr<lfs::core::Tensor> makeViewportCaptureImageHwc(
+            lfs::core::Tensor image) {
+            if (!image.is_valid() || image.ndim() != 3) {
+                return std::make_shared<lfs::core::Tensor>(std::move(image));
+            }
+
+            const auto layout = lfs::rendering::detectImageLayout(image);
+            if (layout == lfs::rendering::ImageLayout::CHW) {
+                image = image.permute({1, 2, 0});
+            }
+            return std::make_shared<lfs::core::Tensor>(image.cpu().contiguous());
         }
 
         struct SplitCompositeContentRect {
@@ -2105,9 +2119,12 @@ namespace lfs::vis {
                         render_lock.reset();
                         note_lod_page_generation(render_result.lod_page_generation);
                         note_vksplat_render_progress(render_result);
+                        const bool transparent_viewer_compositing =
+                            environmentBackgroundUsesTransparentViewerCompositing(settings_);
                         lfs::rendering::FrameMetadata metadata{};
                         metadata.valid = true;
                         metadata.flip_y = render_result.flip_y;
+                        metadata.color_has_alpha = transparent_viewer_compositing;
 
                         const auto publish_mesh_frame_for_vksplat = [&]() {
                             // VkSplat returns before the shared mesh-frame setup below.
@@ -2138,10 +2155,39 @@ namespace lfs::vis {
                             }
                         };
 
+                        const lfs::rendering::FrameView capture_frame_view = request.frame_view;
+                        const auto make_capture_composite_request =
+                            [&]() -> lfs::rendering::VideoCompositeFrameRequest {
+                            return {
+                                .viewport =
+                                    {.rotation = capture_frame_view.rotation,
+                                     .translation = capture_frame_view.translation,
+                                     .size = capture_frame_view.size,
+                                     .focal_length_mm = capture_frame_view.focal_length_mm,
+                                     .orthographic = capture_frame_view.orthographic,
+                                     .ortho_scale = capture_frame_view.ortho_scale},
+                                .frame_view = capture_frame_view,
+                                .background_color = settings_.background_color,
+                                .environment =
+                                    {.enabled = transparent_viewer_compositing,
+                                     .map_path = transparent_viewer_compositing
+                                                     ? std::filesystem::path(settings_.environment_map_path)
+                                                     : std::filesystem::path{},
+                                     .exposure = settings_.environment_exposure,
+                                     .rotation_degrees = settings_.environment_rotation_degrees,
+                                     .equirectangular = settings_.equirectangular},
+                                .meshes = {},
+                            };
+                        };
+
                         if (settings_.apply_appearance_correction) {
-                            auto image = vksplat_viewport_renderer_->readOutputImage(
-                                *context.vulkan_context,
-                                VksplatViewportRenderer::OutputSlot::Main);
+                            auto image = transparent_viewer_compositing
+                                             ? vksplat_viewport_renderer_->readOutputImageRgba(
+                                                   *context.vulkan_context,
+                                                   VksplatViewportRenderer::OutputSlot::Main)
+                                             : vksplat_viewport_renderer_->readOutputImage(
+                                                   *context.vulkan_context,
+                                                   VksplatViewportRenderer::OutputSlot::Main);
                             if (image && *image) {
                                 auto corrected_image = applyViewportAppearanceCorrection(
                                     std::move(*image),
@@ -2166,6 +2212,42 @@ namespace lfs::vis {
                                     vulkan_gt_comparison_content_size_ = {0, 0};
                                     viewport_artifact_service_.updateFromImageOutput(
                                         corrected_image, metadata, render_result.size, true);
+                                    if (transparent_viewer_compositing) {
+                                        const auto capture_composite_request = make_capture_composite_request();
+                                        viewport_artifact_service_.setLazyCaptureForCurrentOutput(
+                                            [this,
+                                             capture_composite_request,
+                                             metadata,
+                                             render_size = render_result.size,
+                                             corrected_capture_image = corrected_image]()
+                                                -> std::shared_ptr<lfs::core::Tensor> {
+                                                auto* const engine = getRenderingEngine();
+                                                if (!engine) {
+                                                    LOG_ERROR("Failed to composite VkSplat viewport capture: rendering engine unavailable");
+                                                    return {};
+                                                }
+                                                auto materialized = engine->materializeGpuFrame(
+                                                    corrected_capture_image,
+                                                    metadata,
+                                                    render_size);
+                                                if (!materialized || !materialized->valid()) {
+                                                    LOG_ERROR("Failed to materialize corrected VkSplat viewport capture for environment composite: {}",
+                                                              materialized ? "invalid frame" : materialized.error());
+                                                    return corrected_capture_image;
+                                                }
+                                                auto composited = engine->renderVideoCompositeFrame(
+                                                    *materialized,
+                                                    capture_composite_request);
+                                                if (!composited) {
+                                                    LOG_ERROR("Failed to composite environment into corrected VkSplat viewport capture: {}",
+                                                              composited.error());
+                                                    return corrected_capture_image;
+                                                }
+                                                return makeViewportCaptureImageHwc(std::move(*composited));
+                                            },
+                                            metadata,
+                                            render_result.size);
+                                    }
 
                                     if (resize_result.completed) {
                                         frame_lifecycle_service_.noteResizeCompleted();
@@ -2196,17 +2278,49 @@ namespace lfs::vis {
                         vulkan_viewport_image_size_ = render_result.size;
                         vulkan_viewport_image_flip_y_ = render_result.flip_y;
                         vulkan_gt_comparison_content_size_ = {0, 0};
+                        const auto capture_composite_request = make_capture_composite_request();
                         viewport_artifact_service_.setLazyCapture(
-                            [this]() -> std::shared_ptr<lfs::core::Tensor> {
+                            [this, transparent_viewer_compositing, capture_composite_request, metadata, render_size = render_result.size]()
+                                -> std::shared_ptr<lfs::core::Tensor> {
                                 if (!vksplat_viewport_renderer_ || !last_vulkan_context_) {
                                     return {};
                                 }
-                                auto image = vksplat_viewport_renderer_->readOutputImage(
-                                    *last_vulkan_context_,
-                                    VksplatViewportRenderer::OutputSlot::Main);
+                                auto image = transparent_viewer_compositing
+                                                 ? vksplat_viewport_renderer_->readOutputImageRgba(
+                                                       *last_vulkan_context_,
+                                                       VksplatViewportRenderer::OutputSlot::Main)
+                                                 : vksplat_viewport_renderer_->readOutputImage(
+                                                       *last_vulkan_context_,
+                                                       VksplatViewportRenderer::OutputSlot::Main);
                                 if (!image) {
                                     LOG_ERROR("Failed to capture VkSplat viewport image: {}", image.error());
                                     return {};
+                                }
+                                if (transparent_viewer_compositing) {
+                                    auto* const engine = getRenderingEngine();
+                                    if (!engine) {
+                                        LOG_ERROR("Failed to composite VkSplat viewport capture: rendering engine unavailable");
+                                        return {};
+                                    }
+                                    auto frame_image = std::move(*image);
+                                    auto materialized = engine->materializeGpuFrame(
+                                        frame_image,
+                                        metadata,
+                                        render_size);
+                                    if (!materialized || !materialized->valid()) {
+                                        LOG_ERROR("Failed to materialize VkSplat viewport capture for environment composite: {}",
+                                                  materialized ? "invalid frame" : materialized.error());
+                                        return frame_image;
+                                    }
+                                    auto composited = engine->renderVideoCompositeFrame(
+                                        *materialized,
+                                        capture_composite_request);
+                                    if (!composited) {
+                                        LOG_ERROR("Failed to composite environment into VkSplat viewport capture: {}",
+                                                  composited.error());
+                                        return frame_image;
+                                    }
+                                    return makeViewportCaptureImageHwc(std::move(*composited));
                                 }
                                 return std::move(*image);
                             },

--- a/src/visualizer/rendering/resources/viewport/vksplat_compose.comp
+++ b/src/visualizer/rendering/resources/viewport/vksplat_compose.comp
@@ -103,6 +103,11 @@ void main() {
     }
 
     if (pc.transparent_background != 0u) {
+        const bool empty = alpha < 0.02 || depth >= 1.0e9 || depth <= 0.0;
+        if (empty) {
+            imageStore(out_image, ivec2(gid), vec4(0.0));
+            return;
+        }
         const vec3 straight_rgb = alpha > 1e-6 ? state.rgb / alpha : vec3(0.0);
         imageStore(out_image, ivec2(gid), vec4(clamp(straight_rgb, vec3(0.0), vec3(1.0)), alpha));
         return;

--- a/src/visualizer/rendering/resources/viewport/vksplat_compose.comp
+++ b/src/visualizer/rendering/resources/viewport/vksplat_compose.comp
@@ -25,6 +25,8 @@ layout(set = 0, binding = 1) readonly buffer PixelDepthBuffer {
 layout(set = 0, binding = 2, rgba8) uniform writeonly image2D out_image;
 layout(set = 0, binding = 3, r32f) uniform writeonly image2D out_depth;
 
+const float ZERO_COVERAGE_ALPHA = 0.5 / 255.0;
+
 float normalizedDepth(float depth, float lo, float hi) {
     lo = max(lo, 1.0e-4);
     hi = max(hi, lo + 1.0e-4);
@@ -103,7 +105,7 @@ void main() {
     }
 
     if (pc.transparent_background != 0u) {
-        const bool empty = alpha < 0.02 || depth >= 1.0e9 || depth <= 0.0;
+        const bool empty = alpha <= ZERO_COVERAGE_ALPHA;
         if (empty) {
             imageStore(out_image, ivec2(gid), vec4(0.0));
             return;

--- a/src/visualizer/rendering/viewport_appearance_correction.cpp
+++ b/src/visualizer/rendering/viewport_appearance_correction.cpp
@@ -3,11 +3,14 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "viewport_appearance_correction.hpp"
+#include "core/logger.hpp"
 #include "scene/scene_manager.hpp"
 #include "training/components/ppisp.hpp"
 #include "training/components/ppisp_controller.hpp"
 #include "training/trainer.hpp"
 #include "training/training_manager.hpp"
+#include <exception>
+#include <vector>
 
 namespace lfs::vis {
 
@@ -37,6 +40,13 @@ namespace lfs::vis {
         [[nodiscard]] bool isImageWithAlpha(const lfs::core::Tensor& image) {
             return image.ndim() == 3 &&
                    ((image.shape()[0] == 4) || (image.shape()[2] == 4));
+        }
+
+        [[nodiscard]] lfs::core::Tensor preparePpispInput(lfs::core::Tensor input) {
+            if (!input.is_valid() || input.device() == lfs::core::Device::CUDA) {
+                return input;
+            }
+            return input.cuda();
         }
 
         [[nodiscard]] lfs::core::Tensor applyStandaloneAppearance(
@@ -117,7 +127,21 @@ namespace lfs::vis {
             if (!has_alpha || !corrected_rgb.is_valid()) {
                 return corrected_rgb;
             }
-            return lfs::core::Tensor::cat({corrected_rgb, alpha}, alpha_concat_dim).contiguous();
+            auto alpha_for_copy = alpha;
+            if (alpha_for_copy.device() != corrected_rgb.device()) {
+                alpha_for_copy = alpha_for_copy.to(corrected_rgb.device());
+            }
+
+            std::vector<size_t> restored_shape = corrected_rgb.shape().dims();
+            restored_shape[static_cast<size_t>(alpha_concat_dim)] = 4;
+            auto restored = lfs::core::Tensor::empty(
+                lfs::core::TensorShape(restored_shape),
+                corrected_rgb.device(),
+                corrected_rgb.dtype());
+
+            restored.slice(static_cast<size_t>(alpha_concat_dim), 0, 3).copy_from(corrected_rgb);
+            restored.slice(static_cast<size_t>(alpha_concat_dim), 3, 4).copy_from(alpha_for_copy);
+            return restored.contiguous();
         };
 
         if (const auto* tm = scene_manager->getTrainerManager()) {
@@ -132,10 +156,19 @@ namespace lfs::vis {
                     trainer_overrides.gamma_multiplier = settings.ppisp_overrides.gamma_multiplier;
                 }
                 const bool use_controller = (settings.ppisp_mode == RenderSettings::PPISPMode::AUTO);
-                auto corrected = trainer->applyPPISPForViewport(
-                    rgb_input, camera_uid, trainer_overrides, use_controller);
-                corrected = restore_alpha(std::move(corrected));
-                return std::make_shared<lfs::core::Tensor>(std::move(corrected));
+                try {
+                    auto ppisp_input = preparePpispInput(rgb_input);
+                    auto corrected = trainer->applyPPISPForViewport(
+                        ppisp_input, camera_uid, trainer_overrides, use_controller);
+                    corrected = restore_alpha(std::move(corrected));
+                    return std::make_shared<lfs::core::Tensor>(std::move(corrected));
+                } catch (const std::exception& e) {
+                    LOG_WARN("Viewport trainer PPISP correction failed: {}", e.what());
+                    return image;
+                } catch (...) {
+                    LOG_WARN("Viewport trainer PPISP correction failed");
+                    return image;
+                }
             }
         }
 
@@ -147,7 +180,17 @@ namespace lfs::vis {
                                     ? settings.ppisp_overrides
                                     : PPISPOverrides{};
         const bool use_controller = (settings.ppisp_mode == RenderSettings::PPISPMode::AUTO);
-        auto corrected = applyStandaloneAppearance(rgb_input, *scene_manager, camera_uid, overrides, use_controller);
+        lfs::core::Tensor corrected;
+        try {
+            auto ppisp_input = preparePpispInput(rgb_input);
+            corrected = applyStandaloneAppearance(ppisp_input, *scene_manager, camera_uid, overrides, use_controller);
+        } catch (const std::exception& e) {
+            LOG_WARN("Standalone viewport PPISP correction failed: {}", e.what());
+            return image;
+        } catch (...) {
+            LOG_WARN("Standalone viewport PPISP correction failed");
+            return image;
+        }
         if (!corrected.is_valid()) {
             return has_alpha ? std::make_shared<lfs::core::Tensor>(restore_alpha(rgb_input)) : image;
         }

--- a/src/visualizer/rendering/viewport_appearance_correction.hpp
+++ b/src/visualizer/rendering/viewport_appearance_correction.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include "core/tensor.hpp"
 #include "rendering_types.hpp"
 #include <memory>
@@ -12,7 +13,7 @@ namespace lfs::vis {
 
     class SceneManager;
 
-    [[nodiscard]] std::shared_ptr<lfs::core::Tensor> applyViewportAppearanceCorrection(
+    [[nodiscard]] LFS_VIS_API std::shared_ptr<lfs::core::Tensor> applyViewportAppearanceCorrection(
         std::shared_ptr<lfs::core::Tensor> image,
         SceneManager* scene_manager,
         const RenderSettings& settings,

--- a/src/visualizer/rendering/viewport_artifact_service.cpp
+++ b/src/visualizer/rendering/viewport_artifact_service.cpp
@@ -67,6 +67,7 @@ namespace lfs::vis {
     void ViewportArtifactService::invalidateCapture() {
         captured_image_.reset();
         captured_artifact_generation_ = 0;
+        captured_image_from_lazy_capture_ = false;
         ++artifact_generation_;
         if (artifact_generation_ == 0) {
             artifact_generation_ = 1;
@@ -110,8 +111,14 @@ namespace lfs::vis {
     }
 
     void ViewportArtifactService::storeCapturedImage(std::shared_ptr<lfs::core::Tensor> image) {
+        storeCapturedImage(std::move(image), false);
+    }
+
+    void ViewportArtifactService::storeCapturedImage(std::shared_ptr<lfs::core::Tensor> image,
+                                                     const bool from_lazy_capture) {
         captured_image_ = std::move(image);
         captured_artifact_generation_ = captured_image_ ? artifact_generation_ : 0;
+        captured_image_from_lazy_capture_ = captured_image_ && from_lazy_capture;
     }
 
     void ViewportArtifactService::setLazyCapture(LazyCaptureFn fn,
@@ -124,15 +131,27 @@ namespace lfs::vis {
         lazy_capture_ = std::move(fn);
     }
 
+    void ViewportArtifactService::setLazyCaptureForCurrentOutput(
+        LazyCaptureFn fn,
+        const lfs::rendering::FrameMetadata& metadata,
+        const glm::ivec2& rendered_size) {
+        metadata_ = makeCachedRenderMetadata(metadata);
+        gpu_frame_.reset();
+        rendered_size_ = rendered_size;
+        captured_image_from_lazy_capture_ = false;
+        lazy_capture_ = std::move(fn);
+    }
+
     std::shared_ptr<lfs::core::Tensor> ViewportArtifactService::resolveLazyCapture() {
         if (!lazy_capture_) {
             return {};
         }
-        if (captured_image_ && captured_artifact_generation_ == artifact_generation_) {
+        if (captured_image_ && captured_artifact_generation_ == artifact_generation_ &&
+            captured_image_from_lazy_capture_) {
             return captured_image_;
         }
         auto image = lazy_capture_();
-        storeCapturedImage(image);
+        storeCapturedImage(image, true);
         return image;
     }
 

--- a/src/visualizer/rendering/viewport_artifact_service.cpp
+++ b/src/visualizer/rendering/viewport_artifact_service.cpp
@@ -66,8 +66,9 @@ namespace lfs::vis {
 
     void ViewportArtifactService::invalidateCapture() {
         captured_image_.reset();
+        lazy_captured_image_.reset();
         captured_artifact_generation_ = 0;
-        captured_image_from_lazy_capture_ = false;
+        lazy_captured_artifact_generation_ = 0;
         ++artifact_generation_;
         if (artifact_generation_ == 0) {
             artifact_generation_ = 1;
@@ -104,6 +105,8 @@ namespace lfs::vis {
         gpu_frame_.reset();
         rendered_size_ = rendered_size;
         lazy_capture_ = {};
+        lazy_captured_image_.reset();
+        lazy_captured_artifact_generation_ = 0;
         if (viewport_output_updated) {
             invalidateCapture();
         }
@@ -111,14 +114,8 @@ namespace lfs::vis {
     }
 
     void ViewportArtifactService::storeCapturedImage(std::shared_ptr<lfs::core::Tensor> image) {
-        storeCapturedImage(std::move(image), false);
-    }
-
-    void ViewportArtifactService::storeCapturedImage(std::shared_ptr<lfs::core::Tensor> image,
-                                                     const bool from_lazy_capture) {
         captured_image_ = std::move(image);
         captured_artifact_generation_ = captured_image_ ? artifact_generation_ : 0;
-        captured_image_from_lazy_capture_ = captured_image_ && from_lazy_capture;
     }
 
     void ViewportArtifactService::setLazyCapture(LazyCaptureFn fn,
@@ -138,7 +135,8 @@ namespace lfs::vis {
         metadata_ = makeCachedRenderMetadata(metadata);
         gpu_frame_.reset();
         rendered_size_ = rendered_size;
-        captured_image_from_lazy_capture_ = false;
+        lazy_captured_image_.reset();
+        lazy_captured_artifact_generation_ = 0;
         lazy_capture_ = std::move(fn);
     }
 
@@ -146,12 +144,12 @@ namespace lfs::vis {
         if (!lazy_capture_) {
             return {};
         }
-        if (captured_image_ && captured_artifact_generation_ == artifact_generation_ &&
-            captured_image_from_lazy_capture_) {
-            return captured_image_;
+        if (lazy_captured_image_ && lazy_captured_artifact_generation_ == artifact_generation_) {
+            return lazy_captured_image_;
         }
         auto image = lazy_capture_();
-        storeCapturedImage(image, true);
+        lazy_captured_image_ = image;
+        lazy_captured_artifact_generation_ = lazy_captured_image_ ? artifact_generation_ : 0;
         return image;
     }
 

--- a/src/visualizer/rendering/viewport_artifact_service.hpp
+++ b/src/visualizer/rendering/viewport_artifact_service.hpp
@@ -53,6 +53,9 @@ namespace lfs::vis {
         void setLazyCapture(LazyCaptureFn fn,
                             const lfs::rendering::FrameMetadata& metadata,
                             const glm::ivec2& rendered_size);
+        void setLazyCaptureForCurrentOutput(LazyCaptureFn fn,
+                                            const lfs::rendering::FrameMetadata& metadata,
+                                            const glm::ivec2& rendered_size);
         [[nodiscard]] std::shared_ptr<lfs::core::Tensor> resolveLazyCapture();
         [[nodiscard]] bool hasLazyCapture() const { return static_cast<bool>(lazy_capture_); }
 
@@ -64,12 +67,14 @@ namespace lfs::vis {
 
     private:
         void invalidateCapture();
+        void storeCapturedImage(std::shared_ptr<lfs::core::Tensor> image, bool from_lazy_capture);
         CachedRenderMetadata metadata_;
         std::optional<lfs::rendering::GpuFrame> gpu_frame_;
         glm::ivec2 rendered_size_{0};
         std::shared_ptr<lfs::core::Tensor> captured_image_;
         uint64_t artifact_generation_ = 1;
         uint64_t captured_artifact_generation_ = 0;
+        bool captured_image_from_lazy_capture_ = false;
         LazyCaptureFn lazy_capture_;
     };
 

--- a/src/visualizer/rendering/viewport_artifact_service.hpp
+++ b/src/visualizer/rendering/viewport_artifact_service.hpp
@@ -47,8 +47,8 @@ namespace lfs::vis {
         // For split-view frames: the live viewport composes on the GPU and never produces
         // a single CPU/CUDA tensor. Capture/screenshot paths still need one, so the caller
         // hands us a closure that does the CPU compose on demand. The first capture
-        // request runs it, caches the result, and subsequent captures reuse the cache
-        // until the next frame's updateFromImageOutput / setLazyCapture invalidates it.
+        // request runs it, caches the result separately from the display-facing
+        // capture, and subsequent captures reuse it until the next frame invalidates it.
         using LazyCaptureFn = std::function<std::shared_ptr<lfs::core::Tensor>()>;
         void setLazyCapture(LazyCaptureFn fn,
                             const lfs::rendering::FrameMetadata& metadata,
@@ -67,14 +67,14 @@ namespace lfs::vis {
 
     private:
         void invalidateCapture();
-        void storeCapturedImage(std::shared_ptr<lfs::core::Tensor> image, bool from_lazy_capture);
         CachedRenderMetadata metadata_;
         std::optional<lfs::rendering::GpuFrame> gpu_frame_;
         glm::ivec2 rendered_size_{0};
         std::shared_ptr<lfs::core::Tensor> captured_image_;
+        std::shared_ptr<lfs::core::Tensor> lazy_captured_image_;
         uint64_t artifact_generation_ = 1;
         uint64_t captured_artifact_generation_ = 0;
-        bool captured_image_from_lazy_capture_ = false;
+        uint64_t lazy_captured_artifact_generation_ = 0;
         LazyCaptureFn lazy_capture_;
     };
 

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -4794,8 +4794,9 @@ namespace lfs::vis {
                                                     output.depth_image.image,
                                                     VK_IMAGE_ASPECT_COLOR_BIT,
                                                     VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-            VkClearColorValue clear{
-                {background.r, background.g, background.b, transparent_background ? 0.0f : 1.0f}};
+            VkClearColorValue clear = transparent_background
+                                          ? VkClearColorValue{{0.0f, 0.0f, 0.0f, 0.0f}}
+                                          : VkClearColorValue{{background.r, background.g, background.b, 1.0f}};
             VkClearColorValue depth_clear{{1.0e10f, 0.0f, 0.0f, 0.0f}};
             VkImageSubresourceRange range{};
             range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -4794,7 +4794,8 @@ namespace lfs::vis {
                                                     output.depth_image.image,
                                                     VK_IMAGE_ASPECT_COLOR_BIT,
                                                     VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-            VkClearColorValue clear{{background.r, background.g, background.b, 1.0f}};
+            VkClearColorValue clear{
+                {background.r, background.g, background.b, transparent_background ? 0.0f : 1.0f}};
             VkClearColorValue depth_clear{{1.0e10f, 0.0f, 0.0f, 0.0f}};
             VkImageSubresourceRange range{};
             range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -5006,6 +5007,28 @@ namespace lfs::vis {
             lfs::core::DataType::Float32);
         if (!tensor.is_valid()) {
             return std::unexpected("VkSplat output readback failed to allocate CPU float RGB tensor");
+        }
+
+        auto ok = readOutputImageIntoCpuHwc(context, output_slot, tensor, 0, 0);
+        if (!ok) {
+            return std::unexpected(ok.error());
+        }
+        return std::make_shared<lfs::core::Tensor>(std::move(tensor));
+    }
+
+    std::expected<std::shared_ptr<lfs::core::Tensor>, std::string>
+    VksplatViewportRenderer::readOutputImageRgba(VulkanContext& context, const OutputSlot output_slot) const {
+        const auto size = latestOutputImageSize(output_slot);
+        if (!size) {
+            return std::unexpected(size.error());
+        }
+
+        auto tensor = lfs::core::Tensor::empty(
+            {static_cast<std::size_t>(size->y), static_cast<std::size_t>(size->x), std::size_t{4}},
+            lfs::core::Device::CPU,
+            lfs::core::DataType::Float32);
+        if (!tensor.is_valid()) {
+            return std::unexpected("VkSplat output readback failed to allocate CPU float RGBA tensor");
         }
 
         auto ok = readOutputImageIntoCpuHwc(context, output_slot, tensor, 0, 0);

--- a/src/visualizer/rendering/vksplat_viewport_renderer.hpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.hpp
@@ -179,6 +179,9 @@ namespace lfs::vis {
         [[nodiscard]] std::expected<std::shared_ptr<lfs::core::Tensor>, std::string> readOutputImage(
             VulkanContext& context,
             OutputSlot output_slot = OutputSlot::Main) const;
+        [[nodiscard]] std::expected<std::shared_ptr<lfs::core::Tensor>, std::string> readOutputImageRgba(
+            VulkanContext& context,
+            OutputSlot output_slot = OutputSlot::Main) const;
         [[nodiscard]] std::expected<std::shared_ptr<lfs::core::Tensor>, std::string> readOutputImageRgb8(
             VulkanContext& context,
             OutputSlot output_slot = OutputSlot::Main) const;


### PR DESCRIPTION
## Summary

Fixes #1354

This patch restores HDRI background correctness across the Vulkan/VkSplat viewport, PPISP correction, viewport capture/export, and Gaussian video export paths. It fixes framebuffer placement for the HDRI pass, preserves VkSplat alpha through PPISP and capture, composites normal exports over HDRI, keeps transparent PNG export as true alpha output, removes a stale Python capture flip, stages bundled HDRIs for dev-build software compositing, and ensures zero-coverage VkSplat pixels export as transparent instead of opaque black.


## List of changes
- HDRI backgrounds now render in the correct viewport panel region without right or bottom black bars.
- PPISP-corrected VkSplat output preserves alpha, so HDRI remains visible behind transparent splat regions.
- Normal viewport capture/export and Gaussian video export composite splats over HDRI instead of flattening alpha against black.
- Python viewport capture and default capture-based export are upright.
- Toolbar viewport JPG/PNG export uses the expected HWC image layout after HDRI compositing.
- Dev builds stage bundled HDRIs where the software compositor's generic asset resolver can find them.
- VkSplat transparent output writes alpha 0 for zero-coverage/background pixels while preserving low-alpha splat coverage, allowing the HDRI to show through in exported images without hard silhouettes.
- fixed export of .ply with .ppisp in both viewport and custom resolutions
 
## Observed symptoms

- Equirectangular HDRI backgrounds appeared shifted in empty scenes, leaving black bars on the right and bottom of the viewport.
- With PPISP correction enabled, HDRI backgrounds disappeared behind Gaussian splats.
- Low-opacity edge splats became opaque and overexposed, especially around sky or large soft splats.
- HDRI exposure and rotation controls appeared unresponsive once a PPISP-enabled splat was loaded.
- Viewport and video exports could show the same straight-alpha fringe artifacts instead of compositing splats over the HDRI.
- Python viewport captures and default capture-based viewport exports were flipped upside down.
- Default viewport export with HDRI could preserve transparent splat alpha but return black where the live viewport showed the HDRI.
- Toolbar JPG viewport export with PPISP and HDRI could expose semi-transparent splat lobes over black instead of producing the same flattened HDRI composite as the live viewport.
- Toolbar JPG/PNG viewport export could save a visibly corrupted full-frame image after HDRI compositing because the software composite returned channel-first image data to a viewport/export boundary that expects channel-last image data.
- In dev builds, toolbar JPG export could fail HDRI compositing with `Environment map not found` for `build/resources/assets/environments/...`, even though the live viewport rendered the bundled HDRI correctly.
- Toolbar JPG export could reach HDRI compositing successfully but still omit the HDRI because zero-coverage VkSplat pixels were exported as opaque black instead of transparent.

## Reproduction steps

1. Open LichtFeld Studio with the Vulkan viewport path.
2. Enable an equirectangular HDRI background in an empty scene.
3. Observe that the HDRI does not align with the viewport panel and can leave right/bottom bars.
4. Load an LFS-trained PLY with PPISP sidecar data, or otherwise enable PPISP correction on a trained splat.
5. Keep the HDRI background enabled and inspect low-alpha splat edges.
6. Adjust HDRI exposure or rotation and observe that the background appears hidden behind the now-opaque corrected splat image.
7. From the Python console, run `lfs.capture_viewport()` and save the result with `lfs.save_image(...)`; compare the saved image orientation against the live viewport. - image is rotated
8. Export the viewport or video with the HDRI enabled and compare edge transparency/background compositing against the live viewport expectation - image is rotated

Python-console orientation check:

```python
import lichtfeld as lfs
from pathlib import Path

out = "C:/tmp/lfs_viewport_export.png"

result = lfs.export_viewport_image(out, format="png")
print(result)
```

Before the fix, `viewport_capture.png` is upside down relative to the live viewport. After the fix, the saved image should match the live viewport orientation.

## Root cause

The Vulkan rewrite moved HDRI compositing from the old OpenGL/CUDA path into the viewport pass graph, where the environment is drawn first and VkSplat output is blended on top with straight alpha. Three regressions came from that plumbing:

- The environment pass received only the viewport width and height, then reset viewport/scissor to origin `(0, 0)`. It ignored the framebuffer-space panel offset, so the HDRI rendered at the window origin instead of the viewport panel.
- VkSplat writes straight-alpha RGBA when transparent HDRI viewer compositing is active. The PPISP viewport path read back only RGB, discarding alpha before applying correction. The corrected texture was then uploaded as opaque, hiding the HDRI and turning amplified straight-alpha edge color into visible overexposed blobs.
- Capture and video export paths could materialize Gaussian frames without alpha, so the later environment composite had no transparency information to place the HDRI behind the splats.
- `viewportRenderImageHwc()` still unconditionally called `flipImageVertical(...)`. That flip was added for an older CUDA/rasterizer-era Python render path, but the current Vulkan/VkSplat capture tensors are already returned in top-left HWC orientation. The stale flip inverted Python API captures and the default capture-based viewport export.
- The VkSplat lazy viewport capture path read RGBA for transparent HDRI viewer compositing but returned the raw transparent frame. That is correct for explicit transparent PNG export, but not for normal viewport export, which is expected to be a flattened image matching what the user sees.
- The PPISP-corrected VkSplat path returned early after storing the corrected RGBA tensor in the viewport artifact cache. Because it never installed the HDRI lazy-composite closure, capture/export reused raw alpha. JPEG has no alpha channel, so those semi-transparent regions were flattened against black by the image writer.
- `renderSoftwareVideoComposite` returns a channel-first tensor (`CHW`) for rendering/video use. Viewport capture/export expects channel-last (`HWC`) image tensors, so returning the composite directly from the lazy capture path let layout-specific data cross an API boundary.
- The dev resource layout staged bundled HDRIs under `build/src/visualizer/resources/assets/environments`, where the live Vulkan environment pass could find them through the visualizer-aware `getAssetPath(...)` fallback. The software composite path uses the generic runtime asset resolver, which expects bundled assets under `build/resources/assets`. Because the top-level dev resource staging did not copy environment maps there, viewport export compositing could not find the built-in HDRI.
- VkSplat transparent compose output derived alpha from transmittance but did not make zero-coverage pixels transparent in the normal color path. Background pixels could therefore cover the software-rendered HDRI during export compositing. The no-pixel-state fallback also cleared the output image with alpha 1 even when transparent background output was requested.

## Why this showed up after the Vulkan update

The HDRI feature originally lived on the old OpenGL/CUDA compositing path. The Vulkan viewport path reimplemented environment rendering as a pass graph stage and changed the Gaussian renderer to output straight-alpha splat color when the environment should be composited by the viewer. That made alpha preservation a required contract between VkSplat, PPISP correction, viewport texture upload, capture, and export. The PPISP path still used the older RGB readback assumption, so models with PPISP sidecar data triggered the failure immediately.

The Python capture flip survived that renderer transition. It had been useful when the old render source exposed bottom-left-oriented image data, but after CUDA renderer removal and the Vulkan/VkSplat capture path became the normal source, the API was flipping data that was already upright.

## Implemented fix

- `VulkanEnvironmentPass::record` now receives a full framebuffer rect and applies its offset to viewport and scissor, keeping shader ray math based on local viewport size.
- Added `VksplatViewportRenderer::readOutputImageRgba` for CPU float32 HWC RGBA readback through the existing readback helper.
- The VkSplat publish path marks `FrameMetadata::color_has_alpha` when transparent HDRI viewer compositing is active.
- PPISP correction reads RGBA in the HDRI transparent-compositing case, applies correction to RGB, and preserves alpha through `applyViewportAppearanceCorrection`.
- Lazy viewport capture reads RGBA when HDRI transparent compositing is active, preventing alpha loss in viewport exports.
- Normal non-transparent VkSplat viewport capture now composites that RGBA frame over the active HDRI through `RenderingEngine::materializeGpuFrame` and `renderVideoCompositeFrame`, reusing the existing software composite path instead of duplicating HDRI sampling.
- The PPISP-corrected VkSplat path now installs the same export-only lazy HDRI composite for its corrected RGBA tensor.
- Viewport capture now resolves lazy capture before reusing a raw cached viewport image. The artifact cache keeps lazy capture results separate from display-facing captured images, so export/screenshot compositing cannot overwrite the image returned by display/Python render callbacks within the same frame.
- Successful viewport HDRI software composites are converted to CPU HWC before they enter the viewport artifact cache.
- `viewportRenderImageHwc()` no longer applies an unconditional vertical flip. It still detects layout and converts CHW to HWC for Python callers.
- Gaussian video export uses RGBA preview output for HDRI composite frames, normalizes uint8 previews to float, and materializes the frame with `color_has_alpha=true` so the software compositor blends splats over the HDRI.
- Top-level dev resource staging now copies bundled environment maps into `build/resources/assets/environments`, matching the generic runtime asset layout used by software HDRI compositing.
- VkSplat transparent compose output now writes alpha 0 only for effectively zero-coverage pixels in the normal color path, preserving low-alpha splat coverage. The no-pixel-state fallback clears to transparent black when transparent output is requested.
- Explicit transparent PNG export remains true alpha output and does not bake in HDRI. Split view behavior is unchanged.

## Export behavior after the fix

- Normal viewport export returns a flattened image matching the live viewport, including HDRI behind transparent splat regions.
- `lfs.capture_viewport()` and `lfs.get_viewport_render()` return upright HWC image data for the current viewport capture path.
- `transparent=True` PNG export keeps true alpha output and intentionally does not bake in the HDRI background.
- Split view remains excluded from transparent HDRI viewer compositing and is not changed by this fix.

## Verification

Manual visual verification checklist:

- Empty scene with HDRI fills the viewport without right/bottom black bars.
- PPISP-enabled LFS-trained PLY with HDRI keeps the HDRI visible behind transparent splat edges.
- HDRI exposure and rotation controls respond with and without PPISP.
- `lfs.capture_viewport()` and default `lfs.export_viewport_image(..., format="png")` produce upright images.
- Normal viewport export includes the HDRI behind splats without straight-alpha fringe artifacts.
- Toolbar JPG export at `Resolution: Viewport` matches the live viewport and does not show raw transparent splat lobes over black.
- Toolbar JPG/PNG viewport export does not show channel-layout corruption after HDRI compositing.
- Toolbar JPG export with the built-in HDRI does not log `Environment map not found` for `build/resources/assets/environments/...`.
- Toolbar JPG export shows the HDRI behind zero-coverage/background VkSplat pixels instead of black.
- `transparent=True` PNG export preserves very low alpha instead of thresholding soft splat edges away.
- Display/Python render callbacks still return display-facing viewport output after a viewport export.
- Video export includes the HDRI behind splats without straight-alpha fringe artifacts.
- Split view, mesh overlays, depth view, and training remain unaffected.
- load a .ply with sidecar .ppisp and load hdri background.verify its visually correct. export to .jpg and .png in viewport size and 4K and verify the contents matches visually the actual viewport
