### PR TITLE
fix duplicate of models with deleted splats

### DIFF
--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -2422,15 +2422,10 @@ namespace lfs::core {
                 const auto* src_for_model = getNodeById(src_id);
                 if (src_for_model && src_for_model->model) {
                     const auto& model = *src_for_model->model;
-                    auto cloned = std::make_unique<lfs::core::SplatData>(
-                        model.get_max_sh_degree(),
-                        model.means_raw().clone(), model.sh0_raw().clone(),
-                        model.shN_raw().is_valid() ? model.shN_raw().clone() : lfs::core::Tensor{},
-                        model.scaling_raw().clone(), model.rotation_raw().clone(), model.opacity_raw().clone(),
-                        model.get_scene_scale(),
-                        lfs::core::SplatData::ShNLayout::Swizzled);
-                    cloned->set_active_sh_degree(model.get_active_sh_degree());
-                    new_id = addSplat(new_name, std::move(cloned), parent_id);
+                    auto cloned = mergeSplatsWithTransforms({{&model, glm::mat4{1.0f}}}, MergeStorageMode::Clone);
+                    if (cloned) {
+                        new_id = addSplat(new_name, std::move(cloned), parent_id);
+                    }
                 }
             }
 
@@ -2439,6 +2434,10 @@ namespace lfs::core {
                 new_node->visible = src_visible;
                 new_node->locked = src_locked;
                 new_node->transform_dirty = true;
+            }
+
+            if (new_id == NULL_NODE) {
+                return NULL_NODE;
             }
 
             for (const NodeId child_id : src_children) {
@@ -2450,9 +2449,13 @@ namespace lfs::core {
 
         const NodeId src_id = src_node->id;
         const NodeId src_parent_id = src_node->parent_id;
-        const std::string result_name = generate_unique_name(src_node->name);
+        const NodeId result_id = duplicate_recursive(src_id, src_parent_id);
+        if (result_id == NULL_NODE) {
+            return "";
+        }
 
-        duplicate_recursive(src_id, src_parent_id);
+        const auto* result_node = getNodeById(result_id);
+        const std::string result_name = result_node ? result_node->name : "";
 
         notifyMutation(MutationType::NODE_ADDED);
         LOG_DEBUG("Duplicated node '{}' as '{}'", name, result_name);

--- a/tests/test_undo_history.cpp
+++ b/tests/test_undo_history.cpp
@@ -185,6 +185,43 @@ namespace {
         return make_test_splat(xyz);
     }
 
+    std::unique_ptr<lfs::core::SplatData> make_patterned_sh_rest_splat(const size_t count) {
+        std::vector<float> means;
+        means.reserve(count * 3);
+        std::vector<float> shN;
+        shN.reserve(count * 3 * 3);
+        for (size_t row = 0; row < count; ++row) {
+            means.push_back(static_cast<float>(row));
+            means.push_back(0.0f);
+            means.push_back(0.0f);
+            for (size_t coeff = 0; coeff < 3; ++coeff) {
+                for (size_t channel = 0; channel < 3; ++channel) {
+                    shN.push_back(static_cast<float>(100 * row + 10 * coeff + channel));
+                }
+            }
+        }
+
+        auto sh0 = Tensor::zeros({count, size_t{1}, size_t{3}}, Device::CUDA, DataType::Float32);
+        auto scaling = Tensor::zeros({count, size_t{3}}, Device::CUDA, DataType::Float32);
+        std::vector<float> rotation_data(count * 4, 0.0f);
+        for (size_t i = 0; i < count; ++i) {
+            rotation_data[i * 4] = 1.0f;
+        }
+        auto opacity = Tensor::zeros({count, size_t{1}}, Device::CUDA, DataType::Float32);
+
+        auto result = std::make_unique<lfs::core::SplatData>(
+            1,
+            Tensor::from_vector(means, {count, size_t{3}}, Device::CUDA).to(DataType::Float32),
+            std::move(sh0),
+            Tensor::from_vector(shN, {count, size_t{3}, size_t{3}}, Device::CUDA).to(DataType::Float32),
+            std::move(scaling),
+            Tensor::from_vector(rotation_data, {count, size_t{4}}, Device::CUDA).to(DataType::Float32),
+            std::move(opacity),
+            1.0f);
+        result->set_active_sh_degree(1);
+        return result;
+    }
+
     std::vector<bool> deleted_mask_values(const lfs::core::SplatData& splat) {
         if (!splat.has_deleted_mask()) {
             return {};
@@ -214,6 +251,15 @@ namespace {
             xs.push_back(means[i * 3]);
         }
         return xs;
+    }
+
+    std::vector<float> sh_rest_row_values(const lfs::core::SplatData& splat, const size_t row) {
+        const auto shN = splat.shN_canonical_cpu().contiguous();
+        const auto flat = shN.to_vector();
+        const size_t stride = static_cast<size_t>(shN.size(1) * shN.size(2));
+        return std::vector<float>(
+            flat.begin() + static_cast<ptrdiff_t>(row * stride),
+            flat.begin() + static_cast<ptrdiff_t>((row + 1) * stride));
     }
 
 } // namespace
@@ -1844,6 +1890,74 @@ TEST_F(UndoHistoryTest, DuplicateNodeCreatesUndoableSceneGraphEntry) {
 
     lfs::vis::op::undoHistory().redo();
     EXPECT_NE(scene_manager->getScene().getNode(duplicate_name), nullptr);
+}
+
+TEST_F(UndoHistoryTest, DuplicateNodeCompactsSoftDeletedSplats) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    scene_manager->getScene().addSplat("model", make_patterned_sh_rest_splat(4));
+    auto* node = scene_manager->getScene().getNode("model");
+    ASSERT_NE(node, nullptr);
+    ASSERT_NE(node->model, nullptr);
+    const auto expected_sh_rest_row_0 = sh_rest_row_values(*node->model, 0);
+    const auto expected_sh_rest_row_2 = sh_rest_row_values(*node->model, 2);
+    node->model->soft_delete(make_uint8_mask({0, 1, 0, 1}).to(DataType::Bool));
+    scene_manager->changeContentType(lfs::vis::SceneManager::ContentType::SplatFiles);
+
+    const auto duplicate_name = scene_manager->duplicateNodeTree("model");
+    ASSERT_FALSE(duplicate_name.empty());
+
+    auto* duplicate = scene_manager->getScene().getNode(duplicate_name);
+    ASSERT_NE(duplicate, nullptr);
+    ASSERT_NE(duplicate->model, nullptr);
+    EXPECT_EQ(duplicate->model->size(), 2);
+    EXPECT_FALSE(duplicate->model->has_deleted_mask());
+    EXPECT_EQ(mean_x_values(*duplicate->model), (std::vector<float>{0.0f, 2.0f}));
+    EXPECT_EQ(sh_rest_row_values(*duplicate->model, 0), expected_sh_rest_row_0);
+    EXPECT_EQ(sh_rest_row_values(*duplicate->model, 1), expected_sh_rest_row_2);
+
+    lfs::vis::op::undoHistory().undo();
+    EXPECT_EQ(scene_manager->getScene().getNode(duplicate_name), nullptr);
+
+    lfs::vis::op::undoHistory().redo();
+    auto* restored_duplicate = scene_manager->getScene().getNode(duplicate_name);
+    ASSERT_NE(restored_duplicate, nullptr);
+    ASSERT_NE(restored_duplicate->model, nullptr);
+    EXPECT_EQ(restored_duplicate->model->size(), 2);
+    EXPECT_FALSE(restored_duplicate->model->has_deleted_mask());
+    EXPECT_EQ(mean_x_values(*restored_duplicate->model), (std::vector<float>{0.0f, 2.0f}));
+    EXPECT_EQ(sh_rest_row_values(*restored_duplicate->model, 0), expected_sh_rest_row_0);
+    EXPECT_EQ(sh_rest_row_values(*restored_duplicate->model, 1), expected_sh_rest_row_2);
+}
+
+TEST_F(UndoHistoryTest, DuplicateFullySoftDeletedSplatDoesNotPromoteChildren) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    scene_manager->getScene().addSplat("model", make_linear_test_splat(2));
+    auto* node = scene_manager->getScene().getNode("model");
+    ASSERT_NE(node, nullptr);
+    ASSERT_NE(node->model, nullptr);
+    const auto model_id = node->id;
+    const auto cropbox_id = scene_manager->getScene().addCropBox("cropbox", model_id);
+    ASSERT_NE(cropbox_id, lfs::core::NULL_NODE);
+    node->model->soft_delete(make_uint8_mask({1, 1}).to(DataType::Bool));
+    scene_manager->changeContentType(lfs::vis::SceneManager::ContentType::SplatFiles);
+
+    const auto duplicate_name = scene_manager->duplicateNodeTree("model");
+    EXPECT_TRUE(duplicate_name.empty());
+    EXPECT_EQ(scene_manager->getScene().getNode("model_copy"), nullptr);
+    EXPECT_EQ(scene_manager->getScene().getNode("cropbox_copy"), nullptr);
+    EXPECT_EQ(lfs::vis::op::undoHistory().undoCount(), 0u);
+
+    const auto* original_child = scene_manager->getScene().getNode("cropbox");
+    ASSERT_NE(original_child, nullptr);
+    EXPECT_EQ(original_child->parent_id, model_id);
 }
 
 TEST_F(UndoHistoryTest, SelectionSnapshotRestoresSelectionGroupsAndActiveGroup) {


### PR DESCRIPTION
## Summary

Scene graph Duplicate now creates a compact splat model that contains only currently visible splats. Soft-deleted rows are no longer resurrected in duplicated nodes.

## Observed Symptoms

1. Open a splat model.
2. Use brush selection to select and remove some splats.
3. In the scene graph, select the model and choose Duplicate.
4. The duplicated model appears with the removed splats visible again.

## What This Patch Fixes

- The splat-node duplicate path now reuses the existing visible-row compaction logic in `Scene::mergeSplatsWithTransforms()`.
- Duplicates of soft-deleted splat models physically contain only non-deleted rows.
- The duplicated model does not carry a deleted mask for rows that were removed from the duplicate.
- Fully soft-deleted splat nodes are treated as no-op duplicates, and their children are not duplicated or promoted to the scene root.
- GUI, Python API, and MCP duplicate paths inherit the corrected behavior because they route through `SceneManager::duplicateNodeTree()` and `Scene::duplicateNode()`.

## Root Cause

Soft deletion keeps rows in `SplatData` and hides them with the `_deleted` mask. Rendering and several copy/export paths already respect this mask, but scene graph Duplicate manually rebuilt a fresh `SplatData` from the raw tensors and did not copy or apply `_deleted`.

Because the duplicate had all raw rows and no deleted mask, previously removed splats became live and visible again.

A related edge case appears when every row in a splat is soft-deleted. The compaction clone intentionally returns no model for that node. Without a guard, duplicate recursion could still duplicate child nodes with no duplicated parent, promoting children such as crop boxes to the scene root.

## Replication Steps

1. Load a splat scene.
2. Brush-select a visible region and remove the selected splats.
3. Select the splat node in the scene graph.
4. Run Duplicate from the scene graph context menu.
5. Before this patch, the duplicate shows deleted splats again.
6. After this patch, the duplicate contains only the still-visible splats.

## Validation

- Added a regression test for `SceneManager::duplicateNodeTree()` that soft-deletes rows, duplicates the node, verifies the duplicate has only visible rows, checks non-zero SH-rest rows survive compaction, and checks undo/redo restores the compacted duplicate.
- Added a regression test for a fully soft-deleted splat with a crop box child to verify the duplicate is a no-op and the child is not orphaned.
