### PR TITLE
transform tools on multiple models

### DIFF
--- a/src/python/lfs/py_store.cpp
+++ b/src/python/lfs/py_store.cpp
@@ -278,6 +278,8 @@ namespace lfs::python {
                 store.transform_space.set(nb::cast<int>(value));
             else if (field == "pivot_mode")
                 store.pivot_mode.set(nb::cast<int>(value));
+            else if (field == "multi_transform_mode")
+                store.multi_transform_mode.set(nb::cast<int>(value));
             else if (field == "import_overlay_state")
                 store.import_overlay_state.set(import_overlay_state_from_object(value));
             else if (field == "video_export_overlay_state")
@@ -336,6 +338,8 @@ namespace lfs::python {
                 return nb::cast(store.transform_space.get());
             if (field == "pivot_mode")
                 return nb::cast(store.pivot_mode.get());
+            if (field == "multi_transform_mode")
+                return nb::cast(store.multi_transform_mode.get());
             if (field == "import_overlay_state")
                 return import_overlay_state_to_dict(store.import_overlay_state.get());
             if (field == "video_export_overlay_state")
@@ -393,6 +397,8 @@ namespace lfs::python {
                 return subscribe_observable(store.transform_space, std::move(callback));
             if (field == "pivot_mode")
                 return subscribe_observable(store.pivot_mode, std::move(callback));
+            if (field == "multi_transform_mode")
+                return subscribe_observable(store.multi_transform_mode, std::move(callback));
             if (field == "import_overlay_state")
                 return subscribe_observable_as(
                     store.import_overlay_state, std::move(callback), import_overlay_state_to_dict);

--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -5168,6 +5168,10 @@ namespace lfs::python {
 
         m.def("set_transform_space", &set_transform_space, nb::arg("space"), "Set transform space (0=Local, 1=World)");
 
+        m.def("get_multi_transform_mode", &get_multi_transform_mode, "Get multi-transform mode (0=Group, 1=Individual)");
+
+        m.def("set_multi_transform_mode", &set_multi_transform_mode, nb::arg("mode"), "Set multi-transform mode (0=Group, 1=Individual)");
+
         // Thumbnail system (for Getting Started window)
         m.def("request_thumbnail", &request_thumbnail, nb::arg("video_id"),
               "Request download of a YouTube thumbnail for the given video ID");

--- a/src/python/lfs_plugins/toolbar.py
+++ b/src/python/lfs_plugins/toolbar.py
@@ -144,6 +144,7 @@ def _button_record(button_id, action, value, icon_src, *,
         "action": action,
         "value": value,
         "icon_src": icon_src,
+        "tooltip_key": tooltip_key,
         "tooltip_text": _ui_label(tooltip_key, tooltip_text),
         "action_id": action_id,
         "shortcut_text": _keymap_shortcut(action_id, shortcut_text),
@@ -184,10 +185,16 @@ class _GizmoToolbarController:
         "builtin.select:sphere": "toolbar.sphere_selection",
         "builtin.translate:local": "toolbar.local_space",
         "builtin.translate:world": "toolbar.world_space",
+        "builtin.translate:group": "toolbar.group_transform",
+        "builtin.translate:individual": "toolbar.individual_transform",
         "builtin.rotate:local": "toolbar.local_space",
         "builtin.rotate:world": "toolbar.world_space",
+        "builtin.rotate:group": "toolbar.group_transform",
+        "builtin.rotate:individual": "toolbar.individual_transform",
         "builtin.scale:local": "toolbar.local_space",
         "builtin.scale:world": "toolbar.world_space",
+        "builtin.scale:group": "toolbar.group_transform",
+        "builtin.scale:individual": "toolbar.individual_transform",
         "builtin.mirror:x": "toolbar.mirror_x",
         "builtin.mirror:y": "toolbar.mirror_y",
         "builtin.mirror:z": "toolbar.mirror_z",
@@ -214,6 +221,7 @@ class _GizmoToolbarController:
     _CROP_TOOL_ID = "builtin.cropbox"
     _HORIZONTAL_TOOL_IDS = {"builtin.select", _MIRROR_TOOL_ID, _CROP_TOOL_ID, *_TRANSFORM_TOOL_IDS}
     _TRANSFORM_SPACE_IDS = {"local": 0, "world": 1}
+    _MULTI_TRANSFORM_MODE_IDS = {"group": 0, "individual": 1}
     _PIVOT_IDS = {"origin": 0, "bounds": 1}
     _CROP_OBJECT_SHAPES = ("box", "ellipsoid")
     _CROP_TRANSFORM_GIZMOS = ("translate", "rotate", "scale")
@@ -277,7 +285,8 @@ class _GizmoToolbarController:
         # When the scene is empty (New Project), clear any lingering active
         # tool so the toolbar doesn't show a tool as selected that can't
         # actually be used on an empty scene.
-        if lf.ui.get_content_type() == "empty":
+        get_content_type = getattr(lf.ui, "get_content_type", None)
+        if callable(get_content_type) and get_content_type() == "empty":
             if not self._was_empty:
                 ToolRegistry.clear_active()
             self._was_empty = True
@@ -334,7 +343,8 @@ class _GizmoToolbarController:
         crop_transform_buttons = self._build_crop_transform_records(active_tool_id) if crop_tool_active else []
         crop_action_buttons = self._build_crop_action_records(active_tool_id) if crop_tool_active else []
         selection_volume_gizmo_buttons = self._build_selection_volume_gizmo_records(active_tool_id)
-        submode_buttons = self._build_submode_records(active_tool_id, tool_def)
+        multi_transform_selection = active_tool_id in self._TRANSFORM_TOOL_IDS and len(selected_nodes) > 1
+        submode_buttons = self._build_submode_records(active_tool_id, tool_def, multi_transform_selection)
         pivot_buttons = self._build_pivot_records(tool_def)
 
         return {
@@ -593,7 +603,8 @@ class _GizmoToolbarController:
         import lichtfeld as lf
 
         shape = self._active_crop_shape()
-        selected = lf.get_selected_node_names() or []
+        selected_getter = getattr(lf, "get_selected_node_names", None)
+        selected = (selected_getter() or []) if callable(selected_getter) else []
         if shape == "box" and selected:
             add_cropbox = getattr(lf.ui, "add_cropbox", None)
             if callable(add_cropbox):
@@ -605,13 +616,39 @@ class _GizmoToolbarController:
 
         lf.ui.set_active_operator(self._CROP_TOOL_ID, gizmo_type)
 
-    def _build_submode_records(self, active_tool_id, tool_def):
+    def _build_submode_records(self, active_tool_id, tool_def, multi_transform_selection=False):
         import lichtfeld as lf
 
         if tool_def is None or not tool_def.submodes:
             return []
         if active_tool_id == "builtin.select":
             return []
+
+        is_transform_tool = active_tool_id in self._TRANSFORM_TOOL_IDS
+        if is_transform_tool and multi_transform_selection:
+            current_multi_mode = _native_store_value("multi_transform_mode", _MISSING)
+            if current_multi_mode is _MISSING:
+                getter = getattr(lf.ui, "get_multi_transform_mode", None)
+                current_multi_mode = getter() if callable(getter) else 0
+
+            records = []
+            for mode_id, icon, label in (
+                ("group", "bounds", "Group"),
+                ("individual", "local", "Individual"),
+            ):
+                tooltip_key = self._SUBMODE_LOCALE_KEYS.get(f"{active_tool_id}:{mode_id}", "")
+                records.append(
+                    _button_record(
+                        f"sub-{mode_id}",
+                        "submode",
+                        mode_id,
+                        _icon_src(icon),
+                        tooltip_key=tooltip_key,
+                        tooltip_text=label,
+                        selected=current_multi_mode == self._MULTI_TRANSFORM_MODE_IDS[mode_id],
+                    )
+                )
+            return records
 
         current_space = _native_store_value("transform_space", _MISSING)
         if current_space is _MISSING:
@@ -620,7 +657,6 @@ class _GizmoToolbarController:
         if active_submode is _MISSING:
             active_submode = lf.ui.get_active_submode()
         active_submode = active_submode or ""
-        is_transform_tool = active_tool_id in self._TRANSFORM_TOOL_IDS
         is_mirror_tool = active_tool_id == self._MIRROR_TOOL_ID
 
         if not active_submode and not is_transform_tool and not is_mirror_tool:
@@ -749,13 +785,23 @@ class _GizmoToolbarController:
             if active_tool_id == self._MIRROR_TOOL_ID:
                 lf.ui.execute_mirror(value)
             elif active_tool_id in self._TRANSFORM_TOOL_IDS:
-                transform_space = self._TRANSFORM_SPACE_IDS.get(value, -1)
-                if transform_space >= 0:
-                    lf.ui.set_transform_space(transform_space)
+                multi_transform_mode = self._MULTI_TRANSFORM_MODE_IDS.get(value, -1)
+                if multi_transform_mode >= 0:
+                    setter = getattr(lf.ui, "set_multi_transform_mode", None)
+                    if callable(setter):
+                        setter(multi_transform_mode)
                     try:
-                        RuntimeState.transform_space.value = transform_space
+                        RuntimeState.multi_transform_mode.value = multi_transform_mode
                     except Exception:
                         pass
+                else:
+                    transform_space = self._TRANSFORM_SPACE_IDS.get(value, -1)
+                    if transform_space >= 0:
+                        lf.ui.set_transform_space(transform_space)
+                        try:
+                            RuntimeState.transform_space.value = transform_space
+                        except Exception:
+                            pass
             else:
                 lf.ui.set_selection_mode(value)
             return
@@ -1259,6 +1305,9 @@ class _ViewportToolbarController:
         pivot_mode = _native_store_value("pivot_mode", _MISSING)
         if pivot_mode is _MISSING:
             pivot_mode = call(0, getattr(lf.ui, "get_pivot_mode", None))
+        multi_transform_mode = _native_store_value("multi_transform_mode", _MISSING)
+        if multi_transform_mode is _MISSING:
+            multi_transform_mode = call(0, getattr(lf.ui, "get_multi_transform_mode", None))
         tool_defs = ToolRegistry.get_all()
         tool_ids = tuple(
             (getattr(tool_def, "id", ""), getattr(tool_def, "group", ""))
@@ -1304,6 +1353,7 @@ class _ViewportToolbarController:
             crop_operation,
             transform_space,
             pivot_mode,
+            multi_transform_mode,
             has_scene,
             num_gaussians,
             has_selection,

--- a/src/python/lfs_plugins/toolbar.py
+++ b/src/python/lfs_plugins/toolbar.py
@@ -185,15 +185,15 @@ class _GizmoToolbarController:
         "builtin.select:sphere": "toolbar.sphere_selection",
         "builtin.translate:local": "toolbar.local_space",
         "builtin.translate:world": "toolbar.world_space",
-        "builtin.translate:group": "toolbar.group_transform",
+        "builtin.translate:selection": "toolbar.selection_transform",
         "builtin.translate:individual": "toolbar.individual_transform",
         "builtin.rotate:local": "toolbar.local_space",
         "builtin.rotate:world": "toolbar.world_space",
-        "builtin.rotate:group": "toolbar.group_transform",
+        "builtin.rotate:selection": "toolbar.selection_transform",
         "builtin.rotate:individual": "toolbar.individual_transform",
         "builtin.scale:local": "toolbar.local_space",
         "builtin.scale:world": "toolbar.world_space",
-        "builtin.scale:group": "toolbar.group_transform",
+        "builtin.scale:selection": "toolbar.selection_transform",
         "builtin.scale:individual": "toolbar.individual_transform",
         "builtin.mirror:x": "toolbar.mirror_x",
         "builtin.mirror:y": "toolbar.mirror_y",
@@ -221,7 +221,7 @@ class _GizmoToolbarController:
     _CROP_TOOL_ID = "builtin.cropbox"
     _HORIZONTAL_TOOL_IDS = {"builtin.select", _MIRROR_TOOL_ID, _CROP_TOOL_ID, *_TRANSFORM_TOOL_IDS}
     _TRANSFORM_SPACE_IDS = {"local": 0, "world": 1}
-    _MULTI_TRANSFORM_MODE_IDS = {"group": 0, "individual": 1}
+    _MULTI_TRANSFORM_MODE_IDS = {"selection": 0, "individual": 1}
     _PIVOT_IDS = {"origin": 0, "bounds": 1}
     _CROP_OBJECT_SHAPES = ("box", "ellipsoid")
     _CROP_TRANSFORM_GIZMOS = ("translate", "rotate", "scale")
@@ -633,7 +633,7 @@ class _GizmoToolbarController:
 
             records = []
             for mode_id, icon, label in (
-                ("group", "bounds", "Group"),
+                ("selection", "bounds", "Selection"),
                 ("individual", "local", "Individual"),
             ):
                 tooltip_key = self._SUBMODE_LOCALE_KEYS.get(f"{active_tool_id}:{mode_id}", "")

--- a/src/python/lfs_plugins/ui/store.py
+++ b/src/python/lfs_plugins/ui/store.py
@@ -229,6 +229,7 @@ class RuntimeState:
     active_submode = StateSignal[str]("active_submode", "")
     transform_space = StateSignal[int]("transform_space", 0)
     pivot_mode = StateSignal[int]("pivot_mode", 0)
+    multi_transform_mode = StateSignal[int]("multi_transform_mode", 0)
     import_overlay_state = StateSignal[dict[str, object]]("import_overlay_state", {})
     video_export_overlay_state = StateSignal[dict[str, object]](
         "video_export_overlay_state",

--- a/src/python/python_runtime.cpp
+++ b/src/python/python_runtime.cpp
@@ -89,6 +89,10 @@ namespace lfs::python {
         GetTransformSpaceCallback g_get_transform_space_cb = nullptr;
         SetTransformSpaceCallback g_set_transform_space_cb = nullptr;
 
+        // Multi-transform mode callbacks
+        GetMultiTransformModeCallback g_get_multi_transform_mode_cb = nullptr;
+        SetMultiTransformModeCallback g_set_multi_transform_mode_cb = nullptr;
+
         // Asset Manager save callback
         SaveAssetCallback g_save_asset_cb = nullptr;
 
@@ -207,6 +211,9 @@ namespace lfs::python {
         }
         if (g_get_transform_space_cb) {
             g_frame_context.transform_space = g_get_transform_space_cb();
+        }
+        if (g_get_multi_transform_mode_cb) {
+            g_frame_context.multi_transform_mode = g_get_multi_transform_mode_cb();
         }
         g_frame_context.selection_submode = g_selection_submode.load();
     }
@@ -551,6 +558,20 @@ namespace lfs::python {
     void set_transform_space(int space) {
         if (g_set_transform_space_cb)
             g_set_transform_space_cb(space);
+    }
+
+    void set_multi_transform_mode_callbacks(GetMultiTransformModeCallback get_cb, SetMultiTransformModeCallback set_cb) {
+        g_get_multi_transform_mode_cb = get_cb;
+        g_set_multi_transform_mode_cb = set_cb;
+    }
+
+    int get_multi_transform_mode() {
+        return g_get_multi_transform_mode_cb ? g_get_multi_transform_mode_cb() : 0;
+    }
+
+    void set_multi_transform_mode(int mode) {
+        if (g_set_multi_transform_mode_cb)
+            g_set_multi_transform_mode_cb(mode);
     }
 
     void set_save_asset_callback(SaveAssetCallback save_cb) {

--- a/src/python/python_runtime.hpp
+++ b/src/python/python_runtime.hpp
@@ -510,7 +510,7 @@ namespace lfs::python {
     LFS_PYTHON_RUNTIME_API int get_transform_space();
     LFS_PYTHON_RUNTIME_API void set_transform_space(int space);
 
-    // Multi-transform mode (group/individual for transform gizmos)
+    // Multi-transform mode (selection/individual for transform gizmos)
     using GetMultiTransformModeCallback = int (*)();
     using SetMultiTransformModeCallback = void (*)(int);
     LFS_PYTHON_RUNTIME_API void set_multi_transform_mode_callbacks(GetMultiTransformModeCallback get_cb,

--- a/src/python/python_runtime.hpp
+++ b/src/python/python_runtime.hpp
@@ -73,6 +73,7 @@ namespace lfs::python {
         int selection_submode = 0;
         int pivot_mode = 0;
         int transform_space = 0;
+        int multi_transform_mode = 0;
 
         // Viewport (set before UI drawing)
         float vp_x = 0, vp_y = 0, vp_w = 0, vp_h = 0;
@@ -508,6 +509,14 @@ namespace lfs::python {
                                                               SetTransformSpaceCallback set_cb);
     LFS_PYTHON_RUNTIME_API int get_transform_space();
     LFS_PYTHON_RUNTIME_API void set_transform_space(int space);
+
+    // Multi-transform mode (group/individual for transform gizmos)
+    using GetMultiTransformModeCallback = int (*)();
+    using SetMultiTransformModeCallback = void (*)(int);
+    LFS_PYTHON_RUNTIME_API void set_multi_transform_mode_callbacks(GetMultiTransformModeCallback get_cb,
+                                                                   SetMultiTransformModeCallback set_cb);
+    LFS_PYTHON_RUNTIME_API int get_multi_transform_mode();
+    LFS_PYTHON_RUNTIME_API void set_multi_transform_mode(int mode);
 
     LFS_PYTHON_RUNTIME_API void set_scene_manager(vis::SceneManager* sm);
     LFS_PYTHON_RUNTIME_API vis::SceneManager* get_scene_manager();

--- a/src/python/stubs/lichtfeld/ui/__init__.pyi
+++ b/src/python/stubs/lichtfeld/ui/__init__.pyi
@@ -2478,6 +2478,12 @@ def get_transform_space() -> int:
 def set_transform_space(space: int) -> None:
     """Set transform space (0=Local, 1=World)"""
 
+def get_multi_transform_mode() -> int:
+    """Get multi-transform mode (0=Group, 1=Individual)"""
+
+def set_multi_transform_mode(mode: int) -> None:
+    """Set multi-transform mode (0=Group, 1=Individual)"""
+
 def request_thumbnail(video_id: str) -> None:
     """Request download of a YouTube thumbnail for the given video ID"""
 

--- a/src/visualizer/app_store.cpp
+++ b/src/visualizer/app_store.cpp
@@ -30,6 +30,7 @@ namespace lfs::vis {
           active_submode(store_, Field::ActiveSubmode, "active_submode", std::string{}),
           transform_space(store_, Field::TransformSpaceValue, "transform_space", 0),
           pivot_mode(store_, Field::PivotModeValue, "pivot_mode", 0),
+          multi_transform_mode(store_, Field::MultiTransformModeValue, "multi_transform_mode", 0),
           import_overlay_state(store_, Field::ImportOverlayStateValue, "import_overlay_state", ImportOverlayState{}),
           video_export_overlay_state(store_,
                                      Field::VideoExportOverlayStateValue,

--- a/src/visualizer/gui/gizmo_manager.cpp
+++ b/src/visualizer/gui/gizmo_manager.cpp
@@ -767,7 +767,7 @@ namespace lfs::vis::gui {
             if (auto* const sm = viewer_->getSceneManager())
                 sm->syncCropBoxToRenderSettings();
             node_bounds_cache_valid_ = false;
-            node_group_bounds_cache_valid_ = false;
+            node_selection_bounds_cache_valid_ = false;
         });
 
         ui::NodeDeselected::when([this](const auto&) {
@@ -775,7 +775,7 @@ namespace lfs::vis::gui {
             if (auto* const t = viewer_->getAlignTool())
                 t->setEnabled(false);
             node_bounds_cache_valid_ = false;
-            node_group_bounds_cache_valid_ = false;
+            node_selection_bounds_cache_valid_ = false;
         });
 
         state::PLYRemoved::when([this](const auto&) { deactivateAllTools(); });
@@ -1118,7 +1118,7 @@ namespace lfs::vis::gui {
 
         const auto& settings = render_manager->getSettings();
         const bool is_multi_selection = (target_names.size() > 1);
-        const bool use_group_mode = !is_multi_selection || multi_transform_mode_ == MultiTransformMode::Group;
+        const bool use_selection_mode = !is_multi_selection || multi_transform_mode_ == MultiTransformMode::Selection;
         const bool use_individual_mode = is_multi_selection && multi_transform_mode_ == MultiTransformMode::Individual;
         std::optional<std::vector<std::string>> top_level_target_names;
         const auto get_top_level_target_names = [&]() -> const std::vector<std::string>& {
@@ -1148,9 +1148,9 @@ namespace lfs::vis::gui {
 
         bool has_valid_bounds = false;
         const bool use_single_bounds_scale = !is_multi_selection && node_gizmo_operation_ == GizmoOperation::Scale;
-        const bool use_group_bounds_scale = is_multi_selection && use_group_mode &&
+        const bool use_selection_bounds_scale = is_multi_selection && use_selection_mode &&
                                             node_gizmo_operation_ == GizmoOperation::Scale;
-        const bool use_bounds_scale = use_single_bounds_scale || use_group_bounds_scale;
+        const bool use_bounds_scale = use_single_bounds_scale || use_selection_bounds_scale;
 
         const auto* first_node = (!is_multi_selection && !target_names.empty())
                                      ? scene.getNode(target_names.front())
@@ -1186,11 +1186,11 @@ namespace lfs::vis::gui {
                 }
             }
         }
-        if (use_group_bounds_scale) {
-            if (node_group_bounds_scale_active_) {
+        if (use_selection_bounds_scale) {
+            if (node_selection_bounds_scale_active_) {
                 has_valid_bounds = true;
-                bounds_min = node_group_bounds_min_;
-                bounds_max = node_group_bounds_max_;
+                bounds_min = node_selection_bounds_min_;
+                bounds_max = node_selection_bounds_max_;
             } else {
                 struct GroupBoundsCacheKeyEntry {
                     core::NodeId id = core::NULL_NODE;
@@ -1221,13 +1221,13 @@ namespace lfs::vis::gui {
                     cache_world_transforms.push_back(entry.visualizer_world_transform);
                 }
 
-                bool cache_matches = node_group_bounds_cache_valid_ &&
-                                     node_group_bounds_cache_node_ids_ == cache_node_ids &&
-                                     node_group_bounds_cache_visualizer_world_transforms_.size() ==
+                bool cache_matches = node_selection_bounds_cache_valid_ &&
+                                     node_selection_bounds_cache_node_ids_ == cache_node_ids &&
+                                     node_selection_bounds_cache_visualizer_world_transforms_.size() ==
                                          cache_world_transforms.size();
                 if (cache_matches) {
                     for (size_t i = 0; i < cache_world_transforms.size(); ++i) {
-                        if (node_group_bounds_cache_visualizer_world_transforms_[i] != cache_world_transforms[i]) {
+                        if (node_selection_bounds_cache_visualizer_world_transforms_[i] != cache_world_transforms[i]) {
                             cache_matches = false;
                             break;
                         }
@@ -1236,20 +1236,20 @@ namespace lfs::vis::gui {
 
                 if (cache_matches) {
                     has_valid_bounds = true;
-                    bounds_min = node_group_bounds_cache_min_;
-                    bounds_max = node_group_bounds_cache_max_;
+                    bounds_min = node_selection_bounds_cache_min_;
+                    bounds_max = node_selection_bounds_cache_max_;
                 } else if (gizmo_ops::computeCombinedVisualizerWorldBounds(
                                scene, top_level_names, bounds_min, bounds_max)) {
                     has_valid_bounds = true;
-                    node_group_bounds_cache_valid_ = true;
-                    node_group_bounds_cache_node_ids_ = std::move(cache_node_ids);
-                    node_group_bounds_cache_visualizer_world_transforms_ = std::move(cache_world_transforms);
-                    node_group_bounds_cache_min_ = bounds_min;
-                    node_group_bounds_cache_max_ = bounds_max;
+                    node_selection_bounds_cache_valid_ = true;
+                    node_selection_bounds_cache_node_ids_ = std::move(cache_node_ids);
+                    node_selection_bounds_cache_visualizer_world_transforms_ = std::move(cache_world_transforms);
+                    node_selection_bounds_cache_min_ = bounds_min;
+                    node_selection_bounds_cache_max_ = bounds_max;
                 } else {
-                    node_group_bounds_cache_valid_ = false;
-                    node_group_bounds_cache_node_ids_.clear();
-                    node_group_bounds_cache_visualizer_world_transforms_.clear();
+                    node_selection_bounds_cache_valid_ = false;
+                    node_selection_bounds_cache_node_ids_.clear();
+                    node_selection_bounds_cache_visualizer_world_transforms_.clear();
                 }
             }
             world_transform = glm::mat4(1.0f);
@@ -1260,7 +1260,7 @@ namespace lfs::vis::gui {
         const bool actually_using_bounds = use_bounds_scale && has_valid_bounds;
 
         const glm::vec3 transform_gizmo_position = (node_gizmo_active_ && !node_bounds_scale_active_ &&
-                                                    !node_group_bounds_scale_active_)
+                                                    !node_selection_bounds_scale_active_)
                                                        ? gizmo_pivot_
                                                        : (is_multi_selection
                                                               ? transform_targets->world_center
@@ -1284,11 +1284,11 @@ namespace lfs::vis::gui {
             const glm::vec3 bounds_center_local = (bounds_min + bounds_max) * 0.5f;
 
             glm::vec3 center_world;
-            if (use_group_bounds_scale) {
-                const glm::vec3 display_size = node_group_bounds_scale_active_
-                                                   ? (node_group_bounds_max_ - node_group_bounds_min_) * gizmo_cumulative_scale_
+            if (use_selection_bounds_scale) {
+                const glm::vec3 display_size = node_selection_bounds_scale_active_
+                                                   ? (node_selection_bounds_max_ - node_selection_bounds_min_) * gizmo_cumulative_scale_
                                                    : bounds_size;
-                center_world = node_group_bounds_scale_active_ ? gizmo_pivot_ : bounds_center_local;
+                center_world = node_selection_bounds_scale_active_ ? gizmo_pivot_ : bounds_center_local;
                 gizmo_matrix[3] = glm::vec4(center_world, 1.0f);
                 gizmo_matrix[0] = glm::vec4(display_size.x, 0.0f, 0.0f, 0.0f);
                 gizmo_matrix[1] = glm::vec4(0.0f, display_size.y, 0.0f, 0.0f);
@@ -1470,13 +1470,13 @@ namespace lfs::vis::gui {
             gizmo_cumulative_rotation_ = glm::mat3(1.0f);
             gizmo_cumulative_scale_ = glm::vec3(1.0f);
 
-            if (actually_using_bounds && use_group_bounds_scale && bounds_gizmo_active) {
+            if (actually_using_bounds && use_selection_bounds_scale && bounds_gizmo_active) {
                 glm::vec3 fresh_min, fresh_max;
                 if (gizmo_ops::computeCombinedVisualizerWorldBounds(
                         scene, get_top_level_target_names(), fresh_min, fresh_max)) {
-                    node_group_bounds_min_ = fresh_min;
-                    node_group_bounds_max_ = fresh_max;
-                    node_group_bounds_scale_active_ = true;
+                    node_selection_bounds_min_ = fresh_min;
+                    node_selection_bounds_max_ = fresh_max;
+                    node_selection_bounds_scale_active_ = true;
                 }
             } else if (actually_using_bounds && first_node && bounds_gizmo_active) {
                 glm::vec3 fresh_min, fresh_max;
@@ -1519,7 +1519,7 @@ namespace lfs::vis::gui {
                                                   node_gizmo_node_names_,
                                                   node_original_visualizer_world_transforms_,
                                                   glm::mat4(gizmo_cumulative_rotation_))
-                                            : gizmo_ops::computeNodeGroupLocalTransforms(
+                                            : gizmo_ops::computeNodeSharedSelectionLocalTransforms(
                                                   scene_manager->getScene(),
                                                   node_gizmo_node_names_,
                                                   node_original_visualizer_world_transforms_,
@@ -1531,7 +1531,7 @@ namespace lfs::vis::gui {
                     scene_manager->setNodeTransform(transform.name, transform.local_transform);
                 }
             } else if (node_gizmo_operation_ == GizmoOperation::Scale &&
-                       node_group_bounds_scale_active_) {
+                       node_selection_bounds_scale_active_) {
                 glm::vec3 new_world_size;
                 glm::vec3 new_center_world;
                 if (bounds_result_valid) {
@@ -1542,18 +1542,18 @@ namespace lfs::vis::gui {
                     new_center_world = glm::vec3(gizmo_matrix[3]);
                 }
 
-                const glm::vec3 original_bounds_size = node_group_bounds_max_ - node_group_bounds_min_;
+                const glm::vec3 original_bounds_size = node_selection_bounds_max_ - node_selection_bounds_min_;
                 const glm::vec3 safe_bounds = glm::max(original_bounds_size, glm::vec3(1e-6f));
                 const glm::vec3 scale_ratio = new_world_size / safe_bounds;
                 gizmo_cumulative_scale_ = scale_ratio;
                 gizmo_pivot_ = new_center_world;
 
-                const glm::vec3 original_center = (node_group_bounds_min_ + node_group_bounds_max_) * 0.5f;
+                const glm::vec3 original_center = (node_selection_bounds_min_ + node_selection_bounds_max_) * 0.5f;
                 const glm::mat4 world_delta = glm::translate(glm::mat4(1.0f), new_center_world) *
                                               glm::scale(glm::mat4(1.0f), scale_ratio) *
                                               glm::translate(glm::mat4(1.0f), -original_center);
 
-                for (const auto& transform : gizmo_ops::computeNodeGroupLocalTransforms(
+                for (const auto& transform : gizmo_ops::computeNodeSharedSelectionLocalTransforms(
                          scene_manager->getScene(),
                          node_gizmo_node_names_,
                          node_original_visualizer_world_transforms_,
@@ -1562,7 +1562,7 @@ namespace lfs::vis::gui {
                 }
             } else if (node_gizmo_operation_ == GizmoOperation::Scale &&
                        !node_bounds_scale_active_ &&
-                       !node_group_bounds_scale_active_ &&
+                       !node_selection_bounds_scale_active_ &&
                        (is_multi_selection || use_world_space)) {
                 gizmo_cumulative_scale_ *= extractScale(delta_matrix);
                 const auto transforms = use_individual_mode
@@ -1571,7 +1571,7 @@ namespace lfs::vis::gui {
                                                   node_gizmo_node_names_,
                                                   node_original_visualizer_world_transforms_,
                                                   glm::scale(glm::mat4(1.0f), gizmo_cumulative_scale_))
-                                            : gizmo_ops::computeNodeGroupLocalTransforms(
+                                            : gizmo_ops::computeNodeSharedSelectionLocalTransforms(
                                                   scene_manager->getScene(),
                                                   node_gizmo_node_names_,
                                                   node_original_visualizer_world_transforms_,
@@ -1588,7 +1588,7 @@ namespace lfs::vis::gui {
                     const glm::vec3 delta = new_gizmo_pos - gizmo_pivot_;
                     const glm::mat4 world_delta = glm::translate(glm::mat4(1.0f), delta);
 
-                    for (const auto& transform : gizmo_ops::computeNodeGroupLocalTransforms(
+                    for (const auto& transform : gizmo_ops::computeNodeSharedSelectionLocalTransforms(
                              scene_manager->getScene(),
                              node_gizmo_node_names_,
                              node_original_visualizer_world_transforms_,
@@ -1650,9 +1650,9 @@ namespace lfs::vis::gui {
         if (!is_using && node_gizmo_active_) {
             node_gizmo_active_ = false;
             node_bounds_scale_active_ = false;
-            node_group_bounds_scale_active_ = false;
+            node_selection_bounds_scale_active_ = false;
             node_bounds_cache_valid_ = false;
-            node_group_bounds_cache_valid_ = false;
+            node_selection_bounds_cache_valid_ = false;
             if (render_manager) {
                 render_manager->setCropboxGizmoActive(false);
                 render_manager->setEllipsoidGizmoActive(false);

--- a/src/visualizer/gui/gizmo_manager.cpp
+++ b/src/visualizer/gui/gizmo_manager.cpp
@@ -2906,9 +2906,10 @@ namespace lfs::vis::gui {
     }
 
     void GizmoManager::setMultiTransformMode(const MultiTransformMode mode) {
-        if (multi_transform_mode_ == mode)
+        const auto normalized_mode = normalizeMultiTransformMode(mode);
+        if (multi_transform_mode_ == normalized_mode)
             return;
-        multi_transform_mode_ = mode;
+        multi_transform_mode_ = normalized_mode;
         app_store().multi_transform_mode.set(static_cast<int>(multi_transform_mode_));
     }
 

--- a/src/visualizer/gui/gizmo_manager.cpp
+++ b/src/visualizer/gui/gizmo_manager.cpp
@@ -38,7 +38,6 @@
 #include <cmath>
 #include <glm/gtc/matrix_transform.hpp>
 #include <optional>
-#include <unordered_set>
 #include <vector>
 
 namespace lfs::vis::gui {
@@ -768,6 +767,7 @@ namespace lfs::vis::gui {
             if (auto* const sm = viewer_->getSceneManager())
                 sm->syncCropBoxToRenderSettings();
             node_bounds_cache_valid_ = false;
+            node_group_bounds_cache_valid_ = false;
         });
 
         ui::NodeDeselected::when([this](const auto&) {
@@ -775,6 +775,7 @@ namespace lfs::vis::gui {
             if (auto* const t = viewer_->getAlignTool())
                 t->setEnabled(false);
             node_bounds_cache_valid_ = false;
+            node_group_bounds_cache_valid_ = false;
         });
 
         state::PLYRemoved::when([this](const auto&) { deactivateAllTools(); });
@@ -1117,6 +1118,17 @@ namespace lfs::vis::gui {
 
         const auto& settings = render_manager->getSettings();
         const bool is_multi_selection = (target_names.size() > 1);
+        const bool use_group_mode = !is_multi_selection || multi_transform_mode_ == MultiTransformMode::Group;
+        const bool use_individual_mode = is_multi_selection && multi_transform_mode_ == MultiTransformMode::Individual;
+        std::optional<std::vector<std::string>> top_level_target_names;
+        const auto get_top_level_target_names = [&]() -> const std::vector<std::string>& {
+            if (!top_level_target_names) {
+                top_level_target_names = is_multi_selection
+                                             ? gizmo_ops::topLevelTransformTargets(scene, target_names)
+                                             : target_names;
+            }
+            return *top_level_target_names;
+        };
 
         const auto active_panel = resolveActiveGizmoPanel(ctx.viewer, viewport);
         if (!active_panel || !active_panel->valid())
@@ -1135,7 +1147,10 @@ namespace lfs::vis::gui {
                                           : transform_targets->local_center;
 
         bool has_valid_bounds = false;
-        const bool use_bounds_scale = !is_multi_selection && node_gizmo_operation_ == GizmoOperation::Scale;
+        const bool use_single_bounds_scale = !is_multi_selection && node_gizmo_operation_ == GizmoOperation::Scale;
+        const bool use_group_bounds_scale = is_multi_selection && use_group_mode &&
+                                            node_gizmo_operation_ == GizmoOperation::Scale;
+        const bool use_bounds_scale = use_single_bounds_scale || use_group_bounds_scale;
 
         const auto* first_node = (!is_multi_selection && !target_names.empty())
                                      ? scene.getNode(target_names.front())
@@ -1146,7 +1161,7 @@ namespace lfs::vis::gui {
         glm::vec3 world_scale(1.0f);
         glm::mat3 node_rotation(1.0f);
 
-        if (use_bounds_scale && first_node) {
+        if (use_single_bounds_scale && first_node) {
             world_transform = scene_coords::nodeVisualizerWorldTransform(scene, first_node->id);
             world_scale = extractScale(world_transform);
             node_rotation = extractRotation(world_transform);
@@ -1171,10 +1186,81 @@ namespace lfs::vis::gui {
                 }
             }
         }
+        if (use_group_bounds_scale) {
+            if (node_group_bounds_scale_active_) {
+                has_valid_bounds = true;
+                bounds_min = node_group_bounds_min_;
+                bounds_max = node_group_bounds_max_;
+            } else {
+                struct GroupBoundsCacheKeyEntry {
+                    core::NodeId id = core::NULL_NODE;
+                    glm::mat4 visualizer_world_transform{1.0f};
+                };
+
+                const auto& top_level_names = get_top_level_target_names();
+                std::vector<GroupBoundsCacheKeyEntry> key_entries;
+                key_entries.reserve(top_level_names.size());
+                for (const auto& name : top_level_names) {
+                    if (const auto* node = scene.getNode(name)) {
+                        key_entries.push_back(GroupBoundsCacheKeyEntry{
+                            .id = node->id,
+                            .visualizer_world_transform = scene_coords::nodeVisualizerWorldTransform(scene, node->id),
+                        });
+                    }
+                }
+                std::sort(key_entries.begin(), key_entries.end(), [](const auto& a, const auto& b) {
+                    return a.id < b.id;
+                });
+
+                std::vector<core::NodeId> cache_node_ids;
+                std::vector<glm::mat4> cache_world_transforms;
+                cache_node_ids.reserve(key_entries.size());
+                cache_world_transforms.reserve(key_entries.size());
+                for (const auto& entry : key_entries) {
+                    cache_node_ids.push_back(entry.id);
+                    cache_world_transforms.push_back(entry.visualizer_world_transform);
+                }
+
+                bool cache_matches = node_group_bounds_cache_valid_ &&
+                                     node_group_bounds_cache_node_ids_ == cache_node_ids &&
+                                     node_group_bounds_cache_visualizer_world_transforms_.size() ==
+                                         cache_world_transforms.size();
+                if (cache_matches) {
+                    for (size_t i = 0; i < cache_world_transforms.size(); ++i) {
+                        if (node_group_bounds_cache_visualizer_world_transforms_[i] != cache_world_transforms[i]) {
+                            cache_matches = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (cache_matches) {
+                    has_valid_bounds = true;
+                    bounds_min = node_group_bounds_cache_min_;
+                    bounds_max = node_group_bounds_cache_max_;
+                } else if (gizmo_ops::computeCombinedVisualizerWorldBounds(
+                               scene, top_level_names, bounds_min, bounds_max)) {
+                    has_valid_bounds = true;
+                    node_group_bounds_cache_valid_ = true;
+                    node_group_bounds_cache_node_ids_ = std::move(cache_node_ids);
+                    node_group_bounds_cache_visualizer_world_transforms_ = std::move(cache_world_transforms);
+                    node_group_bounds_cache_min_ = bounds_min;
+                    node_group_bounds_cache_max_ = bounds_max;
+                } else {
+                    node_group_bounds_cache_valid_ = false;
+                    node_group_bounds_cache_node_ids_.clear();
+                    node_group_bounds_cache_visualizer_world_transforms_.clear();
+                }
+            }
+            world_transform = glm::mat4(1.0f);
+            world_scale = glm::vec3(1.0f);
+            node_rotation = glm::mat3(1.0f);
+        }
 
         const bool actually_using_bounds = use_bounds_scale && has_valid_bounds;
 
-        const glm::vec3 transform_gizmo_position = (node_gizmo_active_ && !node_bounds_scale_active_)
+        const glm::vec3 transform_gizmo_position = (node_gizmo_active_ && !node_bounds_scale_active_ &&
+                                                    !node_group_bounds_scale_active_)
                                                        ? gizmo_pivot_
                                                        : (is_multi_selection
                                                               ? transform_targets->world_center
@@ -1198,7 +1284,16 @@ namespace lfs::vis::gui {
             const glm::vec3 bounds_center_local = (bounds_min + bounds_max) * 0.5f;
 
             glm::vec3 center_world;
-            if (node_bounds_scale_active_) {
+            if (use_group_bounds_scale) {
+                const glm::vec3 display_size = node_group_bounds_scale_active_
+                                                   ? (node_group_bounds_max_ - node_group_bounds_min_) * gizmo_cumulative_scale_
+                                                   : bounds_size;
+                center_world = node_group_bounds_scale_active_ ? gizmo_pivot_ : bounds_center_local;
+                gizmo_matrix[3] = glm::vec4(center_world, 1.0f);
+                gizmo_matrix[0] = glm::vec4(display_size.x, 0.0f, 0.0f, 0.0f);
+                gizmo_matrix[1] = glm::vec4(0.0f, display_size.y, 0.0f, 0.0f);
+                gizmo_matrix[2] = glm::vec4(0.0f, 0.0f, display_size.z, 0.0f);
+            } else if (node_bounds_scale_active_) {
                 const glm::vec3 original_bounds_size = node_bounds_max_ - node_bounds_min_;
                 const glm::vec3 current_size = original_bounds_size * gizmo_cumulative_scale_;
                 const glm::vec3 scaled_center = (node_bounds_min_ + node_bounds_max_) * 0.5f;
@@ -1375,7 +1470,15 @@ namespace lfs::vis::gui {
             gizmo_cumulative_rotation_ = glm::mat3(1.0f);
             gizmo_cumulative_scale_ = glm::vec3(1.0f);
 
-            if (actually_using_bounds && first_node && bounds_gizmo_active) {
+            if (actually_using_bounds && use_group_bounds_scale && bounds_gizmo_active) {
+                glm::vec3 fresh_min, fresh_max;
+                if (gizmo_ops::computeCombinedVisualizerWorldBounds(
+                        scene, get_top_level_target_names(), fresh_min, fresh_max)) {
+                    node_group_bounds_min_ = fresh_min;
+                    node_group_bounds_max_ = fresh_max;
+                    node_group_bounds_scale_active_ = true;
+                }
+            } else if (actually_using_bounds && first_node && bounds_gizmo_active) {
                 glm::vec3 fresh_min, fresh_max;
                 if (scene.getNodeBounds(first_node->id, fresh_min, fresh_max)) {
                     node_bounds_min_ = fresh_min;
@@ -1386,33 +1489,7 @@ namespace lfs::vis::gui {
                 }
             }
 
-            std::unordered_set<core::NodeId> selected_ids;
-            for (const auto& name : target_names) {
-                if (const auto* node = scene.getNode(name)) {
-                    selected_ids.insert(node->id);
-                }
-            }
-
-            node_gizmo_node_names_.clear();
-            for (const auto& name : target_names) {
-                const auto* node = scene.getNode(name);
-                if (!node)
-                    continue;
-
-                bool ancestor_selected = false;
-                for (core::NodeId check_id = node->parent_id; check_id != core::NULL_NODE;) {
-                    if (selected_ids.count(check_id)) {
-                        ancestor_selected = true;
-                        break;
-                    }
-                    const auto* parent = scene.getNodeById(check_id);
-                    check_id = parent ? parent->parent_id : core::NULL_NODE;
-                }
-
-                if (!ancestor_selected) {
-                    node_gizmo_node_names_.push_back(name);
-                }
-            }
+            node_gizmo_node_names_ = get_top_level_target_names();
 
             node_transforms_before_drag_.clear();
             node_original_visualizer_world_transforms_.clear();
@@ -1432,38 +1509,78 @@ namespace lfs::vis::gui {
         if (gizmo_changed && is_using) {
             if (node_gizmo_operation_ == GizmoOperation::Rotate) {
                 const glm::mat3 delta_rot = extractRotation(delta_matrix);
+                // Individual mode uses one drag-defined rotation path for the selection and
+                // post-applies that cumulative delta to each node's drag-start transform.
+                // This keeps each node rotating from its own origin while avoiding drift.
                 gizmo_cumulative_rotation_ = delta_rot * gizmo_cumulative_rotation_;
-                const glm::mat4 world_delta = glm::translate(glm::mat4(1.0f), gizmo_pivot_) *
-                                              glm::mat4(gizmo_cumulative_rotation_) *
-                                              glm::translate(glm::mat4(1.0f), -gizmo_pivot_);
+                const auto transforms = use_individual_mode
+                                            ? gizmo_ops::computeNodeIndividualLocalTransforms(
+                                                  scene_manager->getScene(),
+                                                  node_gizmo_node_names_,
+                                                  node_original_visualizer_world_transforms_,
+                                                  glm::mat4(gizmo_cumulative_rotation_))
+                                            : gizmo_ops::computeNodeGroupLocalTransforms(
+                                                  scene_manager->getScene(),
+                                                  node_gizmo_node_names_,
+                                                  node_original_visualizer_world_transforms_,
+                                                  glm::translate(glm::mat4(1.0f), gizmo_pivot_) *
+                                                      glm::mat4(gizmo_cumulative_rotation_) *
+                                                      glm::translate(glm::mat4(1.0f), -gizmo_pivot_));
 
-                for (size_t i = 0; i < node_gizmo_node_names_.size(); ++i) {
-                    const glm::mat4 new_world_transform = world_delta * node_original_visualizer_world_transforms_[i];
-                    if (const auto new_local_transform =
-                            scene_coords::nodeLocalTransformFromVisualizerWorld(
-                                scene_manager->getScene(),
-                                node_gizmo_node_names_[i],
-                                new_world_transform)) {
-                        scene_manager->setNodeTransform(node_gizmo_node_names_[i], *new_local_transform);
-                    }
+                for (const auto& transform : transforms) {
+                    scene_manager->setNodeTransform(transform.name, transform.local_transform);
+                }
+            } else if (node_gizmo_operation_ == GizmoOperation::Scale &&
+                       node_group_bounds_scale_active_) {
+                glm::vec3 new_world_size;
+                glm::vec3 new_center_world;
+                if (bounds_result_valid) {
+                    new_world_size = bounds_result_local_size;
+                    new_center_world = bounds_result_center_world;
+                } else {
+                    new_world_size = glm::max(extractScale(gizmo_matrix), glm::vec3(MIN_GIZMO_SCALE));
+                    new_center_world = glm::vec3(gizmo_matrix[3]);
+                }
+
+                const glm::vec3 original_bounds_size = node_group_bounds_max_ - node_group_bounds_min_;
+                const glm::vec3 safe_bounds = glm::max(original_bounds_size, glm::vec3(1e-6f));
+                const glm::vec3 scale_ratio = new_world_size / safe_bounds;
+                gizmo_cumulative_scale_ = scale_ratio;
+                gizmo_pivot_ = new_center_world;
+
+                const glm::vec3 original_center = (node_group_bounds_min_ + node_group_bounds_max_) * 0.5f;
+                const glm::mat4 world_delta = glm::translate(glm::mat4(1.0f), new_center_world) *
+                                              glm::scale(glm::mat4(1.0f), scale_ratio) *
+                                              glm::translate(glm::mat4(1.0f), -original_center);
+
+                for (const auto& transform : gizmo_ops::computeNodeGroupLocalTransforms(
+                         scene_manager->getScene(),
+                         node_gizmo_node_names_,
+                         node_original_visualizer_world_transforms_,
+                         world_delta)) {
+                    scene_manager->setNodeTransform(transform.name, transform.local_transform);
                 }
             } else if (node_gizmo_operation_ == GizmoOperation::Scale &&
                        !node_bounds_scale_active_ &&
+                       !node_group_bounds_scale_active_ &&
                        (is_multi_selection || use_world_space)) {
                 gizmo_cumulative_scale_ *= extractScale(delta_matrix);
-                const glm::mat4 world_delta = glm::translate(glm::mat4(1.0f), gizmo_pivot_) *
-                                              glm::scale(glm::mat4(1.0f), gizmo_cumulative_scale_) *
-                                              glm::translate(glm::mat4(1.0f), -gizmo_pivot_);
+                const auto transforms = use_individual_mode
+                                            ? gizmo_ops::computeNodeIndividualLocalTransforms(
+                                                  scene_manager->getScene(),
+                                                  node_gizmo_node_names_,
+                                                  node_original_visualizer_world_transforms_,
+                                                  glm::scale(glm::mat4(1.0f), gizmo_cumulative_scale_))
+                                            : gizmo_ops::computeNodeGroupLocalTransforms(
+                                                  scene_manager->getScene(),
+                                                  node_gizmo_node_names_,
+                                                  node_original_visualizer_world_transforms_,
+                                                  glm::translate(glm::mat4(1.0f), gizmo_pivot_) *
+                                                      glm::scale(glm::mat4(1.0f), gizmo_cumulative_scale_) *
+                                                      glm::translate(glm::mat4(1.0f), -gizmo_pivot_));
 
-                for (size_t i = 0; i < node_gizmo_node_names_.size(); ++i) {
-                    const glm::mat4 new_world_transform = world_delta * node_original_visualizer_world_transforms_[i];
-                    if (const auto new_local_transform =
-                            scene_coords::nodeLocalTransformFromVisualizerWorld(
-                                scene_manager->getScene(),
-                                node_gizmo_node_names_[i],
-                                new_world_transform)) {
-                        scene_manager->setNodeTransform(node_gizmo_node_names_[i], *new_local_transform);
-                    }
+                for (const auto& transform : transforms) {
+                    scene_manager->setNodeTransform(transform.name, transform.local_transform);
                 }
             } else if (is_multi_selection) {
                 if (node_gizmo_operation_ == GizmoOperation::Translate) {
@@ -1471,15 +1588,12 @@ namespace lfs::vis::gui {
                     const glm::vec3 delta = new_gizmo_pos - gizmo_pivot_;
                     const glm::mat4 world_delta = glm::translate(glm::mat4(1.0f), delta);
 
-                    for (size_t i = 0; i < node_gizmo_node_names_.size(); ++i) {
-                        const glm::mat4 new_world_transform = world_delta * node_original_visualizer_world_transforms_[i];
-                        if (const auto new_local_transform =
-                                scene_coords::nodeLocalTransformFromVisualizerWorld(
-                                    scene_manager->getScene(),
-                                    node_gizmo_node_names_[i],
-                                    new_world_transform)) {
-                            scene_manager->setNodeTransform(node_gizmo_node_names_[i], *new_local_transform);
-                        }
+                    for (const auto& transform : gizmo_ops::computeNodeGroupLocalTransforms(
+                             scene_manager->getScene(),
+                             node_gizmo_node_names_,
+                             node_original_visualizer_world_transforms_,
+                             world_delta)) {
+                        scene_manager->setNodeTransform(transform.name, transform.local_transform);
                     }
                 }
             } else if (node_bounds_scale_active_) {
@@ -1536,7 +1650,9 @@ namespace lfs::vis::gui {
         if (!is_using && node_gizmo_active_) {
             node_gizmo_active_ = false;
             node_bounds_scale_active_ = false;
+            node_group_bounds_scale_active_ = false;
             node_bounds_cache_valid_ = false;
+            node_group_bounds_cache_valid_ = false;
             if (render_manager) {
                 render_manager->setCropboxGizmoActive(false);
                 render_manager->setEllipsoidGizmoActive(false);
@@ -1562,6 +1678,19 @@ namespace lfs::vis::gui {
                 props.set("node_names", node_gizmo_node_names_);
                 props.set("old_transforms", node_transforms_before_drag_);
                 op::operators().invoke(op::BuiltinOp::TransformApplyBatch, &props);
+
+                if (is_multi_selection && use_individual_mode &&
+                    (node_gizmo_operation_ == GizmoOperation::Rotate ||
+                     node_gizmo_operation_ == GizmoOperation::Scale)) {
+                    glm::vec3 updated_min, updated_max;
+                    if (gizmo_ops::computeCombinedVisualizerWorldBounds(
+                            scene_manager->getScene(), node_gizmo_node_names_, updated_min, updated_max)) {
+                        gizmo_pivot_ = (updated_min + updated_max) * 0.5f;
+                        if (render_manager) {
+                            render_manager->updateSettings(render_manager->getSettings(), DirtyFlag::OVERLAY);
+                        }
+                    }
+                }
             }
         }
 
@@ -2774,6 +2903,13 @@ namespace lfs::vis::gui {
             return;
         pivot_mode_ = mode;
         app_store().pivot_mode.set(static_cast<int>(pivot_mode_));
+    }
+
+    void GizmoManager::setMultiTransformMode(const MultiTransformMode mode) {
+        if (multi_transform_mode_ == mode)
+            return;
+        multi_transform_mode_ = mode;
+        app_store().multi_transform_mode.set(static_cast<int>(multi_transform_mode_));
     }
 
     bool GizmoManager::isPositionInViewportGizmo(const double x, const double y) const {

--- a/src/visualizer/gui/gizmo_manager.hpp
+++ b/src/visualizer/gui/gizmo_manager.hpp
@@ -32,15 +32,17 @@ namespace lfs::vis {
             Scale
         };
 
+        // Selection mode is the shared-pivot transform for the current multi-selection;
+        // it is unrelated to scene graph GROUP nodes.
         enum class MultiTransformMode {
-            Group = 0,
+            Selection = 0,
             Individual = 1
         };
 
         constexpr MultiTransformMode normalizeMultiTransformMode(const MultiTransformMode mode) {
             return mode == MultiTransformMode::Individual
                        ? MultiTransformMode::Individual
-                       : MultiTransformMode::Group;
+                       : MultiTransformMode::Selection;
         }
 
         class GizmoManager {
@@ -117,7 +119,7 @@ namespace lfs::vis {
             SelectionSubMode selection_mode_ = SelectionSubMode::Centers;
             TransformSpace transform_space_ = TransformSpace::Local;
             PivotMode pivot_mode_ = PivotMode::Origin;
-            MultiTransformMode multi_transform_mode_ = MultiTransformMode::Group;
+            MultiTransformMode multi_transform_mode_ = MultiTransformMode::Selection;
 
             // Node transform gizmo
             bool show_node_gizmo_ = false;
@@ -185,20 +187,20 @@ namespace lfs::vis {
             glm::vec3 node_bounds_max_{0.0f};
             glm::mat4 node_bounds_orig_visualizer_world_transform_{1.0f};
             glm::vec3 node_bounds_world_scale_{1.0f};
-            bool node_group_bounds_scale_active_ = false;
-            glm::vec3 node_group_bounds_min_{0.0f};
-            glm::vec3 node_group_bounds_max_{0.0f};
+            bool node_selection_bounds_scale_active_ = false;
+            glm::vec3 node_selection_bounds_min_{0.0f};
+            glm::vec3 node_selection_bounds_max_{0.0f};
 
             // Display cache to avoid per-frame compute_bounds on large splats
             bool node_bounds_cache_valid_ = false;
             core::NodeId node_bounds_cache_node_id_ = core::NULL_NODE;
             glm::vec3 node_bounds_cache_min_{0.0f};
             glm::vec3 node_bounds_cache_max_{0.0f};
-            bool node_group_bounds_cache_valid_ = false;
-            std::vector<core::NodeId> node_group_bounds_cache_node_ids_;
-            std::vector<glm::mat4> node_group_bounds_cache_visualizer_world_transforms_;
-            glm::vec3 node_group_bounds_cache_min_{0.0f};
-            glm::vec3 node_group_bounds_cache_max_{0.0f};
+            bool node_selection_bounds_cache_valid_ = false;
+            std::vector<core::NodeId> node_selection_bounds_cache_node_ids_;
+            std::vector<glm::mat4> node_selection_bounds_cache_visualizer_world_transforms_;
+            glm::vec3 node_selection_bounds_cache_min_{0.0f};
+            glm::vec3 node_selection_bounds_cache_max_{0.0f};
 
             // Tool tracking
             SelectionSubMode previous_selection_mode_ = SelectionSubMode::Centers;

--- a/src/visualizer/gui/gizmo_manager.hpp
+++ b/src/visualizer/gui/gizmo_manager.hpp
@@ -37,6 +37,12 @@ namespace lfs::vis {
             Individual = 1
         };
 
+        constexpr MultiTransformMode normalizeMultiTransformMode(const MultiTransformMode mode) {
+            return mode == MultiTransformMode::Individual
+                       ? MultiTransformMode::Individual
+                       : MultiTransformMode::Group;
+        }
+
         class GizmoManager {
         public:
             explicit GizmoManager(VisualizerImpl* viewer);

--- a/src/visualizer/gui/gizmo_manager.hpp
+++ b/src/visualizer/gui/gizmo_manager.hpp
@@ -32,6 +32,11 @@ namespace lfs::vis {
             Scale
         };
 
+        enum class MultiTransformMode {
+            Group = 0,
+            Individual = 1
+        };
+
         class GizmoManager {
         public:
             explicit GizmoManager(VisualizerImpl* viewer);
@@ -56,6 +61,8 @@ namespace lfs::vis {
             void setTransformSpace(TransformSpace space);
             [[nodiscard]] PivotMode getPivotMode() const { return pivot_mode_; }
             void setPivotMode(PivotMode mode);
+            [[nodiscard]] MultiTransformMode getMultiTransformMode() const { return multi_transform_mode_; }
+            void setMultiTransformMode(MultiTransformMode mode);
             [[nodiscard]] GizmoOperation getCurrentOperation() const { return current_operation_; }
             void setCurrentOperation(GizmoOperation op) { current_operation_ = op; }
             [[nodiscard]] SelectionSubMode getSelectionSubMode() const { return selection_mode_; }
@@ -104,6 +111,7 @@ namespace lfs::vis {
             SelectionSubMode selection_mode_ = SelectionSubMode::Centers;
             TransformSpace transform_space_ = TransformSpace::Local;
             PivotMode pivot_mode_ = PivotMode::Origin;
+            MultiTransformMode multi_transform_mode_ = MultiTransformMode::Group;
 
             // Node transform gizmo
             bool show_node_gizmo_ = false;
@@ -165,18 +173,26 @@ namespace lfs::vis {
             std::chrono::steady_clock::time_point crop_flash_start_;
             bool crop_flash_active_ = false;
 
-            // Bounds-mode scale gizmo state (single selection only)
+            // Bounds-mode scale gizmo state
             bool node_bounds_scale_active_ = false;
             glm::vec3 node_bounds_min_{0.0f};
             glm::vec3 node_bounds_max_{0.0f};
             glm::mat4 node_bounds_orig_visualizer_world_transform_{1.0f};
             glm::vec3 node_bounds_world_scale_{1.0f};
+            bool node_group_bounds_scale_active_ = false;
+            glm::vec3 node_group_bounds_min_{0.0f};
+            glm::vec3 node_group_bounds_max_{0.0f};
 
             // Display cache to avoid per-frame compute_bounds on large splats
             bool node_bounds_cache_valid_ = false;
             core::NodeId node_bounds_cache_node_id_ = core::NULL_NODE;
             glm::vec3 node_bounds_cache_min_{0.0f};
             glm::vec3 node_bounds_cache_max_{0.0f};
+            bool node_group_bounds_cache_valid_ = false;
+            std::vector<core::NodeId> node_group_bounds_cache_node_ids_;
+            std::vector<glm::mat4> node_group_bounds_cache_visualizer_world_transforms_;
+            glm::vec3 node_group_bounds_cache_min_{0.0f};
+            glm::vec3 node_group_bounds_cache_max_{0.0f};
 
             // Tool tracking
             SelectionSubMode previous_selection_mode_ = SelectionSubMode::Centers;

--- a/src/visualizer/gui/gizmo_transform.cpp
+++ b/src/visualizer/gui/gizmo_transform.cpp
@@ -4,8 +4,11 @@
 
 #include "gui/gizmo_transform.hpp"
 #include "visualizer/scene_coordinate_utils.hpp"
+#include <algorithm>
 #include <cassert>
 #include <glm/gtc/matrix_transform.hpp>
+#include <limits>
+#include <unordered_set>
 
 namespace lfs::vis::gui {
 
@@ -50,6 +53,146 @@ namespace lfs::vis::gui {
                     scene_coords::nodeLocalTransformFromVisualizerWorld(scene, node->id, visualizer_world_transform)) {
                 scene.setNodeTransform(name, *local_transform);
             }
+        }
+
+        std::vector<std::string> topLevelTransformTargets(
+            const core::Scene& scene,
+            const std::vector<std::string>& target_names) {
+            std::unordered_set<core::NodeId> selected_ids;
+            selected_ids.reserve(target_names.size());
+            for (const auto& name : target_names) {
+                if (const auto* node = scene.getNode(name)) {
+                    selected_ids.insert(node->id);
+                }
+            }
+
+            std::vector<std::string> top_level_names;
+            top_level_names.reserve(target_names.size());
+            for (const auto& name : target_names) {
+                const auto* node = scene.getNode(name);
+                if (!node)
+                    continue;
+
+                bool ancestor_selected = false;
+                for (core::NodeId check_id = node->parent_id; check_id != core::NULL_NODE;) {
+                    if (selected_ids.contains(check_id)) {
+                        ancestor_selected = true;
+                        break;
+                    }
+                    const auto* parent = scene.getNodeById(check_id);
+                    check_id = parent ? parent->parent_id : core::NULL_NODE;
+                }
+
+                if (!ancestor_selected) {
+                    top_level_names.push_back(name);
+                }
+            }
+
+            return top_level_names;
+        }
+
+        enum class TransformDeltaComposition {
+            GroupWorld,
+            IndividualLocal,
+        };
+
+        std::vector<NodeLocalTransformResult> computeNodeLocalTransforms(
+            const core::Scene& scene,
+            const std::vector<std::string>& target_names,
+            const std::vector<glm::mat4>& original_visualizer_world_transforms,
+            const glm::mat4& visualizer_delta,
+            const TransformDeltaComposition composition) {
+            std::vector<NodeLocalTransformResult> results;
+            const size_t count = std::min(target_names.size(), original_visualizer_world_transforms.size());
+            results.reserve(count);
+
+            for (size_t i = 0; i < count; ++i) {
+                const glm::mat4 next_visualizer_world = composition == TransformDeltaComposition::GroupWorld
+                                                            ? visualizer_delta * original_visualizer_world_transforms[i]
+                                                            : original_visualizer_world_transforms[i] * visualizer_delta;
+                if (const auto local_transform =
+                        scene_coords::nodeLocalTransformFromVisualizerWorld(
+                            scene, target_names[i], next_visualizer_world)) {
+                    results.push_back(NodeLocalTransformResult{
+                        .name = target_names[i],
+                        .local_transform = *local_transform,
+                    });
+                }
+            }
+
+            return results;
+        }
+
+        std::vector<NodeLocalTransformResult> computeNodeGroupLocalTransforms(
+            const core::Scene& scene,
+            const std::vector<std::string>& target_names,
+            const std::vector<glm::mat4>& original_visualizer_world_transforms,
+            const glm::mat4& visualizer_world_delta) {
+            return computeNodeLocalTransforms(
+                scene,
+                target_names,
+                original_visualizer_world_transforms,
+                visualizer_world_delta,
+                TransformDeltaComposition::GroupWorld);
+        }
+
+        std::vector<NodeLocalTransformResult> computeNodeIndividualLocalTransforms(
+            const core::Scene& scene,
+            const std::vector<std::string>& target_names,
+            const std::vector<glm::mat4>& original_visualizer_world_transforms,
+            const glm::mat4& local_visualizer_delta) {
+            return computeNodeLocalTransforms(
+                scene,
+                target_names,
+                original_visualizer_world_transforms,
+                local_visualizer_delta,
+                TransformDeltaComposition::IndividualLocal);
+        }
+
+        bool computeCombinedVisualizerWorldBounds(
+            const core::Scene& scene,
+            const std::vector<std::string>& target_names,
+            glm::vec3& out_min,
+            glm::vec3& out_max) {
+            bool has_bounds = false;
+            out_min = glm::vec3(std::numeric_limits<float>::max());
+            out_max = glm::vec3(std::numeric_limits<float>::lowest());
+
+            for (const auto& name : target_names) {
+                const auto* node = scene.getNode(name);
+                if (!node)
+                    continue;
+
+                glm::vec3 local_min, local_max;
+                const bool node_has_bounds = scene.getNodeBounds(node->id, local_min, local_max);
+                const glm::mat4 visualizer_world = scene_coords::nodeVisualizerWorldTransform(scene, node->id);
+
+                if (!node_has_bounds) {
+                    const glm::vec3 origin = glm::vec3(visualizer_world[3]);
+                    out_min = glm::min(out_min, origin);
+                    out_max = glm::max(out_max, origin);
+                    has_bounds = true;
+                    continue;
+                }
+
+                for (int x = 0; x < 2; ++x) {
+                    for (int y = 0; y < 2; ++y) {
+                        for (int z = 0; z < 2; ++z) {
+                            const glm::vec3 corner(
+                                x ? local_max.x : local_min.x,
+                                y ? local_max.y : local_min.y,
+                                z ? local_max.z : local_min.z);
+                            const glm::vec3 world_corner =
+                                glm::vec3(visualizer_world * glm::vec4(corner, 1.0f));
+                            out_min = glm::min(out_min, world_corner);
+                            out_max = glm::max(out_max, world_corner);
+                        }
+                    }
+                }
+                has_bounds = true;
+            }
+
+            return has_bounds;
         }
 
         glm::mat4 computeGizmoMatrix(

--- a/src/visualizer/gui/gizmo_transform.cpp
+++ b/src/visualizer/gui/gizmo_transform.cpp
@@ -103,7 +103,11 @@ namespace lfs::vis::gui {
             const glm::mat4& visualizer_delta,
             const TransformDeltaComposition composition) {
             std::vector<NodeLocalTransformResult> results;
-            const size_t count = std::min(target_names.size(), original_visualizer_world_transforms.size());
+            assert(target_names.size() == original_visualizer_world_transforms.size());
+            if (target_names.size() != original_visualizer_world_transforms.size()) {
+                return results;
+            }
+            const size_t count = target_names.size();
             results.reserve(count);
 
             for (size_t i = 0; i < count; ++i) {

--- a/src/visualizer/gui/gizmo_transform.cpp
+++ b/src/visualizer/gui/gizmo_transform.cpp
@@ -92,7 +92,7 @@ namespace lfs::vis::gui {
         }
 
         enum class TransformDeltaComposition {
-            GroupWorld,
+            SharedSelectionWorld,
             IndividualLocal,
         };
 
@@ -111,7 +111,7 @@ namespace lfs::vis::gui {
             results.reserve(count);
 
             for (size_t i = 0; i < count; ++i) {
-                const glm::mat4 next_visualizer_world = composition == TransformDeltaComposition::GroupWorld
+                const glm::mat4 next_visualizer_world = composition == TransformDeltaComposition::SharedSelectionWorld
                                                             ? visualizer_delta * original_visualizer_world_transforms[i]
                                                             : original_visualizer_world_transforms[i] * visualizer_delta;
                 if (const auto local_transform =
@@ -127,7 +127,7 @@ namespace lfs::vis::gui {
             return results;
         }
 
-        std::vector<NodeLocalTransformResult> computeNodeGroupLocalTransforms(
+        std::vector<NodeLocalTransformResult> computeNodeSharedSelectionLocalTransforms(
             const core::Scene& scene,
             const std::vector<std::string>& target_names,
             const std::vector<glm::mat4>& original_visualizer_world_transforms,
@@ -137,7 +137,7 @@ namespace lfs::vis::gui {
                 target_names,
                 original_visualizer_world_transforms,
                 visualizer_world_delta,
-                TransformDeltaComposition::GroupWorld);
+                TransformDeltaComposition::SharedSelectionWorld);
         }
 
         std::vector<NodeLocalTransformResult> computeNodeIndividualLocalTransforms(

--- a/src/visualizer/gui/gizmo_transform.hpp
+++ b/src/visualizer/gui/gizmo_transform.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include "core/editor_context.hpp"
 #include "core/scene.hpp"
 #include <glm/glm.hpp>
@@ -55,6 +56,11 @@ namespace lfs::vis::gui {
 
     namespace gizmo_ops {
 
+        struct LFS_VIS_API NodeLocalTransformResult {
+            std::string name;
+            glm::mat4 local_transform{1.0f};
+        };
+
         // Matrix decomposition helpers
         glm::mat3 extractRotation(const glm::mat4& m);
         glm::vec3 extractScale(const glm::mat4& m);
@@ -62,6 +68,31 @@ namespace lfs::vis::gui {
         void setNodeVisualizerWorldTransform(core::Scene& scene,
                                              const std::string& name,
                                              const glm::mat4& visualizer_world_transform);
+
+        // Multi-node scene graph gizmos operate on selected top-level nodes only.
+        // If both a parent and one of its descendants are selected, transforming
+        // the parent already carries the child, so the descendant is omitted.
+        LFS_VIS_API std::vector<std::string> topLevelTransformTargets(
+            const core::Scene& scene,
+            const std::vector<std::string>& target_names);
+
+        LFS_VIS_API std::vector<NodeLocalTransformResult> computeNodeGroupLocalTransforms(
+            const core::Scene& scene,
+            const std::vector<std::string>& target_names,
+            const std::vector<glm::mat4>& original_visualizer_world_transforms,
+            const glm::mat4& visualizer_world_delta);
+
+        LFS_VIS_API std::vector<NodeLocalTransformResult> computeNodeIndividualLocalTransforms(
+            const core::Scene& scene,
+            const std::vector<std::string>& target_names,
+            const std::vector<glm::mat4>& original_visualizer_world_transforms,
+            const glm::mat4& local_visualizer_delta);
+
+        LFS_VIS_API bool computeCombinedVisualizerWorldBounds(
+            const core::Scene& scene,
+            const std::vector<std::string>& target_names,
+            glm::vec3& out_min,
+            glm::vec3& out_max);
 
         // Compute gizmo display matrix for the custom transform gizmos
         glm::mat4 computeGizmoMatrix(

--- a/src/visualizer/gui/gizmo_transform.hpp
+++ b/src/visualizer/gui/gizmo_transform.hpp
@@ -76,7 +76,7 @@ namespace lfs::vis::gui {
             const core::Scene& scene,
             const std::vector<std::string>& target_names);
 
-        LFS_VIS_API std::vector<NodeLocalTransformResult> computeNodeGroupLocalTransforms(
+        LFS_VIS_API std::vector<NodeLocalTransformResult> computeNodeSharedSelectionLocalTransforms(
             const core::Scene& scene,
             const std::vector<std::string>& target_names,
             const std::vector<glm::mat4>& original_visualizer_world_transforms,

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -758,6 +758,8 @@
     "color_selection": "Color selection",
     "local_space": "Lokaler Raum",
     "world_space": "Weltraum",
+    "group_transform": "Gruppentransform",
+    "individual_transform": "Einzeltransform",
     "origin_pivot": "Ursprung",
     "bounds_center_pivot": "Begrenzungszentrum",
     "resize_bounds": "Grenzen ändern",

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -758,7 +758,7 @@
     "color_selection": "Color selection",
     "local_space": "Lokaler Raum",
     "world_space": "Weltraum",
-    "group_transform": "Gruppentransform",
+    "selection_transform": "Auswahltransform",
     "individual_transform": "Einzeltransform",
     "origin_pivot": "Ursprung",
     "bounds_center_pivot": "Begrenzungszentrum",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -770,6 +770,8 @@
     "color_selection": "Color selection",
     "local_space": "Local Space",
     "world_space": "World Space",
+    "group_transform": "Group Transform",
+    "individual_transform": "Individual Transform",
     "origin_pivot": "Origin",
     "bounds_center_pivot": "Bounds Center",
     "resize_bounds": "Resize Bounds",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -770,7 +770,7 @@
     "color_selection": "Color selection",
     "local_space": "Local Space",
     "world_space": "World Space",
-    "group_transform": "Group Transform",
+    "selection_transform": "Selection Transform",
     "individual_transform": "Individual Transform",
     "origin_pivot": "Origin",
     "bounds_center_pivot": "Bounds Center",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -84,7 +84,7 @@
     "viewport_export": "Exportar vista",
     "local_space": "Espacio local",
     "world_space": "Espacio mundial",
-    "group_transform": "Transformación de grupo",
+    "selection_transform": "Transformaci\u00f3n de selecci\u00f3n",
     "individual_transform": "Transformación individual",
     "origin_pivot": "Origen",
     "bounds_center_pivot": "Centro de límites",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -84,6 +84,8 @@
     "viewport_export": "Exportar vista",
     "local_space": "Espacio local",
     "world_space": "Espacio mundial",
+    "group_transform": "Transformación de grupo",
+    "individual_transform": "Transformación individual",
     "origin_pivot": "Origen",
     "bounds_center_pivot": "Centro de límites",
     "depth_mode_disable": "Desactivar modo de profundidad",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -758,7 +758,7 @@
     "color_selection": "Color selection",
     "local_space": "Espace Local",
     "world_space": "Espace Monde",
-    "group_transform": "Transformation groupée",
+    "selection_transform": "Transformation de s\u00e9lection",
     "individual_transform": "Transformation individuelle",
     "origin_pivot": "Origine",
     "bounds_center_pivot": "Centre des limites",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -758,6 +758,8 @@
     "color_selection": "Color selection",
     "local_space": "Espace Local",
     "world_space": "Espace Monde",
+    "group_transform": "Transformation groupée",
+    "individual_transform": "Transformation individuelle",
     "origin_pivot": "Origine",
     "bounds_center_pivot": "Centre des limites",
     "resize_bounds": "Redimensionner les Limites",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -758,6 +758,8 @@
     "color_selection": "Color selection",
     "local_space": "Spazio Locale",
     "world_space": "Spazio Mondo",
+    "group_transform": "Trasformazione gruppo",
+    "individual_transform": "Trasformazione individuale",
     "origin_pivot": "Origine",
     "bounds_center_pivot": "Centro limiti",
     "resize_bounds": "Ridimensiona Limiti",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -758,7 +758,7 @@
     "color_selection": "Color selection",
     "local_space": "Spazio Locale",
     "world_space": "Spazio Mondo",
-    "group_transform": "Trasformazione gruppo",
+    "selection_transform": "Trasformazione selezione",
     "individual_transform": "Trasformazione individuale",
     "origin_pivot": "Origine",
     "bounds_center_pivot": "Centro limiti",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -758,6 +758,8 @@
     "color_selection": "Color selection",
     "local_space": "ローカル空間",
     "world_space": "ワールド空間",
+    "group_transform": "グループ変換",
+    "individual_transform": "個別変換",
     "origin_pivot": "原点",
     "bounds_center_pivot": "境界中心",
     "resize_bounds": "境界をリサイズ",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -758,7 +758,7 @@
     "color_selection": "Color selection",
     "local_space": "ローカル空間",
     "world_space": "ワールド空間",
-    "group_transform": "グループ変換",
+    "selection_transform": "\u9078\u629e\u5909\u63db",
     "individual_transform": "個別変換",
     "origin_pivot": "原点",
     "bounds_center_pivot": "境界中心",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -758,7 +758,7 @@
     "color_selection": "Color selection",
     "local_space": "로컬 공간",
     "world_space": "월드 공간",
-    "group_transform": "그룹 변환",
+    "selection_transform": "\uc120\ud0dd \ubcc0\ud658",
     "individual_transform": "개별 변환",
     "origin_pivot": "원점",
     "bounds_center_pivot": "경계 중심",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -758,6 +758,8 @@
     "color_selection": "Color selection",
     "local_space": "로컬 공간",
     "world_space": "월드 공간",
+    "group_transform": "그룹 변환",
+    "individual_transform": "개별 변환",
     "origin_pivot": "원점",
     "bounds_center_pivot": "경계 중심",
     "resize_bounds": "경계 크기 조절",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -758,7 +758,7 @@
     "color_selection": "Color selection",
     "local_space": "Lokale Ruimte",
     "world_space": "Wereld Ruimte",
-    "group_transform": "Groepstransformatie",
+    "selection_transform": "Selectietransformatie",
     "individual_transform": "Individuele transformatie",
     "origin_pivot": "Oorsprong",
     "bounds_center_pivot": "Grenzen Midden",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -758,6 +758,8 @@
     "color_selection": "Color selection",
     "local_space": "Lokale Ruimte",
     "world_space": "Wereld Ruimte",
+    "group_transform": "Groepstransformatie",
+    "individual_transform": "Individuele transformatie",
     "origin_pivot": "Oorsprong",
     "bounds_center_pivot": "Grenzen Midden",
     "resize_bounds": "Grenzen Aanpassen",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -758,7 +758,7 @@
     "color_selection": "Color selection",
     "local_space": "Przestrzeń Lokalna",
     "world_space": "Przestrzeń Światowa",
-    "group_transform": "Transformacja grupowa",
+    "selection_transform": "Transformacja zaznaczenia",
     "individual_transform": "Transformacja indywidualna",
     "origin_pivot": "Początek",
     "bounds_center_pivot": "Środek granic",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -758,6 +758,8 @@
     "color_selection": "Color selection",
     "local_space": "Przestrzeń Lokalna",
     "world_space": "Przestrzeń Światowa",
+    "group_transform": "Transformacja grupowa",
+    "individual_transform": "Transformacja indywidualna",
     "origin_pivot": "Początek",
     "bounds_center_pivot": "Środek granic",
     "resize_bounds": "Zmień Rozmiar Granic",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -770,6 +770,8 @@
     "color_selection": "Color selection",
     "local_space": "局部空间",
     "world_space": "世界空间",
+    "group_transform": "组合变换",
+    "individual_transform": "单独变换",
     "origin_pivot": "原点",
     "bounds_center_pivot": "边界中心",
     "resize_bounds": "调整边界大小",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -770,7 +770,7 @@
     "color_selection": "Color selection",
     "local_space": "局部空间",
     "world_space": "世界空间",
-    "group_transform": "组合变换",
+    "selection_transform": "\u9009\u62e9\u53d8\u6362",
     "individual_transform": "单独变换",
     "origin_pivot": "原点",
     "bounds_center_pivot": "边界中心",

--- a/src/visualizer/gui/rml_viewport_overlay.cpp
+++ b/src/visualizer/gui/rml_viewport_overlay.cpp
@@ -456,6 +456,7 @@ namespace lfs::vis::gui {
         document_sync_subscriptions_.push_back(store.active_submode.subscribe(mark_document_dirty));
         document_sync_subscriptions_.push_back(store.transform_space.subscribe(mark_document_dirty));
         document_sync_subscriptions_.push_back(store.pivot_mode.subscribe(mark_document_dirty));
+        document_sync_subscriptions_.push_back(store.multi_transform_mode.subscribe(mark_document_dirty));
         document_sync_subscriptions_.push_back(store.render_settings_generation.subscribe(mark_document_dirty));
         document_sync_subscriptions_.push_back(store.viewport_toolbar_generation.subscribe(mark_document_dirty));
         document_sync_subscriptions_.push_back(store.import_overlay_state.subscribe(mark_document_dirty));

--- a/src/visualizer/include/visualizer/app_store.hpp
+++ b/src/visualizer/include/visualizer/app_store.hpp
@@ -140,6 +140,7 @@ namespace lfs::vis {
             ActiveSubmode,
             TransformSpaceValue,
             PivotModeValue,
+            MultiTransformModeValue,
             ImportOverlayStateValue,
             VideoExportOverlayStateValue,
             ExportProgressStateValue,
@@ -177,6 +178,7 @@ namespace lfs::vis {
         lfs::core::reactive::Observable<std::string> active_submode;
         lfs::core::reactive::Observable<int> transform_space;
         lfs::core::reactive::Observable<int> pivot_mode;
+        lfs::core::reactive::Observable<int> multi_transform_mode;
         lfs::core::reactive::Observable<ImportOverlayState> import_overlay_state;
         lfs::core::reactive::Observable<VideoExportOverlayState> video_export_overlay_state;
         lfs::core::reactive::Observable<ExportProgressState> export_progress_state;

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -543,6 +543,16 @@ namespace lfs::vis {
                     gm->gizmo().setTransformSpace(static_cast<TransformSpace>(space));
             });
         callback_cleanup_.add([] { python::set_transform_space_callbacks(nullptr, nullptr); });
+        python::set_multi_transform_mode_callbacks(
+            []() -> int {
+                const auto* gm = python::get_gui_manager();
+                return gm ? static_cast<int>(gm->gizmo().getMultiTransformMode()) : 0;
+            },
+            [](int mode) {
+                if (auto* gm = python::get_gui_manager())
+                    gm->gizmo().setMultiTransformMode(static_cast<gui::MultiTransformMode>(mode));
+            });
+        callback_cleanup_.add([] { python::set_multi_transform_mode_callbacks(nullptr, nullptr); });
         python::set_thumbnail_callbacks(
             [](const char* video_id) {
                 if (auto* gm = python::get_gui_manager())

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -549,8 +549,11 @@ namespace lfs::vis {
                 return gm ? static_cast<int>(gm->gizmo().getMultiTransformMode()) : 0;
             },
             [](int mode) {
-                if (auto* gm = python::get_gui_manager())
-                    gm->gizmo().setMultiTransformMode(static_cast<gui::MultiTransformMode>(mode));
+                if (auto* gm = python::get_gui_manager()) {
+                    const auto normalized_mode =
+                        gui::normalizeMultiTransformMode(static_cast<gui::MultiTransformMode>(mode));
+                    gm->gizmo().setMultiTransformMode(normalized_mode);
+                }
             });
         callback_cleanup_.add([] { python::set_multi_transform_mode_callbacks(nullptr, nullptr); });
         python::set_thumbnail_callbacks(

--- a/tests/python/test_store.py
+++ b/tests/python/test_store.py
@@ -45,6 +45,7 @@ def test_runtime_state_exposes_panel_reactive_signals():
     assert isinstance(RuntimeState.active_submode, StateSignal)
     assert isinstance(RuntimeState.transform_space, StateSignal)
     assert isinstance(RuntimeState.pivot_mode, StateSignal)
+    assert isinstance(RuntimeState.multi_transform_mode, StateSignal)
     assert isinstance(RuntimeState.import_overlay_state, StateSignal)
     assert isinstance(RuntimeState.video_export_overlay_state, StateSignal)
     assert isinstance(RuntimeState.export_progress_state, StateSignal)

--- a/tests/python/test_toolbar_hooks.py
+++ b/tests/python/test_toolbar_hooks.py
@@ -543,9 +543,9 @@ def test_transform_and_mirror_tools_use_centered_subtool_rows(toolbar_module, mo
     snapshot = controller.snapshot()
 
     assert snapshot["show_transform_space_controls"] is True
-    assert [button["value"] for button in snapshot["submode_buttons"]] == ["group", "individual"]
-    assert next(button for button in snapshot["submode_buttons"] if button["value"] == "group")["selected"] is True
-    assert next(button for button in snapshot["submode_buttons"] if button["value"] == "group")["tooltip_key"] == "toolbar.group_transform"
+    assert [button["value"] for button in snapshot["submode_buttons"]] == ["selection", "individual"]
+    assert next(button for button in snapshot["submode_buttons"] if button["value"] == "selection")["selected"] is True
+    assert next(button for button in snapshot["submode_buttons"] if button["value"] == "selection")["tooltip_key"] == "toolbar.selection_transform"
     assert next(button for button in snapshot["submode_buttons"] if button["value"] == "individual")["tooltip_key"] == "toolbar.individual_transform"
 
     controller.dispatch("submode", "individual")
@@ -789,7 +789,7 @@ def test_viewport_overlay_template_moves_tools_left_and_transform_numbers_center
     transform_toolbar_tooltip_keys = (
         "local_space",
         "world_space",
-        "group_transform",
+        "selection_transform",
         "individual_transform",
         "origin_pivot",
         "bounds_center_pivot",

--- a/tests/python/test_toolbar_hooks.py
+++ b/tests/python/test_toolbar_hooks.py
@@ -414,7 +414,7 @@ def test_selection_tool_uses_centered_modes(toolbar_module, monkeypatch):
 def test_transform_and_mirror_tools_use_centered_subtool_rows(toolbar_module, monkeypatch):
     module, _hook_calls, _remove_calls = toolbar_module
     lf_stub = sys.modules["lichtfeld"]
-    state = SimpleNamespace(active_tool="", transform_space=1, pivot_mode=0, mirror_calls=[])
+    state = SimpleNamespace(active_tool="", transform_space=1, multi_transform_mode=0, pivot_mode=0, mirror_calls=[])
 
     transform_submodes = (
         SimpleNamespace(id="local", label="Local", icon="local", shortcut=""),
@@ -472,6 +472,8 @@ def test_transform_and_mirror_tools_use_centered_subtool_rows(toolbar_module, mo
     monkeypatch.setattr(lf_stub.ui, "get_active_submode", lambda: "", raising=False)
     monkeypatch.setattr(lf_stub.ui, "get_transform_space", lambda: state.transform_space, raising=False)
     monkeypatch.setattr(lf_stub.ui, "set_transform_space", lambda value: setattr(state, "transform_space", value), raising=False)
+    monkeypatch.setattr(lf_stub.ui, "get_multi_transform_mode", lambda: state.multi_transform_mode, raising=False)
+    monkeypatch.setattr(lf_stub.ui, "set_multi_transform_mode", lambda value: setattr(state, "multi_transform_mode", value), raising=False)
     monkeypatch.setattr(lf_stub.ui, "get_pivot_mode", lambda: state.pivot_mode, raising=False)
     monkeypatch.setattr(lf_stub.ui, "set_pivot_mode", lambda value: setattr(state, "pivot_mode", value), raising=False)
     monkeypatch.setattr(lf_stub.ui, "execute_mirror", lambda axis: state.mirror_calls.append(axis), raising=False)
@@ -526,6 +528,7 @@ def test_transform_and_mirror_tools_use_centered_subtool_rows(toolbar_module, mo
     snapshot = controller.snapshot()
     assert snapshot["show_transform_toolbar"] is False
     assert next(button for button in snapshot["transform_tool_buttons"] if button["value"] == "builtin.translate")["selected"] is True
+    assert [button["value"] for button in snapshot["submode_buttons"]] == ["local", "world"]
 
     controller.dispatch("submode", "local")
     controller.dispatch("pivot", "bounds")
@@ -535,6 +538,25 @@ def test_transform_and_mirror_tools_use_centered_subtool_rows(toolbar_module, mo
     assert state.pivot_mode == 1
     assert next(button for button in snapshot["submode_buttons"] if button["value"] == "local")["selected"] is True
     assert next(button for button in snapshot["pivot_buttons"] if button["value"] == "bounds")["selected"] is True
+
+    monkeypatch.setattr(lf_stub, "get_selected_node_names", lambda: ["left", "right"], raising=False)
+    snapshot = controller.snapshot()
+
+    assert snapshot["show_transform_space_controls"] is True
+    assert [button["value"] for button in snapshot["submode_buttons"]] == ["group", "individual"]
+    assert next(button for button in snapshot["submode_buttons"] if button["value"] == "group")["selected"] is True
+    assert next(button for button in snapshot["submode_buttons"] if button["value"] == "group")["tooltip_key"] == "toolbar.group_transform"
+    assert next(button for button in snapshot["submode_buttons"] if button["value"] == "individual")["tooltip_key"] == "toolbar.individual_transform"
+
+    controller.dispatch("submode", "individual")
+    snapshot = controller.snapshot()
+
+    assert state.multi_transform_mode == 1
+    assert next(button for button in snapshot["submode_buttons"] if button["value"] == "individual")["selected"] is True
+
+    monkeypatch.setattr(lf_stub, "get_selected_node_names", lambda: ["target"], raising=False)
+    snapshot = controller.snapshot()
+    assert [button["value"] for button in snapshot["submode_buttons"]] == ["local", "world"]
 
     controller.dispatch("tool", "builtin.translate")
     snapshot = controller.snapshot()
@@ -767,6 +789,8 @@ def test_viewport_overlay_template_moves_tools_left_and_transform_numbers_center
     transform_toolbar_tooltip_keys = (
         "local_space",
         "world_space",
+        "group_transform",
+        "individual_transform",
         "origin_pivot",
         "bounds_center_pivot",
     )
@@ -1025,6 +1049,7 @@ def test_viewport_toolbar_update_syncs_utility_records(toolbar_module, monkeypat
     monkeypatch.setattr(lf_stub.ui, "context", lambda: SimpleNamespace(), raising=False)
     monkeypatch.setattr(lf_stub.ui, "get_active_tool", lambda: "", raising=False)
     monkeypatch.setattr(lf_stub.ui, "get_transform_space", lambda: 1, raising=False)
+    monkeypatch.setattr(lf_stub.ui, "get_multi_transform_mode", lambda: 0, raising=False)
     monkeypatch.setattr(lf_stub.ui, "get_pivot_mode", lambda: 0, raising=False)
     monkeypatch.setattr(lf_stub.ui, "get_split_view_mode", lambda: "single", raising=False)
     monkeypatch.setattr(lf_stub.ui, "is_sequencer_visible", lambda: False, raising=False)

--- a/tests/test_operator_registry_props.cpp
+++ b/tests/test_operator_registry_props.cpp
@@ -6,6 +6,7 @@
 #include "core/services.hpp"
 #include "core/splat_data.hpp"
 #include "core/tensor.hpp"
+#include "gui/gizmo_manager.hpp"
 #include "gui/gizmo_transform.hpp"
 #include "operation/ops/select_ops.hpp"
 #include "operation/ops/transform_ops.hpp"
@@ -506,6 +507,34 @@ TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoRequiresAllTargetsEditable) {
 
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), "selection contains locked nodes");
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoInvalidModeFallsBackToGroup) {
+    EXPECT_EQ(
+        lfs::vis::gui::normalizeMultiTransformMode(lfs::vis::gui::MultiTransformMode::Individual),
+        lfs::vis::gui::MultiTransformMode::Individual);
+    EXPECT_EQ(
+        lfs::vis::gui::normalizeMultiTransformMode(static_cast<lfs::vis::gui::MultiTransformMode>(99)),
+        lfs::vis::gui::MultiTransformMode::Group);
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoTransformHelpersRejectMismatchedSnapshots) {
+    add_node("first");
+    add_node("second");
+    scene_manager_->setNodeTransform("first", glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 0.0f, 0.0f)));
+    scene_manager_->setNodeTransform("second", glm::translate(glm::mat4(1.0f), glm::vec3(2.0f, 0.0f, 0.0f)));
+
+    const std::vector<std::string> names{"first", "second"};
+    const auto originals = capture_visualizer_world_transforms({"first"});
+    const glm::mat4 delta = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 3.0f, 0.0f));
+
+    const auto group_results = lfs::vis::gui::gizmo_ops::computeNodeGroupLocalTransforms(
+        scene_manager_->getScene(), names, originals, delta);
+    const auto individual_results = lfs::vis::gui::gizmo_ops::computeNodeIndividualLocalTransforms(
+        scene_manager_->getScene(), names, originals, delta);
+
+    EXPECT_TRUE(group_results.empty());
+    EXPECT_TRUE(individual_results.empty());
 }
 
 TEST_F(OperatorRegistryPropsTest, EditorContextDisablesTransformToolsForMixedLockedSelection) {

--- a/tests/test_operator_registry_props.cpp
+++ b/tests/test_operator_registry_props.cpp
@@ -164,7 +164,7 @@ protected:
     void apply_group_visualizer_delta(const std::vector<std::string>& names,
                                       const std::vector<glm::mat4>& original_visualizer_world,
                                       const glm::mat4& delta) {
-        for (const auto& transform : lfs::vis::gui::gizmo_ops::computeNodeGroupLocalTransforms(
+        for (const auto& transform : lfs::vis::gui::gizmo_ops::computeNodeSharedSelectionLocalTransforms(
                  scene_manager_->getScene(), names, original_visualizer_world, delta)) {
             scene_manager_->setNodeTransform(transform.name, transform.local_transform);
         }
@@ -295,7 +295,7 @@ TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoScaleUsesSharedPivot) {
     }
 }
 
-TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoGroupScaleUsesCombinedVisualizerBounds) {
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoSelectionScaleUsesCombinedVisualizerBounds) {
     add_node("left");
     add_node("right");
     scene_manager_->setNodeTransform("left", glm::translate(glm::mat4(1.0f), glm::vec3(-2.0f, 0.0f, 0.0f)));
@@ -509,13 +509,13 @@ TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoRequiresAllTargetsEditable) {
     EXPECT_EQ(result.error(), "selection contains locked nodes");
 }
 
-TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoInvalidModeFallsBackToGroup) {
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoInvalidModeFallsBackToSelection) {
     EXPECT_EQ(
         lfs::vis::gui::normalizeMultiTransformMode(lfs::vis::gui::MultiTransformMode::Individual),
         lfs::vis::gui::MultiTransformMode::Individual);
     EXPECT_EQ(
         lfs::vis::gui::normalizeMultiTransformMode(static_cast<lfs::vis::gui::MultiTransformMode>(99)),
-        lfs::vis::gui::MultiTransformMode::Group);
+        lfs::vis::gui::MultiTransformMode::Selection);
 }
 
 TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoTransformHelpersRejectMismatchedSnapshots) {
@@ -528,12 +528,12 @@ TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoTransformHelpersRejectMismatched
     const auto originals = capture_visualizer_world_transforms({"first"});
     const glm::mat4 delta = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 3.0f, 0.0f));
 
-    const auto group_results = lfs::vis::gui::gizmo_ops::computeNodeGroupLocalTransforms(
+    const auto selection_results = lfs::vis::gui::gizmo_ops::computeNodeSharedSelectionLocalTransforms(
         scene_manager_->getScene(), names, originals, delta);
     const auto individual_results = lfs::vis::gui::gizmo_ops::computeNodeIndividualLocalTransforms(
         scene_manager_->getScene(), names, originals, delta);
 
-    EXPECT_TRUE(group_results.empty());
+    EXPECT_TRUE(selection_results.empty());
     EXPECT_TRUE(individual_results.empty());
 }
 

--- a/tests/test_operator_registry_props.cpp
+++ b/tests/test_operator_registry_props.cpp
@@ -6,6 +6,7 @@
 #include "core/services.hpp"
 #include "core/splat_data.hpp"
 #include "core/tensor.hpp"
+#include "gui/gizmo_transform.hpp"
 #include "operation/ops/select_ops.hpp"
 #include "operation/ops/transform_ops.hpp"
 #include "operation/undo_history.hpp"
@@ -19,8 +20,10 @@
 #include "scene/scene_manager.hpp"
 #include "visualizer/core/editor_context.hpp"
 #include "visualizer/gui_capabilities.hpp"
+#include "visualizer/scene_coordinate_utils.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <glm/gtc/matrix_transform.hpp>
 #include <gtest/gtest.h>
 #include <memory>
@@ -71,6 +74,34 @@ namespace {
         return tensor.cuda();
     }
 
+    void expect_matrix_near(const glm::mat4& actual, const glm::mat4& expected, const float epsilon = 1e-4f) {
+        for (int column = 0; column < 4; ++column) {
+            for (int row = 0; row < 4; ++row) {
+                EXPECT_NEAR(actual[column][row], expected[column][row], epsilon)
+                    << "matrix mismatch at column " << column << ", row " << row;
+            }
+        }
+    }
+
+    float matrix_max_abs_diff(const glm::mat4& a, const glm::mat4& b) {
+        float max_diff = 0.0f;
+        for (int column = 0; column < 4; ++column) {
+            for (int row = 0; row < 4; ++row) {
+                max_diff = std::max(max_diff, std::abs(a[column][row] - b[column][row]));
+            }
+        }
+        return max_diff;
+    }
+
+    void expect_matrix_finite(const glm::mat4& value) {
+        for (int column = 0; column < 4; ++column) {
+            for (int row = 0; row < 4; ++row) {
+                EXPECT_TRUE(std::isfinite(value[column][row]))
+                    << "matrix value is not finite at column " << column << ", row " << row;
+            }
+        }
+    }
+
 } // namespace
 
 class OperatorRegistryPropsTest : public ::testing::Test {
@@ -117,6 +148,34 @@ protected:
         scene_manager_->getScene().addSplat(
             name,
             make_test_splat(xyz));
+    }
+
+    std::vector<glm::mat4> capture_visualizer_world_transforms(const std::vector<std::string>& names) const {
+        std::vector<glm::mat4> transforms;
+        transforms.reserve(names.size());
+        for (const auto& name : names) {
+            transforms.push_back(
+                lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene_manager_->getScene(), name).value());
+        }
+        return transforms;
+    }
+
+    void apply_group_visualizer_delta(const std::vector<std::string>& names,
+                                      const std::vector<glm::mat4>& original_visualizer_world,
+                                      const glm::mat4& delta) {
+        for (const auto& transform : lfs::vis::gui::gizmo_ops::computeNodeGroupLocalTransforms(
+                 scene_manager_->getScene(), names, original_visualizer_world, delta)) {
+            scene_manager_->setNodeTransform(transform.name, transform.local_transform);
+        }
+    }
+
+    void apply_individual_visualizer_delta(const std::vector<std::string>& names,
+                                           const std::vector<glm::mat4>& original_visualizer_world,
+                                           const glm::mat4& delta) {
+        for (const auto& transform : lfs::vis::gui::gizmo_ops::computeNodeIndividualLocalTransforms(
+                 scene_manager_->getScene(), names, original_visualizer_world, delta)) {
+            scene_manager_->setNodeTransform(transform.name, transform.local_transform);
+        }
     }
 
     std::unique_ptr<lfs::vis::RenderingManager> rendering_manager_;
@@ -170,6 +229,283 @@ TEST_F(OperatorRegistryPropsTest, TransformTranslateOperatorUsesVisualizerWorldC
     ASSERT_TRUE(resolved.has_value());
     ASSERT_EQ(resolved->size(), 1u);
     EXPECT_EQ(resolved->front(), "move_me");
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoTranslationMovesSelectedTargetsTogether) {
+    add_node("left");
+    add_node("right");
+    scene_manager_->setNodeTransform("left", glm::translate(glm::mat4(1.0f), glm::vec3(-2.0f, 0.0f, 0.0f)));
+    scene_manager_->setNodeTransform("right", glm::translate(glm::mat4(1.0f), glm::vec3(2.0f, 1.0f, 0.0f)));
+
+    const std::vector<std::string> names{"left", "right"};
+    const auto originals = capture_visualizer_world_transforms(names);
+    const glm::mat4 delta = glm::translate(glm::mat4(1.0f), glm::vec3(3.0f, -4.0f, 2.0f));
+
+    apply_group_visualizer_delta(names, originals, delta);
+
+    for (size_t i = 0; i < names.size(); ++i) {
+        const glm::mat4 actual =
+            lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene_manager_->getScene(), names[i]).value();
+        expect_matrix_near(actual, delta * originals[i]);
+    }
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoRotationUsesSharedPivot) {
+    add_node("left");
+    add_node("right");
+    scene_manager_->setNodeTransform("left", glm::translate(glm::mat4(1.0f), glm::vec3(-2.0f, 0.0f, 0.0f)));
+    scene_manager_->setNodeTransform("right", glm::translate(glm::mat4(1.0f), glm::vec3(2.0f, 0.0f, 0.0f)));
+
+    const std::vector<std::string> names{"left", "right"};
+    const auto originals = capture_visualizer_world_transforms(names);
+    const glm::vec3 pivot(0.0f, 0.0f, 0.0f);
+    const glm::mat4 delta = glm::translate(glm::mat4(1.0f), pivot) *
+                            glm::rotate(glm::mat4(1.0f), 1.57079632679f, glm::vec3(0.0f, 0.0f, 1.0f)) *
+                            glm::translate(glm::mat4(1.0f), -pivot);
+
+    apply_group_visualizer_delta(names, originals, delta);
+
+    for (size_t i = 0; i < names.size(); ++i) {
+        const glm::mat4 actual =
+            lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene_manager_->getScene(), names[i]).value();
+        expect_matrix_near(actual, delta * originals[i]);
+    }
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoScaleUsesSharedPivot) {
+    add_node("near");
+    add_node("far");
+    scene_manager_->setNodeTransform("near", glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 0.0f, 0.0f)));
+    scene_manager_->setNodeTransform("far", glm::translate(glm::mat4(1.0f), glm::vec3(3.0f, 0.0f, 0.0f)));
+
+    const std::vector<std::string> names{"near", "far"};
+    const auto originals = capture_visualizer_world_transforms(names);
+    const glm::vec3 pivot(1.0f, 0.0f, 0.0f);
+    const glm::mat4 delta = glm::translate(glm::mat4(1.0f), pivot) *
+                            glm::scale(glm::mat4(1.0f), glm::vec3(2.0f, 3.0f, 0.5f)) *
+                            glm::translate(glm::mat4(1.0f), -pivot);
+
+    apply_group_visualizer_delta(names, originals, delta);
+
+    for (size_t i = 0; i < names.size(); ++i) {
+        const glm::mat4 actual =
+            lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene_manager_->getScene(), names[i]).value();
+        expect_matrix_near(actual, delta * originals[i]);
+    }
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoGroupScaleUsesCombinedVisualizerBounds) {
+    add_node("left");
+    add_node("right");
+    scene_manager_->setNodeTransform("left", glm::translate(glm::mat4(1.0f), glm::vec3(-2.0f, 0.0f, 0.0f)));
+    scene_manager_->setNodeTransform("right", glm::translate(glm::mat4(1.0f), glm::vec3(3.0f, 1.0f, 0.0f)));
+
+    const std::vector<std::string> names{"left", "right"};
+    glm::vec3 bounds_min, bounds_max;
+    ASSERT_TRUE(lfs::vis::gui::gizmo_ops::computeCombinedVisualizerWorldBounds(
+        scene_manager_->getScene(), names, bounds_min, bounds_max));
+
+    const auto originals = capture_visualizer_world_transforms(names);
+    const glm::vec3 center = (bounds_min + bounds_max) * 0.5f;
+    const glm::vec3 scale(2.0f, 1.5f, 0.5f);
+    const glm::mat4 delta = glm::translate(glm::mat4(1.0f), center) *
+                            glm::scale(glm::mat4(1.0f), scale) *
+                            glm::translate(glm::mat4(1.0f), -center);
+
+    apply_group_visualizer_delta(names, originals, delta);
+
+    glm::vec3 scaled_min, scaled_max;
+    ASSERT_TRUE(lfs::vis::gui::gizmo_ops::computeCombinedVisualizerWorldBounds(
+        scene_manager_->getScene(), names, scaled_min, scaled_max));
+    expect_matrix_near(
+        glm::translate(glm::mat4(1.0f), scaled_min),
+        glm::translate(glm::mat4(1.0f), center + (bounds_min - center) * scale));
+    expect_matrix_near(
+        glm::translate(glm::mat4(1.0f), scaled_max),
+        glm::translate(glm::mat4(1.0f), center + (bounds_max - center) * scale));
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoCombinedBoundsFallbackAndZeroSizeScaleAreStable) {
+    auto& scene = scene_manager_->getScene();
+    const auto group_id = scene.addGroup("empty_group");
+    ASSERT_NE(group_id, lfs::core::NULL_NODE);
+    const glm::vec3 group_origin(4.0f, -2.0f, 1.5f);
+    scene_manager_->setNodeTransform("empty_group", glm::translate(glm::mat4(1.0f), group_origin));
+    const glm::vec3 group_visualizer_origin = glm::vec3(
+        lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene, "empty_group").value()[3]);
+
+    glm::vec3 group_min, group_max;
+    ASSERT_TRUE(lfs::vis::gui::gizmo_ops::computeCombinedVisualizerWorldBounds(
+        scene, {"empty_group"}, group_min, group_max));
+    EXPECT_NEAR(group_min.x, group_visualizer_origin.x, 1e-4f);
+    EXPECT_NEAR(group_min.y, group_visualizer_origin.y, 1e-4f);
+    EXPECT_NEAR(group_min.z, group_visualizer_origin.z, 1e-4f);
+    EXPECT_NEAR(group_max.x, group_visualizer_origin.x, 1e-4f);
+    EXPECT_NEAR(group_max.y, group_visualizer_origin.y, 1e-4f);
+    EXPECT_NEAR(group_max.z, group_visualizer_origin.z, 1e-4f);
+
+    add_node("coincident_a", {0.0f, 0.0f, 0.0f});
+    add_node("coincident_b", {0.0f, 0.0f, 0.0f});
+    const glm::vec3 coincident_origin(1.0f, 2.0f, -3.0f);
+    scene_manager_->setNodeTransform("coincident_a", glm::translate(glm::mat4(1.0f), coincident_origin));
+    scene_manager_->setNodeTransform("coincident_b", glm::translate(glm::mat4(1.0f), coincident_origin));
+    const glm::vec3 coincident_visualizer_origin = glm::vec3(
+        lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene, "coincident_a").value()[3]);
+
+    const std::vector<std::string> names{"coincident_a", "coincident_b"};
+    glm::vec3 bounds_min, bounds_max;
+    ASSERT_TRUE(lfs::vis::gui::gizmo_ops::computeCombinedVisualizerWorldBounds(
+        scene, names, bounds_min, bounds_max));
+    expect_matrix_near(glm::translate(glm::mat4(1.0f), bounds_min),
+                       glm::translate(glm::mat4(1.0f), coincident_visualizer_origin));
+    expect_matrix_near(glm::translate(glm::mat4(1.0f), bounds_max),
+                       glm::translate(glm::mat4(1.0f), coincident_visualizer_origin));
+
+    const glm::vec3 safe_bounds = glm::max(bounds_max - bounds_min, glm::vec3(1e-6f));
+    const glm::vec3 requested_size(0.25f, 0.5f, 0.75f);
+    const glm::vec3 scale_ratio = requested_size / safe_bounds;
+    EXPECT_TRUE(std::isfinite(scale_ratio.x));
+    EXPECT_TRUE(std::isfinite(scale_ratio.y));
+    EXPECT_TRUE(std::isfinite(scale_ratio.z));
+
+    const auto originals = capture_visualizer_world_transforms(names);
+    const glm::vec3 center = (bounds_min + bounds_max) * 0.5f;
+    const glm::mat4 delta = glm::translate(glm::mat4(1.0f), center) *
+                            glm::scale(glm::mat4(1.0f), scale_ratio) *
+                            glm::translate(glm::mat4(1.0f), -center);
+
+    apply_group_visualizer_delta(names, originals, delta);
+
+    for (const auto& name : names) {
+        const glm::mat4 actual =
+            lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene, name).value();
+        expect_matrix_finite(actual);
+        EXPECT_NEAR(actual[3].x, coincident_visualizer_origin.x, 1e-4f);
+        EXPECT_NEAR(actual[3].y, coincident_visualizer_origin.y, 1e-4f);
+        EXPECT_NEAR(actual[3].z, coincident_visualizer_origin.z, 1e-4f);
+    }
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoIndividualRotateUsesEachNodeOrigin) {
+    add_node("left");
+    add_node("right");
+    scene_manager_->setNodeTransform("left", glm::translate(glm::mat4(1.0f), glm::vec3(-2.0f, 0.0f, 0.0f)));
+    scene_manager_->setNodeTransform("right", glm::translate(glm::mat4(1.0f), glm::vec3(2.0f, 1.0f, 0.0f)));
+
+    const std::vector<std::string> names{"left", "right"};
+    const auto originals = capture_visualizer_world_transforms(names);
+    const glm::mat4 local_delta =
+        glm::rotate(glm::mat4(1.0f), 1.57079632679f, glm::vec3(0.0f, 0.0f, 1.0f));
+
+    apply_individual_visualizer_delta(names, originals, local_delta);
+
+    for (size_t i = 0; i < names.size(); ++i) {
+        const glm::mat4 actual =
+            lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene_manager_->getScene(), names[i]).value();
+        expect_matrix_near(actual, originals[i] * local_delta);
+        EXPECT_NEAR(actual[3].x, originals[i][3].x, 1e-4f);
+        EXPECT_NEAR(actual[3].y, originals[i][3].y, 1e-4f);
+        EXPECT_NEAR(actual[3].z, originals[i][3].z, 1e-4f);
+    }
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoIndividualRotatePreservesDragCompositionOrder) {
+    add_node("tilted");
+    add_node("offset");
+    scene_manager_->setNodeTransform(
+        "tilted",
+        glm::translate(glm::mat4(1.0f), glm::vec3(-1.0f, 0.5f, 2.0f)) *
+            glm::rotate(glm::mat4(1.0f), 0.35f, glm::vec3(0.0f, 0.0f, 1.0f)));
+    scene_manager_->setNodeTransform(
+        "offset",
+        glm::translate(glm::mat4(1.0f), glm::vec3(2.0f, -1.0f, 0.25f)) *
+            glm::rotate(glm::mat4(1.0f), -0.45f, glm::vec3(0.0f, 1.0f, 0.0f)));
+
+    const std::vector<std::string> names{"tilted", "offset"};
+    const auto originals = capture_visualizer_world_transforms(names);
+    const glm::mat4 delta_x =
+        glm::rotate(glm::mat4(1.0f), 0.55f, glm::vec3(1.0f, 0.0f, 0.0f));
+    const glm::mat4 delta_y =
+        glm::rotate(glm::mat4(1.0f), -0.40f, glm::vec3(0.0f, 1.0f, 0.0f));
+    const glm::mat4 cumulative_drag_delta = delta_y * delta_x;
+    const glm::mat4 opposite_order_delta = delta_x * delta_y;
+
+    apply_individual_visualizer_delta(names, originals, cumulative_drag_delta);
+
+    for (size_t i = 0; i < names.size(); ++i) {
+        const glm::mat4 actual =
+            lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene_manager_->getScene(), names[i]).value();
+        expect_matrix_near(actual, originals[i] * cumulative_drag_delta);
+        EXPECT_GT(matrix_max_abs_diff(actual, originals[i] * opposite_order_delta), 1e-3f);
+        EXPECT_NEAR(actual[3].x, originals[i][3].x, 1e-4f);
+        EXPECT_NEAR(actual[3].y, originals[i][3].y, 1e-4f);
+        EXPECT_NEAR(actual[3].z, originals[i][3].z, 1e-4f);
+    }
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoIndividualScaleUsesEachNodeOrigin) {
+    add_node("near");
+    add_node("far");
+    scene_manager_->setNodeTransform("near", glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 0.0f, 0.0f)));
+    scene_manager_->setNodeTransform("far", glm::translate(glm::mat4(1.0f), glm::vec3(3.0f, 2.0f, 0.0f)));
+
+    const std::vector<std::string> names{"near", "far"};
+    const auto originals = capture_visualizer_world_transforms(names);
+    const glm::mat4 local_delta = glm::scale(glm::mat4(1.0f), glm::vec3(2.0f, 3.0f, 0.5f));
+
+    apply_individual_visualizer_delta(names, originals, local_delta);
+
+    for (size_t i = 0; i < names.size(); ++i) {
+        const glm::mat4 actual =
+            lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene_manager_->getScene(), names[i]).value();
+        expect_matrix_near(actual, originals[i] * local_delta);
+        EXPECT_NEAR(actual[3].x, originals[i][3].x, 1e-4f);
+        EXPECT_NEAR(actual[3].y, originals[i][3].y, 1e-4f);
+        EXPECT_NEAR(actual[3].z, originals[i][3].z, 1e-4f);
+    }
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoFiltersSelectedDescendants) {
+    auto& scene = scene_manager_->getScene();
+    const auto parent_id = scene.addGroup("group");
+    ASSERT_NE(parent_id, lfs::core::NULL_NODE);
+    const auto child_id = scene.addSplat(
+        "child",
+        make_test_splat({0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f}),
+        parent_id);
+    ASSERT_NE(child_id, lfs::core::NULL_NODE);
+
+    scene_manager_->setNodeTransform("group", glm::translate(glm::mat4(1.0f), glm::vec3(2.0f, 0.0f, 0.0f)));
+    scene_manager_->setNodeTransform("child", glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 0.0f, 0.0f)));
+
+    const std::vector<std::string> selected_names{"group", "child"};
+    const auto top_level =
+        lfs::vis::gui::gizmo_ops::topLevelTransformTargets(scene_manager_->getScene(), selected_names);
+    ASSERT_EQ(top_level, (std::vector<std::string>{"group"}));
+
+    const auto group_originals = capture_visualizer_world_transforms(top_level);
+    const glm::mat4 child_original =
+        lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene_manager_->getScene(), "child").value();
+    const glm::mat4 delta = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 5.0f, 0.0f));
+
+    apply_group_visualizer_delta(top_level, group_originals, delta);
+
+    const glm::mat4 child_actual =
+        lfs::vis::scene_coords::nodeVisualizerWorldTransform(scene_manager_->getScene(), "child").value();
+    expect_matrix_near(child_actual, delta * child_original);
+}
+
+TEST_F(OperatorRegistryPropsTest, MultiNodeGizmoRequiresAllTargetsEditable) {
+    add_node("editable");
+    add_node("locked");
+    scene_manager_->getScene().setNodeLocked("locked", true);
+    scene_manager_->selectNodes({"editable", "locked"});
+
+    const auto result = lfs::vis::cap::resolveEditableTransformSelection(
+        *scene_manager_, std::nullopt, lfs::vis::cap::TransformTargetPolicy::RequireAllEditable);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), "selection contains locked nodes");
 }
 
 TEST_F(OperatorRegistryPropsTest, EditorContextDisablesTransformToolsForMixedLockedSelection) {


### PR DESCRIPTION
## Summary

Fixes #780 

This patch adds multi-selection transform modes for scene graph model transforms. Multi-selected models default to Group mode, preserving the existing shared-pivot behavior, and can now be switched to Individual mode so the same rotate or scale operation is applied from each model's own transform basis.

## What this patch does

- Replaces Local/World toolbar buttons with Group/Individual buttons when multiple scene graph nodes are selected and a transform tool is active.
- Persists the multi-transform mode through the app store and Python UI runtime bridge.
- Adds localized Group Transform and Individual Transform keys for every existing locale file.
- Keeps Group mode as the default and preserves shared-pivot translate, rotate, and scale behavior.
- Adds a combined visualizer-world bounds cage for multi-selection Group scale.


## Demo



https://github.com/user-attachments/assets/1b58d5bb-bd95-4407-9486-e0984e97e32e

