### PR TITLE
Prevent Camera Deletion During Active Training

### DIFF
--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -1150,24 +1150,24 @@ namespace lfs::vis {
         LOG_INFO("Scene cleared");
     }
 
-    bool SceneManager::nodeRemovalAffectsTraining(const std::string& name) const {
+    SceneManager::TrainingRemovalImpact SceneManager::classifyTrainingRemovalImpact(const std::string& name) const {
         const auto& training_name = scene_.getTrainingModelNodeName();
         if (!training_name.empty() && name == training_name) {
-            return true;
+            return TrainingRemovalImpact::TrainingModel;
         }
 
         if (!training_name.empty()) {
             for (const auto* n = scene_.getNode(training_name); n && n->parent_id != core::NULL_NODE;) {
                 n = scene_.getNodeById(n->parent_id);
                 if (n && n->name == name) {
-                    return true;
+                    return TrainingRemovalImpact::TrainingModel;
                 }
             }
         }
 
         const auto* root = scene_.getNode(name);
         if (!root) {
-            return false;
+            return TrainingRemovalImpact::None;
         }
 
         std::vector<core::NodeId> pending{root->id};
@@ -1183,17 +1183,26 @@ namespace lfs::vis {
             if (node->type == core::NodeType::CAMERA &&
                 node->camera &&
                 node->training_enabled) {
-                return true;
+                return TrainingRemovalImpact::ActiveTrainingCamera;
             }
 
             pending.insert(pending.end(), node->children.begin(), node->children.end());
         }
-        return false;
+        return TrainingRemovalImpact::None;
+    }
+
+    bool SceneManager::nodeRemovalAffectsTraining(const std::string& name) const {
+        return classifyTrainingRemovalImpact(name) != TrainingRemovalImpact::None;
     }
 
     std::expected<void, std::string> SceneManager::validateNodeRemoval(const std::string& name) const {
+        return validateNodeRemoval(name, classifyTrainingRemovalImpact(name));
+    }
+
+    std::expected<void, std::string> SceneManager::validateNodeRemoval(const std::string& name,
+                                                                       const TrainingRemovalImpact impact) const {
         auto* trainer = services().trainerOrNull();
-        if (!trainer || !nodeRemovalAffectsTraining(name)) {
+        if (!trainer || impact == TrainingRemovalImpact::None) {
             return {};
         }
 
@@ -1208,17 +1217,22 @@ namespace lfs::vis {
     std::expected<void, std::string> SceneManager::removeNodeImpl(const std::string& name,
                                                                   const bool keep_children,
                                                                   const HistoryMode history_mode) {
+        return removeNodeImpl(name, keep_children, history_mode, classifyTrainingRemovalImpact(name));
+    }
+
+    std::expected<void, std::string> SceneManager::removeNodeImpl(const std::string& name,
+                                                                  const bool keep_children,
+                                                                  const HistoryMode history_mode,
+                                                                  const TrainingRemovalImpact training_removal_impact) {
         const auto* node_to_remove = scene_.getNode(name);
         if (!node_to_remove) {
             return {};
         }
 
-        const bool affects_training = nodeRemovalAffectsTraining(name);
-        if (affects_training) {
-            if (const auto result = validateNodeRemoval(name); !result) {
-                return result;
-            }
+        if (const auto result = validateNodeRemoval(name, training_removal_impact); !result) {
+            return result;
         }
+        const bool removes_training_model = training_removal_impact == TrainingRemovalImpact::TrainingModel;
 
         bool trainer_cleared = false;
         const bool record_history = history_mode == HistoryMode::Record;
@@ -1232,7 +1246,7 @@ namespace lfs::vis {
             }
         }
 
-        if (affects_training) {
+        if (removes_training_model) {
             if (auto* trainer = services().trainerOrNull()) {
                 LOG_INFO("Stopping training due to node deletion: {}", name);
                 trainer->stopTraining();
@@ -4746,6 +4760,8 @@ namespace lfs::vis {
 
     std::expected<void, std::string> SceneManager::applySelectedGaussianDeletionPlan(
         const GaussianDeletionPlan& plan) {
+        std::vector<std::pair<std::string, TrainingRemovalImpact>> removed_node_impacts;
+
         if (plan.consolidated) {
             auto* combined = const_cast<core::SplatData*>(scene_.getCombinedModel());
             if (!combined) {
@@ -4755,10 +4771,13 @@ namespace lfs::vis {
                 return std::unexpected("Selection size mismatch");
             }
         } else {
+            removed_node_impacts.reserve(plan.removed_node_names.size());
             for (const auto& node_name : plan.removed_node_names) {
-                if (const auto result = validateNodeRemoval(node_name); !result) {
+                const auto impact = classifyTrainingRemovalImpact(node_name);
+                if (const auto result = validateNodeRemoval(node_name, impact); !result) {
                     return result;
                 }
+                removed_node_impacts.emplace_back(node_name, impact);
             }
 
             for (const auto& slice : plan.partial_slices) {
@@ -4780,8 +4799,8 @@ namespace lfs::vis {
                 node->model->soft_delete(plan.selection_mask.slice(0, slice.begin, slice.end));
             }
 
-            for (const auto& node_name : plan.removed_node_names) {
-                if (const auto result = removeNodeImpl(node_name, false, HistoryMode::Skip); !result) {
+            for (const auto& [node_name, impact] : removed_node_impacts) {
+                if (const auto result = removeNodeImpl(node_name, false, HistoryMode::Skip, impact); !result) {
                     return result;
                 }
             }

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -1152,17 +1152,41 @@ namespace lfs::vis {
 
     bool SceneManager::nodeRemovalAffectsTraining(const std::string& name) const {
         const auto& training_name = scene_.getTrainingModelNodeName();
-        if (training_name.empty()) {
-            return false;
-        }
-        if (name == training_name) {
+        if (!training_name.empty() && name == training_name) {
             return true;
         }
-        for (const auto* n = scene_.getNode(training_name); n && n->parent_id != core::NULL_NODE;) {
-            n = scene_.getNodeById(n->parent_id);
-            if (n && n->name == name) {
+
+        if (!training_name.empty()) {
+            for (const auto* n = scene_.getNode(training_name); n && n->parent_id != core::NULL_NODE;) {
+                n = scene_.getNodeById(n->parent_id);
+                if (n && n->name == name) {
+                    return true;
+                }
+            }
+        }
+
+        const auto* root = scene_.getNode(name);
+        if (!root) {
+            return false;
+        }
+
+        std::vector<core::NodeId> pending{root->id};
+        while (!pending.empty()) {
+            const core::NodeId id = pending.back();
+            pending.pop_back();
+
+            const auto* node = scene_.getNodeById(id);
+            if (!node) {
+                continue;
+            }
+
+            if (node->type == core::NodeType::CAMERA &&
+                node->camera &&
+                node->training_enabled) {
                 return true;
             }
+
+            pending.insert(pending.end(), node->children.begin(), node->children.end());
         }
         return false;
     }

--- a/src/visualizer/scene/scene_manager.hpp
+++ b/src/visualizer/scene/scene_manager.hpp
@@ -315,11 +315,24 @@ namespace lfs::vis {
         };
 
         void resetToEmptyState(bool trainer_already_cleared = false);
+        enum class TrainingRemovalImpact {
+            None,
+            TrainingModel,
+            ActiveTrainingCamera,
+        };
+
+        [[nodiscard]] TrainingRemovalImpact classifyTrainingRemovalImpact(const std::string& name) const;
         [[nodiscard]] bool nodeRemovalAffectsTraining(const std::string& name) const;
         [[nodiscard]] std::expected<void, std::string> validateNodeRemoval(const std::string& name) const;
+        [[nodiscard]] std::expected<void, std::string> validateNodeRemoval(const std::string& name,
+                                                                           TrainingRemovalImpact impact) const;
         [[nodiscard]] std::expected<void, std::string> removeNodeImpl(const std::string& name,
-                                                                      bool keep_children,
-                                                                      HistoryMode history_mode);
+                                                                       bool keep_children,
+                                                                       HistoryMode history_mode);
+        [[nodiscard]] std::expected<void, std::string> removeNodeImpl(const std::string& name,
+                                                                       bool keep_children,
+                                                                       HistoryMode history_mode,
+                                                                       TrainingRemovalImpact impact);
         // Drop the GUI's borrowed scene-image tensor and drain the GPU so no in-flight
         // Vulkan work references model tensors that are about to be freed. Must run
         // before releasing splat models, especially when their tensors are backed by

--- a/tests/test_scene_validity.cpp
+++ b/tests/test_scene_validity.cpp
@@ -18,8 +18,10 @@
 #include "training/optimizer/adam_optimizer.hpp"
 #include "training/training_setup.hpp"
 #include "visualizer/app_store.hpp"
+#include "visualizer/core/services.hpp"
 #include "visualizer/scene/scene_manager.hpp"
 #include "visualizer/scene/selection_state.hpp"
+#include "visualizer/training/training_manager.hpp"
 
 namespace lfs::python {
 
@@ -55,6 +57,37 @@ namespace lfs::python {
             return std::make_shared<core::PointCloud>(
                 core::Tensor::from_vector(means, {count, size_t{3}}, core::Device::CPU),
                 core::Tensor::from_vector(colors, {count, size_t{3}}, core::Device::CPU));
+        }
+
+        struct TrainingSceneNodes {
+            core::NodeId dataset = core::NULL_NODE;
+            core::NodeId cameras = core::NULL_NODE;
+            core::NodeId train_group = core::NULL_NODE;
+            core::NodeId camera = core::NULL_NODE;
+            core::NodeId model = core::NULL_NODE;
+        };
+
+        struct ScopedServicesClear {
+            ScopedServicesClear() { lfs::vis::services().clear(); }
+            ~ScopedServicesClear() { lfs::vis::services().clear(); }
+        };
+
+        TrainingSceneNodes build_training_scene(lfs::vis::SceneManager& manager) {
+            auto& scene = manager.getScene();
+            TrainingSceneNodes nodes;
+            nodes.dataset = scene.addDataset("Dataset");
+            nodes.model = scene.addSplat("Model", make_test_splat(1), nodes.dataset);
+            scene.setTrainingModelNode("Model");
+            nodes.cameras = scene.addGroup("Cameras", nodes.dataset);
+            nodes.train_group = scene.addCameraGroup("Training (1)", nodes.cameras, 1);
+            nodes.camera = scene.addCamera("cam_0001.png", nodes.train_group, std::make_shared<core::Camera>());
+            return nodes;
+        }
+
+        bool transition_trainer_manager_for_test(lfs::vis::TrainerManager& trainer_manager,
+                                                 lfs::vis::TrainingState state) {
+            auto& state_machine = const_cast<lfs::vis::TrainingStateMachine&>(trainer_manager.getStateMachine());
+            return state_machine.transitionTo(state);
         }
 
         core::Tensor make_external_float_tensor(
@@ -751,6 +784,61 @@ namespace lfs::python {
 
         EXPECT_EQ(scene.getNodeById(splat)->parent_id, core::NULL_NODE);
         EXPECT_TRUE(scene.getNodeById(group)->children.empty());
+    }
+
+    TEST_F(SceneValidityTest, SceneManagerBlocksActiveCameraSubtreeAndAllowsInactiveCameraRemoval) {
+        const ScopedServicesClear services_scope;
+        lfs::vis::SceneManager sm;
+        lfs::vis::TrainerManager trainer_manager;
+        lfs::vis::services().set(&sm);
+        lfs::vis::services().set(&trainer_manager);
+
+        auto& scene = sm.getScene();
+        const auto nodes = build_training_scene(sm);
+        sm.selectNodesById({nodes.camera});
+        ASSERT_EQ(scene.getActiveCameraCount(), 1u);
+        ASSERT_EQ(scene.getTrainingModelNodeName(), "Model");
+
+        trainer_manager.setScene(&scene);
+        ASSERT_TRUE(transition_trainer_manager_for_test(trainer_manager, lfs::vis::TrainingState::Paused));
+        ASSERT_TRUE(transition_trainer_manager_for_test(trainer_manager, lfs::vis::TrainingState::Running));
+        ASSERT_TRUE(trainer_manager.isRunning());
+        ASSERT_FALSE(trainer_manager.canPerform(lfs::vis::TrainingAction::DeleteTrainingNode));
+
+        sm.removePLY("Training (1)");
+
+        EXPECT_NE(scene.getNodeById(nodes.train_group), nullptr);
+        EXPECT_NE(scene.getNodeById(nodes.camera), nullptr);
+        EXPECT_EQ(scene.getActiveCameraCount(), 1u);
+        EXPECT_EQ(scene.getTrainingModelNodeName(), "Model");
+
+        const auto selected = sm.getSelectedNodeNames();
+        ASSERT_EQ(selected.size(), 1u);
+        EXPECT_EQ(selected[0], "cam_0001.png");
+
+        ASSERT_TRUE(transition_trainer_manager_for_test(trainer_manager, lfs::vis::TrainingState::Stopping));
+        ASSERT_EQ(trainer_manager.getState(), lfs::vis::TrainingState::Stopping);
+        ASSERT_FALSE(trainer_manager.canPerform(lfs::vis::TrainingAction::DeleteTrainingNode));
+
+        sm.removePLY("Training (1)");
+
+        EXPECT_NE(scene.getNodeById(nodes.train_group), nullptr);
+        EXPECT_NE(scene.getNodeById(nodes.camera), nullptr);
+        EXPECT_EQ(scene.getActiveCameraCount(), 1u);
+        EXPECT_EQ(scene.getTrainingModelNodeName(), "Model");
+        ASSERT_EQ(sm.getSelectedNodeNames().size(), 1u);
+
+        scene.setCameraTrainingEnabled(nodes.camera, false);
+        ASSERT_EQ(scene.getActiveCameraCount(), 0u);
+        ASSERT_EQ(scene.getAllCameras().size(), 1u);
+
+        sm.removePLY("cam_0001.png");
+
+        EXPECT_EQ(scene.getNodeById(nodes.camera), nullptr);
+        EXPECT_TRUE(sm.getSelectedNodeNames().empty());
+        EXPECT_EQ(scene.getAllCameras().size(), 0u);
+        EXPECT_EQ(scene.getActiveCameraCount(), 0u);
+        EXPECT_EQ(scene.getTrainingModelNodeName(), "Model");
     }
 
 } // namespace lfs::python

--- a/tests/test_scene_validity.cpp
+++ b/tests/test_scene_validity.cpp
@@ -841,4 +841,53 @@ namespace lfs::python {
         EXPECT_EQ(scene.getTrainingModelNodeName(), "Model");
     }
 
+    TEST_F(SceneValidityTest, SceneManagerRemovesAllowedActiveCameraSubtreeWithoutClearingTrainer) {
+        const ScopedServicesClear services_scope;
+        lfs::vis::SceneManager sm;
+        lfs::vis::TrainerManager trainer_manager;
+        lfs::vis::services().set(&sm);
+        lfs::vis::services().set(&trainer_manager);
+
+        auto& scene = sm.getScene();
+        const auto nodes = build_training_scene(sm);
+        sm.selectNodesById({nodes.camera});
+
+        trainer_manager.setScene(&scene);
+        ASSERT_TRUE(transition_trainer_manager_for_test(trainer_manager, lfs::vis::TrainingState::Ready));
+        ASSERT_TRUE(trainer_manager.canPerform(lfs::vis::TrainingAction::DeleteTrainingNode));
+
+        sm.removePLY("Training (1)");
+
+        EXPECT_EQ(scene.getNodeById(nodes.train_group), nullptr);
+        EXPECT_EQ(scene.getNodeById(nodes.camera), nullptr);
+        EXPECT_EQ(scene.getAllCameras().size(), 0u);
+        EXPECT_EQ(scene.getActiveCameraCount(), 0u);
+        EXPECT_TRUE(sm.getSelectedNodeNames().empty());
+        EXPECT_NE(scene.getNodeById(nodes.model), nullptr);
+        EXPECT_EQ(scene.getTrainingModelNodeName(), "Model");
+        EXPECT_EQ(trainer_manager.getState(), lfs::vis::TrainingState::Ready);
+        EXPECT_TRUE(trainer_manager.canPerform(lfs::vis::TrainingAction::DeleteTrainingNode));
+    }
+
+    TEST_F(SceneValidityTest, SceneManagerRemovesAllowedTrainingModelAndClearsTrainerState) {
+        const ScopedServicesClear services_scope;
+        lfs::vis::SceneManager sm;
+        lfs::vis::TrainerManager trainer_manager;
+        lfs::vis::services().set(&sm);
+        lfs::vis::services().set(&trainer_manager);
+
+        auto& scene = sm.getScene();
+        const auto nodes = build_training_scene(sm);
+
+        trainer_manager.setScene(&scene);
+        ASSERT_TRUE(transition_trainer_manager_for_test(trainer_manager, lfs::vis::TrainingState::Ready));
+        ASSERT_TRUE(trainer_manager.canPerform(lfs::vis::TrainingAction::DeleteTrainingNode));
+
+        sm.removePLY("Model");
+
+        EXPECT_EQ(scene.getNodeById(nodes.model), nullptr);
+        EXPECT_EQ(scene.getTrainingModelNodeName(), "");
+        EXPECT_EQ(trainer_manager.getState(), lfs::vis::TrainingState::Idle);
+    }
+
 } // namespace lfs::python


### PR DESCRIPTION
## Summary

Fixes #1372 

This patch makes active dataset camera deletion follow the same training-state guard as training model deletion. Removing an active training camera, or a subtree that contains one, is now treated as a training-affecting scene mutation and is rejected while the trainer state disallows training-node deletion.

## Observed Symptoms

In issue #1372, a user could delete a camera from the scene graph while training was active. The delete path removed scene nodes and released rendering/training-adjacent resources even though the trainer still depended on the dataset camera set. That could leave CUDA/Vulkan-facing state inconsistent and cause instability after the deletion.

## Root Cause And Why The Issue Showed Up

`SceneManager::validateNodeRemoval()` already blocks removal when `nodeRemovalAffectsTraining()` reports that the requested node impacts active training. Before this change, `nodeRemovalAffectsTraining()` only recognized the training model node and its parents. Dataset camera nodes, camera groups, and dataset/group ancestors containing training-enabled cameras were not considered training-affecting, so the existing guard was bypassed for camera deletion.

The issue appeared because the trainer depends on the active training camera set, but camera nodes live in a different scene subtree than the training model node. Deleting cameras through the normal scene graph path therefore looked unrelated to training according to the old predicate.

## What This Patch Fixes

- Keeps the existing training model node and parent deletion behavior unchanged.
- Treats a training-enabled camera node as training-affecting.
- Treats any removed subtree containing a training-enabled camera as training-affecting, including camera groups and dataset/group ancestors.
- Reuses the existing `validateNodeRemoval()` failure path and blocked reason; no new UI strings were added.
- Leaves `removeNodeImpl()` side effects unchanged when validation succeeds.
- Ensures validation failure happens before mutation side effects such as history capture, GPU draining, rendering resource release, scene removal, selection cleanup, events, or async model retirement.

## Replication Steps For The Original Issue

1. Load a dataset with training cameras.
2. Start or otherwise enter an active trainer state where training-node deletion is disallowed.
3. In the scene graph, select a training camera or its camera group.
4. Delete the selected node.
5. Before this patch, deletion was allowed even though the trainer still depended on the active camera set. After this patch, the deletion is rejected by the same backend validation path used for training-affecting node removal.

## Impact

- GUI: Delete-key and scene graph deletion routed through `SceneManager` now reject active camera deletion while the trainer state disallows training-node deletion.
- CLI: No direct CLI behavior change is expected unless a CLI path routes scene node removal through `SceneManager`.
- Python API: Python-driven scene removal routed through `SceneManager` receives the same validation.
- MCP: MCP node removal tools routed through `SceneManager`, including `RemovePLY`-style removal, receive the same validation.


