### PR TITLE
onnx patches

### DIFF
--- a/.github/overlays/onnx/fix-cmakelists.patch
+++ b/.github/overlays/onnx/fix-cmakelists.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 8b5af30..6836651 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -668,6 +668,10 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/onnx
+@@ -536,6 +536,10 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/onnx
          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
          FILES_MATCHING
          PATTERN "*.h")
@@ -10,6 +10,6 @@ index 8b5af30..6836651 100644
 +        FILES_MATCHING PATTERN "*.proto")
 +install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/onnx DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 +        FILES_MATCHING PATTERN "*.proto3")
-
+ 
  configure_file(
    ${PROJECT_SOURCE_DIR}/cmake/ONNXConfigVersion.cmake.in

--- a/.github/overlays/onnx/fix-pr-7390.patch
+++ b/.github/overlays/onnx/fix-pr-7390.patch
@@ -2,8 +2,8 @@ diff --git a/onnx/defs/schema.h b/onnx/defs/schema.h
 index acf3aac..adae2d5 100644
 --- a/onnx/defs/schema.h
 +++ b/onnx/defs/schema.h
-@@ -979,8 +979,10 @@ class OpSchemaRegistry final : public ISchemaRegistry {
-
+@@ -999,8 +999,10 @@ class OpSchemaRegistry final : public ISchemaRegistry {
+ 
    class OpSchemaRegisterOnce final {
     public:
 -    // Export to cpp custom register macro
@@ -15,7 +15,7 @@ index acf3aac..adae2d5 100644
          OpSchema op_schema,
          int opset_version_to_load = 0,
          bool fail_duplicate_schema = true) {
-@@ -1311,9 +1313,9 @@ size_t ReplaceAll(std::string& s, const char* from, const char* to);
+@@ -1346,9 +1348,9 @@ size_t ReplaceAll(std::string& s, const char* from, const char* to);
  // Legacy macros to register schema at static initialization
  #define ONNX_OPERATOR_SCHEMA(name) ONNX_OPERATOR_SCHEMA_UNIQ_HELPER(__COUNTER__, name)
  #define ONNX_OPERATOR_SCHEMA_UNIQ_HELPER(Counter, name) ONNX_OPERATOR_SCHEMA_UNIQ(Counter, name)
@@ -25,6 +25,6 @@ index acf3aac..adae2d5 100644
 +#define ONNX_OPERATOR_SCHEMA_UNIQ(Counter, name)                                                                     \
 +  static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce op_schema_register_once##name##Counter ONNX_UNUSED = \
 +      ONNX_NAMESPACE::OpSchema(#name, __FILE__, __LINE__)
-
+ 
  // Helper function
  size_t ReplaceAll(std::string& s, const char* from, const char* to);

--- a/.github/overlays/onnxruntime/fix-cmake-cuda.patch
+++ b/.github/overlays/onnxruntime/fix-cmake-cuda.patch
@@ -6,7 +6,7 @@ index b428ccb..9b73acb 100644
 +find_package(CUDNN REQUIRED) # vcpkg port 'cudnn'
 +get_filename_component(cudnn_LIBRARY "${CUDNN_LIBRARY}" ABSOLUTE)
  add_library(CUDNN::cudnn_all INTERFACE IMPORTED)
-
+ 
  find_path(
 diff --git a/cmake/external/cudnn_frontend.cmake b/cmake/external/cudnn_frontend.cmake
 index d89ab0f..c28568f 100644
@@ -26,7 +26,7 @@ index 91707c4..243783b 100644
 @@ -149,6 +149,9 @@
      onnxruntime_add_shared_library_module(onnxruntime_providers_cuda ${onnxruntime_providers_cuda_all_srcs})
    endif()
-
+ 
 +  if(MSVC)
 +    target_compile_options(onnxruntime_providers_cuda PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/bigobj>)
 +  endif()
@@ -36,7 +36,7 @@ index 91707c4..243783b 100644
 @@ -241,8 +244,8 @@
                ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED} Boost::mp11 safeint_interface)
      endif()
-
+ 
 -    include(cutlass)
 -    target_include_directories(${target} PRIVATE ${cutlass_SOURCE_DIR}/include ${cutlass_SOURCE_DIR}/examples ${cutlass_SOURCE_DIR}/tools/util/include)
 +    find_package(NvidiaCutlass REQUIRED)

--- a/.github/overlays/onnxruntime/fix-cmake.patch
+++ b/.github/overlays/onnxruntime/fix-cmake.patch
@@ -28,10 +28,10 @@ index ffe8661..a3e9b4f 100644
 +++ b/cmake/onnxruntime_webassembly.cmake
 @@ -94,7 +94,7 @@ if (NOT onnxruntime_ENABLE_WEBASSEMBLY_THREADS)
    )
-
+ 
    # Override re2 compiler options to remove -pthread
 -  set_property(TARGET re2 PROPERTY COMPILE_OPTIONS )
 +  # set_property(TARGET re2 PROPERTY COMPILE_OPTIONS )
  endif()
-
+ 
  if (NOT onnxruntime_USE_VCPKG)

--- a/.github/overlays/onnxruntime/skip-avx-ne-convert-asm-on-linux.patch
+++ b/.github/overlays/onnxruntime/skip-avx-ne-convert-asm-on-linux.patch
@@ -21,7 +21,7 @@ index c2924f5310..8400d44460 100644
 +++ b/onnxruntime/core/mlas/lib/platform.cpp
 @@ -509,7 +509,7 @@ MLAS_PLATFORM::MLAS_PLATFORM(void)
                  }
-
+ 
  #ifndef __APPLE__
 -#if (defined(_MSC_VER) && (_MSC_VER >= 1933)) || (defined(__GNUC__) && (__GNUC__ >= 13))
 +#if (defined(_MSC_VER) && (_MSC_VER >= 1933)) || (defined(__GNUC__) && (__GNUC__ >= 13) && !defined(__linux__))

--- a/.github/overlays/onnxruntime/skip-protobuf-in-moe-cuda-tu.patch
+++ b/.github/overlays/onnxruntime/skip-protobuf-in-moe-cuda-tu.patch
@@ -5,13 +5,13 @@ index 0000000000..1111111111 100644
 @@ -42,7 +42,11 @@
  #include <cub/device/device_radix_sort.cuh>
  #include <cub/util_type.cuh>
-
+ 
 -#include "contrib_ops/cuda/utils/dump_cuda_tensor.h"
 +// dump_cuda_tensor.h drags onnx protobuf headers into this CUDA TU; protobuf
 +// 6.x declares an incomplete-type variable template (EnumTraitsImpl::value)
 +// that nvcc rejects. The DUMP_* macros are no-ops at DUMP_TENSOR_LEVEL 0, so
 +// only the macro definitions are needed here.
 +#include "contrib_ops/cpu/utils/debug_macros.h"
-
+ 
  namespace ort_fastertransformer {
  static constexpr int WARP_SIZE = 32;


### PR DESCRIPTION
On Windows/vcpkg, CMake’s patch application path is stricter here and rejected the patch as corrupt 