### PR TITLE
Add headless camera-path render mode (--render-camera-path)

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -24,13 +24,18 @@
 #include "visualizer/visualizer.hpp"
 
 #include "app/mcp_gui_tools.hpp"
+#include "io/loader.hpp"
 #include "io/video/video_encoder.hpp"
 #include "mcp/mcp_http_server.hpp"
 #include "mcp/mcp_tools.hpp"
 #include "python/runner.hpp"
+#include "rendering/coordinate_conventions.hpp"
+#include "sequencer/timeline.hpp"
+#include "training/rasterization/fast_rasterizer.hpp"
 #include "visualizer/gui/panels/python_scripts_panel.hpp"
 #include "visualizer/gui/video_widget_interface.hpp"
 #include "visualizer/gui/windows/video_extractor_dialog.hpp"
+#include <cmath>
 #include <cstdlib>
 #include <cuda_runtime.h>
 #include <future>
@@ -315,6 +320,149 @@ namespace lfs::app {
             return 0;
         }
 
+        // Loads a trained scene (no Trainer/optimizer loop) and a
+        // sequencer::Timeline JSON camera-keyframe path, renders it
+        // frame-by-frame with the same GUI-free CUDA rasterizer the training
+        // loop's --timelapse-images feature already uses headlessly, and
+        // encodes straight to the requested output file. No window, no
+        // Vulkan, no native save dialog.
+        int runHeadlessRender(std::unique_ptr<lfs::core::param::TrainingParameters> params) {
+            const auto& cfg = *params->render_path;
+
+            checkCudaDriverVersion();
+
+            // Load the trained scene.
+            std::shared_ptr<core::SplatData> model;
+            const auto load_ext = cfg.load_path.extension().string();
+            if (load_ext == ".resume") {
+                auto splat_result = core::load_checkpoint_splat_data(cfg.load_path);
+                if (!splat_result) {
+                    LOG_ERROR("Failed to load checkpoint: {}", splat_result.error());
+                    return 1;
+                }
+                model = std::make_shared<core::SplatData>(std::move(*splat_result));
+            } else {
+                auto loader = lfs::io::Loader::create();
+                auto load_result = loader->load(cfg.load_path);
+                if (!load_result) {
+                    LOG_ERROR("Failed to load scene: {}", load_result.error().message);
+                    return 1;
+                }
+                if (auto* const splat = std::get_if<std::shared_ptr<core::SplatData>>(&load_result->data)) {
+                    model = *splat;
+                } else {
+                    LOG_ERROR("--render-load is not a Gaussian splat scene: {}", core::path_to_utf8(cfg.load_path));
+                    return 1;
+                }
+            }
+            if (!model || model->size() == 0) {
+                LOG_ERROR("Loaded scene has no Gaussians: {}", core::path_to_utf8(cfg.load_path));
+                return 1;
+            }
+
+            // Load the camera-keyframe path (same JSON format the GUI sequencer
+            // reads/writes via Timeline::loadFromJson/saveToJson).
+            lfs::sequencer::Timeline timeline;
+            if (!timeline.loadFromJson(core::path_to_utf8(cfg.camera_path)) || timeline.empty()) {
+                LOG_ERROR("Failed to load camera path (or it has no keyframes): {}", core::path_to_utf8(cfg.camera_path));
+                return 1;
+            }
+
+            // Solid black background, matching Trainer's default bg_color init.
+            auto background = core::Tensor::empty({3}, core::Device::CPU, core::DataType::Float32);
+            {
+                auto* const bg_ptr = background.ptr<float>();
+                bg_ptr[0] = bg_ptr[1] = bg_ptr[2] = 0.0f;
+            }
+            background = background.to(core::Device::CUDA);
+
+            lfs::io::video::VideoEncoder encoder;
+            lfs::io::video::VideoExportOptions options;
+            options.preset = lfs::io::video::VideoPreset::CUSTOM;
+            options.width = cfg.width;
+            options.height = cfg.height;
+            options.framerate = cfg.fps;
+            options.crf = cfg.crf;
+            if (const auto open_result = encoder.open(cfg.output_path, options); !open_result) {
+                LOG_ERROR("Failed to open video encoder: {}", open_result.error());
+                return 1;
+            }
+
+            const float duration = timeline.duration();
+            const int total_frames = static_cast<int>(std::ceil(duration * cfg.fps)) + 1;
+            LOG_INFO("Rendering {} frame(s) ({:.2f}s @ {}fps) from {} to {}",
+                     total_frames, duration, cfg.fps,
+                     core::path_to_utf8(cfg.camera_path), core::path_to_utf8(cfg.output_path));
+
+            for (int frame = 0; frame < total_frames; ++frame) {
+                const float t = std::min(static_cast<float>(frame) / static_cast<float>(cfg.fps), duration);
+                const auto cam_state = timeline.evaluate(t);
+
+                // CameraState.rotation is the camera's orientation in world space
+                // (camera-to-world), matching how the GUI viewport consumes it
+                // (see async_task_manager.cpp's makeVideoExportViewport, which
+                // uses glm::mat3_cast(cam_state.rotation) directly as a
+                // camera-to-world orientation). lfs::core::Camera's R/T
+                // constructor args are world-to-camera (COLMAP convention:
+                // p_cam = R*p_world + T, see io/formats/colmap.cpp's
+                // qvec2rotmat()/R,T construction) - invert accordingly.
+                const glm::mat3 r_c2w = glm::mat3_cast(cam_state.rotation);
+                const glm::mat3 r_w2c = glm::transpose(r_c2w);
+                const glm::vec3 t_w2c = -(r_w2c * cam_state.position);
+
+                std::vector<float> r_flat(9);
+                for (int row = 0; row < 3; ++row) {
+                    for (int col = 0; col < 3; ++col) {
+                        r_flat[row * 3 + col] = r_w2c[col][row]; // glm is column-major
+                    }
+                }
+                auto R = core::Tensor::from_vector(r_flat, {3, 3}, core::Device::CPU);
+                auto T = core::Tensor::from_vector(
+                    std::vector<float>{t_w2c.x, t_w2c.y, t_w2c.z}, {3}, core::Device::CPU);
+
+                const auto [focal_x, focal_y] = rendering::computePixelFocalLengths(
+                    {cfg.width, cfg.height}, cam_state.focal_length_mm);
+
+                core::Camera camera(
+                    R, T,
+                    focal_x, focal_y,
+                    static_cast<float>(cfg.width) * 0.5f, static_cast<float>(cfg.height) * 0.5f,
+                    core::Tensor::empty({0}, core::Device::CPU),
+                    core::Tensor::empty({0}, core::Device::CPU),
+                    core::CameraModelType::PINHOLE,
+                    std::format("frame_{:06d}", frame),
+                    {}, {},
+                    cfg.width, cfg.height,
+                    frame);
+
+                auto render_output = training::fast_rasterize(camera, *model, background);
+                auto image = render_output.image;
+                if (image.dtype() != core::DataType::Float32) {
+                    image = image.to(core::DataType::Float32);
+                }
+                if (image.device() != core::Device::CUDA) {
+                    image = image.cuda();
+                }
+                auto image_hwc = image.permute({1, 2, 0}).contiguous();
+
+                const auto write_result = encoder.writeFrameGpu(image_hwc.data_ptr(), cfg.width, cfg.height, nullptr);
+                if (!write_result) {
+                    LOG_ERROR("Failed to encode frame {}: {}", frame, write_result.error());
+                    encoder.close();
+                    return 1;
+                }
+                LOG_INFO("Encoded frame {}/{}", frame + 1, total_frames);
+            }
+
+            if (const auto close_result = encoder.close(); !close_result) {
+                LOG_ERROR("Failed to finalize video: {}", close_result.error());
+                return 1;
+            }
+
+            LOG_INFO("Wrote {} frame(s) to {}", total_frames, core::path_to_utf8(cfg.output_path));
+            return 0;
+        }
+
         bool checkCudaDriverVersion() {
             const auto info = lfs::core::check_cuda_version();
             if (info.query_failed) {
@@ -492,6 +640,10 @@ namespace lfs::app {
                  .cuda_stream = p.stream,
                  .output_uint8 = p.output_uint8});
         });
+
+        if (params->render_path) {
+            return runHeadlessRender(std::move(params));
+        }
 
         if (params->optimization.headless && params->server.tcp_connection) {
             return runHeadlessWithTCP(std::move(params));

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -320,12 +320,7 @@ namespace lfs::app {
             return 0;
         }
 
-        // Loads a trained scene (no Trainer/optimizer loop) and a
-        // sequencer::Timeline JSON camera-keyframe path, renders it
-        // frame-by-frame with the same GUI-free CUDA rasterizer the training
-        // loop's --timelapse-images feature already uses headlessly, and
-        // encodes straight to the requested output file. No window, no
-        // Vulkan, no native save dialog.
+        // Renders a sequencer camera path against a trained scene to a video file, headless.
         int runHeadlessRender(std::unique_ptr<lfs::core::param::TrainingParameters> params) {
             const auto& cfg = *params->render_path;
 
@@ -360,8 +355,6 @@ namespace lfs::app {
                 return 1;
             }
 
-            // Load the camera-keyframe path (same JSON format the GUI sequencer
-            // reads/writes via Timeline::loadFromJson/saveToJson).
             lfs::sequencer::Timeline timeline;
             if (!timeline.loadFromJson(core::path_to_utf8(cfg.camera_path)) || timeline.empty()) {
                 LOG_ERROR("Failed to load camera path (or it has no keyframes): {}", core::path_to_utf8(cfg.camera_path));
@@ -398,14 +391,7 @@ namespace lfs::app {
                 const float t = std::min(static_cast<float>(frame) / static_cast<float>(cfg.fps), duration);
                 const auto cam_state = timeline.evaluate(t);
 
-                // CameraState.rotation is the camera's orientation in world space
-                // (camera-to-world), matching how the GUI viewport consumes it
-                // (see async_task_manager.cpp's makeVideoExportViewport, which
-                // uses glm::mat3_cast(cam_state.rotation) directly as a
-                // camera-to-world orientation). lfs::core::Camera's R/T
-                // constructor args are world-to-camera (COLMAP convention:
-                // p_cam = R*p_world + T, see io/formats/colmap.cpp's
-                // qvec2rotmat()/R,T construction) - invert accordingly.
+                // CameraState is camera-to-world; Camera's R/T are world-to-camera, so invert.
                 const glm::mat3 r_c2w = glm::mat3_cast(cam_state.rotation);
                 const glm::mat3 r_w2c = glm::transpose(r_c2w);
                 const glm::vec3 t_w2c = -(r_w2c * cam_state.position);

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -179,6 +179,7 @@ namespace {
                 "EXAMPLES:\n"
                 "lichtfeld-studio -d ./data -o ./output\n"
                 "lichtfeld-studio --resume checkpoint.resume\n"
+                "lichtfeld-studio --render-camera-path path.json --render-load model.ply --render-output out.mp4\n"
                 "lichtfeld-studio -v model.ply\n"
                 "lichtfeld-studio convert in.ply out.spz\n"
                 "lichtfeld-studio mesh2splat model.obj -o model_splat.ply\n"
@@ -197,6 +198,7 @@ namespace {
             ::args::Flag version(mode_group, "version", "Display version information", {'V', "version"});
             ::args::ValueFlag<std::string> view_ply(mode_group, "path", "View file(s). Supports splat (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz) and mesh (.obj, .fbx, .gltf, .glb, .stl) formats. If directory, loads all.", {'v', "view"});
             ::args::ValueFlag<std::string> resume_checkpoint(mode_group, "checkpoint", "Resume training from checkpoint file", {"resume"});
+            ::args::ValueFlag<std::string> render_camera_path(mode_group, "path", "Render a JSON camera-keyframe path to video, headless (no GUI/window). Requires --render-load and --render-output; see RENDER PATH options.", {"render-camera-path"});
             ::args::CompletionFlag completion(parser, {"complete"});
 
             // =============================================================================
@@ -214,6 +216,18 @@ namespace {
             ::args::Flag exclude_export(paths_group, "exclude_export", "Exclude frozen --add-splat rows from PLY exports", {"exclude-export"});
 
             ::args::ValueFlag<std::string> import_cameras(paths_group, "path", "Import COLMAP cameras from sparse folder (no images required)", {"import-cameras"});
+
+            // =============================================================================
+            // RENDER PATH (used with --render-camera-path)
+            // =============================================================================
+            ::args::Group render_path_sep(parser, " ");
+            ::args::Group render_path_group(parser, "RENDER PATH (used with --render-camera-path):");
+            ::args::ValueFlag<std::string> render_load(render_path_group, "path", "Trained scene to render (.ply/.sog/.spz or .resume checkpoint)", {"render-load"});
+            ::args::ValueFlag<std::string> render_output(render_path_group, "path", "Output video file (.mp4)", {"render-output"});
+            ::args::ValueFlag<int> render_width(render_path_group, "width", "Output width (default 1920)", {"render-width"});
+            ::args::ValueFlag<int> render_height(render_path_group, "height", "Output height (default 1080)", {"render-height"});
+            ::args::ValueFlag<int> render_fps(render_path_group, "fps", "Output framerate (default 30)", {"render-fps"});
+            ::args::ValueFlag<int> render_crf(render_path_group, "crf", "Video quality, lower=better (default 18)", {"render-crf"});
 
             // =============================================================================
             // TRAINING PARAMETERS
@@ -466,6 +480,47 @@ namespace {
                 if (gut) {
                     params.optimization.gut = true;
                 }
+                return std::make_tuple(ParseResult::Success, std::function<void()>{});
+            }
+
+            // Headless camera-path -> video render mode: no training, no window.
+            if (render_camera_path) {
+                const auto& camera_path_str = ::args::get(render_camera_path);
+                const auto camera_path = lfs::core::utf8_to_path(camera_path_str);
+                if (!std::filesystem::exists(camera_path)) {
+                    return std::unexpected(std::format("Camera path file does not exist: {}", camera_path_str));
+                }
+                if (!render_load || ::args::get(render_load).empty()) {
+                    return std::unexpected(std::format(
+                        "ERROR: --render-camera-path requires --render-load\n\n{}", parser.Help()));
+                }
+                if (!render_output || ::args::get(render_output).empty()) {
+                    return std::unexpected(std::format(
+                        "ERROR: --render-camera-path requires --render-output\n\n{}", parser.Help()));
+                }
+                const auto load_path = lfs::core::utf8_to_path(::args::get(render_load));
+                if (!std::filesystem::exists(load_path)) {
+                    return std::unexpected(std::format("Scene to render does not exist: {}", ::args::get(render_load)));
+                }
+
+                lfs::core::param::RenderPathConfig cfg;
+                cfg.camera_path = camera_path;
+                cfg.load_path = load_path;
+                cfg.output_path = lfs::core::utf8_to_path(::args::get(render_output));
+                if (render_width) {
+                    cfg.width = ::args::get(render_width);
+                }
+                if (render_height) {
+                    cfg.height = ::args::get(render_height);
+                }
+                if (render_fps) {
+                    cfg.fps = ::args::get(render_fps);
+                }
+                if (render_crf) {
+                    cfg.crf = ::args::get(render_crf);
+                }
+                params.render_path = cfg;
+
                 return std::make_tuple(ParseResult::Success, std::function<void()>{});
             }
 

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -260,6 +260,20 @@ namespace lfs::core {
             static ServerConfig from_json(const nlohmann::json& j);
         };
 
+        // Headless camera-path -> video render mode (see --render-camera-path):
+        // load a trained scene and a sequencer::Timeline JSON keyframe path,
+        // render it frame-by-frame, and encode directly to an output video file.
+        // No training, no GUI/window.
+        struct LFS_CORE_API RenderPathConfig {
+            std::filesystem::path camera_path; // sequencer::Timeline JSON (see Timeline::loadFromJson)
+            std::filesystem::path load_path;   // trained scene: .ply/.sog/.spz or .resume checkpoint
+            std::filesystem::path output_path; // destination .mp4
+            int width = 1920;
+            int height = 1080;
+            int fps = 30;
+            int crf = 18;
+        };
+
         struct LFS_CORE_API TrainingParameters {
             DatasetConfig dataset;
             OptimizationParameters optimization;
@@ -281,6 +295,9 @@ namespace lfs::core {
 
             // Checkpoint to resume training from
             std::optional<std::filesystem::path> resume_checkpoint = std::nullopt;
+
+            // Headless camera-path -> video render mode (see --render-camera-path)
+            std::optional<RenderPathConfig> render_path = std::nullopt;
 
             // Python scripts to execute for custom training callbacks
             std::vector<std::filesystem::path> python_scripts;

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -260,12 +260,9 @@ namespace lfs::core {
             static ServerConfig from_json(const nlohmann::json& j);
         };
 
-        // Headless camera-path -> video render mode (see --render-camera-path):
-        // load a trained scene and a sequencer::Timeline JSON keyframe path,
-        // render it frame-by-frame, and encode directly to an output video file.
-        // No training, no GUI/window.
+        // Headless camera-path -> video render mode (see --render-camera-path)
         struct LFS_CORE_API RenderPathConfig {
-            std::filesystem::path camera_path; // sequencer::Timeline JSON (see Timeline::loadFromJson)
+            std::filesystem::path camera_path; // sequencer::Timeline JSON keyframe path
             std::filesystem::path load_path;   // trained scene: .ply/.sog/.spz or .resume checkpoint
             std::filesystem::path output_path; // destination .mp4
             int width = 1920;


### PR DESCRIPTION
## Summary
- Adds a `--render-camera-path` CLI mode that loads a trained scene (.ply/.sog/.spz or .resume checkpoint) and a sequencer `Timeline` JSON camera-keyframe path, and renders it frame-by-frame to a video file
- Fully headless: no GUI/window, reusing the same CUDA rasterizer path the training loop's `--timelapse-images` feature already uses
- New `--render-load`, `--render-output`, `--render-width`, `--render-height`, `--render-fps`, `--render-crf` options control the render

## Example usage

```
lichtfeld-studio --render-camera-path path.json \
  --render-load model.ply \
  --render-output out.mp4 \
  --render-width 1920 --render-height 1080 --render-fps 30
```

## Sample camera-path JSON

The `--render-camera-path` file is the same keyframe format the GUI sequencer reads/writes:

```json
{
  "version": 4,
  "clip_duration": 4.0,
  "keyframes": [
    {
      "time": 0.0,
      "position": [-0.228, 0.902, -4.038],
      "rotation": [0.987, 0.0, 0.161, 0.0],
      "focal_length_mm": 24.0,
      "easing": 0
    },
    {
      "time": 4.0,
      "position": [0.811, 0.902, -0.220],
      "rotation": [0.992, 0.0, 0.129, 0.0],
      "focal_length_mm": 24.0,
      "easing": 0
    }
  ]
}
```

## Test plan
- [x] Built and ran `--render-camera-path path.json --render-load model.ply --render-output out.mp4` against a real trained scene (`.ply`) and a sequencer-exported camera path JSON on GPU (H100) — completed with no errors, 421 frames encoded
- [x] Confirmed output video matches the timeline: `ffprobe` shows 640x360, 30fps, 14.000s duration, exactly matching the camera path's `clip_duration: 14.0`
- [x] Verified error handling: missing `--render-load` and missing `--render-output` both print a clear `ERROR: --render-camera-path requires ...` message and exit 1; nonexistent camera path and nonexistent scene file each print a specific `Error: ... does not exist` message and exit non-zero