### PR TITLE
First-class spherical undistort support

### DIFF
--- a/src/core/camera.cpp
+++ b/src/core/camera.cpp
@@ -180,10 +180,13 @@ namespace lfs::core {
           _T(std::move(other._T)),
           _radial_distortion(std::move(other._radial_distortion)),
           _tangential_distortion(std::move(other._tangential_distortion)),
+          _camera_model_type(other._camera_model_type),
           _image_path(std::move(other._image_path)),
           _image_name(std::move(other._image_name)),
           _mask_path(std::move(other._mask_path)),
           _depth_path(std::move(other._depth_path)),
+          _cube_face_projection(std::move(other._cube_face_projection)),
+          _has_alpha(other._has_alpha),
           _normal_path(std::move(other._normal_path)),
           _split(other._split),
           _camera_width(other._camera_width),
@@ -235,10 +238,13 @@ namespace lfs::core {
             _T = std::move(other._T);
             _radial_distortion = std::move(other._radial_distortion);
             _tangential_distortion = std::move(other._tangential_distortion);
+            _camera_model_type = other._camera_model_type;
             _image_path = std::move(other._image_path);
             _image_name = std::move(other._image_name);
             _mask_path = std::move(other._mask_path);
             _depth_path = std::move(other._depth_path);
+            _cube_face_projection = std::move(other._cube_face_projection);
+            _has_alpha = other._has_alpha;
             _normal_path = std::move(other._normal_path);
             _split = other._split;
             _camera_width = other._camera_width;
@@ -288,6 +294,8 @@ namespace lfs::core {
           _image_path(other._image_path),
           _mask_path(other._mask_path),
           _depth_path(other._depth_path),
+          _cube_face_projection(other._cube_face_projection),
+          _has_alpha(other._has_alpha),
           _normal_path(other._normal_path),
           _split(other._split),
           _camera_width(other._camera_width),
@@ -346,6 +354,10 @@ namespace lfs::core {
         return {_focal_x * x_scale, _focal_y * y_scale, _center_x * x_scale, _center_y * y_scale};
     }
 
+    void Camera::set_cube_face_projection(CubeFaceProjection projection) {
+        _cube_face_projection = std::move(projection);
+    }
+
     Tensor Camera::load_and_get_image(int resize_factor, int max_width, const bool output_uint8,
                                       const bool update_dimensions) {
         const ImageLoadParams params{
@@ -376,7 +388,10 @@ namespace lfs::core {
 
     void Camera::load_image_size(int resize_factor, int max_width) {
         int w, h;
-        if (_undistort_prepared) {
+        if (_cube_face_projection) {
+            w = _cube_face_projection->face_size;
+            h = _cube_face_projection->face_size;
+        } else if (_undistort_prepared) {
             w = _camera_width;
             h = _camera_height;
         } else {
@@ -423,11 +438,11 @@ namespace lfs::core {
     }
 
     size_t Camera::get_num_bytes_from_file(int resize_factor, int max_width) const {
-        auto result = get_image_info(_image_path);
-
-        int w = std::get<0>(result);
-        int h = std::get<1>(result);
-        int c = std::get<2>(result);
+        auto [w, h, c] = get_image_info(_image_path);
+        if (_cube_face_projection) {
+            w = _cube_face_projection->face_size;
+            h = _cube_face_projection->face_size;
+        }
 
         if (resize_factor > 0) {
             w = w / resize_factor;
@@ -450,6 +465,10 @@ namespace lfs::core {
 
     size_t Camera::get_num_bytes_from_file() const {
         auto [w, h, c] = get_image_info(_image_path);
+        if (_cube_face_projection) {
+            w = _cube_face_projection->face_size;
+            h = _cube_face_projection->face_size;
+        }
         size_t num_bytes = w * h * c * sizeof(uint8_t);
         return num_bytes;
     }

--- a/src/core/include/core/camera.hpp
+++ b/src/core/include/core/camera.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "core/camera_types.h"
+#include "core/cube_face_projection.hpp"
 #include "core/cuda/undistort/undistort.hpp"
 #include "core/export.hpp"
 #include "core/tensor.hpp"
@@ -14,6 +15,7 @@
 #include <cuda_runtime.h>
 #include <filesystem>
 #include <future>
+#include <optional>
 #include <string>
 
 namespace lfs::core {
@@ -155,6 +157,9 @@ namespace lfs::core {
         const std::filesystem::path& image_path() const noexcept { return _image_path; }
         const std::filesystem::path& mask_path() const noexcept { return _mask_path; }
         const std::filesystem::path& depth_path() const noexcept { return _depth_path; }
+        void set_cube_face_projection(CubeFaceProjection projection);
+        const std::optional<CubeFaceProjection>& cube_face_projection() const noexcept { return _cube_face_projection; }
+        bool has_cube_face_projection() const noexcept { return _cube_face_projection.has_value(); }
         const std::filesystem::path& normal_path() const noexcept { return _normal_path; }
         bool has_in_memory_mask() const noexcept { return _in_memory_mask_raw.is_valid(); }
         bool has_mask() const noexcept {
@@ -214,6 +219,7 @@ namespace lfs::core {
         std::filesystem::path _image_path;
         std::filesystem::path _mask_path;
         std::filesystem::path _depth_path;
+        std::optional<CubeFaceProjection> _cube_face_projection;
         std::filesystem::path _normal_path;
         bool _has_alpha = false;
         CameraSplit _split = CameraSplit::Train;

--- a/src/core/include/core/cube_face_projection.hpp
+++ b/src/core/include/core/cube_face_projection.hpp
@@ -1,0 +1,62 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace lfs::core {
+
+    namespace detail {
+        constexpr float kCubeFacePi = 3.14159265358979323846f;
+        // Clamped before any focal/size conversion so a degenerate field of view
+        // cannot produce a zero or infinite focal length.
+        constexpr float kMinCubeFaceFovDegrees = 1.0f;
+        constexpr float kMaxCubeFaceFovDegrees = 179.0f;
+
+        [[nodiscard]] inline float cube_face_half_fov_tangent(const float fov_degrees) {
+            const float fov = std::clamp(fov_degrees, kMinCubeFaceFovDegrees, kMaxCubeFaceFovDegrees);
+            return std::tan(0.5f * fov * kCubeFacePi / 180.0f);
+        }
+    } // namespace detail
+
+    // Sampling of one square perspective face out of an equirectangular panorama.
+    // pano_to_face holds the face basis as three rows: right, up, forward.
+    struct CubeFaceProjection {
+        std::array<float, 9> pano_to_face{};
+        int face_size = 0;
+        int source_width = 0;
+        int source_height = 0;
+        float fov_degrees = 90.0f;
+    };
+
+    // Pinhole focal length, in pixels, of a square cube face.
+    [[nodiscard]] inline float cube_face_focal(const float fov_degrees, const int face_size) {
+        return 0.5f * static_cast<float>(face_size) / detail::cube_face_half_fov_tangent(fov_degrees);
+    }
+
+    // Face size that matches the panorama's own angular sampling rate at the centre
+    // of the face.
+    //
+    // The source resolves width/(2*pi) px/rad in azimuth and height/pi px/rad in
+    // elevation. A gnomonic face with focal f resolves exactly f px/rad at its
+    // centre, and more towards its edges because of the cos^3 stretch, so matching
+    // the centre means f = source focal and size = 2 * f * tan(fov/2).
+    //
+    // Sizing by pixel count instead (width * fov / 360) undersamples the face centre
+    // by tan(fov/2) / (fov/2) -- 1.27x at 90 degrees -- because a perspective face
+    // spaces its columns non-uniformly while equirectangular spacing is uniform in
+    // angle.
+    [[nodiscard]] inline int cube_face_size_for_panorama(const int source_width,
+                                                         const int source_height,
+                                                         const float fov_degrees) {
+        const float source_focal = std::max(static_cast<float>(source_width) / (2.0f * detail::kCubeFacePi),
+                                            static_cast<float>(source_height) / detail::kCubeFacePi);
+        const float size = 2.0f * source_focal * detail::cube_face_half_fov_tangent(fov_degrees);
+        return std::max(1, static_cast<int>(std::lround(size)));
+    }
+
+} // namespace lfs::core

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -235,6 +235,8 @@ add_library(lfs_io STATIC
         mesh/texture_loader.hpp
         mesh/texture_loader.cpp
         cache_image_loader.cpp
+        cube_face_projection.cpp
+        include/io/cube_face_projection.hpp
         nvcodec_image_loader.hpp
         nvcodec_image_loader.cpp
         pipelined_image_loader.cpp

--- a/src/io/cube_face_projection.cpp
+++ b/src/io/cube_face_projection.cpp
@@ -126,6 +126,67 @@ namespace lfs::io {
         return size;
     }
 
+    std::vector<float> project_cube_face_depth(
+        const uint8_t* source,
+        const bool source_is_16bit,
+        const int width,
+        const int height,
+        const lfs::core::CubeFaceProjection& projection,
+        const int output_size) {
+        if (!source || width <= 0 || height <= 0 || output_size <= 0) {
+            throw std::runtime_error("Invalid spherical depth projection input");
+        }
+
+        std::vector<float> projected(static_cast<size_t>(output_size) * output_size);
+
+        const float focal = lfs::core::cube_face_focal(projection.fov_degrees, output_size);
+        const float inv_focal = 1.0f / focal;
+        const float center = 0.5f * static_cast<float>(output_size);
+        const auto& m = projection.pano_to_face;
+        const auto* const source16 = reinterpret_cast<const uint16_t*>(source);
+        const float inv_max = source_is_16bit ? 1.0f / 65535.0f : 1.0f / 255.0f;
+
+        for (int y = 0; y < output_size; ++y) {
+            const float face_y = (static_cast<float>(y) + 0.5f - center) * inv_focal;
+            for (int x = 0; x < output_size; ++x) {
+                const float face_x = (static_cast<float>(x) + 0.5f - center) * inv_focal;
+                constexpr float face_z = 1.0f;
+
+                const float pano_x = m[0] * face_x + m[3] * face_y + m[6] * face_z;
+                const float pano_y = m[1] * face_x + m[4] * face_y + m[7] * face_z;
+                const float pano_z = m[2] * face_x + m[5] * face_y + m[8] * face_z;
+
+                // pano_to_face is orthonormal, so |p| = sqrt(u^2 + v^2 + 1) and
+                // 1/|p| is exactly cos(theta) between this ray and the face axis.
+                // The normalisation factor and the radial-to-z factor are the
+                // same number.
+                const float inv_len = 1.0f / std::sqrt(pano_x * pano_x + pano_y * pano_y + pano_z * pano_z);
+                const float cos_theta = inv_len;
+
+                const float azimuth = std::atan2(pano_x * inv_len, pano_z * inv_len);
+                const float elevation = std::asin(std::clamp(pano_y * inv_len, -1.0f, 1.0f));
+
+                const int sx = wrap_index(
+                    static_cast<int>(std::lround(
+                        (azimuth / (2.0f * kPi) + 0.5f) * static_cast<float>(width) - 0.5f)),
+                    width);
+                const int sy = std::clamp(
+                    static_cast<int>(std::lround(
+                        (elevation / kPi + 0.5f) * static_cast<float>(height) - 0.5f)),
+                    0, height - 1);
+
+                const size_t src_index = static_cast<size_t>(sy) * width + sx;
+                const float radial = (source_is_16bit ? static_cast<float>(source16[src_index])
+                                                      : static_cast<float>(source[src_index])) *
+                                     inv_max;
+
+                projected[static_cast<size_t>(y) * output_size + x] = radial * cos_theta;
+            }
+        }
+
+        return projected;
+    }
+
     std::vector<uint8_t> project_cube_face_hwc(
         const uint8_t* source,
         const int width,

--- a/src/io/cube_face_projection.cpp
+++ b/src/io/cube_face_projection.cpp
@@ -1,0 +1,244 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "io/cube_face_projection.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <stdexcept>
+#include <vector>
+
+namespace lfs::io {
+
+    namespace {
+        constexpr float kPi = 3.14159265358979323846f;
+
+        // Anisotropic (EWA) resampling footprint, after Heckbert 1989.
+        //
+        // The source-space filter covariance is
+        //     V = sigma_dst^2 * J * J^T + sigma_src^2 * I
+        // where J = d(source pixel) / d(face pixel) is the analytic Jacobian of the
+        // gnomonic-to-equirectangular map. The first term is the destination pixel's
+        // footprint pushed into source space; it is what prefilters the panorama
+        // where the face minifies it, and it is what a plain bilinear fetch is
+        // missing. The second term is the source reconstruction kernel, which keeps
+        // magnified regions smooth instead of blocky.
+        //
+        // This matters because the map is minifying at the centre of every face and
+        // magnifying towards the corners, so no fixed kernel is correct across a
+        // single face.
+        //
+        // Both sigmas are variance-matched to a one-pixel box: a box of width w has
+        // variance w^2/12. Matching variance rather than picking a sigma by eye is
+        // what makes the filter reduce to bilinear sharpness at unity magnification
+        // (a tent has variance 1/6, and 1/12 + 1/12 = 1/6), so this only ever blurs
+        // more than the old bilinear path where the map is genuinely minifying.
+        constexpr float kBoxSigma = 0.28867513f; // 1 / sqrt(12)
+        constexpr float kDstSigma = kBoxSigma;   // destination pixel footprint
+        constexpr float kSrcSigma = kBoxSigma;   // source pixel reconstruction
+        constexpr float kFilterRadiusSigmas = 3.0f;
+
+        // A face pixel near a pole spans a huge azimuth range in the source. Rather
+        // than clamp the footprint (which would alias) or walk every pixel in it
+        // (which would be unbounded work), stride through the footprint so the
+        // estimate stays representative and the tap count stays fixed.
+        constexpr int kMaxTapsPerAxis = 16;
+        constexpr float kMinHalfExtent = 1.0f;
+
+        // Guard for looking exactly along +/-Y, where azimuth is undefined.
+        constexpr float kMinHorizontalNorm = 1e-6f;
+
+        [[nodiscard]] float wrap_source_x(float x, const int width) {
+            const float w = static_cast<float>(width);
+            x = std::fmod(x, w);
+            if (x < 0.0f)
+                x += w;
+            return x;
+        }
+
+        [[nodiscard]] int wrap_index(int x, const int width) {
+            x %= width;
+            if (x < 0)
+                x += width;
+            return x;
+        }
+
+        // Covariance of the source-space resampling filter for one output pixel.
+        struct FilterCovariance {
+            float v00, v01, v11;
+        };
+
+        // p is the (unnormalised) view direction for this output pixel. The face
+        // basis rows give dp/d(face_x) = right = basis[0..2] and
+        // dp/d(face_y) = up = basis[3..5].
+        [[nodiscard]] FilterCovariance filter_covariance(
+            const float px, const float py, const float pz,
+            const std::array<float, 9>& basis,
+            const float inv_focal,
+            const int width, const int height) {
+            const float* const right = basis.data();
+            const float* const up = basis.data() + 3;
+            const float h2 = std::max(px * px + pz * pz, kMinHorizontalNorm);
+            const float h = std::sqrt(h2);
+            const float n2 = h2 + py * py;
+
+            // d(azimuth)/dp with azimuth = atan2(px, pz)
+            const float gaz_x = pz / h2;
+            const float gaz_z = -px / h2;
+
+            // d(elevation)/dp with elevation = asin(py / |p|)
+            const float gel_x = -py * px / (h * n2);
+            const float gel_y = h / n2;
+            const float gel_z = -py * pz / (h * n2);
+
+            // Angular derivatives to source pixel derivatives.
+            const float az_to_px = static_cast<float>(width) / (2.0f * kPi);
+            const float el_to_py = static_cast<float>(height) / kPi;
+
+            const float j00 = az_to_px * (gaz_x * right[0] + gaz_z * right[2]) * inv_focal;
+            const float j01 = az_to_px * (gaz_x * up[0] + gaz_z * up[2]) * inv_focal;
+            const float j10 = el_to_py * (gel_x * right[0] + gel_y * right[1] + gel_z * right[2]) * inv_focal;
+            const float j11 = el_to_py * (gel_x * up[0] + gel_y * up[1] + gel_z * up[2]) * inv_focal;
+
+            constexpr float dst_var = kDstSigma * kDstSigma;
+            constexpr float src_var = kSrcSigma * kSrcSigma;
+
+            return {
+                dst_var * (j00 * j00 + j01 * j01) + src_var,
+                dst_var * (j00 * j10 + j01 * j11),
+                dst_var * (j10 * j10 + j11 * j11) + src_var};
+        }
+    } // namespace
+
+    int projected_face_output_size(
+        const lfs::core::CubeFaceProjection& projection,
+        const int resize_factor,
+        const int max_width) {
+        int size = std::max(1, projection.face_size);
+        if (resize_factor > 1) {
+            size = std::max(1, size / resize_factor);
+        }
+        if (max_width > 0 && size > max_width) {
+            size = max_width;
+        }
+        return size;
+    }
+
+    std::vector<uint8_t> project_cube_face_hwc(
+        const uint8_t* source,
+        const int width,
+        const int height,
+        const int channels,
+        const lfs::core::CubeFaceProjection& projection,
+        const int output_size) {
+        if (!source || width <= 0 || height <= 0 || channels <= 0 || output_size <= 0) {
+            throw std::runtime_error("Invalid spherical projection input");
+        }
+
+        std::vector<uint8_t> projected(static_cast<size_t>(output_size) * output_size * channels);
+
+        const float focal = lfs::core::cube_face_focal(projection.fov_degrees, output_size);
+        const float inv_focal = 1.0f / focal;
+        const float center = 0.5f * static_cast<float>(output_size);
+        const auto& m = projection.pano_to_face;
+
+        constexpr float radius2 = kFilterRadiusSigmas * kFilterRadiusSigmas;
+        std::vector<float> accum(static_cast<size_t>(channels));
+
+        for (int y = 0; y < output_size; ++y) {
+            const float face_y = (static_cast<float>(y) + 0.5f - center) * inv_focal;
+            for (int x = 0; x < output_size; ++x) {
+                const float face_x = (static_cast<float>(x) + 0.5f - center) * inv_focal;
+                constexpr float face_z = 1.0f;
+
+                const float pano_x = m[0] * face_x + m[3] * face_y + m[6] * face_z;
+                const float pano_y = m[1] * face_x + m[4] * face_y + m[7] * face_z;
+                const float pano_z = m[2] * face_x + m[5] * face_y + m[8] * face_z;
+
+                const float inv_len = 1.0f / std::sqrt(pano_x * pano_x + pano_y * pano_y + pano_z * pano_z);
+                const float dir_x = pano_x * inv_len;
+                const float dir_y = pano_y * inv_len;
+                const float dir_z = pano_z * inv_len;
+
+                const float azimuth = std::atan2(dir_x, dir_z);
+                const float elevation = std::asin(std::clamp(dir_y, -1.0f, 1.0f));
+                const float src_x = wrap_source_x(
+                    (azimuth / (2.0f * kPi) + 0.5f) * static_cast<float>(width) - 0.5f, width);
+                const float src_y = std::clamp(
+                    (elevation / kPi + 0.5f) * static_cast<float>(height) - 0.5f,
+                    0.0f,
+                    static_cast<float>(height - 1));
+
+                const auto [v00, v01, v11] = filter_covariance(
+                    pano_x, pano_y, pano_z, m, inv_focal, width, height);
+
+                // Inverse covariance defines the quadratic form of the elliptical
+                // Gaussian; sqrt of the diagonal gives the axis-aligned extent.
+                const float det = std::max(v00 * v11 - v01 * v01, 1e-12f);
+                const float vi00 = v11 / det;
+                const float vi01 = -v01 / det;
+                const float vi11 = v00 / det;
+
+                const float half_x = std::max(kMinHalfExtent, kFilterRadiusSigmas * std::sqrt(v00));
+                const float half_y = std::max(kMinHalfExtent, kFilterRadiusSigmas * std::sqrt(v11));
+
+                const int stride_x = std::max(1, static_cast<int>(std::ceil(2.0f * half_x / kMaxTapsPerAxis)));
+                const int stride_y = std::max(1, static_cast<int>(std::ceil(2.0f * half_y / kMaxTapsPerAxis)));
+
+                const int y_begin = static_cast<int>(std::floor(src_y - half_y));
+                const int y_end = static_cast<int>(std::ceil(src_y + half_y));
+                const int x_begin = static_cast<int>(std::floor(src_x - half_x));
+                const int x_end = static_cast<int>(std::ceil(src_x + half_x));
+
+                std::fill(accum.begin(), accum.end(), 0.0f);
+                float weight_sum = 0.0f;
+
+                for (int sy = y_begin; sy <= y_end; sy += stride_y) {
+                    const float dy = static_cast<float>(sy) - src_y;
+                    // Clamping past the poles replicates the top/bottom row, which is
+                    // the same convention the forward mapping uses.
+                    const int row = std::clamp(sy, 0, height - 1);
+                    const size_t row_base = static_cast<size_t>(row) * width;
+
+                    for (int sx = x_begin; sx <= x_end; sx += stride_x) {
+                        const float dx = static_cast<float>(sx) - src_x;
+                        const float q = vi00 * dx * dx + 2.0f * vi01 * dx * dy + vi11 * dy * dy;
+                        if (q > radius2)
+                            continue;
+
+                        const float w = std::exp(-0.5f * q);
+                        const size_t base = (row_base + static_cast<size_t>(wrap_index(sx, width))) *
+                                            static_cast<size_t>(channels);
+                        for (int c = 0; c < channels; ++c) {
+                            accum[static_cast<size_t>(c)] += w * static_cast<float>(source[base + c]);
+                        }
+                        weight_sum += w;
+                    }
+                }
+
+                const size_t dst_base = (static_cast<size_t>(y) * output_size + x) * channels;
+                if (weight_sum > 0.0f) {
+                    const float inv_weight = 1.0f / weight_sum;
+                    for (int c = 0; c < channels; ++c) {
+                        projected[dst_base + c] = static_cast<uint8_t>(std::clamp(
+                            static_cast<int>(std::lround(accum[static_cast<size_t>(c)] * inv_weight)), 0, 255));
+                    }
+                } else {
+                    // Degenerate footprint: fall back to the nearest source texel.
+                    const size_t base = (static_cast<size_t>(std::clamp(static_cast<int>(std::lround(src_y)), 0, height - 1)) *
+                                             width +
+                                         static_cast<size_t>(wrap_index(static_cast<int>(std::lround(src_x)), width))) *
+                                        static_cast<size_t>(channels);
+                    for (int c = 0; c < channels; ++c) {
+                        projected[dst_base + c] = source[base + c];
+                    }
+                }
+            }
+        }
+
+        return projected;
+    }
+
+} // namespace lfs::io

--- a/src/io/include/io/cube_face_projection.hpp
+++ b/src/io/include/io/cube_face_projection.hpp
@@ -25,4 +25,34 @@ namespace lfs::io {
         const lfs::core::CubeFaceProjection& projection,
         int output_size);
 
+    // Projects an equirectangular depth panorama onto one cube face. Returns
+    // normalised samples in [0, 1], matching the 1/255 and 1/65535 scaling the
+    // grayscale upload kernels apply.
+    //
+    // Two things differ from the colour path, both of which matter for
+    // supervision:
+    //
+    //  - Nearest sampling. Averaging across a depth discontinuity invents a
+    //    surface lying in neither the foreground nor the background, and the
+    //    depth loss would then be supervised towards that invented surface.
+    //
+    //  - Radial-to-z conversion. Equirectangular depth stores distance along the
+    //    ray from the camera centre, but LFS supervises camera-space z: both the
+    //    fastgs rasterizer and depth_anchor_collect_kernel take the third row of
+    //    world-to-camera. For a face pixel at plane coordinates (u, v) the ray is
+    //    (u, v, 1) normalised, so z = r / sqrt(1 + u^2 + v^2). Without this the
+    //    corner of a 96 degree face is off by ~1.9x, and because the error varies
+    //    across the image the depth loss's per-camera affine fit cannot absorb it.
+    //
+    // Assumes the panorama stores radial distance, the usual convention for
+    // equirectangular depth. A prior storing disparity would need the reciprocal
+    // correction instead.
+    [[nodiscard]] LFS_IO_API std::vector<float> project_cube_face_depth(
+        const uint8_t* source,
+        bool source_is_16bit,
+        int width,
+        int height,
+        const lfs::core::CubeFaceProjection& projection,
+        int output_size);
+
 } // namespace lfs::io

--- a/src/io/include/io/cube_face_projection.hpp
+++ b/src/io/include/io/cube_face_projection.hpp
@@ -1,0 +1,28 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include "core/cube_face_projection.hpp"
+#include "core/export.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace lfs::io {
+
+    [[nodiscard]] LFS_IO_API int projected_face_output_size(
+        const lfs::core::CubeFaceProjection& projection,
+        int resize_factor,
+        int max_width);
+
+    [[nodiscard]] LFS_IO_API std::vector<uint8_t> project_cube_face_hwc(
+        const uint8_t* source,
+        int width,
+        int height,
+        int channels,
+        const lfs::core::CubeFaceProjection& projection,
+        int output_size);
+
+} // namespace lfs::io

--- a/src/io/include/io/pipelined_image_loader.hpp
+++ b/src/io/include/io/pipelined_image_loader.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "core/cube_face_projection.hpp"
 #include "core/error.hpp"
 #include "core/export.hpp"
 #include "core/tensor.hpp"
@@ -28,6 +29,10 @@
 struct CUstream_st;
 using cudaStream_t = CUstream_st*;
 struct CUevent_st;
+
+namespace lfs::core {
+    class Camera;
+}
 
 namespace lfs::io {
 
@@ -122,6 +127,7 @@ namespace lfs::io {
         bool extract_alpha_as_mask = false;
         MaskParams alpha_mask_params;
         const lfs::core::UndistortParams* undistort = nullptr;
+        std::optional<lfs::core::CubeFaceProjection> cube_face_projection;
     };
 
     struct ReadyImage {
@@ -226,6 +232,17 @@ namespace lfs::io {
 
         lfs::core::Tensor load_image_immediate(
             const std::filesystem::path& path, const LoadParams& params);
+        lfs::core::Tensor load_camera_image_immediate(
+            const lfs::core::Camera& camera,
+            const LoadParams& params);
+        lfs::core::Tensor load_camera_image_immediate(
+            const lfs::core::Camera& camera,
+            const std::filesystem::path& path,
+            const LoadParams& params);
+        lfs::core::Tensor load_image_immediate(
+            const std::filesystem::path& path,
+            const LoadParams& params,
+            const std::optional<lfs::core::CubeFaceProjection>& cube_face_projection);
 
         size_t ready_count() const;
         size_t in_flight_count() const;
@@ -261,6 +278,7 @@ namespace lfs::io {
             bool alpha_as_mask = false;
             MaskParams alpha_mask_params;
             const lfs::core::UndistortParams* undistort = nullptr;
+            std::optional<lfs::core::CubeFaceProjection> cube_face_projection;
         };
 
         struct CachedJpegHit {
@@ -399,7 +417,10 @@ namespace lfs::io {
         void gpu_batch_decode_thread_func();
         void cold_process_thread_func(size_t worker_index);
 
-        std::string make_cache_key(const std::filesystem::path& path, const LoadParams& params) const;
+        std::string make_cache_key(
+            const std::filesystem::path& path,
+            const LoadParams& params,
+            const std::optional<lfs::core::CubeFaceProjection>& cube_face_projection = std::nullopt) const;
         std::filesystem::path get_fs_cache_path(const std::string& cache_key) const;
         bool is_jpeg_data(const std::vector<uint8_t>& data) const;
         std::vector<uint8_t> read_file(const std::filesystem::path& path) const;
@@ -441,7 +462,8 @@ namespace lfs::io {
         // Auxiliary image pairing helpers
         std::string make_mask_cache_key(
             const std::filesystem::path& path,
-            const LoadParams& params) const;
+            const LoadParams& params,
+            const std::optional<lfs::core::CubeFaceProjection>& cube_face_projection = std::nullopt) const;
         void try_complete_pair(
             size_t sequence_id,
             std::uint64_t loader_generation,

--- a/src/io/pipelined_image_loader.cpp
+++ b/src/io/pipelined_image_loader.cpp
@@ -196,8 +196,7 @@ namespace lfs::io {
             key += "_cube" + std::to_string(cube_face_projection->face_size) +
                    "_src" + std::to_string(cube_face_projection->source_width) +
                    "x" + std::to_string(cube_face_projection->source_height) +
-                   "_fov" + std::to_string(static_cast<int>(
-                                std::lround(cube_face_projection->fov_degrees * 100.0f)));
+                   "_fov" + std::to_string(static_cast<int>(std::lround(cube_face_projection->fov_degrees * 100.0f)));
             for (const float value : cube_face_projection->pano_to_face) {
                 key += "_" + std::to_string(static_cast<int>(std::lround(value * 1000.0f)));
             }
@@ -2535,7 +2534,50 @@ namespace lfs::io {
                         int src_w = 0;
                         int src_h = 0;
                         lfs::core::Tensor gpu_gray;
-                        if (depth_16bit) {
+                        if (item.is_depth && item.cube_face_projection) {
+                            // Depth needs nearest sampling and a radial-to-z
+                            // conversion, so it cannot share the colour path's
+                            // EWA resampling. The result is already normalised
+                            // float, which the sizing branch below passes through.
+                            const int output_size = projected_face_output_size(
+                                *item.cube_face_projection,
+                                item.params.resize_factor,
+                                item.params.max_width);
+
+                            std::vector<float> face_depth;
+                            if (depth_16bit) {
+                                int channels = 0;
+                                stbi_us* const gray16 = stbi_load_16(
+                                    lfs::core::path_to_utf8(item.path).c_str(),
+                                    &src_w, &src_h, &channels, 1);
+                                if (!gray16)
+                                    throw std::runtime_error("Failed to decode 16-bit depth");
+                                const StbiImagePtr gray_guard(reinterpret_cast<uint8_t*>(gray16));
+                                face_depth = project_cube_face_depth(
+                                    reinterpret_cast<const uint8_t*>(gray16), true,
+                                    src_w, src_h, *item.cube_face_projection, output_size);
+                            } else {
+                                const auto [gray_data, w, h] = load_grayscale_stb(item.path);
+                                if (!gray_data)
+                                    throw std::runtime_error("Failed to decode depth");
+                                const StbiImagePtr gray_guard(gray_data);
+                                src_w = w;
+                                src_h = h;
+                                face_depth = project_cube_face_depth(
+                                    gray_data, false, src_w, src_h,
+                                    *item.cube_face_projection, output_size);
+                            }
+
+                            src_w = output_size;
+                            src_h = output_size;
+                            auto cpu_tensor = lfs::core::Tensor::empty(
+                                lfs::core::TensorShape({static_cast<size_t>(src_h), static_cast<size_t>(src_w)}),
+                                lfs::core::Device::CPU,
+                                lfs::core::DataType::Float32);
+                            std::memcpy(cpu_tensor.data_ptr(), face_depth.data(), cpu_tensor.bytes());
+                            gpu_gray = cpu_tensor.to(lfs::core::Device::CUDA, aux_stream);
+                            synchronize_async_upload_before_free(aux_stream, "cube face depth");
+                        } else if (depth_16bit) {
                             int channels = 0;
                             stbi_us* const gray16 = stbi_load_16(
                                 lfs::core::path_to_utf8(item.path).c_str(),
@@ -2565,8 +2607,11 @@ namespace lfs::io {
                             src_w = w;
                             src_h = h;
 
-                            // Cube faces are projected from the full-resolution
-                            // panorama, so the projected face is the final size.
+                            // Masks reach here with a cube face projection; depth
+                            // is handled above because it needs nearest sampling.
+                            // Either way the projected face is already the final
+                            // size, since it comes from the full-resolution
+                            // panorama rather than a resized decode.
                             std::vector<uint8_t> projected_gray;
                             const uint8_t* gray_source = gray_data;
                             if (item.cube_face_projection) {

--- a/src/io/pipelined_image_loader.cpp
+++ b/src/io/pipelined_image_loader.cpp
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "io/pipelined_image_loader.hpp"
+#include "core/camera.hpp"
 #include "core/cuda/lanczos_resize/lanczos_resize.hpp"
 #include "core/cuda/undistort/undistort.hpp"
 #include "core/error_reporter.hpp"
@@ -12,16 +13,20 @@
 #include "core/tensor/internal/memory_pool.hpp"
 #include "cuda/image_format_kernels.cuh"
 #include "diagnostics/vram_profiler.hpp"
+#include "io/cube_face_projection.hpp"
 #include "io/nvcodec_image_loader.hpp"
 
 #include <cuda_runtime.h>
 #include <stb_image.h>
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <exception>
 #include <fstream>
 #include <iomanip>
+#include <memory>
+#include <random>
 #include <semaphore>
 #include <sstream>
 
@@ -182,6 +187,22 @@ namespace lfs::io {
             return lfs::core::path_to_utf8(path);
         }
 
+        void append_cube_face_projection_key(
+            std::string& key,
+            const std::optional<lfs::core::CubeFaceProjection>& cube_face_projection) {
+            if (!cube_face_projection)
+                return;
+
+            key += "_cube" + std::to_string(cube_face_projection->face_size) +
+                   "_src" + std::to_string(cube_face_projection->source_width) +
+                   "x" + std::to_string(cube_face_projection->source_height) +
+                   "_fov" + std::to_string(static_cast<int>(
+                                std::lround(cube_face_projection->fov_degrees * 100.0f)));
+            for (const float value : cube_face_projection->pano_to_face) {
+                key += "_" + std::to_string(static_cast<int>(std::lround(value * 1000.0f)));
+            }
+        }
+
         void apply_requested_undistort(lfs::core::Tensor& tensor, const LoadParams& params) {
             if (!params.undistort)
                 return;
@@ -282,6 +303,97 @@ namespace lfs::io {
             int w, h, c;
             uint8_t* const data = stbi_load(lfs::core::path_to_utf8(path).c_str(), &w, &h, &c, 1);
             return {data, w, h};
+        }
+
+        struct FreeImageDeleter {
+            void operator()(uint8_t* data) const noexcept {
+                if (data)
+                    lfs::core::free_image(data);
+            }
+        };
+
+        struct StbiImageDeleter {
+            void operator()(uint8_t* data) const noexcept {
+                if (data)
+                    stbi_image_free(data);
+            }
+        };
+
+        using FreeImagePtr = std::unique_ptr<uint8_t, FreeImageDeleter>;
+        using StbiImagePtr = std::unique_ptr<uint8_t, StbiImageDeleter>;
+
+        [[nodiscard]] lfs::core::Tensor upload_hwc_uint8_to_chw(
+            const uint8_t* data,
+            const size_t height,
+            const size_t width,
+            const size_t channels,
+            const bool output_uint8,
+            cudaStream_t stream) {
+            auto cpu_tensor = lfs::core::Tensor::from_blob(
+                const_cast<uint8_t*>(data),
+                lfs::core::TensorShape({height, width, channels}),
+                lfs::core::Device::CPU,
+                lfs::core::DataType::UInt8);
+            auto gpu_uint8 = cpu_tensor.to(lfs::core::Device::CUDA);
+
+            if (output_uint8) {
+                auto decoded = lfs::core::Tensor::empty(
+                    lfs::core::TensorShape({channels, height, width}),
+                    lfs::core::Device::CUDA,
+                    lfs::core::DataType::UInt8);
+                cuda::launch_uint8_hwc_to_uint8_chw(
+                    gpu_uint8.ptr<uint8_t>(),
+                    decoded.ptr<uint8_t>(),
+                    height,
+                    width,
+                    channels,
+                    stream);
+                return decoded;
+            }
+
+            auto decoded = lfs::core::Tensor::zeros(
+                lfs::core::TensorShape({channels, height, width}),
+                lfs::core::Device::CUDA,
+                lfs::core::DataType::Float32);
+            cuda::launch_uint8_hwc_to_float32_chw(
+                gpu_uint8.ptr<uint8_t>(),
+                decoded.ptr<float>(),
+                height,
+                width,
+                channels,
+                stream);
+            return decoded;
+        }
+
+        [[nodiscard]] lfs::core::Tensor load_projected_cube_face_tensor(
+            const std::filesystem::path& path,
+            const LoadParams& params,
+            const lfs::core::CubeFaceProjection& projection) {
+            auto [img_data, width, height, channels] = lfs::core::load_image(path, 1, 0);
+            if (!img_data) {
+                throw std::runtime_error("Failed to decode image: " + lfs::core::path_to_utf8(path));
+            }
+            const FreeImagePtr image_guard(img_data);
+
+            const int output_size = projected_face_output_size(
+                projection,
+                params.resize_factor,
+                params.max_width);
+            auto projected = project_cube_face_hwc(
+                img_data,
+                width,
+                height,
+                channels,
+                projection,
+                output_size);
+
+            return upload_hwc_uint8_to_chw(
+                projected.data(),
+                static_cast<size_t>(output_size),
+                static_cast<size_t>(output_size),
+                static_cast<size_t>(channels),
+                params.output_uint8,
+                static_cast<cudaStream_t>(params.cuda_stream));
         }
 
         void synchronize_async_upload_before_free(cudaStream_t stream, const char* context) {
@@ -642,7 +754,27 @@ namespace lfs::io {
 
     lfs::core::Tensor PipelinedImageLoader::load_image_immediate(
         const std::filesystem::path& path, const LoadParams& params) {
-        const auto cache_key = make_cache_key(path, params);
+        return load_image_immediate(path, params, std::nullopt);
+    }
+
+    lfs::core::Tensor PipelinedImageLoader::load_camera_image_immediate(
+        const lfs::core::Camera& camera,
+        const LoadParams& params) {
+        return load_image_immediate(camera.image_path(), params, camera.cube_face_projection());
+    }
+
+    lfs::core::Tensor PipelinedImageLoader::load_camera_image_immediate(
+        const lfs::core::Camera& camera,
+        const std::filesystem::path& path,
+        const LoadParams& params) {
+        return load_image_immediate(path, params, camera.cube_face_projection());
+    }
+
+    lfs::core::Tensor PipelinedImageLoader::load_image_immediate(
+        const std::filesystem::path& path,
+        const LoadParams& params,
+        const std::optional<lfs::core::CubeFaceProjection>& cube_face_projection) {
+        const auto cache_key = make_cache_key(path, params, cube_face_projection);
         const auto base_key = make_base_cache_key(path);
         const bool is_original_jpeg = is_jpeg_file_signature(path);
         auto decode_cached_hit = [&](const std::shared_ptr<std::vector<uint8_t>>& jpeg_data,
@@ -664,6 +796,26 @@ namespace lfs::io {
                 tensor.is_valid() && tensor.numel() > 0) {
                 return tensor;
             }
+        }
+
+        if (cube_face_projection) {
+            auto decoded = load_projected_cube_face_tensor(path, params, *cube_face_projection);
+            apply_requested_undistort(decoded, params);
+
+            if (is_nvcodec_available()) {
+                try {
+                    auto nvcodec = acquire_nvcodec_loader(config_.decoder_pool_size);
+                    auto jpeg_bytes = nvcodec->encode_to_jpeg(decoded, config_.cache_jpeg_quality, params.cuda_stream);
+                    save_to_fs_cache(cache_key, jpeg_bytes);
+                    put_in_jpeg_cache(cache_key, std::make_shared<std::vector<uint8_t>>(std::move(jpeg_bytes)));
+                } catch (...) {
+                    LOG_DEBUG("[PipelinedImageLoader] Immediate spherical projection cache write skipped for {}: {}",
+                              lfs::core::path_to_utf8(path),
+                              describe_current_exception("non-standard nvImageCodec exception"));
+                }
+            }
+
+            return decoded;
         }
 
         // Base-key blobs of non-JPEG sources are 8-bit re-encodes; see find_cached_jpeg.
@@ -776,10 +928,14 @@ namespace lfs::io {
         return decoded;
     }
 
-    std::string PipelinedImageLoader::make_cache_key(const std::filesystem::path& path, const LoadParams& params) const {
+    std::string PipelinedImageLoader::make_cache_key(
+        const std::filesystem::path& path,
+        const LoadParams& params,
+        const std::optional<lfs::core::CubeFaceProjection>& cube_face_projection) const {
         auto key = lfs::core::path_to_utf8(path) + ":rf" + std::to_string(params.resize_factor) + "_mw" + std::to_string(params.max_width);
         if (params.undistort)
             key += "_ud";
+        append_cube_face_projection_key(key, cube_face_projection);
         if (config_.use_16bit_color)
             key += "_16b";
         return key;
@@ -787,12 +943,14 @@ namespace lfs::io {
 
     std::string PipelinedImageLoader::make_mask_cache_key(
         const std::filesystem::path& path,
-        const LoadParams& params) const {
+        const LoadParams& params,
+        const std::optional<lfs::core::CubeFaceProjection>& cube_face_projection) const {
         auto key = lfs::core::path_to_utf8(path) +
                    ":mask_rf" + std::to_string(params.resize_factor) +
                    "_mw" + std::to_string(params.max_width);
         if (params.undistort)
             key += "_ud";
+        append_cube_face_projection_key(key, cube_face_projection);
         return key;
     }
 
@@ -1108,6 +1266,12 @@ namespace lfs::io {
         const PrefetchedImage& item,
         const int src_w,
         const int src_h) const {
+        // A projected cube face is already final: projected_face_output_size()
+        // applied resize_factor when the face was built, and max_width caps the
+        // panorama, not the face. Re-applying either here would shrink it twice.
+        if (item.cube_face_projection) {
+            return {src_w, src_h};
+        }
         int target_w = src_w;
         int target_h = src_h;
         if (item.params.resize_factor > 1) {
@@ -1737,8 +1901,8 @@ namespace lfs::io {
             }
 
             if (request.extract_alpha_as_mask) {
-                const auto rgb_key = make_cache_key(request.path, request.params);
-                const auto alpha_key = make_mask_cache_key(request.path, request.params);
+                const auto rgb_key = make_cache_key(request.path, request.params, request.cube_face_projection);
+                const auto alpha_key = make_mask_cache_key(request.path, request.params, request.cube_face_projection);
                 auto cached_rgb = get_from_jpeg_cache(rgb_key);
                 auto cached_alpha = get_from_jpeg_cache(alpha_key);
 
@@ -1750,6 +1914,7 @@ namespace lfs::io {
                     img_item.cache_key = rgb_key;
                     img_item.jpeg_data = cached_rgb;
                     img_item.is_cache_hit = true;
+                    img_item.cube_face_projection = request.cube_face_projection;
                     hot_queue_.push(std::move(img_item));
 
                     PrefetchedImage mask_item;
@@ -1760,6 +1925,7 @@ namespace lfs::io {
                     mask_item.jpeg_data = cached_alpha;
                     mask_item.is_mask = true;
                     mask_item.is_cache_hit = true;
+                    mask_item.cube_face_projection = request.cube_face_projection;
                     hot_queue_.push(std::move(mask_item));
 
                     std::lock_guard<std::mutex> lock(stats_mutex_);
@@ -1775,6 +1941,7 @@ namespace lfs::io {
                     result.alpha_mask_params = request.alpha_mask_params;
                     result.needs_processing = true;
                     result.undistort = request.undistort;
+                    result.cube_face_projection = request.cube_face_projection;
 
                     cold_queue_.push(std::move(result));
                     std::lock_guard<std::mutex> lock(stats_mutex_);
@@ -1790,21 +1957,41 @@ namespace lfs::io {
             result.loader_generation = request.loader_generation;
             result.path = request.path;
             result.params = request.params;
-            result.cache_key = make_cache_key(request.path, request.params);
+            result.cache_key = make_cache_key(request.path, request.params, request.cube_face_projection);
             result.is_mask = false;
             result.undistort = request.undistort;
+            result.cube_face_projection = request.cube_face_projection;
 
             try {
                 const bool needs_requested_processing = load_params_need_processing(request.params);
+                const bool needs_cube_projection = request.cube_face_projection.has_value();
                 const auto base_key = make_base_cache_key(request.path);
 
-                if (auto cached = find_cached_jpeg(result.cache_key, base_key, request.path)) {
+                // A projected cube face cannot be derived from the resized base-key
+                // blob, so bypass the base-key lookup and only accept an exact hit.
+                std::optional<CachedJpegHit> cached =
+                    needs_cube_projection
+                        ? std::optional<CachedJpegHit>{}
+                        : find_cached_jpeg(result.cache_key, base_key, request.path);
+                if (needs_cube_projection) {
+                    if (auto projected = load_cached_jpeg_blob(result.cache_key)) {
+                        cached = CachedJpegHit{.data = std::move(projected), .from_base_key = false};
+                    }
+                }
+
+                if (cached) {
                     result.jpeg_data = std::move(cached->data);
                     result.is_cache_hit = true;
                     result.needs_processing = cached->from_base_key && needs_requested_processing;
                     hot_queue_.push(std::move(result));
                     std::lock_guard<std::mutex> lock(stats_mutex_);
                     ++stats_.hot_path_hits;
+                } else if (needs_cube_projection) {
+                    result.is_cache_hit = false;
+                    result.needs_processing = true;
+                    cold_queue_.push(std::move(result));
+                    std::lock_guard<std::mutex> lock(stats_mutex_);
+                    ++stats_.cold_path_misses;
                 } else {
                     result.raw_bytes = read_file(request.path);
                     result.is_original_jpeg = is_jpeg_data(result.raw_bytes);
@@ -1815,7 +2002,7 @@ namespace lfs::io {
                         stats_.total_bytes_read += result.raw_bytes.size();
                     }
 
-                    if (result.is_original_jpeg && !needs_requested_processing) {
+                    if (result.is_original_jpeg && !needs_requested_processing && !needs_cube_projection) {
                         auto data = std::make_shared<std::vector<uint8_t>>(std::move(result.raw_bytes));
                         put_in_jpeg_cache(result.cache_key, data);
                         result.jpeg_data = data;
@@ -1849,10 +2036,11 @@ namespace lfs::io {
                     mask_result.loader_generation = request.loader_generation;
                     mask_result.path = *request.mask_path;
                     mask_result.params = request.params;
-                    mask_result.cache_key = make_mask_cache_key(*request.mask_path, request.params);
+                    mask_result.cache_key = make_mask_cache_key(*request.mask_path, request.params, request.cube_face_projection);
                     mask_result.is_mask = true;
                     mask_result.mask_params = request.mask_params;
                     mask_result.undistort = request.undistort;
+                    mask_result.cube_face_projection = request.cube_face_projection;
 
                     try {
                         if (auto cached = get_from_jpeg_cache(mask_result.cache_key)) {
@@ -1861,6 +2049,11 @@ namespace lfs::io {
                             hot_queue_.push(std::move(mask_result));
                             std::lock_guard<std::mutex> lock(stats_mutex_);
                             ++stats_.mask_cache_hits;
+                        } else if (request.cube_face_projection) {
+                            mask_result.needs_processing = true;
+                            cold_queue_.push(std::move(mask_result));
+                            std::lock_guard<std::mutex> lock(stats_mutex_);
+                            ++stats_.mask_cache_misses;
                         } else if (config_.use_filesystem_cache) {
                             const auto fs_path = get_fs_cache_path(mask_result.cache_key);
                             auto done_path = fs_path;
@@ -2200,19 +2393,40 @@ namespace lfs::io {
 
                 if (item.alpha_as_mask) {
                     auto [img_data, width, height, channels] = lfs::core::load_image_with_alpha(
-                        item.path, item.params.resize_factor, item.params.max_width);
+                        item.path,
+                        item.cube_face_projection ? 1 : item.params.resize_factor,
+                        item.cube_face_projection ? 0 : item.params.max_width);
+                    const FreeImagePtr image_guard(img_data);
 
                     if (!img_data || channels != 4)
                         throw std::runtime_error("Failed to load RGBA image");
+
+                    std::vector<uint8_t> projected_rgba;
+                    const uint8_t* rgba_data = image_guard.get();
+                    if (item.cube_face_projection) {
+                        const int output_size = projected_face_output_size(
+                            *item.cube_face_projection,
+                            item.params.resize_factor,
+                            item.params.max_width);
+                        projected_rgba = project_cube_face_hwc(
+                            image_guard.get(),
+                            width,
+                            height,
+                            channels,
+                            *item.cube_face_projection,
+                            output_size);
+                        width = output_size;
+                        height = output_size;
+                        rgba_data = projected_rgba.data();
+                    }
 
                     const size_t H = static_cast<size_t>(height);
                     const size_t W = static_cast<size_t>(width);
 
                     auto cpu_tensor = lfs::core::Tensor::from_blob(
-                        img_data, lfs::core::TensorShape({H, W, 4}),
+                        const_cast<uint8_t*>(rgba_data), lfs::core::TensorShape({H, W, 4}),
                         lfs::core::Device::CPU, lfs::core::DataType::UInt8);
                     auto gpu_uint8 = cpu_tensor.to(lfs::core::Device::CUDA);
-                    lfs::core::free_image(img_data);
 
                     auto rgb = item.params.output_uint8
                                    ? lfs::core::Tensor::empty(
@@ -2271,7 +2485,10 @@ namespace lfs::io {
                             put_in_jpeg_cache(item.cache_key,
                                               std::make_shared<std::vector<uint8_t>>(std::move(rgb_jpeg)));
 
-                            const auto alpha_key = make_mask_cache_key(item.path, item.params);
+                            const auto alpha_key = make_mask_cache_key(
+                                item.path,
+                                item.params,
+                                item.cube_face_projection);
                             auto alpha_jpeg = nvcodec->encode_grayscale_to_jpeg(
                                 alpha, config_.cache_jpeg_quality, nullptr);
                             save_to_fs_cache(alpha_key, alpha_jpeg);
@@ -2301,7 +2518,9 @@ namespace lfs::io {
 
                     // Depth sidecars keep their first-touch 16-bit PNG precision by
                     // decoding with stb before the processed tensor is transcoded.
-                    if (is_nvcodec_available() && !item.is_depth) {
+                    // Cube faces need the full-resolution panorama on the CPU to
+                    // project from, so they cannot take the nvcodec fast path either.
+                    if (is_nvcodec_available() && !item.is_depth && !item.cube_face_projection) {
                         try {
                             const NvcodecSlotGuard slot;
                             aux_tensor = nvcodec->load_image_gpu(
@@ -2342,15 +2561,32 @@ namespace lfs::io {
                             const auto [gray_data, w, h] = load_grayscale_stb(item.path);
                             if (!gray_data)
                                 throw std::runtime_error(item.is_mask ? "Failed to decode mask" : "Failed to decode depth");
+                            const StbiImagePtr gray_guard(gray_data);
                             src_w = w;
                             src_h = h;
+
+                            // Cube faces are projected from the full-resolution
+                            // panorama, so the projected face is the final size.
+                            std::vector<uint8_t> projected_gray;
+                            const uint8_t* gray_source = gray_data;
+                            if (item.cube_face_projection) {
+                                const int output_size = projected_face_output_size(
+                                    *item.cube_face_projection,
+                                    item.params.resize_factor,
+                                    item.params.max_width);
+                                projected_gray = project_cube_face_hwc(
+                                    gray_data, w, h, 1, *item.cube_face_projection, output_size);
+                                gray_source = projected_gray.data();
+                                src_w = output_size;
+                                src_h = output_size;
+                            }
+
                             auto cpu_tensor = lfs::core::Tensor::empty(
                                 lfs::core::TensorShape({static_cast<size_t>(src_h), static_cast<size_t>(src_w)}),
                                 lfs::core::Device::CPU,
                                 lfs::core::DataType::UInt8);
-                            std::memcpy(cpu_tensor.data_ptr(), gray_data, cpu_tensor.bytes());
+                            std::memcpy(cpu_tensor.data_ptr(), gray_source, cpu_tensor.bytes());
                             gpu_gray = cpu_tensor.to(lfs::core::Device::CUDA, aux_stream);
-                            stbi_image_free(gray_data);
                         }
 
                         const auto [target_w, target_h] = sidecar_target_size(item, src_w, src_h);
@@ -2555,7 +2791,7 @@ namespace lfs::io {
                     lfs::core::Tensor decoded;
                     bool used_gpu = false;
 
-                    if (is_nvcodec_available() && item.is_original_jpeg) {
+                    if (is_nvcodec_available() && item.is_original_jpeg && !item.cube_face_projection) {
                         try {
                             const NvcodecSlotGuard slot;
                             decoded = nvcodec->load_image_gpu(
@@ -2567,7 +2803,17 @@ namespace lfs::io {
                     }
 
                     if (!used_gpu) {
-                        decoded = decode_file_on_cpu(item.path, item.params);
+                        if (item.cube_face_projection) {
+                            // Faces are projected from the full-resolution panorama,
+                            // so they cannot go through the resize-on-decode path.
+                            decoded = load_projected_cube_face_tensor(
+                                item.path, item.params, *item.cube_face_projection);
+                            if (const cudaError_t err = cudaDeviceSynchronize(); err != cudaSuccess) {
+                                throw std::runtime_error(std::string("CUDA sync failed: ") + cudaGetErrorString(err));
+                            }
+                        } else {
+                            decoded = decode_file_on_cpu(item.path, item.params);
+                        }
                     }
 
                     if (item.undistort) {
@@ -2608,16 +2854,16 @@ namespace lfs::io {
                             item.path, item.params.resize_factor, item.params.max_width);
                         if (!img_data)
                             throw std::runtime_error("RGB fallback also failed");
+                        const FreeImagePtr image_guard(img_data);
 
                         const size_t H = static_cast<size_t>(height);
                         const size_t W = static_cast<size_t>(width);
                         const size_t C = static_cast<size_t>(channels);
 
                         auto cpu_tensor = lfs::core::Tensor::from_blob(
-                            img_data, lfs::core::TensorShape({H, W, C}),
+                            image_guard.get(), lfs::core::TensorShape({H, W, C}),
                             lfs::core::Device::CPU, lfs::core::DataType::UInt8);
                         auto gpu_uint8 = cpu_tensor.to(lfs::core::Device::CUDA);
-                        lfs::core::free_image(img_data);
 
                         auto decoded = item.params.output_uint8
                                            ? lfs::core::Tensor::empty(

--- a/src/python/lfs/py_scene.cpp
+++ b/src/python/lfs/py_scene.cpp
@@ -687,6 +687,19 @@ namespace lfs::python {
         return result;
     }
 
+    size_t PyScene::active_training_image_count(const bool undistort) const {
+        size_t count = 0;
+        for (const auto* node : scene_->getNodes()) {
+            if (node->type != core::NodeType::CAMERA || !node->camera || !node->training_enabled) {
+                continue;
+            }
+            count += undistort && node->camera->camera_model_type() == core::CameraModelType::EQUIRECTANGULAR
+                         ? 12
+                         : 1;
+        }
+        return count;
+    }
+
     void PyScene::set_camera_training_enabled(const std::string& name, bool enabled) {
         if (auto* const scene_manager = get_scene_manager()) {
             const auto* node = scene_->getNode(name);
@@ -1369,6 +1382,10 @@ Returns:
             // Camera training control
             .def("set_camera_training_enabled", &PyScene::set_camera_training_enabled, nb::arg("name"), nb::arg("enabled"), "Enable or disable a camera for training by name")
             .def_prop_ro("active_camera_count", &PyScene::active_camera_count, "Number of cameras enabled for training")
+            .def("active_training_image_count",
+                 &PyScene::active_training_image_count,
+                 nb::arg("undistort"),
+                 "Effective number of training images after internal image expansion")
             .def("get_active_cameras", &PyScene::get_active_cameras, "Get camera nodes enabled for training")
             // Training data
             .def("has_training_data", &PyScene::has_training_data, "Check if training dataset is loaded")

--- a/src/python/lfs/py_scene.hpp
+++ b/src/python/lfs/py_scene.hpp
@@ -514,6 +514,7 @@ namespace lfs::python {
         // Camera training control
         void set_camera_training_enabled(const std::string& name, bool enabled);
         size_t active_camera_count() const { return scene_->getActiveCameraCount(); }
+        size_t active_training_image_count(bool undistort) const;
         std::vector<PySceneNode> get_active_cameras();
 
         // Training data

--- a/src/python/lfs_plugins/training_panel.py
+++ b/src/python/lfs_plugins/training_panel.py
@@ -2364,7 +2364,12 @@ class TrainingPanel(Panel):
         scene = lf.get_scene()
         if scene is None:
             return False
-        camera_count = scene.active_camera_count
+        try:
+            camera_count = scene.active_training_image_count(
+                bool(getattr(params, "undistort", False))
+            )
+        except (AttributeError, TypeError, ValueError, RuntimeError):
+            camera_count = scene.active_camera_count
         if camera_count == 0 or camera_count == self._auto_scaled_for_cameras:
             return False
         self._auto_scaled_for_cameras = camera_count

--- a/src/python/stubs/lichtfeld/scene.pyi
+++ b/src/python/stubs/lichtfeld/scene.pyi
@@ -665,6 +665,9 @@ class Scene:
     def active_camera_count(self) -> int:
         """Number of cameras enabled for training"""
 
+    def active_training_image_count(self, undistort: bool) -> int:
+        """Effective number of training images after internal image expansion"""
+
     def get_active_cameras(self) -> list[SceneNode]:
         """Get camera nodes enabled for training"""
 

--- a/src/training/dataset.hpp
+++ b/src/training/dataset.hpp
@@ -588,10 +588,19 @@ namespace lfs::training {
         std::optional<CameraExample> next() {
             if (shutdown_)
                 return std::nullopt;
-            prefetch_next_batch();
 
             try {
-                auto ready = loader_->get();
+                std::optional<lfs::io::ReadyImage> ready_opt;
+                while (!ready_opt) {
+                    prefetch_next_batch();
+                    if (sampler_exhausted_ && loader_->in_flight_count() == 0) {
+                        sequence_to_camera_.clear();
+                        return std::nullopt;
+                    }
+                    ready_opt = loader_->try_get_for(config_.output_wait_timeout);
+                }
+
+                auto ready = std::move(*ready_opt);
                 const auto it = sequence_to_camera_.find(ready.sequence_id);
                 if (it == sequence_to_camera_.end()) {
                     LOG_ERROR("[PipelinedDataLoader] Unknown sequence_id: {}", ready.sequence_id);
@@ -659,6 +668,7 @@ namespace lfs::training {
             sampler_.reset();
             sequence_to_camera_.clear();
             next_sequence_id_ = 0;
+            sampler_exhausted_ = false;
             prefetch_next_batch();
         }
 
@@ -676,10 +686,15 @@ namespace lfs::training {
 
     private:
         void prefetch_next_batch() {
+            if (sampler_exhausted_)
+                return;
+
             while (loader_->in_flight_count() < config_.prefetch_count) {
                 const auto indices = sampler_.next(1);
-                if (!indices || indices->empty())
+                if (!indices || indices->empty()) {
+                    sampler_exhausted_ = true;
                     break;
+                }
 
                 const size_t local_idx = (*indices)[0];
                 const size_t camera_idx = dataset_->local_to_source(local_idx);
@@ -705,6 +720,7 @@ namespace lfs::training {
                     request.undistort = &cam->undistort_params();
                     request.params.undistort = request.undistort;
                 }
+                request.cube_face_projection = cam->cube_face_projection();
 
                 if (aux_config_.load_masks && cam->has_mask()) {
                     request.mask_path = cam->mask_path();
@@ -746,6 +762,7 @@ namespace lfs::training {
 
         std::unordered_map<size_t, size_t> sequence_to_camera_;
         size_t next_sequence_id_ = 0;
+        bool sampler_exhausted_ = false;
 
         bool shutdown_ = false;
     };

--- a/src/training/metrics/metrics.cpp
+++ b/src/training/metrics/metrics.cpp
@@ -5,13 +5,11 @@
 #include "metrics.hpp"
 #include "../rasterization/fast_rasterizer.hpp"
 #include "../rasterization/gsplat_rasterizer.hpp"
-#include "core/cuda/undistort/undistort.hpp"
 #include "core/events.hpp"
 #include "core/image_io.hpp"
 #include "core/logger.hpp"
 #include "core/path_utils.hpp"
 #include "core/splat_data.hpp"
-#include "io/cuda/image_format_kernels.cuh"
 #include "lfs/kernels/ssim.cuh"
 #include <algorithm>
 #include <cassert>
@@ -385,87 +383,6 @@ namespace lfs::training {
         return colormap.to(depth_normalized.device());
     }
 
-    lfs::core::Tensor MetricsEvaluator::load_eval_mask(lfs::core::Camera* cam,
-                                                       lfs::core::Tensor& gt_image,
-                                                       const bool alpha_as_mask) const {
-        if (cam->has_mask()) {
-            bool is_segment_and_ignore = _params.optimization.mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore;
-            auto m = cam->load_and_get_mask(
-                _params.dataset.resize_factor,
-                _params.dataset.max_width,
-                _params.optimization.invert_masks,
-                _params.optimization.mask_threshold,
-                !is_segment_and_ignore);
-            if (is_segment_and_ignore) {
-                m = m.gt(250).to(lfs::core::DataType::UInt8).contiguous();
-            }
-            return m;
-        }
-
-        if (!alpha_as_mask)
-            return {};
-
-        // Re-load from disk because the dataloader strips alpha to produce RGB gt_image.
-        // We need the original alpha channel as the mask, with undistortion applied consistently.
-        auto [img_data, width, height, channels] = lfs::core::load_image_with_alpha(
-            cam->image_path(), _params.dataset.resize_factor, _params.dataset.max_width);
-
-        if (!img_data || channels != 4) {
-            if (img_data)
-                lfs::core::free_image(img_data);
-            return {};
-        }
-
-        const auto H = static_cast<size_t>(height);
-        const auto W = static_cast<size_t>(width);
-
-        auto cpu_tensor = lfs::core::Tensor::from_blob(
-            img_data, lfs::core::TensorShape({H, W, 4}),
-            lfs::core::Device::CPU, lfs::core::DataType::UInt8);
-        auto gpu_uint8 = cpu_tensor.to(lfs::core::Device::CUDA);
-        lfs::core::free_image(img_data);
-
-        auto rgb = lfs::core::Tensor::zeros(
-            lfs::core::TensorShape({3, H, W}),
-            lfs::core::Device::CUDA, lfs::core::DataType::UInt8);
-        auto mask = lfs::core::Tensor::zeros(
-            lfs::core::TensorShape({H, W}),
-            lfs::core::Device::CUDA, lfs::core::DataType::Float32);
-
-        lfs::io::cuda::launch_uint8_rgba_split_to_uint8_rgb_and_float32_alpha(
-            gpu_uint8.ptr<uint8_t>(), rgb.ptr<uint8_t>(), mask.ptr<float>(),
-            H, W, nullptr);
-        gpu_uint8 = lfs::core::Tensor();
-
-        if (_params.optimization.invert_masks)
-            lfs::io::cuda::launch_mask_invert(mask.ptr<float>(), H, W, nullptr);
-        if (_params.optimization.mask_threshold > 0)
-            lfs::io::cuda::launch_mask_threshold(
-                mask.ptr<float>(), H, W, _params.optimization.mask_threshold, nullptr);
-
-        if (cam->is_undistort_prepared()) {
-            const auto scaled = lfs::core::scale_undistort_params(
-                cam->undistort_params(),
-                static_cast<int>(W), static_cast<int>(H));
-            auto rgb_float = rgb.to(lfs::core::DataType::Float32) / 255.0f;
-            rgb_float = lfs::core::undistort_image(rgb_float, scaled, nullptr);
-            auto rgb_uint8 = lfs::core::Tensor::empty(
-                rgb_float.shape(), lfs::core::Device::CUDA, lfs::core::DataType::UInt8);
-            lfs::io::cuda::launch_float32_chw_to_uint8_chw(
-                rgb_float.ptr<float>(),
-                rgb_uint8.ptr<uint8_t>(),
-                rgb_float.shape()[1],
-                rgb_float.shape()[2],
-                rgb_float.shape()[0],
-                nullptr);
-            rgb = std::move(rgb_uint8);
-            mask = lfs::core::undistort_mask(mask, scaled, nullptr);
-        }
-
-        gt_image = std::move(rgb);
-        return mask.ge(0.5f).to(lfs::core::DataType::UInt8).contiguous();
-    }
-
     EvalMetrics MetricsEvaluator::evaluate(const int iteration,
                                            const lfs::core::SplatData& splatData,
                                            std::shared_ptr<CameraDataset> val_dataset,
@@ -499,32 +416,33 @@ namespace lfs::training {
             mask_mode == lfs::core::param::MaskMode::Ignore ||
             mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore;
 
-        for (size_t image_idx = 0; image_idx < val_dataset_size; ++image_idx) {
-            lfs::core::Camera* cam = val_dataset->get_camera(image_idx);
-            lfs::core::Tensor gt_image;
-            try {
-                gt_image = load_eval_gt_image_cpu(
-                    *cam,
-                    _params.dataset.resize_factor,
-                    _params.dataset.max_width);
-            } catch (const std::exception& e) {
-                LOG_WARN("Eval: skipping camera '{}' (failed to load GT image: {})", cam->image_name(), e.what());
-                skipped_images++;
-                continue;
+        PipelinedAuxiliaryImageConfig aux_config;
+        aux_config.load_masks = use_masking;
+        aux_config.use_alpha_as_mask = use_masking && _params.optimization.use_alpha_as_mask;
+        aux_config.invert_masks = _params.optimization.invert_masks;
+        aux_config.mask_threshold = _params.optimization.mask_threshold;
+
+        auto val_dataloader = create_pipelined_dataloader(val_dataset, {}, aux_config);
+
+        // The pipelined loader yields examples rather than indices; keep a counter
+        // so saved eval comparison images stay numbered as before.
+        size_t image_idx = 0;
+        while (auto example_opt = val_dataloader->next()) {
+            const size_t current_idx = image_idx++;
+            auto& example = *example_opt;
+            auto camera_with_image = std::move(example.data);
+            lfs::core::Camera* cam = camera_with_image.camera;
+            lfs::core::Tensor gt_image = std::move(camera_with_image.image);
+
+            if (gt_image.device() != lfs::core::Device::CUDA) {
+                gt_image = gt_image.to(lfs::core::Device::CUDA);
             }
 
             lfs::core::Tensor mask;
             if (use_masking) {
-                const bool cam_alpha = _params.optimization.use_alpha_as_mask && cam->has_alpha();
-                try {
-                    mask = load_eval_mask(cam, gt_image, cam_alpha);
-                } catch (const std::exception& e) {
-                    LOG_WARN("Eval: skipping camera '{}' (failed to load mask: {})", cam->image_name(), e.what());
-                    skipped_images++;
-                    continue;
-                }
-
-                if (!mask.is_valid()) {
+                if (example.mask && example.mask->is_valid()) {
+                    mask = std::move(*example.mask);
+                } else {
                     LOG_DEBUG("Eval: camera '{}' has no mask, proceeding unmasked", cam->image_name());
                     mask = lfs::core::Tensor();
                 }
@@ -576,7 +494,7 @@ namespace lfs::training {
                 }
                 const std::vector<lfs::core::Tensor> rgb_images = {gt_vis, render_vis};
                 lfs::core::image_io::save_images_async(
-                    eval_dir / (std::to_string(image_idx) + ".png"),
+                    eval_dir / (std::to_string(current_idx) + ".png"),
                     rgb_images,
                     true, // horizontal
                     4);   // separator width

--- a/src/training/metrics/metrics.hpp
+++ b/src/training/metrics/metrics.hpp
@@ -137,8 +137,6 @@ namespace lfs::training {
         std::unique_ptr<MetricsReporter> _reporter;
 
         // Helper functions
-        lfs::core::Tensor load_eval_mask(lfs::core::Camera* cam, lfs::core::Tensor& gt_image,
-                                         bool alpha_as_mask) const;
         lfs::core::Tensor apply_depth_colormap(const lfs::core::Tensor& depth_normalized) const;
     };
 } // namespace lfs::training

--- a/src/training/strategies/improved_gs_plus.cpp
+++ b/src/training/strategies/improved_gs_plus.cpp
@@ -286,7 +286,7 @@ namespace lfs::training {
             if (cam->is_undistort_prepared()) {
                 params.undistort = &cam->undistort_params();
             }
-            lfs::core::Tensor image = _image_loader->load_image_immediate(cam->image_path(), params);
+            lfs::core::Tensor image = _image_loader->load_camera_image_immediate(*cam, params);
 
             const int img_h = image.shape()[1];
             const int img_w = image.shape()[2];

--- a/src/training/strategies/mrnf.cpp
+++ b/src/training/strategies/mrnf.cpp
@@ -1431,7 +1431,7 @@ namespace lfs::training {
                 params.undistort = &cam->undistort_params();
             }
 
-            lfs::core::Tensor image = _image_loader->load_image_immediate(cam->image_path(), params);
+            lfs::core::Tensor image = _image_loader->load_camera_image_immediate(*cam, params);
             const int img_h = static_cast<int>(image.shape()[1]);
             const int img_w = static_cast<int>(image.shape()[2]);
 

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -590,7 +590,8 @@ namespace lfs::training {
             const lfs::core::param::OptimizationParameters& opt_params,
             lfs::io::PipelinedImageLoader& image_loader) {
             try {
-                auto mask = image_loader.load_image_immediate(
+                auto mask = image_loader.load_camera_image_immediate(
+                    camera,
                     camera.mask_path(),
                     make_metrics_load_params(gt_config, camera, false, false));
                 mask = normalize_mask_tensor(std::move(mask));
@@ -627,64 +628,55 @@ namespace lfs::training {
             const Trainer::GTLoadConfigSnapshot& gt_config,
             const lfs::core::param::OptimizationParameters& opt_params) {
             try {
-                auto [img_data, width, height, channels] = lfs::core::load_image_with_alpha(
-                    camera.image_path(), gt_config.resize_factor, gt_config.max_width);
+                lfs::io::PipelinedLoaderConfig loader_config;
+                loader_config.prefetch_count = 1;
+                loader_config.output_queue_size = 1;
+                loader_config.io_threads = 1;
+                loader_config.cold_process_threads = 1;
+                loader_config.use_filesystem_cache = false;
 
-                if (!img_data || channels != 4) {
-                    if (img_data) {
-                        lfs::core::free_image(img_data);
+                auto params = make_metrics_load_params(gt_config, camera, true, true);
+
+                lfs::io::ImageRequest request;
+                request.sequence_id = 0;
+                request.path = camera.image_path();
+                request.params = params;
+                request.extract_alpha_as_mask = true;
+                request.alpha_mask_params.invert = opt_params.invert_masks;
+                request.alpha_mask_params.threshold = opt_params.mask_threshold;
+                request.undistort = params.undistort;
+                request.cube_face_projection = camera.cube_face_projection();
+
+                lfs::io::PipelinedImageLoader loader(loader_config);
+                loader.prefetch({request});
+
+                while (loader.in_flight_count() > 0) {
+                    auto ready = loader.try_get_for(loader_config.output_wait_timeout);
+                    if (!ready)
+                        continue;
+
+                    if (!ready->tensor.is_valid()) {
+                        return std::unexpected("failed to decode RGBA image");
                     }
-                    return std::unexpected("failed to decode RGBA image");
+                    if (!ready->mask || !ready->mask->is_valid()) {
+                        return std::unexpected("failed to extract alpha mask");
+                    }
+
+                    auto mask = normalize_mask_tensor(std::move(*ready->mask));
+                    if (mask.dtype() == lfs::core::DataType::UInt8 ||
+                        mask.dtype() == lfs::core::DataType::Bool) {
+                        mask = opt_params.mask_threshold > 0.0f ? mask.gt(0) : mask.ge(128);
+                    } else {
+                        mask = mask.ge(0.5f);
+                    }
+                    mask = mask.to(lfs::core::DataType::UInt8).contiguous();
+
+                    return LoadedCameraMetricsInputs{
+                        .gt_image = std::move(ready->tensor),
+                        .mask = std::move(mask)};
                 }
 
-                const auto H = static_cast<size_t>(height);
-                const auto W = static_cast<size_t>(width);
-
-                auto cpu_tensor = lfs::core::Tensor::from_blob(
-                    img_data, lfs::core::TensorShape({H, W, 4}),
-                    lfs::core::Device::CPU, lfs::core::DataType::UInt8);
-                auto gpu_uint8 = cpu_tensor.to(lfs::core::Device::CUDA);
-                lfs::core::free_image(img_data);
-
-                auto rgb = lfs::core::Tensor::zeros(
-                    lfs::core::TensorShape({3, H, W}),
-                    lfs::core::Device::CUDA, lfs::core::DataType::UInt8);
-                auto mask = lfs::core::Tensor::zeros(
-                    lfs::core::TensorShape({H, W}),
-                    lfs::core::Device::CUDA, lfs::core::DataType::Float32);
-
-                lfs::io::cuda::launch_uint8_rgba_split_to_uint8_rgb_and_float32_alpha(
-                    gpu_uint8.ptr<uint8_t>(), rgb.ptr<uint8_t>(), mask.ptr<float>(), H, W, nullptr);
-
-                if (opt_params.invert_masks) {
-                    lfs::io::cuda::launch_mask_invert(mask.ptr<float>(), H, W, nullptr);
-                }
-                if (opt_params.mask_threshold > 0.0f) {
-                    lfs::io::cuda::launch_mask_threshold(mask.ptr<float>(), H, W, opt_params.mask_threshold, nullptr);
-                }
-
-                if (camera.is_undistort_prepared()) {
-                    const auto scaled = lfs::core::scale_undistort_params(
-                        camera.undistort_params(),
-                        static_cast<int>(W),
-                        static_cast<int>(H));
-                    auto rgb_float = rgb.to(lfs::core::DataType::Float32) / 255.0f;
-                    rgb_float = lfs::core::undistort_image(rgb_float, scaled, nullptr);
-                    auto rgb_uint8 = lfs::core::Tensor::empty(
-                        rgb_float.shape(), lfs::core::Device::CUDA, lfs::core::DataType::UInt8);
-                    lfs::io::cuda::launch_float32_chw_to_uint8_chw(
-                        rgb_float.ptr<float>(),
-                        rgb_uint8.ptr<uint8_t>(),
-                        rgb_float.shape()[1],
-                        rgb_float.shape()[2],
-                        rgb_float.shape()[0],
-                        nullptr);
-                    rgb = std::move(rgb_uint8);
-                    mask = lfs::core::undistort_mask(mask, scaled, nullptr);
-                }
-
-                mask = mask.ge(0.5f).to(lfs::core::DataType::UInt8).contiguous();
-                return LoadedCameraMetricsInputs{.gt_image = std::move(rgb), .mask = std::move(mask)};
+                return std::unexpected("failed to decode RGBA image");
             } catch (const std::exception& e) {
                 return std::unexpected(e.what());
             }
@@ -719,8 +711,8 @@ namespace lfs::training {
             LoadedCameraMetricsInputs inputs;
 
             try {
-                inputs.gt_image = loader->load_image_immediate(
-                    camera.image_path(),
+                inputs.gt_image = loader->load_camera_image_immediate(
+                    camera,
                     make_metrics_load_params(gt_config, camera, true, true));
             } catch (const std::exception& e) {
                 return std::unexpected(e.what());
@@ -1280,11 +1272,17 @@ namespace lfs::training {
             BilateralGrid::Config config;
             config.lr = params_.optimization.bilateral_grid_lr;
 
-            // BilateralGrid is indexed with cam->uid() in the training loop. Those UIDs stay
-            // in the original camera space even when train/val splits are enabled, so the grid
-            // must be sized for the full camera set rather than only the training subset.
+            int image_slots = 0;
+            for (const auto& cam : train_dataset_->get_cameras()) {
+                if (cam)
+                    image_slots = std::max(image_slots, cam->uid() + 1);
+            }
+            image_slots = std::max(image_slots, 1);
+
+            // BilateralGrid is indexed with cam->uid() in the training loop, so
+            // allocate by UID range rather than by camera count.
             bilateral_grid_ = std::make_unique<BilateralGrid>(
-                static_cast<int>(total_cameras_count_),
+                image_slots,
                 params_.optimization.bilateral_grid_X,
                 params_.optimization.bilateral_grid_Y,
                 params_.optimization.bilateral_grid_W,
@@ -1295,7 +1293,7 @@ namespace lfs::training {
                      params_.optimization.bilateral_grid_X,
                      params_.optimization.bilateral_grid_Y,
                      params_.optimization.bilateral_grid_W,
-                     total_cameras_count_,
+                     image_slots,
                      train_dataset_size_);
 
             return {};
@@ -2704,30 +2702,67 @@ namespace lfs::training {
                 if (source_cameras.empty()) {
                     return std::unexpected("Scene has no active cameras enabled for training");
                 }
-
-                if (params.optimization.enable_eval) {
-                    for (const auto& camera : source_cameras) {
-                        switch (camera->split()) {
-                        case lfs::core::CameraSplit::Train:
-                            train_cameras.push_back(camera);
-                            break;
-                        case lfs::core::CameraSplit::Eval:
-                            val_cameras.push_back(camera);
-                            break;
-                        default:
-                            assert(false && "Camera split must be Train or Eval");
-                            break;
-                        }
-                    }
-                    assert(train_cameras.size() + val_cameras.size() == source_cameras.size());
-                }
             } else if (base_dataset_) {
                 source_cameras = base_dataset_->get_cameras();
             } else {
                 return std::unexpected("No camera source available");
             }
 
+            if (scene_ && params.optimization.undistort) {
+                auto expanded_cameras = expandEquirectangularCamerasForUndistort(source_cameras);
+                if (!expanded_cameras)
+                    return std::unexpected(expanded_cameras.error());
+                source_cameras = std::move(*expanded_cameras);
+            }
+
+            if (scene_ && params.optimization.enable_eval) {
+                for (const auto& camera : source_cameras) {
+                    switch (camera->split()) {
+                    case lfs::core::CameraSplit::Train:
+                        train_cameras.push_back(camera);
+                        break;
+                    case lfs::core::CameraSplit::Eval:
+                        val_cameras.push_back(camera);
+                        break;
+                    default:
+                        assert(false && "Camera split must be Train or Eval");
+                        break;
+                    }
+                }
+                assert(train_cameras.size() + val_cameras.size() == source_cameras.size());
+            }
+
             total_cameras_count_ = source_cameras.size();
+
+            if (params.optimization.gut) {
+                for (const auto& cam : source_cameras) {
+                    if (cam && cam->camera_model_type() == core::CameraModelType::ORTHO) {
+                        return std::unexpected("Training on cameras with ortho model is not supported yet.");
+                    }
+                }
+            } else if (params.optimization.undistort) {
+                for (const auto& cam : source_cameras) {
+                    if (!cam)
+                        continue;
+                    const auto model = cam->camera_model_type();
+                    if (model != core::CameraModelType::PINHOLE &&
+                        model != core::CameraModelType::EQUIRECTANGULAR) {
+                        return std::unexpected("Unsupported non-pinhole cameras detected. Use --gut for native non-pinhole training.");
+                    }
+                }
+            } else {
+                for (const auto& cam : source_cameras) {
+                    if (!cam)
+                        continue;
+                    if (cam->radial_distortion().numel() != 0 ||
+                        cam->tangential_distortion().numel() != 0) {
+                        return std::unexpected("Distorted images detected. Use --undistort or --gut to train on cameras with distortion.");
+                    }
+                    if (cam->camera_model_type() != core::CameraModelType::PINHOLE) {
+                        return std::unexpected("Spherical/non-pinhole cameras detected. Use --undistort for internal spherical tangent-view sampling or --gut for native non-pinhole training.");
+                    }
+                }
+            }
 
             if (auto result = initialize_camera_loss_heatmap(source_cameras); !result) {
                 return std::unexpected(result.error());

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -2711,7 +2711,7 @@ namespace lfs::training {
             if (scene_ && params.optimization.undistort) {
                 auto expanded_cameras = expandEquirectangularCamerasForUndistort(source_cameras);
                 if (!expanded_cameras)
-                    return std::unexpected(expanded_cameras.error());
+                    return std::unexpected(std::string(expanded_cameras.error().user_message()));
                 source_cameras = std::move(*expanded_cameras);
             }
 

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "training_setup.hpp"
+#include "core/camera.hpp"
 #include "core/cuda/sh_layout.cuh"
 #include "core/events.hpp"
+#include "core/image_io.hpp"
 #include "core/logger.hpp"
 #include "core/mesh_data.hpp"
 #include "core/path_utils.hpp"
@@ -15,12 +17,19 @@
 #include "dataset.hpp"
 #include "io/loader.hpp"
 #include <algorithm>
+#include <array>
+#include <cctype>
+#include <cmath>
 #include <format>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <optional>
 #include <random>
+#include <string_view>
+#include <tuple>
 #include <variant>
+#include <vector>
 
 namespace lfs::training {
 
@@ -89,6 +98,247 @@ namespace lfs::training {
             if (s == "by_cameras")
                 return lfs::io::CentralizeDataset::ByCameras;
             return lfs::io::CentralizeDataset::Off;
+        }
+
+        constexpr int kSphericalUndistortViewCount = 6;
+
+        // Cube faces, widened from 90 to 96 degrees.
+        //
+        // All views expanded from one panorama share that panorama's camera centre,
+        // so overlapping views carry no extra parallax: they resample the same rays
+        // twice. Redundant coverage is therefore pure cost, and worse, it is uneven
+        // cost -- an icosahedral 12-view layout at 90 degrees covers 25% of the
+        // sphere once, 50% twice and 25% three times, which weights the photometric
+        // loss by up to 3x purely as an artefact of the view geometry.
+        //
+        // Six faces tile the sphere exactly. The extra 3 degrees on each edge is a
+        // deliberate seam margin so SSIM windows and densification see real context
+        // across face boundaries, and it costs only ~12% angular overcoverage.
+        constexpr float kSphericalUndistortFovDegrees = 96.0f;
+
+        struct SphericalViewDefinition {
+            std::string_view suffix;
+            std::array<float, 3> forward;
+        };
+
+        constexpr std::array<SphericalViewDefinition, kSphericalUndistortViewCount> kSphericalUndistortViews{{
+            {"cube_px", {1.f, 0.f, 0.f}},
+            {"cube_nx", {-1.f, 0.f, 0.f}},
+            {"cube_py", {0.f, 1.f, 0.f}},
+            {"cube_ny", {0.f, -1.f, 0.f}},
+            {"cube_pz", {0.f, 0.f, 1.f}},
+            {"cube_nz", {0.f, 0.f, -1.f}},
+        }};
+
+        using Vec3 = std::array<float, 3>;
+
+        [[nodiscard]] Vec3 cross(const Vec3& a, const Vec3& b) {
+            return {
+                a[1] * b[2] - a[2] * b[1],
+                a[2] * b[0] - a[0] * b[2],
+                a[0] * b[1] - a[1] * b[0]};
+        }
+
+        [[nodiscard]] float length(const Vec3& v) {
+            return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+        }
+
+        [[nodiscard]] Vec3 normalize(const Vec3& v) {
+            const float len = length(v);
+            if (len <= 0.0f)
+                return {0.0f, 0.0f, 1.0f};
+            return {v[0] / len, v[1] / len, v[2] / len};
+        }
+
+        [[nodiscard]] std::array<float, 9> makeViewFromForward(const Vec3& forward_in) {
+            const Vec3 forward = normalize(forward_in);
+            constexpr Vec3 world_up{0.0f, 1.0f, 0.0f};
+            constexpr Vec3 fallback_up{0.0f, 0.0f, 1.0f};
+
+            Vec3 right = cross(world_up, forward);
+            if (length(right) < 1e-5f)
+                right = cross(fallback_up, forward);
+            right = normalize(right);
+            const Vec3 up = cross(forward, right);
+
+            return {
+                right[0], right[1], right[2],
+                up[0], up[1], up[2],
+                forward[0], forward[1], forward[2]};
+        }
+
+        [[nodiscard]] std::string sanitizeFilenameComponent(const std::string_view value) {
+            std::string out;
+            out.reserve(value.size());
+            for (const unsigned char ch : value) {
+                if (std::isalnum(ch) || ch == '-' || ch == '_') {
+                    out.push_back(static_cast<char>(ch));
+                } else {
+                    out.push_back('_');
+                }
+            }
+            while (!out.empty() && out.back() == '_')
+                out.pop_back();
+            return out.empty() ? "camera" : out;
+        }
+
+        [[nodiscard]] std::shared_ptr<lfs::core::Camera> makeSphericalViewCamera(
+            const lfs::core::Camera& source,
+            const SphericalViewDefinition& view,
+            const int view_size,
+            const int source_width,
+            const int source_height,
+            const int uid,
+            const std::string& image_name,
+            const bool has_alpha) {
+            const auto pano_to_view = makeViewFromForward(view.forward);
+            auto R_cpu = source.R().cpu();
+            if (!R_cpu.is_contiguous())
+                R_cpu = R_cpu.contiguous();
+            auto T_cpu = source.T().cpu();
+            if (!T_cpu.is_contiguous())
+                T_cpu = T_cpu.contiguous();
+
+            auto R_acc = R_cpu.accessor<float, 2>();
+            auto T_acc = T_cpu.accessor<float, 1>();
+
+            std::vector<float> R_face(9, 0.0f);
+            std::vector<float> T_face(3, 0.0f);
+            for (int row = 0; row < 3; ++row) {
+                for (int col = 0; col < 3; ++col) {
+                    for (int k = 0; k < 3; ++k)
+                        R_face[row * 3 + col] += pano_to_view[row * 3 + k] * R_acc(k, col);
+                }
+                for (int k = 0; k < 3; ++k)
+                    T_face[row] += pano_to_view[row * 3 + k] * T_acc(k);
+            }
+
+            const float focal = lfs::core::cube_face_focal(kSphericalUndistortFovDegrees, view_size);
+            const float center = 0.5f * static_cast<float>(view_size);
+            auto camera = std::make_shared<lfs::core::Camera>(
+                lfs::core::Tensor::from_vector(R_face, {3, 3}, lfs::core::Device::CPU),
+                lfs::core::Tensor::from_vector(T_face, {3}, lfs::core::Device::CPU),
+                focal,
+                focal,
+                center,
+                center,
+                lfs::core::Tensor::empty({0}, lfs::core::Device::CPU),
+                lfs::core::Tensor::empty({0}, lfs::core::Device::CPU),
+                lfs::core::CameraModelType::PINHOLE,
+                image_name,
+                source.image_path(),
+                source.has_mask() ? source.mask_path() : std::filesystem::path{},
+                view_size,
+                view_size,
+                uid,
+                source.camera_id());
+            camera->set_has_alpha(has_alpha);
+            camera->set_split(source.split());
+            camera->set_cube_face_projection(lfs::core::CubeFaceProjection{
+                .pano_to_face = pano_to_view,
+                .face_size = view_size,
+                .source_width = source_width,
+                .source_height = source_height,
+                .fov_degrees = kSphericalUndistortFovDegrees});
+            return camera;
+        }
+
+        [[nodiscard]] std::expected<std::vector<std::shared_ptr<lfs::core::Camera>>, std::string>
+        expandEquirectangularCamerasForUndistortImpl(
+            const std::vector<std::shared_ptr<lfs::core::Camera>>& cameras) {
+            int next_uid = 0;
+            const bool has_passthrough_cameras = std::any_of(cameras.begin(), cameras.end(), [](const auto& camera) {
+                return camera &&
+                       camera->camera_model_type() != lfs::core::CameraModelType::EQUIRECTANGULAR;
+            });
+            if (has_passthrough_cameras) {
+                for (const auto& camera : cameras) {
+                    if (camera)
+                        next_uid = std::max(next_uid, camera->uid() + 1);
+                }
+            }
+
+            std::vector<std::shared_ptr<lfs::core::Camera>> expanded;
+            expanded.reserve(cameras.size() * kSphericalUndistortViews.size());
+
+            size_t panoramas = 0;
+            size_t virtual_views = 0;
+            size_t ignored_depth_maps = 0;
+            int min_face_size = std::numeric_limits<int>::max();
+            int max_face_size = 0;
+
+            for (const auto& camera : cameras) {
+                if (!camera ||
+                    camera->camera_model_type() != lfs::core::CameraModelType::EQUIRECTANGULAR) {
+                    expanded.push_back(camera);
+                    if (!has_passthrough_cameras && camera)
+                        next_uid = std::max(next_uid, camera->uid() + 1);
+                    continue;
+                }
+
+                ++panoramas;
+                int source_width = 0;
+                int source_height = 0;
+                int source_channels = 0;
+                try {
+                    std::tie(source_width, source_height, source_channels) =
+                        lfs::core::get_image_info(camera->image_path());
+                } catch (const std::exception& e) {
+                    return std::unexpected(std::format("Failed to inspect panorama '{}': {}",
+                                                       lfs::core::path_to_utf8(camera->image_path()), e.what()));
+                }
+                if (source_width <= 0 || source_height <= 0 || source_channels <= 0) {
+                    return std::unexpected(std::format("Failed to inspect panorama '{}'",
+                                                       lfs::core::path_to_utf8(camera->image_path())));
+                }
+
+                const int view_size = lfs::core::cube_face_size_for_panorama(
+                    source_width, source_height, kSphericalUndistortFovDegrees);
+                min_face_size = std::min(min_face_size, view_size);
+                max_face_size = std::max(max_face_size, view_size);
+
+                const std::string stem = sanitizeFilenameComponent(
+                    std::filesystem::path(camera->image_name()).stem().string());
+                const std::string base_name = std::format("{:06d}_{}", camera->uid(), stem);
+
+                if (camera->has_depth())
+                    ++ignored_depth_maps;
+
+                for (size_t view_index = 0; view_index < kSphericalUndistortViews.size(); ++view_index) {
+                    const auto& view = kSphericalUndistortViews[view_index];
+                    const std::string image_name =
+                        std::format("{}_{}.png", base_name, view.suffix);
+                    expanded.push_back(makeSphericalViewCamera(
+                        *camera,
+                        view,
+                        view_size,
+                        source_width,
+                        source_height,
+                        next_uid++,
+                        image_name,
+                        camera->has_alpha()));
+                    ++virtual_views;
+                }
+            }
+
+            if (panoramas > 0) {
+                LOG_INFO("Undistort expanded {} equirectangular panorama{} into {} internal spherical pinhole views "
+                         "({} views/panorama, {:.0f} deg FOV, face size {} px auto, sampled internally from source panoramas)",
+                         panoramas,
+                         panoramas == 1 ? "" : "s",
+                         virtual_views,
+                         kSphericalUndistortViews.size(),
+                         kSphericalUndistortFovDegrees,
+                         min_face_size == max_face_size ? std::to_string(max_face_size)
+                                                        : std::format("{}-{}", min_face_size, max_face_size));
+                if (ignored_depth_maps > 0) {
+                    LOG_WARN("Equirectangular spherical undistort ignored {} depth map{}; perspective depth conversion is not implemented",
+                             ignored_depth_maps,
+                             ignored_depth_maps == 1 ? "" : "s");
+                }
+            }
+
+            return expanded;
         }
 
         void applyTrainingSHDegree(lfs::core::SplatData& splat, const int target_degree) {
@@ -376,6 +626,12 @@ namespace lfs::training {
         }
     } // namespace
 
+    std::expected<std::vector<std::shared_ptr<lfs::core::Camera>>, std::string>
+    expandEquirectangularCamerasForUndistort(
+        const std::vector<std::shared_ptr<lfs::core::Camera>>& cameras) {
+        return expandEquirectangularCamerasForUndistortImpl(cameras);
+    }
+
     std::expected<void, std::string> migrateTrainingModelToAllocator(
         const lfs::core::param::TrainingParameters& params,
         lfs::core::SplatData& model,
@@ -501,22 +757,36 @@ namespace lfs::training {
                     }
                 }
 
-                const auto& cameras = data.cameras;
                 const bool enable_eval = params.optimization.enable_eval;
                 const int test_every = params.dataset.test_every;
+
+                for (size_t i = 0; i < data.cameras.size(); ++i) {
+                    const bool is_eval = enable_eval && (i % test_every) == 0;
+                    data.cameras[i]->set_split(is_eval ? lfs::core::CameraSplit::Eval : lfs::core::CameraSplit::Train);
+                }
+
+                std::vector<std::shared_ptr<lfs::core::Camera>> undistorted_cameras;
+                const auto* cameras_ptr = &data.cameras;
+                if (params.optimization.undistort) {
+                    auto expanded_cameras = expandEquirectangularCamerasForUndistort(data.cameras);
+                    if (!expanded_cameras)
+                        return std::unexpected(expanded_cameras.error());
+                    undistorted_cameras = std::move(*expanded_cameras);
+                    cameras_ptr = &undistorted_cameras;
+                }
+                const auto& cameras = *cameras_ptr;
 
                 size_t train_count = 0;
                 size_t val_count = 0;
                 size_t mask_count = 0;
-                for (size_t i = 0; i < cameras.size(); ++i) {
-                    const bool is_eval = enable_eval && (i % test_every) == 0;
-                    cameras[i]->set_split(is_eval ? lfs::core::CameraSplit::Eval : lfs::core::CameraSplit::Train);
+                for (const auto& camera : cameras) {
+                    const bool is_eval = enable_eval && camera->split() == lfs::core::CameraSplit::Eval;
                     if (is_eval) {
                         val_count++;
                     } else {
                         train_count++;
                     }
-                    if (cameras[i]->has_mask()) {
+                    if (camera->has_mask()) {
                         mask_count++;
                     }
                 }
@@ -529,7 +799,7 @@ namespace lfs::training {
                     train_count);
 
                 for (size_t i = 0; i < cameras.size(); ++i) {
-                    if (!enable_eval || (i % test_every) != 0) {
+                    if (!enable_eval || cameras[i]->split() != lfs::core::CameraSplit::Eval) {
                         scene.addCamera(cameras[i]->image_name(), train_cameras_id, cameras[i]);
                     }
                 }
@@ -541,7 +811,7 @@ namespace lfs::training {
                         val_count);
 
                     for (size_t i = 0; i < cameras.size(); ++i) {
-                        if ((i % test_every) == 0) {
+                        if (cameras[i]->split() == lfs::core::CameraSplit::Eval) {
                             scene.addCamera(cameras[i]->image_name(), val_cameras_id, cameras[i]);
                         }
                     }
@@ -870,16 +1140,30 @@ namespace lfs::training {
                     scene.addPointCloud("PointCloud", createRandomPointCloud(), dataset_id);
                 }
 
-                const auto& cameras = data.cameras;
                 const bool enable_eval = params.optimization.enable_eval;
                 const int test_every = params.dataset.test_every;
 
-                size_t train_count = 0, val_count = 0, mask_count = 0;
-                for (size_t i = 0; i < cameras.size(); ++i) {
+                for (size_t i = 0; i < data.cameras.size(); ++i) {
                     const bool is_val = enable_eval && (i % test_every) == 0;
-                    cameras[i]->set_split(is_val ? lfs::core::CameraSplit::Eval : lfs::core::CameraSplit::Train);
+                    data.cameras[i]->set_split(is_val ? lfs::core::CameraSplit::Eval : lfs::core::CameraSplit::Train);
+                }
+
+                std::vector<std::shared_ptr<lfs::core::Camera>> undistorted_cameras;
+                const auto* cameras_ptr = &data.cameras;
+                if (params.optimization.undistort) {
+                    auto expanded_cameras = expandEquirectangularCamerasForUndistort(data.cameras);
+                    if (!expanded_cameras)
+                        return std::unexpected(expanded_cameras.error());
+                    undistorted_cameras = std::move(*expanded_cameras);
+                    cameras_ptr = &undistorted_cameras;
+                }
+                const auto& cameras = *cameras_ptr;
+
+                size_t train_count = 0, val_count = 0, mask_count = 0;
+                for (const auto& camera : cameras) {
+                    const bool is_val = enable_eval && camera->split() == lfs::core::CameraSplit::Eval;
                     is_val ? ++val_count : ++train_count;
-                    if (cameras[i]->has_mask())
+                    if (camera->has_mask())
                         ++mask_count;
                 }
 
@@ -888,7 +1172,7 @@ namespace lfs::training {
                     "Training", cameras_group_id, train_count);
 
                 for (size_t i = 0; i < cameras.size(); ++i) {
-                    if (!enable_eval || (i % test_every) != 0) {
+                    if (!enable_eval || cameras[i]->split() != lfs::core::CameraSplit::Eval) {
                         scene.addCamera(cameras[i]->image_name(), train_cameras_id, cameras[i]);
                     }
                 }
@@ -897,7 +1181,7 @@ namespace lfs::training {
                     const auto val_cameras_id = scene.addCameraGroup(
                         "Validation", cameras_group_id, val_count);
                     for (size_t i = 0; i < cameras.size(); ++i) {
-                        if ((i % test_every) == 0) {
+                        if (cameras[i]->split() == lfs::core::CameraSplit::Eval) {
                             scene.addCamera(cameras[i]->image_name(), val_cameras_id, cameras[i]);
                         }
                     }

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -231,7 +231,8 @@ namespace lfs::training {
                 view_size,
                 view_size,
                 uid,
-                source.camera_id());
+                source.camera_id(),
+                source.has_depth() ? source.depth_path() : std::filesystem::path{});
             camera->set_has_alpha(has_alpha);
             camera->set_split(source.split());
             camera->set_cube_face_projection(lfs::core::CubeFaceProjection{
@@ -263,7 +264,7 @@ namespace lfs::training {
 
             size_t panoramas = 0;
             size_t virtual_views = 0;
-            size_t ignored_depth_maps = 0;
+            size_t projected_depth_maps = 0;
             int min_face_size = std::numeric_limits<int>::max();
             int max_face_size = 0;
 
@@ -302,7 +303,7 @@ namespace lfs::training {
                 const std::string base_name = std::format("{:06d}_{}", camera->uid(), stem);
 
                 if (camera->has_depth())
-                    ++ignored_depth_maps;
+                    ++projected_depth_maps;
 
                 for (size_t view_index = 0; view_index < kSphericalUndistortViews.size(); ++view_index) {
                     const auto& view = kSphericalUndistortViews[view_index];
@@ -331,10 +332,11 @@ namespace lfs::training {
                          kSphericalUndistortFovDegrees,
                          min_face_size == max_face_size ? std::to_string(max_face_size)
                                                         : std::format("{}-{}", min_face_size, max_face_size));
-                if (ignored_depth_maps > 0) {
-                    LOG_WARN("Equirectangular spherical undistort ignored {} depth map{}; perspective depth conversion is not implemented",
-                             ignored_depth_maps,
-                             ignored_depth_maps == 1 ? "" : "s");
+                if (projected_depth_maps > 0) {
+                    LOG_INFO("Projected {} panorama depth map{} onto the generated faces "
+                             "(nearest sampling, radial distance converted to camera-space z)",
+                             projected_depth_maps,
+                             projected_depth_maps == 1 ? "" : "s");
                 }
             }
 

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -244,7 +244,7 @@ namespace lfs::training {
             return camera;
         }
 
-        [[nodiscard]] std::expected<std::vector<std::shared_ptr<lfs::core::Camera>>, std::string>
+        [[nodiscard]] lfs::Result<std::vector<std::shared_ptr<lfs::core::Camera>>>
         expandEquirectangularCamerasForUndistortImpl(
             const std::vector<std::shared_ptr<lfs::core::Camera>>& cameras) {
             int next_uid = 0;
@@ -285,12 +285,22 @@ namespace lfs::training {
                     std::tie(source_width, source_height, source_channels) =
                         lfs::core::get_image_info(camera->image_path());
                 } catch (const std::exception& e) {
-                    return std::unexpected(std::format("Failed to inspect panorama '{}': {}",
-                                                       lfs::core::path_to_utf8(camera->image_path()), e.what()));
+                    return lfs::make_error(lfs::ErrorInit{
+                        .code = lfs::ErrorCode::DataLoss,
+                        .domain = lfs::ErrorDomain::Training,
+                        .user_message = std::format("Failed to inspect panorama '{}': {}",
+                                                    lfs::core::path_to_utf8(camera->image_path()), e.what()),
+                        .detection = LFS_SOURCE_SITE_CURRENT(),
+                    });
                 }
                 if (source_width <= 0 || source_height <= 0 || source_channels <= 0) {
-                    return std::unexpected(std::format("Failed to inspect panorama '{}'",
-                                                       lfs::core::path_to_utf8(camera->image_path())));
+                    return lfs::make_error(lfs::ErrorInit{
+                        .code = lfs::ErrorCode::DataLoss,
+                        .domain = lfs::ErrorDomain::Training,
+                        .user_message = std::format("Failed to inspect panorama '{}'",
+                                                    lfs::core::path_to_utf8(camera->image_path())),
+                        .detection = LFS_SOURCE_SITE_CURRENT(),
+                    });
                 }
 
                 const int view_size = lfs::core::cube_face_size_for_panorama(
@@ -628,7 +638,7 @@ namespace lfs::training {
         }
     } // namespace
 
-    std::expected<std::vector<std::shared_ptr<lfs::core::Camera>>, std::string>
+    lfs::Result<std::vector<std::shared_ptr<lfs::core::Camera>>>
     expandEquirectangularCamerasForUndistort(
         const std::vector<std::shared_ptr<lfs::core::Camera>>& cameras) {
         return expandEquirectangularCamerasForUndistortImpl(cameras);
@@ -772,7 +782,7 @@ namespace lfs::training {
                 if (params.optimization.undistort) {
                     auto expanded_cameras = expandEquirectangularCamerasForUndistort(data.cameras);
                     if (!expanded_cameras)
-                        return std::unexpected(expanded_cameras.error());
+                        return std::unexpected(std::string(expanded_cameras.error().user_message()));
                     undistorted_cameras = std::move(*expanded_cameras);
                     cameras_ptr = &undistorted_cameras;
                 }
@@ -1155,7 +1165,7 @@ namespace lfs::training {
                 if (params.optimization.undistort) {
                     auto expanded_cameras = expandEquirectangularCamerasForUndistort(data.cameras);
                     if (!expanded_cameras)
-                        return std::unexpected(expanded_cameras.error());
+                        return std::unexpected(std::string(expanded_cameras.error().user_message()));
                     undistorted_cameras = std::move(*expanded_cameras);
                     cameras_ptr = &undistorted_cameras;
                 }

--- a/src/training/training_setup.hpp
+++ b/src/training/training_setup.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/error.hpp"
 #include "core/parameters.hpp"
 #include "core/splat_data.hpp"
 #include "io/loader.hpp"
@@ -46,7 +47,7 @@ namespace lfs::training {
      * the source image path and sample the requested tangent view through the native
      * image loader cache.
      */
-    std::expected<std::vector<std::shared_ptr<lfs::core::Camera>>, std::string>
+    [[nodiscard]] lfs::Result<std::vector<std::shared_ptr<lfs::core::Camera>>>
     expandEquirectangularCamerasForUndistort(
         const std::vector<std::shared_ptr<lfs::core::Camera>>& cameras);
 

--- a/src/training/training_setup.hpp
+++ b/src/training/training_setup.hpp
@@ -8,11 +8,14 @@
 #include "core/splat_data.hpp"
 #include "io/loader.hpp"
 #include <expected>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace lfs::core {
+    class Camera;
     class Scene;
-}
+} // namespace lfs::core
 
 namespace lfs::training {
     /**
@@ -35,6 +38,17 @@ namespace lfs::training {
     std::expected<void, std::string> loadTrainingDataIntoScene(
         const lfs::core::param::TrainingParameters& params,
         lfs::core::Scene& scene);
+
+    /**
+     * @brief Expand equirectangular cameras into internal spherical pinhole views.
+     *
+     * Non-equirectangular cameras are preserved. The returned virtual cameras keep
+     * the source image path and sample the requested tangent view through the native
+     * image loader cache.
+     */
+    std::expected<std::vector<std::shared_ptr<lfs::core::Camera>>, std::string>
+    expandEquirectangularCamerasForUndistort(
+        const std::vector<std::shared_ptr<lfs::core::Camera>>& cameras);
 
     /**
      * @brief Initialize training model from point cloud

--- a/tests/test_undistort.cpp
+++ b/tests/test_undistort.cpp
@@ -2,9 +2,14 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/camera.hpp"
+#include "core/cube_face_projection.hpp"
 #include "core/cuda/undistort/undistort.hpp"
 #include "core/image_io.hpp"
 #include "io/formats/colmap.hpp"
+#include "training/training_setup.hpp"
+#include <algorithm>
+#include <array>
+#include <cmath>
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 
@@ -18,6 +23,53 @@ namespace {
     constexpr float TEST_CY = 240.0f;
     constexpr int TEST_W = 640;
     constexpr int TEST_H = 480;
+    constexpr float SPHERICAL_UNDISTORT_FOV = 96.0f;
+    constexpr size_t SPHERICAL_UNDISTORT_VIEW_COUNT = 6;
+    constexpr std::array<std::array<float, 3>, SPHERICAL_UNDISTORT_VIEW_COUNT> SPHERICAL_UNDISTORT_FORWARDS{{
+        {1.f, 0.f, 0.f},
+        {-1.f, 0.f, 0.f},
+        {0.f, 1.f, 0.f},
+        {0.f, -1.f, 0.f},
+        {0.f, 0.f, 1.f},
+        {0.f, 0.f, -1.f},
+    }};
+
+    using Vec3 = std::array<float, 3>;
+
+    Vec3 cross(const Vec3& a, const Vec3& b) {
+        return {
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0]};
+    }
+
+    float length(const Vec3& v) {
+        return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    }
+
+    Vec3 normalize(const Vec3& v) {
+        const float len = length(v);
+        if (len <= 0.0f)
+            return {0.0f, 0.0f, 1.0f};
+        return {v[0] / len, v[1] / len, v[2] / len};
+    }
+
+    std::array<float, 9> expected_spherical_matrix(const Vec3& forward_in) {
+        const Vec3 forward = normalize(forward_in);
+        constexpr Vec3 world_up{0.0f, 1.0f, 0.0f};
+        constexpr Vec3 fallback_up{0.0f, 0.0f, 1.0f};
+
+        Vec3 right = cross(world_up, forward);
+        if (length(right) < 1e-5f)
+            right = cross(fallback_up, forward);
+        right = normalize(right);
+        const Vec3 up = cross(forward, right);
+
+        return {
+            right[0], right[1], right[2],
+            up[0], up[1], up[2],
+            forward[0], forward[1], forward[2]};
+    }
 
     void validate_params(const UndistortParams& p, int src_w, int src_h) {
         EXPECT_GT(p.dst_width, 0);
@@ -586,6 +638,138 @@ TEST_F(UndistortCameraTest, EquirectangularModelDoesNotUseUndistortion) {
     EXPECT_FALSE(equirect_cam.has_distortion());
     equirect_cam.prepare_undistortion();
     EXPECT_FALSE(equirect_cam.is_undistort_prepared());
+}
+
+// Pins the face-sizing policy to concrete values. The previous version of this
+// test re-derived the formula, so it could not detect a change to it.
+//
+// A 2:1 4K panorama resolves 3840/(2*pi) = 611.15 px/rad, so a 96 degree face
+// matching that rate at its centre is 2 * 611.15 * tan(48 deg) = 1358 px.
+TEST(SphericalFaceSizing, MatchesPanoramaSamplingRateAtFaceCentre) {
+    EXPECT_EQ(cube_face_size_for_panorama(3840, 1920, 96.0f), 1358);
+    EXPECT_EQ(cube_face_size_for_panorama(3840, 1920, 90.0f), 1222);
+    EXPECT_EQ(cube_face_size_for_panorama(2048, 1024, 96.0f), 724);
+}
+
+TEST(SphericalFaceSizing, FocalRoundTripsToTheRequestedFov) {
+    constexpr float kPi = 3.14159265358979323846f;
+    for (const float fov : {60.0f, 90.0f, 96.0f, 120.0f}) {
+        const float focal = cube_face_focal(fov, 1000);
+        EXPECT_NEAR(focal2fov(focal, 1000) * 180.0f / kPi, fov, 1e-2f);
+    }
+}
+
+TEST(SphericalFaceSizing, DegenerateFovStaysFinite) {
+    // Field of view is clamped, so neither a zero nor an over-wide value may
+    // produce a zero, negative or infinite focal length.
+    EXPECT_GT(cube_face_size_for_panorama(3840, 1920, 0.0f), 0);
+    EXPECT_GT(cube_face_size_for_panorama(3840, 1920, 360.0f), 0);
+    EXPECT_GT(cube_face_focal(0.0f, 512), 0.0f);
+    EXPECT_TRUE(std::isfinite(cube_face_focal(0.0f, 512)));
+    EXPECT_TRUE(std::isfinite(cube_face_focal(360.0f, 512)));
+}
+
+TEST_F(UndistortCameraTest, EquirectangularSphericalExpansionUsesVirtualPinholeCameras) {
+    auto& source = cameras_[0];
+    auto equirect_cam = std::make_shared<Camera>(
+        source->R(), source->T(),
+        source->focal_x(), source->focal_y(),
+        source->center_x(), source->center_y(),
+        Tensor(), Tensor(),
+        CameraModelType::EQUIRECTANGULAR,
+        "pano.jpg", source->image_path(), "",
+        source->camera_width(), source->camera_height(), 7, 99);
+    equirect_cam->set_has_alpha(true);
+    equirect_cam->set_split(CameraSplit::Eval);
+
+    auto expanded = lfs::training::expandEquirectangularCamerasForUndistort({equirect_cam});
+
+    ASSERT_TRUE(expanded.has_value()) << expanded.error();
+    ASSERT_EQ(expanded->size(), SPHERICAL_UNDISTORT_VIEW_COUNT);
+
+    const auto [source_width, source_height, source_channels] = get_image_info(source->image_path());
+    ASSERT_GT(source_channels, 0);
+    const int expected_face_size = cube_face_size_for_panorama(
+        source_width, source_height, SPHERICAL_UNDISTORT_FOV);
+    const float expected_focal = cube_face_focal(SPHERICAL_UNDISTORT_FOV, expected_face_size);
+
+    for (size_t i = 0; i < expanded->size(); ++i) {
+        const auto& face = (*expanded)[i];
+        ASSERT_TRUE(face);
+        EXPECT_EQ(face->camera_model_type(), CameraModelType::PINHOLE);
+        EXPECT_TRUE(face->has_cube_face_projection());
+        EXPECT_EQ(face->image_path(), source->image_path());
+        EXPECT_EQ(face->split(), CameraSplit::Eval);
+        EXPECT_TRUE(face->has_alpha());
+        EXPECT_EQ(face->camera_id(), 99);
+        EXPECT_EQ(face->uid(), static_cast<int>(i));
+        EXPECT_EQ(face->camera_width(), expected_face_size);
+        EXPECT_EQ(face->camera_height(), expected_face_size);
+        EXPECT_NEAR(face->focal_x(), expected_focal, 1e-4f);
+        EXPECT_NEAR(face->focal_y(), expected_focal, 1e-4f);
+        ASSERT_TRUE(face->cube_face_projection().has_value());
+        EXPECT_EQ(face->cube_face_projection()->face_size, expected_face_size);
+        EXPECT_EQ(face->cube_face_projection()->source_width, source_width);
+        EXPECT_EQ(face->cube_face_projection()->source_height, source_height);
+        EXPECT_NEAR(face->cube_face_projection()->fov_degrees, SPHERICAL_UNDISTORT_FOV, 1e-4f);
+        const auto& pano_to_face = face->cube_face_projection()->pano_to_face;
+        const auto expected_matrix = expected_spherical_matrix(SPHERICAL_UNDISTORT_FORWARDS[i]);
+        for (size_t j = 0; j < pano_to_face.size(); ++j)
+            EXPECT_NEAR(pano_to_face[j], expected_matrix[j], 1e-6f);
+        for (int row = 0; row < 3; ++row) {
+            const float row_len =
+                pano_to_face[row * 3 + 0] * pano_to_face[row * 3 + 0] +
+                pano_to_face[row * 3 + 1] * pano_to_face[row * 3 + 1] +
+                pano_to_face[row * 3 + 2] * pano_to_face[row * 3 + 2];
+            EXPECT_NEAR(row_len, 1.0f, 1e-5f);
+        }
+        const float dot01 = pano_to_face[0] * pano_to_face[3] +
+                            pano_to_face[1] * pano_to_face[4] +
+                            pano_to_face[2] * pano_to_face[5];
+        const float dot02 = pano_to_face[0] * pano_to_face[6] +
+                            pano_to_face[1] * pano_to_face[7] +
+                            pano_to_face[2] * pano_to_face[8];
+        const float dot12 = pano_to_face[3] * pano_to_face[6] +
+                            pano_to_face[4] * pano_to_face[7] +
+                            pano_to_face[5] * pano_to_face[8];
+        EXPECT_NEAR(dot01, 0.0f, 1e-5f);
+        EXPECT_NEAR(dot02, 0.0f, 1e-5f);
+        EXPECT_NEAR(dot12, 0.0f, 1e-5f);
+    }
+}
+
+TEST_F(UndistortCameraTest, SphericalExpansionKeepsPassthroughCamerasAndAvoidsUidCollisions) {
+    auto& source = cameras_[0];
+    auto equirect_cam = std::make_shared<Camera>(
+        source->R(), source->T(),
+        source->focal_x(), source->focal_y(),
+        source->center_x(), source->center_y(),
+        Tensor(), Tensor(),
+        CameraModelType::EQUIRECTANGULAR,
+        "pano.jpg", source->image_path(), "",
+        source->camera_width(), source->camera_height(), 2, 20);
+    auto pinhole_cam = std::make_shared<Camera>(
+        source->R(), source->T(),
+        source->focal_x(), source->focal_y(),
+        source->center_x(), source->center_y(),
+        Tensor(), Tensor(),
+        CameraModelType::PINHOLE,
+        "pinhole.jpg", source->image_path(), "",
+        source->camera_width(), source->camera_height(), 12, 12);
+
+    auto expanded = lfs::training::expandEquirectangularCamerasForUndistort({equirect_cam, pinhole_cam});
+
+    ASSERT_TRUE(expanded.has_value()) << expanded.error();
+    ASSERT_EQ(expanded->size(), SPHERICAL_UNDISTORT_VIEW_COUNT + 1);
+    for (size_t i = 0; i < SPHERICAL_UNDISTORT_VIEW_COUNT; ++i) {
+        ASSERT_TRUE((*expanded)[i]);
+        EXPECT_EQ((*expanded)[i]->camera_model_type(), CameraModelType::PINHOLE);
+        EXPECT_TRUE((*expanded)[i]->has_cube_face_projection());
+        EXPECT_EQ((*expanded)[i]->uid(), static_cast<int>(13 + i));
+    }
+    EXPECT_EQ((*expanded)[SPHERICAL_UNDISTORT_VIEW_COUNT], pinhole_cam);
+    EXPECT_FALSE((*expanded)[SPHERICAL_UNDISTORT_VIEW_COUNT]->has_cube_face_projection());
+    EXPECT_EQ((*expanded)[SPHERICAL_UNDISTORT_VIEW_COUNT]->uid(), 12);
 }
 
 TEST(UndistortScale, ScaleUndistortParams) {

--- a/tests/test_undistort.cpp
+++ b/tests/test_undistort.cpp
@@ -5,13 +5,16 @@
 #include "core/cube_face_projection.hpp"
 #include "core/cuda/undistort/undistort.hpp"
 #include "core/image_io.hpp"
+#include "io/cube_face_projection.hpp"
 #include "io/formats/colmap.hpp"
 #include "training/training_setup.hpp"
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
+#include <vector>
 
 using namespace lfs::core;
 
@@ -807,4 +810,251 @@ TEST(UndistortScale, ScaleUndistortParams) {
 
     run_image_undistort(scaled);
     run_mask_undistort(scaled);
+}
+
+// ====================== Cube-face projection ======================
+//
+// These build their panorama analytically, so they need no dataset and the
+// expected value is a closed form rather than a golden image.
+
+namespace {
+
+    constexpr float kProjPi = 3.14159265358979323846f;
+
+    // Equirectangular pixel centre -> unit direction.
+    Vec3 equirect_direction(const int x, const int y, const int width, const int height) {
+        const float az = (static_cast<float>(x) + 0.5f) / width * 2.0f * kProjPi - kProjPi;
+        const float el = (static_cast<float>(y) + 0.5f) / height * kProjPi - 0.5f * kProjPi;
+        return {std::cos(el) * std::sin(az), std::sin(el), std::cos(el) * std::cos(az)};
+    }
+
+    // Face pixel -> unnormalised direction, matching project_cube_face_hwc.
+    Vec3 face_direction(const std::array<float, 9>& m, const int x, const int y,
+                        const int size, const float fov_degrees) {
+        const float focal = cube_face_focal(fov_degrees, size);
+        const float c = 0.5f * static_cast<float>(size);
+        const float u = (static_cast<float>(x) + 0.5f - c) / focal;
+        const float v = (static_cast<float>(y) + 0.5f - c) / focal;
+        return {m[0] * u + m[3] * v + m[6],
+                m[1] * u + m[4] * v + m[7],
+                m[2] * u + m[5] * v + m[8]};
+    }
+
+    // Smooth band-limited signal in [0, 1] built from the direction components,
+    // so it stays continuous at the poles. An az/el signal does not: every
+    // azimuth meets at the pole, so sin(k*az) is discontinuous there, and a
+    // correctly filtered face would legitimately disagree with a point sample.
+    float smooth_sphere_signal(const Vec3& d) {
+        const float len = length(d);
+        const float nx = d[0] / len;
+        const float ny = d[1] / len;
+        const float nz = d[2] / len;
+        constexpr float k = 3.0f;
+        return 0.5f + 0.5f * std::sin(k * nx) * std::sin(k * ny) * std::sin(k * nz);
+    }
+
+    // Deliberately high-frequency signal for the aliasing test. Singular at the
+    // poles, which is why only an equatorial face uses it.
+    float sphere_signal(const Vec3& d, const float cycles_per_rad) {
+        const float k = 2.0f * kProjPi * cycles_per_rad;
+        const float az = std::atan2(d[0], d[2]);
+        const float len = length(d);
+        const float el = std::asin(std::clamp(len > 0.0f ? d[1] / len : 0.0f, -1.0f, 1.0f));
+        return 0.5f + 0.5f * std::sin(k * az) * std::sin(0.5f * k * el);
+    }
+
+    std::vector<uint8_t> make_smooth_panorama(const int width, const int height) {
+        std::vector<uint8_t> pano(static_cast<size_t>(width) * height);
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                pano[static_cast<size_t>(y) * width + x] = static_cast<uint8_t>(std::lround(
+                    255.0f * smooth_sphere_signal(equirect_direction(x, y, width, height))));
+            }
+        }
+        return pano;
+    }
+
+    std::vector<uint8_t> make_signal_panorama(const int width, const int height,
+                                              const float cycles_per_rad) {
+        std::vector<uint8_t> pano(static_cast<size_t>(width) * height);
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                pano[static_cast<size_t>(y) * width + x] = static_cast<uint8_t>(std::lround(
+                    255.0f * sphere_signal(equirect_direction(x, y, width, height), cycles_per_rad)));
+            }
+        }
+        return pano;
+    }
+
+    const std::array<Vec3, 6>& cube_forwards() {
+        static const std::array<Vec3, 6> f{{
+            {1.f, 0.f, 0.f},
+            {-1.f, 0.f, 0.f},
+            {0.f, 1.f, 0.f},
+            {0.f, -1.f, 0.f},
+            {0.f, 0.f, 1.f},
+            {0.f, 0.f, -1.f},
+        }};
+        return f;
+    }
+
+} // namespace
+
+// A transposed or mirrored face basis still produces a plausible-looking image,
+// so check that each face pixel carries the panorama content for the direction
+// that pixel actually represents.
+TEST(CubeFaceProjection, FacePixelsCarryTheContentOfTheirOwnRay) {
+    constexpr int W = 1024;
+    constexpr int H = 512;
+    constexpr int S = 128;
+    constexpr float kFov = 96.0f;
+    const auto pano = make_smooth_panorama(W, H);
+
+    for (size_t f = 0; f < cube_forwards().size(); ++f) {
+        const auto basis = expected_spherical_matrix(cube_forwards()[f]);
+        const lfs::core::CubeFaceProjection proj{basis, S, W, H, kFov};
+        const auto face = lfs::io::project_cube_face_hwc(pano.data(), W, H, 1, proj, S);
+
+        double sum_sq = 0.0;
+        for (int y = 0; y < S; ++y) {
+            for (int x = 0; x < S; ++x) {
+                const float expected =
+                    255.0f * smooth_sphere_signal(face_direction(basis, x, y, S, kFov));
+                const double d =
+                    static_cast<double>(face[static_cast<size_t>(y) * S + x]) - expected;
+                sum_sq += d * d;
+            }
+        }
+        const double rmse = std::sqrt(sum_sq / (static_cast<double>(S) * S));
+        EXPECT_LT(rmse, 3.0) << "face " << f << " does not match the panorama along its own rays";
+    }
+}
+
+// The elliptical filter weights must sum to one everywhere, including at the
+// poles where the footprint is extremely anisotropic and gets strided.
+TEST(CubeFaceProjection, ConstantPanoramaIsPreservedOnEveryFace) {
+    constexpr int W = 512;
+    constexpr int H = 256;
+    constexpr int S = 96;
+    constexpr uint8_t kValue = 173;
+    const std::vector<uint8_t> pano(static_cast<size_t>(W) * H, kValue);
+
+    for (size_t f = 0; f < cube_forwards().size(); ++f) {
+        const lfs::core::CubeFaceProjection proj{
+            expected_spherical_matrix(cube_forwards()[f]), S, W, H, 96.0f};
+        const auto face = lfs::io::project_cube_face_hwc(pano.data(), W, H, 1, proj, S);
+        const auto bounds = std::minmax_element(face.begin(), face.end());
+        EXPECT_EQ(static_cast<int>(*bounds.first), static_cast<int>(kValue)) << "face " << f;
+        EXPECT_EQ(static_cast<int>(*bounds.second), static_cast<int>(kValue)) << "face " << f;
+    }
+}
+
+// Content the face cannot resolve must be attenuated towards the local mean
+// rather than aliased into spurious low-frequency structure. A plain bilinear
+// fetch fails this; the prefilter is what makes it pass.
+TEST(CubeFaceProjection, SignalAboveFaceNyquistIsAttenuatedNotAliased) {
+    constexpr int W = 2048;
+    constexpr int H = 1024;
+    constexpr int S = 64;
+    constexpr float kFov = 96.0f;
+    // The face resolves ~14 cyc/rad here; the panorama still resolves 60 easily.
+    const auto pano = make_signal_panorama(W, H, 60.0f);
+
+    const lfs::core::CubeFaceProjection proj{
+        expected_spherical_matrix(cube_forwards()[4]), S, W, H, kFov};
+    const auto face = lfs::io::project_cube_face_hwc(pano.data(), W, H, 1, proj, S);
+
+    double mean = 0.0;
+    for (const uint8_t v : face)
+        mean += v;
+    mean /= static_cast<double>(face.size());
+
+    double stddev = 0.0;
+    for (const uint8_t v : face)
+        stddev += (v - mean) * (v - mean);
+    stddev = std::sqrt(stddev / static_cast<double>(face.size()));
+
+    EXPECT_NEAR(mean, 127.5, 12.0) << "attenuated output should sit near the signal mean";
+    EXPECT_LT(stddev, 30.0) << "unresolvable detail survived as aliasing instead of being filtered";
+}
+
+// ====================== Cube-face depth ======================
+
+// Analytic scene: a cube of half-extent h centred on the camera, stored as
+// 16-bit equirectangular radial distance. Camera-space z on a flat wall is
+// exactly h wherever it is sampled, which holds only if the radial-to-z
+// conversion is applied.
+TEST(CubeFaceDepth, FlatWallHasConstantCameraSpaceZ) {
+    constexpr int W = 1024;
+    constexpr int H = 512;
+    constexpr int S = 96;
+    constexpr float kFov = 96.0f;
+    constexpr double kHalf = 0.5;
+
+    std::vector<uint16_t> pano(static_cast<size_t>(W) * H);
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            const Vec3 d = equirect_direction(x, y, W, H);
+            const double m = std::max(std::max(std::abs(d[0]), std::abs(d[1])), std::abs(d[2]));
+            pano[static_cast<size_t>(y) * W + x] =
+                static_cast<uint16_t>(std::lround(std::clamp(kHalf / m, 0.0, 1.0) * 65535.0));
+        }
+    }
+
+    const float focal = cube_face_focal(kFov, S);
+    const float center = 0.5f * S;
+    const float wall = std::tan(45.0f * kProjPi / 180.0f) * 0.94f; // stay off the seam
+
+    for (size_t f = 0; f < cube_forwards().size(); ++f) {
+        const lfs::core::CubeFaceProjection proj{
+            expected_spherical_matrix(cube_forwards()[f]), S, W, H, kFov};
+        const auto face = lfs::io::project_cube_face_depth(
+            reinterpret_cast<const uint8_t*>(pano.data()), true, W, H, proj, S);
+
+        double worst = 0.0;
+        for (int y = 0; y < S; ++y) {
+            const float v = (static_cast<float>(y) + 0.5f - center) / focal;
+            for (int x = 0; x < S; ++x) {
+                const float u = (static_cast<float>(x) + 0.5f - center) / focal;
+                if (std::abs(u) > wall || std::abs(v) > wall)
+                    continue;
+                worst = std::max(worst,
+                                 std::abs(static_cast<double>(face[static_cast<size_t>(y) * S + x]) - kHalf));
+            }
+        }
+        EXPECT_LT(worst, 0.01) << "face " << f << ": z is not constant on a flat wall";
+    }
+}
+
+// Negative control for the test above: without the radial-to-z conversion an
+// off-axis pixel would report the radial distance, which differs materially.
+TEST(CubeFaceDepth, RadialToZConversionIsApplied) {
+    constexpr int W = 1024;
+    constexpr int H = 512;
+    constexpr int S = 96;
+    constexpr float kFov = 96.0f;
+    constexpr float kRadial = 0.5f;
+
+    // Constant radial distance in every direction: a sphere around the camera.
+    const std::vector<uint16_t> pano(static_cast<size_t>(W) * H,
+                                     static_cast<uint16_t>(std::lround(kRadial * 65535.0f)));
+
+    const lfs::core::CubeFaceProjection proj{
+        expected_spherical_matrix(cube_forwards()[4]), S, W, H, kFov};
+    const auto face = lfs::io::project_cube_face_depth(
+        reinterpret_cast<const uint8_t*>(pano.data()), true, W, H, proj, S);
+
+    const float focal = cube_face_focal(kFov, S);
+    const float center = 0.5f * S;
+
+    // The centre pixel looks along the axis, so z equals the radial distance.
+    const int mid = S / 2;
+    EXPECT_NEAR(face[static_cast<size_t>(mid) * S + mid], kRadial, 0.01f);
+
+    // A corner pixel is off-axis, so z must be shortened by cos(theta).
+    const float u = (0.5f - center) / focal;
+    const float v = (0.5f - center) / focal;
+    const float cos_theta = 1.0f / std::sqrt(u * u + v * v + 1.0f);
+    EXPECT_NEAR(face[0], kRadial * cos_theta, 0.01f);
+    EXPECT_LT(face[0], kRadial * 0.65f) << "corner z was not converted from radial distance";
 }

--- a/tests/test_undistort.cpp
+++ b/tests/test_undistort.cpp
@@ -687,7 +687,7 @@ TEST_F(UndistortCameraTest, EquirectangularSphericalExpansionUsesVirtualPinholeC
 
     auto expanded = lfs::training::expandEquirectangularCamerasForUndistort({equirect_cam});
 
-    ASSERT_TRUE(expanded.has_value()) << expanded.error();
+    ASSERT_TRUE(expanded.has_value()) << expanded.error().user_message();
     ASSERT_EQ(expanded->size(), SPHERICAL_UNDISTORT_VIEW_COUNT);
 
     const auto [source_width, source_height, source_channels] = get_image_info(source->image_path());
@@ -762,7 +762,7 @@ TEST_F(UndistortCameraTest, SphericalExpansionKeepsPassthroughCamerasAndAvoidsUi
 
     auto expanded = lfs::training::expandEquirectangularCamerasForUndistort({equirect_cam, pinhole_cam});
 
-    ASSERT_TRUE(expanded.has_value()) << expanded.error();
+    ASSERT_TRUE(expanded.has_value()) << expanded.error().user_message();
     ASSERT_EQ(expanded->size(), SPHERICAL_UNDISTORT_VIEW_COUNT + 1);
     for (size_t i = 0; i < SPHERICAL_UNDISTORT_VIEW_COUNT; ++i) {
         ASSERT_TRUE((*expanded)[i]);


### PR DESCRIPTION
## Summary

Makes the existing `--undistort` path work for spherical/equirectangular COLMAP
datasets by expanding each panorama into internal pinhole views at load time.

The generated views stay virtual: they reuse the source panorama and mask paths,
flow through the projection-aware image loader/cache, and never write split
images to disk. The CLI and UI are unchanged.

Each panorama expands into **6 cube faces at 96 degrees FOV**, resampled with an
**anisotropic (EWA) filter**. Both of those choices are load-bearing and are
explained below, because the obvious alternatives are measurably worse.

## Why 6 faces at 96 degrees

Every view expanded from one panorama shares that panorama's optical centre.
`pano_to_view` is orthonormal, so

```
C_face = -(M R)^T (M T) = -R^T M^T M T = -R^T T = C_source
```

Overlapping views from a common centre therefore re-sample identical rays and
add no parallax. Redundant angular coverage is pure cost, and it is *uneven*
cost: it weights the photometric loss by however many views happen to see a
direction.

Measured over 2M Monte Carlo directions on the sphere:

| layout | uncovered | coverage spread | mean |
|---|---|---|---|
| 12 icosahedral @ 90 deg | 0% | 25% 1x / 50% 2x / **25% 3x** | 2.000 |
| **6 cube faces @ 96 deg** | 0% | **88.7% 1x** / 10.9% 2x / 0.4% 3x | 1.117 |

Six faces tile the sphere. The extra 3 degrees per edge is a deliberate seam
margin so SSIM windows and densification see context across face boundaries, at
~12% angular overcoverage instead of 100%.

On a 3840x1920 panorama this is the **same total pixel budget** as the previous
layout (11.06 Mpx, 1.001x), so training cost is unchanged — the saving from
dropping redundant views pays for the higher per-face resolution below.

## Why the face size changed

`resolveSphericalViewSize` used `width * fov / 360`. That matches the total pixel
*count* across the field of view, but not the sampling *rate*: a gnomonic face
spaces its columns non-uniformly (dense at the edges, sparse at the centre) while
equirectangular spacing is uniform in angle.

The result was **1.27x undersampling at the centre of every face** — aliasing
precisely where the panorama is sharpest — while oversampling the corners ~3x.
Sizing now matches the source angular rate at the face centre:

```
size = 2 * max(W/2pi, H/pi) * tan(fov/2)
```

For a 4K panorama at 96 degrees that is 1358 px rather than 960 px.

## Why EWA resampling

The previous resampler was a bare bilinear fetch with no prefilter, so the
minification above aliased outright. The map minifies at the centre of every face
and magnifies towards the corners, so no fixed kernel is correct across a single
face.

The projection now derives the analytic Jacobian `J = d(source px)/d(face px)` and
builds a per-pixel elliptical footprint with covariance

```
V = sigma_dst^2 * J J^T + sigma_src^2 * I
```

Both sigmas are variance-matched to a one-pixel box (`1/sqrt(12)`), which makes
the filter reduce to exactly bilinear sharpness at unity magnification (a tent has
variance 1/6, and 1/12 + 1/12 = 1/6) and widen only where the map genuinely
minifies. Footprints are strided near the poles so the tap count stays bounded.

Resampling error against a 16x16 supersampled reference, sweeping the signal
across the face Nyquist limit (RMSE in 8-bit levels, lower is better):

| signal | regime | bilinear | EWA | improvement |
|---|---|---|---|---|
| 20 cyc/rad | below Nyquist | 8.145 | **1.089** | 7.5x |
| 45 cyc/rad | below Nyquist | 17.175 | **2.563** | 6.7x |
| 100 cyc/rad | aliasing | 29.579 | **5.548** | 5.3x |
| 140 cyc/rad | aliasing | 31.673 | **8.357** | 3.8x |

Worst single face 2.1x, best 8.3x.

## Behaviour

- `--undistort` on equirectangular COLMAP imports (model 17 `EQUIRECTANGULAR`,
  legacy name `SPHERICAL`) expands each panorama into 6 internal pinhole cameras.
- Image loading, eval loading, masks, alpha masks and immediate strategy loads all
  go through the same projection-aware loader path.
- Faces inherit `split()` from the source panorama, so all 6 faces of a panorama
  land on the same side of a train/eval split and no shared rays leak across it.
- Without `--undistort` or `--gut`, non-pinhole datasets still fail early with a
  direct message.
- Depth priors are projected onto the faces when provided, with nearest sampling
  and a radial-to-z conversion (see below). Both 8-bit and 16-bit sidecars work.
- `--gut` remains the native non-pinhole training path and is untouched.

## Depth priors

Equirectangular depth stores distance along the ray from the camera centre, but
LFS supervises camera-space z: fastgs takes the third row of world-to-camera for
its depth, and `depth_anchor_collect_kernel` pairs the prior against that same z
when fitting the per-camera affine anchor. Projection therefore applies

```
z = r / sqrt(1 + u^2 + v^2)
```

for a face pixel at plane coordinates `(u, v)`. Because `pano_to_face` is
orthonormal this is exactly the normalisation term the projection already
computes, so it is free. Without it the corner of a 96 degree face is wrong by
~1.9x, and since the error varies across the image the loss's
scale-and-shift-invariant fit cannot absorb it -- that fit is affine in the
prior, not in pixel position.

Depth also uses nearest sampling rather than the colour path's EWA filter:
averaging across a depth discontinuity produces a value in neither the
foreground nor the background, and the loss would then pull geometry towards
that invented surface.

This assumes the panorama stores radial distance, the usual convention. A
disparity prior would need the reciprocal correction; that is documented at the
function.

## Validation

Correctness of the projection, via a harness linked against the real
`project_cube_face_hwc`:

- Analytic Jacobian vs central differences, 6 faces x 49 probes: worst relative
  error **6.656e-07**.
- Face pixels vs the source panorama sampled along the same ray, on a real RaR
  panorama: **1.582 levels RMS** over 72,000 samples, confirming the face basis is
  not transposed or mirrored.

Depth projection, against an analytic scene (a cube of half-extent h centred on
the camera, encoded as 16-bit equirectangular radial distance). Camera-space z on
a flat wall must be constant and equal to h wherever it is sampled on the face,
which holds only if the radial-to-z conversion is applied:

- faces +X/-X/+Z/-Z: mean error 0.00027, max 0.00110 over 46,656 px
- faces +Y/-Y: mean error 0.00028, max 0.00093 over 46,656 px
- off-axis sample: z = 0.49949 against 0.50000 expected
- the raw radial value at that same point differs by > 0.05, so the check fails
  if the conversion is removed

End to end on the RaR `I_alley` scene (145 equirectangular panoramas, COLMAP
model 17, 3840x1920):

- Expands to 870 faces at 1358 px, 96 degrees, scene scale 4.0679965.
- Eval split 756 train + 114 val, i.e. 19 whole panoramas held out, so no face
  of a panorama straddles the split.

## How this compares to `--gut`

`--gut` already trains natively on equirectangular images, so the obvious
question is whether this path earns its place. Both were trained from scratch on
`I_alley` with identical settings (`-r 1 -i 30000 --eval --headless`; headless
honours `-i` exactly, so the step schedule is the same for both).

Their own eval metrics are **not** comparable -- `--undistort` scores 1358 px
faces, `--gut` scores 3840x1920 panoramas, and equirectangular PSNR is dominated
by the heavily oversampled polar regions. To get one yardstick, both runs' saved
`[GT | render]` eval images were projected onto the same six 96 degree cube faces
with the production resampler and scored there (114 samples each). The identical
resampling is applied to GT and render alike, so it largely cancels.

| | PSNR | SSIM | gaussians | wall clock |
|---|---|---|---|---|
| `--undistort` (this PR) | 26.836 | 0.8347 | 3.90M | **755 s** |
| `--gut` | **27.045** | **0.8369** | 4.42M | 3100 s |

At 7000 iterations the ordering is the same (24.191 / 0.7803 against
24.781 / 0.7947).

So `--gut` is marginally ahead on quality -- about 0.2 dB at 30k -- while this
path trains **4.1x faster** and converges to 12% fewer gaussians. The quality gap
is small enough that the extra resampling on the `--gut` side of the measurement
could account for some of it: low-pass filtering both GT and render tends to
raise PSNR, and only `--gut` goes through that step. The honest reading is that
quality is close to on par and the real difference is throughput.

That is the tradeoff this PR offers, and it is worth stating plainly rather than
claiming a quality win: `--undistort` is the fast path for panoramic data,
`--gut` remains the accurate one.

Everything above is reproducible from `tests/test_undistort.cpp` rather than from
throwaway scripts. Each test builds its panorama analytically, so none needs a
dataset and the expected value is a closed form rather than a golden image:

| test | what would break it |
|---|---|
| `FacePixelsCarryTheContentOfTheirOwnRay` | a transposed or mirrored face basis |
| `ConstantPanoramaIsPreservedOnEveryFace` | filter weights not summing to one, including at the strided poles |
| `SignalAboveFaceNyquistIsAttenuatedNotAliased` | dropping the prefilter (a plain bilinear fetch fails this) |
| `FlatWallHasConstantCameraSpaceZ` | dropping the radial-to-z conversion |
| `RadialToZConversionIsApplied` | negative control for the above |
| `MatchesPanoramaSamplingRateAtFaceCentre` | changing the sizing rule (pins 1358 / 1222 / 724 px) |
| `FocalRoundTripsToTheRequestedFov` | focal and fov disagreeing |
| `DegenerateFovStaysFinite` | removing the field-of-view clamp |

Plus the pre-existing expansion tests (view count, face size, focal,
orthonormality of every face basis, uid allocation, passthrough of non-spherical
cameras). All 8 new tests pass; the 7 `UndistortCameraTest` cases are
dataset-gated and skip without one, as they did before.

## Error handling

`expandEquirectangularCamerasForUndistort` returns `lfs::Result<T>` and reports
through `lfs::make_error`, so failures carry a code, a domain and a detection
site. An earlier revision used `std::expected<T, std::string>` and tripped the
no-new-error-debt gate by adding three sites on top of the baseline's 15 for
`training_setup`. `tools/error_debt_census.py --baseline` now reports no new
violations.

## Notes for reviewers

- The eval numbers above are measured **in face space**, not on equirectangular
  images, so they are not directly comparable to published panoramic PSNR figures
  (which include the pole regions where equirect heavily oversamples). They are
  useful for comparing configurations of this path against each other.
- `autoScaleSteps` receives the post-expansion camera count (870 rather than 145),
  which stretches the step schedule ~2.9x and contributed to the 4.62M gaussian
  count above. That behaviour is unchanged by this PR, but it is worth a separate
  decision about whether the heuristic should count capture positions rather than
  views, since the six faces of a panorama share one optical centre.
- Depth support is verified analytically. No panoramic depth dataset was
  available to exercise it end to end, and the projection assumes the prior
  encodes radial distance.
