### PR TITLE
Clamped color gradient [Volinga]

### DIFF
--- a/src/training/rasterization/fastgs/rasterization/include/kernels_backward.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernels_backward.cuh
@@ -489,7 +489,7 @@ namespace fast_lfs::rasterization::kernels::backward {
                     const float3 color_unclamped = primitive_color[primitive_idx];
                     color = fminf(fmaxf(color_unclamped, 0.0f), config::max_blend_color);
                     depth = primitive_depths[primitive_idx];
-                    color_grad_factor = color_grad_factor = make_float3(
+                    color_grad_factor = make_float3(
                         color_unclamped.x <= config::max_blend_color ? 1.0f : 0.0f,
                         color_unclamped.y <= config::max_blend_color ? 1.0f : 0.0f,
                         color_unclamped.z <= config::max_blend_color ? 1.0f : 0.0f);

--- a/src/training/rasterization/fastgs/rasterization/include/kernels_backward.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernels_backward.cuh
@@ -489,10 +489,10 @@ namespace fast_lfs::rasterization::kernels::backward {
                     const float3 color_unclamped = primitive_color[primitive_idx];
                     color = fminf(fmaxf(color_unclamped, 0.0f), config::max_blend_color);
                     depth = primitive_depths[primitive_idx];
-                    color_grad_factor = make_float3(
-                        (color_unclamped.x >= 0.0f && color_unclamped.x <= config::max_blend_color) ? 1.0f : 0.0f,
-                        (color_unclamped.y >= 0.0f && color_unclamped.y <= config::max_blend_color) ? 1.0f : 0.0f,
-                        (color_unclamped.z >= 0.0f && color_unclamped.z <= config::max_blend_color) ? 1.0f : 0.0f);
+                    color_grad_factor = color_grad_factor = make_float3(
+                        color_unclamped.x <= config::max_blend_color ? 1.0f : 0.0f,
+                        color_unclamped.y <= config::max_blend_color ? 1.0f : 0.0f,
+                        color_unclamped.z <= config::max_blend_color ? 1.0f : 0.0f);
                 }
             }
 


### PR DESCRIPTION
I have found the following behaviour where gaussians with a strongly negative SH0 color will stop updating their colors. Colors outside `[0, max_blend_color]` get a 0 gradient factor and can never climb out of black leaving permanently dark gaussians. The issue seems to be mitigated (and hidden) since position, scale, rotation and opacity are still updated.

This fix changes the clamp on the gradient for the backward pass (forward still clamps as before).

I also ran a few fast tests on the truck dataset (MCMC, 500K splats, 10K iter, resize factor = 2). There are no big changes to the naked eye but the average loss seems to be better. All runs took a similar amount of time.

```
+-----+----------------+------------------+
| Run | Loss with fix  | Loss without fix |
+-----+----------------+------------------+
| 1   | 0.030854       | 0.052152         |
| 2   | 0.033743       | 0.047833         |
| 3   | 0.032813       | 0.048883         |
| 4   | 0.040502       | 0.046050         |
| 5   | 0.035585       | 0.054314         |
+-----+----------------+------------------+
```

<img width="1781" height="655" alt="image" src="https://github.com/user-attachments/assets/4e2a4c7c-0edc-4f94-8ca6-291b21f7de5e" />
