### PR TITLE
Harden tensor library

### DIFF
--- a/src/core/cuda/kernels/kmeans_new.cu
+++ b/src/core/cuda/kernels/kmeans_new.cu
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/cuda/kmeans.cuh"
+#include "core/logger.hpp"
 #include "core/tensor.hpp"
 #include <cuda_runtime.h>
 #include <curand_kernel.h>

--- a/src/core/include/core/pinned_memory_allocator.hpp
+++ b/src/core/include/core/pinned_memory_allocator.hpp
@@ -74,6 +74,9 @@ namespace lfs::core {
          */
         void record_stream(void* ptr, cudaStream_t stream);
 
+        /** Returns whether an active allocation can be read directly by CUDA kernels. */
+        bool is_cuda_host_allocation(const void* ptr) const;
+
         /**
          * @brief Severs references to `stream` before it is destroyed: waits for
          * its pending work, then drops it from all recorded uses.

--- a/src/core/include/core/tensor_fwd.hpp
+++ b/src/core/include/core/tensor_fwd.hpp
@@ -12,6 +12,8 @@ namespace lfs::core {
 
     class Tensor;
 
+    inline constexpr size_t MAX_TENSOR_RANK = 8;
+
     enum class Device : uint8_t {
         CPU = 0,
         CUDA = 1

--- a/src/core/tensor/cuda_stream_context.cpp
+++ b/src/core/tensor/cuda_stream_context.cpp
@@ -4,6 +4,7 @@
 #include "internal/cuda_stream_context.hpp"
 #include "core/cuda_error.hpp"
 #include "internal/cuda_event_pool.hpp"
+#include "internal/tensor_impl.hpp"
 
 #include <format>
 
@@ -61,6 +62,33 @@ namespace lfs::core {
                                 static_cast<void*>(execution_stream)));
             }
         }
+    }
+
+    cudaStream_t prepare_inputs_for_stream(
+        const std::initializer_list<const Tensor*> inputs,
+        const std::optional<cudaStream_t> requested_stream) {
+        cudaStream_t execution_stream = requested_stream.has_value()
+                                            ? *requested_stream
+                                            : getCurrentCUDAStream();
+        if (!requested_stream.has_value() && execution_stream == nullptr) {
+            for (const Tensor* input : inputs) {
+                LFS_ASSERT_MSG(input != nullptr && input->is_valid(),
+                               "stream preparation requires valid tensor inputs");
+                if (input->device() == Device::CUDA) {
+                    execution_stream = input->stream();
+                    break;
+                }
+            }
+        }
+
+        for (const Tensor* input : inputs) {
+            LFS_ASSERT_MSG(input != nullptr && input->is_valid(),
+                           "stream preparation requires valid tensor inputs");
+            if (input->device() == Device::CUDA) {
+                input->sync_to_stream(execution_stream);
+            }
+        }
+        return execution_stream;
     }
 
 } // namespace lfs::core

--- a/src/core/tensor/internal/cuda_stream_context.hpp
+++ b/src/core/tensor/internal/cuda_stream_context.hpp
@@ -4,8 +4,11 @@
 #pragma once
 
 #include <cuda_runtime.h>
+#include <initializer_list>
+#include <optional>
 
 #include "core/export.hpp"
+#include "core/tensor_fwd.hpp"
 
 namespace lfs::core {
 
@@ -17,6 +20,10 @@ namespace lfs::core {
     // Makes execution_stream wait (GPU-side) for work currently enqueued on
     // dependency_stream. Uses pooled events; falls back to a host sync on failure.
     LFS_CORE_API void waitForCUDAStream(cudaStream_t execution_stream, cudaStream_t dependency_stream);
+
+    LFS_CORE_API cudaStream_t prepare_inputs_for_stream(
+        std::initializer_list<const Tensor*> inputs,
+        std::optional<cudaStream_t> execution_stream = std::nullopt);
 
     /**
      * RAII guard for temporarily setting the current CUDA stream

--- a/src/core/tensor/internal/lazy_executor.hpp
+++ b/src/core/tensor/internal/lazy_executor.hpp
@@ -75,6 +75,10 @@ namespace lfs::core {
             uint64_t peak_cache_bytes = 0;
         };
 
+        // Retain eager operands when a graph is deferred. The returned cell is detached only
+        // if the source storage is subsequently exposed for mutation.
+        LFS_CORE_API std::shared_ptr<Tensor> lazy_executor_snapshot_operand(const Tensor& source);
+
         // Build topological execution plan metadata for a root tensor.
         LFS_CORE_API LazyExecutionPlanDebug lazy_planner_build_plan_for_tensor(const Tensor& output);
 

--- a/src/core/tensor/internal/tensor_broadcast.hpp
+++ b/src/core/tensor/internal/tensor_broadcast.hpp
@@ -3,11 +3,16 @@
 
 #pragma once
 
-#include "tensor_impl.hpp"
 #include <algorithm>
+#include <cstddef>
 #include <ranges>
+#include <span>
+#include <vector>
 
 namespace lfs::core {
+
+    class Tensor;
+    class TensorShape;
 
     // Pure functions for broadcasting - no classes!
     namespace broadcast {
@@ -21,7 +26,7 @@ namespace lfs::core {
          * - Aligns shapes from the right
          * - Dimensions must either match or one must be 1
          * - Result takes the maximum of each dimension
-         * - Handles zero dimensions: 0 can only broadcast with another 0
+         * - A size-1 dimension broadcasts to zero, producing a zero dimension
          */
         inline std::vector<size_t> shape(std::span<const size_t> a, std::span<const size_t> b) {
             size_t max_rank = std::max(a.size(), b.size());
@@ -32,16 +37,14 @@ namespace lfs::core {
                 size_t dim_a = (i < a.size()) ? a[a.size() - 1 - i] : 1;
                 size_t dim_b = (i < b.size()) ? b[b.size() - 1 - i] : 1;
 
-                // Handle zero dimensions
-                if (dim_a == 0 && dim_b == 0) {
-                    result[max_rank - 1 - i] = 0;
-                } else if (dim_a == 0 || dim_b == 0) {
-                    // Can't broadcast 0 with non-zero (except matching 0)
-                    return {}; // Incompatible
-                } else if (dim_a != dim_b && dim_a != 1 && dim_b != 1) {
-                    return {}; // Incompatible
+                if (dim_a == dim_b) {
+                    result[max_rank - 1 - i] = dim_a;
+                } else if (dim_a == 1) {
+                    result[max_rank - 1 - i] = dim_b;
+                } else if (dim_b == 1) {
+                    result[max_rank - 1 - i] = dim_a;
                 } else {
-                    result[max_rank - 1 - i] = std::max(dim_a, dim_b);
+                    return {}; // Incompatible
                 }
             }
             return result;
@@ -58,10 +61,6 @@ namespace lfs::core {
             for (size_t i = 0; i < max_rank; ++i) {
                 size_t dim_a = (i < a.size()) ? a[a.size() - 1 - i] : 1;
                 size_t dim_b = (i < b.size()) ? b[b.size() - 1 - i] : 1;
-                if (dim_a == 0 && dim_b == 0)
-                    continue;
-                if (dim_a == 0 || dim_b == 0)
-                    return false;
                 if (dim_a != dim_b && dim_a != 1 && dim_b != 1)
                     return false;
             }

--- a/src/core/tensor/internal/tensor_broadcast_ops.cuh
+++ b/src/core/tensor/internal/tensor_broadcast_ops.cuh
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "core/cuda_error.hpp"
-#include "core/logger.hpp"
-#include "memory_pool.hpp"
+#include "core/assert.hpp"
+#include "core/tensor_fwd.hpp"
+#include <algorithm>
 #include <cuda_runtime.h>
 #include <type_traits>
 
@@ -726,59 +726,70 @@ namespace lfs::core::tensor_ops {
     // BINARY BROADCAST KERNEL (Generic fallback)
     // ============================================================================
 
+    struct BroadcastBinaryParams {
+        size_t a_shape[MAX_TENSOR_RANK];
+        size_t b_shape[MAX_TENSOR_RANK];
+        size_t c_shape[MAX_TENSOR_RANK];
+        int a_rank;
+        int b_rank;
+        int c_rank;
+        size_t c_elements;
+    };
+
     template <typename T, typename OutputT, typename BinaryOp>
     __global__ void broadcast_binary_kernel(
-        const T* a, const T* b, OutputT* c,
-        const int* a_shape, const int* b_shape, const int* c_shape,
-        int a_rank, int b_rank, int c_rank,
-        size_t c_elements, BinaryOp op) {
+        const T* a, const T* b, OutputT* c, BroadcastBinaryParams params,
+        BinaryOp op) {
         size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-        if (idx >= c_elements)
+        if (idx >= params.c_elements)
             return;
 
         // Compute strides inline
-        int c_strides[8], a_strides[8], b_strides[8];
+        size_t c_strides[MAX_TENSOR_RANK];
+        size_t a_strides[MAX_TENSOR_RANK];
+        size_t b_strides[MAX_TENSOR_RANK];
 
-        c_strides[c_rank - 1] = 1;
-        for (int i = c_rank - 2; i >= 0; --i) {
-            c_strides[i] = c_strides[i + 1] * c_shape[i + 1];
+        c_strides[params.c_rank - 1] = 1;
+        for (int i = params.c_rank - 2; i >= 0; --i) {
+            c_strides[i] = c_strides[i + 1] * params.c_shape[i + 1];
         }
 
-        if (a_rank > 0) {
-            a_strides[a_rank - 1] = 1;
-            for (int i = a_rank - 2; i >= 0; --i) {
-                a_strides[i] = a_strides[i + 1] * a_shape[i + 1];
+        if (params.a_rank > 0) {
+            a_strides[params.a_rank - 1] = 1;
+            for (int i = params.a_rank - 2; i >= 0; --i) {
+                a_strides[i] = a_strides[i + 1] * params.a_shape[i + 1];
             }
         }
 
-        if (b_rank > 0) {
-            b_strides[b_rank - 1] = 1;
-            for (int i = b_rank - 2; i >= 0; --i) {
-                b_strides[i] = b_strides[i + 1] * b_shape[i + 1];
+        if (params.b_rank > 0) {
+            b_strides[params.b_rank - 1] = 1;
+            for (int i = params.b_rank - 2; i >= 0; --i) {
+                b_strides[i] = b_strides[i + 1] * params.b_shape[i + 1];
             }
         }
 
         // Broadcast indexing
-        int a_idx = 0, b_idx = 0;
+        size_t a_idx = 0;
+        size_t b_idx = 0;
         size_t remaining = idx;
 
-        for (int i = 0; i < c_rank; ++i) {
-            int c_coord = remaining / c_strides[i];
+        for (int i = 0; i < params.c_rank; ++i) {
+            const size_t c_coord = remaining / c_strides[i];
             remaining %= c_strides[i];
 
             // Map to a's coordinate
-            int offset_a = c_rank - a_rank;
+            const int offset_a = params.c_rank - params.a_rank;
             if (i >= offset_a) {
-                int dim = i - offset_a;
-                int coord = (a_shape[dim] == 1) ? 0 : c_coord;
+                const int dim = i - offset_a;
+                const size_t coord = (params.a_shape[dim] == 1) ? 0 : c_coord;
                 a_idx += coord * a_strides[dim];
             }
 
             // Map to b's coordinate
-            int offset_b = c_rank - b_rank;
+            const int offset_b = params.c_rank - params.b_rank;
             if (i >= offset_b) {
-                int dim = i - offset_b;
-                int coord = (b_shape[dim] == 1) ? 0 : c_coord;
+                const int dim = i - offset_b;
+                const size_t coord = (params.b_shape[dim] == 1) ? 0 : c_coord;
                 b_idx += coord * b_strides[dim];
             }
         }
@@ -797,6 +808,10 @@ namespace lfs::core::tensor_ops {
                                  const size_t* a_shape, const size_t* b_shape, const size_t* c_shape,
                                  size_t a_rank, size_t b_rank, size_t c_rank,
                                  size_t c_elements, BinaryOp op, cudaStream_t stream) {
+        LFS_ASSERT_MSG(a_rank <= MAX_TENSOR_RANK &&
+                           b_rank <= MAX_TENSOR_RANK &&
+                           c_rank <= MAX_TENSOR_RANK,
+                       "Binary broadcast rank exceeds MAX_TENSOR_RANK");
         if (c_elements == 0)
             return;
 
@@ -1028,56 +1043,25 @@ namespace lfs::core::tensor_ops {
         // Generic kernel for all types and complex patterns
         const int block_size = 256;
 
-        // Generic N-D broadcast - use existing implementation
-        int* d_a_shape = static_cast<int*>(
-            CudaMemoryPool::instance().allocate(a_rank * sizeof(int), stream));
-        int* d_b_shape = static_cast<int*>(
-            CudaMemoryPool::instance().allocate(b_rank * sizeof(int), stream));
-        int* d_c_shape = static_cast<int*>(
-            CudaMemoryPool::instance().allocate(c_rank * sizeof(int), stream));
-
-        if (!d_a_shape || !d_b_shape || !d_c_shape) {
-            LOG_ERROR("Failed to allocate shape arrays from memory pool");
-            if (d_a_shape)
-                CudaMemoryPool::instance().deallocate(d_a_shape, stream);
-            if (d_b_shape)
-                CudaMemoryPool::instance().deallocate(d_b_shape, stream);
-            if (d_c_shape)
-                CudaMemoryPool::instance().deallocate(d_c_shape, stream);
-            return;
-        }
-
-        std::vector<int> a_vec(a_shape, a_shape + a_rank);
-        std::vector<int> b_vec(b_shape, b_shape + b_rank);
-        std::vector<int> c_vec(c_shape, c_shape + c_rank);
-
-        // Use async memcpy to avoid synchronization overhead
-        LFS_CUDA_CHECK_MSG(
-            cudaMemcpyAsync(d_a_shape, a_vec.data(), a_rank * sizeof(int),
-                            cudaMemcpyHostToDevice, stream),
-            "broadcast lhs shape copy (rank={})", a_rank);
-        LFS_CUDA_CHECK_MSG(
-            cudaMemcpyAsync(d_b_shape, b_vec.data(), b_rank * sizeof(int),
-                            cudaMemcpyHostToDevice, stream),
-            "broadcast rhs shape copy (rank={})", b_rank);
-        LFS_CUDA_CHECK_MSG(
-            cudaMemcpyAsync(d_c_shape, c_vec.data(), c_rank * sizeof(int),
-                            cudaMemcpyHostToDevice, stream),
-            "broadcast output shape copy (rank={})", c_rank);
+        LFS_ASSERT_MSG(c_rank > 0,
+                       "Generic binary broadcast requires a non-scalar output");
+        BroadcastBinaryParams params{};
+        params.a_rank = static_cast<int>(a_rank);
+        params.b_rank = static_cast<int>(b_rank);
+        params.c_rank = static_cast<int>(c_rank);
+        params.c_elements = c_elements;
+        std::copy_n(a_shape, a_rank, params.a_shape);
+        std::copy_n(b_shape, b_rank, params.b_shape);
+        std::copy_n(c_shape, c_rank, params.c_shape);
 
         const int grid_size = (c_elements + block_size - 1) / block_size;
 
 #ifdef __CUDACC__
         broadcast_binary_kernel<<<grid_size, block_size, 0, stream>>>(
-            a, b, c, d_a_shape, d_b_shape, d_c_shape,
-            a_rank, b_rank, c_rank, c_elements, op);
+            a, b, c, params, op);
 #else
         static_assert(sizeof(T) == 0, "CUDA compiler required for broadcast operations");
 #endif
-
-        CudaMemoryPool::instance().deallocate(d_a_shape, stream);
-        CudaMemoryPool::instance().deallocate(d_b_shape, stream);
-        CudaMemoryPool::instance().deallocate(d_c_shape, stream);
     }
 
 } // namespace lfs::core::tensor_ops

--- a/src/core/tensor/internal/tensor_dtype_dispatch.hpp
+++ b/src/core/tensor/internal/tensor_dtype_dispatch.hpp
@@ -1,0 +1,127 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include "core/assert.hpp"
+#include "core/tensor_fwd.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <cuda_fp16.h>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace lfs::core::detail {
+
+    template <typename Function>
+    void dispatch_dtype(const DataType dtype, Function&& function) {
+        switch (dtype) {
+        case DataType::Float32:
+            std::forward<Function>(function).template operator()<float>();
+            return;
+        case DataType::Float16:
+            std::forward<Function>(function).template operator()<__half>();
+            return;
+        case DataType::Int32:
+            std::forward<Function>(function).template operator()<int32_t>();
+            return;
+        case DataType::Int64:
+            std::forward<Function>(function).template operator()<int64_t>();
+            return;
+        case DataType::UInt8:
+            std::forward<Function>(function).template operator()<uint8_t>();
+            return;
+        case DataType::Bool:
+            std::forward<Function>(function).template operator()<bool>();
+            return;
+        }
+
+        LFS_ASSERT_MSG(false,
+                       "unsupported dtype reached exhaustive tensor dispatch");
+    }
+
+    inline void require_scalar_representable(const DataType dtype,
+                                             const float value,
+                                             const std::string_view operation) {
+        const auto failure = [&](const std::string_view reason) {
+            LFS_ASSERT_MSG(false, std::string(operation) + ": " + std::string(reason));
+        };
+
+        switch (dtype) {
+        case DataType::Float32:
+        case DataType::Bool:
+            return;
+        case DataType::Float16:
+            if (std::isfinite(value) && std::abs(value) > 65504.0f) {
+                failure("scalar is outside the Float16 range");
+            }
+            return;
+        case DataType::Int32:
+            if (!std::isfinite(value) ||
+                static_cast<double>(value) <
+                    static_cast<double>(std::numeric_limits<int32_t>::lowest()) ||
+                static_cast<double>(value) >
+                    static_cast<double>(std::numeric_limits<int32_t>::max())) {
+                failure("scalar is outside the Int32 range");
+            }
+            return;
+        case DataType::Int64:
+            if (!std::isfinite(value) ||
+                static_cast<long double>(value) <
+                    static_cast<long double>(std::numeric_limits<int64_t>::lowest()) ||
+                static_cast<long double>(value) >
+                    static_cast<long double>(std::numeric_limits<int64_t>::max())) {
+                failure("scalar is outside the Int64 range");
+            }
+            return;
+        case DataType::UInt8:
+            if (!std::isfinite(value) || value < 0.0f || value > 255.0f) {
+                failure("scalar is outside the UInt8 range");
+            }
+            return;
+        }
+
+        failure("unsupported dtype");
+    }
+
+    inline bool is_exact_int32_scalar(const float value) {
+        return std::isfinite(value) && std::trunc(value) == value &&
+               static_cast<double>(value) >=
+                   static_cast<double>(std::numeric_limits<int32_t>::lowest()) &&
+               static_cast<double>(value) <=
+                   static_cast<double>(std::numeric_limits<int32_t>::max());
+    }
+
+    __host__ __device__ inline uint8_t torch_uint8_cast(const float value) {
+#ifdef __CUDA_ARCH__
+        if (!isfinite(value)) {
+            return 0;
+        }
+        float wrapped = fmodf(truncf(value), 256.0f);
+#else
+        if (!std::isfinite(value)) {
+            return 0;
+        }
+        float wrapped = std::fmod(std::trunc(value), 256.0f);
+#endif
+        if (wrapped < 0.0f) {
+            wrapped += 256.0f;
+        }
+        return static_cast<uint8_t>(wrapped);
+    }
+
+    __host__ __device__ inline uint8_t torch_uint8_cast(const __half value) {
+        return torch_uint8_cast(__half2float(value));
+    }
+
+    template <typename T>
+        requires std::is_integral_v<T>
+    __host__ __device__ inline uint8_t torch_uint8_cast(const T value) {
+        return static_cast<uint8_t>(value);
+    }
+
+} // namespace lfs::core::detail

--- a/src/core/tensor/internal/tensor_expr.hpp
+++ b/src/core/tensor/internal/tensor_expr.hpp
@@ -61,6 +61,8 @@ namespace lfs::core {
         Device device() const { return derived().device_impl(); }
         DataType dtype() const { return derived().dtype_impl(); }
         cudaStream_t stream_hint() const { return derived().stream_hint_impl(); }
+
+        Derived snapshot() const { return derived().snapshot_impl(); }
     };
 
     // ============================================================================
@@ -73,9 +75,11 @@ namespace lfs::core {
         std::shared_ptr<Tensor> tensor_ptr_;
 
     public:
-        explicit TensorLeaf(Tensor tensor); // Implemented in .cpp
+        explicit TensorLeaf(Tensor tensor);                  // Implemented in .cpp
+        explicit TensorLeaf(std::shared_ptr<Tensor> tensor); // Implemented in .cpp
 
-        Tensor eval_impl() const; // Implemented in .cpp
+        Tensor eval_impl() const;         // Implemented in .cpp
+        TensorLeaf snapshot_impl() const; // Implemented in .cpp
 
         const TensorShape& shape_impl() const;
         Device device_impl() const;
@@ -119,6 +123,10 @@ namespace lfs::core {
         // Evaluation: implemented in tensor_expr_impl.hpp (needs full Tensor definition)
         Tensor eval_impl() const;
 
+        UnaryExpr snapshot_impl() const {
+            return UnaryExpr(input_.snapshot(), op_, shape_, device_, dtype_);
+        }
+
         // Compose with another unary operation (fusion opportunity!)
         template <typename NewOp>
         auto map(NewOp new_op) const {
@@ -159,6 +167,10 @@ namespace lfs::core {
 
         // FUSION DETECTED! Implemented in tensor_expr_impl.hpp
         Tensor eval_impl() const;
+
+        UnaryExpr snapshot_impl() const {
+            return UnaryExpr(inner_expr_.snapshot(), outer_op_, shape_, device_, dtype_);
+        }
 
         // Continue fusion chain
         template <typename NewOp>
@@ -201,6 +213,10 @@ namespace lfs::core {
 
         // Implemented in tensor_expr_impl.hpp
         Tensor eval_impl() const;
+
+        BinaryExpr snapshot_impl() const {
+            return BinaryExpr(left_.snapshot(), right_.snapshot(), op_, shape_, device_, dtype_);
+        }
 
         // Apply unary operation to result (fuses with binary op)
         template <typename UnaryOp>
@@ -249,6 +265,10 @@ namespace lfs::core {
         // Implemented in tensor_expr_impl.hpp
         Tensor eval_impl() const;
 
+        ScalarUnaryExpr snapshot_impl() const {
+            return ScalarUnaryExpr(input_.snapshot(), op_, shape_, device_, dtype_);
+        }
+
         template <typename NewOp>
         auto map(NewOp new_op) const {
             auto fused_op = ops::compose(op_, new_op);
@@ -290,6 +310,11 @@ namespace lfs::core {
 
         // Implemented in tensor_expr_impl.hpp
         Tensor eval_impl() const;
+
+        PermutationExpr snapshot_impl() const {
+            return PermutationExpr(
+                input_.snapshot(), indices_.snapshot(), shape_, device_, dtype_);
+        }
 
         // Apply unary operation to gathered result (fuses with gather!)
         template <typename UnaryOp>
@@ -337,6 +362,10 @@ namespace lfs::core {
 
         // FUSED gather + unary! Implemented in tensor_expr_impl.hpp
         Tensor eval_impl() const;
+
+        UnaryExpr snapshot_impl() const {
+            return UnaryExpr(perm_expr_.snapshot(), op_, shape_, device_, dtype_);
+        }
 
         const TensorShape& shape_impl() const { return shape_; }
         Device device_impl() const { return device_; }

--- a/src/core/tensor/internal/tensor_expr_impl.hpp
+++ b/src/core/tensor/internal/tensor_expr_impl.hpp
@@ -36,6 +36,7 @@ namespace lfs::core {
             return expr.eval();
         }
 
+        expr = expr.snapshot();
         const cudaStream_t stream_hint = expr.stream_hint_impl();
         Tensor deferred = Tensor::make_deferred_expr_tensor(
             shape, device, dtype,
@@ -50,35 +51,6 @@ namespace lfs::core {
 
     // Helper struct for eval_impl dispatch based on operation return type
     namespace detail {
-        inline cudaStream_t resolve_cuda_execution_stream(const Tensor& primary) {
-            cudaStream_t execution_stream = getCurrentCUDAStream();
-            if (execution_stream == nullptr && primary.device() == Device::CUDA) {
-                execution_stream = primary.stream();
-            }
-            return execution_stream;
-        }
-
-        inline cudaStream_t resolve_cuda_execution_stream(const Tensor& primary, const Tensor& secondary) {
-            cudaStream_t execution_stream = resolve_cuda_execution_stream(primary);
-            if (execution_stream == nullptr && secondary.device() == Device::CUDA) {
-                execution_stream = secondary.stream();
-            }
-            return execution_stream;
-        }
-
-        inline cudaStream_t prepare_cuda_execution_stream(const Tensor& primary) {
-            const cudaStream_t execution_stream = resolve_cuda_execution_stream(primary);
-            primary.sync_to_stream(execution_stream);
-            return execution_stream;
-        }
-
-        inline cudaStream_t prepare_cuda_execution_stream(const Tensor& primary, const Tensor& secondary) {
-            const cudaStream_t execution_stream = resolve_cuda_execution_stream(primary, secondary);
-            primary.sync_to_stream(execution_stream);
-            secondary.sync_to_stream(execution_stream);
-            return execution_stream;
-        }
-
         inline void validate_permutation_indices(const Tensor& input, const Tensor& indices) {
             if (indices.numel() == 0) {
                 return;
@@ -115,7 +87,7 @@ namespace lfs::core {
 
                 std::optional<CUDAStreamGuard> execution_guard;
                 if (device == Device::CUDA) {
-                    execution_guard.emplace(prepare_cuda_execution_stream(input_tensor));
+                    execution_guard.emplace(prepare_inputs_for_stream({&input_tensor}));
                 }
 
                 // Create result tensor (needs Tensor::empty)
@@ -180,7 +152,7 @@ namespace lfs::core {
                 } else {
                     // Float -> Float operations (default case)
                     if (device == Device::CUDA) {
-                        tensor_ops::launch_unary_op_generic(
+                        tensor_ops::launch_float_unary_with_numeric_policy(
                             input_tensor.template ptr<float>(),
                             result.template ptr<float>(),
                             result.numel(), op, result.stream());
@@ -213,7 +185,7 @@ namespace lfs::core {
 
                 std::optional<CUDAStreamGuard> execution_guard;
                 if (device == Device::CUDA) {
-                    execution_guard.emplace(prepare_cuda_execution_stream(input_tensor));
+                    execution_guard.emplace(prepare_inputs_for_stream({&input_tensor}));
                 }
 
                 // Create result tensor (Bool dtype)
@@ -317,7 +289,7 @@ namespace lfs::core {
 
         std::optional<CUDAStreamGuard> execution_guard;
         if (device_ == Device::CUDA) {
-            execution_guard.emplace(detail::prepare_cuda_execution_stream(base));
+            execution_guard.emplace(prepare_inputs_for_stream({&base}));
         }
 
         // Create result tensor
@@ -362,7 +334,7 @@ namespace lfs::core {
 
                 std::optional<CUDAStreamGuard> execution_guard;
                 if (device == Device::CUDA) {
-                    execution_guard.emplace(prepare_cuda_execution_stream(left_tensor, right_tensor));
+                    execution_guard.emplace(prepare_inputs_for_stream({&left_tensor, &right_tensor}));
                 }
 
                 // Create result tensor
@@ -582,7 +554,7 @@ namespace lfs::core {
                     if (device == Device::CUDA) {
                         if (needs_broadcast) {
                             // Use broadcast binary kernel
-                            tensor_ops::launch_broadcast_binary(
+                            tensor_ops::launch_float_broadcast_with_numeric_policy(
                                 left_tensor.template ptr<float>(),
                                 right_tensor.template ptr<float>(),
                                 result.template ptr<float>(),
@@ -593,7 +565,7 @@ namespace lfs::core {
                                 result.numel(), op, result.stream());
                         } else {
                             // Element-wise binary operation (no broadcasting)
-                            tensor_ops::launch_binary_op_generic(
+                            tensor_ops::launch_float_binary_with_numeric_policy(
                                 left_tensor.template ptr<float>(),
                                 right_tensor.template ptr<float>(),
                                 result.template ptr<float>(),
@@ -650,7 +622,7 @@ namespace lfs::core {
 
                 std::optional<CUDAStreamGuard> execution_guard;
                 if (device == Device::CUDA) {
-                    execution_guard.emplace(prepare_cuda_execution_stream(left_tensor, right_tensor));
+                    execution_guard.emplace(prepare_inputs_for_stream({&left_tensor, &right_tensor}));
                 }
 
                 // Create result tensor (Bool dtype)
@@ -987,7 +959,7 @@ namespace lfs::core {
 
         std::optional<CUDAStreamGuard> execution_guard;
         if (device_ == Device::CUDA) {
-            execution_guard.emplace(detail::prepare_cuda_execution_stream(input_tensor));
+            execution_guard.emplace(prepare_inputs_for_stream({&input_tensor}));
         }
 
         Tensor result = Tensor::empty(shape_, device_, dtype_);
@@ -1057,7 +1029,7 @@ namespace lfs::core {
 
         std::optional<CUDAStreamGuard> execution_guard;
         if (device_ == Device::CUDA) {
-            execution_guard.emplace(detail::prepare_cuda_execution_stream(flat_input, indices_tensor));
+            execution_guard.emplace(prepare_inputs_for_stream({&flat_input, &indices_tensor}));
         }
 
         // Create result tensor

--- a/src/core/tensor/internal/tensor_functors.hpp
+++ b/src/core/tensor/internal/tensor_functors.hpp
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <bit>
 #include <cmath>
+#include <cstdint>
 #include <type_traits>
 
 #ifndef M_PI
@@ -20,6 +22,52 @@
 
 namespace lfs::core {
     namespace ops {
+
+        HOST_DEVICE inline uint32_t float_bits(float value) {
+#ifdef __CUDA_ARCH__
+            return __float_as_uint(value);
+#else
+            return std::bit_cast<uint32_t>(value);
+#endif
+        }
+
+        HOST_DEVICE inline bool float_is_nan(float value) {
+            const uint32_t bits = float_bits(value);
+            return (bits & 0x7f800000U) == 0x7f800000U &&
+                   (bits & 0x007fffffU) != 0;
+        }
+
+        HOST_DEVICE inline bool float_is_finite(float value) {
+            return (float_bits(value) & 0x7f800000U) != 0x7f800000U;
+        }
+
+        HOST_DEVICE inline bool float_sign_bit(float value) {
+            return (float_bits(value) & 0x80000000U) != 0;
+        }
+
+        struct sort_less_op {
+            HOST_DEVICE bool operator()(float a, float b) const {
+                const bool a_nan = float_is_nan(a);
+                const bool b_nan = float_is_nan(b);
+                if (a_nan != b_nan)
+                    return !a_nan;
+                if (a_nan)
+                    return false;
+                return a < b;
+            }
+        };
+
+        struct sort_greater_op {
+            HOST_DEVICE bool operator()(float a, float b) const {
+                const bool a_nan = float_is_nan(a);
+                const bool b_nan = float_is_nan(b);
+                if (a_nan != b_nan)
+                    return a_nan;
+                if (a_nan)
+                    return false;
+                return a > b;
+            }
+        };
 
         // Helper for clamping (std::clamp not always available in CUDA)
         template <typename T>
@@ -62,7 +110,7 @@ namespace lfs::core {
         struct reciprocal_op {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& x) const {
-                return T(1) / (x + T(1e-8));
+                return T(1) / x;
             }
         };
 
@@ -103,9 +151,9 @@ namespace lfs::core {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& x) const {
 #ifdef __CUDA_ARCH__
-                return logf(fmaxf(x, T(1e-10)));
+                return logf(x);
 #else
-                return std::log(std::max(x, T(1e-10)));
+                return std::log(x);
 #endif
             }
         };
@@ -114,9 +162,9 @@ namespace lfs::core {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& x) const {
 #ifdef __CUDA_ARCH__
-                return log2f(fmaxf(x, T(1e-10)));
+                return log2f(x);
 #else
-                return std::log2(std::max(x, T(1e-10)));
+                return std::log2(x);
 #endif
             }
         };
@@ -125,9 +173,9 @@ namespace lfs::core {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& x) const {
 #ifdef __CUDA_ARCH__
-                return log10f(fmaxf(x, T(1e-10)));
+                return log10f(x);
 #else
-                return std::log10(std::max(x, T(1e-10)));
+                return std::log10(x);
 #endif
             }
         };
@@ -147,9 +195,9 @@ namespace lfs::core {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& x) const {
 #ifdef __CUDA_ARCH__
-                return sqrtf(fmaxf(x, T(0)));
+                return sqrtf(x);
 #else
-                return std::sqrt(std::max(x, T(0)));
+                return std::sqrt(x);
 #endif
             }
         };
@@ -158,9 +206,9 @@ namespace lfs::core {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& x) const {
 #ifdef __CUDA_ARCH__
-                return rsqrtf(fmaxf(x, T(1e-10)));
+                return rsqrtf(x);
 #else
-                return T(1) / std::sqrt(std::max(x, T(1e-10)));
+                return T(1) / std::sqrt(x);
 #endif
             }
         };
@@ -297,9 +345,9 @@ namespace lfs::core {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& x) const {
 #ifdef __CUDA_ARCH__
-                return fmaxf(x, T(0));
+                return isnan(static_cast<float>(x)) ? x : fmaxf(x, T(0));
 #else
-                return std::max(x, T(0));
+                return std::isnan(static_cast<float>(x)) ? x : std::max(x, T(0));
 #endif
             }
         };
@@ -364,11 +412,40 @@ namespace lfs::core {
                 if constexpr (std::is_integral_v<T>)
                     return x;
                 else {
+                    if constexpr (std::is_same_v<T, float>) {
+                        if (!float_is_finite(x))
+                            return x;
 #ifdef __CUDA_ARCH__
-                    return roundf(x);
+                        const T lower = floorf(x);
+                        const T fraction = x - lower;
+                        T rounded = fraction < T(0.5f)
+                                        ? lower
+                                    : fraction > T(0.5f)
+                                        ? lower + T(1)
+                                        : (fmodf(lower, T(2)) == T(0)
+                                               ? lower
+                                               : lower + T(1));
 #else
-                    return std::round(x);
+                        const T lower = std::floor(x);
+                        const T fraction = x - lower;
+                        T rounded = fraction < T(0.5f)
+                                        ? lower
+                                    : fraction > T(0.5f)
+                                        ? lower + T(1)
+                                        : (std::fmod(lower, T(2)) == T(0)
+                                               ? lower
+                                               : lower + T(1));
 #endif
+                        if (rounded == T(0) && float_sign_bit(x))
+                            return T(-0.0f);
+                        return rounded;
+                    } else {
+#ifdef __CUDA_ARCH__
+                        return nearbyint(x);
+#else
+                        return std::nearbyint(x);
+#endif
+                    }
                 }
             }
         };
@@ -491,9 +568,9 @@ namespace lfs::core {
         struct mod_op {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& a, const T& b) const {
-                if constexpr (std::is_integral_v<T>)
-                    return a % b;
-                else {
+                if constexpr (std::is_integral_v<T>) {
+                    return b == 0 ? T{0} : a % b;
+                } else {
 #ifdef __CUDA_ARCH__
                     return fmodf(a, b);
 #else
@@ -528,22 +605,60 @@ namespace lfs::core {
         struct maximum_op {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& a, const T& b) const {
+                if constexpr (std::is_floating_point_v<T>) {
 #ifdef __CUDA_ARCH__
-                return fmaxf(a, b);
+                    if constexpr (std::is_same_v<T, float>) {
+                        if (float_is_nan(a))
+                            return a;
+                        if (float_is_nan(b))
+                            return b;
+                        if (a == T(0) && b == T(0)) {
+                            return float_sign_bit(a) && float_sign_bit(b) ? T(-0.0f) : T(0.0f);
+                        }
+                    } else {
+                        if (isnan(a))
+                            return a;
+                        if (isnan(b))
+                            return b;
+                    }
 #else
-                return std::max(a, b);
+                    if (std::isnan(a))
+                        return a;
+                    if (std::isnan(b))
+                        return b;
 #endif
+                }
+                return a < b ? b : a;
             }
         };
 
         struct minimum_op {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& a, const T& b) const {
+                if constexpr (std::is_floating_point_v<T>) {
 #ifdef __CUDA_ARCH__
-                return fminf(a, b);
+                    if constexpr (std::is_same_v<T, float>) {
+                        if (float_is_nan(a))
+                            return a;
+                        if (float_is_nan(b))
+                            return b;
+                        if (a == T(0) && b == T(0)) {
+                            return float_sign_bit(a) || float_sign_bit(b) ? T(-0.0f) : T(0.0f);
+                        }
+                    } else {
+                        if (isnan(a))
+                            return a;
+                        if (isnan(b))
+                            return b;
+                    }
 #else
-                return std::min(a, b);
+                    if (std::isnan(a))
+                        return a;
+                    if (std::isnan(b))
+                        return b;
 #endif
+                }
+                return b < a ? b : a;
             }
         };
 
@@ -785,22 +900,48 @@ namespace lfs::core {
         struct max_reduce_op {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& a, const T& b) const {
-#ifdef __CUDA_ARCH__
-                return fmaxf(a, b);
-#else
-                return std::max(a, b);
-#endif
+                if constexpr (std::is_floating_point_v<T>) {
+                    if constexpr (std::is_same_v<T, float>) {
+                        if (float_is_nan(a))
+                            return a;
+                        if (float_is_nan(b))
+                            return b;
+                        if (a == T(0) && b == T(0)) {
+                            return float_sign_bit(a) && float_sign_bit(b) ? T(-0.0f) : T(0.0f);
+                        }
+                    } else {
+                        if (std::isnan(a))
+                            return a;
+                        if (std::isnan(b))
+                            return b;
+                    }
+                    return a < b ? b : a;
+                }
+                return a < b ? b : a;
             }
         };
 
         struct min_reduce_op {
             template <typename T>
             HOST_DEVICE constexpr T operator()(const T& a, const T& b) const {
-#ifdef __CUDA_ARCH__
-                return fminf(a, b);
-#else
-                return std::min(a, b);
-#endif
+                if constexpr (std::is_floating_point_v<T>) {
+                    if constexpr (std::is_same_v<T, float>) {
+                        if (float_is_nan(a))
+                            return a;
+                        if (float_is_nan(b))
+                            return b;
+                        if (a == T(0) && b == T(0)) {
+                            return float_sign_bit(a) || float_sign_bit(b) ? T(-0.0f) : T(0.0f);
+                        }
+                    } else {
+                        if (std::isnan(a))
+                            return a;
+                        if (std::isnan(b))
+                            return b;
+                    }
+                    return b < a ? b : a;
+                }
+                return b < a ? b : a;
             }
         };
 
@@ -1138,8 +1279,11 @@ namespace lfs::core {
             HOST_DEVICE constexpr T operator()(size_t idx) const {
                 if (steps <= 1)
                     return start;
-                T t = static_cast<T>(idx) / static_cast<T>(steps - 1);
-                return start + t * (end - start);
+                const T step = (end - start) / static_cast<T>(steps - 1);
+                if (idx < steps / 2) {
+                    return start + step * static_cast<T>(idx);
+                }
+                return end - step * static_cast<T>(steps - idx - 1);
             }
         };
 

--- a/src/core/tensor/internal/tensor_impl.hpp
+++ b/src/core/tensor/internal/tensor_impl.hpp
@@ -14,10 +14,12 @@
 #include <concepts>
 #include <cstring>
 #include <cuda_runtime.h>
+#include <deque>
 #include <functional>
 #include <initializer_list>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <random>
 #include <span>
@@ -33,6 +35,8 @@
 #include "lazy_config.hpp"
 #include "lazy_executor.hpp"
 #include "lazy_ir.hpp"
+#include "tensor_broadcast.hpp"
+#include "tensor_dtype_dispatch.hpp"
 #include "tensor_functors.hpp"
 #include "tensor_ops.hpp"
 
@@ -41,6 +45,22 @@
 namespace lfs::core {
 
     namespace detail {
+        constexpr size_t tensor_logical_rank(const size_t physical_rank) {
+            return physical_rank == 0 ? 1 : physical_rank;
+        }
+
+        constexpr int resolve_tensor_dim(const int dim, const size_t physical_rank) {
+            return dim < 0
+                       ? static_cast<int>(tensor_logical_rank(physical_rank)) + dim
+                       : dim;
+        }
+
+        constexpr bool tensor_dim_is_valid(const int resolved_dim,
+                                           const size_t physical_rank) {
+            return resolved_dim >= 0 &&
+                   resolved_dim < static_cast<int>(tensor_logical_rank(physical_rank));
+        }
+
         template <typename T>
         constexpr const char* tensor_cpp_type_name() {
             using Value = std::remove_cv_t<T>;
@@ -228,6 +248,8 @@ namespace lfs::core {
 
     private:
         void compute_total() {
+            LFS_ASSERT_MSG(dims_.size() <= MAX_TENSOR_RANK,
+                           "Tensor rank exceeds MAX_TENSOR_RANK");
             if (dims_.empty()) {
                 total_elements_ = 1;
             } else {
@@ -333,7 +355,8 @@ namespace lfs::core {
         uint64_t get_seed() const { return seed_; }
         void* get_generator(Device device);
         uint64_t get_next_cuda_seed();
-        uint64_t get_next_cuda_offset(); // Get next offset for cuRAND generator
+        void generate_cuda_normal(float* output, size_t count, float mean, float std,
+                                  cudaStream_t stream);
         void* get_impl() { return impl_; }
         const void* get_impl() const { return impl_; }
 
@@ -349,6 +372,9 @@ namespace lfs::core {
 
     struct StorageMeta {
         std::atomic<uint64_t> generation{0};
+        std::atomic<uint32_t> pending_lazy_snapshots{0};
+        std::mutex lazy_snapshot_mutex;
+        std::vector<std::weak_ptr<Tensor>> lazy_snapshots;
         std::string external_kind;
         std::shared_ptr<void> external_owner;
     };
@@ -363,6 +389,9 @@ namespace lfs::core {
     class LFS_CORE_API Tensor {
     private:
         friend struct internal::LazyIrTensorAccess;
+        friend class TensorLeaf;
+        friend std::shared_ptr<Tensor> internal::lazy_executor_snapshot_operand(
+            const Tensor& source);
 
         struct TensorState {
             // Capacity management for in-place growth (like std::vector)
@@ -463,6 +492,27 @@ namespace lfs::core {
             storage_meta_ = std::make_shared<StorageMeta>();
         }
 
+        template <typename Deleter>
+        void adopt_storage(void* data, Deleter&& deleter) {
+            using StoredDeleter = std::decay_t<Deleter>;
+            struct StorageOwner {
+                void* data;
+                StoredDeleter deleter;
+                StorageMeta meta;
+
+                StorageOwner(void* data_value, StoredDeleter&& deleter_value)
+                    : data(data_value),
+                      deleter(std::move(deleter_value)) {}
+
+                ~StorageOwner() { deleter(data); }
+            };
+
+            auto owner = std::make_shared<StorageOwner>(
+                data, StoredDeleter(std::forward<Deleter>(deleter)));
+            data_owner_ = std::shared_ptr<void>(owner, data);
+            storage_meta_ = std::shared_ptr<StorageMeta>(owner, &owner->meta);
+        }
+
         void ensure_storage_meta() {
             if (!storage_meta_) {
                 storage_meta_ = std::make_shared<StorageMeta>();
@@ -474,6 +524,11 @@ namespace lfs::core {
                 storage_meta_->generation.fetch_add(1, std::memory_order_relaxed);
             }
         }
+
+        std::shared_ptr<Tensor> create_lazy_snapshot() const;
+        void register_lazy_snapshot_cell(const std::shared_ptr<Tensor>& snapshot) const;
+        void preserve_lazy_snapshots_before_write();
+        void replace_lazy_snapshot_storage(Tensor&& replacement);
 
         bool has_external_storage() const {
             return storage_meta_ && !storage_meta_->external_kind.empty();
@@ -500,13 +555,52 @@ namespace lfs::core {
                 storage_meta_->generation.load(std::memory_order_relaxed);
         }
 
+        const Tensor& contiguous_read(Tensor& materialized) const {
+            if (is_contiguous()) {
+                return *this;
+            }
+
+            materialized = contiguous();
+            LFS_ASSERT_MSG(materialized.is_contiguous(),
+                           "non-contiguous read materialization must produce dense storage");
+            return materialized;
+        }
+
+        template <typename Mutation>
+        Tensor& mutate_logical_view(Mutation&& mutation) {
+            LFS_ASSERT_MSG(!is_contiguous(),
+                           "logical-view writeback is only valid for non-contiguous destinations");
+            Tensor materialized = contiguous();
+            LFS_ASSERT_MSG(materialized.is_contiguous(),
+                           "logical-view write staging must produce dense storage");
+            std::forward<Mutation>(mutation)(materialized);
+            return copy_from(materialized);
+        }
+
+        bool shares_storage_with(const Tensor& other) const {
+            if (storage_meta_ && other.storage_meta_ && storage_meta_ == other.storage_meta_) {
+                return true;
+            }
+            return data_owner_ && other.data_owner_ &&
+                   !data_owner_.owner_before(other.data_owner_) &&
+                   !other.data_owner_.owner_before(data_owner_);
+        }
+
         // Generic functor-based binary operation (zero enum overhead)
         template <typename SrcT, typename OutT, typename Op>
         Tensor binary_op_generic(const Tensor& other, Op op) const {
             validate_binary_op(other, false, true);
 
+            Tensor lhs_materialized;
+            Tensor rhs_materialized;
+            const Tensor& lhs_dense = contiguous_read(lhs_materialized);
+            const Tensor& rhs_dense = other.contiguous_read(rhs_materialized);
+            if (&lhs_dense != this || &rhs_dense != &other) {
+                return lhs_dense.binary_op_generic<SrcT, OutT>(rhs_dense, op);
+            }
+
             auto broadcast_shape = this->broadcast_shape(other.shape());
-            if (broadcast_shape.rank() == 0) {
+            if (!broadcast::can_broadcast(shape_.dims(), other.shape_.dims())) {
                 throw std::runtime_error(
                     "Incompatible shapes for broadcasting: " + shape_.str() + " vs " + other.shape_.str());
             }
@@ -643,6 +737,13 @@ namespace lfs::core {
                 *this, DataType::Float32, "in-place scalar operation", "input",
                 LFS_SOURCE_SITE_CURRENT());
 
+            if (!is_contiguous()) {
+                return mutate_logical_view(
+                    [&](Tensor& materialized) {
+                        materialized.scalar_op_inplace_generic(scalar, op);
+                    });
+            }
+
             if (device_ == Device::CUDA) {
                 tensor_ops::launch_scalar_op_generic(
                     ptr<float>(), scalar, ptr<float>(),
@@ -684,14 +785,24 @@ namespace lfs::core {
                 *this, DataType::Float32, "in-place binary operation", "destination",
                 LFS_SOURCE_SITE_CURRENT());
 
+            if (!is_contiguous()) {
+                return mutate_logical_view(
+                    [&](Tensor& materialized) {
+                        materialized.binary_op_inplace_generic<SrcT>(other, op);
+                    });
+            }
+
+            Tensor other_materialized;
+            const Tensor& other_dense = other.contiguous_read(other_materialized);
+
             if (device_ == Device::CUDA) {
                 tensor_ops::launch_binary_op_generic(
-                    ptr<SrcT>(), other.ptr<SrcT>(), ptr<SrcT>(),
+                    ptr<SrcT>(), other_dense.ptr<SrcT>(), ptr<SrcT>(),
                     numel(), op, stream());
                 // No sync - tensor operation
             } else {
                 // CPU implementation
-                apply_binary_cpu(ptr<SrcT>(), other.ptr<SrcT>(), ptr<SrcT>(),
+                apply_binary_cpu(ptr<SrcT>(), other_dense.ptr<SrcT>(), ptr<SrcT>(),
                                  numel(), op);
             }
 
@@ -703,7 +814,7 @@ namespace lfs::core {
         int resolve_dim(int dim) const {
             if (!is_valid())
                 return -1;
-            return dim < 0 ? static_cast<int>(shape_.rank()) + dim : dim;
+            return detail::resolve_tensor_dim(dim, shape_.rank());
         }
 
         // Validation helpers - throw on error
@@ -720,16 +831,7 @@ namespace lfs::core {
             if (!require_same_shape && shape_ != other.shape()) {
                 const auto& a = shape_.dims();
                 const auto& b = other.shape_.dims();
-                size_t max_rank = std::max(a.size(), b.size());
-                bool compatible = true;
-                for (size_t i = 0; i < max_rank && compatible; ++i) {
-                    size_t da = (i < a.size()) ? a[a.size() - 1 - i] : 1;
-                    size_t db = (i < b.size()) ? b[b.size() - 1 - i] : 1;
-                    if (da == 0 && db == 0)
-                        continue;
-                    compatible = (da == db || da == 1 || db == 1) && da != 0 && db != 0;
-                }
-                if (!compatible) {
+                if (!broadcast::can_broadcast(a, b)) {
                     throw std::runtime_error("Incompatible shapes for broadcasting: " + shape_.str() + " vs " + other.shape_.str());
                 }
             }
@@ -741,11 +843,16 @@ namespace lfs::core {
         // unary/scalar chains — deferring binary ops provides no fusion benefit
         // and creates dangerous reference chains when stored in member variables.
         template <typename Op>
-        Tensor binary_op_with_promotion(const Tensor& other, Op op) const {
+        Tensor binary_op_with_promotion(const Tensor& other, Op op,
+                                        bool true_division = false) const {
             validate_binary_op(other, false, true);
 
             // Determine promoted dtype for the result
             DataType result_dtype = promote_dtypes(dtype_, other.dtype());
+            if (true_division && result_dtype != DataType::Float32 &&
+                result_dtype != DataType::Float16) {
+                result_dtype = DataType::Float32;
+            }
             LFS_ASSERT_MSG(result_dtype != DataType::Bool,
                            "arithmetic on two Bool tensors is unsupported; use a logical operation");
 
@@ -872,6 +979,38 @@ namespace lfs::core {
             view.storage_offset_ = storage_offset_;
             view.is_view_ = true;
             view.is_contiguous_ = true;
+            propagate_view_meta(view);
+            return view;
+        }
+
+        Tensor create_strided_view(const TensorShape& new_shape,
+                                   std::vector<size_t> new_strides) const {
+            LFS_ASSERT_MSG(new_strides.size() == new_shape.rank(),
+                           "strided view shape and stride ranks must match");
+            LFS_ASSERT_MSG(new_shape.elements() == numel(),
+                           "metadata-only view must preserve the logical element count");
+
+            Tensor view;
+            view.data_ = data_;
+            view.data_owner_ = data_owner_;
+            view.shape_ = new_shape;
+            view.strides_ = std::move(new_strides);
+            view.storage_offset_ = storage_offset_;
+            view.device_ = device_;
+            view.dtype_ = dtype_;
+            view.is_view_ = true;
+            view.id_ = profiling_enabled_ ? next_id_++ : 0;
+
+            size_t expected_stride = 1;
+            view.is_contiguous_ = true;
+            for (int dimension = static_cast<int>(new_shape.rank()) - 1;
+                 dimension >= 0; --dimension) {
+                if (view.strides_[dimension] != expected_stride) {
+                    view.is_contiguous_ = false;
+                    break;
+                }
+                expected_stride *= new_shape[dimension];
+            }
             propagate_view_meta(view);
             return view;
         }
@@ -1139,6 +1278,7 @@ namespace lfs::core {
 
         template <typename T>
         T* ptr() {
+            preserve_lazy_snapshots_before_write();
             return const_cast<T*>(std::as_const(*this).template ptr<T>());
         }
 
@@ -1153,12 +1293,10 @@ namespace lfs::core {
                     (std::is_same_v<Value, float> && dtype_ == DataType::Float32) ||
                     (std::is_same_v<Value, __half> && dtype_ == DataType::Float16) ||
                     ((std::is_same_v<Value, int> || std::is_same_v<Value, int32_t> ||
-                      std::is_same_v<Value, uint32_t>) &&
-                     dtype_ == DataType::Int32) ||
+                      std::is_same_v<Value, uint32_t>)&&dtype_ == DataType::Int32) ||
                     (std::is_same_v<Value, int64_t> && dtype_ == DataType::Int64) ||
                     ((std::is_same_v<Value, bool> || std::is_same_v<Value, unsigned char> ||
-                      std::is_same_v<Value, uint8_t>) &&
-                     (dtype_ == DataType::Bool || dtype_ == DataType::UInt8));
+                      std::is_same_v<Value, uint8_t>)&&(dtype_ == DataType::Bool || dtype_ == DataType::UInt8));
                 LFS_ASSERT_MSG(dtype_matches,
                                "ptr<T>() type does not match tensor dtype");
             }
@@ -1171,6 +1309,7 @@ namespace lfs::core {
 
         void* data_ptr() {
             materialize_if_deferred();
+            preserve_lazy_snapshots_before_write();
             tensor_contract::require_valid(
                 *this, "data_ptr", "tensor", LFS_SOURCE_SITE_CURRENT());
             assert_view_not_stale();
@@ -1191,6 +1330,7 @@ namespace lfs::core {
         // Base of allocation (for memory management only)
         void* storage_ptr() {
             materialize_if_deferred();
+            preserve_lazy_snapshots_before_write();
             tensor_contract::require_valid(
                 *this, "storage_ptr", "tensor", LFS_SOURCE_SITE_CURRENT());
             return data_;
@@ -1213,6 +1353,7 @@ namespace lfs::core {
         bool has_lazy_expr() const {
             return (state_ && state_->has_deferred_expr) || internal::tensor_has_lazy_expr(*this);
         }
+        bool is_deferred() const { return state_ && state_->has_deferred_expr; }
         uint64_t lazy_expr_id() const {
             if (state_ && state_->has_deferred_expr && state_->deferred_expr_node_id != 0) {
                 return state_->deferred_expr_node_id;
@@ -1431,11 +1572,15 @@ namespace lfs::core {
                                                              #name, #name, dtype_name(dtype_),                     \
                                                              static_cast<int>(dtype_), shape_.str(),               \
                                                              device_name(device_)));                               \
+        const DataType result_dtype =                                                                              \
+            dtype_ == DataType::Int32 && !ops::supports_int32_v<ops::op_type>                                      \
+                ? DataType::Float32                                                                                \
+                : dtype_;                                                                                          \
         if (numel() == 0) {                                                                                        \
-            return Tensor::empty(shape_, device_, dtype_);                                                         \
+            return Tensor::empty(shape_, device_, result_dtype);                                                   \
         }                                                                                                          \
         Tensor result = UnaryExpr<TensorLeaf, ops::op_type>(                                                       \
-            TensorLeaf(*this), ops::op_type{}, shape_, device_, dtype_);                                           \
+            TensorLeaf(*this), ops::op_type{}, shape_, device_, result_dtype);                                     \
         link_deferred_result_to_inputs(result, {lazy_expr_id()});                                                  \
         return result;                                                                                             \
     }
@@ -1445,11 +1590,15 @@ namespace lfs::core {
         validate_unary_op();                                                              \
         LFS_ASSERT_MSG(dtype_ == DataType::Float32 || dtype_ == DataType::Int32,          \
                        #name " currently supports only Float32 and Int32");               \
+        const DataType result_dtype =                                                     \
+            dtype_ == DataType::Int32 && !ops::supports_int32_v<ops::op_type>             \
+                ? DataType::Float32                                                       \
+                : dtype_;                                                                 \
         if (numel() == 0) {                                                               \
-            return Tensor::empty(shape_, device_, dtype_);                                \
+            return Tensor::empty(shape_, device_, result_dtype);                          \
         }                                                                                 \
         Tensor result = UnaryExpr<TensorLeaf, ops::op_type>(                              \
-            TensorLeaf(*this), ops::op_type{}, shape_, device_, dtype_);                  \
+            TensorLeaf(*this), ops::op_type{}, shape_, device_, result_dtype);            \
         link_deferred_result_to_inputs(result, {lazy_expr_id()});                         \
         if (dtype_ == DataType::Float32 &&                                                \
             result.is_valid() && result.has_lazy_expr()) {                                \
@@ -1559,7 +1708,7 @@ namespace lfs::core {
         }
 
         Tensor div(const Tensor& other) const {
-            return binary_op_with_promotion(other, ops::div_op{});
+            return binary_op_with_promotion(other, ops::div_op{}, true);
         }
 
         Tensor pow(const Tensor& other) const {
@@ -1567,6 +1716,39 @@ namespace lfs::core {
         }
 
         Tensor mod(const Tensor& other) const {
+            if ((dtype_ == DataType::Int32 || dtype_ == DataType::Int64 ||
+                 dtype_ == DataType::UInt8 || dtype_ == DataType::Bool) &&
+                (other.dtype_ == DataType::Int32 || other.dtype_ == DataType::Int64 ||
+                 other.dtype_ == DataType::UInt8 || other.dtype_ == DataType::Bool)) {
+                const Tensor divisor = other.cpu().contiguous();
+                bool contains_zero = false;
+                switch (divisor.dtype_) {
+                case DataType::Int32:
+                    contains_zero = std::find(divisor.ptr<int32_t>(),
+                                              divisor.ptr<int32_t>() + divisor.numel(), 0) !=
+                                    divisor.ptr<int32_t>() + divisor.numel();
+                    break;
+                case DataType::Int64:
+                    contains_zero = std::find(divisor.ptr<int64_t>(),
+                                              divisor.ptr<int64_t>() + divisor.numel(), 0) !=
+                                    divisor.ptr<int64_t>() + divisor.numel();
+                    break;
+                case DataType::UInt8:
+                    contains_zero = std::find(divisor.ptr<uint8_t>(),
+                                              divisor.ptr<uint8_t>() + divisor.numel(), 0) !=
+                                    divisor.ptr<uint8_t>() + divisor.numel();
+                    break;
+                case DataType::Bool:
+                    contains_zero = std::find(divisor.ptr<bool>(),
+                                              divisor.ptr<bool>() + divisor.numel(), false) !=
+                                    divisor.ptr<bool>() + divisor.numel();
+                    break;
+                default:
+                    break;
+                }
+                LFS_ASSERT_MSG(!contains_zero,
+                               "integer modulo divisor must not contain zero");
+            }
             return binary_op_with_promotion(other, ops::mod_op{});
         }
 
@@ -1580,72 +1762,102 @@ namespace lfs::core {
 
     private:
         template <typename T>
-        float validated_scalar_operand(
+        auto validated_scalar_operand(
             const T& value,
             const std::string_view operation,
             const std::initializer_list<DataType> allowed_dtypes) const {
             validate_unary_op();
             tensor_contract::require_dtype(
                 *this, allowed_dtypes, operation, "input", LFS_SOURCE_SITE_CURRENT());
-            const float scalar = static_cast<float>(value);
-            LFS_ASSERT_MSG(std::isfinite(scalar),
-                           std::string(operation) + " scalar must be finite");
-            return scalar;
+            if constexpr (std::is_floating_point_v<T>) {
+                return static_cast<float>(value);
+            } else {
+                LFS_ASSERT_MSG(std::in_range<int32_t>(value),
+                               std::string(operation) + " integer scalar is outside Int32 range");
+                if (dtype_ == DataType::Int32 && operation == "mod") {
+                    LFS_ASSERT_MSG(value != 0,
+                                   "integer modulo divisor must not be zero");
+                }
+                if (dtype_ == DataType::Int32 && operation == "pow") {
+                    LFS_ASSERT_MSG(value >= 0,
+                                   "integer power does not accept a negative integer exponent");
+                }
+                return static_cast<int32_t>(value);
+            }
+        }
+
+        template <typename T>
+        static constexpr DataType scalar_operand_dtype() {
+            return std::is_floating_point_v<T> ? DataType::Float32 : DataType::Int32;
         }
 
     public:
         // Macro for scalar binary operations (lazy evaluation with scalar_right_op)
-#define LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE(name, op_type, fusion_kind)                   \
-    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>           \
-    Tensor name(const T& other) const {                                                   \
-        const float scalar_value = validated_scalar_operand(                              \
-            other, #name, {DataType::Float32, DataType::Int32});                          \
-        if (numel() == 0) {                                                               \
-            return Tensor::empty(shape_, device_, dtype_);                                \
-        }                                                                                 \
-        Tensor result = UnaryExpr<TensorLeaf, ops::scalar_right_op<ops::op_type, float>>( \
-            TensorLeaf(*this), ops::scalar_right_op<ops::op_type, float>(scalar_value),   \
-            shape_, device_, dtype_);                                                     \
-        link_deferred_result_to_inputs(result, {lazy_expr_id()});                         \
-        if (dtype_ == DataType::Float32 &&                                                \
-            result.is_valid() && result.has_lazy_expr()) {                                \
-            const uint64_t result_node_id = result.lazy_expr_id();                        \
-            if (result_node_id != 0 && result.state_) {                                   \
-                internal::lazy_executor_register_pointwise_fusion_op(                     \
-                    result_node_id,                                                       \
-                    lazy_expr_id(),                                                       \
-                    *this,                                                                \
-                    internal::LazyPointwiseOp{internal::LazyPointwiseOpKind::fusion_kind, \
-                                              scalar_value},                              \
-                    std::weak_ptr<void>(result.state_));                                  \
-            }                                                                             \
-        }                                                                                 \
-        return result;                                                                    \
+#define LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE(name, op_type, fusion_kind, true_division)     \
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>            \
+    Tensor name(const T& other) const {                                                    \
+        const auto scalar_value = validated_scalar_operand(                                \
+            other, #name, {DataType::Float32, DataType::Int32});                           \
+        DataType result_dtype = promote_dtypes(dtype_, scalar_operand_dtype<T>());         \
+        if (true_division && result_dtype != DataType::Float32) {                          \
+            result_dtype = DataType::Float32;                                              \
+        }                                                                                  \
+        if (numel() == 0) {                                                                \
+            return Tensor::empty(shape_, device_, result_dtype);                           \
+        }                                                                                  \
+        Tensor scalar_input = dtype_ == result_dtype ? *this : to(result_dtype);           \
+        using Scalar = std::remove_cv_t<decltype(scalar_value)>;                           \
+        Tensor result = UnaryExpr<TensorLeaf, ops::scalar_right_op<ops::op_type, Scalar>>( \
+            TensorLeaf(scalar_input),                                                      \
+            ops::scalar_right_op<ops::op_type, Scalar>(scalar_value),                      \
+            shape_, device_, result_dtype);                                                \
+        link_deferred_result_to_inputs(result, {lazy_expr_id()});                          \
+        if (result_dtype == DataType::Float32 &&                                           \
+            result.is_valid() && result.has_lazy_expr()) {                                 \
+            const uint64_t result_node_id = result.lazy_expr_id();                         \
+            if (result_node_id != 0 && result.state_) {                                    \
+                internal::lazy_executor_register_pointwise_fusion_op(                      \
+                    result_node_id,                                                        \
+                    lazy_expr_id(),                                                        \
+                    scalar_input,                                                          \
+                    internal::LazyPointwiseOp{internal::LazyPointwiseOpKind::fusion_kind,  \
+                                              static_cast<float>(scalar_value)},           \
+                    std::weak_ptr<void>(result.state_));                                   \
+            }                                                                              \
+        }                                                                                  \
+        return result;                                                                     \
     }
 
-#define LFS_DEFINE_SCALAR_BINARY_OP(name, op_type)                                        \
-    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>           \
-    Tensor name(const T& other) const {                                                   \
-        const float scalar_value = validated_scalar_operand(                              \
-            other, #name, {DataType::Float32, DataType::Int32});                          \
-        if (numel() == 0) {                                                               \
-            return Tensor::empty(shape_, device_, dtype_);                                \
-        }                                                                                 \
-        Tensor result = UnaryExpr<TensorLeaf, ops::scalar_right_op<ops::op_type, float>>( \
-            TensorLeaf(*this), ops::scalar_right_op<ops::op_type, float>(scalar_value),   \
-            shape_, device_, dtype_);                                                     \
-        link_deferred_result_to_inputs(result, {lazy_expr_id()});                         \
-        return result;                                                                    \
+#define LFS_DEFINE_SCALAR_BINARY_OP(name, op_type, true_division)                          \
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>            \
+    Tensor name(const T& other) const {                                                    \
+        const auto scalar_value = validated_scalar_operand(                                \
+            other, #name, {DataType::Float32, DataType::Int32});                           \
+        DataType result_dtype = promote_dtypes(dtype_, scalar_operand_dtype<T>());         \
+        if (true_division && result_dtype != DataType::Float32) {                          \
+            result_dtype = DataType::Float32;                                              \
+        }                                                                                  \
+        if (numel() == 0) {                                                                \
+            return Tensor::empty(shape_, device_, result_dtype);                           \
+        }                                                                                  \
+        Tensor scalar_input = dtype_ == result_dtype ? *this : to(result_dtype);           \
+        using Scalar = std::remove_cv_t<decltype(scalar_value)>;                           \
+        Tensor result = UnaryExpr<TensorLeaf, ops::scalar_right_op<ops::op_type, Scalar>>( \
+            TensorLeaf(scalar_input),                                                      \
+            ops::scalar_right_op<ops::op_type, Scalar>(scalar_value),                      \
+            shape_, device_, result_dtype);                                                \
+        link_deferred_result_to_inputs(result, {lazy_expr_id()});                          \
+        return result;                                                                     \
     }
 
-        LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE(add, add_op, AddScalar)
-        LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE(sub, sub_op, SubScalar)
-        LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE(mul, mul_op, MulScalar)
-        LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE(div, div_op, DivScalar)
-        LFS_DEFINE_SCALAR_BINARY_OP(pow, pow_op)
-        LFS_DEFINE_SCALAR_BINARY_OP(mod, mod_op)
-        LFS_DEFINE_SCALAR_BINARY_OP(maximum, maximum_op)
-        LFS_DEFINE_SCALAR_BINARY_OP(minimum, minimum_op)
+        LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE(add, add_op, AddScalar, false)
+        LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE(sub, sub_op, SubScalar, false)
+        LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE(mul, mul_op, MulScalar, false)
+        LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE(div, div_op, DivScalar, true)
+        LFS_DEFINE_SCALAR_BINARY_OP(pow, pow_op, false)
+        LFS_DEFINE_SCALAR_BINARY_OP(mod, mod_op, false)
+        LFS_DEFINE_SCALAR_BINARY_OP(maximum, maximum_op, false)
+        LFS_DEFINE_SCALAR_BINARY_OP(minimum, minimum_op, false)
 
 #undef LFS_DEFINE_SCALAR_BINARY_OP
 #undef LFS_DEFINE_SCALAR_BINARY_OP_FUSABLE
@@ -1678,18 +1890,22 @@ namespace lfs::core {
         }
 
         // Macro for scalar comparison operations (return Bool dtype)
-#define LFS_DEFINE_SCALAR_CMP_OP(name, op_type)                                         \
-    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>         \
-    Tensor name(const T& other) const {                                                 \
-        const float scalar_value = validated_scalar_operand(                            \
-            other, #name,                                                               \
-            {DataType::Float32, DataType::Int32, DataType::UInt8, DataType::Bool});     \
-        if (numel() == 0) {                                                             \
-            return Tensor::empty(shape_, device_, DataType::Bool);                      \
-        }                                                                               \
-        return UnaryExpr<TensorLeaf, ops::scalar_right_op<ops::op_type, float>>(        \
-            TensorLeaf(*this), ops::scalar_right_op<ops::op_type, float>(scalar_value), \
-            shape_, device_, DataType::Bool);                                           \
+#define LFS_DEFINE_SCALAR_CMP_OP(name, op_type)                                           \
+    template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>           \
+    Tensor name(const T& other) const {                                                   \
+        const auto scalar_value = validated_scalar_operand(                               \
+            other, #name,                                                                 \
+            {DataType::Float32, DataType::Int32, DataType::UInt8, DataType::Bool});       \
+        const DataType compare_dtype = promote_dtypes(dtype_, scalar_operand_dtype<T>()); \
+        if (numel() == 0) {                                                               \
+            return Tensor::empty(shape_, device_, DataType::Bool);                        \
+        }                                                                                 \
+        Tensor scalar_input = dtype_ == compare_dtype ? *this : to(compare_dtype);        \
+        using Scalar = std::remove_cv_t<decltype(scalar_value)>;                          \
+        return UnaryExpr<TensorLeaf, ops::scalar_right_op<ops::op_type, Scalar>>(         \
+            TensorLeaf(scalar_input),                                                     \
+            ops::scalar_right_op<ops::op_type, Scalar>(scalar_value),                     \
+            shape_, device_, DataType::Bool);                                             \
     }
 
         LFS_DEFINE_SCALAR_CMP_OP(eq, equal_op)
@@ -1980,6 +2196,45 @@ namespace lfs::core {
                     "item<T>() requires single-element tensor, got " + std::to_string(numel()) + " elements");
             }
 
+            const auto read_storage_value = [this]<typename StorageT>() {
+                StorageT value{};
+                const void* item_ptr = data_ptr();
+
+                if (device_ == Device::CUDA) {
+                    // A blocking memcpy only orders against the legacy stream; data
+                    // produced on the tensor's home stream must be drained first.
+                    if (const cudaStream_t home = state_->stream; home != nullptr) {
+                        LFS_CUDA_CHECK_MSG(
+                            cudaStreamSynchronize(home),
+                            "item<T>() home-stream synchronization (stream={}, "
+                            "requested_cpp_type={}, tensor_shape={}, tensor_dtype={}({}))",
+                            static_cast<const void*>(home), detail::tensor_cpp_type_name<T>(),
+                            shape_.str(), dtype_name(dtype_), static_cast<int>(dtype_));
+                    }
+                    LFS_CUDA_CHECK_MSG(
+                        cudaMemcpy(&value, item_ptr, sizeof(StorageT), cudaMemcpyDeviceToHost),
+                        "item<T>() readback (bytes={}, source_pointer={}, storage_cpp_type={}, "
+                        "requested_cpp_type={}, tensor_shape={}, tensor_dtype={}({}))",
+                        sizeof(StorageT), item_ptr, detail::tensor_cpp_type_name<StorageT>(),
+                        detail::tensor_cpp_type_name<T>(), shape_.str(), dtype_name(dtype_),
+                        static_cast<int>(dtype_));
+                } else {
+                    value = *static_cast<const StorageT*>(item_ptr);
+                }
+                return value;
+            };
+
+            if constexpr (std::is_same_v<T, int32_t> || std::is_same_v<T, int>) {
+                if (dtype_ == DataType::Int64) {
+                    const int64_t value = read_storage_value.template operator()<int64_t>();
+                    LFS_ASSERT_MSG(
+                        value >= static_cast<int64_t>(std::numeric_limits<T>::min()) &&
+                            value <= static_cast<int64_t>(std::numeric_limits<T>::max()),
+                        "item<int>() cannot narrow an out-of-range Int64 scalar");
+                    return static_cast<T>(value);
+                }
+            }
+
             // Validate that template type T matches tensor's dtype
             // Note: unsigned char can be used for both Bool and UInt8 (since uint8_t is typedef of unsigned char)
             bool dtype_matches = false;
@@ -2003,30 +2258,7 @@ namespace lfs::core {
                     ", but requested incompatible type T");
             }
 
-            T value{};
-            const void* item_ptr = data_ptr();
-
-            if (device_ == Device::CUDA) {
-                // A blocking memcpy only orders against the legacy stream; data
-                // produced on the tensor's home stream must be drained first.
-                if (const cudaStream_t home = state_->stream; home != nullptr) {
-                    LFS_CUDA_CHECK_MSG(
-                        cudaStreamSynchronize(home),
-                        "item<T>() home-stream synchronization (stream={}, "
-                        "requested_cpp_type={}, tensor_shape={}, tensor_dtype={}({}))",
-                        static_cast<const void*>(home), detail::tensor_cpp_type_name<T>(),
-                        shape_.str(), dtype_name(dtype_), static_cast<int>(dtype_));
-                }
-                LFS_CUDA_CHECK_MSG(
-                    cudaMemcpy(&value, item_ptr, sizeof(T), cudaMemcpyDeviceToHost),
-                    "item<T>() readback (bytes={}, source_pointer={}, requested_cpp_type={}, "
-                    "tensor_shape={}, tensor_dtype={}({}))",
-                    sizeof(T), item_ptr, detail::tensor_cpp_type_name<T>(), shape_.str(),
-                    dtype_name(dtype_), static_cast<int>(dtype_));
-            } else {
-                value = *static_cast<const T*>(item_ptr);
-            }
-            return value;
+            return read_storage_value.template operator()<T>();
         }
 
         size_t count_nonzero() const;
@@ -2387,11 +2619,14 @@ namespace lfs::core {
     // Implementations in tensor_row_proxy.cpp (except template methods)
     class LFS_CORE_API TensorRowProxy {
     private:
+        struct CudaStagingSlot {
+            float value = 0.0f;
+            size_t linear_index = 0;
+        };
+
         Tensor* tensor_;
         size_t row_index_;
-        mutable float cuda_staging_ = 0.0f;
-        mutable size_t cuda_staging_linear_idx_ = 0;
-        mutable bool cuda_staging_pending_write_ = false;
+        mutable std::deque<CudaStagingSlot> cuda_staging_slots_;
         void flush_cuda_staging() const;
 
     public:

--- a/src/core/tensor/internal/tensor_ops.hpp
+++ b/src/core/tensor/internal/tensor_ops.hpp
@@ -7,6 +7,7 @@
 #include "tensor_functors.hpp"
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#include <type_traits>
 #include <vector>
 
 namespace lfs::core {
@@ -74,7 +75,8 @@ namespace lfs::core::tensor_ops {
                                        const size_t* shape, size_t rank,
                                        const int* axes, size_t num_axes,
                                        bool keepdim, ReduceOp op,
-                                       DataType dtype, cudaStream_t stream);
+                                       DataType input_dtype, DataType output_dtype,
+                                       cudaStream_t stream);
 
     // ============= WARP-LEVEL REDUCTIONS (OPTIMIZED) =============
     // Fast reductions using warp shuffle instructions (5-10x faster than CUB for small-medium tensors)
@@ -90,7 +92,8 @@ namespace lfs::core::tensor_ops {
                                                  ReduceOp op, cudaStream_t stream);
 
     LFS_CORE_API void launch_warp_multi_axis_reduce(const float* input, float* output,
-                                                    size_t output_size, size_t reduce_count,
+                                                    size_t outer_size, size_t reduce_count,
+                                                    size_t inner_size,
                                                     ReduceOp op, cudaStream_t stream);
 
     LFS_CORE_API bool should_use_warp_reduce(size_t n, size_t num_segments);
@@ -218,6 +221,67 @@ namespace lfs::core::tensor_ops {
 #endif
 
 namespace lfs::core::tensor_ops {
+
+    LFS_CORE_API void launch_ieee_round_float(const float* input, float* output,
+                                              size_t n, cudaStream_t stream);
+    LFS_CORE_API void launch_ieee_maximum_float(const float* lhs, const float* rhs,
+                                                float* output, size_t n, cudaStream_t stream);
+    LFS_CORE_API void launch_ieee_minimum_float(const float* lhs, const float* rhs,
+                                                float* output, size_t n, cudaStream_t stream);
+    LFS_CORE_API void launch_ieee_maximum_float_broadcast(
+        const float* lhs, const float* rhs, float* output,
+        const size_t* lhs_shape, const size_t* rhs_shape, const size_t* output_shape,
+        size_t lhs_rank, size_t rhs_rank, size_t output_rank, size_t output_elements,
+        cudaStream_t stream);
+    LFS_CORE_API void launch_ieee_minimum_float_broadcast(
+        const float* lhs, const float* rhs, float* output,
+        const size_t* lhs_shape, const size_t* rhs_shape, const size_t* output_shape,
+        size_t lhs_rank, size_t rhs_rank, size_t output_rank, size_t output_elements,
+        cudaStream_t stream);
+
+    template <typename UnaryOp>
+    void launch_float_unary_with_numeric_policy(const float* input, float* output,
+                                                size_t n, UnaryOp op, cudaStream_t stream) {
+        if constexpr (std::is_same_v<UnaryOp, ops::round_op>) {
+            launch_ieee_round_float(input, output, n, stream);
+        } else {
+            launch_unary_op_generic(input, output, n, op, stream);
+        }
+    }
+
+    template <typename BinaryOp>
+    void launch_float_binary_with_numeric_policy(const float* lhs, const float* rhs,
+                                                 float* output, size_t n, BinaryOp op,
+                                                 cudaStream_t stream) {
+        if constexpr (std::is_same_v<BinaryOp, ops::maximum_op>) {
+            launch_ieee_maximum_float(lhs, rhs, output, n, stream);
+        } else if constexpr (std::is_same_v<BinaryOp, ops::minimum_op>) {
+            launch_ieee_minimum_float(lhs, rhs, output, n, stream);
+        } else {
+            launch_binary_op_generic(lhs, rhs, output, n, op, stream);
+        }
+    }
+
+    template <typename BinaryOp>
+    void launch_float_broadcast_with_numeric_policy(
+        const float* lhs, const float* rhs, float* output,
+        const size_t* lhs_shape, const size_t* rhs_shape, const size_t* output_shape,
+        size_t lhs_rank, size_t rhs_rank, size_t output_rank, size_t output_elements,
+        BinaryOp op, cudaStream_t stream) {
+        if constexpr (std::is_same_v<BinaryOp, ops::maximum_op>) {
+            launch_ieee_maximum_float_broadcast(
+                lhs, rhs, output, lhs_shape, rhs_shape, output_shape,
+                lhs_rank, rhs_rank, output_rank, output_elements, stream);
+        } else if constexpr (std::is_same_v<BinaryOp, ops::minimum_op>) {
+            launch_ieee_minimum_float_broadcast(
+                lhs, rhs, output, lhs_shape, rhs_shape, output_shape,
+                lhs_rank, rhs_rank, output_rank, output_elements, stream);
+        } else {
+            launch_broadcast_binary(
+                lhs, rhs, output, lhs_shape, rhs_shape, output_shape,
+                lhs_rank, rhs_rank, output_rank, output_elements, op, stream);
+        }
+    }
 
     // ============= Matrix Operations =============
     LFS_CORE_API void launch_matmul(const float* a, const float* b, float* c,

--- a/src/core/tensor/internal/tensor_serialization.hpp
+++ b/src/core/tensor/internal/tensor_serialization.hpp
@@ -15,7 +15,6 @@ namespace lfs::core {
 
     constexpr uint32_t TENSOR_FILE_MAGIC = 0x4C465354;
     constexpr uint32_t TENSOR_FILE_VERSION = 1;
-    constexpr uint16_t MAX_SERIALIZED_TENSOR_RANK = 8;
     constexpr uint64_t MAX_SERIALIZED_TENSOR_BYTES = 64ULL * 1024ULL * 1024ULL * 1024ULL;
 
     struct TensorFileHeader {

--- a/src/core/tensor/internal/warp_reduce.cuh
+++ b/src/core/tensor/internal/warp_reduce.cuh
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "tensor_functors.hpp"
+
 #include <cstdint>
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -46,7 +48,7 @@ namespace lfs::core {
 #pragma unroll
             for (int offset = 16; offset > 0; offset /= 2) {
                 T other = __shfl_xor_sync(0xffffffff, val, offset);
-                val = (val > other) ? val : other;
+                val = ops::max_reduce_op{}(val, other);
             }
             return val;
         }
@@ -59,7 +61,7 @@ namespace lfs::core {
 #pragma unroll
             for (int offset = 16; offset > 0; offset /= 2) {
                 T other = __shfl_xor_sync(0xffffffff, val, offset);
-                val = (val < other) ? val : other;
+                val = ops::min_reduce_op{}(val, other);
             }
             return val;
         }
@@ -251,10 +253,10 @@ namespace lfs::core {
 
                 if (is_aligned && idx + 3 < n) {
                     float4 vals = reinterpret_cast<const float4*>(input)[vec_idx];
-                    val = fmaxf(fmaxf(vals.x, vals.y), fmaxf(vals.z, vals.w));
+                    val = ops::max_reduce_op{}(ops::max_reduce_op{}(vals.x, vals.y), ops::max_reduce_op{}(vals.z, vals.w));
                 } else if (idx < n) {
                     for (size_t i = idx; i < n && i < idx + 4; ++i) {
-                        val = fmaxf(val, input[i]);
+                        val = ops::max_reduce_op{}(val, input[i]);
                     }
                 }
             } else {
@@ -282,10 +284,10 @@ namespace lfs::core {
 
                 if (is_aligned && idx + 3 < n) {
                     float4 vals = reinterpret_cast<const float4*>(input)[vec_idx];
-                    val = fminf(fminf(vals.x, vals.y), fminf(vals.z, vals.w));
+                    val = ops::min_reduce_op{}(ops::min_reduce_op{}(vals.x, vals.y), ops::min_reduce_op{}(vals.z, vals.w));
                 } else if (idx < n) {
                     for (size_t i = idx; i < n && i < idx + 4; ++i) {
-                        val = fminf(val, input[i]);
+                        val = ops::min_reduce_op{}(val, input[i]);
                     }
                 }
             } else {
@@ -406,10 +408,10 @@ namespace lfs::core {
 
                     if (is_aligned && idx + 3 < segment_size) {
                         float4 vals = reinterpret_cast<const float4*>(segment_start)[base / 4 + vec_idx];
-                        val = fmaxf(val, fmaxf(fmaxf(vals.x, vals.y), fmaxf(vals.z, vals.w)));
+                        val = ops::max_reduce_op{}(val, ops::max_reduce_op{}(ops::max_reduce_op{}(vals.x, vals.y), ops::max_reduce_op{}(vals.z, vals.w)));
                     } else if (idx < segment_size) {
                         for (size_t i = idx; i < segment_size && i < idx + 4; ++i) {
-                            val = fmaxf(val, segment_start[i]);
+                            val = ops::max_reduce_op{}(val, segment_start[i]);
                         }
                     }
                 }
@@ -447,10 +449,10 @@ namespace lfs::core {
 
                     if (is_aligned && idx + 3 < segment_size) {
                         float4 vals = reinterpret_cast<const float4*>(segment_start)[base / 4 + vec_idx];
-                        val = fminf(val, fminf(fminf(vals.x, vals.y), fminf(vals.z, vals.w)));
+                        val = ops::min_reduce_op{}(val, ops::min_reduce_op{}(ops::min_reduce_op{}(vals.x, vals.y), ops::min_reduce_op{}(vals.z, vals.w)));
                     } else if (idx < segment_size) {
                         for (size_t i = idx; i < segment_size && i < idx + 4; ++i) {
-                            val = fminf(val, segment_start[i]);
+                            val = ops::min_reduce_op{}(val, segment_start[i]);
                         }
                     }
                 }

--- a/src/core/tensor/lazy_executor.cpp
+++ b/src/core/tensor/lazy_executor.cpp
@@ -3,6 +3,7 @@
 
 #include "internal/lazy_executor.hpp"
 
+#include "core/cuda_error.hpp"
 #include "core/logger.hpp"
 #include "internal/cuda_stream_context.hpp"
 #include "internal/lazy_config.hpp"
@@ -40,7 +41,7 @@ namespace lfs::core::internal {
         struct PointwiseFusionRegistry {
             struct Entry {
                 uint64_t parent_node_id = 0;
-                Tensor source;
+                std::shared_ptr<Tensor> source;
                 std::vector<LazyPointwiseOp> ops;
                 std::weak_ptr<void> owner;
             };
@@ -303,7 +304,7 @@ namespace lfs::core::internal {
 
         struct PointwiseFusionRecipe {
             uint64_t parent_node_id = 0;
-            Tensor source;
+            std::shared_ptr<Tensor> source;
             std::vector<LazyPointwiseOp> ops;
         };
 
@@ -366,15 +367,6 @@ namespace lfs::core::internal {
             return internal_nodes;
         }
 
-        bool is_pure_scalar_chain(const std::vector<LazyPointwiseOp>& ops) {
-            for (const auto& op : ops) {
-                if (static_cast<uint8_t>(op.kind) >= 10) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
         float apply_pointwise_op_cpu(float x, LazyPointwiseOpKind kind, float scalar) {
             switch (kind) {
             case LazyPointwiseOpKind::AddScalar: return x + scalar;
@@ -384,57 +376,21 @@ namespace lfs::core::internal {
             case LazyPointwiseOpKind::Abs: return std::abs(x);
             case LazyPointwiseOpKind::Neg: return -x;
             case LazyPointwiseOpKind::Exp: return std::exp(x);
-            case LazyPointwiseOpKind::Log: return std::log(std::max(x, 1e-10f));
-            case LazyPointwiseOpKind::Sqrt: return std::sqrt(std::max(x, 0.0f));
+            case LazyPointwiseOpKind::Log: return std::log(x);
+            case LazyPointwiseOpKind::Sqrt: return std::sqrt(x);
             case LazyPointwiseOpKind::Sigmoid: return 1.0f / (1.0f + std::exp(-x));
-            case LazyPointwiseOpKind::Relu: return std::max(x, 0.0f);
+            case LazyPointwiseOpKind::Relu:
+                return std::isnan(x) ? x : std::max(x, 0.0f);
             case LazyPointwiseOpKind::Square: return x * x;
             case LazyPointwiseOpKind::Tanh: return std::tanh(x);
-            case LazyPointwiseOpKind::Rsqrt: return 1.0f / std::sqrt(std::max(x, 1e-10f));
+            case LazyPointwiseOpKind::Rsqrt: return 1.0f / std::sqrt(x);
             case LazyPointwiseOpKind::Sign: return float((x > 0) - (x < 0));
-            case LazyPointwiseOpKind::Reciprocal: return 1.0f / (x + 1e-8f);
+            case LazyPointwiseOpKind::Reciprocal: return 1.0f / x;
             case LazyPointwiseOpKind::Floor: return std::floor(x);
             case LazyPointwiseOpKind::Ceil: return std::ceil(x);
-            case LazyPointwiseOpKind::Round: return std::round(x);
+            case LazyPointwiseOpKind::Round: return ops::round_op{}(x);
             }
             return x;
-        }
-
-        struct AffineCoeffs {
-            float a = 1.0f;
-            float b = 0.0f;
-        };
-
-        AffineCoeffs fold_affine(const std::vector<LazyPointwiseOp>& ops) {
-            float a = 1.0f;
-            float b = 0.0f;
-            for (const auto& op : ops) {
-                switch (op.kind) {
-                case LazyPointwiseOpKind::AddScalar:
-                    b += op.scalar;
-                    break;
-                case LazyPointwiseOpKind::SubScalar:
-                    b -= op.scalar;
-                    break;
-                case LazyPointwiseOpKind::MulScalar:
-                    a *= op.scalar;
-                    b *= op.scalar;
-                    break;
-                case LazyPointwiseOpKind::DivScalar:
-                    a /= op.scalar;
-                    b /= op.scalar;
-                    break;
-                }
-            }
-            return {a, b};
-        }
-
-        cudaStream_t resolve_pointwise_execution_stream(const Tensor& source) {
-            cudaStream_t execution_stream = getCurrentCUDAStream();
-            if (execution_stream == nullptr && source.device() == Device::CUDA) {
-                execution_stream = source.stream();
-            }
-            return execution_stream;
         }
 
         bool execute_pointwise_fusion_recipe(const PointwiseFusionRecipe& recipe, Tensor& materialized) {
@@ -446,7 +402,10 @@ namespace lfs::core::internal {
                 return false;
             }
 
-            Tensor source = recipe.source;
+            if (!recipe.source) {
+                return false;
+            }
+            Tensor source = *recipe.source;
             if (!source.is_valid() ||
                 source.dtype() != DataType::Float32 ||
                 !source.is_contiguous()) {
@@ -454,40 +413,6 @@ namespace lfs::core::internal {
             }
 
             const size_t n = source.numel();
-            const bool pure_scalar = is_pure_scalar_chain(recipe.ops);
-
-            if (pure_scalar) {
-                const auto [a, b] = fold_affine(recipe.ops);
-
-                if (source.device() == Device::CUDA) {
-                    const float* in_ptr = source.ptr<float>();
-                    assert(in_ptr != nullptr);
-                    const cudaStream_t execution_stream = resolve_pointwise_execution_stream(source);
-                    source.sync_to_stream(execution_stream);
-                    CUDAStreamGuard guard(execution_stream);
-                    Tensor out = Tensor::empty(source.shape(), Device::CUDA, DataType::Float32);
-                    float* out_ptr = out.ptr<float>();
-                    assert(out_ptr != nullptr);
-                    tensor_ops::launch_fused_affine_transform(in_ptr, out_ptr, n, a, b, out.stream());
-                    materialized = std::move(out);
-                    return true;
-                }
-
-                const float* in_ptr = source.ptr<float>();
-                if (in_ptr == nullptr)
-                    return false;
-                Tensor out = Tensor::empty(source.shape(), Device::CPU, DataType::Float32);
-                float* out_ptr = out.ptr<float>();
-                if (out_ptr == nullptr)
-                    return false;
-                for (size_t i = 0; i < n; ++i) {
-                    out_ptr[i] = std::fma(a, in_ptr[i], b);
-                }
-                materialized = std::move(out);
-                return materialized.is_valid();
-            }
-
-            // Mixed chain: build op chain and dispatch
             tensor_ops::FusedPointwiseOpChain chain{};
             chain.num_ops = static_cast<int>(recipe.ops.size());
             for (int i = 0; i < chain.num_ops; ++i) {
@@ -498,8 +423,7 @@ namespace lfs::core::internal {
             if (source.device() == Device::CUDA) {
                 const float* in_ptr = source.ptr<float>();
                 assert(in_ptr != nullptr);
-                const cudaStream_t execution_stream = resolve_pointwise_execution_stream(source);
-                source.sync_to_stream(execution_stream);
+                const cudaStream_t execution_stream = prepare_inputs_for_stream({&source});
                 CUDAStreamGuard guard(execution_stream);
                 Tensor out = Tensor::empty(source.shape(), Device::CUDA, DataType::Float32);
                 float* out_ptr = out.ptr<float>();
@@ -628,6 +552,10 @@ namespace lfs::core::internal {
                            static_cast<uint64_t>(registry.by_node_id.size()));
     }
 
+    std::shared_ptr<Tensor> lazy_executor_snapshot_operand(const Tensor& source) {
+        return source.create_lazy_snapshot();
+    }
+
     void lazy_executor_register_pointwise_fusion_op(uint64_t node_id,
                                                     uint64_t parent_node_id,
                                                     const Tensor& source_tensor,
@@ -654,8 +582,8 @@ namespace lfs::core::internal {
                 entry.ops = parent_it->second.ops;
             }
         }
-        if (!entry.source.is_valid()) {
-            entry.source = source_tensor;
+        if (!entry.source || !entry.source->is_valid()) {
+            entry.source = lazy_executor_snapshot_operand(source_tensor);
         }
         entry.ops.push_back(op);
         registry.by_node_id[node_id] = std::move(entry);
@@ -965,7 +893,11 @@ namespace lfs::core::internal {
             return false;
         }
 
-        *out_source = std::move(it->second.source);
+        if (!it->second.source) {
+            registry.by_node_id.erase(it);
+            return false;
+        }
+        *out_source = *it->second.source;
         *out_ops = std::move(it->second.ops);
         registry.by_node_id.erase(it);
         return true;

--- a/src/core/tensor/pinned_memory_allocator.cpp
+++ b/src/core/tensor/pinned_memory_allocator.cpp
@@ -508,6 +508,15 @@ namespace lfs::core {
         }
     }
 
+    bool PinnedMemoryAllocator::is_cuda_host_allocation(const void* ptr) const {
+        if (!ptr) {
+            return false;
+        }
+        std::lock_guard lock(mutex_);
+        const auto it = allocated_blocks_.find(const_cast<void*>(ptr));
+        return it != allocated_blocks_.end() && it->second.backend == Backend::CudaHost;
+    }
+
     void PinnedMemoryAllocator::release_stream(const cudaStream_t stream) {
         if (!stream) {
             return;

--- a/src/core/tensor/tensor.cpp
+++ b/src/core/tensor/tensor.cpp
@@ -13,6 +13,7 @@
 #include "internal/lazy_executor.hpp"
 #include "internal/memory_pool.hpp"
 #include "internal/tensor_broadcast.hpp"
+#include "internal/tensor_dtype_dispatch.hpp"
 #include "internal/tensor_impl.hpp"
 #include "internal/tensor_ops.hpp"
 #include <cstring>
@@ -318,6 +319,12 @@ namespace lfs::core {
     TensorLeaf::TensorLeaf(Tensor tensor)
         : tensor_ptr_(std::make_shared<Tensor>(std::move(tensor))) {}
 
+    TensorLeaf::TensorLeaf(std::shared_ptr<Tensor> tensor)
+        : tensor_ptr_(std::move(tensor)) {
+        LFS_ASSERT_MSG(tensor_ptr_ != nullptr,
+                       "TensorLeaf requires a valid tensor cell");
+    }
+
     Tensor TensorLeaf::eval_impl() const {
         // Materialize non-contiguous or offset tensors
         if (tensor_ptr_->storage_offset() != 0 || !tensor_ptr_->is_contiguous()) {
@@ -326,10 +333,76 @@ namespace lfs::core {
         return *tensor_ptr_;
     }
 
+    TensorLeaf TensorLeaf::snapshot_impl() const {
+        tensor_ptr_->register_lazy_snapshot_cell(tensor_ptr_);
+        return TensorLeaf(tensor_ptr_);
+    }
+
     const TensorShape& TensorLeaf::shape_impl() const { return tensor_ptr_->shape(); }
     Device TensorLeaf::device_impl() const { return tensor_ptr_->device(); }
     DataType TensorLeaf::dtype_impl() const { return tensor_ptr_->dtype(); }
     cudaStream_t TensorLeaf::stream_hint_impl() const { return tensor_ptr_ ? tensor_ptr_->stream() : nullptr; }
+
+    std::shared_ptr<Tensor> Tensor::create_lazy_snapshot() const {
+        auto snapshot = std::make_shared<Tensor>(*this);
+        register_lazy_snapshot_cell(snapshot);
+        return snapshot;
+    }
+
+    void Tensor::register_lazy_snapshot_cell(
+        const std::shared_ptr<Tensor>& snapshot) const {
+        if (is_deferred() || numel() == 0) {
+            return;
+        }
+
+        auto* mutable_source = const_cast<Tensor*>(this);
+        mutable_source->ensure_storage_meta();
+        const auto storage = mutable_source->storage_meta_;
+        {
+            std::lock_guard lock(storage->lazy_snapshot_mutex);
+            auto& snapshots = storage->lazy_snapshots;
+            snapshots.erase(
+                std::remove_if(snapshots.begin(), snapshots.end(),
+                               [](const std::weak_ptr<Tensor>& candidate) {
+                                   return candidate.expired();
+                               }),
+                snapshots.end());
+            snapshots.emplace_back(snapshot);
+            storage->pending_lazy_snapshots.store(
+                static_cast<uint32_t>(snapshots.size()), std::memory_order_release);
+        }
+    }
+
+    void Tensor::replace_lazy_snapshot_storage(Tensor&& replacement) {
+        is_view_ = false;
+        *this = std::move(replacement);
+    }
+
+    void Tensor::preserve_lazy_snapshots_before_write() {
+        const auto storage = storage_meta_;
+        if (!storage ||
+            storage->pending_lazy_snapshots.load(std::memory_order_acquire) == 0) {
+            return;
+        }
+
+        std::vector<std::shared_ptr<Tensor>> snapshots;
+        {
+            std::lock_guard lock(storage->lazy_snapshot_mutex);
+            snapshots.reserve(storage->lazy_snapshots.size());
+            for (const auto& candidate : storage->lazy_snapshots) {
+                if (auto snapshot = candidate.lock()) {
+                    snapshots.emplace_back(std::move(snapshot));
+                }
+            }
+            storage->lazy_snapshots.clear();
+            storage->pending_lazy_snapshots.store(0, std::memory_order_release);
+        }
+
+        for (const auto& snapshot : snapshots) {
+            Tensor preserved = std::as_const(*snapshot).clone();
+            snapshot->replace_lazy_snapshot_storage(std::move(preserved));
+        }
+    }
 
     Tensor Tensor::make_deferred_expr_tensor(TensorShape shape,
                                              const Device device,
@@ -512,6 +585,7 @@ namespace lfs::core {
         LFS_ASSERT_MSG(data_ != nullptr || shape_.elements() == 0,
                        "Tensor constructor received null storage for a non-empty tensor");
 
+        init_storage_meta();
         compute_alignment();
 
         if (profiling_enabled_) {
@@ -558,44 +632,7 @@ namespace lfs::core {
         // If LHS is a view/slice and shapes match, do deep copy
         if (is_view_ && is_valid() && other.is_valid() &&
             shape_ == other.shape_ && dtype_ == other.dtype_) {
-
-            // Deep copy the data, accounting for storage offsets
-            if (numel() > 0) {
-                // Calculate actual data pointers accounting for storage offsets
-                void* dst_ptr = static_cast<char*>(data_) + storage_offset_ * dtype_size(dtype_);
-                const void* src_ptr = other.data_ptr();
-
-                if (device_ == Device::CUDA && other.device_ == Device::CUDA) {
-                    const cudaStream_t copy_stream = stream();
-                    other.sync_to_stream(copy_stream);
-                    LFS_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, src_ptr, bytes(), cudaMemcpyDeviceToDevice, copy_stream));
-                    record_stream(copy_stream);
-                    other.record_stream(copy_stream);
-                } else if (device_ == Device::CUDA && other.device_ == Device::CPU) {
-                    const cudaStream_t copy_stream = stream();
-                    LFS_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, src_ptr, bytes(), cudaMemcpyHostToDevice, copy_stream));
-                    record_stream(copy_stream);
-                    other.record_stream(copy_stream);
-                } else if (device_ == Device::CPU && other.device_ == Device::CUDA) {
-                    const cudaStream_t copy_stream = stream();
-                    other.sync_to_stream(copy_stream);
-                    LFS_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, src_ptr, bytes(), cudaMemcpyDeviceToHost, copy_stream));
-                    record_stream(copy_stream);
-                    other.record_stream(copy_stream);
-                } else {
-                    std::memcpy(dst_ptr, src_ptr, bytes());
-                }
-                // No sync after copy - operations are async like LibTorch
-                // User can sync explicitly if needed via cudaDeviceSynchronize()
-            }
-
-            if (profiling_enabled_) {
-                LOG_DEBUG("Deep copy assign (view): tensor #{} from #{}: shape={}, device={}, dtype={}, offset={}, src_offset={}",
-                          id_, other.id_, shape_.str(), device_name(device_), dtype_name(dtype_),
-                          storage_offset_, other.storage_offset_);
-            }
-
-            return *this;
+            return copy_from(other);
         }
 
         if (lazy_ir_registered_) {
@@ -677,41 +714,7 @@ namespace lfs::core {
 
             if (is_view_ && is_valid() && other.is_valid() &&
                 shape_ == other.shape_ && dtype_ == other.dtype_) {
-
-                // Deep copy the data from the temporary view
-                if (numel() > 0) {
-                    void* dst_ptr = static_cast<char*>(data_) + storage_offset_ * dtype_size(dtype_);
-                    const void* src_ptr = other.data_ptr();
-
-                    if (device_ == Device::CUDA && other.device_ == Device::CUDA) {
-                        const cudaStream_t copy_stream = stream();
-                        other.sync_to_stream(copy_stream);
-                        LFS_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, src_ptr, bytes(), cudaMemcpyDeviceToDevice, copy_stream));
-                        record_stream(copy_stream);
-                        other.record_stream(copy_stream);
-                    } else if (device_ == Device::CUDA && other.device_ == Device::CPU) {
-                        const cudaStream_t copy_stream = stream();
-                        LFS_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, src_ptr, bytes(), cudaMemcpyHostToDevice, copy_stream));
-                        record_stream(copy_stream);
-                        other.record_stream(copy_stream);
-                    } else if (device_ == Device::CPU && other.device_ == Device::CUDA) {
-                        const cudaStream_t copy_stream = stream();
-                        other.sync_to_stream(copy_stream);
-                        LFS_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, src_ptr, bytes(), cudaMemcpyDeviceToHost, copy_stream));
-                        record_stream(copy_stream);
-                        other.record_stream(copy_stream);
-                    } else {
-                        std::memcpy(dst_ptr, src_ptr, bytes());
-                    }
-                    // No sync after copy - operations are async like LibTorch
-                }
-
-                if (profiling_enabled_) {
-                    LOG_DEBUG("Deep copy move assign (view): tensor #{} from #{}: shape={}, device={}, dtype={}",
-                              id_, other.id_, shape_.str(), device_name(device_), dtype_name(dtype_));
-                }
-
-                return *this;
+                return copy_from(other);
             }
 
             if (lazy_ir_registered_) {
@@ -877,9 +880,11 @@ namespace lfs::core {
         size_t num_bytes = this->bytes();
 
         if (device_ == Device::CUDA) {
+            const cudaStream_t execution_stream =
+                prepare_inputs_for_stream({this}, result.stream());
             LFS_CUDA_CHECK_MSG(
-                cudaMemcpy(result.data_ptr(), data_ptr(), num_bytes,
-                           cudaMemcpyDeviceToDevice),
+                cudaMemcpyAsync(result.data_ptr(), data_ptr(), num_bytes,
+                                cudaMemcpyDeviceToDevice, execution_stream),
                 "tensor clone (bytes={}, source_shape={}, source_pointer={}, "
                 "destination_pointer={})",
                 num_bytes, shape_.str(), data_ptr(), result.data_ptr());
@@ -914,12 +919,14 @@ namespace lfs::core {
         }
 
         if (device_ == Device::CUDA) {
+            const cudaStream_t execution_stream =
+                prepare_inputs_for_stream({this}, result.stream());
             const char* src_base = static_cast<const char*>(data_) + storage_offset_ * dtype_size(dtype_);
             const size_t rank = shape_.rank();
 
             if (rank >= 2 && rank <= 4) {
                 tensor_ops::launch_strided_copy_immediate(
-                    src_base, result.data_, shape_.dims(), strides_, numel(), dtype_, result.stream());
+                    src_base, result.data_, shape_.dims(), strides_, numel(), dtype_, execution_stream);
             } else {
                 CudaDeviceMemory<size_t> d_shape(rank);
                 CudaDeviceMemory<size_t> d_strides(rank);
@@ -929,7 +936,7 @@ namespace lfs::core {
                 LFS_CUDA_CHECK(d_strides.copy_from_host(strides_.data(), rank));
                 tensor_ops::launch_strided_copy(
                     src_base, result.data_, d_shape.get(), d_strides.get(), rank,
-                    numel(), dtype_, result.stream());
+                    numel(), dtype_, execution_stream);
             }
         } else {
             // CPU strided copy - optimized for common cases with SIMD + multi-threading
@@ -1132,6 +1139,11 @@ namespace lfs::core {
                 LOG_DEBUG("GPU→CPU: materializing on GPU before download");
                 return contiguous().to(device, stream);
             } else if (device_ == Device::CPU && device == Device::CUDA) {
+                if (!PinnedMemoryAllocator::instance().is_cuda_host_allocation(
+                        data_owner_.get())) {
+                    return contiguous().to(device, stream);
+                }
+
                 // CPU→GPU: Use fused strided upload kernel!
                 LOG_DEBUG("CPU→GPU non-contiguous: using fused strided upload kernel (rank={})", shape_.rank());
 
@@ -1313,7 +1325,7 @@ namespace lfs::core {
             // Order the transfer after the source's producing stream without
             // draining unrelated CUDA work. Explicit-stream calls remain async.
             const cudaStream_t transfer_stream = stream ? stream : nullptr;
-            sync_to_stream(transfer_stream);
+            prepare_inputs_for_stream({this}, transfer_stream);
             if (stream) {
                 t.set_stream(transfer_stream);
             }
@@ -1346,32 +1358,28 @@ namespace lfs::core {
         }
 
 // Macro for type conversions using launch_convert_type
-#define CONVERT_DTYPE_CUDA(FROM_TYPE, TO_TYPE, FROM_DTYPE, TO_DTYPE)                                                                         \
-    if (dtype_ == FROM_DTYPE && dtype == TO_DTYPE) {                                                                                         \
-        auto result = empty(shape_, device_, TO_DTYPE);                                                                                      \
-        if (numel() == 0)                                                                                                                    \
-            return result;                                                                                                                   \
-        if (device_ == Device::CUDA) {                                                                                                       \
-            tensor_ops::launch_convert_type<FROM_TYPE, TO_TYPE>(                                                                             \
-                ptr<FROM_TYPE>(), result.ptr<TO_TYPE>(), numel(), result.stream());                                                          \
-            /* No sync - tensor-to-tensor operation */                                                                                       \
-            return result;                                                                                                                   \
-        }                                                                                                                                    \
-        /* CPU fallback */                                                                                                                   \
-        const FROM_TYPE* src = ptr<FROM_TYPE>();                                                                                             \
-        TO_TYPE* dst = result.ptr<TO_TYPE>();                                                                                                \
-        for (size_t i = 0; i < numel(); ++i) {                                                                                               \
-            if constexpr (std::is_same_v<FROM_TYPE, float> && std::is_same_v<TO_TYPE, uint8_t>) {                                            \
-                dst[i] = static_cast<uint8_t>(std::round(std::clamp(static_cast<float>(src[i]), 0.0f, 255.0f)));                             \
-            } else if constexpr (std::is_same_v<FROM_TYPE, int> && std::is_same_v<TO_TYPE, uint8_t>) {                                       \
-                dst[i] = static_cast<uint8_t>(std::clamp(static_cast<int>(src[i]), 0, 255));                                                 \
-            } else if constexpr (std::is_same_v<FROM_TYPE, int64_t> && std::is_same_v<TO_TYPE, uint8_t>) {                                   \
-                dst[i] = static_cast<uint8_t>(std::clamp(static_cast<int64_t>(src[i]), static_cast<int64_t>(0), static_cast<int64_t>(255))); \
-            } else {                                                                                                                         \
-                dst[i] = static_cast<TO_TYPE>(src[i]);                                                                                       \
-            }                                                                                                                                \
-        }                                                                                                                                    \
-        return result;                                                                                                                       \
+#define CONVERT_DTYPE_CUDA(FROM_TYPE, TO_TYPE, FROM_DTYPE, TO_DTYPE)                \
+    if (dtype_ == FROM_DTYPE && dtype == TO_DTYPE) {                                \
+        auto result = empty(shape_, device_, TO_DTYPE);                             \
+        if (numel() == 0)                                                           \
+            return result;                                                          \
+        if (device_ == Device::CUDA) {                                              \
+            tensor_ops::launch_convert_type<FROM_TYPE, TO_TYPE>(                    \
+                ptr<FROM_TYPE>(), result.ptr<TO_TYPE>(), numel(), result.stream()); \
+            /* No sync - tensor-to-tensor operation */                              \
+            return result;                                                          \
+        }                                                                           \
+        /* CPU fallback */                                                          \
+        const FROM_TYPE* src = ptr<FROM_TYPE>();                                    \
+        TO_TYPE* dst = result.ptr<TO_TYPE>();                                       \
+        for (size_t i = 0; i < numel(); ++i) {                                      \
+            if constexpr (std::is_same_v<TO_TYPE, uint8_t>) {                       \
+                dst[i] = detail::torch_uint8_cast(src[i]);                          \
+            } else {                                                                \
+                dst[i] = static_cast<TO_TYPE>(src[i]);                              \
+            }                                                                       \
+        }                                                                           \
+        return result;                                                              \
     }
 
         // Bool <-> Float32 (manual - can't use launch_convert_type due to uint8_t conflict)
@@ -1689,6 +1697,13 @@ namespace lfs::core {
         if (numel() == 0) {
             return *this;
         }
+        preserve_lazy_snapshots_before_write();
+
+        if (!is_contiguous()) {
+            return mutate_logical_view([](Tensor& materialized) {
+                materialized.zero_();
+            });
+        }
 
         // Account for storage offset
         char* dest = static_cast<char*>(data_) + storage_offset_ * dtype_size(dtype_);
@@ -1708,11 +1723,11 @@ namespace lfs::core {
                        "fill_ requires a valid tensor");
         LFS_ASSERT_MSG(dtype_ == DataType::Float32 || dtype_ == DataType::Int32 || dtype_ == DataType::Bool,
                        "fill_ currently supports only Float32, Int32, and Bool");
-        LFS_ASSERT_MSG(std::isfinite(value),
-                       "fill_ value must be finite");
+        detail::require_scalar_representable(dtype_, value, "fill_");
         if (numel() == 0) {
             return *this;
         }
+        preserve_lazy_snapshots_before_write();
 
         // CRITICAL FIX: For non-contiguous tensors (from slice/view operations),
         // we must respect strides and fill only the elements in the view
@@ -1815,11 +1830,11 @@ namespace lfs::core {
                        "stream-aware fill_ requires a valid tensor");
         LFS_ASSERT_MSG(dtype_ == DataType::Float32 || dtype_ == DataType::Int32 || dtype_ == DataType::Bool,
                        "stream-aware fill_ currently supports only Float32, Int32, and Bool");
-        LFS_ASSERT_MSG(std::isfinite(value),
-                       "stream-aware fill_ value must be finite");
+        detail::require_scalar_representable(dtype_, value, "stream-aware fill_");
         if (numel() == 0) {
             return *this;
         }
+        preserve_lazy_snapshots_before_write();
 
         // Only CUDA tensors benefit from stream-aware fill
         if (device_ != Device::CUDA) {
@@ -1878,20 +1893,36 @@ namespace lfs::core {
         LFS_ASSERT_MSG(shape_ == other.shape_,
                        std::format("copy_from shape mismatch: {} vs {}", shape_.str(), other.shape_.str()));
 
+        if (this == &other) {
+            return *this;
+        }
+
+        Tensor source_storage;
+        const Tensor* source = &other;
+        if (shares_storage_with(other)) {
+            source_storage = other.clone();
+            source = &source_storage;
+        } else if (!other.is_contiguous()) {
+            source_storage = other.contiguous();
+            source = &source_storage;
+        }
+        const Tensor& src = *source;
+
         // Type conversion path
-        if (dtype_ != other.dtype_) {
+        if (dtype_ != src.dtype_) {
             // Fused int32→float32 strided scatter
-            if (!is_contiguous() && other.is_contiguous() &&
-                device_ == Device::CUDA && other.device_ == Device::CUDA &&
-                dtype_ == DataType::Float32 && other.dtype_ == DataType::Int32 && ndim() == 2) {
+            if (!is_contiguous() && src.is_contiguous() &&
+                device_ == Device::CUDA && src.device_ == Device::CUDA &&
+                dtype_ == DataType::Float32 && src.dtype_ == DataType::Int32 && ndim() == 2) {
+                const cudaStream_t execution_stream =
+                    prepare_inputs_for_stream({this, &src}, stream());
                 const size_t shape_arr[2] = {static_cast<size_t>(size(0)), static_cast<size_t>(size(1))};
                 const size_t strides_arr[2] = {strides_[0], strides_[1]};
                 tensor_ops::launch_strided_scatter_int32_to_float32(
-                    other.data_ptr(), data_ptr(), shape_arr, strides_arr, 2, numel(), stream());
+                    src.data_ptr(), data_ptr(), shape_arr, strides_arr, 2, numel(), execution_stream);
                 return *this;
             }
             // Convert then copy
-            const Tensor src = other.is_contiguous() ? other : other.contiguous();
             return copy_from(src.to(dtype_));
         }
 
@@ -1899,24 +1930,31 @@ namespace lfs::core {
             return *this;
 
         const bool dst_contig = is_contiguous();
-        const bool src_contig = other.is_contiguous();
+        const bool src_contig = src.is_contiguous();
 
         // Both contiguous: direct memcpy
         if (dst_contig && src_contig) {
-            if (device_ == Device::CUDA && other.device_ == Device::CUDA) {
-                LFS_CUDA_CHECK(cudaMemcpy(data_ptr(), other.data_ptr(), bytes(), cudaMemcpyDeviceToDevice));
-            } else if (device_ == Device::CUDA && other.device_ == Device::CPU) {
-                LFS_CUDA_CHECK(cudaMemcpy(data_ptr(), other.data_ptr(), bytes(), cudaMemcpyHostToDevice));
-            } else if (device_ == Device::CPU && other.device_ == Device::CUDA) {
-                LFS_CUDA_CHECK(cudaMemcpy(data_ptr(), other.data_ptr(), bytes(), cudaMemcpyDeviceToHost));
+            if (device_ == Device::CUDA && src.device_ == Device::CUDA) {
+                const cudaStream_t execution_stream =
+                    prepare_inputs_for_stream({this, &src}, stream());
+                LFS_CUDA_CHECK(cudaMemcpyAsync(data_ptr(), src.data_ptr(), bytes(),
+                                               cudaMemcpyDeviceToDevice, execution_stream));
+            } else if (device_ == Device::CUDA && src.device_ == Device::CPU) {
+                prepare_inputs_for_stream({this, &src}, stream());
+                LFS_CUDA_CHECK(cudaMemcpy(data_ptr(), src.data_ptr(), bytes(), cudaMemcpyHostToDevice));
+            } else if (device_ == Device::CPU && src.device_ == Device::CUDA) {
+                prepare_inputs_for_stream({this, &src}, src.stream());
+                LFS_CUDA_CHECK(cudaMemcpy(data_ptr(), src.data_ptr(), bytes(), cudaMemcpyDeviceToHost));
             } else {
-                std::memcpy(data_ptr(), other.data_ptr(), bytes());
+                std::memcpy(data_ptr(), src.data_ptr(), bytes());
             }
             return *this;
         }
 
         // Strided destination, contiguous source (CUDA)
-        if (!dst_contig && src_contig && device_ == Device::CUDA && other.device_ == Device::CUDA) {
+        if (!dst_contig && src_contig && device_ == Device::CUDA && src.device_ == Device::CUDA) {
+            const cudaStream_t execution_stream =
+                prepare_inputs_for_stream({this, &src}, stream());
             const size_t rank = ndim();
             std::vector<size_t> shape_vec(rank);
             for (size_t i = 0; i < rank; ++i)
@@ -1924,7 +1962,7 @@ namespace lfs::core {
 
             if (rank >= 2 && rank <= 4) {
                 tensor_ops::launch_strided_scatter_immediate(
-                    other.data_ptr(), data_ptr(), shape_vec, strides_, numel(), dtype_, stream());
+                    src.data_ptr(), data_ptr(), shape_vec, strides_, numel(), dtype_, execution_stream);
             } else {
                 size_t* d_shape = nullptr;
                 size_t* d_strides = nullptr;
@@ -1933,7 +1971,7 @@ namespace lfs::core {
                 LFS_CUDA_CHECK(cudaMemcpy(d_shape, shape_vec.data(), rank * sizeof(size_t), cudaMemcpyHostToDevice));
                 LFS_CUDA_CHECK(cudaMemcpy(d_strides, strides_.data(), rank * sizeof(size_t), cudaMemcpyHostToDevice));
                 tensor_ops::launch_strided_scatter(
-                    other.data_ptr(), data_ptr(), d_shape, d_strides, rank, numel(), dtype_, stream());
+                    src.data_ptr(), data_ptr(), d_shape, d_strides, rank, numel(), dtype_, execution_stream);
                 LFS_CUDA_CHECK(cudaFree(d_shape));
                 LFS_CUDA_CHECK(cudaFree(d_strides));
             }
@@ -1941,16 +1979,31 @@ namespace lfs::core {
         }
 
         // Strided destination, contiguous source (cross-device: move src to dst device first)
-        if (!dst_contig && src_contig && device_ != other.device_) {
-            return copy_from(other.to(device_));
+        if (!dst_contig && src_contig && device_ != src.device_) {
+            return copy_from(src.to(device_));
         }
 
-        // Fallback: materialize non-contiguous source
-        if (!src_contig) {
-            return copy_from(other.contiguous());
+        if (!dst_contig && src_contig && device_ == Device::CPU && src.device_ == Device::CPU) {
+            const size_t element_size = dtype_size(dtype_);
+            char* destination = static_cast<char*>(data_ptr());
+            const char* source_data = static_cast<const char*>(src.data_ptr());
+            for (size_t linear_index = 0; linear_index < numel(); ++linear_index) {
+                size_t remaining = linear_index;
+                size_t destination_offset = 0;
+                for (int dimension = static_cast<int>(ndim()) - 1; dimension >= 0; --dimension) {
+                    const size_t coordinate = remaining % shape_[dimension];
+                    remaining /= shape_[dimension];
+                    destination_offset += coordinate * strides_[dimension];
+                }
+                std::memcpy(destination + destination_offset * element_size,
+                            source_data + linear_index * element_size,
+                            element_size);
+            }
+            return *this;
         }
 
-        return *this;
+        LFS_ASSERT_MSG(false,
+                       "copy_from reached an unsupported strided copy configuration");
     }
 
     // ============= Shape Operations =============
@@ -1993,7 +2046,8 @@ namespace lfs::core {
 
     bool Tensor::can_broadcast_to(const TensorShape& target) const {
         auto result = broadcast::shape(shape_.dims(), target.dims());
-        return !result.empty() && result == target.dims();
+        return broadcast::can_broadcast(shape_.dims(), target.dims()) &&
+               result == target.dims();
     }
 
     TensorShape Tensor::broadcast_shape(const TensorShape& other) const {
@@ -2072,17 +2126,38 @@ namespace lfs::core {
                        "clamp_ currently supports only Float32 and Int32");
         LFS_ASSERT_MSG(!std::isnan(min_val) && !std::isnan(max_val) && min_val <= max_val,
                        "clamp_ bounds must not be NaN and must be ordered");
+        if (dtype_ == DataType::Int32) {
+            const bool integer_bounds =
+                (min_val == -std::numeric_limits<float>::infinity() ||
+                 detail::is_exact_int32_scalar(min_val)) &&
+                (max_val == std::numeric_limits<float>::infinity() ||
+                 detail::is_exact_int32_scalar(max_val));
+            LFS_ASSERT_MSG(integer_bounds,
+                           "in-place Int32 clamp cannot represent fractional float bounds");
+        }
         if (numel() == 0) {
             return *this;
+        }
+
+        if (!is_contiguous()) {
+            return mutate_logical_view(
+                [&](Tensor& materialized) {
+                    materialized.clamp_(min_val, max_val);
+                });
         }
 
         if (device_ == Device::CUDA) {
             if (dtype_ == DataType::Float32) {
                 tensor_ops::launch_clamp_scalar(ptr<float>(), min_val, max_val, numel(), stream());
             } else if (dtype_ == DataType::Int32) {
+                const int min_int = min_val == -std::numeric_limits<float>::infinity()
+                                        ? std::numeric_limits<int>::lowest()
+                                        : static_cast<int>(min_val);
+                const int max_int = max_val == std::numeric_limits<float>::infinity()
+                                        ? std::numeric_limits<int>::max()
+                                        : static_cast<int>(max_val);
                 tensor_ops::launch_clamp_scalar_int(ptr<int>(),
-                                                    static_cast<int>(min_val),
-                                                    static_cast<int>(max_val),
+                                                    min_int, max_int,
                                                     numel(), stream());
             }
         } else {
@@ -2095,8 +2170,12 @@ namespace lfs::core {
                 }
             } else if (dtype_ == DataType::Int32) {
                 int* data = ptr<int>();
-                int min_int = static_cast<int>(min_val);
-                int max_int = static_cast<int>(max_val);
+                const int min_int = min_val == -std::numeric_limits<float>::infinity()
+                                        ? std::numeric_limits<int>::lowest()
+                                        : static_cast<int>(min_val);
+                const int max_int = max_val == std::numeric_limits<float>::infinity()
+                                        ? std::numeric_limits<int>::max()
+                                        : static_cast<int>(max_val);
                 for (size_t i = 0; i < numel(); ++i) {
                     data[i] = std::clamp(data[i], min_int, max_int);
                 }
@@ -2123,8 +2202,11 @@ namespace lfs::core {
                        "cumsum currently supports only Float32 and Int32");
 
         dim = resolve_dim(dim);
-        LFS_ASSERT_MSG(dim >= 0 && dim < static_cast<int>(shape_.rank()),
+        LFS_ASSERT_MSG(detail::tensor_dim_is_valid(dim, shape_.rank()),
                        "cumsum dimension is out of range");
+
+        if (shape_.rank() == 0)
+            return clone();
 
         auto result = clone();
 
@@ -2338,6 +2420,10 @@ namespace lfs::core {
                        "split_batch batch size must be positive");
 
         size_t total_size = tensor.shape()[0];
+        if (total_size == 0) {
+            batches.push_back(tensor);
+            return batches;
+        }
         size_t num_batches = (total_size + batch_size - 1) / batch_size;
 
         for (size_t i = 0; i < num_batches; ++i) {
@@ -2469,9 +2555,10 @@ namespace lfs::core {
             return {};
         }
 
-        // If tensor is not contiguous, materialize it first
-        if (!is_contiguous_) {
-            return contiguous().to_vector();
+        Tensor materialized;
+        const Tensor& dense = contiguous_read(materialized);
+        if (&dense != this) {
+            return dense.to_vector();
         }
 
         // Handle Bool dtype by converting to float
@@ -2535,6 +2622,12 @@ namespace lfs::core {
             return {};
         }
 
+        Tensor materialized;
+        const Tensor& dense = contiguous_read(materialized);
+        if (&dense != this) {
+            return dense.to_vector_int64();
+        }
+
         LOG_DEBUG("Creating result vector of size {}", numel());
         std::vector<int64_t> result(numel());
 
@@ -2559,6 +2652,12 @@ namespace lfs::core {
 
         if (numel() == 0) {
             return {};
+        }
+
+        Tensor materialized;
+        const Tensor& dense = contiguous_read(materialized);
+        if (&dense != this) {
+            return dense.to_vector_int();
         }
 
         // Handle Bool dtype by converting to int
@@ -2600,6 +2699,12 @@ namespace lfs::core {
             return {};
         }
 
+        Tensor materialized;
+        const Tensor& dense = contiguous_read(materialized);
+        if (&dense != this) {
+            return dense.to_vector_bool();
+        }
+
         std::vector<bool> result(numel());
 
         if (device_ == Device::CUDA) {
@@ -2627,6 +2732,12 @@ namespace lfs::core {
 
         if (numel() == 0) {
             return {};
+        }
+
+        Tensor materialized;
+        const Tensor& dense = contiguous_read(materialized);
+        if (&dense != this) {
+            return dense.to_vector_uint8();
         }
 
         // Handle UInt8 dtype directly
@@ -2771,6 +2882,12 @@ namespace lfs::core {
             return false;
         }
 
+        Tensor materialized;
+        const Tensor& dense = contiguous_read(materialized);
+        if (&dense != this) {
+            return dense.has_nan();
+        }
+
         // Use fast GPU check for CUDA tensors (only transfers 1 int back)
         if (device_ == Device::CUDA && dtype_ == DataType::Float32) {
             return tensor_ops::has_nan_gpu(ptr<float>(), numel(), stream());
@@ -2787,6 +2904,12 @@ namespace lfs::core {
                        "has_inf requires a valid tensor");
         if (numel() == 0) {
             return false;
+        }
+
+        Tensor materialized;
+        const Tensor& dense = contiguous_read(materialized);
+        if (&dense != this) {
+            return dense.has_inf();
         }
 
         // Use fast GPU check for CUDA tensors (only transfers 1 int back)
@@ -2817,23 +2940,28 @@ namespace lfs::core {
             return true;
         }
 
+        Tensor a_materialized;
+        Tensor b_materialized;
+        const Tensor& a = contiguous_read(a_materialized);
+        const Tensor& b = other.contiguous_read(b_materialized);
+
         const float* a_data = nullptr;
         const float* b_data = nullptr;
 
         Tensor a_temp, b_temp;
 
-        if (device_ == Device::CUDA) {
-            a_temp = to(Device::CPU);
+        if (a.device_ == Device::CUDA) {
+            a_temp = a.to(Device::CPU);
             a_data = a_temp.ptr<float>();
         } else {
-            a_data = ptr<float>();
+            a_data = a.ptr<float>();
         }
 
-        if (other.device() == Device::CUDA) {
-            b_temp = other.to(Device::CPU);
+        if (b.device() == Device::CUDA) {
+            b_temp = b.to(Device::CPU);
             b_data = b_temp.ptr<float>();
         } else {
-            b_data = other.ptr<float>();
+            b_data = b.ptr<float>();
         }
 
         if (!a_data || !b_data) {
@@ -2841,6 +2969,12 @@ namespace lfs::core {
         }
 
         for (size_t i = 0; i < numel(); ++i) {
+            if (a_data[i] == b_data[i]) {
+                continue;
+            }
+            if (!std::isfinite(a_data[i]) || !std::isfinite(b_data[i])) {
+                return false;
+            }
             float diff = std::abs(a_data[i] - b_data[i]);
             float tol = atol + rtol * std::abs(b_data[i]);
             if (diff > tol) {
@@ -2858,6 +2992,7 @@ namespace lfs::core {
         materialize_if_deferred();
         LFS_ASSERT_MSG(is_valid(),
                        "reserve requires a valid tensor");
+        preserve_lazy_snapshots_before_write();
         LFS_ASSERT_MSG(is_supported_device(device_),
                        "reserve encountered an invalid device");
         LFS_ASSERT_MSG(is_supported_dtype(dtype_),
@@ -2921,7 +3056,12 @@ namespace lfs::core {
 
         // Keep the installed owner untouched until allocation, copy, and all
         // replacement metadata have succeeded.
-        void* const old_data = data_;
+        Tensor logical_source;
+        const void* old_data = data_ptr();
+        if (!is_contiguous()) {
+            logical_source = contiguous();
+            old_data = logical_source.data_ptr();
+        }
 
         // Allocate new buffer
         void* new_data = nullptr;
@@ -2989,6 +3129,11 @@ namespace lfs::core {
         data_ = new_data;
         data_owner_ = std::move(new_owner);
         storage_meta_ = std::move(new_storage_meta);
+        strides_ = shape_.strides();
+        storage_offset_ = 0;
+        is_contiguous_ = true;
+        is_view_ = false;
+        view_generation_snapshot_ = 0;
         state_->capacity = new_capacity;
         state_->logical_size = current_rows;
 
@@ -3038,6 +3183,7 @@ namespace lfs::core {
             t.state_->capacity = capacity;
             t.state_->logical_size = current_size;
             t.id_ = next_id_++;
+            t.init_storage_meta();
             return t;
         }
 
@@ -3081,6 +3227,7 @@ namespace lfs::core {
         t.state_->capacity = capacity;
         t.state_->logical_size = current_size;
         t.id_ = next_id_++;
+        t.init_storage_meta();
 
         return t;
     }

--- a/src/core/tensor/tensor_advanced_ops.cpp
+++ b/src/core/tensor/tensor_advanced_ops.cpp
@@ -22,23 +22,29 @@ namespace lfs::core {
                        "cdist requires rank-2 tensors");
         LFS_ASSERT_MSG(size(1) == other.size(1),
                        "cdist feature dimensions must match");
-        LFS_ASSERT_MSG(std::isfinite(p) && p > 0.0f,
-                       "cdist p must be finite and positive");
+        LFS_ASSERT_MSG(!std::isnan(p) && p >= 0.0f,
+                       "cdist p must be non-negative");
+
+        Tensor lhs_materialized;
+        Tensor rhs_materialized;
+        const Tensor& lhs = contiguous_read(lhs_materialized);
+        const Tensor& rhs = other.contiguous_read(rhs_materialized);
 
         size_t N = size(0);
         size_t M = other.size(0);
         size_t D = size(1);
 
-        auto other_same_device = other.clone();
         auto result = empty({N, M}, device_, dtype_);
 
         if (device_ == Device::CUDA) {
-            tensor_ops::launch_cdist(ptr<float>(), other_same_device.ptr<float>(),
-                                     result.ptr<float>(), N, M, D, p, 0);
+            const cudaStream_t execution_stream =
+                prepare_inputs_for_stream({&lhs, &rhs}, result.stream());
+            tensor_ops::launch_cdist(lhs.ptr<float>(), rhs.ptr<float>(),
+                                     result.ptr<float>(), N, M, D, p, execution_stream);
             // No sync - returns tensor
         } else {
-            const float* a_data = ptr<float>();
-            const float* b_data = other_same_device.ptr<float>();
+            const float* a_data = lhs.ptr<float>();
+            const float* b_data = rhs.ptr<float>();
             float* out_data = result.ptr<float>();
 
             if (p == 2.0f) {
@@ -62,6 +68,27 @@ namespace lfs::core {
                         out_data[i * M + j] = dist;
                     }
                 }
+            } else if (p == 0.0f) {
+                for (size_t i = 0; i < N; ++i) {
+                    for (size_t j = 0; j < M; ++j) {
+                        float dist = 0.0f;
+                        for (size_t d = 0; d < D; ++d) {
+                            dist += a_data[i * D + d] != b_data[j * D + d] ? 1.0f : 0.0f;
+                        }
+                        out_data[i * M + j] = dist;
+                    }
+                }
+            } else if (std::isinf(p)) {
+                for (size_t i = 0; i < N; ++i) {
+                    for (size_t j = 0; j < M; ++j) {
+                        float dist = 0.0f;
+                        for (size_t d = 0; d < D; ++d) {
+                            const float diff = std::abs(a_data[i * D + d] - b_data[j * D + d]);
+                            dist = ops::maximum_op{}(dist, diff);
+                        }
+                        out_data[i * M + j] = dist;
+                    }
+                }
             } else {
                 for (size_t i = 0; i < N; ++i) {
                     for (size_t j = 0; j < M; ++j) {
@@ -79,418 +106,132 @@ namespace lfs::core {
         return result;
     }
 
+    namespace {
+        std::pair<Tensor, Tensor> indexed_extreme_with_indices(
+            const Tensor& input, int dim, const bool keepdim, const bool find_maximum) {
+            LFS_ASSERT_MSG(input.is_valid(),
+                           "indexed extrema require a valid tensor");
+            LFS_ASSERT_MSG(input.dtype() == DataType::Float32,
+                           "indexed extrema currently support only Float32");
+
+            const size_t rank = input.ndim();
+            if (rank == 0) {
+                LFS_ASSERT_MSG(dim == 0 || dim == -1,
+                               "scalar indexed-extrema dimension is out of range");
+                dim = 0;
+            } else {
+                if (dim < 0)
+                    dim += static_cast<int>(rank);
+                LFS_ASSERT_MSG(dim >= 0 && dim < static_cast<int>(rank),
+                               "indexed-extrema dimension is out of range");
+            }
+
+            Tensor cpu = input.device() == Device::CPU
+                             ? input.contiguous()
+                             : input.to(Device::CPU).contiguous();
+            const size_t dim_size = rank == 0 ? 1 : cpu.size(static_cast<size_t>(dim));
+
+            std::vector<size_t> output_shape;
+            if (rank > 0) {
+                output_shape.reserve(rank - (keepdim ? 0 : 1));
+                for (size_t axis = 0; axis < rank; ++axis) {
+                    if (static_cast<int>(axis) == dim) {
+                        if (keepdim)
+                            output_shape.push_back(1);
+                    } else {
+                        output_shape.push_back(cpu.size(axis));
+                    }
+                }
+            }
+
+            Tensor values = Tensor::empty(
+                TensorShape(output_shape), Device::CPU, DataType::Float32);
+            Tensor indices = Tensor::empty(
+                TensorShape(output_shape), Device::CPU, DataType::Int64);
+            if (values.numel() > 0) {
+                LFS_ASSERT_MSG(dim_size > 0,
+                               "indexed extrema cannot reduce an empty dimension");
+
+                size_t outer_size = 1;
+                size_t inner_size = 1;
+                if (rank > 0) {
+                    for (int axis = 0; axis < dim; ++axis) {
+                        outer_size *= cpu.size(static_cast<size_t>(axis));
+                    }
+                    for (size_t axis = static_cast<size_t>(dim) + 1;
+                         axis < rank; ++axis) {
+                        inner_size *= cpu.size(axis);
+                    }
+                }
+
+                const float* src = cpu.ptr<float>();
+                float* dst_values = values.ptr<float>();
+                int64_t* dst_indices = indices.ptr<int64_t>();
+                for (size_t outer = 0; outer < outer_size; ++outer) {
+                    for (size_t inner = 0; inner < inner_size; ++inner) {
+                        const size_t base = outer * dim_size * inner_size + inner;
+                        float selected = src[base];
+                        int64_t selected_index = 0;
+                        for (size_t index = 1; index < dim_size; ++index) {
+                            const float candidate = src[base + index * inner_size];
+                            if (std::isnan(candidate)) {
+                                selected = candidate;
+                                selected_index = static_cast<int64_t>(index);
+                                break;
+                            }
+                            if (!std::isnan(selected) &&
+                                (find_maximum ? candidate > selected
+                                              : candidate < selected)) {
+                                selected = candidate;
+                                selected_index = static_cast<int64_t>(index);
+                            }
+                        }
+                        const size_t output_index = outer * inner_size + inner;
+                        dst_values[output_index] = selected;
+                        dst_indices[output_index] = selected_index;
+                    }
+                }
+            }
+
+            if (input.device() == Device::CUDA) {
+                return {values.to(Device::CUDA), indices.to(Device::CUDA)};
+            }
+            return {values, indices};
+        }
+    } // namespace
+
     // ============= MIN/MAX WITH INDICES =============
     std::pair<Tensor, Tensor> Tensor::min_with_indices(int dim, bool keepdim) const {
-        LOG_DEBUG("=== min_with_indices START ===");
-        LOG_DEBUG("  Input shape: {}", shape_.str());
-        LOG_DEBUG("  Input device: {}", device_name(device_));
-        LOG_DEBUG("  Input dtype: {}", dtype_name(dtype_));
-        LOG_DEBUG("  dim: {}, keepdim: {}", dim, keepdim);
-        LOG_DEBUG("  numel: {}", numel());
-
-        LFS_ASSERT_MSG(is_valid(),
-                       "min_with_indices requires a valid tensor");
-        LFS_ASSERT_MSG(numel() > 0,
-                       "min_with_indices requires a non-empty tensor");
-        LFS_ASSERT_MSG(dtype_ == DataType::Float32,
-                       "min_with_indices currently supports only Float32");
-
-        // Move to CPU for computation
-        LOG_DEBUG("  Moving to CPU if needed...");
-        auto cpu_tensor = (device_ == Device::CPU) ? clone() : to(Device::CPU);
-        LOG_DEBUG("  CPU tensor created, shape: {}", cpu_tensor.shape().str());
-
-        // Resolve dimension
-        dim = cpu_tensor.resolve_dim(dim);
-        LOG_DEBUG("  Resolved dim: {}", dim);
-
-        LFS_ASSERT_MSG(dim >= 0 && dim < static_cast<int>(cpu_tensor.ndim()),
-                       "min_with_indices dimension is out of range");
-
-        // Handle 1D scalar reduction
-        if (cpu_tensor.ndim() == 1 && dim == 0 && !keepdim) {
-            LOG_DEBUG("  1D scalar reduction path");
-            auto values = cpu_tensor.to_vector();
-            LOG_DEBUG("  Got {} values from vector", values.size());
-
-            auto min_it = std::min_element(values.begin(), values.end());
-            size_t min_idx = std::distance(values.begin(), min_it);
-            LOG_DEBUG("  Min value: {}, index: {}", *min_it, min_idx);
-
-            // Create scalar value tensor
-            LOG_DEBUG("  Creating scalar value tensor...");
-            auto val = Tensor::empty({1}, Device::CPU, dtype_);
-            LOG_DEBUG("  Val tensor created, setting value...");
-            *val.ptr<float>() = *min_it;
-            LOG_DEBUG("  Value set, squeezing...");
-            val = val.squeeze();
-            LOG_DEBUG("  Val squeezed, shape: {}", val.shape().str());
-
-            // Create scalar index tensor - CRITICAL: proper Int64 handling
-            LOG_DEBUG("  Creating scalar index tensor with Int64...");
-            auto idx = Tensor::empty({1}, Device::CPU, DataType::Int64);
-            LOG_DEBUG("  Idx tensor created, bytes: {}", idx.bytes());
-            LOG_DEBUG("  Idx tensor data_ptr: {}", static_cast<void*>(idx.data_ptr()));
-
-            int64_t* idx_ptr = reinterpret_cast<int64_t*>(idx.data_ptr());
-            LOG_DEBUG("  Idx pointer obtained: {}", static_cast<void*>(idx_ptr));
-            LOG_DEBUG("  Setting index value to: {}", static_cast<int64_t>(min_idx));
-            *idx_ptr = static_cast<int64_t>(min_idx);
-            LOG_DEBUG("  Index value set, squeezing...");
-            idx = idx.squeeze();
-            LOG_DEBUG("  Idx squeezed, shape: {}", idx.shape().str());
-
-            // Move back to original device if needed
-            if (device_ == Device::CUDA) {
-                LOG_DEBUG("  Moving results to CUDA...");
-                auto val_cuda = val.to(Device::CUDA);
-                LOG_DEBUG("  Val moved to CUDA");
-                auto idx_cuda = idx.to(Device::CUDA);
-                LOG_DEBUG("  Idx moved to CUDA");
-                LOG_DEBUG("=== min_with_indices END (1D scalar) ===");
-                return {val_cuda, idx_cuda};
-            }
-            LOG_DEBUG("=== min_with_indices END (1D scalar CPU) ===");
-            return {val, idx};
-        }
-
-        // Calculate output shape
-        LOG_DEBUG("  Calculating output shape...");
-        std::vector<size_t> out_shape;
-        for (size_t i = 0; i < cpu_tensor.ndim(); ++i) {
-            if (static_cast<int>(i) != dim) {
-                out_shape.push_back(cpu_tensor.size(i));
-            } else if (keepdim) {
-                out_shape.push_back(1);
-            }
-        }
-        if (out_shape.empty())
-            out_shape.push_back(1);
-
-        LOG_DEBUG("  Output shape: [{}]", [&]() {
-            std::string s;
-            for (size_t i = 0; i < out_shape.size(); ++i) {
-                if (i > 0)
-                    s += ", ";
-                s += std::to_string(out_shape[i]);
-            }
-            return s;
-        }());
-
-        // Create output tensors
-        LOG_DEBUG("  Creating output tensors...");
-        auto values = Tensor::empty(TensorShape(out_shape), Device::CPU, dtype_);
-        LOG_DEBUG("  Values tensor created, numel: {}, bytes: {}", values.numel(), values.bytes());
-
-        auto indices = Tensor::empty(TensorShape(out_shape), Device::CPU, DataType::Int64);
-        LOG_DEBUG("  Indices tensor created, numel: {}, bytes: {}", indices.numel(), indices.bytes());
-
-        const float* src = cpu_tensor.ptr<float>();
-        LOG_DEBUG("  Source pointer: {}", static_cast<const void*>(src));
-
-        float* vals = values.ptr<float>();
-        LOG_DEBUG("  Values pointer: {}", static_cast<void*>(vals));
-
-        int64_t* idxs = reinterpret_cast<int64_t*>(indices.data_ptr());
-        LOG_DEBUG("  Indices pointer: {}", static_cast<void*>(idxs));
-
-        // 2D optimized path
-        if (cpu_tensor.ndim() == 2) {
-            LOG_DEBUG("  Using 2D optimized path");
-            size_t rows = cpu_tensor.size(0);
-            size_t cols = cpu_tensor.size(1);
-            LOG_DEBUG("  Rows: {}, Cols: {}", rows, cols);
-
-            if (dim == 0) {
-                LOG_DEBUG("  Reducing along dim 0 (rows)");
-                // Reduce along rows -> output is (cols,) or (1, cols)
-                for (size_t c = 0; c < cols; ++c) {
-                    if (c % 100 == 0) {
-                        LOG_DEBUG("    Processing column {}/{}", c, cols);
-                    }
-                    float min_val = src[c];
-                    int64_t min_row = 0;
-                    for (size_t r = 1; r < rows; ++r) {
-                        float v = src[r * cols + c];
-                        if (v < min_val) {
-                            min_val = v;
-                            min_row = static_cast<int64_t>(r);
-                        }
-                    }
-                    vals[c] = min_val;
-                    idxs[c] = min_row;
-                }
-                LOG_DEBUG("  Finished reducing along dim 0");
-            } else {
-                LOG_DEBUG("  Reducing along dim 1 (cols)");
-                // Reduce along cols -> output is (rows,) or (rows, 1)
-                for (size_t r = 0; r < rows; ++r) {
-                    if (r % 100 == 0) {
-                        LOG_DEBUG("    Processing row {}/{}", r, rows);
-                    }
-                    float min_val = src[r * cols];
-                    int64_t min_col = 0;
-                    for (size_t c = 1; c < cols; ++c) {
-                        float v = src[r * cols + c];
-                        if (v < min_val) {
-                            min_val = v;
-                            min_col = static_cast<int64_t>(c);
-                        }
-                    }
-                    vals[r] = min_val;
-                    idxs[r] = min_col;
-                }
-                LOG_DEBUG("  Finished reducing along dim 1");
-            }
-        } else {
-            // N-dimensional case - general implementation
-            LOG_DEBUG("  Using N-D general path for rank {}", cpu_tensor.ndim());
-            size_t dim_size = cpu_tensor.size(dim);
-            size_t outer_size = 1;
-            size_t inner_size = 1;
-
-            for (int i = 0; i < dim; ++i) {
-                outer_size *= cpu_tensor.size(i);
-            }
-            for (size_t i = dim + 1; i < cpu_tensor.ndim(); ++i) {
-                inner_size *= cpu_tensor.size(i);
-            }
-
-            LOG_DEBUG("  dim_size: {}, outer_size: {}, inner_size: {}", dim_size, outer_size, inner_size);
-
-            for (size_t outer = 0; outer < outer_size; ++outer) {
-                for (size_t inner = 0; inner < inner_size; ++inner) {
-                    size_t base_idx = outer * dim_size * inner_size + inner;
-
-                    float min_val = src[base_idx];
-                    int64_t min_idx = 0;
-
-                    for (size_t d = 1; d < dim_size; ++d) {
-                        size_t idx = base_idx + d * inner_size;
-                        if (src[idx] < min_val) {
-                            min_val = src[idx];
-                            min_idx = static_cast<int64_t>(d);
-                        }
-                    }
-
-                    size_t out_idx = outer * inner_size + inner;
-                    vals[out_idx] = min_val;
-                    idxs[out_idx] = min_idx;
-                }
-            }
-            LOG_DEBUG("  Finished N-D reduction");
-        }
-
-        LOG_DEBUG("  Reduction complete, preparing return values");
-        LOG_DEBUG("  Values tensor valid: {}, numel: {}", values.is_valid(), values.numel());
-        LOG_DEBUG("  Indices tensor valid: {}, numel: {}", indices.is_valid(), indices.numel());
-
-        // Move back to original device if needed
-        if (device_ == Device::CUDA) {
-            LOG_DEBUG("  Moving results to CUDA...");
-            auto values_cuda = values.to(Device::CUDA);
-            LOG_DEBUG("  Values moved to CUDA");
-            auto indices_cuda = indices.to(Device::CUDA);
-            LOG_DEBUG("  Indices moved to CUDA");
-            LOG_DEBUG("=== min_with_indices END (2D CUDA) ===");
-            return {values_cuda, indices_cuda};
-        }
-
-        LOG_DEBUG("=== min_with_indices END (2D CPU) ===");
-        return {values, indices};
+        return indexed_extreme_with_indices(*this, dim, keepdim, false);
     }
 
     std::pair<Tensor, Tensor> Tensor::max_with_indices(int dim, bool keepdim) const {
-        LOG_DEBUG("=== max_with_indices START ===");
-        LOG_DEBUG("  Input shape: {}", shape_.str());
-        LOG_DEBUG("  Input device: {}", device_name(device_));
-        LOG_DEBUG("  dim: {}, keepdim: {}", dim, keepdim);
-
-        LFS_ASSERT_MSG(is_valid(),
-                       "max_with_indices requires a valid tensor");
-        LFS_ASSERT_MSG(numel() > 0,
-                       "max_with_indices requires a non-empty tensor");
-        LFS_ASSERT_MSG(dtype_ == DataType::Float32,
-                       "max_with_indices currently supports only Float32");
-
-        // Move to CPU for computation
-        LOG_DEBUG("  Moving to CPU if needed...");
-        auto cpu_tensor = (device_ == Device::CPU) ? clone() : to(Device::CPU);
-        LOG_DEBUG("  CPU tensor shape: {}", cpu_tensor.shape().str());
-
-        // Resolve dimension
-        dim = cpu_tensor.resolve_dim(dim);
-        LOG_DEBUG("  Resolved dim: {}", dim);
-
-        LFS_ASSERT_MSG(dim >= 0 && dim < static_cast<int>(cpu_tensor.ndim()),
-                       "max_with_indices dimension is out of range");
-
-        // For 1D tensors with dim=0 (returns scalar)
-        if (cpu_tensor.ndim() == 1 && dim == 0 && !keepdim) {
-            LOG_DEBUG("  1D scalar reduction path");
-            auto values = cpu_tensor.to_vector();
-            auto max_it = std::max_element(values.begin(), values.end());
-            size_t max_idx = std::distance(values.begin(), max_it);
-
-            auto val = Tensor::empty({1}, Device::CPU, dtype_);
-            *val.ptr<float>() = *max_it;
-            val = val.squeeze();
-
-            auto idx = Tensor::empty({1}, Device::CPU, DataType::Int64);
-            int64_t* idx_ptr = reinterpret_cast<int64_t*>(idx.data_ptr());
-            *idx_ptr = static_cast<int64_t>(max_idx);
-            idx = idx.squeeze();
-
-            if (device_ == Device::CUDA) {
-                LOG_DEBUG("  Moving to CUDA...");
-                return {val.to(Device::CUDA), idx.to(Device::CUDA)};
-            }
-            LOG_DEBUG("=== max_with_indices END (1D) ===");
-            return {val, idx};
-        }
-
-        // Calculate output shape
-        LOG_DEBUG("  Calculating output shape...");
-        std::vector<size_t> out_shape;
-        for (size_t i = 0; i < cpu_tensor.ndim(); ++i) {
-            if (static_cast<int>(i) != dim || keepdim) {
-                out_shape.push_back((static_cast<int>(i) == dim) ? 1 : cpu_tensor.size(i));
-            }
-        }
-        if (out_shape.empty()) {
-            out_shape.push_back(1);
-        }
-
-        LOG_DEBUG("  Creating output tensors...");
-        auto values = Tensor::empty(TensorShape(out_shape), Device::CPU, dtype_);
-        auto indices = Tensor::empty(TensorShape(out_shape), Device::CPU, DataType::Int64);
-
-        const float* data = cpu_tensor.ptr<float>();
-        float* val_data = values.ptr<float>();
-        int64_t* idx_data = reinterpret_cast<int64_t*>(indices.data_ptr());
-
-        LOG_DEBUG("  Pointers - data: {}, val_data: {}, idx_data: {}",
-                  static_cast<const void*>(data),
-                  static_cast<void*>(val_data),
-                  static_cast<void*>(idx_data));
-
-        // Special case for 2D tensors
-        if (cpu_tensor.ndim() == 2) {
-            LOG_DEBUG("  Using 2D optimized path");
-            size_t rows = cpu_tensor.size(0);
-            size_t cols = cpu_tensor.size(1);
-            LOG_DEBUG("  Rows: {}, Cols: {}", rows, cols);
-
-            if (dim == 0) {
-                LOG_DEBUG("  Reducing along dim 0 (rows)");
-                // Max along rows (across columns)
-                for (size_t col = 0; col < cols; ++col) {
-                    if (col % 100 == 0) {
-                        LOG_DEBUG("    Processing column {}/{}", col, cols);
-                    }
-                    float max_val = data[col];
-                    int64_t max_idx = 0;
-
-                    for (size_t row = 1; row < rows; ++row) {
-                        float val = data[row * cols + col];
-                        if (val > max_val) {
-                            max_val = val;
-                            max_idx = static_cast<int64_t>(row);
-                        }
-                    }
-
-                    val_data[col] = max_val;
-                    idx_data[col] = max_idx;
-                }
-            } else if (dim == 1) {
-                LOG_DEBUG("  Reducing along dim 1 (cols)");
-                // Max along columns (across rows)
-                for (size_t row = 0; row < rows; ++row) {
-                    if (row % 100 == 0) {
-                        LOG_DEBUG("    Processing row {}/{}", row, rows);
-                    }
-                    float max_val = data[row * cols];
-                    int64_t max_idx = 0;
-
-                    for (size_t col = 1; col < cols; ++col) {
-                        float val = data[row * cols + col];
-                        if (val > max_val) {
-                            max_val = val;
-                            max_idx = static_cast<int64_t>(col);
-                        }
-                    }
-
-                    val_data[row] = max_val;
-                    idx_data[row] = max_idx;
-                }
-            }
-            LOG_DEBUG("  Reduction complete");
-        } else {
-            // General N-dimensional case
-            LOG_DEBUG("  Using N-D general path");
-            size_t dim_size = cpu_tensor.size(dim);
-            size_t outer_size = 1;
-            size_t inner_size = 1;
-
-            for (size_t i = 0; i < static_cast<size_t>(dim); ++i) {
-                outer_size *= cpu_tensor.size(i);
-            }
-            for (size_t i = dim + 1; i < cpu_tensor.ndim(); ++i) {
-                inner_size *= cpu_tensor.size(i);
-            }
-
-            for (size_t outer = 0; outer < outer_size; ++outer) {
-                for (size_t inner = 0; inner < inner_size; ++inner) {
-                    size_t base_idx = outer * dim_size * inner_size + inner;
-
-                    float max_val = data[base_idx];
-                    int64_t max_idx = 0;
-
-                    for (size_t d = 1; d < dim_size; ++d) {
-                        size_t idx = base_idx + d * inner_size;
-                        if (data[idx] > max_val) {
-                            max_val = data[idx];
-                            max_idx = static_cast<int64_t>(d);
-                        }
-                    }
-
-                    size_t out_idx = outer * inner_size + inner;
-                    val_data[out_idx] = max_val;
-                    idx_data[out_idx] = max_idx;
-                }
-            }
-        }
-
-        LOG_DEBUG("  Moving to original device if needed...");
-        if (device_ == Device::CUDA) {
-            LOG_DEBUG("  Moving to CUDA...");
-            auto values_cuda = values.to(Device::CUDA);
-            LOG_DEBUG("  Values moved");
-            auto indices_cuda = indices.to(Device::CUDA);
-            LOG_DEBUG("  Indices moved");
-            LOG_DEBUG("=== max_with_indices END (CUDA) ===");
-            return {values_cuda, indices_cuda};
-        }
-        LOG_DEBUG("=== max_with_indices END (CPU) ===");
-        return {values, indices};
+        return indexed_extreme_with_indices(*this, dim, keepdim, true);
     }
-
     // ============= SORTING =============
     std::pair<Tensor, Tensor> Tensor::sort(int dim, bool descending) const {
         LFS_ASSERT_MSG(is_valid(),
                        "sort requires a valid tensor");
         LFS_ASSERT_MSG(dtype_ == DataType::Float32,
                        "sort currently supports only Float32");
-        LFS_ASSERT_MSG(numel() > 0,
-                       "sort requires a non-empty tensor");
+        if (ndim() == 0) {
+            LFS_ASSERT_MSG(dim == 0 || dim == -1,
+                           "scalar sort dimension is out of range");
+            return {clone(), Tensor::zeros(TensorShape{}, device_, DataType::Int64)};
+        }
 
         dim = resolve_dim(dim);
         LFS_ASSERT_MSG(dim >= 0 && dim < static_cast<int>(ndim()),
                        "sort dimension is out of range");
 
+        Tensor materialized;
+        const Tensor& source = contiguous_read(materialized);
+
         // Create output tensors on same device
-        auto sorted = clone();
+        auto sorted = source.clone();
         auto indices = Tensor::empty(shape_, device_, DataType::Int64);
+        if (numel() == 0)
+            return {sorted, indices};
 
         // 1D case - optimized path
         if (ndim() == 1 && dim == 0) {
@@ -506,11 +247,15 @@ namespace lfs::core {
                 std::iota(idx_vec.begin(), idx_vec.end(), 0);
 
                 if (descending) {
-                    std::sort(idx_vec.begin(), idx_vec.end(),
-                              [&](size_t a, size_t b) { return values_vec[a] > values_vec[b]; });
+                    std::stable_sort(idx_vec.begin(), idx_vec.end(),
+                                     [&](size_t a, size_t b) {
+                                         return ops::sort_greater_op{}(values_vec[a], values_vec[b]);
+                                     });
                 } else {
-                    std::sort(idx_vec.begin(), idx_vec.end(),
-                              [&](size_t a, size_t b) { return values_vec[a] < values_vec[b]; });
+                    std::stable_sort(idx_vec.begin(), idx_vec.end(),
+                                     [&](size_t a, size_t b) {
+                                         return ops::sort_less_op{}(values_vec[a], values_vec[b]);
+                                     });
                 }
 
                 float* sorted_data = sorted.ptr<float>();
@@ -545,7 +290,7 @@ namespace lfs::core {
             // No sync - returns tensors
         } else {
             // CPU implementation
-            const float* src_data = ptr<float>();
+            const float* src_data = source.ptr<float>();
             float* sorted_data = sorted.ptr<float>();
             int64_t* idx_data = reinterpret_cast<int64_t*>(indices.data_ptr());
 
@@ -561,11 +306,15 @@ namespace lfs::core {
 
                     // Sort the slice
                     if (descending) {
-                        std::sort(slice_data.begin(), slice_data.end(),
-                                  [](const auto& a, const auto& b) { return a.first > b.first; });
+                        std::stable_sort(slice_data.begin(), slice_data.end(),
+                                         [](const auto& a, const auto& b) {
+                                             return ops::sort_greater_op{}(a.first, b.first);
+                                         });
                     } else {
-                        std::sort(slice_data.begin(), slice_data.end(),
-                                  [](const auto& a, const auto& b) { return a.first < b.first; });
+                        std::stable_sort(slice_data.begin(), slice_data.end(),
+                                         [](const auto& a, const auto& b) {
+                                             return ops::sort_less_op{}(a.first, b.first);
+                                         });
                     }
 
                     // Write back sorted values and indices

--- a/src/core/tensor/tensor_broadcast.cpp
+++ b/src/core/tensor/tensor_broadcast.cpp
@@ -24,10 +24,6 @@ namespace lfs::core {
             return src.clone();
         }
 
-        if (src.numel() == 0 || target.elements() == 0) {
-            return Tensor::empty(target, src.device(), src.dtype());
-        }
-
         // Check if shapes are compatible for broadcasting
         auto src_dims = src.shape().dims();
         auto target_dims = target.dims();
@@ -37,11 +33,13 @@ namespace lfs::core {
         LFS_ASSERT_MSG(!broadcast_shape.empty() && broadcast_shape == target_dims,
                        std::format("Cannot broadcast shape {} to {}", src.shape().str(), target.str()));
 
+        if (src.numel() == 0 || target.elements() == 0) {
+            return Tensor::empty(target, src.device(), src.dtype());
+        }
+
         Tensor result;
         if (src.device() == Device::CUDA) {
-            const cudaStream_t execution_stream =
-                getCurrentCUDAStream() ? getCurrentCUDAStream() : src.stream();
-            src.sync_to_stream(execution_stream);
+            const cudaStream_t execution_stream = prepare_inputs_for_stream({&src});
             CUDAStreamGuard guard(execution_stream);
             result = Tensor::empty(target, src.device(), src.dtype());
         } else {

--- a/src/core/tensor/tensor_broadcast_ops.cu
+++ b/src/core/tensor/tensor_broadcast_ops.cu
@@ -1,7 +1,9 @@
 /* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "core/assert.hpp"
 #include "core/logger.hpp"
+#include "core/tensor_fwd.hpp"
 #include "internal/memory_pool.hpp"
 #include "internal/tensor_functors.hpp"
 #include "internal/tensor_ops.hpp"
@@ -15,14 +17,27 @@
 
 namespace lfs::core::tensor_ops {
 
-    constexpr int MAX_RANK = 8;
     constexpr int BLOCK_SIZE = 256;
+
+    namespace {
+        struct ieee_broadcast_maximum_float_op {
+            __host__ __device__ float operator()(const float lhs, const float rhs) const {
+                return ops::maximum_op{}(lhs, rhs);
+            }
+        };
+
+        struct ieee_broadcast_minimum_float_op {
+            __host__ __device__ float operator()(const float lhs, const float rhs) const {
+                return ops::minimum_op{}(lhs, rhs);
+            }
+        };
+    } // namespace
 
     // Strided broadcast kernel params (passed by value, no device alloc)
     struct BroadcastStridedParams {
-        size_t src_shape[MAX_RANK];
-        size_t src_strides[MAX_RANK];
-        size_t dst_strides[MAX_RANK];
+        size_t src_shape[MAX_TENSOR_RANK];
+        size_t src_strides[MAX_TENSOR_RANK];
+        size_t dst_strides[MAX_TENSOR_RANK];
         int src_rank;
         int dst_rank;
         size_t dst_elements;
@@ -60,10 +75,8 @@ namespace lfs::core::tensor_ops {
                                        const size_t dst_elements, cudaStream_t stream) {
         if (dst_elements == 0)
             return;
-        if (src_rank > MAX_RANK || dst_rank > MAX_RANK) {
-            LOG_ERROR("Broadcast strided: rank exceeds {}", MAX_RANK);
-            return;
-        }
+        LFS_ASSERT_MSG(src_rank <= MAX_TENSOR_RANK && dst_rank <= MAX_TENSOR_RANK,
+                       "Broadcast strided rank exceeds MAX_TENSOR_RANK");
 
         BroadcastStridedParams params{};
         params.src_rank = static_cast<int>(src_rank);
@@ -106,11 +119,11 @@ namespace lfs::core::tensor_ops {
 
     // Pad kernel params (passed by value, no device alloc)
     struct PadParams {
-        size_t src_shape[MAX_RANK];
-        size_t src_strides[MAX_RANK];
-        size_t dst_strides[MAX_RANK];
-        size_t pad_before[MAX_RANK];
-        size_t contiguous_strides[MAX_RANK];
+        size_t src_shape[MAX_TENSOR_RANK];
+        size_t src_strides[MAX_TENSOR_RANK];
+        size_t dst_strides[MAX_TENSOR_RANK];
+        size_t pad_before[MAX_TENSOR_RANK];
+        size_t contiguous_strides[MAX_TENSOR_RANK];
         int rank;
         size_t src_elements;
     };
@@ -121,7 +134,7 @@ namespace lfs::core::tensor_ops {
         if (idx >= params.src_elements)
             return;
 
-        size_t coords[MAX_RANK];
+        size_t coords[MAX_TENSOR_RANK];
         size_t remaining = idx;
 
         for (int i = 0; i < params.rank; ++i) {
@@ -144,10 +157,8 @@ namespace lfs::core::tensor_ops {
                     const size_t rank, const size_t src_elements, cudaStream_t stream) {
         if (src_elements == 0)
             return;
-        if (rank > MAX_RANK) {
-            LOG_ERROR("Pad: rank exceeds {}", MAX_RANK);
-            return;
-        }
+        LFS_ASSERT_MSG(rank <= MAX_TENSOR_RANK,
+                       "Pad rank exceeds MAX_TENSOR_RANK");
 
         PadParams params{};
         params.rank = static_cast<int>(rank);
@@ -174,7 +185,7 @@ namespace lfs::core::tensor_ops {
 
     // Broadcasting index functor
 
-    template <int MaxRank = 8>
+    template <int MaxRank = static_cast<int>(MAX_TENSOR_RANK)>
     struct broadcast_index_functor {
         int src_rank, dst_rank;
         int src_shape[MaxRank];
@@ -271,6 +282,28 @@ namespace lfs::core::tensor_ops {
                                size_t src_rank, size_t dst_rank,
                                size_t dst_elements, cudaStream_t stream) {
         launch_broadcast_generic(src, dst, src_shape, dst_shape, src_rank, dst_rank, dst_elements, stream);
+    }
+
+    void launch_ieee_maximum_float_broadcast(
+        const float* lhs, const float* rhs, float* output,
+        const size_t* lhs_shape, const size_t* rhs_shape, const size_t* output_shape,
+        const size_t lhs_rank, const size_t rhs_rank, const size_t output_rank,
+        const size_t output_elements, const cudaStream_t stream) {
+        launch_broadcast_binary(
+            lhs, rhs, output, lhs_shape, rhs_shape, output_shape,
+            lhs_rank, rhs_rank, output_rank, output_elements,
+            ieee_broadcast_maximum_float_op{}, stream);
+    }
+
+    void launch_ieee_minimum_float_broadcast(
+        const float* lhs, const float* rhs, float* output,
+        const size_t* lhs_shape, const size_t* rhs_shape, const size_t* output_shape,
+        const size_t lhs_rank, const size_t rhs_rank, const size_t output_rank,
+        const size_t output_elements, const cudaStream_t stream) {
+        launch_broadcast_binary(
+            lhs, rhs, output, lhs_shape, rhs_shape, output_shape,
+            lhs_rank, rhs_rank, output_rank, output_elements,
+            ieee_broadcast_minimum_float_op{}, stream);
     }
 
     // ============================================================================

--- a/src/core/tensor/tensor_fused_pointwise.cu
+++ b/src/core/tensor/tensor_fused_pointwise.cu
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <cfloat>
 #include <cuda_runtime.h>
+#include <limits>
 
 static_assert(static_cast<uint8_t>(lfs::core::internal::LazyPointwiseOpKind::AddScalar) == 0);
 static_assert(static_cast<uint8_t>(lfs::core::internal::LazyPointwiseOpKind::Abs) == 10);
@@ -77,25 +78,25 @@ namespace lfs::core::tensor_ops {
 
         __device__ __forceinline__ float apply_pointwise_op(float x, const FusedPointwiseOp& op) {
             switch (op.kind) {
-            case 0: return x + op.scalar;             // AddScalar
-            case 1: return x - op.scalar;             // SubScalar
-            case 2: return x * op.scalar;             // MulScalar
-            case 3: return x / op.scalar;             // DivScalar
-            case 10: return fabsf(x);                 // Abs
-            case 11: return -x;                       // Neg
-            case 12: return expf(x);                  // Exp
-            case 13: return logf(fmaxf(x, 1e-10f));   // Log
-            case 14: return sqrtf(fmaxf(x, 0.0f));    // Sqrt
-            case 15: return 1.0f / (1.0f + expf(-x)); // Sigmoid
-            case 16: return fmaxf(x, 0.0f);           // Relu
-            case 17: return x * x;                    // Square
-            case 18: return tanhf(x);                 // Tanh
-            case 19: return rsqrtf(fmaxf(x, 1e-10f)); // Rsqrt
-            case 20: return float((x > 0) - (x < 0)); // Sign
-            case 21: return 1.0f / (x + 1e-8f);       // Reciprocal
-            case 22: return floorf(x);                // Floor
-            case 23: return ceilf(x);                 // Ceil
-            case 24: return roundf(x);                // Round
+            case 0: return x + op.scalar;                  // AddScalar
+            case 1: return x - op.scalar;                  // SubScalar
+            case 2: return x * op.scalar;                  // MulScalar
+            case 3: return x / op.scalar;                  // DivScalar
+            case 10: return fabsf(x);                      // Abs
+            case 11: return -x;                            // Neg
+            case 12: return expf(x);                       // Exp
+            case 13: return logf(x);                       // Log
+            case 14: return sqrtf(x);                      // Sqrt
+            case 15: return 1.0f / (1.0f + expf(-x));      // Sigmoid
+            case 16: return isnan(x) ? x : fmaxf(x, 0.0f); // Relu
+            case 17: return x * x;                         // Square
+            case 18: return tanhf(x);                      // Tanh
+            case 19: return rsqrtf(x);                     // Rsqrt
+            case 20: return float((x > 0) - (x < 0));      // Sign
+            case 21: return 1.0f / x;                      // Reciprocal
+            case 22: return floorf(x);                     // Floor
+            case 23: return ceilf(x);                      // Ceil
+            case 24: return ops::round_op{}(x);            // Round
             default: return x;
             }
         }
@@ -166,11 +167,11 @@ namespace lfs::core::tensor_ops {
 
         __device__ __forceinline__ float reduce_identity(int reduce_op_int) {
             switch (reduce_op_int) {
-            case 0: return 0.0f;     // Sum
-            case 1: return 0.0f;     // Mean (accumulates like sum)
-            case 2: return -FLT_MAX; // Max
-            case 3: return FLT_MAX;  // Min
-            case 4: return 1.0f;     // Prod
+            case 0: return 0.0f;                                    // Sum
+            case 1: return 0.0f;                                    // Mean (accumulates like sum)
+            case 2: return -std::numeric_limits<float>::infinity(); // Max
+            case 3: return std::numeric_limits<float>::infinity();  // Min
+            case 4: return 1.0f;                                    // Prod
             default: return 0.0f;
             }
         }
@@ -179,19 +180,49 @@ namespace lfs::core::tensor_ops {
             switch (reduce_op_int) {
             case 0: return a + b;
             case 1: return a + b;
-            case 2: return fmaxf(a, b);
-            case 3: return fminf(a, b);
+            case 2: return (isnan(a) || isnan(b)) ? a + b : fmaxf(a, b);
+            case 3: return (isnan(a) || isnan(b)) ? a + b : fminf(a, b);
             case 4: return a * b;
             default: return a + b;
             }
+        }
+
+        __device__ __forceinline__ float warp_reduce_extrema(float val, int reduce_op_int) {
+#pragma unroll
+            for (int offset = 16; offset > 0; offset /= 2) {
+                val = reduce_combine(
+                    val, __shfl_xor_sync(0xffffffff, val, offset), reduce_op_int);
+            }
+            return val;
+        }
+
+        __device__ __forceinline__ float block_reduce_extrema(float val,
+                                                              int reduce_op_int) {
+            static __shared__ float shared[32];
+            const int lane = threadIdx.x % 32;
+            const int warp_id = threadIdx.x / 32;
+
+            val = warp_reduce_extrema(val, reduce_op_int);
+            if (lane == 0) {
+                shared[warp_id] = val;
+            }
+            __syncthreads();
+
+            if (warp_id == 0) {
+                val = threadIdx.x < (blockDim.x + 31) / 32
+                          ? shared[lane]
+                          : reduce_identity(reduce_op_int);
+                val = warp_reduce_extrema(val, reduce_op_int);
+            }
+            return val;
         }
 
         __device__ __forceinline__ float block_reduce_op(float val, int reduce_op_int) {
             switch (reduce_op_int) {
             case 0: return warp_ops::block_reduce_sum(val);
             case 1: return warp_ops::block_reduce_sum(val);
-            case 2: return warp_ops::block_reduce_max(val);
-            case 3: return warp_ops::block_reduce_min(val);
+            case 2: return block_reduce_extrema(val, reduce_op_int);
+            case 3: return block_reduce_extrema(val, reduce_op_int);
             case 4: return warp_ops::block_reduce_prod(val);
             default: return warp_ops::block_reduce_sum(val);
             }

--- a/src/core/tensor/tensor_masking_ops.cpp
+++ b/src/core/tensor/tensor_masking_ops.cpp
@@ -56,37 +56,6 @@ namespace lfs::core {
             }
         }
 
-        void assert_masked_fill_value_representable(const DataType dtype, const float value) {
-            switch (dtype) {
-            case DataType::Float32:
-                return;
-            case DataType::Float16:
-                LFS_ASSERT_MSG(std::abs(value) <= 65504.0f,
-                               "masked_fill_ value is outside the Float16 finite range");
-                return;
-            case DataType::Int32:
-                LFS_ASSERT_MSG(value >= -std::ldexp(1.0f, 31) &&
-                                   value < std::ldexp(1.0f, 31),
-                               "masked_fill_ value is outside the Int32 range");
-                return;
-            case DataType::Int64:
-                LFS_ASSERT_MSG(value >= -std::ldexp(1.0f, 63) &&
-                                   value < std::ldexp(1.0f, 63),
-                               "masked_fill_ value is outside the Int64 range");
-                return;
-            case DataType::UInt8:
-                LFS_ASSERT_MSG(value >= 0.0f && value <= 255.0f,
-                               "masked_fill_ value is outside the UInt8 range");
-                return;
-            case DataType::Bool:
-                LFS_ASSERT_MSG(value == 0.0f || value == 1.0f,
-                               "masked_fill_ Bool value must be zero or one");
-                return;
-            }
-            LFS_ASSERT_MSG(false,
-                           "masked_fill_ encountered an unsupported dtype");
-        }
-
         [[nodiscard]] bool is_integer_index_dtype(const DataType dtype) {
             return dtype == DataType::Int32 || dtype == DataType::Int64;
         }
@@ -149,10 +118,25 @@ namespace lfs::core {
         tensor_contract::require_dtype(
             mask, {DataType::Bool, DataType::UInt8}, "masked_select", "mask",
             LFS_SOURCE_SITE_CURRENT());
-        tensor_contract::require_shape(
-            *this, mask, "masked_select", "input", "mask", LFS_SOURCE_SITE_CURRENT());
         tensor_contract::require_same_device(
             *this, mask, "masked_select", "input", "mask", LFS_SOURCE_SITE_CURRENT());
+        LFS_ASSERT_MSG(mask.can_broadcast_to(shape_),
+                       std::format("masked_select cannot broadcast mask shape {} to {}",
+                                   mask.shape().str(), shape_.str()));
+
+        Tensor input_materialized;
+        Tensor broadcast_mask;
+        const Tensor* logical_mask = &mask;
+        if (mask.shape() != shape_) {
+            broadcast_mask = mask.broadcast_to(shape_);
+            logical_mask = &broadcast_mask;
+        }
+        Tensor mask_materialized;
+        const Tensor& input = contiguous_read(input_materialized);
+        const Tensor& dense_mask = logical_mask->contiguous_read(mask_materialized);
+        if (&input != this || &dense_mask != &mask) {
+            return input.masked_select(dense_mask);
+        }
 
         // Count TRUE values in mask
         size_t output_size = mask.count_nonzero();
@@ -230,60 +214,76 @@ namespace lfs::core {
         tensor_contract::require_dtype(
             mask, {DataType::Bool, DataType::UInt8}, "masked_fill_", "mask",
             LFS_SOURCE_SITE_CURRENT());
-        tensor_contract::require_shape(
-            *this, mask, "masked_fill_", "destination", "mask", LFS_SOURCE_SITE_CURRENT());
         tensor_contract::require_same_device(
             *this, mask, "masked_fill_", "destination", "mask", LFS_SOURCE_SITE_CURRENT());
-        LFS_ASSERT_MSG(std::isfinite(value),
-                       "masked_fill_ value must be finite");
-        assert_masked_fill_value_representable(dtype_, value);
+        LFS_ASSERT_MSG(mask.can_broadcast_to(shape_),
+                       std::format("masked_fill_ cannot broadcast mask shape {} to {}",
+                                   mask.shape().str(), shape_.str()));
+        detail::require_scalar_representable(dtype_, value, "masked_fill_");
+        const float stored_value = dtype_ == DataType::Bool && value != 0.0f ? 1.0f : value;
+
+        if (!is_contiguous()) {
+            return mutate_logical_view(
+                [&](Tensor& materialized) {
+                    materialized.masked_fill_(mask, value);
+                });
+        }
+
+        Tensor broadcast_mask;
+        const Tensor* logical_mask = &mask;
+        if (mask.shape() != shape_) {
+            broadcast_mask = mask.broadcast_to(shape_);
+            logical_mask = &broadcast_mask;
+        }
+        Tensor mask_materialized;
+        const Tensor& dense_mask = logical_mask->contiguous_read(mask_materialized);
 
         if (device_ == Device::CUDA) {
             switch (dtype_) {
             case DataType::Float32:
-                tensor_ops::launch_masked_fill(ptr<float>(), mask.ptr<unsigned char>(),
-                                               value, numel(), stream());
+                tensor_ops::launch_masked_fill(ptr<float>(), dense_mask.ptr<unsigned char>(),
+                                               stored_value, numel(), stream());
                 break;
             case DataType::Float16:
-                tensor_ops::launch_masked_fill(ptr<__half>(), mask.ptr<unsigned char>(),
-                                               __float2half(value), numel(), stream());
+                tensor_ops::launch_masked_fill(ptr<__half>(), dense_mask.ptr<unsigned char>(),
+                                               __float2half(stored_value), numel(), stream());
                 break;
             case DataType::Int32:
-                tensor_ops::launch_masked_fill(ptr<int32_t>(), mask.ptr<unsigned char>(),
-                                               static_cast<int32_t>(value), numel(), stream());
+                tensor_ops::launch_masked_fill(ptr<int32_t>(), dense_mask.ptr<unsigned char>(),
+                                               static_cast<int32_t>(stored_value), numel(), stream());
                 break;
             case DataType::Int64:
-                tensor_ops::launch_masked_fill(ptr<int64_t>(), mask.ptr<unsigned char>(),
-                                               static_cast<int64_t>(value), numel(), stream());
+                tensor_ops::launch_masked_fill(ptr<int64_t>(), dense_mask.ptr<unsigned char>(),
+                                               static_cast<int64_t>(stored_value), numel(), stream());
                 break;
             case DataType::UInt8:
             case DataType::Bool:
-                tensor_ops::launch_masked_fill(ptr<uint8_t>(), mask.ptr<unsigned char>(),
-                                               static_cast<uint8_t>(value), numel(), stream());
+                tensor_ops::launch_masked_fill(ptr<uint8_t>(), dense_mask.ptr<unsigned char>(),
+                                               static_cast<uint8_t>(stored_value), numel(), stream());
                 break;
             default:
                 throw std::runtime_error("masked_fill_: unsupported dtype");
             }
             // No sync - tensor operation
         } else {
-            const unsigned char* mask_data = mask.ptr<unsigned char>();
+            const unsigned char* mask_data = dense_mask.ptr<unsigned char>();
 
             switch (dtype_) {
             case DataType::Float32:
-                masked_fill_cpu(ptr<float>(), mask_data, numel(), value);
+                masked_fill_cpu(ptr<float>(), mask_data, numel(), stored_value);
                 break;
             case DataType::Float16:
-                masked_fill_cpu(ptr<__half>(), mask_data, numel(), value);
+                masked_fill_cpu(ptr<__half>(), mask_data, numel(), stored_value);
                 break;
             case DataType::Int32:
-                masked_fill_cpu(ptr<int32_t>(), mask_data, numel(), value);
+                masked_fill_cpu(ptr<int32_t>(), mask_data, numel(), stored_value);
                 break;
             case DataType::Int64:
-                masked_fill_cpu(ptr<int64_t>(), mask_data, numel(), value);
+                masked_fill_cpu(ptr<int64_t>(), mask_data, numel(), stored_value);
                 break;
             case DataType::UInt8:
             case DataType::Bool:
-                masked_fill_cpu(ptr<unsigned char>(), mask_data, numel(), value);
+                masked_fill_cpu(ptr<unsigned char>(), mask_data, numel(), stored_value);
                 break;
             default:
                 throw std::runtime_error("masked_fill_: unsupported dtype");
@@ -313,6 +313,14 @@ namespace lfs::core {
                        "index_select requires rank-1 indices");
         LFS_ASSERT_MSG(indices.device() == device_,
                        "index_select indices must be on the input device");
+
+        Tensor input_materialized;
+        Tensor indices_materialized;
+        const Tensor& input = contiguous_read(input_materialized);
+        const Tensor& dense_indices = indices.contiguous_read(indices_materialized);
+        if (&input != this || &dense_indices != &indices) {
+            return input.index_select(dim, dense_indices, mode);
+        }
 
         const int requested_dim = dim;
         dim = resolve_dim(dim);
@@ -357,6 +365,47 @@ namespace lfs::core {
         expected_shape[dim] = indices.numel();
         LFS_ASSERT_MSG(out.shape() == TensorShape(expected_shape),
                        "index_select_into output shape does not match the requested gather");
+
+        if (dtype_ == DataType::Float16) {
+            Tensor selected = to(DataType::Float32)
+                                  .index_select(dim, indices, mode)
+                                  .to(DataType::Float16);
+            out.copy_from(selected);
+            return;
+        }
+
+        Tensor input_snapshot;
+        Tensor index_snapshot;
+        const Tensor* input_source = this;
+        const Tensor* index_source = &indices;
+        if (out.shares_storage_with(*this)) {
+            input_snapshot = clone();
+            input_source = &input_snapshot;
+        }
+        if (out.shares_storage_with(indices)) {
+            index_snapshot = indices.clone();
+            index_source = &index_snapshot;
+        }
+        if (input_source != this || index_source != &indices) {
+            input_source->index_select_into(out, dim, *index_source, mode);
+            return;
+        }
+
+        if (!out.is_contiguous()) {
+            Tensor materialized_output = empty(out.shape(), out.device(), out.dtype());
+            index_select_into(materialized_output, dim, indices, mode);
+            out.copy_from(materialized_output);
+            return;
+        }
+
+        Tensor input_materialized;
+        Tensor indices_materialized;
+        const Tensor& input = contiguous_read(input_materialized);
+        const Tensor& dense_indices = indices.contiguous_read(indices_materialized);
+        if (&input != this || &dense_indices != &indices) {
+            input.index_select_into(out, dim, dense_indices, mode);
+            return;
+        }
         assert_index_tensor(indices, shape_[dim], "index_select_into",
                             mode == BoundaryMode::Assert);
 
@@ -372,28 +421,31 @@ namespace lfs::core {
 
         if (device_ == Device::CUDA) {
             const int* idx_ptr = is_int64 ? indices_int32.ptr<int>() : indices_same_device.ptr<int>();
+            const Tensor& kernel_index = is_int64 ? indices_int32 : indices_same_device;
+            const cudaStream_t execution_stream =
+                prepare_inputs_for_stream({&out, this, &kernel_index}, out.stream());
 
             // Dispatch based on source tensor dtype
             if (dtype_ == DataType::Float32) {
                 tensor_ops::launch_index_select(ptr<float>(), idx_ptr,
                                                 out.ptr<float>(), shape_.dims().data(),
                                                 shape_.rank(), dim, indices.numel(),
-                                                static_cast<int>(mode), stream());
+                                                static_cast<int>(mode), execution_stream);
             } else if (dtype_ == DataType::Int64) {
                 tensor_ops::launch_index_select(ptr<int64_t>(), idx_ptr,
                                                 out.ptr<int64_t>(), shape_.dims().data(),
                                                 shape_.rank(), dim, indices.numel(),
-                                                static_cast<int>(mode), stream());
+                                                static_cast<int>(mode), execution_stream);
             } else if (dtype_ == DataType::Int32) {
                 tensor_ops::launch_index_select(ptr<int32_t>(), idx_ptr,
                                                 out.ptr<int32_t>(), shape_.dims().data(),
                                                 shape_.rank(), dim, indices.numel(),
-                                                static_cast<int>(mode), stream());
+                                                static_cast<int>(mode), execution_stream);
             } else if (dtype_ == DataType::UInt8 || dtype_ == DataType::Bool) {
                 tensor_ops::launch_index_select(ptr<uint8_t>(), idx_ptr,
                                                 out.ptr<uint8_t>(), shape_.dims().data(),
                                                 shape_.rank(), dim, indices.numel(),
-                                                static_cast<int>(mode), stream());
+                                                static_cast<int>(mode), execution_stream);
             } else {
                 throw std::runtime_error("index_select: unsupported dtype for CUDA");
             }
@@ -468,9 +520,12 @@ namespace lfs::core {
         LFS_ASSERT_MSG(dtype_ == DataType::Float32 || dtype_ == DataType::Int64,
                        "gather currently supports only Float32 and Int64 inputs");
 
-        // Ensure we have contiguous data for correct memory access
-        if (!is_contiguous()) {
-            return contiguous().gather(dim, indices, mode);
+        Tensor input_materialized;
+        Tensor indices_materialized;
+        const Tensor& input = contiguous_read(input_materialized);
+        const Tensor& dense_indices = indices.contiguous_read(indices_materialized);
+        if (&input != this || &dense_indices != &indices) {
+            return input.gather(dim, dense_indices, mode);
         }
 
         const int requested_dim = dim;
@@ -480,93 +535,7 @@ namespace lfs::core {
         assert_index_tensor(indices, shape_[dim], "gather", mode == BoundaryMode::Assert);
 
         if (indices.ndim() == 1) {
-            std::vector<size_t> out_dims = shape_.dims();
-            out_dims[dim] = indices.numel();
-            auto result = zeros(TensorShape(out_dims), device_, dtype_);
-
-            auto indices_same_device = ensure_same_device(indices);
-
-            // Handle Int64 indices properly
-            bool is_int64 = indices_same_device.dtype() == DataType::Int64;
-            Tensor indices_int32;
-            if (is_int64) {
-                indices_int32 = indices_same_device.to(DataType::Int32);
-            }
-
-            if (device_ == Device::CUDA) {
-                const int* idx_ptr = is_int64 ? indices_int32.ptr<int>() : indices_same_device.ptr<int>();
-
-                // Dispatch based on source tensor dtype
-                if (dtype_ == DataType::Float32) {
-                    tensor_ops::launch_gather(ptr<float>(), idx_ptr,
-                                              result.ptr<float>(), shape_.dims().data(),
-                                              indices.shape().dims().data(), shape_.rank(), dim,
-                                              result.numel(), static_cast<int>(mode), stream());
-                } else if (dtype_ == DataType::Int64) {
-                    tensor_ops::launch_gather(ptr<int64_t>(), idx_ptr,
-                                              result.ptr<int64_t>(), shape_.dims().data(),
-                                              indices.shape().dims().data(), shape_.rank(), dim,
-                                              result.numel(), static_cast<int>(mode), stream());
-                } else {
-                    throw std::runtime_error("gather: unsupported dtype for CUDA");
-                }
-                LFS_CUDA_CHECK_MSG(
-                    cudaGetLastError(),
-                    "gather kernel launch (input_shape={}, output_shape={}, "
-                    "index_shape={}, dimension={}, boundary_mode={}, stream={})",
-                    shape_.str(), result.shape().str(), indices.shape().str(), dim,
-                    static_cast<int>(mode), static_cast<const void*>(stream()));
-                // No sync - tensor operation
-            } else {
-                const int* idx_data = is_int64 ? indices_int32.ptr<int>() : indices_same_device.ptr<int>();
-
-                size_t outer = 1;
-                for (int i = 0; i < dim; ++i) {
-                    outer *= shape_[i];
-                }
-
-                size_t inner = 1;
-                for (size_t i = dim + 1; i < shape_.rank(); ++i) {
-                    inner *= shape_[i];
-                }
-
-                auto process_gather = [&](auto* src, auto* dst) {
-                    for (size_t o = 0; o < outer; ++o) {
-                        for (size_t i = 0; i < indices.numel(); ++i) {
-                            int idx = idx_data[i];
-
-                            if (mode == BoundaryMode::Clamp) {
-                                idx = std::clamp(idx, 0, static_cast<int>(shape_[dim]) - 1);
-                            } else if (mode == BoundaryMode::Wrap) {
-                                idx = ((idx % static_cast<int>(shape_[dim])) + static_cast<int>(shape_[dim])) % static_cast<int>(shape_[dim]);
-                            } else {
-                                if (idx < 0)
-                                    idx += shape_[dim];
-                                if (idx < 0 || idx >= static_cast<int>(shape_[dim])) {
-                                    continue;
-                                }
-                            }
-
-                            size_t src_base = o * shape_[dim] * inner + idx * inner;
-                            size_t dst_base = o * indices.numel() * inner + i * inner;
-                            for (size_t j = 0; j < inner; ++j) {
-                                dst[dst_base + j] = src[src_base + j];
-                            }
-                        }
-                    }
-                };
-
-                // Dispatch based on dtype
-                if (dtype_ == DataType::Float32) {
-                    process_gather(ptr<float>(), result.ptr<float>());
-                } else if (dtype_ == DataType::Int64) {
-                    process_gather(ptr<int64_t>(), result.ptr<int64_t>());
-                } else {
-                    throw std::runtime_error("gather: unsupported dtype for CPU");
-                }
-            }
-
-            return result;
+            return index_select(dim, indices, mode);
         }
 
         LFS_ASSERT_MSG(indices.ndim() == shape_.rank(),
@@ -578,7 +547,15 @@ namespace lfs::core {
             }
         }
 
-        auto result = zeros(indices.shape(), device_, dtype_);
+        Tensor result;
+        if (device_ == Device::CUDA) {
+            const cudaStream_t allocation_stream =
+                prepare_inputs_for_stream({this, &indices});
+            CUDAStreamGuard guard(allocation_stream);
+            result = zeros(indices.shape(), device_, dtype_);
+        } else {
+            result = zeros(indices.shape(), device_, dtype_);
+        }
         auto indices_same_device = ensure_same_device(indices);
         const bool is_int64 = indices_same_device.dtype() == DataType::Int64;
         Tensor indices_int32;
@@ -588,24 +565,26 @@ namespace lfs::core {
         const int* idx_ptr = is_int64 ? indices_int32.ptr<int>() : indices_same_device.ptr<int>();
 
         if (device_ == Device::CUDA) {
-            result.set_stream(stream());
+            const Tensor& kernel_index = is_int64 ? indices_int32 : indices_same_device;
+            const cudaStream_t execution_stream =
+                prepare_inputs_for_stream({&result, this, &kernel_index}, result.stream());
             if (dtype_ == DataType::Float32) {
                 tensor_ops::launch_gather(ptr<float>(), idx_ptr,
                                           result.ptr<float>(), shape_.dims().data(),
                                           indices.shape().dims().data(), shape_.rank(), dim,
-                                          result.numel(), static_cast<int>(mode), stream());
+                                          result.numel(), static_cast<int>(mode), execution_stream);
             } else {
                 tensor_ops::launch_gather(ptr<int64_t>(), idx_ptr,
                                           result.ptr<int64_t>(), shape_.dims().data(),
                                           indices.shape().dims().data(), shape_.rank(), dim,
-                                          result.numel(), static_cast<int>(mode), stream());
+                                          result.numel(), static_cast<int>(mode), execution_stream);
             }
             LFS_CUDA_CHECK_MSG(
                 cudaGetLastError(),
                 "multi-dimensional gather kernel launch (input_shape={}, output_shape={}, "
                 "index_shape={}, dimension={}, boundary_mode={}, stream={})",
                 shape_.str(), result.shape().str(), indices.shape().str(), dim,
-                static_cast<int>(mode), static_cast<const void*>(stream()));
+                static_cast<int>(mode), static_cast<const void*>(execution_stream));
             // No sync - tensor operation
         } else {
             const int* idx_data = idx_ptr;
@@ -676,9 +655,7 @@ namespace lfs::core {
         // DEBUG: Log device and CUDA state
         if (device_ == Device::CUDA) {
             const cudaStream_t execution_stream =
-                getCurrentCUDAStream() ? getCurrentCUDAStream() : stream();
-            sync_to_stream(execution_stream);
-            indices_int32.sync_to_stream(execution_stream);
+                prepare_inputs_for_stream({this, &indices_int32});
             CUDAStreamGuard guard(execution_stream);
             result = empty(indices.shape(), device_, dtype_);
             tensor_ops::launch_take(flat.ptr<float>(), indices_int32.ptr<int>(),
@@ -707,12 +684,18 @@ namespace lfs::core {
     // Scatter Operations
     Tensor& Tensor::scatter_(int dim, const Tensor& idx, const Tensor& src, ScatterMode mode) {
         materialize_if_deferred();
+        LFS_ASSERT_MSG(is_valid() && idx.is_valid() && src.is_valid(),
+                       "scatter_ requires valid tensors");
+        LFS_ASSERT_MSG(!shares_storage_with(idx) && !shares_storage_with(src),
+                       "scatter_ does not support destination overlap with index or source");
         if (mode == ScatterMode::Add) {
+            const int resolved_dim = resolve_dim(dim);
+            LFS_ASSERT_MSG(resolved_dim >= 0 && resolved_dim < static_cast<int>(shape_.rank()),
+                           "scatter_ dimension is out of range");
+            assert_index_tensor(idx, shape_[resolved_dim], "scatter_", true);
             return index_add_(dim, idx, src);
         }
 
-        LFS_ASSERT_MSG(is_valid() && idx.is_valid() && src.is_valid(),
-                       "scatter_ requires valid tensors");
         LFS_ASSERT_MSG(idx.ndim() == 1,
                        "scatter_ currently requires rank-1 indices");
         LFS_ASSERT_MSG(idx.device() == device_ && src.device() == device_,
@@ -725,11 +708,26 @@ namespace lfs::core {
         LFS_ASSERT_MSG(device_ != Device::CUDA || mode == ScatterMode::None,
                        "CUDA scatter_ supports assignment only; use index_add_ for addition");
 
+        if (!is_contiguous()) {
+            return mutate_logical_view(
+                [&](Tensor& materialized) {
+                    materialized.scatter_(dim, idx, src, mode);
+                });
+        }
+
+        Tensor index_materialized;
+        Tensor source_materialized;
+        const Tensor& dense_index = idx.contiguous_read(index_materialized);
+        const Tensor& dense_source = src.contiguous_read(source_materialized);
+        if (&dense_index != &idx || &dense_source != &src) {
+            return scatter_(dim, dense_index, dense_source, mode);
+        }
+
         const int requested_dim = dim;
         dim = resolve_dim(dim);
         LFS_ASSERT_MSG(dim >= 0 && dim < static_cast<int>(shape_.rank()),
                        "scatter_ dimension is out of range");
-        assert_index_tensor(idx, shape_[dim], "scatter_", true, true);
+        assert_index_tensor(idx, shape_[dim], "scatter_", true);
 
         if (shape_.rank() == 1 && dim == 0) {
             LFS_ASSERT_MSG(src.ndim() == 1,
@@ -748,21 +746,24 @@ namespace lfs::core {
             const int* indices = is_int64 ? indices_int32.ptr<int>() : indices_same_device.ptr<int>();
 
             if (device_ == Device::CUDA) {
+                const Tensor& kernel_index = is_int64 ? indices_int32 : indices_same_device;
+                const cudaStream_t execution_stream =
+                    prepare_inputs_for_stream({this, &kernel_index, &src_same_device}, stream());
                 if (dtype_ == DataType::Float32) {
                     tensor_ops::launch_scatter(ptr<float>(), indices, src_same_device.ptr<float>(),
                                                shape_.dims().data(), src.shape().dims().data(),
                                                shape_.rank(), dim, src.numel(),
-                                               static_cast<int>(mode), stream());
+                                               static_cast<int>(mode), execution_stream);
                 } else if (dtype_ == DataType::Int32) {
                     tensor_ops::launch_scatter(ptr<int>(), indices, src_same_device.ptr<int>(),
                                                shape_.dims().data(), src.shape().dims().data(),
                                                shape_.rank(), dim, src.numel(),
-                                               static_cast<int>(mode), stream());
+                                               static_cast<int>(mode), execution_stream);
                 } else if (dtype_ == DataType::Bool || dtype_ == DataType::UInt8) {
                     tensor_ops::launch_scatter(ptr<uint8_t>(), indices, src_same_device.ptr<uint8_t>(),
                                                shape_.dims().data(), src.shape().dims().data(),
                                                shape_.rank(), dim, src.numel(),
-                                               static_cast<int>(mode), stream());
+                                               static_cast<int>(mode), execution_stream);
                 } else {
                     LFS_ASSERT_MSG(false,
                                    "scatter_ encountered an unsupported CUDA dtype");
@@ -779,10 +780,10 @@ namespace lfs::core {
                                 dst[pos] *= src_data[i];
                                 break;
                             case ScatterMode::Max:
-                                dst[pos] = std::max(dst[pos], src_data[i]);
+                                dst[pos] = ops::maximum_op{}(dst[pos], src_data[i]);
                                 break;
                             case ScatterMode::Min:
-                                dst[pos] = std::min(dst[pos], src_data[i]);
+                                dst[pos] = ops::minimum_op{}(dst[pos], src_data[i]);
                                 break;
                             default:
                                 dst[pos] = src_data[i];
@@ -825,24 +826,27 @@ namespace lfs::core {
         const int* idx_ptr = is_int64 ? idx_int32.ptr<int>() : idx_same_device.ptr<int>();
 
         if (device_ == Device::CUDA) {
+            const Tensor& kernel_index = is_int64 ? idx_int32 : idx_same_device;
+            const cudaStream_t execution_stream =
+                prepare_inputs_for_stream({this, &kernel_index, &src_same_device}, stream());
             if (dtype_ == DataType::Float32) {
                 tensor_ops::launch_scatter(ptr<float>(), idx_ptr,
                                            src_same_device.ptr<float>(), shape_.dims().data(),
                                            src.shape().dims().data(),
                                            shape_.rank(), dim, src.numel(),
-                                           static_cast<int>(mode), stream());
+                                           static_cast<int>(mode), execution_stream);
             } else if (dtype_ == DataType::Int32) {
                 tensor_ops::launch_scatter(ptr<int>(), idx_ptr,
                                            src_same_device.ptr<int>(), shape_.dims().data(),
                                            src.shape().dims().data(),
                                            shape_.rank(), dim, src.numel(),
-                                           static_cast<int>(mode), stream());
+                                           static_cast<int>(mode), execution_stream);
             } else if (dtype_ == DataType::Bool || dtype_ == DataType::UInt8) {
                 tensor_ops::launch_scatter(ptr<uint8_t>(), idx_ptr,
                                            src_same_device.ptr<uint8_t>(), shape_.dims().data(),
                                            src.shape().dims().data(),
                                            shape_.rank(), dim, src.numel(),
-                                           static_cast<int>(mode), stream());
+                                           static_cast<int>(mode), execution_stream);
             } else {
                 LFS_ASSERT_MSG(false,
                                "scatter_ encountered an unsupported CUDA dtype");
@@ -892,10 +896,12 @@ namespace lfs::core {
                                 dst[dst_idx] *= src_data[src_idx];
                                 break;
                             case ScatterMode::Max:
-                                dst[dst_idx] = std::max(dst[dst_idx], src_data[src_idx]);
+                                dst[dst_idx] = ops::maximum_op{}(
+                                    dst[dst_idx], src_data[src_idx]);
                                 break;
                             case ScatterMode::Min:
-                                dst[dst_idx] = std::min(dst[dst_idx], src_data[src_idx]);
+                                dst[dst_idx] = ops::minimum_op{}(
+                                    dst[dst_idx], src_data[src_idx]);
                                 break;
                             default:
                                 dst[dst_idx] = src_data[src_idx];
@@ -955,6 +961,21 @@ namespace lfs::core {
                            dtype_ == DataType::Bool || dtype_ == DataType::UInt8,
                        "index_copy_ encountered an unsupported dtype");
 
+        if (!is_contiguous()) {
+            return mutate_logical_view(
+                [&](Tensor& materialized) {
+                    materialized.index_copy_(dim, idx, src);
+                });
+        }
+
+        Tensor index_materialized;
+        Tensor source_materialized;
+        const Tensor& dense_index = idx.contiguous_read(index_materialized);
+        const Tensor& dense_source = src.contiguous_read(source_materialized);
+        if (&dense_index != &idx || &dense_source != &src) {
+            return index_copy_(dim, dense_index, dense_source);
+        }
+
         const int requested_dim = dim;
         dim = resolve_dim(dim);
         LFS_ASSERT_MSG(dim >= 0 && dim < static_cast<int>(shape_.rank()),
@@ -978,18 +999,21 @@ namespace lfs::core {
         const int* idx_ptr = is_int64 ? idx_int32.ptr<int>() : idx_same_device.ptr<int>();
 
         if (device_ == Device::CUDA) {
+            const Tensor& kernel_index = is_int64 ? idx_int32 : idx_same_device;
+            const cudaStream_t execution_stream =
+                prepare_inputs_for_stream({this, &kernel_index, &src_same_device}, stream());
             if (dtype_ == DataType::Float32) {
                 tensor_ops::launch_index_copy(ptr<float>(), idx_ptr,
                                               src_same_device.ptr<float>(), shape_.dims().data(),
-                                              shape_.rank(), dim, idx.numel(), stream());
+                                              shape_.rank(), dim, idx.numel(), execution_stream);
             } else if (dtype_ == DataType::Int32) {
                 tensor_ops::launch_index_copy(ptr<int>(), idx_ptr,
                                               src_same_device.ptr<int>(), shape_.dims().data(),
-                                              shape_.rank(), dim, idx.numel(), stream());
+                                              shape_.rank(), dim, idx.numel(), execution_stream);
             } else if (dtype_ == DataType::Bool || dtype_ == DataType::UInt8) {
                 tensor_ops::launch_index_copy(ptr<uint8_t>(), idx_ptr,
                                               src_same_device.ptr<uint8_t>(), shape_.dims().data(),
-                                              shape_.rank(), dim, idx.numel(), stream());
+                                              shape_.rank(), dim, idx.numel(), execution_stream);
             } else {
                 LFS_ASSERT_MSG(false,
                                "index_copy_ encountered an unsupported CUDA dtype");
@@ -1052,6 +1076,21 @@ namespace lfs::core {
         LFS_ASSERT_MSG(dtype_ == DataType::Float32 || dtype_ == DataType::Int32,
                        "index_add_ currently supports only Float32 and Int32");
 
+        if (!is_contiguous()) {
+            return mutate_logical_view(
+                [&](Tensor& materialized) {
+                    materialized.index_add_(dim, idx, src);
+                });
+        }
+
+        Tensor index_materialized;
+        Tensor source_materialized;
+        const Tensor& dense_index = idx.contiguous_read(index_materialized);
+        const Tensor& dense_source = src.contiguous_read(source_materialized);
+        if (&dense_index != &idx || &dense_source != &src) {
+            return index_add_(dim, dense_index, dense_source);
+        }
+
         const int requested_dim = dim;
         dim = resolve_dim(dim);
         LFS_ASSERT_MSG(dim >= 0 && dim < static_cast<int>(shape_.rank()),
@@ -1070,16 +1109,18 @@ namespace lfs::core {
                 auto idx_int32 = (idx_same_device.dtype() == DataType::Int64)
                                      ? idx_same_device.to(DataType::Int32)
                                      : idx_same_device;
+                const cudaStream_t execution_stream =
+                    prepare_inputs_for_stream({this, &idx_int32, &src_same_device}, stream());
 
                 // Dispatch based on data type
                 if (dtype_ == DataType::Float32) {
                     tensor_ops::launch_index_add<float>(ptr<float>(), idx_int32.ptr<int>(),
                                                         src_same_device.ptr<float>(), shape_.dims().data(),
-                                                        shape_.rank(), dim, idx.numel(), stream());
+                                                        shape_.rank(), dim, idx.numel(), execution_stream);
                 } else if (dtype_ == DataType::Int32) {
                     tensor_ops::launch_index_add<int>(ptr<int>(), idx_int32.ptr<int>(),
                                                       src_same_device.ptr<int>(), shape_.dims().data(),
-                                                      shape_.rank(), dim, idx.numel(), stream());
+                                                      shape_.rank(), dim, idx.numel(), execution_stream);
                 } else {
                     LFS_ASSERT_MSG(false,
                                    "index_add_ encountered an unsupported CUDA dtype");
@@ -1162,16 +1203,18 @@ namespace lfs::core {
             auto idx_int32 = (idx_same_device.dtype() == DataType::Int64)
                                  ? idx_same_device.to(DataType::Int32)
                                  : idx_same_device;
+            const cudaStream_t execution_stream =
+                prepare_inputs_for_stream({this, &idx_int32, &src_same_device}, stream());
 
             // Dispatch based on data type
             if (dtype_ == DataType::Float32) {
                 tensor_ops::launch_index_add<float>(ptr<float>(), idx_int32.ptr<int>(),
                                                     src_same_device.ptr<float>(), shape_.dims().data(),
-                                                    shape_.rank(), dim, idx.numel(), stream());
+                                                    shape_.rank(), dim, idx.numel(), execution_stream);
             } else if (dtype_ == DataType::Int32) {
                 tensor_ops::launch_index_add<int>(ptr<int>(), idx_int32.ptr<int>(),
                                                   src_same_device.ptr<int>(), shape_.dims().data(),
-                                                  shape_.rank(), dim, idx.numel(), stream());
+                                                  shape_.rank(), dim, idx.numel(), execution_stream);
             } else {
                 LFS_ASSERT_MSG(false,
                                "index_add_ encountered an unsupported CUDA dtype");
@@ -1310,6 +1353,21 @@ namespace lfs::core {
         LFS_ASSERT_MSG(is_integer_index_dtype(idx.dtype()),
                        "index_put_ indices must be Int32 or Int64");
 
+        if (!is_contiguous()) {
+            return mutate_logical_view(
+                [&](Tensor& materialized) {
+                    materialized.index_put_(idx, vals);
+                });
+        }
+
+        Tensor index_materialized;
+        Tensor values_materialized;
+        const Tensor& dense_index = idx.contiguous_read(index_materialized);
+        const Tensor& dense_values = vals.contiguous_read(values_materialized);
+        if (&dense_index != &idx || &dense_values != &vals) {
+            return index_put_(dense_index, dense_values);
+        }
+
         // No-op for zero-element tensors
         if (idx.numel() == 0 || vals.numel() == 0)
             return *this;
@@ -1342,9 +1400,12 @@ namespace lfs::core {
                 Tensor idx_int32 = (idx_same_device.dtype() == DataType::Int32)
                                        ? idx_same_device
                                        : idx_same_device.to(DataType::Int32);
+                const cudaStream_t execution_stream =
+                    prepare_inputs_for_stream(
+                        {this, &idx_int32, &vals_same_device}, stream());
                 tensor_ops::launch_index_copy(ptr<float>(), idx_int32.ptr<int>(),
                                               vals_same_device.ptr<float>(), shape_.dims().data(),
-                                              shape_.rank(), 0, idx_int32.numel(), stream());
+                                              shape_.rank(), 0, idx_int32.numel(), execution_stream);
                 return *this;
             }
         }
@@ -1393,7 +1454,10 @@ namespace lfs::core {
                 // Copy back preserving capacity
                 auto result = cpu_tensor.to(device_);
                 const size_t bytes = numel() * dtype_size(dtype_);
-                LFS_CUDA_CHECK(cudaMemcpyAsync(data_, result.ptr<void>(), bytes, cudaMemcpyDeviceToDevice, stream()));
+                const cudaStream_t execution_stream =
+                    prepare_inputs_for_stream({this, &result}, stream());
+                LFS_CUDA_CHECK(cudaMemcpyAsync(data_ptr(), result.ptr<void>(), bytes,
+                                               cudaMemcpyDeviceToDevice, execution_stream));
                 LFS_CUDA_CHECK(cudaStreamSynchronize(stream()));
             } else {
                 // CPU implementation
@@ -1497,17 +1561,29 @@ namespace lfs::core {
                            "multi-index index_put_ tensors must be on the same device");
             LFS_ASSERT_MSG(dtype_ == DataType::Float32 && vals.dtype() == DataType::Float32,
                            "multi-index index_put_ currently supports Float32 values only");
+
+            if (!is_contiguous()) {
+                return mutate_logical_view(
+                    [&](Tensor& materialized) {
+                        materialized.index_put_(indices, vals);
+                    });
+            }
+
             assert_index_tensor(indices[0], shape_[0], "index_put_ row index", true, true);
             assert_index_tensor(indices[1], shape_[1], "index_put_ column index", true, true);
-            auto row_idx = ensure_same_device(indices[0]);
-            auto col_idx = ensure_same_device(indices[1]);
-            auto vals_same_device = ensure_same_device(vals);
 
-            LFS_ASSERT_MSG(row_idx.numel() == col_idx.numel() &&
-                               row_idx.numel() == vals_same_device.numel(),
+            Tensor row_materialized;
+            Tensor col_materialized;
+            Tensor vals_materialized;
+            const Tensor& row_dense = indices[0].contiguous_read(row_materialized);
+            const Tensor& col_dense = indices[1].contiguous_read(col_materialized);
+            const Tensor& vals_dense = vals.contiguous_read(vals_materialized);
+
+            LFS_ASSERT_MSG(row_dense.numel() == col_dense.numel() &&
+                               row_dense.numel() == vals_dense.numel(),
                            "multi-index index_put_ indices and values must have equal lengths");
 
-            auto normalize_index_to_int64 = [&](Tensor index, const char* label) -> Tensor {
+            auto normalize_index_to_int64 = [&](const Tensor& index, const char* label) -> Tensor {
                 if (index.dtype() == DataType::Int64) {
                     return index;
                 }
@@ -1519,21 +1595,16 @@ namespace lfs::core {
                                            label));
             };
 
-            row_idx = normalize_index_to_int64(std::move(row_idx), "row");
-            col_idx = normalize_index_to_int64(std::move(col_idx), "col");
+            Tensor row_idx = normalize_index_to_int64(row_dense, "row");
+            Tensor col_idx = normalize_index_to_int64(col_dense, "col");
+            const Tensor& vals_same_device = vals_dense;
             LFS_DEBUG_ASSERT_MSG(row_idx.is_valid() && col_idx.is_valid(),
                                  std::format("normalized multi-index tensors must remain valid "
                                              "(row_index={}, column_index={})",
                                              row_idx.str(), col_idx.str()));
-            if (!row_idx.is_contiguous()) {
-                row_idx = row_idx.contiguous();
-            }
-            if (!col_idx.is_contiguous()) {
-                col_idx = col_idx.contiguous();
-            }
-            if (!vals_same_device.is_contiguous()) {
-                vals_same_device = vals_same_device.contiguous();
-            }
+            LFS_DEBUG_ASSERT_MSG(row_idx.is_contiguous() && col_idx.is_contiguous() &&
+                                     vals_same_device.is_contiguous(),
+                                 "multi-index index_put_ operands must be dense after normalization");
 
             const int64_t row_bound = static_cast<int64_t>(shape_[0]);
             const int64_t col_bound = static_cast<int64_t>(shape_[1]);
@@ -1600,9 +1671,10 @@ namespace lfs::core {
     size_t Tensor::count_nonzero() const {
         LFS_ASSERT_MSG(is_valid(),
                        "count_nonzero requires a valid tensor");
-        LFS_ASSERT_MSG(is_bool_like(dtype_) || dtype_ == DataType::Float32 ||
-                           (device_ == Device::CPU && dtype_ == DataType::Int32),
-                       "count_nonzero encountered an unsupported dtype/device combination");
+        const bool native_dtype = is_bool_like(dtype_) || dtype_ == DataType::Float32 ||
+                                  (device_ == Device::CPU && dtype_ == DataType::Int32);
+        if (!native_dtype)
+            return to(DataType::Float32).count_nonzero();
         if (numel() == 0) {
             return 0;
         }
@@ -1662,9 +1734,10 @@ namespace lfs::core {
     Tensor Tensor::nonzero() const {
         LFS_ASSERT_MSG(is_valid(),
                        "nonzero requires a valid tensor");
-        LFS_ASSERT_MSG(is_bool_like(dtype_) || dtype_ == DataType::Float32 ||
-                           (device_ == Device::CPU && dtype_ == DataType::Int32),
-                       "nonzero encountered an unsupported dtype/device combination");
+        const bool native_dtype = is_bool_like(dtype_) || dtype_ == DataType::Float32 ||
+                                  (device_ == Device::CPU && dtype_ == DataType::Int32);
+        if (!native_dtype)
+            return to(DataType::Float32).nonzero();
 
         // Ensure we have contiguous data for correct linear iteration
         if (!is_contiguous()) {
@@ -1819,7 +1892,12 @@ namespace lfs::core {
 
     std::vector<Tensor> Tensor::nonzero_split() const {
         std::vector<Tensor> result;
-        result.push_back(nonzero());
+        result.reserve(ndim());
+        Tensor coordinates = nonzero();
+        for (size_t axis = 0; axis < ndim(); ++axis) {
+            result.push_back(
+                coordinates.slice(1, axis, axis + 1).squeeze(1).contiguous());
+        }
         return result;
     }
 
@@ -2052,6 +2130,40 @@ namespace lfs::core {
                        "masked assignment tensors must have the same dtype");
         LFS_ASSERT_MSG(tensor_->device() == other.device(),
                        "masked assignment tensors must be on the same device");
+
+        Tensor mask_materialized;
+        const Tensor* effective_mask = &mask_.contiguous_read(mask_materialized);
+        Tensor bool_mask;
+        if (effective_mask->dtype() == DataType::UInt8) {
+            bool_mask = effective_mask->to(DataType::Bool);
+            effective_mask = &bool_mask;
+        }
+
+        Tensor source_materialized;
+        const Tensor* effective_source = nullptr;
+        Tensor* destination = const_cast<Tensor*>(tensor_);
+        if (destination->shares_storage_with(other)) {
+            source_materialized = other.clone();
+            effective_source = &source_materialized;
+        } else {
+            effective_source = &other.contiguous_read(source_materialized);
+        }
+
+        if (!destination->is_contiguous()) {
+            destination->mutate_logical_view(
+                [&](Tensor& materialized) {
+                    MaskedTensorProxy proxy(&materialized, *effective_mask);
+                    proxy = *effective_source;
+                });
+            return;
+        }
+
+        if (effective_mask != &mask_ || effective_source != &other) {
+            MaskedTensorProxy proxy(destination, *effective_mask);
+            proxy = *effective_source;
+            return;
+        }
+
         auto selected = tensor_->masked_select(mask_);
         LFS_ASSERT_MSG(selected.numel() == other.numel(),
                        "masked assignment value count must equal selected element count");
@@ -2121,8 +2233,10 @@ namespace lfs::core {
                        "masked tensor conversion requires a Bool or UInt8 mask");
         LFS_ASSERT_MSG(mask_.device() == tensor_->device(),
                        "masked tensor conversion requires mask and tensor on the same device");
-        // For 1D mask on ND tensor, use row selection (PyTorch-style)
-        // tensor[bool_mask] selects rows where mask is True
+        if (mask_.shape() == tensor_->shape()) {
+            return tensor_->masked_select(mask_);
+        }
+        // A one-dimensional mask selects rows from an N-dimensional tensor.
         return tensor_->index_select(0, mask_);
     }
 
@@ -2156,7 +2270,11 @@ namespace lfs::core {
                        "TensorIndexer references an invalid tensor");
         LFS_ASSERT_MSG(indices_.size() == 1,
                        "TensorIndexer conversion currently supports exactly one index tensor");
-        // For both bool and int indices, use index_select for row selection.
+        if (is_bool_like(indices_[0].dtype()) &&
+            indices_[0].shape() == tensor_->shape()) {
+            return tensor_->masked_select(indices_[0]);
+        }
+        // One-dimensional indices select rows; higher-rank integer indices use take.
         return indices_[0].ndim() == 1 ? tensor_->index_select(0, indices_[0]) : tensor_->take(indices_[0]);
     }
 
@@ -2221,6 +2339,9 @@ namespace lfs::core {
 
         // Launch kernel to append gathered rows directly to the end
         if (device_ == Device::CUDA) {
+            const Tensor& kernel_index = is_int64 ? indices_int32 : indices_same_device;
+            const cudaStream_t execution_stream =
+                prepare_inputs_for_stream({this, &kernel_index}, stream());
             LOG_DEBUG("  Launching index_select kernel: write_offset_elements={}, output_offset_bytes={}, n_gather={}",
                       write_offset_elements, write_offset_elements * dtype_size(dtype_), n_gather);
 
@@ -2234,14 +2355,14 @@ namespace lfs::core {
                 tensor_ops::launch_index_select(ptr<float>(), idx_ptr,
                                                 output_ptr, input_shape,
                                                 shape_.rank(), 0, n_gather,
-                                                0 /*BoundaryMode::Assert*/, stream());
+                                                0 /*BoundaryMode::Assert*/, execution_stream);
                 LFS_CUDA_CHECK(cudaStreamSynchronize(stream()));
             } else if (dtype_ == DataType::UInt8 || dtype_ == DataType::Bool) {
                 uint8_t* output_ptr = ptr<uint8_t>() + write_offset_elements;
                 tensor_ops::launch_index_select(ptr<uint8_t>(), idx_ptr,
                                                 output_ptr, input_shape,
                                                 shape_.rank(), 0, n_gather,
-                                                0 /*BoundaryMode::Assert*/, stream());
+                                                0 /*BoundaryMode::Assert*/, execution_stream);
                 LFS_CUDA_CHECK(cudaStreamSynchronize(stream()));
             } else {
                 LFS_ASSERT_MSG(false,

--- a/src/core/tensor/tensor_masking_ops.cu
+++ b/src/core/tensor/tensor_masking_ops.cu
@@ -14,6 +14,7 @@
 
 // Thrust headers
 #include "core/assert.hpp"
+#include "core/tensor_fwd.hpp"
 #include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/device_ptr.h>
@@ -30,6 +31,27 @@
 #include <thrust/tuple.h>
 
 namespace lfs::core::tensor_ops {
+
+    inline constexpr size_t BINARY_BROADCAST_SHAPE_SLOTS = 3 * MAX_TENSOR_RANK;
+    inline constexpr size_t TERNARY_BROADCAST_SHAPE_SLOTS = 4 * MAX_TENSOR_RANK;
+
+    struct BinaryBroadcastShapes {
+        size_t values[BINARY_BROADCAST_SHAPE_SLOTS]{};
+    };
+
+    struct TernaryBroadcastShapes {
+        size_t values[TERNARY_BROADCAST_SHAPE_SLOTS]{};
+    };
+
+    BinaryBroadcastShapes pack_binary_broadcast_shapes(
+        const size_t* a_shape, const size_t* b_shape, const size_t* c_shape,
+        const size_t a_rank, const size_t b_rank, const size_t c_rank) {
+        BinaryBroadcastShapes shapes;
+        std::copy(a_shape, a_shape + a_rank, shapes.values);
+        std::copy(b_shape, b_shape + b_rank, shapes.values + MAX_TENSOR_RANK);
+        std::copy(c_shape, c_shape + c_rank, shapes.values + 2 * MAX_TENSOR_RANK);
+        return shapes;
+    }
 
     namespace {
         template <typename T>
@@ -94,7 +116,9 @@ namespace lfs::core::tensor_ops {
 
     // ============= Comparison Kernels (with broadcasting) =============
     __global__ void compare_eq_kernel(const float* a, const float* b, unsigned char* c,
-                                      const size_t* shapes, size_t info, size_t total) {
+                                      const BinaryBroadcastShapes shape_storage,
+                                      size_t info, size_t total) {
+        const size_t* shapes = shape_storage.values;
         size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
         if (idx >= total)
             return;
@@ -107,14 +131,19 @@ namespace lfs::core::tensor_ops {
         if (fast_path) {
             c[idx] = (a[idx] == b[idx]) ? 1 : 0;
         } else {
-            size_t a_idx = compute_broadcast_index(idx, shapes, a_rank, shapes + 20, c_rank);
-            size_t b_idx = compute_broadcast_index(idx, shapes + 10, b_rank, shapes + 20, c_rank);
+            size_t a_idx = compute_broadcast_index(
+                idx, shapes, a_rank, shapes + 2 * MAX_TENSOR_RANK, c_rank);
+            size_t b_idx = compute_broadcast_index(
+                idx, shapes + MAX_TENSOR_RANK, b_rank,
+                shapes + 2 * MAX_TENSOR_RANK, c_rank);
             c[idx] = (a[a_idx] == b[b_idx]) ? 1 : 0;
         }
     }
 
     __global__ void compare_lt_kernel(const float* a, const float* b, unsigned char* c,
-                                      const size_t* shapes, size_t info, size_t total) {
+                                      const BinaryBroadcastShapes shape_storage,
+                                      size_t info, size_t total) {
+        const size_t* shapes = shape_storage.values;
         size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
         if (idx >= total)
             return;
@@ -127,14 +156,19 @@ namespace lfs::core::tensor_ops {
         if (fast_path) {
             c[idx] = (a[idx] < b[idx]) ? 1 : 0;
         } else {
-            size_t a_idx = compute_broadcast_index(idx, shapes, a_rank, shapes + 20, c_rank);
-            size_t b_idx = compute_broadcast_index(idx, shapes + 10, b_rank, shapes + 20, c_rank);
+            size_t a_idx = compute_broadcast_index(
+                idx, shapes, a_rank, shapes + 2 * MAX_TENSOR_RANK, c_rank);
+            size_t b_idx = compute_broadcast_index(
+                idx, shapes + MAX_TENSOR_RANK, b_rank,
+                shapes + 2 * MAX_TENSOR_RANK, c_rank);
             c[idx] = (a[a_idx] < b[b_idx]) ? 1 : 0;
         }
     }
 
     __global__ void compare_gt_kernel(const float* a, const float* b, unsigned char* c,
-                                      const size_t* shapes, size_t info, size_t total) {
+                                      const BinaryBroadcastShapes shape_storage,
+                                      size_t info, size_t total) {
+        const size_t* shapes = shape_storage.values;
         size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
         if (idx >= total)
             return;
@@ -147,8 +181,11 @@ namespace lfs::core::tensor_ops {
         if (fast_path) {
             c[idx] = (a[idx] > b[idx]) ? 1 : 0;
         } else {
-            size_t a_idx = compute_broadcast_index(idx, shapes, a_rank, shapes + 20, c_rank);
-            size_t b_idx = compute_broadcast_index(idx, shapes + 10, b_rank, shapes + 20, c_rank);
+            size_t a_idx = compute_broadcast_index(
+                idx, shapes, a_rank, shapes + 2 * MAX_TENSOR_RANK, c_rank);
+            size_t b_idx = compute_broadcast_index(
+                idx, shapes + MAX_TENSOR_RANK, b_rank,
+                shapes + 2 * MAX_TENSOR_RANK, c_rank);
             c[idx] = (a[a_idx] > b[b_idx]) ? 1 : 0;
         }
     }
@@ -177,8 +214,9 @@ namespace lfs::core::tensor_ops {
 
     // ============= Logical Operation Kernels (with broadcasting) =============
     __global__ void logical_and_kernel(const unsigned char* a, const unsigned char* b,
-                                       unsigned char* c, const size_t* shapes,
+                                       unsigned char* c, const BinaryBroadcastShapes shape_storage,
                                        size_t info, size_t total) {
+        const size_t* shapes = shape_storage.values;
         size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
         if (idx >= total)
             return;
@@ -191,15 +229,19 @@ namespace lfs::core::tensor_ops {
         if (fast_path) {
             c[idx] = (a[idx] && b[idx]) ? 1 : 0;
         } else {
-            size_t a_idx = compute_broadcast_index(idx, shapes, a_rank, shapes + 20, c_rank);
-            size_t b_idx = compute_broadcast_index(idx, shapes + 10, b_rank, shapes + 20, c_rank);
+            size_t a_idx = compute_broadcast_index(
+                idx, shapes, a_rank, shapes + 2 * MAX_TENSOR_RANK, c_rank);
+            size_t b_idx = compute_broadcast_index(
+                idx, shapes + MAX_TENSOR_RANK, b_rank,
+                shapes + 2 * MAX_TENSOR_RANK, c_rank);
             c[idx] = (a[a_idx] && b[b_idx]) ? 1 : 0;
         }
     }
 
     __global__ void logical_or_kernel(const unsigned char* a, const unsigned char* b,
-                                      unsigned char* c, const size_t* shapes,
+                                      unsigned char* c, const BinaryBroadcastShapes shape_storage,
                                       size_t info, size_t total) {
+        const size_t* shapes = shape_storage.values;
         size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
         if (idx >= total)
             return;
@@ -212,15 +254,19 @@ namespace lfs::core::tensor_ops {
         if (fast_path) {
             c[idx] = (a[idx] || b[idx]) ? 1 : 0;
         } else {
-            size_t a_idx = compute_broadcast_index(idx, shapes, a_rank, shapes + 20, c_rank);
-            size_t b_idx = compute_broadcast_index(idx, shapes + 10, b_rank, shapes + 20, c_rank);
+            size_t a_idx = compute_broadcast_index(
+                idx, shapes, a_rank, shapes + 2 * MAX_TENSOR_RANK, c_rank);
+            size_t b_idx = compute_broadcast_index(
+                idx, shapes + MAX_TENSOR_RANK, b_rank,
+                shapes + 2 * MAX_TENSOR_RANK, c_rank);
             c[idx] = (a[a_idx] || b[b_idx]) ? 1 : 0;
         }
     }
 
     __global__ void logical_xor_kernel(const unsigned char* a, const unsigned char* b,
-                                       unsigned char* c, const size_t* shapes,
+                                       unsigned char* c, const BinaryBroadcastShapes shape_storage,
                                        size_t info, size_t total) {
+        const size_t* shapes = shape_storage.values;
         size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
         if (idx >= total)
             return;
@@ -233,8 +279,11 @@ namespace lfs::core::tensor_ops {
         if (fast_path) {
             c[idx] = ((a[idx] != 0) != (b[idx] != 0)) ? 1 : 0;
         } else {
-            size_t a_idx = compute_broadcast_index(idx, shapes, a_rank, shapes + 20, c_rank);
-            size_t b_idx = compute_broadcast_index(idx, shapes + 10, b_rank, shapes + 20, c_rank);
+            size_t a_idx = compute_broadcast_index(
+                idx, shapes, a_rank, shapes + 2 * MAX_TENSOR_RANK, c_rank);
+            size_t b_idx = compute_broadcast_index(
+                idx, shapes + MAX_TENSOR_RANK, b_rank,
+                shapes + 2 * MAX_TENSOR_RANK, c_rank);
             c[idx] = ((a[a_idx] != 0) != (b[b_idx] != 0)) ? 1 : 0;
         }
     }
@@ -251,12 +300,11 @@ namespace lfs::core::tensor_ops {
                            const size_t* a_shape, const size_t* b_shape, const size_t* c_shape,
                            size_t a_rank, size_t b_rank, size_t c_rank,
                            size_t c_elements, cudaStream_t stream) {
-        static thread_local CudaDeviceMemory<size_t> shapes(30);
-        size_t h_shapes[30] = {0};
-        std::copy(a_shape, a_shape + a_rank, h_shapes);
-        std::copy(b_shape, b_shape + b_rank, h_shapes + 10);
-        std::copy(c_shape, c_shape + c_rank, h_shapes + 20);
-        LFS_CUDA_CHECK(shapes.copy_from_host(h_shapes, 30));
+        LFS_ASSERT_MSG(a_rank <= MAX_TENSOR_RANK && b_rank <= MAX_TENSOR_RANK &&
+                           c_rank <= MAX_TENSOR_RANK,
+                       "comparison broadcast rank exceeds MAX_TENSOR_RANK");
+        const auto shapes = pack_binary_broadcast_shapes(
+            a_shape, b_shape, c_shape, a_rank, b_rank, c_rank);
 
         bool fast_path = (a_rank == c_rank && b_rank == c_rank &&
                           std::equal(a_shape, a_shape + a_rank, c_shape) &&
@@ -264,19 +312,18 @@ namespace lfs::core::tensor_ops {
         size_t info = a_rank | (b_rank << 5) | (c_rank << 10) | (fast_path << 15);
 
         int blocks = (c_elements + 255) / 256;
-        compare_eq_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes.get(), info, c_elements);
+        compare_eq_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes, info, c_elements);
     }
 
     void launch_compare_lt(const float* a, const float* b, unsigned char* c,
                            const size_t* a_shape, const size_t* b_shape, const size_t* c_shape,
                            size_t a_rank, size_t b_rank, size_t c_rank,
                            size_t c_elements, cudaStream_t stream) {
-        static thread_local CudaDeviceMemory<size_t> shapes(30);
-        size_t h_shapes[30] = {0};
-        std::copy(a_shape, a_shape + a_rank, h_shapes);
-        std::copy(b_shape, b_shape + b_rank, h_shapes + 10);
-        std::copy(c_shape, c_shape + c_rank, h_shapes + 20);
-        LFS_CUDA_CHECK(shapes.copy_from_host(h_shapes, 30));
+        LFS_ASSERT_MSG(a_rank <= MAX_TENSOR_RANK && b_rank <= MAX_TENSOR_RANK &&
+                           c_rank <= MAX_TENSOR_RANK,
+                       "comparison broadcast rank exceeds MAX_TENSOR_RANK");
+        const auto shapes = pack_binary_broadcast_shapes(
+            a_shape, b_shape, c_shape, a_rank, b_rank, c_rank);
 
         bool fast_path = (a_rank == c_rank && b_rank == c_rank &&
                           std::equal(a_shape, a_shape + a_rank, c_shape) &&
@@ -284,19 +331,18 @@ namespace lfs::core::tensor_ops {
         size_t info = a_rank | (b_rank << 5) | (c_rank << 10) | (fast_path << 15);
 
         int blocks = (c_elements + 255) / 256;
-        compare_lt_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes.get(), info, c_elements);
+        compare_lt_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes, info, c_elements);
     }
 
     void launch_compare_gt(const float* a, const float* b, unsigned char* c,
                            const size_t* a_shape, const size_t* b_shape, const size_t* c_shape,
                            size_t a_rank, size_t b_rank, size_t c_rank,
                            size_t c_elements, cudaStream_t stream) {
-        static thread_local CudaDeviceMemory<size_t> shapes(30);
-        size_t h_shapes[30] = {0};
-        std::copy(a_shape, a_shape + a_rank, h_shapes);
-        std::copy(b_shape, b_shape + b_rank, h_shapes + 10);
-        std::copy(c_shape, c_shape + c_rank, h_shapes + 20);
-        LFS_CUDA_CHECK(shapes.copy_from_host(h_shapes, 30));
+        LFS_ASSERT_MSG(a_rank <= MAX_TENSOR_RANK && b_rank <= MAX_TENSOR_RANK &&
+                           c_rank <= MAX_TENSOR_RANK,
+                       "comparison broadcast rank exceeds MAX_TENSOR_RANK");
+        const auto shapes = pack_binary_broadcast_shapes(
+            a_shape, b_shape, c_shape, a_rank, b_rank, c_rank);
 
         bool fast_path = (a_rank == c_rank && b_rank == c_rank &&
                           std::equal(a_shape, a_shape + a_rank, c_shape) &&
@@ -304,19 +350,18 @@ namespace lfs::core::tensor_ops {
         size_t info = a_rank | (b_rank << 5) | (c_rank << 10) | (fast_path << 15);
 
         int blocks = (c_elements + 255) / 256;
-        compare_gt_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes.get(), info, c_elements);
+        compare_gt_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes, info, c_elements);
     }
 
     void launch_logical_and(const unsigned char* a, const unsigned char* b, unsigned char* c,
                             const size_t* a_shape, const size_t* b_shape, const size_t* c_shape,
                             size_t a_rank, size_t b_rank, size_t c_rank,
                             size_t c_elements, cudaStream_t stream) {
-        static thread_local CudaDeviceMemory<size_t> shapes(30);
-        size_t h_shapes[30] = {0};
-        std::copy(a_shape, a_shape + a_rank, h_shapes);
-        std::copy(b_shape, b_shape + b_rank, h_shapes + 10);
-        std::copy(c_shape, c_shape + c_rank, h_shapes + 20);
-        LFS_CUDA_CHECK(shapes.copy_from_host(h_shapes, 30));
+        LFS_ASSERT_MSG(a_rank <= MAX_TENSOR_RANK && b_rank <= MAX_TENSOR_RANK &&
+                           c_rank <= MAX_TENSOR_RANK,
+                       "logical broadcast rank exceeds MAX_TENSOR_RANK");
+        const auto shapes = pack_binary_broadcast_shapes(
+            a_shape, b_shape, c_shape, a_rank, b_rank, c_rank);
 
         bool fast_path = (a_rank == c_rank && b_rank == c_rank &&
                           std::equal(a_shape, a_shape + a_rank, c_shape) &&
@@ -324,19 +369,18 @@ namespace lfs::core::tensor_ops {
         size_t info = a_rank | (b_rank << 5) | (c_rank << 10) | (fast_path << 15);
 
         int blocks = (c_elements + 255) / 256;
-        logical_and_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes.get(), info, c_elements);
+        logical_and_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes, info, c_elements);
     }
 
     void launch_logical_or(const unsigned char* a, const unsigned char* b, unsigned char* c,
                            const size_t* a_shape, const size_t* b_shape, const size_t* c_shape,
                            size_t a_rank, size_t b_rank, size_t c_rank,
                            size_t c_elements, cudaStream_t stream) {
-        static thread_local CudaDeviceMemory<size_t> shapes(30);
-        size_t h_shapes[30] = {0};
-        std::copy(a_shape, a_shape + a_rank, h_shapes);
-        std::copy(b_shape, b_shape + b_rank, h_shapes + 10);
-        std::copy(c_shape, c_shape + c_rank, h_shapes + 20);
-        LFS_CUDA_CHECK(shapes.copy_from_host(h_shapes, 30));
+        LFS_ASSERT_MSG(a_rank <= MAX_TENSOR_RANK && b_rank <= MAX_TENSOR_RANK &&
+                           c_rank <= MAX_TENSOR_RANK,
+                       "logical broadcast rank exceeds MAX_TENSOR_RANK");
+        const auto shapes = pack_binary_broadcast_shapes(
+            a_shape, b_shape, c_shape, a_rank, b_rank, c_rank);
 
         bool fast_path = (a_rank == c_rank && b_rank == c_rank &&
                           std::equal(a_shape, a_shape + a_rank, c_shape) &&
@@ -344,19 +388,18 @@ namespace lfs::core::tensor_ops {
         size_t info = a_rank | (b_rank << 5) | (c_rank << 10) | (fast_path << 15);
 
         int blocks = (c_elements + 255) / 256;
-        logical_or_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes.get(), info, c_elements);
+        logical_or_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes, info, c_elements);
     }
 
     void launch_logical_xor(const unsigned char* a, const unsigned char* b, unsigned char* c,
                             const size_t* a_shape, const size_t* b_shape, const size_t* c_shape,
                             size_t a_rank, size_t b_rank, size_t c_rank,
                             size_t c_elements, cudaStream_t stream) {
-        static thread_local CudaDeviceMemory<size_t> shapes(30);
-        size_t h_shapes[30] = {0};
-        std::copy(a_shape, a_shape + a_rank, h_shapes);
-        std::copy(b_shape, b_shape + b_rank, h_shapes + 10);
-        std::copy(c_shape, c_shape + c_rank, h_shapes + 20);
-        LFS_CUDA_CHECK(shapes.copy_from_host(h_shapes, 30));
+        LFS_ASSERT_MSG(a_rank <= MAX_TENSOR_RANK && b_rank <= MAX_TENSOR_RANK &&
+                           c_rank <= MAX_TENSOR_RANK,
+                       "logical broadcast rank exceeds MAX_TENSOR_RANK");
+        const auto shapes = pack_binary_broadcast_shapes(
+            a_shape, b_shape, c_shape, a_rank, b_rank, c_rank);
 
         bool fast_path = (a_rank == c_rank && b_rank == c_rank &&
                           std::equal(a_shape, a_shape + a_rank, c_shape) &&
@@ -364,7 +407,7 @@ namespace lfs::core::tensor_ops {
         size_t info = a_rank | (b_rank << 5) | (c_rank << 10) | (fast_path << 15);
 
         int blocks = (c_elements + 255) / 256;
-        logical_xor_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes.get(), info, c_elements);
+        logical_xor_kernel<<<blocks, 256, 0, stream>>>(a, b, c, shapes, info, c_elements);
     }
 
     // ============= Masking Operations =============
@@ -469,17 +512,23 @@ namespace lfs::core::tensor_ops {
 
     // ============= Where Operation =============
     __global__ void where_kernel(const unsigned char* cond, const float* x, const float* y,
-                                 float* r, const size_t* shapes,
+                                 float* r, const TernaryBroadcastShapes shape_storage,
                                  size_t cr, size_t xr, size_t yr, size_t rr, size_t n) {
+        const size_t* shapes = shape_storage.values;
         // Support both 1D and 2D grids for large arrays
         size_t block_id = blockIdx.y * gridDim.x + blockIdx.x;
         size_t idx = block_id * blockDim.x + threadIdx.x;
         if (idx >= n)
             return;
 
-        size_t c_idx = compute_broadcast_index(idx, shapes, cr, shapes + 30, rr);
-        size_t x_idx = compute_broadcast_index(idx, shapes + 10, xr, shapes + 30, rr);
-        size_t y_idx = compute_broadcast_index(idx, shapes + 20, yr, shapes + 30, rr);
+        size_t c_idx = compute_broadcast_index(
+            idx, shapes, cr, shapes + 3 * MAX_TENSOR_RANK, rr);
+        size_t x_idx = compute_broadcast_index(
+            idx, shapes + MAX_TENSOR_RANK, xr,
+            shapes + 3 * MAX_TENSOR_RANK, rr);
+        size_t y_idx = compute_broadcast_index(
+            idx, shapes + 2 * MAX_TENSOR_RANK, yr,
+            shapes + 3 * MAX_TENSOR_RANK, rr);
 
         r[idx] = cond[c_idx] ? x[x_idx] : y[y_idx];
     }
@@ -490,13 +539,14 @@ namespace lfs::core::tensor_ops {
                       size_t cond_rank, size_t x_rank, size_t y_rank, size_t r_rank,
                       size_t total, cudaStream_t stream) {
 
-        static thread_local CudaDeviceMemory<size_t> shapes(40);
-        size_t h_shapes[40] = {0};
-        std::copy(cond_shape, cond_shape + cond_rank, h_shapes);
-        std::copy(x_shape, x_shape + x_rank, h_shapes + 10);
-        std::copy(y_shape, y_shape + y_rank, h_shapes + 20);
-        std::copy(r_shape, r_shape + r_rank, h_shapes + 30);
-        LFS_CUDA_CHECK(shapes.copy_from_host(h_shapes, 40));
+        LFS_ASSERT_MSG(cond_rank <= MAX_TENSOR_RANK && x_rank <= MAX_TENSOR_RANK &&
+                           y_rank <= MAX_TENSOR_RANK && r_rank <= MAX_TENSOR_RANK,
+                       "where rank exceeds MAX_TENSOR_RANK");
+        TernaryBroadcastShapes shapes;
+        std::copy(cond_shape, cond_shape + cond_rank, shapes.values);
+        std::copy(x_shape, x_shape + x_rank, shapes.values + MAX_TENSOR_RANK);
+        std::copy(y_shape, y_shape + y_rank, shapes.values + 2 * MAX_TENSOR_RANK);
+        std::copy(r_shape, r_shape + r_rank, shapes.values + 3 * MAX_TENSOR_RANK);
 
         // Use 2D grid for large arrays to avoid exceeding grid dimension limits
         size_t num_blocks = (total + 255) / 256;
@@ -504,12 +554,12 @@ namespace lfs::core::tensor_ops {
 
         if (num_blocks <= max_blocks_x) {
             where_kernel<<<num_blocks, 256, 0, stream>>>(
-                cond, x, y, r, shapes.get(), cond_rank, x_rank, y_rank, r_rank, total);
+                cond, x, y, r, shapes, cond_rank, x_rank, y_rank, r_rank, total);
         } else {
             dim3 grid(std::min(num_blocks, max_blocks_x),
                       (num_blocks + max_blocks_x - 1) / max_blocks_x);
             where_kernel<<<grid, 256, 0, stream>>>(
-                cond, x, y, r, shapes.get(), cond_rank, x_rank, y_rank, r_rank, total);
+                cond, x, y, r, shapes, cond_rank, x_rank, y_rank, r_rank, total);
         }
     }
 
@@ -744,19 +794,19 @@ namespace lfs::core::tensor_ops {
         if (tid >= total)
             return;
 
-        size_t in_strides[10];
+        size_t in_strides[MAX_TENSOR_RANK];
         in_strides[in_rank - 1] = 1;
         for (int i = in_rank - 2; i >= 0; --i) {
             in_strides[i] = in_strides[i + 1] * in_shape[i + 1];
         }
 
-        size_t out_strides[10];
+        size_t out_strides[MAX_TENSOR_RANK];
         out_strides[idx_rank - 1] = 1;
         for (int i = idx_rank - 2; i >= 0; --i) {
             out_strides[i] = out_strides[i + 1] * idx_shape[i + 1];
         }
 
-        size_t out_coords[10] = {0};
+        size_t out_coords[MAX_TENSOR_RANK] = {0};
         size_t temp = tid;
         for (size_t d = 0; d < idx_rank; ++d) {
             out_coords[d] = temp / out_strides[d];
@@ -818,105 +868,39 @@ namespace lfs::core::tensor_ops {
     void launch_gather(const float* in, const int* idx, float* out,
                        const size_t* in_shape, const size_t* idx_shape,
                        size_t rank, int dim, size_t total, int boundary, cudaStream_t stream) {
+        LFS_ASSERT_MSG(rank > 0 && rank <= MAX_TENSOR_RANK,
+                       "gather rank exceeds MAX_TENSOR_RANK");
         if (total == 0) {
             return;
         }
-        CudaDeviceMemory<size_t> d_in_shape(10);
-        CudaDeviceMemory<size_t> d_idx_shape(10);
-
-        size_t h_in_shape[10] = {0};
-        size_t h_idx_shape[10] = {0};
-
-        size_t idx_rank = rank;
-        size_t idx_elements = 1;
-        for (size_t i = 0; i < rank; ++i) {
-            if (idx_shape[i] > 0) {
-                h_idx_shape[i] = idx_shape[i];
-                idx_elements *= idx_shape[i];
-            } else {
-                break;
-            }
-        }
-
-        idx_rank = 0;
-        size_t check_elements = 1;
-        for (size_t i = 0; i < 10; ++i) {
-            if (idx_shape[i] > 0) {
-                check_elements *= idx_shape[i];
-                idx_rank++;
-                if (check_elements == total)
-                    break;
-            } else {
-                break;
-            }
-        }
-
-        if (idx_rank == 0)
-            idx_rank = 1;
-
-        for (size_t i = 0; i < rank; ++i) {
-            h_in_shape[i] = in_shape[i];
-        }
-
-        LFS_CUDA_CHECK(d_in_shape.copy_from_host(h_in_shape, 10));
-        LFS_CUDA_CHECK(d_idx_shape.copy_from_host(h_idx_shape, 10));
+        CudaDeviceMemory<size_t> d_in_shape(rank);
+        CudaDeviceMemory<size_t> d_idx_shape(rank);
+        LFS_CUDA_CHECK(d_in_shape.copy_from_host(in_shape, rank));
+        LFS_CUDA_CHECK(d_idx_shape.copy_from_host(idx_shape, rank));
 
         int blocks = (total + 255) / 256;
         gather_kernel<float><<<blocks, 256, 0, stream>>>(
             in, idx, out, d_in_shape.get(), d_idx_shape.get(),
-            rank, idx_rank, dim, total, boundary);
+            rank, rank, dim, total, boundary);
     }
 
     void launch_gather(const int64_t* in, const int* idx, int64_t* out,
                        const size_t* in_shape, const size_t* idx_shape,
                        size_t rank, int dim, size_t total, int boundary, cudaStream_t stream) {
+        LFS_ASSERT_MSG(rank > 0 && rank <= MAX_TENSOR_RANK,
+                       "gather rank exceeds MAX_TENSOR_RANK");
         if (total == 0) {
             return;
         }
-        CudaDeviceMemory<size_t> d_in_shape(10);
-        CudaDeviceMemory<size_t> d_idx_shape(10);
-
-        size_t h_in_shape[10] = {0};
-        size_t h_idx_shape[10] = {0};
-
-        size_t idx_rank = rank;
-        size_t idx_elements = 1;
-        for (size_t i = 0; i < rank; ++i) {
-            if (idx_shape[i] > 0) {
-                h_idx_shape[i] = idx_shape[i];
-                idx_elements *= idx_shape[i];
-            } else {
-                break;
-            }
-        }
-
-        idx_rank = 0;
-        size_t check_elements = 1;
-        for (size_t i = 0; i < 10; ++i) {
-            if (idx_shape[i] > 0) {
-                check_elements *= idx_shape[i];
-                idx_rank++;
-                if (check_elements == total)
-                    break;
-            } else {
-                break;
-            }
-        }
-
-        if (idx_rank == 0)
-            idx_rank = 1;
-
-        for (size_t i = 0; i < rank; ++i) {
-            h_in_shape[i] = in_shape[i];
-        }
-
-        LFS_CUDA_CHECK(d_in_shape.copy_from_host(h_in_shape, 10));
-        LFS_CUDA_CHECK(d_idx_shape.copy_from_host(h_idx_shape, 10));
+        CudaDeviceMemory<size_t> d_in_shape(rank);
+        CudaDeviceMemory<size_t> d_idx_shape(rank);
+        LFS_CUDA_CHECK(d_in_shape.copy_from_host(in_shape, rank));
+        LFS_CUDA_CHECK(d_idx_shape.copy_from_host(idx_shape, rank));
 
         int blocks = (total + 255) / 256;
         gather_kernel<int64_t><<<blocks, 256, 0, stream>>>(
             in, idx, out, d_in_shape.get(), d_idx_shape.get(),
-            rank, idx_rank, dim, total, boundary);
+            rank, rank, dim, total, boundary);
     }
 
     void launch_take(const float* in, const int* idx, float* out,
@@ -1009,6 +993,8 @@ namespace lfs::core::tensor_ops {
     void launch_scatter(T* out, const int* idx, const T* in,
                         const size_t* out_shape, const size_t* in_shape,
                         size_t rank, int dim, size_t /*total*/, int mode, cudaStream_t stream) {
+        LFS_ASSERT_MSG(rank > 0 && rank <= MAX_TENSOR_RANK,
+                       "scatter rank exceeds MAX_TENSOR_RANK");
         size_t outer = 1, inner = 1;
         for (int i = 0; i < dim; ++i)
             outer *= out_shape[i];
@@ -1039,7 +1025,7 @@ namespace lfs::core::tensor_ops {
         auto val_ptr = thrust::device_pointer_cast(val_buffer.get());
         thrust::fill(thrust::cuda::par.on(stream), val_ptr, val_ptr + n_idx, val);
 
-        size_t in_shape[10] = {0};
+        size_t in_shape[MAX_TENSOR_RANK] = {0};
         std::copy(shape, shape + rank, in_shape);
         in_shape[dim] = n_idx;
         launch_scatter<T>(data, idx, val_buffer.get(), shape, in_shape, rank, dim, n_idx, 0, stream);
@@ -1049,7 +1035,7 @@ namespace lfs::core::tensor_ops {
     void launch_index_copy(T* dst, const int* idx, const T* src,
                            const size_t* shape, size_t rank, int dim,
                            size_t n_idx, cudaStream_t stream) {
-        size_t in_shape[10] = {0};
+        size_t in_shape[MAX_TENSOR_RANK] = {0};
         std::copy(shape, shape + rank, in_shape);
         in_shape[dim] = n_idx;
         launch_scatter<T>(dst, idx, src, shape, in_shape, rank, dim, n_idx, 0, stream);
@@ -1059,7 +1045,7 @@ namespace lfs::core::tensor_ops {
     void launch_index_add(T* dst, const int* idx, const T* src,
                           const size_t* shape, size_t rank, int dim,
                           size_t n_idx, cudaStream_t stream) {
-        size_t in_shape[10] = {0};
+        size_t in_shape[MAX_TENSOR_RANK] = {0};
         std::copy(shape, shape + rank, in_shape);
         in_shape[dim] = n_idx;
         launch_scatter<T>(dst, idx, src, shape, in_shape, rank, dim, n_idx, 1, stream);

--- a/src/core/tensor/tensor_matrix_ops.cpp
+++ b/src/core/tensor/tensor_matrix_ops.cpp
@@ -3,6 +3,7 @@
 
 #include "core/logger.hpp"
 #include "core/tensor_trace.hpp"
+#include "internal/cuda_stream_context.hpp"
 #include "internal/tensor_impl.hpp"
 #include "internal/tensor_ops.hpp"
 
@@ -54,6 +55,7 @@ namespace lfs::core {
         // GPU: use tiled CUDA sgemm kernel
         if (device_ == Device::CUDA) {
             auto result = empty({m, n}, Device::CUDA, dtype_);
+            prepare_inputs_for_stream({&a, &b}, result.stream());
             tensor_ops::launch_sgemm(a.ptr<float>(), b.ptr<float>(), result.ptr<float>(),
                                      m, n, k, result.stream());
             return result;
@@ -94,6 +96,7 @@ namespace lfs::core {
         // GPU: use tiled CUDA batched sgemm kernel
         if (device_ == Device::CUDA) {
             auto result = empty({batch_size, m, n}, Device::CUDA, dtype_);
+            prepare_inputs_for_stream({&a, &b}, result.stream());
             tensor_ops::launch_sgemm_batched(a.ptr<float>(), b.ptr<float>(), result.ptr<float>(),
                                              batch_size, m, n, k, result.stream());
             return result;
@@ -161,7 +164,31 @@ namespace lfs::core {
 
         // Batch matrix multiply: [B, m, k] @ [B, k, n] -> [B, m, n]
         if (a.shape_.rank() == 3 && b.shape_.rank() == 3) {
-            return a.bmm(b);
+            LFS_ASSERT_MSG(a.shape_[2] == b.shape_[1],
+                           "matmul batched matrix dimensions must match");
+            const size_t a_batch = a.shape_[0];
+            const size_t b_batch = b.shape_[0];
+            LFS_ASSERT_MSG(a_batch == b_batch || a_batch == 1 || b_batch == 1,
+                           std::format("matmul batch dimensions are not broadcastable: {} and {}",
+                                       a_batch, b_batch));
+            if (a_batch == b_batch) {
+                return a.bmm(b);
+            }
+
+            const size_t batch = a_batch == 1 ? b_batch : a_batch;
+            Tensor a_broadcast;
+            Tensor b_broadcast;
+            const Tensor* a_operand = &a;
+            const Tensor* b_operand = &b;
+            if (a_batch == 1) {
+                a_broadcast = a.broadcast_to({batch, a.shape_[1], a.shape_[2]});
+                a_operand = &a_broadcast;
+            }
+            if (b_batch == 1) {
+                b_broadcast = b.broadcast_to({batch, b.shape_[1], b.shape_[2]});
+                b_operand = &b_broadcast;
+            }
+            return a_operand->bmm(*b_operand);
         }
 
         // 2D @ 3D: broadcast [m, k] @ [B, k, n] -> [B, m, n]
@@ -214,6 +241,7 @@ namespace lfs::core {
         // GPU: Use optimized CUDA kernel
         if (device_ == Device::CUDA) {
             auto result = empty({}, Device::CUDA, dtype_);
+            prepare_inputs_for_stream({&a, &b}, result.stream());
             tensor_ops::launch_dot_product(
                 a.ptr<float>(),
                 b.ptr<float>(),
@@ -235,6 +263,7 @@ namespace lfs::core {
         // Return as scalar (rank-0 view)
         Tensor scalar(result.data_ptr(), TensorShape(std::vector<size_t>{}), Device::CPU, dtype_);
         scalar.data_owner_ = result.data_owner_;
+        scalar.storage_meta_ = result.storage_meta_;
         scalar.is_view_ = true;
         return scalar;
     }

--- a/src/core/tensor/tensor_movement_ops.cpp
+++ b/src/core/tensor/tensor_movement_ops.cpp
@@ -72,8 +72,6 @@ namespace lfs::core {
         case MovementOp::Reshape: {
             if (auto* vec = std::get_if<std::vector<int>>(&args.args)) {
                 auto new_shape = infer_shape(*vec, numel());
-                LFS_ASSERT_MSG(!new_shape.empty(),
-                               "reshape requires at least one output dimension");
 
                 size_t total = 1;
                 for (auto d : new_shape)
@@ -132,9 +130,13 @@ namespace lfs::core {
                 int dim1 = resolve_dim(pair->first);
                 int dim2 = resolve_dim(pair->second);
 
-                LFS_ASSERT_MSG(dim1 >= 0 && dim1 < static_cast<int>(shape_.rank()) &&
-                                   dim2 >= 0 && dim2 < static_cast<int>(shape_.rank()),
+                LFS_ASSERT_MSG(detail::tensor_dim_is_valid(dim1, shape_.rank()) &&
+                                   detail::tensor_dim_is_valid(dim2, shape_.rank()),
                                "transpose dimensions are out of range");
+
+                if (shape_.rank() == 0) {
+                    return create_strided_view(shape_, strides_);
+                }
 
                 if (state_ && state_->has_deferred_expr) {
                     std::vector<int> axes(shape_.rank());
@@ -170,7 +172,7 @@ namespace lfs::core {
                 return view;
             }
             if (shape_.rank() < 2)
-                return clone();
+                return create_strided_view(shape_, strides_);
             return transpose(-2, -1);
         }
 
@@ -178,6 +180,7 @@ namespace lfs::core {
             if (auto* dim_ptr = std::get_if<int>(&args.args)) {
                 int dim = *dim_ptr;
                 std::vector<size_t> new_shape;
+                std::vector<size_t> new_strides;
 
                 // Check if this is "squeeze all" (using sentinel value)
                 bool squeeze_all = (dim == std::numeric_limits<int>::min());
@@ -187,14 +190,17 @@ namespace lfs::core {
                     for (size_t i = 0; i < shape_.rank(); ++i) {
                         if (shape_[i] != 1) {
                             new_shape.push_back(shape_[i]);
+                            new_strides.push_back(strides_[i]);
                         }
                     }
 
-                    // If all dims were 1, keep at least one dimension
-                    if (new_shape.empty()) {
-                        new_shape.push_back(1);
-                    }
                 } else {
+                    if (shape_.rank() == 0) {
+                        LFS_ASSERT_MSG(dim == 0 || dim == -1,
+                                       "scalar squeeze dimension is out of range");
+                        return create_strided_view(shape_, strides_);
+                    }
+
                     // Squeeze specific dimension
                     int resolved = resolve_dim(dim);
 
@@ -203,25 +209,22 @@ namespace lfs::core {
 
                     // Check if the dimension has size 1
                     if (shape_[resolved] != 1) {
-                        LOG_WARN("Squeeze dimension {} has size {}, not 1. Returning clone.",
-                                 dim, shape_[resolved]);
-                        return clone();
+                        return create_strided_view(shape_, strides_);
                     }
 
                     // Build new shape without this dimension
                     for (size_t i = 0; i < shape_.rank(); ++i) {
                         if (i != static_cast<size_t>(resolved)) {
                             new_shape.push_back(shape_[i]);
+                            new_strides.push_back(strides_[i]);
                         }
-                    }
-
-                    // Ensure we have at least one dimension
-                    if (new_shape.empty()) {
-                        new_shape.push_back(1);
                     }
                 }
 
-                return create_view(TensorShape(new_shape));
+                if (state_ && state_->has_deferred_expr) {
+                    return create_view(TensorShape(new_shape));
+                }
+                return create_strided_view(TensorShape(new_shape), std::move(new_strides));
             }
 
             LFS_ASSERT_MSG(false,
@@ -239,15 +242,25 @@ namespace lfs::core {
                                "unsqueeze dimension is out of range");
 
                 std::vector<size_t> new_shape;
+                std::vector<size_t> new_strides;
                 for (int i = 0; i < resolved; ++i) {
                     new_shape.push_back(shape_[i]);
+                    new_strides.push_back(strides_[i]);
                 }
                 new_shape.push_back(1);
+                new_strides.push_back(
+                    resolved == static_cast<int>(shape_.rank())
+                        ? 1
+                        : shape_[resolved] * strides_[resolved]);
                 for (size_t i = resolved; i < shape_.rank(); ++i) {
                     new_shape.push_back(shape_[i]);
+                    new_strides.push_back(strides_[i]);
                 }
 
-                return create_view(TensorShape(new_shape));
+                if (state_ && state_->has_deferred_expr) {
+                    return create_view(TensorShape(new_shape));
+                }
+                return create_strided_view(TensorShape(new_shape), std::move(new_strides));
             }
             LFS_ASSERT_MSG(false,
                            "unsqueeze requires an integer dimension");
@@ -258,9 +271,13 @@ namespace lfs::core {
                 int start = resolve_dim(pair->first);
                 int end = resolve_dim(pair->second);
 
-                LFS_ASSERT_MSG(start >= 0 && start < static_cast<int>(shape_.rank()) &&
-                                   end >= 0 && end < static_cast<int>(shape_.rank()) && start <= end,
+                LFS_ASSERT_MSG(detail::tensor_dim_is_valid(start, shape_.rank()) &&
+                                   detail::tensor_dim_is_valid(end, shape_.rank()) && start <= end,
                                "flatten dimensions are invalid");
+
+                if (shape_.rank() == 0) {
+                    return create_view(TensorShape({1}));
+                }
 
                 std::vector<size_t> new_shape;
                 for (int i = 0; i < start; ++i) {

--- a/src/core/tensor/tensor_nn_ops.cpp
+++ b/src/core/tensor/tensor_nn_ops.cpp
@@ -3,6 +3,7 @@
 
 #include "internal/tensor_nn_ops.hpp"
 #include "core/logger.hpp"
+#include "internal/tensor_functors.hpp"
 #include "internal/tensor_impl.hpp"
 #include "internal/tensor_ops.hpp"
 
@@ -50,6 +51,32 @@ namespace lfs::core {
                                        operation, bias.shape().str(), expected_channels));
         }
 
+        bool has_definite_internal_overlap(const Tensor& tensor) {
+            for (size_t first = 0; first < tensor.ndim(); ++first) {
+                if (tensor.shape()[first] <= 1) {
+                    continue;
+                }
+                if (tensor.stride(first) == 0) {
+                    return true;
+                }
+                for (size_t second = first + 1; second < tensor.ndim(); ++second) {
+                    if (tensor.shape()[second] > 1 &&
+                        tensor.stride(first) == tensor.stride(second)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        int64_t floor_div(const int64_t numerator, const int64_t denominator) {
+            LFS_ASSERT_MSG(denominator > 0,
+                           "floor_div requires a positive denominator");
+            const int64_t quotient = numerator / denominator;
+            const int64_t remainder = numerator % denominator;
+            return quotient - (remainder < 0 ? 1 : 0);
+        }
+
         void cpu_max_pool2d(const float* input, float* output,
                             int N, int C, int H_in, int W_in,
                             int H_out, int W_out,
@@ -61,7 +88,7 @@ namespace lfs::core {
                             const int h_start = h_out * stride - padding;
                             const int w_start = w_out * stride - padding;
 
-                            float max_val = -std::numeric_limits<float>::max();
+                            float max_val = -std::numeric_limits<float>::infinity();
 
                             for (int kh = 0; kh < kernel; ++kh) {
                                 const int h_in = h_start + kh;
@@ -74,7 +101,7 @@ namespace lfs::core {
                                         continue;
 
                                     const int idx = ((n * C + c) * H_in + h_in) * W_in + w_in;
-                                    max_val = std::max(max_val, input[idx]);
+                                    max_val = ops::max_reduce_op{}(max_val, input[idx]);
                                 }
                             }
 
@@ -162,8 +189,14 @@ namespace lfs::core {
             assert_bias_shape(bias, C_out, "conv1x1");
         }
 
-        const Tensor& input_cont = is_contiguous() ? *this : contiguous();
-        const Tensor& weight_cont = weight.is_contiguous() ? weight : weight.contiguous();
+        Tensor input_materialized;
+        Tensor weight_materialized;
+        Tensor bias_materialized;
+        const Tensor& input_cont = contiguous_read(input_materialized);
+        const Tensor& weight_cont = weight.contiguous_read(weight_materialized);
+        const Tensor* bias_cont = bias.is_valid()
+                                      ? &bias.contiguous_read(bias_materialized)
+                                      : &bias;
 
         // GPU path: Output[C_out, S] = Weight[C_out, C_in] @ Input[C_in, S]
         if (device_ == Device::CUDA && N == 1) {
@@ -174,7 +207,7 @@ namespace lfs::core {
 
             if (bias.is_valid()) {
                 const int total = static_cast<int>(N * C_out * H * W);
-                tensor_ops::launch_bias_add(output.ptr<float>(), bias.ptr<float>(),
+                tensor_ops::launch_bias_add(output.ptr<float>(), bias_cont->ptr<float>(),
                                             output.ptr<float>(), total,
                                             static_cast<int>(C_out), static_cast<int>(S),
                                             stream());
@@ -196,7 +229,7 @@ namespace lfs::core {
 
             if (bias.is_valid()) {
                 const int total = static_cast<int>(N * C_out * H * W);
-                tensor_ops::launch_bias_add(output.ptr<float>(), bias.ptr<float>(),
+                tensor_ops::launch_bias_add(output.ptr<float>(), bias_cont->ptr<float>(),
                                             output.ptr<float>(), total,
                                             static_cast<int>(C_out), static_cast<int>(S),
                                             stream());
@@ -212,7 +245,7 @@ namespace lfs::core {
         auto output_2d = input_2d.matmul(weight_t);
 
         if (bias.is_valid()) {
-            output_2d = output_2d + bias;
+            output_2d = output_2d + *bias_cont;
         }
 
         auto output_nhwc = output_2d.reshape({static_cast<int>(N), static_cast<int>(H),
@@ -231,22 +264,48 @@ namespace lfs::core {
                                    "(kernel_size={})",
                                    kernel_size));
 
-        if (stride <= 0)
+        LFS_ASSERT_MSG(stride == -1 || stride > 0,
+                       std::format("max_pool2d stride must be positive when specified "
+                                   "(stride={})",
+                                   stride));
+        LFS_ASSERT_MSG(padding >= 0 && padding <= kernel_size / 2,
+                       std::format("max_pool2d padding must be non-negative and no greater "
+                                   "than half the kernel size (padding={}, kernel_size={})",
+                                   padding, kernel_size));
+
+        if (stride == -1)
             stride = kernel_size;
+
+        for (size_t dim = 0; dim < shape_.rank(); ++dim) {
+            LFS_ASSERT_MSG(shape_[dim] <= static_cast<size_t>(std::numeric_limits<int>::max()),
+                           "max_pool2d dimensions must fit in signed 32-bit kernel metadata");
+        }
 
         const int N = static_cast<int>(shape_[0]);
         const int C = static_cast<int>(shape_[1]);
         const int H_in = static_cast<int>(shape_[2]);
         const int W_in = static_cast<int>(shape_[3]);
 
-        const int H_out = (H_in + 2 * padding - kernel_size) / stride + 1;
-        const int W_out = (W_in + 2 * padding - kernel_size) / stride + 1;
+        const int64_t H_out_wide =
+            floor_div(static_cast<int64_t>(H_in) + 2LL * padding - kernel_size, stride) + 1;
+        const int64_t W_out_wide =
+            floor_div(static_cast<int64_t>(W_in) + 2LL * padding - kernel_size, stride) + 1;
 
-        LFS_ASSERT_MSG(H_out > 0 && W_out > 0,
+        LFS_ASSERT_MSG(H_out_wide > 0 && W_out_wide > 0 &&
+                           H_out_wide <= std::numeric_limits<int>::max() &&
+                           W_out_wide <= std::numeric_limits<int>::max(),
                        std::format("max_pool2d output dimensions must be positive "
                                    "(output_height={}, output_width={}, input_shape={}, "
                                    "kernel_size={}, stride={}, padding={})",
-                                   H_out, W_out, shape_.str(), kernel_size, stride, padding));
+                                   H_out_wide, W_out_wide, shape_.str(), kernel_size, stride,
+                                   padding));
+
+        const int H_out = static_cast<int>(H_out_wide);
+        const int W_out = static_cast<int>(W_out_wide);
+        const size_t output_elements = static_cast<size_t>(N) * static_cast<size_t>(C) *
+                                       static_cast<size_t>(H_out) * static_cast<size_t>(W_out);
+        LFS_ASSERT_MSG(output_elements <= static_cast<size_t>(std::numeric_limits<int>::max()),
+                       "max_pool2d output has too many elements for its CUDA launch metadata");
 
         const Tensor& input_cont = is_contiguous() ? *this : contiguous();
         auto output = empty({static_cast<size_t>(N), static_cast<size_t>(C),
@@ -276,6 +335,10 @@ namespace lfs::core {
                        std::format("adaptive_avg_pool2d output dimensions must be positive "
                                    "(output_height={}, output_width={})",
                                    output_h, output_w));
+        LFS_ASSERT_MSG(shape_[2] > 0 && shape_[3] > 0,
+                       std::format("adaptive_avg_pool2d spatial input dimensions must be positive "
+                                   "(input_shape={})",
+                                   shape_.str()));
 
         const int N = static_cast<int>(shape_[0]);
         const int C = static_cast<int>(shape_[1]);
@@ -334,8 +397,14 @@ namespace lfs::core {
             batch_size *= shape_[i];
         }
 
-        const Tensor& input_cont = is_contiguous() ? *this : contiguous();
-        const Tensor& weight_cont = weight.is_contiguous() ? weight : weight.contiguous();
+        Tensor input_materialized;
+        Tensor weight_materialized;
+        Tensor bias_materialized;
+        const Tensor& input_cont = contiguous_read(input_materialized);
+        const Tensor& weight_cont = weight.contiguous_read(weight_materialized);
+        const Tensor* bias_cont = bias.is_valid()
+                                      ? &bias.contiguous_read(bias_materialized)
+                                      : &bias;
 
         // GPU path: Output[batch, out] = Input[batch, in] @ Weight^T[in, out]
         if (device_ == Device::CUDA) {
@@ -347,7 +416,7 @@ namespace lfs::core {
 
             if (bias.is_valid()) {
                 const int total = static_cast<int>(batch_size * out_features);
-                tensor_ops::launch_bias_add(output.ptr<float>(), bias.ptr<float>(),
+                tensor_ops::launch_bias_add(output.ptr<float>(), bias_cont->ptr<float>(),
                                             output.ptr<float>(), total,
                                             static_cast<int>(out_features), 1,
                                             stream());
@@ -367,7 +436,7 @@ namespace lfs::core {
         auto output_2d = input_2d.matmul(weight_t);
 
         if (bias.is_valid()) {
-            output_2d = output_2d + bias;
+            output_2d = output_2d + *bias_cont;
         }
 
         std::vector<int> output_shape;
@@ -405,8 +474,12 @@ namespace lfs::core {
 
         assert_bias_shape(bias, C_out, "conv1x1_bias_relu");
 
-        const Tensor& input_cont = is_contiguous() ? *this : contiguous();
-        const Tensor& weight_cont = weight.is_contiguous() ? weight : weight.contiguous();
+        Tensor input_materialized;
+        Tensor weight_materialized;
+        Tensor bias_materialized;
+        const Tensor& input_cont = contiguous_read(input_materialized);
+        const Tensor& weight_cont = weight.contiguous_read(weight_materialized);
+        const Tensor& bias_cont = bias.contiguous_read(bias_materialized);
 
         if (device_ == Device::CUDA && N == 1) {
             auto output = empty({N, C_out, H, W}, Device::CUDA, dtype_);
@@ -415,7 +488,7 @@ namespace lfs::core {
                                      output.ptr<float>(), C_out, S, C_in, stream());
 
             const int total = static_cast<int>(N * C_out * H * W);
-            tensor_ops::launch_bias_relu(output.ptr<float>(), bias.ptr<float>(),
+            tensor_ops::launch_bias_relu(output.ptr<float>(), bias_cont.ptr<float>(),
                                          output.ptr<float>(), total,
                                          static_cast<int>(C_out), static_cast<int>(S),
                                          stream());
@@ -454,8 +527,12 @@ namespace lfs::core {
             batch_size *= shape_[i];
         }
 
-        const Tensor& input_cont = is_contiguous() ? *this : contiguous();
-        const Tensor& weight_cont = weight.is_contiguous() ? weight : weight.contiguous();
+        Tensor input_materialized;
+        Tensor weight_materialized;
+        Tensor bias_materialized;
+        const Tensor& input_cont = contiguous_read(input_materialized);
+        const Tensor& weight_cont = weight.contiguous_read(weight_materialized);
+        const Tensor& bias_cont = bias.contiguous_read(bias_materialized);
 
         if (device_ == Device::CUDA) {
             auto output = empty({batch_size, out_features}, Device::CUDA, dtype_);
@@ -465,7 +542,7 @@ namespace lfs::core {
                                         stream());
 
             const int total = static_cast<int>(batch_size * out_features);
-            tensor_ops::launch_bias_relu(output.ptr<float>(), bias.ptr<float>(),
+            tensor_ops::launch_bias_relu(output.ptr<float>(), bias_cont.ptr<float>(),
                                          output.ptr<float>(), total,
                                          static_cast<int>(out_features), 1,
                                          stream());
@@ -528,14 +605,32 @@ namespace lfs::core {
                                    output.shape().str(), N, C_out, H, W));
         assert_bias_shape(bias, C_out, "conv1x1_bias_out");
 
-        const Tensor& input_cont = is_contiguous() ? *this : contiguous();
-        const Tensor& weight_cont = weight.is_contiguous() ? weight : weight.contiguous();
+        LFS_ASSERT_MSG(!has_definite_internal_overlap(output),
+                       "conv1x1_bias_out output must not have overlapping logical elements");
+        LFS_ASSERT_MSG(!output.shares_storage_with(*this) &&
+                           !output.shares_storage_with(weight) &&
+                           !output.shares_storage_with(bias),
+                       "conv1x1_bias_out output must not overlap an input operand");
+
+        if (!output.is_contiguous()) {
+            Tensor materialized_output = empty(output.shape(), output.device(), output.dtype());
+            conv1x1_bias_out(weight, bias, materialized_output);
+            output.copy_from(materialized_output);
+            return;
+        }
+
+        Tensor input_materialized;
+        Tensor weight_materialized;
+        Tensor bias_materialized;
+        const Tensor& input_cont = contiguous_read(input_materialized);
+        const Tensor& weight_cont = weight.contiguous_read(weight_materialized);
+        const Tensor& bias_cont = bias.contiguous_read(bias_materialized);
 
         tensor_ops::launch_sgemm(weight_cont.ptr<float>(), input_cont.ptr<float>(),
                                  output.ptr<float>(), C_out, S, C_in, stream());
 
         const int total = static_cast<int>(N * C_out * H * W);
-        tensor_ops::launch_bias_add(output.ptr<float>(), bias.ptr<float>(),
+        tensor_ops::launch_bias_add(output.ptr<float>(), bias_cont.ptr<float>(),
                                     output.ptr<float>(), total,
                                     static_cast<int>(C_out), static_cast<int>(S),
                                     stream());
@@ -601,21 +696,39 @@ namespace lfs::core {
                                    output.shape().str(), N, C_out, H, W));
         assert_bias_shape(bias, C_out, "conv1x1_bias_relu_out");
 
-        const Tensor& input_cont = is_contiguous() ? *this : contiguous();
-        const Tensor& weight_cont = weight.is_contiguous() ? weight : weight.contiguous();
+        LFS_ASSERT_MSG(!has_definite_internal_overlap(output),
+                       "conv1x1_bias_relu_out output must not have overlapping logical elements");
+        LFS_ASSERT_MSG(!output.shares_storage_with(*this) &&
+                           !output.shares_storage_with(weight) &&
+                           !output.shares_storage_with(bias),
+                       "conv1x1_bias_relu_out output must not overlap an input operand");
+
+        if (!output.is_contiguous()) {
+            Tensor materialized_output = empty(output.shape(), output.device(), output.dtype());
+            conv1x1_bias_relu_out(weight, bias, materialized_output);
+            output.copy_from(materialized_output);
+            return;
+        }
+
+        Tensor input_materialized;
+        Tensor weight_materialized;
+        Tensor bias_materialized;
+        const Tensor& input_cont = contiguous_read(input_materialized);
+        const Tensor& weight_cont = weight.contiguous_read(weight_materialized);
+        const Tensor& bias_cont = bias.contiguous_read(bias_materialized);
 
         const size_t output_size = C_out * S;
         if (output_size >= 500000) {
             // Large outputs: use fused kernel to save memory bandwidth
             tensor_ops::launch_sgemm_bias_relu(weight_cont.ptr<float>(), input_cont.ptr<float>(),
-                                               bias.ptr<float>(), output.ptr<float>(),
+                                               bias_cont.ptr<float>(), output.ptr<float>(),
                                                C_out, S, C_in, stream());
         } else {
             // Small outputs: separate kernels have less overhead
             tensor_ops::launch_sgemm(weight_cont.ptr<float>(), input_cont.ptr<float>(),
                                      output.ptr<float>(), C_out, S, C_in, stream());
             const int total = static_cast<int>(N * C_out * H * W);
-            tensor_ops::launch_bias_relu(output.ptr<float>(), bias.ptr<float>(),
+            tensor_ops::launch_bias_relu(output.ptr<float>(), bias_cont.ptr<float>(),
                                          output.ptr<float>(), total,
                                          static_cast<int>(C_out), static_cast<int>(S),
                                          stream());
@@ -747,15 +860,35 @@ namespace lfs::core {
                                    output.numel(), batch_size * out_features, batch_size,
                                    out_features, output.shape().str()));
 
-        const Tensor& input_cont = is_contiguous() ? *this : contiguous();
-        const Tensor& weight_cont = weight.is_contiguous() ? weight : weight.contiguous();
+        LFS_ASSERT_MSG(!has_definite_internal_overlap(output),
+                       "linear_bias_relu_out output must not have overlapping logical elements");
+        LFS_ASSERT_MSG(!output.shares_storage_with(*this) &&
+                           !output.shares_storage_with(weight) &&
+                           (!bias.is_valid() || !output.shares_storage_with(bias)),
+                       "linear_bias_relu_out output must not overlap an input operand");
+
+        if (!output.is_contiguous()) {
+            Tensor materialized_output = empty(output.shape(), output.device(), output.dtype());
+            linear_bias_relu_out(weight, bias, materialized_output);
+            output.copy_from(materialized_output);
+            return;
+        }
+
+        Tensor input_materialized;
+        Tensor weight_materialized;
+        Tensor bias_materialized;
+        const Tensor& input_cont = contiguous_read(input_materialized);
+        const Tensor& weight_cont = weight.contiguous_read(weight_materialized);
+        const Tensor* bias_cont = bias.is_valid()
+                                      ? &bias.contiguous_read(bias_materialized)
+                                      : &bias;
 
         tensor_ops::launch_sgemm_tn(input_cont.ptr<float>(), weight_cont.ptr<float>(),
                                     output.ptr<float>(), batch_size, out_features, in_features,
                                     stream());
 
         const int total = static_cast<int>(batch_size * out_features);
-        tensor_ops::launch_bias_relu(output.ptr<float>(), bias.ptr<float>(),
+        tensor_ops::launch_bias_relu(output.ptr<float>(), bias_cont->ptr<float>(),
                                      output.ptr<float>(), total,
                                      static_cast<int>(out_features), 1,
                                      stream());
@@ -806,8 +939,28 @@ namespace lfs::core {
                                    output.numel(), batch_size * out_features, batch_size,
                                    out_features, output.shape().str()));
 
-        const Tensor& input_cont = is_contiguous() ? *this : contiguous();
-        const Tensor& weight_cont = weight.is_contiguous() ? weight : weight.contiguous();
+        LFS_ASSERT_MSG(!has_definite_internal_overlap(output),
+                       "linear_out output must not have overlapping logical elements");
+        LFS_ASSERT_MSG(!output.shares_storage_with(*this) &&
+                           !output.shares_storage_with(weight) &&
+                           (!bias.is_valid() || !output.shares_storage_with(bias)),
+                       "linear_out output must not overlap an input operand");
+
+        if (!output.is_contiguous()) {
+            Tensor materialized_output = empty(output.shape(), output.device(), output.dtype());
+            linear_out(weight, bias, materialized_output);
+            output.copy_from(materialized_output);
+            return;
+        }
+
+        Tensor input_materialized;
+        Tensor weight_materialized;
+        Tensor bias_materialized;
+        const Tensor& input_cont = contiguous_read(input_materialized);
+        const Tensor& weight_cont = weight.contiguous_read(weight_materialized);
+        const Tensor* bias_cont = bias.is_valid()
+                                      ? &bias.contiguous_read(bias_materialized)
+                                      : &bias;
 
         tensor_ops::launch_sgemm_tn(input_cont.ptr<float>(), weight_cont.ptr<float>(),
                                     output.ptr<float>(), batch_size, out_features, in_features,
@@ -815,7 +968,7 @@ namespace lfs::core {
 
         if (bias.is_valid()) {
             const int total = static_cast<int>(batch_size * out_features);
-            tensor_ops::launch_bias_add(output.ptr<float>(), bias.ptr<float>(),
+            tensor_ops::launch_bias_add(output.ptr<float>(), bias_cont->ptr<float>(),
                                         output.ptr<float>(), total,
                                         static_cast<int>(out_features), 1,
                                         stream());

--- a/src/core/tensor/tensor_nn_ops.cu
+++ b/src/core/tensor/tensor_nn_ops.cu
@@ -1,10 +1,11 @@
 /* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "internal/tensor_functors.hpp"
 #include "internal/tensor_nn_ops.hpp"
 #include <cassert>
-#include <cfloat>
 #include <cuda_runtime.h>
+#include <limits>
 
 namespace lfs::core::tensor_ops {
 
@@ -29,7 +30,7 @@ namespace lfs::core::tensor_ops {
             const int h_start = h_out * stride - padding;
             const int w_start = w_out * stride - padding;
 
-            float max_val = -FLT_MAX;
+            float max_val = -std::numeric_limits<float>::infinity();
 
             for (int kh = 0; kh < kernel; ++kh) {
                 const int h_in = h_start + kh;
@@ -42,7 +43,7 @@ namespace lfs::core::tensor_ops {
                         continue;
 
                     const int input_idx = ((n * C + c) * H_in + h_in) * W_in + w_in;
-                    max_val = fmaxf(max_val, input[input_idx]);
+                    max_val = ops::max_reduce_op{}(max_val, input[input_idx]);
                 }
             }
 

--- a/src/core/tensor/tensor_ops.cu
+++ b/src/core/tensor/tensor_ops.cu
@@ -2180,227 +2180,227 @@ namespace lfs::core::tensor_ops {
     // so we need explicit instantiations for functors used by C++ expression templates.
 
     // Basic unary operations (comprehensive list)
-    template void launch_unary_op_generic<float, float, ops::log_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::log_op>(
         const float*, float*, size_t, ops::log_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::log_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::log_op>(
         const int*, int*, size_t, ops::log_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::exp_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::exp_op>(
         const float*, float*, size_t, ops::exp_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::exp_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::exp_op>(
         const int*, int*, size_t, ops::exp_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::abs_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::abs_op>(
         const float*, float*, size_t, ops::abs_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::abs_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::abs_op>(
         const int*, int*, size_t, ops::abs_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::sqrt_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::sqrt_op>(
         const float*, float*, size_t, ops::sqrt_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::sqrt_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::sqrt_op>(
         const int*, int*, size_t, ops::sqrt_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::square_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::square_op>(
         const float*, float*, size_t, ops::square_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::square_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::square_op>(
         const int*, int*, size_t, ops::square_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::relu_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::relu_op>(
         const float*, float*, size_t, ops::relu_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::relu_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::relu_op>(
         const int*, int*, size_t, ops::relu_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::sigmoid_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::sigmoid_op>(
         const float*, float*, size_t, ops::sigmoid_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::sigmoid_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::sigmoid_op>(
         const int*, int*, size_t, ops::sigmoid_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::neg_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::neg_op>(
         const float*, float*, size_t, ops::neg_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::neg_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::neg_op>(
         const int*, int*, size_t, ops::neg_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::floor_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::floor_op>(
         const float*, float*, size_t, ops::floor_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::floor_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::floor_op>(
         const int*, int*, size_t, ops::floor_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::ceil_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::ceil_op>(
         const float*, float*, size_t, ops::ceil_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::ceil_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::ceil_op>(
         const int*, int*, size_t, ops::ceil_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::sin_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::sin_op>(
         const float*, float*, size_t, ops::sin_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::sin_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::sin_op>(
         const int*, int*, size_t, ops::sin_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::cos_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::cos_op>(
         const float*, float*, size_t, ops::cos_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::cos_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::cos_op>(
         const int*, int*, size_t, ops::cos_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::tan_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::tan_op>(
         const float*, float*, size_t, ops::tan_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::tan_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::tan_op>(
         const int*, int*, size_t, ops::tan_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::tanh_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::tanh_op>(
         const float*, float*, size_t, ops::tanh_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::tanh_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::tanh_op>(
         const int*, int*, size_t, ops::tanh_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::sign_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::sign_op>(
         const float*, float*, size_t, ops::sign_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::sign_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::sign_op>(
         const int*, int*, size_t, ops::sign_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::reciprocal_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::reciprocal_op>(
         const float*, float*, size_t, ops::reciprocal_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::reciprocal_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::reciprocal_op>(
         const int*, int*, size_t, ops::reciprocal_op, cudaStream_t);
-    template void launch_unary_op_generic<float, unsigned char, ops::logical_not_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char, ops::logical_not_op>(
         const float*, unsigned char*, size_t, ops::logical_not_op, cudaStream_t);
-    template void launch_unary_op_generic<int, unsigned char, ops::logical_not_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char, ops::logical_not_op>(
         const int*, unsigned char*, size_t, ops::logical_not_op, cudaStream_t);
-    template void launch_unary_op_generic<unsigned char, unsigned char, ops::logical_not_op>(
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char, ops::logical_not_op>(
         const unsigned char*, unsigned char*, size_t, ops::logical_not_op, cudaStream_t);
 
     // Extended unary operations (log2, log10, rsqrt, exp2, trig, hyperbolic, etc.)
-    template void launch_unary_op_generic<float, float, ops::log2_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::log2_op>(
         const float*, float*, size_t, ops::log2_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::log2_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::log2_op>(
         const int*, int*, size_t, ops::log2_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::log10_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::log10_op>(
         const float*, float*, size_t, ops::log10_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::log10_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::log10_op>(
         const int*, int*, size_t, ops::log10_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::log1p_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::log1p_op>(
         const float*, float*, size_t, ops::log1p_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::log1p_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::log1p_op>(
         const int*, int*, size_t, ops::log1p_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::exp2_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::exp2_op>(
         const float*, float*, size_t, ops::exp2_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::exp2_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::exp2_op>(
         const int*, int*, size_t, ops::exp2_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::rsqrt_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::rsqrt_op>(
         const float*, float*, size_t, ops::rsqrt_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::rsqrt_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::rsqrt_op>(
         const int*, int*, size_t, ops::rsqrt_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::asin_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::asin_op>(
         const float*, float*, size_t, ops::asin_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::asin_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::asin_op>(
         const int*, int*, size_t, ops::asin_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::acos_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::acos_op>(
         const float*, float*, size_t, ops::acos_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::acos_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::acos_op>(
         const int*, int*, size_t, ops::acos_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::atan_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::atan_op>(
         const float*, float*, size_t, ops::atan_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::atan_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::atan_op>(
         const int*, int*, size_t, ops::atan_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::sinh_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::sinh_op>(
         const float*, float*, size_t, ops::sinh_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::sinh_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::sinh_op>(
         const int*, int*, size_t, ops::sinh_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::cosh_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::cosh_op>(
         const float*, float*, size_t, ops::cosh_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::cosh_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::cosh_op>(
         const int*, int*, size_t, ops::cosh_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::trunc_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::trunc_op>(
         const float*, float*, size_t, ops::trunc_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::trunc_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::trunc_op>(
         const int*, int*, size_t, ops::trunc_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::gelu_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::gelu_op>(
         const float*, float*, size_t, ops::gelu_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::gelu_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::gelu_op>(
         const int*, int*, size_t, ops::gelu_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::swish_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::swish_op>(
         const float*, float*, size_t, ops::swish_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::swish_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::swish_op>(
         const int*, int*, size_t, ops::swish_op, cudaStream_t);
-    template void launch_unary_op_generic<float, unsigned char, ops::isnan_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char, ops::isnan_op>(
         const float*, unsigned char*, size_t, ops::isnan_op, cudaStream_t);
-    template void launch_unary_op_generic<int, unsigned char, ops::isnan_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char, ops::isnan_op>(
         const int*, unsigned char*, size_t, ops::isnan_op, cudaStream_t);
-    template void launch_unary_op_generic<float, unsigned char, ops::isinf_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char, ops::isinf_op>(
         const float*, unsigned char*, size_t, ops::isinf_op, cudaStream_t);
-    template void launch_unary_op_generic<int, unsigned char, ops::isinf_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char, ops::isinf_op>(
         const int*, unsigned char*, size_t, ops::isinf_op, cudaStream_t);
-    template void launch_unary_op_generic<float, unsigned char, ops::isfinite_op>(
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char, ops::isfinite_op>(
         const float*, unsigned char*, size_t, ops::isfinite_op, cudaStream_t);
-    template void launch_unary_op_generic<int, unsigned char, ops::isfinite_op>(
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char, ops::isfinite_op>(
         const int*, unsigned char*, size_t, ops::isfinite_op, cudaStream_t);
-    template void launch_unary_op_generic<unsigned char, unsigned char, ops::isnan_op>(
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char, ops::isnan_op>(
         const unsigned char*, unsigned char*, size_t, ops::isnan_op, cudaStream_t);
-    template void launch_unary_op_generic<unsigned char, unsigned char, ops::isinf_op>(
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char, ops::isinf_op>(
         const unsigned char*, unsigned char*, size_t, ops::isinf_op, cudaStream_t);
-    template void launch_unary_op_generic<unsigned char, unsigned char, ops::isfinite_op>(
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char, ops::isfinite_op>(
         const unsigned char*, unsigned char*, size_t, ops::isfinite_op, cudaStream_t);
 
     // Basic binary operations (same input/output type - comprehensive list)
-    template void launch_binary_op_generic<float, float, ops::add_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, float, ops::add_op>(
         const float*, const float*, float*, size_t, ops::add_op, cudaStream_t);
-    template void launch_binary_op_generic<int, int, ops::add_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, int, ops::add_op>(
         const int*, const int*, int*, size_t, ops::add_op, cudaStream_t);
-    template void launch_binary_op_generic<float, float, ops::sub_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, float, ops::sub_op>(
         const float*, const float*, float*, size_t, ops::sub_op, cudaStream_t);
-    template void launch_binary_op_generic<int, int, ops::sub_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, int, ops::sub_op>(
         const int*, const int*, int*, size_t, ops::sub_op, cudaStream_t);
-    template void launch_binary_op_generic<float, float, ops::mul_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, float, ops::mul_op>(
         const float*, const float*, float*, size_t, ops::mul_op, cudaStream_t);
-    template void launch_binary_op_generic<int, int, ops::mul_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, int, ops::mul_op>(
         const int*, const int*, int*, size_t, ops::mul_op, cudaStream_t);
-    template void launch_binary_op_generic<float, float, ops::div_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, float, ops::div_op>(
         const float*, const float*, float*, size_t, ops::div_op, cudaStream_t);
-    template void launch_binary_op_generic<int, int, ops::div_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, int, ops::div_op>(
         const int*, const int*, int*, size_t, ops::div_op, cudaStream_t);
-    template void launch_binary_op_generic<float, float, ops::pow_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, float, ops::pow_op>(
         const float*, const float*, float*, size_t, ops::pow_op, cudaStream_t);
-    template void launch_binary_op_generic<int, int, ops::pow_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, int, ops::pow_op>(
         const int*, const int*, int*, size_t, ops::pow_op, cudaStream_t);
 
     // Comparison operations (input T -> output unsigned char/bool)
-    template void launch_binary_op_generic<float, unsigned char, ops::greater_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, unsigned char, ops::greater_op>(
         const float*, const float*, unsigned char*, size_t, ops::greater_op, cudaStream_t);
-    template void launch_binary_op_generic<int, unsigned char, ops::greater_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, unsigned char, ops::greater_op>(
         const int*, const int*, unsigned char*, size_t, ops::greater_op, cudaStream_t);
-    template void launch_binary_op_generic<unsigned char, unsigned char, ops::greater_op>(
+    template LFS_CORE_API void launch_binary_op_generic<unsigned char, unsigned char, ops::greater_op>(
         const unsigned char*, const unsigned char*, unsigned char*, size_t, ops::greater_op, cudaStream_t);
 
-    template void launch_binary_op_generic<float, unsigned char, ops::greater_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, unsigned char, ops::greater_equal_op>(
         const float*, const float*, unsigned char*, size_t, ops::greater_equal_op, cudaStream_t);
-    template void launch_binary_op_generic<int, unsigned char, ops::greater_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, unsigned char, ops::greater_equal_op>(
         const int*, const int*, unsigned char*, size_t, ops::greater_equal_op, cudaStream_t);
-    template void launch_binary_op_generic<unsigned char, unsigned char, ops::greater_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<unsigned char, unsigned char, ops::greater_equal_op>(
         const unsigned char*, const unsigned char*, unsigned char*, size_t, ops::greater_equal_op, cudaStream_t);
 
-    template void launch_binary_op_generic<float, unsigned char, ops::less_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, unsigned char, ops::less_equal_op>(
         const float*, const float*, unsigned char*, size_t, ops::less_equal_op, cudaStream_t);
-    template void launch_binary_op_generic<int, unsigned char, ops::less_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, unsigned char, ops::less_equal_op>(
         const int*, const int*, unsigned char*, size_t, ops::less_equal_op, cudaStream_t);
-    template void launch_binary_op_generic<unsigned char, unsigned char, ops::less_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<unsigned char, unsigned char, ops::less_equal_op>(
         const unsigned char*, const unsigned char*, unsigned char*, size_t, ops::less_equal_op, cudaStream_t);
 
     // Logical operations (bool/unsigned char -> unsigned char)
-    template void launch_binary_op_generic<float, unsigned char, ops::logical_and_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, unsigned char, ops::logical_and_op>(
         const float*, const float*, unsigned char*, size_t, ops::logical_and_op, cudaStream_t);
-    template void launch_binary_op_generic<int, unsigned char, ops::logical_and_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, unsigned char, ops::logical_and_op>(
         const int*, const int*, unsigned char*, size_t, ops::logical_and_op, cudaStream_t);
-    template void launch_binary_op_generic<unsigned char, unsigned char, ops::logical_and_op>(
+    template LFS_CORE_API void launch_binary_op_generic<unsigned char, unsigned char, ops::logical_and_op>(
         const unsigned char*, const unsigned char*, unsigned char*, size_t, ops::logical_and_op, cudaStream_t);
 
-    template void launch_binary_op_generic<float, unsigned char, ops::logical_or_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, unsigned char, ops::logical_or_op>(
         const float*, const float*, unsigned char*, size_t, ops::logical_or_op, cudaStream_t);
-    template void launch_binary_op_generic<int, unsigned char, ops::logical_or_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, unsigned char, ops::logical_or_op>(
         const int*, const int*, unsigned char*, size_t, ops::logical_or_op, cudaStream_t);
-    template void launch_binary_op_generic<unsigned char, unsigned char, ops::logical_or_op>(
+    template LFS_CORE_API void launch_binary_op_generic<unsigned char, unsigned char, ops::logical_or_op>(
         const unsigned char*, const unsigned char*, unsigned char*, size_t, ops::logical_or_op, cudaStream_t);
 
-    template void launch_binary_op_generic<float, unsigned char, ops::less_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, unsigned char, ops::less_op>(
         const float*, const float*, unsigned char*, size_t, ops::less_op, cudaStream_t);
-    template void launch_binary_op_generic<int, unsigned char, ops::less_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, unsigned char, ops::less_op>(
         const int*, const int*, unsigned char*, size_t, ops::less_op, cudaStream_t);
-    template void launch_binary_op_generic<unsigned char, unsigned char, ops::less_op>(
+    template LFS_CORE_API void launch_binary_op_generic<unsigned char, unsigned char, ops::less_op>(
         const unsigned char*, const unsigned char*, unsigned char*, size_t, ops::less_op, cudaStream_t);
 
-    template void launch_binary_op_generic<float, unsigned char, ops::equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, unsigned char, ops::equal_op>(
         const float*, const float*, unsigned char*, size_t, ops::equal_op, cudaStream_t);
-    template void launch_binary_op_generic<int, unsigned char, ops::equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, unsigned char, ops::equal_op>(
         const int*, const int*, unsigned char*, size_t, ops::equal_op, cudaStream_t);
-    template void launch_binary_op_generic<unsigned char, unsigned char, ops::equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<unsigned char, unsigned char, ops::equal_op>(
         const unsigned char*, const unsigned char*, unsigned char*, size_t, ops::equal_op, cudaStream_t);
 
-    template void launch_binary_op_generic<float, unsigned char, ops::not_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, unsigned char, ops::not_equal_op>(
         const float*, const float*, unsigned char*, size_t, ops::not_equal_op, cudaStream_t);
-    template void launch_binary_op_generic<int, unsigned char, ops::not_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, unsigned char, ops::not_equal_op>(
         const int*, const int*, unsigned char*, size_t, ops::not_equal_op, cudaStream_t);
-    template void launch_binary_op_generic<unsigned char, unsigned char, ops::not_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<unsigned char, unsigned char, ops::not_equal_op>(
         const unsigned char*, const unsigned char*, unsigned char*, size_t, ops::not_equal_op, cudaStream_t);
 
     // Scalar operations (uses constant_iterator, different from scalar_right_op!)
@@ -2414,80 +2414,80 @@ namespace lfs::core::tensor_ops {
         const float*, float, float*, size_t, ops::div_op, cudaStream_t);
 
     // scalar_right_op instantiations for various operations (comprehensive list)
-    template void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::add_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::add_op, float>>(
         const float*, float*, size_t, ops::scalar_right_op<ops::add_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::add_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::add_op, float>>(
         const int*, int*, size_t, ops::scalar_right_op<ops::add_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::sub_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::sub_op, float>>(
         const float*, float*, size_t, ops::scalar_right_op<ops::sub_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::sub_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::sub_op, float>>(
         const int*, int*, size_t, ops::scalar_right_op<ops::sub_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::mul_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::mul_op, float>>(
         const float*, float*, size_t, ops::scalar_right_op<ops::mul_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::mul_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::mul_op, float>>(
         const int*, int*, size_t, ops::scalar_right_op<ops::mul_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::div_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::div_op, float>>(
         const float*, float*, size_t, ops::scalar_right_op<ops::div_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::div_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::div_op, float>>(
         const int*, int*, size_t, ops::scalar_right_op<ops::div_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::pow_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::pow_op, float>>(
         const float*, float*, size_t, ops::scalar_right_op<ops::pow_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::pow_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::pow_op, float>>(
         const int*, int*, size_t, ops::scalar_right_op<ops::pow_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::not_equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::not_equal_op, float>>(
         const float*, unsigned char*, size_t, ops::scalar_right_op<ops::not_equal_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::not_equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::not_equal_op, float>>(
         const int*, unsigned char*, size_t, ops::scalar_right_op<ops::not_equal_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::not_equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::not_equal_op, float>>(
         const unsigned char*, unsigned char*, size_t, ops::scalar_right_op<ops::not_equal_op, float>, cudaStream_t);
 
-    template void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::equal_op, float>>(
         const float*, unsigned char*, size_t, ops::scalar_right_op<ops::equal_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::equal_op, float>>(
         const int*, unsigned char*, size_t, ops::scalar_right_op<ops::equal_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::equal_op, float>>(
         const unsigned char*, unsigned char*, size_t, ops::scalar_right_op<ops::equal_op, float>, cudaStream_t);
 
-    template void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::greater_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::greater_op, float>>(
         const float*, unsigned char*, size_t, ops::scalar_right_op<ops::greater_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::greater_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::greater_op, float>>(
         const int*, unsigned char*, size_t, ops::scalar_right_op<ops::greater_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::greater_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::greater_op, float>>(
         const unsigned char*, unsigned char*, size_t, ops::scalar_right_op<ops::greater_op, float>, cudaStream_t);
 
-    template void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::less_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::less_op, float>>(
         const float*, unsigned char*, size_t, ops::scalar_right_op<ops::less_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::less_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::less_op, float>>(
         const int*, unsigned char*, size_t, ops::scalar_right_op<ops::less_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::less_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::less_op, float>>(
         const unsigned char*, unsigned char*, size_t, ops::scalar_right_op<ops::less_op, float>, cudaStream_t);
 
-    template void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::greater_equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::greater_equal_op, float>>(
         const float*, unsigned char*, size_t, ops::scalar_right_op<ops::greater_equal_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::greater_equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::greater_equal_op, float>>(
         const int*, unsigned char*, size_t, ops::scalar_right_op<ops::greater_equal_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::greater_equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::greater_equal_op, float>>(
         const unsigned char*, unsigned char*, size_t, ops::scalar_right_op<ops::greater_equal_op, float>, cudaStream_t);
 
-    template void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::less_equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char, ops::scalar_right_op<ops::less_equal_op, float>>(
         const float*, unsigned char*, size_t, ops::scalar_right_op<ops::less_equal_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::less_equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char, ops::scalar_right_op<ops::less_equal_op, float>>(
         const int*, unsigned char*, size_t, ops::scalar_right_op<ops::less_equal_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::less_equal_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char, ops::scalar_right_op<ops::less_equal_op, float>>(
         const unsigned char*, unsigned char*, size_t, ops::scalar_right_op<ops::less_equal_op, float>, cudaStream_t);
 
-    template void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::mod_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::scalar_right_op<ops::mod_op, float>>(
         const float*, float*, size_t, ops::scalar_right_op<ops::mod_op, float>, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::mod_op, float>>(
+    template LFS_CORE_API void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::mod_op, float>>(
         const int*, int*, size_t, ops::scalar_right_op<ops::mod_op, float>, cudaStream_t);
 
-#define LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(OP)                                \
-    template void launch_unary_op_generic<float, float,                            \
-                                          ops::scalar_right_op<ops::OP, int32_t>>( \
-        const float*, float*, size_t, ops::scalar_right_op<ops::OP, int32_t>,      \
-        cudaStream_t);                                                             \
-    template void launch_unary_op_generic<int, int,                                \
-                                          ops::scalar_right_op<ops::OP, int32_t>>( \
+#define LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(OP)                                             \
+    template LFS_CORE_API void launch_unary_op_generic<float, float,                            \
+                                                       ops::scalar_right_op<ops::OP, int32_t>>( \
+        const float*, float*, size_t, ops::scalar_right_op<ops::OP, int32_t>,                   \
+        cudaStream_t);                                                                          \
+    template LFS_CORE_API void launch_unary_op_generic<int, int,                                \
+                                                       ops::scalar_right_op<ops::OP, int32_t>>( \
         const int*, int*, size_t, ops::scalar_right_op<ops::OP, int32_t>, cudaStream_t);
 
     LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(add_op)
@@ -2501,18 +2501,18 @@ namespace lfs::core::tensor_ops {
 
 #undef LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC
 
-#define LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON(OP)                                   \
-    template void launch_unary_op_generic<float, unsigned char,                       \
-                                          ops::scalar_right_op<ops::OP, int32_t>>(    \
-        const float*, unsigned char*, size_t, ops::scalar_right_op<ops::OP, int32_t>, \
-        cudaStream_t);                                                                \
-    template void launch_unary_op_generic<int, unsigned char,                         \
-                                          ops::scalar_right_op<ops::OP, int32_t>>(    \
-        const int*, unsigned char*, size_t, ops::scalar_right_op<ops::OP, int32_t>,   \
-        cudaStream_t);                                                                \
-    template void launch_unary_op_generic<unsigned char, unsigned char,               \
-                                          ops::scalar_right_op<ops::OP, int32_t>>(    \
-        const unsigned char*, unsigned char*, size_t,                                 \
+#define LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON(OP)                                             \
+    template LFS_CORE_API void launch_unary_op_generic<float, unsigned char,                    \
+                                                       ops::scalar_right_op<ops::OP, int32_t>>( \
+        const float*, unsigned char*, size_t, ops::scalar_right_op<ops::OP, int32_t>,           \
+        cudaStream_t);                                                                          \
+    template LFS_CORE_API void launch_unary_op_generic<int, unsigned char,                      \
+                                                       ops::scalar_right_op<ops::OP, int32_t>>( \
+        const int*, unsigned char*, size_t, ops::scalar_right_op<ops::OP, int32_t>,             \
+        cudaStream_t);                                                                          \
+    template LFS_CORE_API void launch_unary_op_generic<unsigned char, unsigned char,            \
+                                                       ops::scalar_right_op<ops::OP, int32_t>>( \
+        const unsigned char*, unsigned char*, size_t,                                           \
         ops::scalar_right_op<ops::OP, int32_t>, cudaStream_t);
 
     LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON(equal_op)
@@ -2525,13 +2525,13 @@ namespace lfs::core::tensor_ops {
 #undef LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON
 
     // Composed unary operations (expression template fusion) - test-specific
-    template void launch_unary_op_generic<float, float, ops::composed_unary_op<ops::exp_op, ops::scalar_right_op<ops::mul_op, float>>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::composed_unary_op<ops::exp_op, ops::scalar_right_op<ops::mul_op, float>>>(
         const float*, float*, size_t, ops::composed_unary_op<ops::exp_op, ops::scalar_right_op<ops::mul_op, float>>, cudaStream_t);
 
-    template void launch_unary_op_generic<float, float, ops::composed_unary_op<ops::scalar_right_op<ops::mul_op, float>, ops::abs_op>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::composed_unary_op<ops::scalar_right_op<ops::mul_op, float>, ops::abs_op>>(
         const float*, float*, size_t, ops::composed_unary_op<ops::scalar_right_op<ops::mul_op, float>, ops::abs_op>, cudaStream_t);
 
-    template void launch_unary_op_generic<float, float, ops::composed_unary_op<ops::scalar_right_op<ops::mul_op, float>, ops::relu_op>>(
+    template LFS_CORE_API void launch_unary_op_generic<float, float, ops::composed_unary_op<ops::scalar_right_op<ops::mul_op, float>, ops::relu_op>>(
         const float*, float*, size_t, ops::composed_unary_op<ops::scalar_right_op<ops::mul_op, float>, ops::relu_op>, cudaStream_t);
 
     // ============================================================================
@@ -2544,98 +2544,98 @@ namespace lfs::core::tensor_ops {
     // ============================================================================
 
     // Float16 operations
-    template void launch_binary_op_generic<__half, __half, ops::add_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, __half, ops::add_op>(
         const __half*, const __half*, __half*, size_t, ops::add_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, __half, ops::sub_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, __half, ops::sub_op>(
         const __half*, const __half*, __half*, size_t, ops::sub_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, __half, ops::mul_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, __half, ops::mul_op>(
         const __half*, const __half*, __half*, size_t, ops::mul_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, __half, ops::div_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, __half, ops::div_op>(
         const __half*, const __half*, __half*, size_t, ops::div_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, __half, ops::pow_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, __half, ops::pow_op>(
         const __half*, const __half*, __half*, size_t, ops::pow_op, cudaStream_t);
 
     // Int64 operations
-    template void launch_binary_op_generic<int64_t, int64_t, ops::add_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, int64_t, ops::add_op>(
         const int64_t*, const int64_t*, int64_t*, size_t, ops::add_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, int64_t, ops::sub_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, int64_t, ops::sub_op>(
         const int64_t*, const int64_t*, int64_t*, size_t, ops::sub_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, int64_t, ops::mul_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, int64_t, ops::mul_op>(
         const int64_t*, const int64_t*, int64_t*, size_t, ops::mul_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, int64_t, ops::div_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, int64_t, ops::div_op>(
         const int64_t*, const int64_t*, int64_t*, size_t, ops::div_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, int64_t, ops::pow_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, int64_t, ops::pow_op>(
         const int64_t*, const int64_t*, int64_t*, size_t, ops::pow_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, int64_t, ops::mod_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, int64_t, ops::mod_op>(
         const int64_t*, const int64_t*, int64_t*, size_t, ops::mod_op, cudaStream_t);
 
     // UInt8 operations
-    template void launch_binary_op_generic<uint8_t, uint8_t, ops::add_op>(
+    template LFS_CORE_API void launch_binary_op_generic<uint8_t, uint8_t, ops::add_op>(
         const uint8_t*, const uint8_t*, uint8_t*, size_t, ops::add_op, cudaStream_t);
-    template void launch_binary_op_generic<uint8_t, uint8_t, ops::sub_op>(
+    template LFS_CORE_API void launch_binary_op_generic<uint8_t, uint8_t, ops::sub_op>(
         const uint8_t*, const uint8_t*, uint8_t*, size_t, ops::sub_op, cudaStream_t);
-    template void launch_binary_op_generic<uint8_t, uint8_t, ops::mul_op>(
+    template LFS_CORE_API void launch_binary_op_generic<uint8_t, uint8_t, ops::mul_op>(
         const uint8_t*, const uint8_t*, uint8_t*, size_t, ops::mul_op, cudaStream_t);
-    template void launch_binary_op_generic<uint8_t, uint8_t, ops::div_op>(
+    template LFS_CORE_API void launch_binary_op_generic<uint8_t, uint8_t, ops::div_op>(
         const uint8_t*, const uint8_t*, uint8_t*, size_t, ops::div_op, cudaStream_t);
-    template void launch_binary_op_generic<uint8_t, uint8_t, ops::pow_op>(
+    template LFS_CORE_API void launch_binary_op_generic<uint8_t, uint8_t, ops::pow_op>(
         const uint8_t*, const uint8_t*, uint8_t*, size_t, ops::pow_op, cudaStream_t);
 
     // mod_op for float and int (was missing!)
-    template void launch_binary_op_generic<float, float, ops::mod_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, float, ops::mod_op>(
         const float*, const float*, float*, size_t, ops::mod_op, cudaStream_t);
-    template void launch_binary_op_generic<int, int, ops::mod_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, int, ops::mod_op>(
         const int*, const int*, int*, size_t, ops::mod_op, cudaStream_t);
-    template void launch_binary_op_generic<unsigned char, unsigned char, ops::mod_op>(
+    template LFS_CORE_API void launch_binary_op_generic<unsigned char, unsigned char, ops::mod_op>(
         const unsigned char*, const unsigned char*, unsigned char*, size_t, ops::mod_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, __half, ops::mod_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, __half, ops::mod_op>(
         const __half*, const __half*, __half*, size_t, ops::mod_op, cudaStream_t);
 
     // Comparison operations for additional types
-    template void launch_binary_op_generic<int64_t, unsigned char, ops::greater_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, unsigned char, ops::greater_op>(
         const int64_t*, const int64_t*, unsigned char*, size_t, ops::greater_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, unsigned char, ops::greater_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, unsigned char, ops::greater_equal_op>(
         const int64_t*, const int64_t*, unsigned char*, size_t, ops::greater_equal_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, unsigned char, ops::less_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, unsigned char, ops::less_op>(
         const int64_t*, const int64_t*, unsigned char*, size_t, ops::less_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, unsigned char, ops::less_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, unsigned char, ops::less_equal_op>(
         const int64_t*, const int64_t*, unsigned char*, size_t, ops::less_equal_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, unsigned char, ops::equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, unsigned char, ops::equal_op>(
         const int64_t*, const int64_t*, unsigned char*, size_t, ops::equal_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, unsigned char, ops::not_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, unsigned char, ops::not_equal_op>(
         const int64_t*, const int64_t*, unsigned char*, size_t, ops::not_equal_op, cudaStream_t);
 
-    template void launch_binary_op_generic<__half, unsigned char, ops::greater_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, unsigned char, ops::greater_op>(
         const __half*, const __half*, unsigned char*, size_t, ops::greater_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, unsigned char, ops::greater_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, unsigned char, ops::greater_equal_op>(
         const __half*, const __half*, unsigned char*, size_t, ops::greater_equal_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, unsigned char, ops::less_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, unsigned char, ops::less_op>(
         const __half*, const __half*, unsigned char*, size_t, ops::less_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, unsigned char, ops::less_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, unsigned char, ops::less_equal_op>(
         const __half*, const __half*, unsigned char*, size_t, ops::less_equal_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, unsigned char, ops::equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, unsigned char, ops::equal_op>(
         const __half*, const __half*, unsigned char*, size_t, ops::equal_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, unsigned char, ops::not_equal_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, unsigned char, ops::not_equal_op>(
         const __half*, const __half*, unsigned char*, size_t, ops::not_equal_op, cudaStream_t);
 
     // Logical operations for additional types
-    template void launch_binary_op_generic<int64_t, unsigned char, ops::logical_and_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, unsigned char, ops::logical_and_op>(
         const int64_t*, const int64_t*, unsigned char*, size_t, ops::logical_and_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, unsigned char, ops::logical_or_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, unsigned char, ops::logical_or_op>(
         const int64_t*, const int64_t*, unsigned char*, size_t, ops::logical_or_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, unsigned char, ops::logical_and_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, unsigned char, ops::logical_and_op>(
         const __half*, const __half*, unsigned char*, size_t, ops::logical_and_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, unsigned char, ops::logical_or_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, unsigned char, ops::logical_or_op>(
         const __half*, const __half*, unsigned char*, size_t, ops::logical_or_op, cudaStream_t);
-    template void launch_binary_op_generic<float, unsigned char, ops::logical_xor_op>(
+    template LFS_CORE_API void launch_binary_op_generic<float, unsigned char, ops::logical_xor_op>(
         const float*, const float*, unsigned char*, size_t, ops::logical_xor_op, cudaStream_t);
-    template void launch_binary_op_generic<int, unsigned char, ops::logical_xor_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int, unsigned char, ops::logical_xor_op>(
         const int*, const int*, unsigned char*, size_t, ops::logical_xor_op, cudaStream_t);
-    template void launch_binary_op_generic<unsigned char, unsigned char, ops::logical_xor_op>(
+    template LFS_CORE_API void launch_binary_op_generic<unsigned char, unsigned char, ops::logical_xor_op>(
         const unsigned char*, const unsigned char*, unsigned char*, size_t, ops::logical_xor_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, unsigned char, ops::logical_xor_op>(
+    template LFS_CORE_API void launch_binary_op_generic<int64_t, unsigned char, ops::logical_xor_op>(
         const int64_t*, const int64_t*, unsigned char*, size_t, ops::logical_xor_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, unsigned char, ops::logical_xor_op>(
+    template LFS_CORE_API void launch_binary_op_generic<__half, unsigned char, ops::logical_xor_op>(
         const __half*, const __half*, unsigned char*, size_t, ops::logical_xor_op, cudaStream_t);
 
     // ============= STRIDED FILL KERNEL =============

--- a/src/core/tensor/tensor_ops.cu
+++ b/src/core/tensor/tensor_ops.cu
@@ -5,6 +5,7 @@
 #include "core/logger.hpp"
 #include "internal/cub_workspace.hpp"
 #include "internal/memory_pool.hpp"
+#include "internal/tensor_dtype_dispatch.hpp"
 #include "internal/tensor_functors.hpp"
 #include "internal/tensor_impl.hpp"
 #include "internal/tensor_ops.hpp"
@@ -40,6 +41,24 @@ namespace lfs::core::tensor_ops {
     namespace {
         std::atomic_bool force_cub_workspace_failure{false};
 
+        struct ieee_round_float_op {
+            __host__ __device__ float operator()(const float value) const {
+                return ops::round_op{}(value);
+            }
+        };
+
+        struct ieee_maximum_float_op {
+            __host__ __device__ float operator()(const float lhs, const float rhs) const {
+                return ops::maximum_op{}(lhs, rhs);
+            }
+        };
+
+        struct ieee_minimum_float_op {
+            __host__ __device__ float operator()(const float lhs, const float rhs) const {
+                return ops::minimum_op{}(lhs, rhs);
+            }
+        };
+
         template <typename Operation>
         float direct_reduce_scalar(const float* data,
                                    const size_t n,
@@ -66,6 +85,21 @@ namespace lfs::core::tensor_ops {
             return result;
         }
     } // namespace
+
+    void launch_ieee_round_float(const float* input, float* output,
+                                 const size_t n, const cudaStream_t stream) {
+        launch_unary_op_generic(input, output, n, ieee_round_float_op{}, stream);
+    }
+
+    void launch_ieee_maximum_float(const float* lhs, const float* rhs, float* output,
+                                   const size_t n, const cudaStream_t stream) {
+        launch_binary_op_generic(lhs, rhs, output, n, ieee_maximum_float_op{}, stream);
+    }
+
+    void launch_ieee_minimum_float(const float* lhs, const float* rhs, float* output,
+                                   const size_t n, const cudaStream_t stream) {
+        launch_binary_op_generic(lhs, rhs, output, n, ieee_minimum_float_op{}, stream);
+    }
 
     bool cub_workspace_failure_is_forced() {
         return force_cub_workspace_failure.load(std::memory_order_acquire);
@@ -297,26 +331,32 @@ namespace lfs::core::tensor_ops {
         }
     };
 
-    // Specializations for clamping conversions
+    // Numeric-to-byte casts follow Torch's truncation and modulo semantics.
     template <>
     struct ConvertFunctor<float, uint8_t> {
         __device__ uint8_t operator()(float x) const {
-            return static_cast<uint8_t>(fminf(fmaxf(roundf(x), 0.0f), 255.0f));
+            return detail::torch_uint8_cast(x);
         }
     };
 
     template <>
     struct ConvertFunctor<int, uint8_t> {
         __device__ uint8_t operator()(int x) const {
-            return static_cast<uint8_t>(max(0, min(255, x)));
+            return detail::torch_uint8_cast(x);
         }
     };
 
     template <>
     struct ConvertFunctor<int64_t, uint8_t> {
         __device__ uint8_t operator()(int64_t x) const {
-            return static_cast<uint8_t>(max(static_cast<int64_t>(0),
-                                            min(static_cast<int64_t>(255), x)));
+            return detail::torch_uint8_cast(x);
+        }
+    };
+
+    template <>
+    struct ConvertFunctor<__half, uint8_t> {
+        __device__ uint8_t operator()(__half x) const {
+            return detail::torch_uint8_cast(x);
         }
     };
 
@@ -437,23 +477,23 @@ namespace lfs::core::tensor_ops {
 
     // ============= MULTI-AXIS REDUCTION (USING FUNCTORS) =============
 
-    template <typename Op>
+    template <typename InputT, typename OutputT, typename AccumulatorT, typename Op>
     __global__ void multi_axis_reduce_kernel(
-        const float* input, float* output,
+        const InputT* input, OutputT* output,
         const size_t* input_shape, const bool* is_reduced_dim,
-        size_t input_rank, size_t output_elements, float init_val,
+        size_t input_rank, size_t output_elements, AccumulatorT init_val,
         Op op) {
         size_t out_idx = blockIdx.x * blockDim.x + threadIdx.x;
         if (out_idx >= output_elements)
             return;
 
-        size_t input_strides[10];
+        size_t input_strides[MAX_TENSOR_RANK];
         input_strides[input_rank - 1] = 1;
         for (int i = input_rank - 2; i >= 0; --i) {
             input_strides[i] = input_strides[i + 1] * input_shape[i + 1];
         }
 
-        size_t out_shape[10];
+        size_t out_shape[MAX_TENSOR_RANK];
         size_t out_rank = 0;
         for (size_t i = 0; i < input_rank; ++i) {
             if (!is_reduced_dim[i]) {
@@ -461,7 +501,7 @@ namespace lfs::core::tensor_ops {
             }
         }
 
-        size_t output_strides[10];
+        size_t output_strides[MAX_TENSOR_RANK];
         if (out_rank > 0) {
             output_strides[out_rank - 1] = 1;
             for (int i = out_rank - 2; i >= 0; --i) {
@@ -469,21 +509,21 @@ namespace lfs::core::tensor_ops {
             }
         }
 
-        size_t out_coords[10] = {0};
+        size_t out_coords[MAX_TENSOR_RANK] = {0};
         size_t temp = out_idx;
         for (size_t i = 0; i < out_rank; ++i) {
             out_coords[i] = temp / output_strides[i];
             temp %= output_strides[i];
         }
 
-        size_t base_input_coords[10];
+        size_t base_input_coords[MAX_TENSOR_RANK];
         size_t out_coord_idx = 0;
         for (size_t i = 0; i < input_rank; ++i) {
             base_input_coords[i] = is_reduced_dim[i] ? 0 : out_coords[out_coord_idx++];
         }
 
         size_t reduce_count = 1;
-        size_t reduced_dims[10];
+        size_t reduced_dims[MAX_TENSOR_RANK];
         size_t num_reduced = 0;
         for (size_t i = 0; i < input_rank; ++i) {
             if (is_reduced_dim[i]) {
@@ -492,10 +532,10 @@ namespace lfs::core::tensor_ops {
             }
         }
 
-        float result = init_val;
+        AccumulatorT result = init_val;
         for (size_t r = 0; r < reduce_count; ++r) {
             size_t temp_r = r;
-            size_t full_input_coords[10];
+            size_t full_input_coords[MAX_TENSOR_RANK];
 
             for (size_t i = 0; i < input_rank; ++i) {
                 full_input_coords[i] = base_input_coords[i];
@@ -512,10 +552,10 @@ namespace lfs::core::tensor_ops {
                 in_idx += full_input_coords[i] * input_strides[i];
             }
 
-            result = op(result, input[in_idx]);
+            result = op(result, static_cast<AccumulatorT>(input[in_idx]));
         }
 
-        output[out_idx] = result;
+        output[out_idx] = static_cast<OutputT>(result);
     }
 
     void launch_multi_axis_reduce(
@@ -523,6 +563,8 @@ namespace lfs::core::tensor_ops {
         const size_t* input_shape, const bool* is_reduced_dim,
         size_t input_rank, size_t output_elements,
         float init_val, ReduceOp op, cudaStream_t stream) {
+        LFS_ASSERT_MSG(input_rank > 0 && input_rank <= MAX_TENSOR_RANK,
+                       "multi-axis reduction rank exceeds MAX_TENSOR_RANK");
         int blocks = (output_elements + 255) / 256;
 
         switch (op) {
@@ -547,6 +589,9 @@ namespace lfs::core::tensor_ops {
                 input, output, input_shape, is_reduced_dim,
                 input_rank, output_elements, init_val, ops::mul_op{});
             break;
+        default:
+            LFS_ASSERT_MSG(false,
+                           "multi-axis reduction encountered an unsupported operation");
         }
     }
 
@@ -595,6 +640,9 @@ namespace lfs::core::tensor_ops {
                 case ReduceOp::Prod:
                     init_val = 1.0f;
                     break;
+                default:
+                    LFS_ASSERT_MSG(false,
+                                   "full Float32 reduction encountered an unsupported operation");
                 }
                 init_scalar_gpu(d_out, init_val, stream); // GPU init instead of CPU→GPU upload!
 
@@ -638,18 +686,22 @@ namespace lfs::core::tensor_ops {
             }
             case ReduceOp::Max:
                 run_cub_operation(
-                    "cub::DeviceReduce::Max", stream,
+                    "cub::DeviceReduce::Reduce(max)", stream,
                     [&](void* workspace, size_t& workspace_bytes) {
-                        return cub::DeviceReduce::Max(
-                            workspace, workspace_bytes, d_in, d_out, n, stream);
+                        return cub::DeviceReduce::Reduce(
+                            workspace, workspace_bytes, d_in, d_out, n,
+                            ops::max_reduce_op{},
+                            -std::numeric_limits<float>::infinity(), stream);
                     });
                 break;
             case ReduceOp::Min:
                 run_cub_operation(
-                    "cub::DeviceReduce::Min", stream,
+                    "cub::DeviceReduce::Reduce(min)", stream,
                     [&](void* workspace, size_t& workspace_bytes) {
-                        return cub::DeviceReduce::Min(
-                            workspace, workspace_bytes, d_in, d_out, n, stream);
+                        return cub::DeviceReduce::Reduce(
+                            workspace, workspace_bytes, d_in, d_out, n,
+                            ops::min_reduce_op{},
+                            std::numeric_limits<float>::infinity(), stream);
                     });
                 break;
             case ReduceOp::Prod: {
@@ -661,8 +713,8 @@ namespace lfs::core::tensor_ops {
                 break;
             }
             default:
-                init_scalar_gpu(static_cast<float*>(output), 0.0f, stream);
-                break;
+                LFS_ASSERT_MSG(false,
+                               "full Float32 reduction encountered an unsupported operation");
             }
             return;
         }
@@ -755,7 +807,8 @@ namespace lfs::core::tensor_ops {
                                         init_val, ops::mul_op{}, stream);
                 break;
             default:
-                break;
+                LFS_ASSERT_MSG(false,
+                               "single-axis Float32 reduction encountered an unsupported operation");
             }
             return;
         }
@@ -831,6 +884,9 @@ namespace lfs::core::tensor_ops {
                         case ReduceOp::Prod:
                             init_val = 1.0f;
                             break;
+                        default:
+                            LFS_ASSERT_MSG(false,
+                                           "multi-axis Float32 reduction encountered an unsupported operation");
                         }
                         init_scalar_gpu(output_f, init_val, stream); // GPU init instead of CPU→GPU upload!
                         launch_warp_reduce_full(input_f, output_f, n, op, stream);
@@ -849,14 +905,6 @@ namespace lfs::core::tensor_ops {
                 // If inner_size == 1, we can treat this as segmented reduction
                 if (inner_size == 1 && should_use_warp_reduce(n, outer_size)) {
                     launch_warp_segmented_reduce(input_f, output_f, outer_size, reduce_count, op, stream);
-
-                    if (op == ReduceOp::Mean) {
-                        auto out_ptr = thrust::device_pointer_cast(output_f);
-                        run_with_thrust_policy(stream, [&](auto policy) {
-                            thrust::transform(policy, out_ptr, out_ptr + outer_size, out_ptr,
-                                              DivideByFunctor(static_cast<float>(reduce_count)));
-                        });
-                    }
                     return;
                 }
 
@@ -878,15 +926,8 @@ namespace lfs::core::tensor_ops {
                                            n < 100000000;
 
                 if (use_warp_multi_axis) {
-                    launch_warp_multi_axis_reduce(input_f, output_f, output_size, reduce_count, op, stream);
-
-                    if (op == ReduceOp::Mean) {
-                        auto out_ptr = thrust::device_pointer_cast(output_f);
-                        run_with_thrust_policy(stream, [&](auto policy) {
-                            thrust::transform(policy, out_ptr, out_ptr + output_size, out_ptr,
-                                              DivideByFunctor(static_cast<float>(reduce_count)));
-                        });
-                    }
+                    launch_warp_multi_axis_reduce(
+                        input_f, output_f, outer_size, reduce_count, inner_size, op, stream);
                     return;
                 }
             }
@@ -922,6 +963,9 @@ namespace lfs::core::tensor_ops {
         case ReduceOp::Prod:
             init_val = 1.0f;
             break;
+        default:
+            LFS_ASSERT_MSG(false,
+                           "generic Float32 reduction encountered an unsupported operation");
         }
 
         launch_multi_axis_reduce(
@@ -945,68 +989,154 @@ namespace lfs::core::tensor_ops {
         }
     }
 
-    // Internal Int32 implementation (simplified - only handles full reductions)
+    struct Int32ToInt64Op {
+        __host__ __device__ __forceinline__ int64_t operator()(const int32_t value) const {
+            return static_cast<int64_t>(value);
+        }
+    };
+
+    struct IntegerMaximumOp {
+        template <typename T>
+        __host__ __device__ __forceinline__ T operator()(const T lhs, const T rhs) const {
+            return lhs < rhs ? rhs : lhs;
+        }
+    };
+
+    struct IntegerMinimumOp {
+        template <typename T>
+        __host__ __device__ __forceinline__ T operator()(const T lhs, const T rhs) const {
+            return rhs < lhs ? rhs : lhs;
+        }
+    };
+
     void launch_reduce_op_int32(const void* input, void* output, const size_t* shape, size_t rank,
                                 const int* axes, size_t num_axes, bool keepdim, ReduceOp op,
-                                cudaStream_t stream) {
+                                DataType output_dtype, cudaStream_t stream) {
         size_t n = 1;
         for (size_t i = 0; i < rank; ++i)
             n *= shape[i];
         if (n == 0)
             return;
+        LFS_ASSERT_MSG(rank <= MAX_TENSOR_RANK,
+                       "Int32 reduction rank exceeds MAX_TENSOR_RANK");
 
-        const int* d_in = static_cast<const int*>(input);
-        int* d_out = static_cast<int*>(output);
+        const auto* d_in = static_cast<const int32_t*>(input);
 
-        // Only support full reduction for Int32
         if (num_axes == 0 || num_axes == rank) {
             switch (op) {
-            case ReduceOp::Sum:
-            case ReduceOp::Mean:
+            case ReduceOp::Sum: {
+                LFS_ASSERT_MSG(output_dtype == DataType::Int64,
+                               "Int32 sum requires Int64 output");
+                auto transformed = thrust::make_transform_iterator(
+                    thrust::device_pointer_cast(d_in), Int32ToInt64Op{});
                 run_cub_operation(
                     "cub::DeviceReduce::Sum", stream,
                     [&](void* workspace, size_t& workspace_bytes) {
                         return cub::DeviceReduce::Sum(
-                            workspace, workspace_bytes, d_in, d_out, n, stream);
+                            workspace, workspace_bytes, transformed,
+                            static_cast<int64_t*>(output), n, stream);
                     });
-                if (op == ReduceOp::Mean) {
-                    // Divide by count for mean - use Thrust directly
-                    auto out_ptr = thrust::device_pointer_cast(d_out);
-                    const int count = static_cast<int>(n);
-                    thrust::transform(thrust::cuda::par_nosync.on(stream), out_ptr, out_ptr + 1, out_ptr,
-                                      [count] __device__(int val) { return val / count; });
-                }
-                break;
+            } break;
             case ReduceOp::Max:
+                LFS_ASSERT_MSG(output_dtype == DataType::Int32,
+                               "Int32 max requires Int32 output");
                 run_cub_operation(
                     "cub::DeviceReduce::Max", stream,
                     [&](void* workspace, size_t& workspace_bytes) {
                         return cub::DeviceReduce::Max(
-                            workspace, workspace_bytes, d_in, d_out, n, stream);
+                            workspace, workspace_bytes, d_in,
+                            static_cast<int32_t*>(output), n, stream);
                     });
                 break;
             case ReduceOp::Min:
+                LFS_ASSERT_MSG(output_dtype == DataType::Int32,
+                               "Int32 min requires Int32 output");
                 run_cub_operation(
                     "cub::DeviceReduce::Min", stream,
                     [&](void* workspace, size_t& workspace_bytes) {
                         return cub::DeviceReduce::Min(
-                            workspace, workspace_bytes, d_in, d_out, n, stream);
+                            workspace, workspace_bytes, d_in,
+                            static_cast<int32_t*>(output), n, stream);
                     });
                 break;
             case ReduceOp::Prod: {
+                LFS_ASSERT_MSG(output_dtype == DataType::Int64,
+                               "Int32 product requires Int64 output");
                 auto in_ptr = thrust::device_pointer_cast(d_in);
-                int result = 1;
+                int64_t result = 1;
                 run_with_thrust_policy(stream, [&](auto policy) {
-                    result = thrust::reduce(policy, in_ptr, in_ptr + n, 1, ops::mul_op{});
+                    result = thrust::transform_reduce(
+                        policy, in_ptr, in_ptr + n, Int32ToInt64Op{}, int64_t{1},
+                        thrust::multiplies<int64_t>{});
                 });
-                init_scalar_gpu(d_out, result, stream); // GPU init instead of CPU→GPU upload!
+                init_scalar_gpu(static_cast<int64_t*>(output), result, stream);
             } break;
-            default: {
-                init_scalar_gpu(d_out, 0, stream); // GPU init instead of CPU→GPU upload!
-            } break;
+            default:
+                LFS_ASSERT_MSG(false,
+                               "Int32 reduction encountered an unsupported operation");
+            }
+            return;
+        }
+
+        std::vector<bool> reduced(rank, false);
+        for (size_t i = 0; i < num_axes; ++i) {
+            LFS_ASSERT_MSG(axes[i] >= 0 && axes[i] < static_cast<int>(rank),
+                           "Int32 reduction axis is out of range");
+            reduced[static_cast<size_t>(axes[i])] = true;
+        }
+
+        size_t output_elements = 1;
+        for (size_t i = 0; i < rank; ++i) {
+            if (!reduced[i] || keepdim) {
+                output_elements *= reduced[i] ? 1 : shape[i];
             }
         }
-        // Partial reductions not supported for Int32 yet
+
+        thrust::device_vector<bool> d_reduced(reduced.begin(), reduced.end());
+        thrust::device_vector<size_t> d_shape(shape, shape + rank);
+        const int blocks = static_cast<int>((output_elements + 255) / 256);
+
+        switch (op) {
+        case ReduceOp::Sum:
+            LFS_ASSERT_MSG(output_dtype == DataType::Int64,
+                           "Int32 sum requires Int64 output");
+            multi_axis_reduce_kernel<<<blocks, 256, 0, stream>>>(
+                d_in, static_cast<int64_t*>(output),
+                thrust::raw_pointer_cast(d_shape.data()),
+                thrust::raw_pointer_cast(d_reduced.data()),
+                rank, output_elements, int64_t{0}, ops::add_op{});
+            break;
+        case ReduceOp::Prod:
+            LFS_ASSERT_MSG(output_dtype == DataType::Int64,
+                           "Int32 product requires Int64 output");
+            multi_axis_reduce_kernel<<<blocks, 256, 0, stream>>>(
+                d_in, static_cast<int64_t*>(output),
+                thrust::raw_pointer_cast(d_shape.data()),
+                thrust::raw_pointer_cast(d_reduced.data()),
+                rank, output_elements, int64_t{1}, ops::mul_op{});
+            break;
+        case ReduceOp::Max:
+            LFS_ASSERT_MSG(output_dtype == DataType::Int32,
+                           "Int32 max requires Int32 output");
+            multi_axis_reduce_kernel<<<blocks, 256, 0, stream>>>(
+                d_in, static_cast<int32_t*>(output),
+                thrust::raw_pointer_cast(d_shape.data()),
+                thrust::raw_pointer_cast(d_reduced.data()),
+                rank, output_elements, std::numeric_limits<int32_t>::lowest(), IntegerMaximumOp{});
+            break;
+        case ReduceOp::Min:
+            LFS_ASSERT_MSG(output_dtype == DataType::Int32,
+                           "Int32 min requires Int32 output");
+            multi_axis_reduce_kernel<<<blocks, 256, 0, stream>>>(
+                d_in, static_cast<int32_t*>(output),
+                thrust::raw_pointer_cast(d_shape.data()),
+                thrust::raw_pointer_cast(d_reduced.data()),
+                rank, output_elements, std::numeric_limits<int32_t>::max(), IntegerMinimumOp{});
+            break;
+        default:
+            LFS_ASSERT_MSG(false,
+                           "partial Int32 reduction encountered an unsupported operation");
+        }
     }
 
     // Bool to int64 conversion functor for CUB
@@ -1053,7 +1183,7 @@ namespace lfs::core::tensor_ops {
     // Bool reduction implementation
     void launch_reduce_op_bool(const void* input, void* output, const size_t* shape, const size_t rank,
                                const int* axes, const size_t num_axes, const bool keepdim, const ReduceOp op,
-                               cudaStream_t stream) {
+                               const DataType output_dtype, cudaStream_t stream) {
         size_t n = 1;
         for (size_t i = 0; i < rank; ++i)
             n *= shape[i];
@@ -1063,12 +1193,17 @@ namespace lfs::core::tensor_ops {
         const bool* d_in = static_cast<const bool*>(input);
         bool* d_out_bool = static_cast<bool*>(output);
         int64_t* d_out_int64 = static_cast<int64_t*>(output);
+        LFS_ASSERT_MSG(op != ReduceOp::Mean,
+                       "mean requires a floating-point tensor");
 
         // Full reduction
         if (num_axes == 0 || num_axes == rank) {
+            const DataType expected_output_dtype =
+                (op == ReduceOp::Any || op == ReduceOp::All) ? DataType::Bool : DataType::Int64;
+            LFS_ASSERT_MSG(output_dtype == expected_output_dtype,
+                           "Bool reduction output dtype does not match its operation");
             switch (op) {
-            case ReduceOp::Sum:
-            case ReduceOp::Mean: {
+            case ReduceOp::Sum: {
                 auto transform_iter = thrust::make_transform_iterator(
                     thrust::device_pointer_cast(d_in), BoolToInt64Op());
 
@@ -1080,12 +1215,6 @@ namespace lfs::core::tensor_ops {
                             transform_iter, d_out_int64, n, stream);
                     });
 
-                if (op == ReduceOp::Mean) {
-                    const int64_t count = static_cast<int64_t>(n);
-                    auto out_ptr = thrust::device_pointer_cast(d_out_int64);
-                    thrust::transform(thrust::cuda::par_nosync.on(stream), out_ptr, out_ptr + 1, out_ptr,
-                                      [count] __device__(int64_t val) { return val / count; });
-                }
             } break;
 
             case ReduceOp::Max:
@@ -1150,13 +1279,17 @@ namespace lfs::core::tensor_ops {
             } break;
 
             default:
-                init_scalar_gpu(d_out_int64, static_cast<int64_t>(0), stream);
-                break;
+                LFS_ASSERT_MSG(false,
+                               "Bool reduction encountered an unsupported operation");
             }
             return;
         }
 
         // Partial reduction for Any/All
+        LFS_ASSERT_MSG(output_dtype == DataType::Bool,
+                       "partial Bool reduction requires Bool output");
+        LFS_ASSERT_MSG(op == ReduceOp::Any || op == ReduceOp::All,
+                       "partial Bool reduction supports only any and all");
         if (op == ReduceOp::Any || op == ReduceOp::All) {
             const int dim = axes[0];
             size_t outer_size = 1;
@@ -1215,15 +1348,26 @@ namespace lfs::core::tensor_ops {
     // Public dispatcher function
     void launch_reduce_op(const void* input, void* output, const size_t* shape, size_t rank,
                           const int* axes, size_t num_axes, bool keepdim, ReduceOp op,
-                          DataType dtype, cudaStream_t stream) {
-        if (dtype == DataType::Float32) {
-            launch_reduce_op_float32(input, output, shape, rank, axes, num_axes, keepdim, op, stream);
-        } else if (dtype == DataType::Int32) {
-            launch_reduce_op_int32(input, output, shape, rank, axes, num_axes, keepdim, op, stream);
-        } else if (dtype == DataType::Bool) {
-            launch_reduce_op_bool(input, output, shape, rank, axes, num_axes, keepdim, op, stream);
-        }
-        // Other dtypes not supported
+                          DataType input_dtype, DataType output_dtype, cudaStream_t stream) {
+        detail::dispatch_dtype(input_dtype, [&]<typename T>() {
+            if constexpr (std::is_same_v<T, float>) {
+                LFS_ASSERT_MSG(output_dtype == DataType::Float32,
+                               "Float32 reduction requires Float32 output");
+                launch_reduce_op_float32(
+                    input, output, shape, rank, axes, num_axes, keepdim, op, stream);
+            } else if constexpr (std::is_same_v<T, int32_t>) {
+                launch_reduce_op_int32(
+                    input, output, shape, rank, axes, num_axes, keepdim, op,
+                    output_dtype, stream);
+            } else if constexpr (std::is_same_v<T, bool>) {
+                launch_reduce_op_bool(
+                    input, output, shape, rank, axes, num_axes, keepdim, op,
+                    output_dtype, stream);
+            } else {
+                LFS_ASSERT_MSG(false,
+                               "reduction encountered an unsupported input dtype");
+            }
+        });
     }
 
     // ============= TERNARY OPERATIONS =============
@@ -1524,9 +1668,15 @@ namespace lfs::core::tensor_ops {
         float dist = 0.0f;
         for (size_t d = 0; d < D; ++d) {
             float diff = fabsf(a[i * D + d] - b[j * D + d]);
-            dist += powf(diff, p);
+            if (p == 0.0f) {
+                dist += diff != 0.0f ? 1.0f : 0.0f;
+            } else if (isinf(p)) {
+                dist = ops::maximum_op{}(dist, diff);
+            } else {
+                dist += powf(diff, p);
+            }
         }
-        out[i * M + j] = powf(dist, 1.0f / p);
+        out[i * M + j] = (p == 0.0f || isinf(p)) ? dist : powf(dist, 1.0f / p);
     }
 
     void launch_cdist(const float* a, const float* b, float* out,
@@ -1589,18 +1739,18 @@ namespace lfs::core::tensor_ops {
         if (stream) {
             if (descending) {
                 thrust::sort_by_key(thrust::cuda::par_nosync.on(stream), values_ptr, values_ptr + n,
-                                    indices_ptr, thrust::greater<float>());
+                                    indices_ptr, ops::sort_greater_op{});
             } else {
                 thrust::sort_by_key(thrust::cuda::par_nosync.on(stream), values_ptr, values_ptr + n,
-                                    indices_ptr, thrust::less<float>());
+                                    indices_ptr, ops::sort_less_op{});
             }
         } else {
             if (descending) {
                 thrust::sort_by_key(thrust::cuda::par_nosync, values_ptr, values_ptr + n,
-                                    indices_ptr, thrust::greater<float>());
+                                    indices_ptr, ops::sort_greater_op{});
             } else {
                 thrust::sort_by_key(thrust::cuda::par_nosync, values_ptr, values_ptr + n,
-                                    indices_ptr, thrust::less<float>());
+                                    indices_ptr, ops::sort_less_op{});
             }
         }
     }
@@ -1648,11 +1798,11 @@ namespace lfs::core::tensor_ops {
                 if (descending) {
                     thrust::sort_by_key(thrust::cuda::par_nosync.on(stream),
                                         temp_vals.begin(), temp_vals.end(), temp_idx.begin(),
-                                        thrust::greater<float>());
+                                        ops::sort_greater_op{});
                 } else {
                     thrust::sort_by_key(thrust::cuda::par_nosync.on(stream),
                                         temp_vals.begin(), temp_vals.end(), temp_idx.begin(),
-                                        thrust::less<float>());
+                                        ops::sort_less_op{});
                 }
 
                 write_slice_kernel<<<blocks, 256, 0, stream>>>(
@@ -1671,8 +1821,8 @@ namespace lfs::core::tensor_ops {
     __global__ void cat_rgb_to_rgba_kernel(
         float* output,
         const float* rgb,
-        size_t num_pixels,
-        float alpha_value) {
+        const float* alpha,
+        size_t num_pixels) {
         size_t pixel_idx = blockIdx.x * blockDim.x + threadIdx.x;
         if (pixel_idx >= num_pixels)
             return;
@@ -1685,6 +1835,7 @@ namespace lfs::core::tensor_ops {
             rgb[rgb_offset + 0],
             rgb[rgb_offset + 1],
             rgb[rgb_offset + 2]);
+        const float alpha_value = alpha[pixel_idx];
 
         // Check alignment for float4 output
         bool out_aligned = (reinterpret_cast<uintptr_t>(&output[rgba_offset]) % 16) == 0;
@@ -1800,20 +1951,19 @@ namespace lfs::core::tensor_ops {
         if (num_tensors == 2 &&
             tensors[0].shape()[tensors[0].shape().rank() - 1] == 3 &&
             tensors[1].shape()[tensors[1].shape().rank() - 1] == 1 &&
+            tensors[0].dtype() == DataType::Float32 &&
+            tensors[1].dtype() == DataType::Float32 &&
             element_size == sizeof(float)) {
             // Special case: cat([RGB, alpha]) → RGBA
             size_t num_pixels = num_rows;
             int block_size = 256;
             int grid_size = (num_pixels + block_size - 1) / block_size;
 
-            // Assume alpha is constant (most common case)
-            float alpha_value = 1.0f; // Default alpha = 1.0 for opaque
-
             cat_rgb_to_rgba_kernel<<<grid_size, block_size, 0, stream>>>(
                 static_cast<float*>(output),
                 static_cast<const float*>(tensors[0].data_ptr()),
-                num_pixels,
-                alpha_value);
+                static_cast<const float*>(tensors[1].data_ptr()),
+                num_pixels);
             return;
         }
 
@@ -2070,10 +2220,6 @@ namespace lfs::core::tensor_ops {
         const float*, float*, size_t, ops::ceil_op, cudaStream_t);
     template void launch_unary_op_generic<int, int, ops::ceil_op>(
         const int*, int*, size_t, ops::ceil_op, cudaStream_t);
-    template void launch_unary_op_generic<float, float, ops::round_op>(
-        const float*, float*, size_t, ops::round_op, cudaStream_t);
-    template void launch_unary_op_generic<int, int, ops::round_op>(
-        const int*, int*, size_t, ops::round_op, cudaStream_t);
     template void launch_unary_op_generic<float, float, ops::sin_op>(
         const float*, float*, size_t, ops::sin_op, cudaStream_t);
     template void launch_unary_op_generic<int, int, ops::sin_op>(
@@ -2194,14 +2340,6 @@ namespace lfs::core::tensor_ops {
         const float*, const float*, float*, size_t, ops::div_op, cudaStream_t);
     template void launch_binary_op_generic<int, int, ops::div_op>(
         const int*, const int*, int*, size_t, ops::div_op, cudaStream_t);
-    template void launch_binary_op_generic<float, float, ops::minimum_op>(
-        const float*, const float*, float*, size_t, ops::minimum_op, cudaStream_t);
-    template void launch_binary_op_generic<int, int, ops::minimum_op>(
-        const int*, const int*, int*, size_t, ops::minimum_op, cudaStream_t);
-    template void launch_binary_op_generic<float, float, ops::maximum_op>(
-        const float*, const float*, float*, size_t, ops::maximum_op, cudaStream_t);
-    template void launch_binary_op_generic<int, int, ops::maximum_op>(
-        const int*, const int*, int*, size_t, ops::maximum_op, cudaStream_t);
     template void launch_binary_op_generic<float, float, ops::pow_op>(
         const float*, const float*, float*, size_t, ops::pow_op, cudaStream_t);
     template void launch_binary_op_generic<int, int, ops::pow_op>(
@@ -2343,6 +2481,49 @@ namespace lfs::core::tensor_ops {
     template void launch_unary_op_generic<int, int, ops::scalar_right_op<ops::mod_op, float>>(
         const int*, int*, size_t, ops::scalar_right_op<ops::mod_op, float>, cudaStream_t);
 
+#define LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(OP)                                \
+    template void launch_unary_op_generic<float, float,                            \
+                                          ops::scalar_right_op<ops::OP, int32_t>>( \
+        const float*, float*, size_t, ops::scalar_right_op<ops::OP, int32_t>,      \
+        cudaStream_t);                                                             \
+    template void launch_unary_op_generic<int, int,                                \
+                                          ops::scalar_right_op<ops::OP, int32_t>>( \
+        const int*, int*, size_t, ops::scalar_right_op<ops::OP, int32_t>, cudaStream_t);
+
+    LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(add_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(sub_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(mul_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(div_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(pow_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(mod_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(maximum_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC(minimum_op)
+
+#undef LFS_INSTANTIATE_TYPED_SCALAR_ARITHMETIC
+
+#define LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON(OP)                                   \
+    template void launch_unary_op_generic<float, unsigned char,                       \
+                                          ops::scalar_right_op<ops::OP, int32_t>>(    \
+        const float*, unsigned char*, size_t, ops::scalar_right_op<ops::OP, int32_t>, \
+        cudaStream_t);                                                                \
+    template void launch_unary_op_generic<int, unsigned char,                         \
+                                          ops::scalar_right_op<ops::OP, int32_t>>(    \
+        const int*, unsigned char*, size_t, ops::scalar_right_op<ops::OP, int32_t>,   \
+        cudaStream_t);                                                                \
+    template void launch_unary_op_generic<unsigned char, unsigned char,               \
+                                          ops::scalar_right_op<ops::OP, int32_t>>(    \
+        const unsigned char*, unsigned char*, size_t,                                 \
+        ops::scalar_right_op<ops::OP, int32_t>, cudaStream_t);
+
+    LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON(equal_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON(not_equal_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON(less_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON(less_equal_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON(greater_op)
+    LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON(greater_equal_op)
+
+#undef LFS_INSTANTIATE_TYPED_SCALAR_COMPARISON
+
     // Composed unary operations (expression template fusion) - test-specific
     template void launch_unary_op_generic<float, float, ops::composed_unary_op<ops::exp_op, ops::scalar_right_op<ops::mul_op, float>>>(
         const float*, float*, size_t, ops::composed_unary_op<ops::exp_op, ops::scalar_right_op<ops::mul_op, float>>, cudaStream_t);
@@ -2371,10 +2552,6 @@ namespace lfs::core::tensor_ops {
         const __half*, const __half*, __half*, size_t, ops::mul_op, cudaStream_t);
     template void launch_binary_op_generic<__half, __half, ops::div_op>(
         const __half*, const __half*, __half*, size_t, ops::div_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, __half, ops::maximum_op>(
-        const __half*, const __half*, __half*, size_t, ops::maximum_op, cudaStream_t);
-    template void launch_binary_op_generic<__half, __half, ops::minimum_op>(
-        const __half*, const __half*, __half*, size_t, ops::minimum_op, cudaStream_t);
     template void launch_binary_op_generic<__half, __half, ops::pow_op>(
         const __half*, const __half*, __half*, size_t, ops::pow_op, cudaStream_t);
 
@@ -2387,10 +2564,6 @@ namespace lfs::core::tensor_ops {
         const int64_t*, const int64_t*, int64_t*, size_t, ops::mul_op, cudaStream_t);
     template void launch_binary_op_generic<int64_t, int64_t, ops::div_op>(
         const int64_t*, const int64_t*, int64_t*, size_t, ops::div_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, int64_t, ops::maximum_op>(
-        const int64_t*, const int64_t*, int64_t*, size_t, ops::maximum_op, cudaStream_t);
-    template void launch_binary_op_generic<int64_t, int64_t, ops::minimum_op>(
-        const int64_t*, const int64_t*, int64_t*, size_t, ops::minimum_op, cudaStream_t);
     template void launch_binary_op_generic<int64_t, int64_t, ops::pow_op>(
         const int64_t*, const int64_t*, int64_t*, size_t, ops::pow_op, cudaStream_t);
     template void launch_binary_op_generic<int64_t, int64_t, ops::mod_op>(
@@ -2405,10 +2578,6 @@ namespace lfs::core::tensor_ops {
         const uint8_t*, const uint8_t*, uint8_t*, size_t, ops::mul_op, cudaStream_t);
     template void launch_binary_op_generic<uint8_t, uint8_t, ops::div_op>(
         const uint8_t*, const uint8_t*, uint8_t*, size_t, ops::div_op, cudaStream_t);
-    template void launch_binary_op_generic<uint8_t, uint8_t, ops::maximum_op>(
-        const uint8_t*, const uint8_t*, uint8_t*, size_t, ops::maximum_op, cudaStream_t);
-    template void launch_binary_op_generic<uint8_t, uint8_t, ops::minimum_op>(
-        const uint8_t*, const uint8_t*, uint8_t*, size_t, ops::minimum_op, cudaStream_t);
     template void launch_binary_op_generic<uint8_t, uint8_t, ops::pow_op>(
         const uint8_t*, const uint8_t*, uint8_t*, size_t, ops::pow_op, cudaStream_t);
 

--- a/src/core/tensor/tensor_random_ops.cpp
+++ b/src/core/tensor/tensor_random_ops.cpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <curand.h>
 #include <curand_kernel.h>
+#include <mutex>
 #include <random>
 
 #define CHECK_CURAND(call)                                                   \
@@ -25,9 +26,11 @@ namespace lfs::core {
     class RandomGeneratorImpl {
     public:
         std::atomic<uint64_t> call_counter_{0};
+        uint64_t cuda_offset_ = 0;
         uint64_t seed_ = 42;
         void* cuda_generator_ = nullptr;
         std::mt19937_64 cpu_generator_;
+        std::mutex cuda_mutex_;
 
         RandomGeneratorImpl() : seed_(42),
                                 cpu_generator_(seed_) {
@@ -69,9 +72,11 @@ namespace lfs::core {
         cpu_generator_.seed(seed);
 
         auto* impl = static_cast<RandomGeneratorImpl*>(impl_);
+        std::lock_guard lock(impl->cuda_mutex_);
         impl->seed_ = seed;
         impl->cpu_generator_.seed(seed);
-        impl->call_counter_.store(0); // Reset call counter when seed is set
+        impl->call_counter_.store(0);
+        impl->cuda_offset_ = 0;
 
         if (impl->cuda_generator_) {
             curandGenerator_t* gen = static_cast<curandGenerator_t*>(impl->cuda_generator_);
@@ -88,10 +93,22 @@ namespace lfs::core {
         return base_seed + counter * 1000000ULL;
     }
 
-    uint64_t RandomGenerator::get_next_cuda_offset() {
+    void RandomGenerator::generate_cuda_normal(float* output, const size_t count,
+                                               const float mean, const float std,
+                                               const cudaStream_t stream) {
+        LFS_ASSERT_MSG(output != nullptr,
+                       "CUDA normal generation requires a valid output pointer");
+        LFS_ASSERT_MSG(count > 0 && count % 2 == 0,
+                       "CUDA normal generation requires a positive even value count");
         auto* impl = static_cast<RandomGeneratorImpl*>(impl_);
-        uint64_t counter = impl->call_counter_.fetch_add(1);
-        return counter * 1000000ULL;
+        std::lock_guard lock(impl->cuda_mutex_);
+        LFS_ASSERT_MSG(count <= std::numeric_limits<uint64_t>::max() - impl->cuda_offset_,
+                       "CUDA random generator offset overflow");
+
+        curandGenerator_t* gen = static_cast<curandGenerator_t*>(impl->cuda_generator_);
+        impl->cuda_offset_ += count;
+        CHECK_CURAND(curandSetStream(*gen, stream));
+        CHECK_CURAND(curandGenerateNormal(*gen, output, count, mean, std));
     }
 
     void* RandomGenerator::get_generator(Device device) {
@@ -116,6 +133,13 @@ namespace lfs::core {
                        "uniform_ bounds must be finite and ordered");
         if (numel() == 0) {
             return *this;
+        }
+
+        if (!is_contiguous()) {
+            return mutate_logical_view(
+                [&](Tensor& materialized) {
+                    materialized.uniform_(low, high);
+                });
         }
 
         size_t n = numel();
@@ -145,37 +169,40 @@ namespace lfs::core {
                        "normal_ requires a valid tensor");
         LFS_ASSERT_MSG(dtype_ == DataType::Float32,
                        "normal_ requires Float32 dtype");
-        LFS_ASSERT_MSG(std::isfinite(mean) && std::isfinite(std) && std > 0.0f,
-                       "normal_ mean and standard deviation must be finite, with std > 0");
+        LFS_ASSERT_MSG(std::isfinite(mean) && std::isfinite(std) && std >= 0.0f,
+                       "normal_ mean and standard deviation must be finite, with std >= 0");
         if (numel() == 0) {
             return *this;
+        }
+
+        if (std == 0.0f) {
+            return fill_(mean);
+        }
+
+        if (!is_contiguous()) {
+            return mutate_logical_view(
+                [&](Tensor& materialized) {
+                    materialized.normal_(mean, std);
+                });
         }
 
         size_t n = numel();
 
         if (device_ == Device::CUDA) {
-            // OPTIMIZATION: Use curandGenerateNormal for bulk generation (much faster!)
-            // This avoids the slow per-element curand_init in the kernel
-            curandGenerator_t* gen = static_cast<curandGenerator_t*>(
-                RandomGenerator::instance().get_generator(Device::CUDA));
-
-            // Advance the generator offset (not the seed!) for reproducibility
-            uint64_t offset = RandomGenerator::instance().get_next_cuda_offset();
-            CHECK_CURAND(curandSetGeneratorOffset(*gen, offset));
-
             // curandGenerateNormal requires even number of elements
             if (n % 2 == 1) {
                 // Generate into an n+1 scratch allocation. Writing n+1 values into
                 // the n-element destination was a one-float buffer overflow.
                 auto scratch = Tensor::empty({n + 1}, Device::CUDA, DataType::Float32);
-                CHECK_CURAND(curandGenerateNormal(*gen, scratch.ptr<float>(), n + 1, mean, std));
+                RandomGenerator::instance().generate_cuda_normal(
+                    scratch.ptr<float>(), n + 1, mean, std, stream());
                 LFS_CUDA_CHECK(cudaMemcpyAsync(ptr<float>(), scratch.ptr<float>(), n * sizeof(float),
                                                cudaMemcpyDeviceToDevice, stream()));
                 LFS_CUDA_CHECK(cudaStreamSynchronize(stream()));
             } else {
-                CHECK_CURAND(curandGenerateNormal(*gen, ptr<float>(), n, mean, std));
+                RandomGenerator::instance().generate_cuda_normal(
+                    ptr<float>(), n, mean, std, stream());
             }
-            // Note: No need for cudaDeviceSynchronize() - curandGenerateNormal is blocking
         } else {
             // CPU uses stateful generator
             auto* impl = static_cast<RandomGeneratorImpl*>(

--- a/src/core/tensor/tensor_random_ops.cu
+++ b/src/core/tensor/tensor_random_ops.cu
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "core/assert.hpp"
 #include "core/cuda_error.hpp"
 #include "internal/tensor_functors.hpp"
 #include "internal/tensor_ops.hpp"
@@ -9,13 +10,36 @@
 
 // Thrust headers for multinomial without replacement
 #include <thrust/copy.h>
+#include <thrust/count.h>
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
 #include <thrust/reduce.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+#include <thrust/transform_reduce.h>
 
 namespace lfs::core::tensor_ops {
+
+    namespace {
+
+        __device__ float uniform_unit_interval(curandState* state) {
+            constexpr float SCALE = 1.0f / 16777216.0f;
+            return static_cast<float>(curand(state) >> 8) * SCALE;
+        }
+
+        struct invalid_multinomial_weight {
+            __host__ __device__ bool operator()(float weight) const {
+                return !isfinite(weight) || weight < 0.0f;
+            }
+        };
+
+        struct multinomial_weight_to_double {
+            __host__ __device__ double operator()(float weight) const {
+                return static_cast<double>(weight);
+            }
+        };
+
+    } // namespace
 
     // Note: run_with_thrust_policy is now in include/core/tensor_generic_ops.cuh
 
@@ -29,8 +53,13 @@ namespace lfs::core::tensor_ops {
         if (idx < n) {
             curandState state;
             curand_init(seed, idx, 0, &state);
-            float val = curand_uniform(&state);
-            data[idx] = val * (high - low) + low;
+            if (low == high) {
+                data[idx] = low;
+                return;
+            }
+            const float val = uniform_unit_interval(&state);
+            const float result = fmaf(val, high - low, low);
+            data[idx] = result < high ? result : nextafterf(high, low);
         }
     }
 
@@ -54,7 +83,7 @@ namespace lfs::core::tensor_ops {
         if (idx < n) {
             curandState state;
             curand_init(seed, idx, 0, &state);
-            float val = curand_uniform(&state);
+            const float val = uniform_unit_interval(&state);
             data[idx] = (val < p) ? 1.0f : 0.0f;
         }
     }
@@ -68,24 +97,19 @@ namespace lfs::core::tensor_ops {
             curandState state;
             curand_init(seed, idx, 0, &state);
 
-            float val = curand_uniform(&state);
-            int range = high - low;
-
-            int result = low + static_cast<int>(val * range);
-
-            if (result >= high)
-                result = high - 1;
-            if (result < low)
-                result = low;
-
-            data[idx] = result;
+            const uint64_t random = curand(&state);
+            const uint64_t range = static_cast<uint64_t>(
+                static_cast<int64_t>(high) - static_cast<int64_t>(low));
+            const uint64_t offset = (random * range) >> 32;
+            data[idx] = static_cast<int>(static_cast<int64_t>(low) +
+                                         static_cast<int64_t>(offset));
         }
     }
 
     // Kernel for multinomial sampling with replacement
     __global__ void multinomial_with_replacement_kernel(const float* weights, int64_t* samples,
                                                         unsigned long n, unsigned long num_samples,
-                                                        float sum, unsigned long long seed) {
+                                                        double sum, unsigned long long seed) {
         int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
         if (idx >= num_samples)
@@ -94,12 +118,12 @@ namespace lfs::core::tensor_ops {
         curandState state;
         curand_init(seed, idx, 0, &state);
 
-        float u = curand_uniform(&state) * sum;
+        const double u = static_cast<double>(uniform_unit_interval(&state)) * sum;
 
-        float cumsum = 0.0f;
+        double cumsum = 0.0;
         for (unsigned long i = 0; i < n; ++i) {
-            cumsum += weights[i];
-            if (u <= cumsum) {
+            cumsum += static_cast<double>(weights[i]);
+            if (u < cumsum) {
                 samples[idx] = static_cast<int64_t>(i);
                 return;
             }
@@ -181,21 +205,25 @@ namespace lfs::core::tensor_ops {
         // Compute sum of weights using Thrust with centralized sum_op
         auto weights_ptr = thrust::device_pointer_cast(weights);
 
-        float sum;
+        size_t invalid_count = 0;
+        double sum = 0.0;
         run_with_thrust_policy(stream, [&](auto policy) {
-            sum = thrust::reduce(
+            invalid_count = thrust::count_if(
                 policy,
                 weights_ptr, weights_ptr + n,
-                0.0f,
-                ops::sum_op());
+                invalid_multinomial_weight{});
+            sum = thrust::transform_reduce(
+                policy,
+                weights_ptr, weights_ptr + n,
+                multinomial_weight_to_double{},
+                0.0,
+                thrust::plus<double>());
         });
 
-        if (sum <= 0) {
-            LFS_CUDA_CHECK_MSG(
-                cudaMemsetAsync(samples, 0, num_samples * sizeof(int64_t), stream),
-                "multinomial empty-weight output (sample_count={})", num_samples);
-            return;
-        }
+        LFS_ASSERT_MSG(invalid_count == 0,
+                       "multinomial weights must be finite and non-negative");
+        LFS_ASSERT_MSG(std::isfinite(sum) && sum > 0.0,
+                       "multinomial weights must have a positive finite sum");
 
         if (replacement) {
             int block_size = 256;

--- a/src/core/tensor/tensor_row_proxy.cpp
+++ b/src/core/tensor/tensor_row_proxy.cpp
@@ -38,25 +38,25 @@ namespace lfs::core {
     } // namespace
 
     void TensorRowProxy::flush_cuda_staging() const {
-        if (!cuda_staging_pending_write_) {
+        if (cuda_staging_slots_.empty()) {
             return;
         }
         if (!tensor_ || !tensor_->is_valid() || tensor_->device() != Device::CUDA) {
-            cuda_staging_pending_write_ = false;
             return;
         }
         if (tensor_->dtype() != DataType::Float32) {
             throw std::runtime_error("TensorRowProxy CUDA staging writeback only supports Float32 tensors");
         }
 
-        cuda_copy_async_sync(
-            tensor_->ptr<float>() + cuda_staging_linear_idx_,
-            &cuda_staging_,
-            sizeof(float),
-            cudaMemcpyHostToDevice,
-            tensor_->stream(),
-            "TensorRowProxy::flush_cuda_staging");
-        cuda_staging_pending_write_ = false;
+        for (const auto& slot : cuda_staging_slots_) {
+            cuda_copy_async_sync(
+                tensor_->ptr<float>() + slot.linear_index,
+                &slot.value,
+                sizeof(float),
+                cudaMemcpyHostToDevice,
+                tensor_->stream(),
+                "TensorRowProxy::flush_cuda_staging");
+        }
     }
 
     TensorRowProxy::~TensorRowProxy() {
@@ -82,18 +82,25 @@ namespace lfs::core {
         size_t linear_idx = row_index_ * tensor_->stride(0) + col_index * tensor_->stride(1);
 
         if (tensor_->device() != Device::CPU) {
-            // Commit any previously staged element before staging another one.
-            flush_cuda_staging();
+            const auto existing = std::find_if(
+                cuda_staging_slots_.begin(), cuda_staging_slots_.end(),
+                [linear_idx](const CudaStagingSlot& slot) {
+                    return slot.linear_index == linear_idx;
+                });
+            if (existing != cuda_staging_slots_.end()) {
+                return existing->value;
+            }
+
+            cuda_staging_slots_.push_back(CudaStagingSlot{.linear_index = linear_idx});
+            auto& slot = cuda_staging_slots_.back();
             cuda_copy_async_sync(
-                &cuda_staging_,
+                &slot.value,
                 tensor_->ptr<float>() + linear_idx,
                 sizeof(float),
                 cudaMemcpyDeviceToHost,
                 tensor_->stream(),
                 "TensorRowProxy::operator[]");
-            cuda_staging_linear_idx_ = linear_idx;
-            cuda_staging_pending_write_ = true;
-            return cuda_staging_;
+            return slot.value;
         }
 
         return tensor_->ptr<float>()[linear_idx];
@@ -182,34 +189,10 @@ namespace lfs::core {
         assert_proxy_tensor(tensor_, row_index_, "TensorRowProxy tensor conversion");
         flush_cuda_staging();
 
-        if (tensor_->shape().rank() > 1) {
-            // Build a proper row view so storage offsets/strides are respected for non-contiguous tensors.
-            Tensor row_view = tensor_->slice(0, row_index_, row_index_ + 1).squeeze(0);
-            LFS_ASSERT_MSG(row_view.is_valid(),
-                           "TensorRowProxy failed to create a row view");
-            return row_view.clone();
-        }
-
-        // For 1D tensors, return a scalar tensor
-        LFS_ASSERT_MSG(tensor_->dtype() == DataType::Float32,
-                       "TensorRowProxy scalar tensor conversion currently supports only Float32");
-        float val = item();
-
-        auto result = Tensor::empty({1}, tensor_->device(), tensor_->dtype());
-
-        if (tensor_->device() == Device::CUDA) {
-            cuda_copy_async_sync(
-                result.data_ptr(),
-                &val,
-                sizeof(float),
-                cudaMemcpyHostToDevice,
-                tensor_->stream(),
-                "TensorRowProxy scalar tensor conversion");
-        } else {
-            *result.ptr<float>() = val;
-        }
-
-        return result.squeeze();
+        Tensor row_view = tensor_->slice(0, row_index_, row_index_ + 1).squeeze(0);
+        LFS_ASSERT_MSG(row_view.is_valid(),
+                       "TensorRowProxy failed to create a row view");
+        return row_view;
     }
 
     // ============= TensorRowProxy Assignment Operators =============
@@ -333,8 +316,8 @@ namespace lfs::core {
                        "TensorRowProxy float assignment requires a 1D tensor");
         LFS_ASSERT_MSG(tensor_->dtype() == DataType::Float32,
                        "TensorRowProxy float assignment requires Float32");
-        LFS_ASSERT_MSG(std::isfinite(value),
-                       "TensorRowProxy float assignment requires a finite value");
+        detail::require_scalar_representable(
+            tensor_->dtype(), value, "TensorRowProxy float assignment");
 
         // Use stride for proper indexing on non-contiguous 1D tensors
         size_t linear_idx = row_index_ * tensor_->stride(0);

--- a/src/core/tensor/tensor_serialization.cpp
+++ b/src/core/tensor/tensor_serialization.cpp
@@ -66,10 +66,8 @@ namespace lfs::core {
             os.write(reinterpret_cast<const char*>(&d), sizeof(d));
         }
 
-        Tensor src = tensor.device() == Device::CUDA ? tensor.cpu() : tensor;
-        if (!src.is_contiguous()) {
-            src = src.contiguous();
-        }
+        const Tensor host = tensor.device() == Device::CUDA ? tensor.cpu() : tensor;
+        const Tensor src = host.is_contiguous() ? host : host.contiguous();
         os.write(reinterpret_cast<const char*>(src.data_ptr()), src.bytes());
 
         if (!os) {
@@ -88,7 +86,7 @@ namespace lfs::core {
         if (header.version != TENSOR_FILE_VERSION) {
             throw std::runtime_error("Unsupported tensor file version");
         }
-        if (header.rank > MAX_SERIALIZED_TENSOR_RANK) {
+        if (header.rank > MAX_TENSOR_RANK) {
             throw std::runtime_error("Invalid tensor file: rank exceeds supported maximum");
         }
         if (header.dtype > static_cast<uint8_t>(DataType::Bool)) {

--- a/src/core/tensor/tensor_shape_ops.cpp
+++ b/src/core/tensor/tensor_shape_ops.cpp
@@ -32,7 +32,7 @@ namespace lfs::core {
                        "t() requires a valid tensor");
 
         if (shape_.rank() <= 1) {
-            return clone();
+            return create_strided_view(shape_, strides_);
         }
 
         return transpose(-2, -1);
@@ -230,20 +230,28 @@ namespace lfs::core {
             return deferred;
         }
 
-        bool is_contiguous = is_contiguous_slice(starts, ends);
+        Tensor view;
+        view.data_ = data_;
+        view.data_owner_ = data_owner_;
+        view.shape_ = TensorShape(new_shape);
+        view.strides_ = strides_;
+        view.storage_offset_ = storage_offset_ + calculate_offset(starts);
+        view.device_ = device_;
+        view.dtype_ = dtype_;
+        view.is_view_ = true;
+        view.id_ = profiling_enabled_ ? next_id_++ : 0;
 
-        if (is_contiguous) {
-            size_t offset = calculate_offset(starts);
-            void* new_data = static_cast<char*>(data_) + offset * dtype_size(dtype_);
-
-            Tensor view(new_data, TensorShape(new_shape), device_, dtype_);
-            view.data_owner_ = data_owner_;
-            view.is_view_ = true;
-            propagate_view_meta(view);
-            return view;
-        } else {
-            return copy_slice(starts, ends, new_shape);
+        size_t expected_stride = 1;
+        view.is_contiguous_ = true;
+        for (int i = static_cast<int>(view.shape_.rank()) - 1; i >= 0; --i) {
+            if (view.strides_[i] != expected_stride) {
+                view.is_contiguous_ = false;
+                break;
+            }
+            expected_stride *= view.shape_[i];
         }
+        propagate_view_meta(view);
+        return view;
     }
 
     Tensor Tensor::slice(size_t dim, size_t start, size_t end) const {
@@ -397,7 +405,7 @@ namespace lfs::core {
 
         for (int dim : dims) {
             int r = resolve_dim(dim);
-            LFS_ASSERT_MSG(r >= 0 && r < static_cast<int>(shape_.rank()),
+            LFS_ASSERT_MSG(detail::tensor_dim_is_valid(r, shape_.rank()),
                            std::format("dimension {} is out of range for rank {}", dim, shape_.rank()));
             resolved.push_back(static_cast<size_t>(r));
         }

--- a/src/core/tensor/tensor_strided_ops.cu
+++ b/src/core/tensor/tensor_strided_ops.cu
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/cuda_error.hpp"
+#include "internal/tensor_dtype_dispatch.hpp"
 #include "internal/tensor_impl.hpp"
 #include "internal/tensor_ops.hpp"
 #include <algorithm>
@@ -121,42 +122,27 @@ namespace lfs::core {
             const size_t* shape, const size_t* strides,
             const size_t rank, const size_t n,
             const DataType dtype, cudaStream_t stream) {
+            if (n == 0)
+                return;
+            LFS_ASSERT_MSG(input != nullptr && output != nullptr,
+                           "strided scatter requires valid input and output pointers");
+            LFS_ASSERT_MSG(shape != nullptr && strides != nullptr && rank > 0,
+                           "strided scatter requires non-empty shape metadata");
             const int blocks = static_cast<int>(std::min(
                 (n + SCATTER_BLOCK_SIZE - 1) / SCATTER_BLOCK_SIZE,
                 static_cast<size_t>(MAX_GRID)));
 
-#define LAUNCH_RANK2(T)                                                      \
-    strided_scatter_kernel_rank2<<<blocks, SCATTER_BLOCK_SIZE, 0, stream>>>( \
-        static_cast<const T*>(input), static_cast<T*>(output),               \
-        shape[0], shape[1], strides[0], strides[1], n)
-
-#define LAUNCH_GENERIC(T)                                              \
-    strided_scatter_kernel<<<blocks, SCATTER_BLOCK_SIZE, 0, stream>>>( \
-        static_cast<const T*>(input), static_cast<T*>(output),         \
-        shape, strides, rank, n)
-
-            if (rank == 2) {
-                switch (dtype) {
-                case DataType::Float32: LAUNCH_RANK2(float); break;
-                case DataType::Int32: LAUNCH_RANK2(int32_t); break;
-                case DataType::Int64: LAUNCH_RANK2(int64_t); break;
-                case DataType::UInt8: LAUNCH_RANK2(uint8_t); break;
-                case DataType::Bool: LAUNCH_RANK2(bool); break;
-                default: break;
+            detail::dispatch_dtype(dtype, [&]<typename T>() {
+                if (rank == 2) {
+                    strided_scatter_kernel_rank2<<<blocks, SCATTER_BLOCK_SIZE, 0, stream>>>(
+                        static_cast<const T*>(input), static_cast<T*>(output),
+                        shape[0], shape[1], strides[0], strides[1], n);
+                } else {
+                    strided_scatter_kernel<<<blocks, SCATTER_BLOCK_SIZE, 0, stream>>>(
+                        static_cast<const T*>(input), static_cast<T*>(output),
+                        shape, strides, rank, n);
                 }
-            } else {
-                switch (dtype) {
-                case DataType::Float32: LAUNCH_GENERIC(float); break;
-                case DataType::Int32: LAUNCH_GENERIC(int32_t); break;
-                case DataType::Int64: LAUNCH_GENERIC(int64_t); break;
-                case DataType::UInt8: LAUNCH_GENERIC(uint8_t); break;
-                case DataType::Bool: LAUNCH_GENERIC(bool); break;
-                default: break;
-                }
-            }
-
-#undef LAUNCH_RANK2
-#undef LAUNCH_GENERIC
+            });
             LFS_CUDA_CHECK(cudaGetLastError());
         }
 
@@ -166,49 +152,34 @@ namespace lfs::core {
             const size_t n, const DataType dtype, cudaStream_t stream) {
             if (n == 0)
                 return;
+            LFS_ASSERT_MSG(input != nullptr && output != nullptr,
+                           "strided scatter requires valid input and output pointers");
+            LFS_ASSERT_MSG(shape.size() == strides.size(),
+                           "strided scatter shape and stride ranks must match");
             const int blocks = static_cast<int>(std::min(
                 (n + SCATTER_BLOCK_SIZE - 1) / SCATTER_BLOCK_SIZE,
                 static_cast<size_t>(MAX_GRID)));
             const size_t rank = shape.size();
+            LFS_ASSERT_MSG(rank >= 2 && rank <= 4,
+                           "immediate strided scatter supports only ranks 2 through 4");
 
-#define LAUNCH_SCATTER2(T) strided_scatter_kernel_rank2<<<blocks, SCATTER_BLOCK_SIZE, 0, stream>>>( \
-    static_cast<const T*>(input), static_cast<T*>(output), shape[0], shape[1], strides[0], strides[1], n)
-#define LAUNCH_SCATTER3(T) strided_scatter_kernel_rank3<<<blocks, SCATTER_BLOCK_SIZE, 0, stream>>>( \
-    static_cast<const T*>(input), static_cast<T*>(output), shape[0], shape[1], shape[2], strides[0], strides[1], strides[2], n)
-#define LAUNCH_SCATTER4(T) strided_scatter_kernel_rank4<<<blocks, SCATTER_BLOCK_SIZE, 0, stream>>>( \
-    static_cast<const T*>(input), static_cast<T*>(output), shape[0], shape[1], shape[2], shape[3], strides[0], strides[1], strides[2], strides[3], n)
-
-            if (rank == 2) {
-                switch (dtype) {
-                case DataType::Float32: LAUNCH_SCATTER2(float); break;
-                case DataType::Int32: LAUNCH_SCATTER2(int32_t); break;
-                case DataType::Int64: LAUNCH_SCATTER2(int64_t); break;
-                case DataType::UInt8: LAUNCH_SCATTER2(uint8_t); break;
-                case DataType::Bool: LAUNCH_SCATTER2(bool); break;
-                default: break;
+            detail::dispatch_dtype(dtype, [&]<typename T>() {
+                if (rank == 2) {
+                    strided_scatter_kernel_rank2<<<blocks, SCATTER_BLOCK_SIZE, 0, stream>>>(
+                        static_cast<const T*>(input), static_cast<T*>(output),
+                        shape[0], shape[1], strides[0], strides[1], n);
+                } else if (rank == 3) {
+                    strided_scatter_kernel_rank3<<<blocks, SCATTER_BLOCK_SIZE, 0, stream>>>(
+                        static_cast<const T*>(input), static_cast<T*>(output),
+                        shape[0], shape[1], shape[2],
+                        strides[0], strides[1], strides[2], n);
+                } else {
+                    strided_scatter_kernel_rank4<<<blocks, SCATTER_BLOCK_SIZE, 0, stream>>>(
+                        static_cast<const T*>(input), static_cast<T*>(output),
+                        shape[0], shape[1], shape[2], shape[3],
+                        strides[0], strides[1], strides[2], strides[3], n);
                 }
-            } else if (rank == 3) {
-                switch (dtype) {
-                case DataType::Float32: LAUNCH_SCATTER3(float); break;
-                case DataType::Int32: LAUNCH_SCATTER3(int32_t); break;
-                case DataType::Int64: LAUNCH_SCATTER3(int64_t); break;
-                case DataType::UInt8: LAUNCH_SCATTER3(uint8_t); break;
-                case DataType::Bool: LAUNCH_SCATTER3(bool); break;
-                default: break;
-                }
-            } else if (rank == 4) {
-                switch (dtype) {
-                case DataType::Float32: LAUNCH_SCATTER4(float); break;
-                case DataType::Int32: LAUNCH_SCATTER4(int32_t); break;
-                case DataType::Int64: LAUNCH_SCATTER4(int64_t); break;
-                case DataType::UInt8: LAUNCH_SCATTER4(uint8_t); break;
-                case DataType::Bool: LAUNCH_SCATTER4(bool); break;
-                default: break;
-                }
-            }
-#undef LAUNCH_SCATTER2
-#undef LAUNCH_SCATTER3
-#undef LAUNCH_SCATTER4
+            });
             LFS_CUDA_CHECK(cudaGetLastError());
         }
 
@@ -282,49 +253,36 @@ namespace lfs::core {
             const void* input, void* output,
             const std::vector<size_t>& shape, const std::vector<size_t>& strides,
             const size_t n, const DataType dtype, cudaStream_t stream) {
+            if (n == 0)
+                return;
+            LFS_ASSERT_MSG(input != nullptr && output != nullptr,
+                           "strided copy requires valid input and output pointers");
+            LFS_ASSERT_MSG(shape.size() == strides.size(),
+                           "strided copy shape and stride ranks must match");
             const int num_blocks = static_cast<int>(std::min(
                 (n + SCATTER_BLOCK_SIZE - 1) / SCATTER_BLOCK_SIZE,
                 static_cast<size_t>(MAX_GRID)));
             const size_t rank = shape.size();
+            LFS_ASSERT_MSG(rank >= 2 && rank <= 4,
+                           "immediate strided copy supports only ranks 2 through 4");
 
-#define LAUNCH_COPY2(T) strided_copy_kernel_rank2<<<num_blocks, SCATTER_BLOCK_SIZE, 0, stream>>>( \
-    static_cast<const T*>(input), static_cast<T*>(output), shape[0], shape[1], strides[0], strides[1], n)
-#define LAUNCH_COPY3(T) strided_copy_kernel_rank3<<<num_blocks, SCATTER_BLOCK_SIZE, 0, stream>>>( \
-    static_cast<const T*>(input), static_cast<T*>(output), shape[0], shape[1], shape[2], strides[0], strides[1], strides[2], n)
-#define LAUNCH_COPY4(T) strided_copy_kernel_rank4<<<num_blocks, SCATTER_BLOCK_SIZE, 0, stream>>>( \
-    static_cast<const T*>(input), static_cast<T*>(output), shape[0], shape[1], shape[2], shape[3], strides[0], strides[1], strides[2], strides[3], n)
-
-            if (rank == 2) {
-                switch (dtype) {
-                case DataType::Float32: LAUNCH_COPY2(float); break;
-                case DataType::Int32: LAUNCH_COPY2(int32_t); break;
-                case DataType::Int64: LAUNCH_COPY2(int64_t); break;
-                case DataType::UInt8: LAUNCH_COPY2(uint8_t); break;
-                case DataType::Bool: LAUNCH_COPY2(bool); break;
-                default: break;
+            detail::dispatch_dtype(dtype, [&]<typename T>() {
+                if (rank == 2) {
+                    strided_copy_kernel_rank2<<<num_blocks, SCATTER_BLOCK_SIZE, 0, stream>>>(
+                        static_cast<const T*>(input), static_cast<T*>(output),
+                        shape[0], shape[1], strides[0], strides[1], n);
+                } else if (rank == 3) {
+                    strided_copy_kernel_rank3<<<num_blocks, SCATTER_BLOCK_SIZE, 0, stream>>>(
+                        static_cast<const T*>(input), static_cast<T*>(output),
+                        shape[0], shape[1], shape[2],
+                        strides[0], strides[1], strides[2], n);
+                } else {
+                    strided_copy_kernel_rank4<<<num_blocks, SCATTER_BLOCK_SIZE, 0, stream>>>(
+                        static_cast<const T*>(input), static_cast<T*>(output),
+                        shape[0], shape[1], shape[2], shape[3],
+                        strides[0], strides[1], strides[2], strides[3], n);
                 }
-            } else if (rank == 3) {
-                switch (dtype) {
-                case DataType::Float32: LAUNCH_COPY3(float); break;
-                case DataType::Int32: LAUNCH_COPY3(int32_t); break;
-                case DataType::Int64: LAUNCH_COPY3(int64_t); break;
-                case DataType::UInt8: LAUNCH_COPY3(uint8_t); break;
-                case DataType::Bool: LAUNCH_COPY3(bool); break;
-                default: break;
-                }
-            } else if (rank == 4) {
-                switch (dtype) {
-                case DataType::Float32: LAUNCH_COPY4(float); break;
-                case DataType::Int32: LAUNCH_COPY4(int32_t); break;
-                case DataType::Int64: LAUNCH_COPY4(int64_t); break;
-                case DataType::UInt8: LAUNCH_COPY4(uint8_t); break;
-                case DataType::Bool: LAUNCH_COPY4(bool); break;
-                default: break;
-                }
-            }
-#undef LAUNCH_COPY2
-#undef LAUNCH_COPY3
-#undef LAUNCH_COPY4
+            });
             LFS_CUDA_CHECK(cudaGetLastError());
         }
 
@@ -337,45 +295,22 @@ namespace lfs::core {
             size_t total_elements,
             DataType dtype,
             cudaStream_t stream) {
+            if (total_elements == 0)
+                return;
+            LFS_ASSERT_MSG(input != nullptr && output != nullptr,
+                           "strided copy requires valid input and output pointers");
+            LFS_ASSERT_MSG(shape != nullptr && strides != nullptr && rank > 0,
+                           "strided copy requires non-empty shape metadata");
             const int block_size = 256;
             const int num_blocks = static_cast<int>(std::min(
                 (total_elements + block_size - 1) / block_size,
                 static_cast<size_t>(MAX_GRID)));
 
-            switch (dtype) {
-            case DataType::Float32:
+            detail::dispatch_dtype(dtype, [&]<typename T>() {
                 strided_copy_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    static_cast<const float*>(input),
-                    static_cast<float*>(output),
+                    static_cast<const T*>(input), static_cast<T*>(output),
                     shape, strides, rank, total_elements);
-                break;
-            case DataType::Int32:
-                strided_copy_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    static_cast<const int32_t*>(input),
-                    static_cast<int32_t*>(output),
-                    shape, strides, rank, total_elements);
-                break;
-            case DataType::Int64:
-                strided_copy_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    static_cast<const int64_t*>(input),
-                    static_cast<int64_t*>(output),
-                    shape, strides, rank, total_elements);
-                break;
-            case DataType::UInt8:
-                strided_copy_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    static_cast<const uint8_t*>(input),
-                    static_cast<uint8_t*>(output),
-                    shape, strides, rank, total_elements);
-                break;
-            case DataType::Bool:
-                strided_copy_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    static_cast<const bool*>(input),
-                    static_cast<bool*>(output),
-                    shape, strides, rank, total_elements);
-                break;
-            default:
-                break;
-            }
+            });
             LFS_CUDA_CHECK(cudaGetLastError());
         }
 
@@ -508,6 +443,13 @@ namespace lfs::core {
             DataType dtype,
             cudaStream_t stream) {
 
+            if (total_elements == 0)
+                return;
+            LFS_ASSERT_MSG(host_input != nullptr && gpu_output != nullptr,
+                           "strided upload requires valid input and output pointers");
+            LFS_ASSERT_MSG(d_shape != nullptr && d_strides != nullptr && rank > 0,
+                           "strided upload requires non-empty shape metadata");
+
             const int block_size = 256;
             const int num_blocks = static_cast<int>(std::min(
                 (total_elements + block_size - 1) / block_size,
@@ -537,23 +479,12 @@ namespace lfs::core {
                     size_t H = d_shape[1];
                     size_t W = d_shape[2];
 
-                    switch (dtype) {
-                    case DataType::Float32:
+                    detail::dispatch_dtype(dtype, [&]<typename T>() {
                         strided_upload_kernel_hwc_to_chw<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const float*>(host_input),
-                            static_cast<float*>(gpu_output),
+                            static_cast<const T*>(host_input),
+                            static_cast<T*>(gpu_output),
                             H, W, C);
-                        break;
-                    case DataType::UInt8:
-                        strided_upload_kernel_hwc_to_chw<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const uint8_t*>(host_input),
-                            static_cast<uint8_t*>(gpu_output),
-                            H, W, C);
-                        break;
-                    default:
-                        // Fall through to generic path
-                        break;
-                    }
+                    });
                     return;
                 }
 
@@ -601,171 +532,40 @@ namespace lfs::core {
                     order = IterOrder::ORDER_012;
                 }
 
-                // Dispatch to appropriate kernel based on dtype and iteration order
-                switch (dtype) {
-                case DataType::Float32:
+                detail::dispatch_dtype(dtype, [&]<typename T>() {
                     if (order == IterOrder::ORDER_210) {
                         strided_upload_kernel_rank3_gather<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const float*>(host_input),
-                            static_cast<float*>(gpu_output),
+                            static_cast<const T*>(host_input),
+                            static_cast<T*>(gpu_output),
                             d_shape[0], d_shape[1], d_shape[2],
                             d_strides[0], d_strides[1], d_strides[2],
                             total_elements);
                     } else if (order == IterOrder::ORDER_120) {
                         strided_upload_kernel_rank3_gather_order_120<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const float*>(host_input),
-                            static_cast<float*>(gpu_output),
+                            static_cast<const T*>(host_input),
+                            static_cast<T*>(gpu_output),
                             d_shape[0], d_shape[1], d_shape[2],
                             d_strides[0], d_strides[1], d_strides[2],
                             total_elements);
                     } else {
                         strided_upload_kernel_rank3_gather_order_012<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const float*>(host_input),
-                            static_cast<float*>(gpu_output),
+                            static_cast<const T*>(host_input),
+                            static_cast<T*>(gpu_output),
                             d_shape[0], d_shape[1], d_shape[2],
                             d_strides[0], d_strides[1], d_strides[2],
                             total_elements);
                     }
-                    break;
-                case DataType::Int32:
-                    if (order == IterOrder::ORDER_210) {
-                        strided_upload_kernel_rank3_gather<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const int32_t*>(host_input),
-                            static_cast<int32_t*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    } else if (order == IterOrder::ORDER_120) {
-                        strided_upload_kernel_rank3_gather_order_120<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const int32_t*>(host_input),
-                            static_cast<int32_t*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    } else {
-                        strided_upload_kernel_rank3_gather_order_012<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const int32_t*>(host_input),
-                            static_cast<int32_t*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    }
-                    break;
-                case DataType::Int64:
-                    if (order == IterOrder::ORDER_210) {
-                        strided_upload_kernel_rank3_gather<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const int64_t*>(host_input),
-                            static_cast<int64_t*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    } else if (order == IterOrder::ORDER_120) {
-                        strided_upload_kernel_rank3_gather_order_120<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const int64_t*>(host_input),
-                            static_cast<int64_t*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    } else {
-                        strided_upload_kernel_rank3_gather_order_012<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const int64_t*>(host_input),
-                            static_cast<int64_t*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    }
-                    break;
-                case DataType::UInt8:
-                    if (order == IterOrder::ORDER_210) {
-                        strided_upload_kernel_rank3_gather<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const uint8_t*>(host_input),
-                            static_cast<uint8_t*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    } else if (order == IterOrder::ORDER_120) {
-                        strided_upload_kernel_rank3_gather_order_120<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const uint8_t*>(host_input),
-                            static_cast<uint8_t*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    } else {
-                        strided_upload_kernel_rank3_gather_order_012<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const uint8_t*>(host_input),
-                            static_cast<uint8_t*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    }
-                    break;
-                case DataType::Bool:
-                    if (order == IterOrder::ORDER_210) {
-                        strided_upload_kernel_rank3_gather<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const bool*>(host_input),
-                            static_cast<bool*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    } else if (order == IterOrder::ORDER_120) {
-                        strided_upload_kernel_rank3_gather_order_120<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const bool*>(host_input),
-                            static_cast<bool*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    } else {
-                        strided_upload_kernel_rank3_gather_order_012<<<num_blocks, block_size, 0, stream>>>(
-                            static_cast<const bool*>(host_input),
-                            static_cast<bool*>(gpu_output),
-                            d_shape[0], d_shape[1], d_shape[2],
-                            d_strides[0], d_strides[1], d_strides[2],
-                            total_elements);
-                    }
-                    break;
-                default:
-                    // Unsupported dtype - do nothing
-                    break;
-                }
+                });
                 return;
             }
 
             // GENERIC PATH: Uses device memory for shape/strides (requires caller to allocate)
-            switch (dtype) {
-            case DataType::Float32:
+            detail::dispatch_dtype(dtype, [&]<typename T>() {
                 strided_upload_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    static_cast<const float*>(host_input),
-                    static_cast<float*>(gpu_output),
+                    static_cast<const T*>(host_input),
+                    static_cast<T*>(gpu_output),
                     d_shape, d_strides, rank, total_elements);
-                break;
-            case DataType::Int32:
-                strided_upload_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    static_cast<const int32_t*>(host_input),
-                    static_cast<int32_t*>(gpu_output),
-                    d_shape, d_strides, rank, total_elements);
-                break;
-            case DataType::Int64:
-                strided_upload_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    static_cast<const int64_t*>(host_input),
-                    static_cast<int64_t*>(gpu_output),
-                    d_shape, d_strides, rank, total_elements);
-                break;
-            case DataType::UInt8:
-                strided_upload_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    static_cast<const uint8_t*>(host_input),
-                    static_cast<uint8_t*>(gpu_output),
-                    d_shape, d_strides, rank, total_elements);
-                break;
-            case DataType::Bool:
-                strided_upload_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    static_cast<const bool*>(host_input),
-                    static_cast<bool*>(gpu_output),
-                    d_shape, d_strides, rank, total_elements);
-                break;
-            default:
-                // Unsupported dtype - do nothing
-                break;
-            }
+            });
         }
 
     } // namespace tensor_ops

--- a/src/core/tensor/tensor_unified_ops.cpp
+++ b/src/core/tensor/tensor_unified_ops.cpp
@@ -20,7 +20,6 @@
 #include <cmath>
 #include <cstring>
 #include <cuda_runtime.h>
-#include <curand.h>
 #include <format>
 #include <numeric>
 #include <optional>
@@ -29,24 +28,297 @@
 namespace lfs::core {
 
     namespace {
-
-        cudaStream_t resolve_cuda_execution_stream(const Tensor& tensor) {
-            cudaStream_t execution_stream = getCurrentCUDAStream();
-            if (execution_stream == nullptr && tensor.device() == Device::CUDA) {
-                execution_stream = tensor.stream();
-            }
-            return execution_stream;
-        }
-
         Tensor empty_on_tensor_stream(const TensorShape& shape, Device device, DataType dtype, const Tensor& tensor) {
             if (device != Device::CUDA) {
                 return Tensor::empty(shape, device, dtype);
             }
 
-            const cudaStream_t execution_stream = resolve_cuda_execution_stream(tensor);
-            tensor.sync_to_stream(execution_stream);
+            const cudaStream_t execution_stream = prepare_inputs_for_stream({&tensor});
             CUDAStreamGuard guard(execution_stream);
             return Tensor::empty(shape, device, dtype);
+        }
+
+        std::optional<std::vector<Tensor>> promote_tensor_list(
+            const std::vector<Tensor>& tensors) {
+            DataType result_dtype = tensors.front().dtype();
+            for (const Tensor& tensor : tensors) {
+                result_dtype = promote_dtypes(result_dtype, tensor.dtype());
+            }
+
+            const bool needs_promotion = std::any_of(
+                tensors.begin(), tensors.end(),
+                [result_dtype](const Tensor& tensor) {
+                    return tensor.dtype() != result_dtype;
+                });
+            if (!needs_promotion)
+                return std::nullopt;
+
+            std::vector<Tensor> promoted;
+            promoted.reserve(tensors.size());
+            for (const Tensor& tensor : tensors) {
+                promoted.push_back(tensor.dtype() == result_dtype
+                                       ? tensor
+                                       : tensor.to(result_dtype));
+            }
+            return promoted;
+        }
+
+        struct ReductionPlan {
+            std::vector<int> axes;
+            std::vector<size_t> output_shape;
+            DataType result_dtype = DataType::Float32;
+            size_t reduce_count = 1;
+        };
+
+        ReductionPlan make_reduction_plan(const TensorShape& shape,
+                                          const DataType input_dtype,
+                                          const ReduceOp op,
+                                          const ReduceArgs& args) {
+            const size_t rank = shape.rank();
+            LFS_ASSERT_MSG(rank <= static_cast<size_t>(std::numeric_limits<int>::max()),
+                           "reduction rank exceeds supported axis index range");
+
+            ReductionPlan plan;
+            std::vector<bool> reduced(rank, false);
+            if (args.axes.empty()) {
+                plan.axes.resize(rank);
+                std::iota(plan.axes.begin(), plan.axes.end(), 0);
+                std::fill(reduced.begin(), reduced.end(), true);
+            } else if (rank == 0) {
+                bool scalar_axis_seen = false;
+                for (const int axis : args.axes) {
+                    const int resolved = detail::resolve_tensor_dim(axis, rank);
+                    LFS_ASSERT_MSG(detail::tensor_dim_is_valid(resolved, rank),
+                                   std::format("reduce axis {} is out of range for rank {}",
+                                               axis, rank));
+                    LFS_ASSERT_MSG(!scalar_axis_seen,
+                                   "reduce axes must be unique");
+                    scalar_axis_seen = true;
+                }
+            } else {
+                plan.axes.reserve(args.axes.size());
+                for (const int axis : args.axes) {
+                    const int resolved = axis < 0 ? axis + static_cast<int>(rank) : axis;
+                    LFS_ASSERT_MSG(resolved >= 0 && resolved < static_cast<int>(rank),
+                                   std::format("reduce axis {} is out of range for rank {}",
+                                               axis, rank));
+                    LFS_ASSERT_MSG(!reduced[static_cast<size_t>(resolved)],
+                                   "reduce axes must be unique");
+                    reduced[static_cast<size_t>(resolved)] = true;
+                    plan.axes.push_back(resolved);
+                }
+                std::sort(plan.axes.begin(), plan.axes.end());
+            }
+
+            for (size_t dim = 0; dim < rank; ++dim) {
+                if (reduced[dim]) {
+                    plan.reduce_count *= shape[dim];
+                }
+                if (!reduced[dim] || args.keepdim) {
+                    plan.output_shape.push_back(reduced[dim] ? 1 : shape[dim]);
+                }
+            }
+
+            if (op == ReduceOp::Mean) {
+                LFS_ASSERT_MSG(input_dtype == DataType::Float32 ||
+                                   input_dtype == DataType::Float16,
+                               "mean requires a floating-point tensor");
+            }
+
+            if (op == ReduceOp::Any || op == ReduceOp::All ||
+                ((op == ReduceOp::Max || op == ReduceOp::Min) &&
+                 input_dtype == DataType::Bool)) {
+                plan.result_dtype = DataType::Bool;
+            } else if ((op == ReduceOp::Sum || op == ReduceOp::Prod) &&
+                       (input_dtype == DataType::Int32 || input_dtype == DataType::Bool ||
+                        input_dtype == DataType::UInt8)) {
+                plan.result_dtype = DataType::Int64;
+            } else if (input_dtype == DataType::Bool) {
+                plan.result_dtype = DataType::Int64;
+            } else {
+                plan.result_dtype = input_dtype;
+            }
+
+            return plan;
+        }
+
+        Tensor make_empty_reduction_result(const ReductionPlan& plan,
+                                           const Device device,
+                                           const ReduceOp op) {
+            const TensorShape output_shape(plan.output_shape);
+            if (output_shape.elements() == 0) {
+                return Tensor::empty(output_shape, device, plan.result_dtype);
+            }
+
+            float value = 0.0f;
+            switch (op) {
+            case ReduceOp::Sum:
+            case ReduceOp::Any:
+                value = 0.0f;
+                break;
+            case ReduceOp::Prod:
+            case ReduceOp::All:
+                value = 1.0f;
+                break;
+            case ReduceOp::Mean:
+            case ReduceOp::Std:
+            case ReduceOp::Var:
+                value = std::numeric_limits<float>::quiet_NaN();
+                break;
+            case ReduceOp::Max:
+            case ReduceOp::Min:
+                LFS_ASSERT_MSG(false,
+                               "max/min reduction has no identity for an empty reduction slice");
+                break;
+            default:
+                LFS_ASSERT_MSG(false,
+                               "empty reduction encountered an unsupported operation");
+            }
+            return Tensor::full(output_shape, value, device, plan.result_dtype);
+        }
+
+        void reduce_int32_cpu(const int32_t* input,
+                              void* output,
+                              const TensorShape& shape,
+                              const std::vector<size_t>& strides,
+                              const ReductionPlan& plan,
+                              const ReduceOp op,
+                              const size_t output_elements) {
+            const size_t rank = shape.rank();
+            LFS_ASSERT_MSG(input != nullptr && output != nullptr,
+                           "Int32 CPU reduction requires valid input and output pointers");
+            LFS_ASSERT_MSG(strides.size() == rank,
+                           "Int32 CPU reduction shape and stride ranks must match");
+
+            if (plan.axes.size() == rank) {
+                LFS_ASSERT_MSG(output_elements == 1,
+                               "full Int32 reduction must produce one output element");
+                switch (op) {
+                case ReduceOp::Sum: {
+                    LFS_ASSERT_MSG(plan.result_dtype == DataType::Int64,
+                                   "Int32 sum requires Int64 output");
+                    int64_t sum = 0;
+                    for (size_t i = 0; i < plan.reduce_count; ++i) {
+                        sum += static_cast<int64_t>(input[i]);
+                    }
+                    static_cast<int64_t*>(output)[0] = sum;
+                    return;
+                }
+                case ReduceOp::Prod: {
+                    LFS_ASSERT_MSG(plan.result_dtype == DataType::Int64,
+                                   "Int32 product requires Int64 output");
+                    int64_t product = 1;
+                    for (size_t i = 0; i < plan.reduce_count; ++i) {
+                        product *= static_cast<int64_t>(input[i]);
+                    }
+                    static_cast<int64_t*>(output)[0] = product;
+                    return;
+                }
+                case ReduceOp::Max:
+                    LFS_ASSERT_MSG(plan.result_dtype == DataType::Int32,
+                                   "Int32 max requires Int32 output");
+                    static_cast<int32_t*>(output)[0] =
+                        *std::max_element(input, input + plan.reduce_count);
+                    return;
+                case ReduceOp::Min:
+                    LFS_ASSERT_MSG(plan.result_dtype == DataType::Int32,
+                                   "Int32 min requires Int32 output");
+                    static_cast<int32_t*>(output)[0] =
+                        *std::min_element(input, input + plan.reduce_count);
+                    return;
+                default:
+                    LFS_ASSERT_MSG(false,
+                                   "full Int32 CPU reduction encountered an unsupported operation");
+                }
+            }
+
+            std::vector<bool> reduced(rank, false);
+            for (const int axis : plan.axes) {
+                reduced[static_cast<size_t>(axis)] = true;
+            }
+
+            std::vector<size_t> reduced_dims;
+            std::vector<size_t> retained_dims;
+            for (size_t dim = 0; dim < rank; ++dim) {
+                (reduced[dim] ? reduced_dims : retained_dims).push_back(dim);
+            }
+
+            const auto input_offset = [&](const size_t output_index,
+                                          const size_t reduction_index) {
+                size_t offset = 0;
+                size_t remainder = output_index;
+                for (auto it = retained_dims.rbegin(); it != retained_dims.rend(); ++it) {
+                    const size_t dim = *it;
+                    offset += (remainder % shape[dim]) * strides[dim];
+                    remainder /= shape[dim];
+                }
+
+                remainder = reduction_index;
+                for (auto it = reduced_dims.rbegin(); it != reduced_dims.rend(); ++it) {
+                    const size_t dim = *it;
+                    offset += (remainder % shape[dim]) * strides[dim];
+                    remainder /= shape[dim];
+                }
+                return offset;
+            };
+
+            switch (op) {
+            case ReduceOp::Sum: {
+                LFS_ASSERT_MSG(plan.result_dtype == DataType::Int64,
+                               "Int32 sum requires Int64 output");
+                auto* result = static_cast<int64_t*>(output);
+                for (size_t out_idx = 0; out_idx < output_elements; ++out_idx) {
+                    int64_t sum = 0;
+                    for (size_t r = 0; r < plan.reduce_count; ++r) {
+                        sum += static_cast<int64_t>(input[input_offset(out_idx, r)]);
+                    }
+                    result[out_idx] = sum;
+                }
+                break;
+            }
+            case ReduceOp::Prod: {
+                LFS_ASSERT_MSG(plan.result_dtype == DataType::Int64,
+                               "Int32 product requires Int64 output");
+                auto* result = static_cast<int64_t*>(output);
+                for (size_t out_idx = 0; out_idx < output_elements; ++out_idx) {
+                    int64_t product = 1;
+                    for (size_t r = 0; r < plan.reduce_count; ++r) {
+                        product *= static_cast<int64_t>(input[input_offset(out_idx, r)]);
+                    }
+                    result[out_idx] = product;
+                }
+                break;
+            }
+            case ReduceOp::Max: {
+                LFS_ASSERT_MSG(plan.result_dtype == DataType::Int32,
+                               "Int32 max requires Int32 output");
+                auto* result = static_cast<int32_t*>(output);
+                for (size_t out_idx = 0; out_idx < output_elements; ++out_idx) {
+                    int32_t value = std::numeric_limits<int32_t>::lowest();
+                    for (size_t r = 0; r < plan.reduce_count; ++r) {
+                        value = std::max(value, input[input_offset(out_idx, r)]);
+                    }
+                    result[out_idx] = value;
+                }
+                break;
+            }
+            case ReduceOp::Min: {
+                LFS_ASSERT_MSG(plan.result_dtype == DataType::Int32,
+                               "Int32 min requires Int32 output");
+                auto* result = static_cast<int32_t*>(output);
+                for (size_t out_idx = 0; out_idx < output_elements; ++out_idx) {
+                    int32_t value = std::numeric_limits<int32_t>::max();
+                    for (size_t r = 0; r < plan.reduce_count; ++r) {
+                        value = std::min(value, input[input_offset(out_idx, r)]);
+                    }
+                    result[out_idx] = value;
+                }
+                break;
+            }
+            default:
+                LFS_ASSERT_MSG(false,
+                               "Int32 CPU reduction encountered an unsupported operation");
+            }
         }
 
     } // namespace
@@ -102,7 +374,7 @@ namespace lfs::core {
                     void* dummy = allocate_cuda_storage(1, s);
                     LFS_ASSERT_MSG(dummy != nullptr,
                                    "failed to allocate CUDA sentinel storage for an empty tensor");
-                    result.data_owner_ = std::shared_ptr<void>(dummy, [s](void* p) {
+                    result.adopt_storage(dummy, [s](void* p) {
                         CudaMemoryPool::instance().deallocate(p, s);
                     });
                 } else {
@@ -112,7 +384,7 @@ namespace lfs::core {
                         LFS_ASSERT_MSG(dummy != nullptr,
                                        "failed to allocate pinned sentinel storage for an empty tensor");
                         cudaStream_t s = result.stream();
-                        result.data_owner_ = std::shared_ptr<void>(dummy, [s](void* p) {
+                        result.adopt_storage(dummy, [s](void* p) {
                             if (p)
                                 PinnedMemoryAllocator::instance().deallocate(p, s);
                         });
@@ -120,7 +392,7 @@ namespace lfs::core {
                         dummy = std::malloc(1);
                         LFS_ASSERT_MSG(dummy != nullptr,
                                        "failed to allocate sentinel storage for an empty tensor");
-                        result.data_owner_ = std::shared_ptr<void>(dummy, [](void* p) {
+                        result.adopt_storage(dummy, [](void* p) {
                             std::free(p);
                         });
                     }
@@ -132,7 +404,7 @@ namespace lfs::core {
             if (result.device_ == Device::CUDA) {
                 cudaStream_t s = result.stream();
                 void* ptr = allocate_cuda_storage(bytes, s);
-                result.data_owner_ = std::shared_ptr<void>(ptr, [s](void* p) {
+                result.adopt_storage(ptr, [s](void* p) {
                     CudaMemoryPool::instance().deallocate(p, s);
                 });
                 result.data_ = result.data_owner_.get();
@@ -156,7 +428,7 @@ namespace lfs::core {
                             bytes, bytes / (1024.0 * 1024.0 * 1024.0)));
                     }
                     cudaStream_t s = result.stream();
-                    result.data_owner_ = std::shared_ptr<void>(ptr, [s](void* p) {
+                    result.adopt_storage(ptr, [s](void* p) {
                         if (p)
                             PinnedMemoryAllocator::instance().deallocate(p, s);
                     });
@@ -168,7 +440,7 @@ namespace lfs::core {
                             "Out of memory: failed to allocate {} bytes ({:.2f} GB) of CPU memory.",
                             bytes, bytes / (1024.0 * 1024.0 * 1024.0)));
                     }
-                    result.data_owner_ = std::shared_ptr<void>(ptr, [](void* p) {
+                    result.adopt_storage(ptr, [](void* p) {
                         std::free(p);
                     });
                 }
@@ -411,8 +683,10 @@ namespace lfs::core {
             auto [low, high] = std::get<std::pair<float, float>>(args.args);
             LFS_ASSERT_MSG(args.dtype == DataType::Float32 || args.dtype == DataType::Int32,
                            "uniform/rand supports only Float32 and Int32");
-            LFS_ASSERT_MSG(std::isfinite(low) && std::isfinite(high) && low < high,
-                           "uniform/rand bounds must be finite and low < high");
+            LFS_ASSERT_MSG(std::isfinite(low) && std::isfinite(high) &&
+                               ((args.dtype == DataType::Float32 && low <= high) ||
+                                (args.dtype == DataType::Int32 && low < high)),
+                           "uniform/rand bounds must be finite and ordered");
             LFS_ASSERT_MSG(args.dtype != DataType::Int32 ||
                                (low >= static_cast<float>(std::numeric_limits<int32_t>::lowest()) &&
                                 high <= std::nextafter(
@@ -463,34 +737,34 @@ namespace lfs::core {
             auto [mean, std] = std::get<std::pair<float, float>>(args.args);
             LFS_ASSERT_MSG(args.dtype == DataType::Float32,
                            "normal/randn supports only Float32");
-            LFS_ASSERT_MSG(std::isfinite(mean) && std::isfinite(std) && std > 0.0f,
-                           "normal/randn requires finite mean and std > 0");
+            LFS_ASSERT_MSG(std::isfinite(mean) && std::isfinite(std) && std >= 0.0f,
+                           "normal/randn requires finite mean and std >= 0");
             result = load(LoadOp::Empty, args);
             if (!result.is_valid() || result.numel() == 0)
                 return result;
 
-            if (result.device_ == Device::CUDA) {
-                // Use Philox RNG without resetting offset (stateful like PyTorch - much faster!)
-                curandGenerator_t* gen = static_cast<curandGenerator_t*>(
-                    RandomGenerator::instance().get_generator(Device::CUDA));
+            if (std == 0.0f) {
+                result.fill_(mean);
+                break;
+            }
 
+            if (result.device_ == Device::CUDA) {
                 size_t n = result.numel();
                 if (n % 2 == 1) {
                     auto scratch = Tensor::empty({n + 1}, Device::CUDA, DataType::Float32);
-                    const auto status = curandGenerateNormal(*gen, scratch.ptr<float>(), n + 1, mean, std);
-                    LFS_ASSERT_MSG(status == CURAND_STATUS_SUCCESS,
-                                   "normal/randn cuRAND generation failed");
+                    RandomGenerator::instance().generate_cuda_normal(
+                        scratch.ptr<float>(), n + 1, mean, std, result.stream());
                     LFS_CUDA_CHECK_MSG(
-                        cudaMemcpy(result.ptr<float>(), scratch.ptr<float>(), n * sizeof(float),
-                                   cudaMemcpyDeviceToDevice),
+                        cudaMemcpyAsync(result.ptr<float>(), scratch.ptr<float>(),
+                                        n * sizeof(float), cudaMemcpyDeviceToDevice,
+                                        result.stream()),
                         "normal/randn scratch copy (bytes={}, requested_count={})",
                         n * sizeof(float), n);
+                    LFS_CUDA_CHECK(cudaStreamSynchronize(result.stream()));
                 } else {
-                    const auto status = curandGenerateNormal(*gen, result.ptr<float>(), n, mean, std);
-                    LFS_ASSERT_MSG(status == CURAND_STATUS_SUCCESS,
-                                   "normal/randn cuRAND generation failed");
+                    RandomGenerator::instance().generate_cuda_normal(
+                        result.ptr<float>(), n, mean, std, result.stream());
                 }
-                // curandGenerateNormal is blocking, no need for explicit sync
             } else {
                 auto& gen = *static_cast<std::mt19937_64*>(
                     RandomGenerator::instance().get_generator(Device::CPU));
@@ -619,6 +893,9 @@ namespace lfs::core {
             LFS_ASSERT_MSG(args.dtype == DataType::Int64,
                            "multinomial output must use Int64 dtype");
 
+            Tensor weights_materialized;
+            weights = &weights->contiguous_read(weights_materialized);
+
             size_t n = weights->numel();
             size_t num_samples = args.shape.elements();
             LFS_ASSERT_MSG(n > 0 && num_samples > 0,
@@ -631,6 +908,7 @@ namespace lfs::core {
                 return result;
 
             if (weights->device() == Device::CUDA) {
+                prepare_inputs_for_stream({weights}, result.stream());
                 tensor_ops::launch_multinomial(weights->ptr<float>(), result.ptr<int64_t>(),
                                                n, num_samples, replacement,
                                                RandomGenerator::instance().get_next_cuda_seed(), result.stream());
@@ -638,11 +916,16 @@ namespace lfs::core {
             } else {
                 auto weights_data = weights->to_vector();
 
-                float sum = std::accumulate(weights_data.begin(), weights_data.end(), 0.0f);
+                LFS_ASSERT_MSG(
+                    std::all_of(weights_data.begin(), weights_data.end(), [](float weight) {
+                        return std::isfinite(weight) && weight >= 0.0f;
+                    }),
+                    "multinomial weights must be finite and non-negative");
+                double sum = std::accumulate(weights_data.begin(), weights_data.end(), 0.0);
                 LFS_ASSERT_MSG(std::isfinite(sum) && sum > 0.0f,
                                "multinomial weights must have a positive finite sum");
 
-                std::vector<float> cdf(n);
+                std::vector<double> cdf(n);
                 cdf[0] = weights_data[0] / sum;
                 for (size_t i = 1; i < n; ++i) {
                     cdf[i] = cdf[i - 1] + weights_data[i] / sum;
@@ -650,13 +933,13 @@ namespace lfs::core {
 
                 auto& gen = *static_cast<std::mt19937_64*>(
                     RandomGenerator::instance().get_generator(Device::CPU));
-                std::uniform_real_distribution<float> dis(0.0f, 1.0f);
+                std::uniform_real_distribution<double> dis(0.0, 1.0);
 
                 int64_t* samples = result.ptr<int64_t>();
 
                 if (replacement) {
                     for (size_t i = 0; i < num_samples; ++i) {
-                        float u = dis(gen);
+                        double u = dis(gen);
                         auto it = std::lower_bound(cdf.begin(), cdf.end(), u);
                         samples[i] = static_cast<int64_t>(std::distance(cdf.begin(), it));
                     }
@@ -796,32 +1079,45 @@ namespace lfs::core {
         debug::OpTraceGuard trace(op_name, *this, LFS_SOURCE_SITE_CURRENT());
 
         validate_unary_op();
-        LFS_ASSERT_MSG(op != ReduceOp::Argmax && op != ReduceOp::Argmin,
-                       "argmax and argmin are not implemented by the reduction backend");
+        if (op == ReduceOp::Argmax || op == ReduceOp::Argmin) {
+            LFS_ASSERT_MSG(dtype_ == DataType::Float32,
+                           "argmax and argmin currently require Float32 input");
+            LFS_ASSERT_MSG(args.axes.size() <= 1,
+                           "argmax and argmin accept at most one dimension");
+            if (!args.axes.empty()) {
+                return op == ReduceOp::Argmax
+                           ? max_with_indices(args.axes.front(), args.keepdim).second
+                           : min_with_indices(args.axes.front(), args.keepdim).second;
+            }
+
+            auto flattened = reshape(TensorShape({numel()}));
+            Tensor indices = op == ReduceOp::Argmax
+                                 ? flattened.max_with_indices(0, false).second
+                                 : flattened.min_with_indices(0, false).second;
+            if (args.keepdim && ndim() > 0) {
+                indices = indices.reshape(
+                    TensorShape(std::vector<size_t>(ndim(), 1)));
+            }
+            return indices;
+        }
         LFS_ASSERT_MSG(op != ReduceOp::CountNonzero && op != ReduceOp::Norm,
                        "count_nonzero and norm must use their dedicated tensor operations");
         LFS_ASSERT_MSG(dtype_ == DataType::Float32 || dtype_ == DataType::Int32 ||
                            dtype_ == DataType::Bool,
                        "reduce currently supports only Float32, Int32, and Bool");
-        std::vector<bool> seen_axes(shape_.rank(), false);
-        for (const int axis : args.axes) {
-            const int resolved = resolve_dim(axis);
-            LFS_ASSERT_MSG(resolved >= 0 && resolved < static_cast<int>(shape_.rank()),
-                           std::format("reduce axis {} is out of range for rank {}", axis, shape_.rank()));
-            LFS_ASSERT_MSG(!seen_axes[resolved],
-                           "reduce axes must be unique");
-            seen_axes[resolved] = true;
+        if (dtype_ == DataType::Bool && op == ReduceOp::Max) {
+            return reduce(ReduceOp::Any, args);
         }
+        if (dtype_ == DataType::Bool && op == ReduceOp::Min) {
+            return reduce(ReduceOp::All, args);
+        }
+        const ReductionPlan reduction = make_reduction_plan(shape_, dtype_, op, args);
         if ((op == ReduceOp::Std || op == ReduceOp::Var || op == ReduceOp::Norm)) {
             LFS_ASSERT_MSG(dtype_ == DataType::Float32,
                            "std, var, and norm reductions currently require Float32");
         }
-        if (dtype_ == DataType::Int32 && !args.axes.empty()) {
-            LFS_ASSERT_MSG(args.axes.size() == shape_.rank(),
-                           "Int32 partial reductions are unsupported");
-        }
         if (dtype_ == DataType::Int32) {
-            LFS_ASSERT_MSG(op == ReduceOp::Sum || op == ReduceOp::Mean ||
+            LFS_ASSERT_MSG(op == ReduceOp::Sum ||
                                op == ReduceOp::Max || op == ReduceOp::Min ||
                                op == ReduceOp::Prod,
                            "Int32 reduction encountered an unsupported operation");
@@ -829,6 +1125,9 @@ namespace lfs::core {
         if (dtype_ == DataType::Float32) {
             LFS_ASSERT_MSG(op != ReduceOp::Any && op != ReduceOp::All,
                            "Float32 any/all reductions are unsupported");
+        }
+        if (numel() == 0) {
+            return make_empty_reduction_result(reduction, device_, op);
         }
         if (dtype_ == DataType::Bool && device_ == Device::CPU &&
             !args.axes.empty() && args.axes.size() != shape_.rank()) {
@@ -887,8 +1186,7 @@ namespace lfs::core {
                     const size_t n = fused_source.numel();
                     Tensor result;
                     {
-                        const cudaStream_t execution_stream = resolve_cuda_execution_stream(fused_source);
-                        fused_source.sync_to_stream(execution_stream);
+                        const cudaStream_t execution_stream = prepare_inputs_for_stream({&fused_source});
                         CUDAStreamGuard guard(execution_stream);
                         result = Tensor::empty(
                             TensorShape(args.keepdim
@@ -975,8 +1273,7 @@ namespace lfs::core {
 
                     Tensor result;
                     {
-                        const cudaStream_t execution_stream = resolve_cuda_execution_stream(fused_source);
-                        fused_source.sync_to_stream(execution_stream);
+                        const cudaStream_t execution_stream = prepare_inputs_for_stream({&fused_source});
                         CUDAStreamGuard guard(execution_stream);
                         result = Tensor::empty(TensorShape(out_shape), Device::CUDA, DataType::Float32);
                         tensor_ops::launch_fused_segmented_transform_reduce(
@@ -1074,7 +1371,16 @@ namespace lfs::core {
                     ReduceArgs new_args = args;
                     new_args.axes = {static_cast<int>(transposed.shape().rank()) - 1}; // Use transposed.shape()!
 
-                    return transposed.reduce(op, new_args);
+                    Tensor reduced = transposed.reduce(op, new_args);
+                    if (!args.keepdim) {
+                        return reduced;
+                    }
+
+                    std::vector<int> inverse_perm(perm.size());
+                    for (size_t i = 0; i < perm.size(); ++i) {
+                        inverse_perm[static_cast<size_t>(perm[i])] = static_cast<int>(i);
+                    }
+                    return reduced.permute(inverse_perm);
                 }
             }
         }
@@ -1093,7 +1399,8 @@ namespace lfs::core {
             bool unbiased = args.unbiased;
 
             ReduceArgs mean_args = args;
-            mean_args.args = std::monostate{}; // Clear variant args for mean calculation
+            mean_args.args = std::monostate{};
+            mean_args.keepdim = true;
             auto mean_tensor = reduce(ReduceOp::Mean, mean_args);
 
             Tensor mean_broadcast = (mean_tensor.shape() == shape_)
@@ -1104,7 +1411,9 @@ namespace lfs::core {
             auto squared = diff.mul(diff);
 
             // Compute sum of squared differences
-            auto sum_sq = squared.reduce(ReduceOp::Sum, mean_args);
+            ReduceArgs sum_args = args;
+            sum_args.args = std::monostate{};
+            auto sum_sq = squared.reduce(ReduceOp::Sum, sum_args);
 
             // Calculate N (number of elements being reduced)
             std::vector<int> axes = args.axes;
@@ -1121,11 +1430,8 @@ namespace lfs::core {
                 }
             }
 
-            // Apply Bessel's correction if unbiased and N > 1
-            float correction = static_cast<float>(reduce_count);
-            if (unbiased && reduce_count > 1) {
-                correction = static_cast<float>(reduce_count - 1);
-            }
+            const float correction = static_cast<float>(reduce_count) -
+                                     (unbiased ? 1.0f : 0.0f);
 
             auto variance = sum_sq.div(correction);
 
@@ -1136,145 +1442,17 @@ namespace lfs::core {
             }
         }
 
-        std::vector<int> axes = args.axes;
-        if (axes.empty()) {
-            axes.resize(input->shape_.rank());
-            std::iota(axes.begin(), axes.end(), 0);
-        }
-
-        // Resolve negative indices to positive indices
-        for (auto& ax : axes) {
-            ax = input->resolve_dim(ax);
-        }
-
-        std::vector<size_t> out_shape;
-        for (size_t i = 0; i < input->shape_.rank(); ++i) {
-            bool is_reduced = std::find(axes.begin(), axes.end(), static_cast<int>(i)) != axes.end();
-            if (!is_reduced || args.keepdim) {
-                out_shape.push_back(is_reduced ? 1 : input->shape_[i]);
-            }
-        }
-
-        DataType out_dtype = input->dtype_;
-        if (op == ReduceOp::Any || op == ReduceOp::All) {
-            out_dtype = DataType::Bool;
-        } else if (op == ReduceOp::Argmax || op == ReduceOp::Argmin) {
-            out_dtype = DataType::Int64;
-        } else if (input->dtype_ == DataType::Bool) {
-            // Bool reductions return Int64 (PyTorch behavior)
-            out_dtype = DataType::Int64;
-        }
+        const std::vector<int>& axes = reduction.axes;
+        const std::vector<size_t>& out_shape = reduction.output_shape;
+        const DataType out_dtype = reduction.result_dtype;
 
         std::optional<CUDAStreamGuard> execution_guard;
         if (input->device_ == Device::CUDA) {
-            const cudaStream_t execution_stream = resolve_cuda_execution_stream(*input);
-            input->sync_to_stream(execution_stream);
+            const cudaStream_t execution_stream = prepare_inputs_for_stream({input});
             execution_guard.emplace(execution_stream);
         }
 
         auto result = Tensor::empty(TensorShape(out_shape), input->device_, out_dtype);
-
-        if (input->numel() == 0) {
-            float identity_value = 0.0f;
-            switch (op) {
-            case ReduceOp::Sum:
-            case ReduceOp::Mean:
-                identity_value = 0.0f;
-                break;
-            case ReduceOp::Prod:
-                identity_value = 1.0f;
-                break;
-            case ReduceOp::Max:
-                identity_value = input->dtype_ == DataType::Bool
-                                     ? 0.0f
-                                     : -std::numeric_limits<float>::infinity();
-                break;
-            case ReduceOp::Min:
-                identity_value = input->dtype_ == DataType::Bool
-                                     ? 1.0f
-                                     : std::numeric_limits<float>::infinity();
-                break;
-            case ReduceOp::Any:
-                identity_value = 0.0f;
-                break;
-            case ReduceOp::All:
-                identity_value = 1.0f;
-                break;
-            default:
-                LFS_ASSERT_MSG(false,
-                               "empty reduction encountered an unsupported operation");
-            }
-
-            if (input->dtype_ == DataType::Int32 &&
-                (op == ReduceOp::Max || op == ReduceOp::Min)) {
-                LFS_ASSERT_MSG(false,
-                               "empty Int32 max/min reductions have no identity value");
-            }
-
-            if (result.numel() == 0) {
-                return result;
-            }
-
-            if (input->device_ == Device::CUDA) {
-                if (out_dtype == DataType::Float32) {
-                    std::vector<float> temp(result.numel(), identity_value);
-                    LFS_CUDA_CHECK_MSG(
-                        cudaMemcpy(result.data_ptr(), temp.data(), result.bytes(),
-                                   cudaMemcpyHostToDevice),
-                        "empty reduction CUDA copy");
-                } else if (out_dtype == DataType::Bool) {
-                    unsigned char bool_val = (identity_value != 0.0f) ? 1 : 0;
-                    LFS_CUDA_CHECK_MSG(
-                        cudaMemset(result.data_ptr(), bool_val, result.bytes()),
-                        "empty reduction CUDA memset");
-                } else if (out_dtype == DataType::Int32) {
-                    if (identity_value == 0.0f) {
-                        LFS_CUDA_CHECK_MSG(cudaMemset(result.data_ptr(), 0, result.bytes()),
-                                           "empty Int32 reduction CUDA memset");
-                    } else {
-                        std::vector<int32_t> temp(
-                            result.numel(), static_cast<int32_t>(identity_value));
-                        LFS_CUDA_CHECK_MSG(
-                            cudaMemcpy(result.data_ptr(), temp.data(), result.bytes(),
-                                       cudaMemcpyHostToDevice),
-                            "empty Int32 reduction CUDA copy");
-                    }
-                } else if (out_dtype == DataType::Int64) {
-                    if (identity_value == 0.0f) {
-                        LFS_CUDA_CHECK_MSG(cudaMemset(result.data_ptr(), 0, result.bytes()),
-                                           "empty Int64 reduction CUDA memset");
-                    } else {
-                        std::vector<int64_t> temp(
-                            result.numel(), static_cast<int64_t>(identity_value));
-                        LFS_CUDA_CHECK_MSG(
-                            cudaMemcpy(result.data_ptr(), temp.data(), result.bytes(),
-                                       cudaMemcpyHostToDevice),
-                            "empty Int64 reduction CUDA copy");
-                    }
-                } else {
-                    LFS_ASSERT_MSG(false,
-                                   "empty CUDA reduction encountered an unsupported output dtype");
-                }
-            } else {
-                if (out_dtype == DataType::Float32) {
-                    float* ptr = static_cast<float*>(result.data_ptr());
-                    std::fill_n(ptr, result.numel(), identity_value);
-                } else if (out_dtype == DataType::Bool) {
-                    unsigned char* ptr = static_cast<unsigned char*>(result.data_ptr());
-                    std::fill_n(ptr, result.numel(), identity_value != 0.0f ? 1 : 0);
-                } else if (out_dtype == DataType::Int32) {
-                    int32_t* ptr = static_cast<int32_t*>(result.data_ptr());
-                    std::fill_n(ptr, result.numel(), static_cast<int32_t>(identity_value));
-                } else if (out_dtype == DataType::Int64) {
-                    int64_t* ptr = static_cast<int64_t*>(result.data_ptr());
-                    std::fill_n(ptr, result.numel(), static_cast<int64_t>(identity_value));
-                } else {
-                    LFS_ASSERT_MSG(false,
-                                   "empty CPU reduction encountered an unsupported output dtype");
-                }
-            }
-            return result;
-        }
 
         if (input->device_ == Device::CUDA) {
             tensor_ops::launch_reduce_op(
@@ -1282,52 +1460,16 @@ namespace lfs::core {
                 input->shape_.dims().data(), input->shape_.rank(),
                 axes.data(), axes.size(),
                 args.keepdim, op,
-                input->dtype_, result.stream());
+                input->dtype_, out_dtype, result.stream());
             // No sync - tensor operation
         } else {
             // CPU implementation
 
             // Handle Int32 dtype
             if (input->dtype_ == DataType::Int32) {
-                const int* src = static_cast<const int*>(input->data_ptr());
-                int* dst = static_cast<int*>(result.data_ptr());
-
-                // Full reduction to scalar (only mode supported for Int32)
-                if (axes.size() == input->shape_.rank()) {
-                    if (op == ReduceOp::Sum) {
-                        int sum = 0;
-                        for (size_t i = 0; i < input->numel(); ++i) {
-                            sum += src[i];
-                        }
-                        dst[0] = sum;
-                    } else if (op == ReduceOp::Mean) {
-                        int sum = 0;
-                        for (size_t i = 0; i < input->numel(); ++i) {
-                            sum += src[i];
-                        }
-                        dst[0] = sum / static_cast<int>(input->numel());
-                    } else if (op == ReduceOp::Max) {
-                        int max_val = src[0];
-                        for (size_t i = 1; i < input->numel(); ++i) {
-                            max_val = std::max(max_val, src[i]);
-                        }
-                        dst[0] = max_val;
-                    } else if (op == ReduceOp::Min) {
-                        int min_val = src[0];
-                        for (size_t i = 1; i < input->numel(); ++i) {
-                            min_val = std::min(min_val, src[i]);
-                        }
-                        dst[0] = min_val;
-                    } else if (op == ReduceOp::Prod) {
-                        int prod = 1;
-                        for (size_t i = 0; i < input->numel(); ++i) {
-                            prod *= src[i];
-                        }
-                        dst[0] = prod;
-                    }
-                    return result;
-                }
-                // Partial reductions not supported for Int32
+                reduce_int32_cpu(
+                    static_cast<const int32_t*>(input->data_ptr()), result.data_ptr(),
+                    input->shape_, input->strides_, reduction, op, result.numel());
                 return result;
             }
 
@@ -1530,13 +1672,13 @@ namespace lfs::core {
                 } else if (op == ReduceOp::Max) {
                     float max_val = src[0];
                     for (size_t i = 1; i < input->numel(); ++i) {
-                        max_val = std::max(max_val, src[i]);
+                        max_val = ops::max_reduce_op{}(max_val, src[i]);
                     }
                     dst[0] = max_val;
                 } else if (op == ReduceOp::Min) {
                     float min_val = src[0];
                     for (size_t i = 1; i < input->numel(); ++i) {
-                        min_val = std::min(min_val, src[i]);
+                        min_val = ops::min_reduce_op{}(min_val, src[i]);
                     }
                     dst[0] = min_val;
                 } else if (op == ReduceOp::Prod) {
@@ -1545,6 +1687,9 @@ namespace lfs::core {
                         prod *= src[i];
                     }
                     dst[0] = prod;
+                } else {
+                    LFS_ASSERT_MSG(false,
+                                   "full CPU Float32 reduction encountered an unsupported operation");
                 }
                 return result;
             }
@@ -1653,16 +1798,17 @@ namespace lfs::core {
                         result_val_double += val; // Use double accumulation
                         break;
                     case ReduceOp::Max:
-                        result_val_float = std::max(result_val_float, val);
+                        result_val_float = ops::max_reduce_op{}(result_val_float, val);
                         break;
                     case ReduceOp::Min:
-                        result_val_float = std::min(result_val_float, val);
+                        result_val_float = ops::min_reduce_op{}(result_val_float, val);
                         break;
                     case ReduceOp::Prod:
                         result_val_float *= val;
                         break;
                     default:
-                        break;
+                        LFS_ASSERT_MSG(false,
+                                       "CPU Float32 reduction encountered an unsupported operation");
                     }
                 }
 
@@ -1689,24 +1835,24 @@ namespace lfs::core {
                        "where condition must have Bool dtype");
 
         if (numel() == 0 || b.numel() == 0 || c.numel() == 0) {
-            auto shape_ab = this->broadcast_shape(b.shape());
-            LFS_ASSERT_MSG(shape_ab.rank() != 0,
+            LFS_ASSERT_MSG(broadcast::can_broadcast(shape_.dims(), b.shape().dims()),
                            "where inputs have incompatible broadcast shapes");
+            auto shape_ab = this->broadcast_shape(b.shape());
 
             auto shape_abc_vec = broadcast::shape(shape_ab.dims(), c.shape().dims());
-            LFS_ASSERT_MSG(!shape_abc_vec.empty(),
+            LFS_ASSERT_MSG(broadcast::can_broadcast(shape_ab.dims(), c.shape().dims()),
                            "where inputs have incompatible broadcast shapes");
 
             DataType out_dtype = promote_types(b.dtype(), c.dtype());
             return empty(TensorShape(shape_abc_vec), device_, out_dtype);
         }
 
-        auto shape_ab = this->broadcast_shape(b.shape());
-        LFS_ASSERT_MSG(shape_ab.rank() != 0,
+        LFS_ASSERT_MSG(broadcast::can_broadcast(shape_.dims(), b.shape().dims()),
                        "where condition and x shapes are incompatible");
+        auto shape_ab = this->broadcast_shape(b.shape());
 
         auto shape_abc_vec = broadcast::shape(shape_ab.dims(), c.shape().dims());
-        LFS_ASSERT_MSG(!shape_abc_vec.empty(),
+        LFS_ASSERT_MSG(broadcast::can_broadcast(shape_ab.dims(), c.shape().dims()),
                        "where input shapes are incompatible");
 
         TensorShape shape_abc(shape_abc_vec);
@@ -1741,6 +1887,8 @@ namespace lfs::core {
 
         if (device_ == Device::CUDA && out_dtype == DataType::Float32) {
             auto result = Tensor::empty(shape_abc, device_, out_dtype);
+            prepare_inputs_for_stream(
+                {&a_broadcast, &b_cast, &c_cast}, result.stream());
             tensor_ops::launch_where(
                 a_broadcast.ptr<unsigned char>(),
                 b_cast.ptr<float>(),
@@ -1814,8 +1962,11 @@ namespace lfs::core {
             return std::sqrt(squared.sum_scalar());
         } else if (p == 1.0f) {
             return this->abs().sum_scalar();
+        } else if (p == 0.0f) {
+            return this->ne(0.0f).sum_scalar();
         } else if (std::isinf(p)) {
-            return this->abs().max_scalar();
+            return p > 0.0f ? this->abs().max_scalar()
+                            : this->abs().min_scalar();
         } else {
             auto abs_vals = this->abs();
             auto powered = abs_vals.pow(p);
@@ -1832,24 +1983,6 @@ namespace lfs::core {
         LFS_ASSERT_MSG(!std::isnan(p),
                        "norm order cannot be NaN");
         (void)resolve_dims(dims);
-
-        if (numel() == 0) {
-            // Return appropriate empty tensor
-            std::vector<size_t> out_shape;
-            for (size_t i = 0; i < shape_.rank(); ++i) {
-                bool is_reduced = false;
-                for (int d : dims) {
-                    if (resolve_dim(d) == static_cast<int>(i)) {
-                        is_reduced = true;
-                        break;
-                    }
-                }
-                if (!is_reduced || keepdim) {
-                    out_shape.push_back(is_reduced ? 1 : shape_[i]);
-                }
-            }
-            return empty(TensorShape(out_shape), device_, dtype_);
-        }
 
         // Special cases for common norms
         if (p == 2.0f) {
@@ -1889,7 +2022,7 @@ namespace lfs::core {
                        "broadcast operands must be on the same device");
 
         auto bcast_shape = this->broadcast_shape(other.shape());
-        LFS_ASSERT_MSG(bcast_shape.rank() != 0,
+        LFS_ASSERT_MSG(broadcast::can_broadcast(shape_.dims(), other.shape().dims()),
                        "broadcast shapes are incompatible");
 
         Tensor a_broadcast = (shape_ == bcast_shape) ? this->clone() : broadcast_to(bcast_shape);
@@ -1915,9 +2048,25 @@ namespace lfs::core {
         if (tensors.empty()) {
             throw std::invalid_argument("Cannot concatenate empty vector of tensors");
         }
+        bool has_non_contiguous_input = false;
         for (const auto& tensor : tensors) {
             tensor_contract::require_valid(
                 tensor, "cat", "input", LFS_SOURCE_SITE_CURRENT());
+            has_non_contiguous_input |= !tensor.is_contiguous();
+        }
+
+        if (auto promoted = promote_tensor_list(tensors)) {
+            return cat(*promoted, dim);
+        }
+
+        if (has_non_contiguous_input) {
+            std::vector<Tensor> materialized;
+            materialized.reserve(tensors.size());
+            for (const Tensor& tensor : tensors) {
+                Tensor storage;
+                materialized.push_back(tensor.contiguous_read(storage));
+            }
+            return cat(materialized, dim);
         }
 
         if (tensors.size() == 1) {
@@ -2050,6 +2199,7 @@ namespace lfs::core {
             result.dtype_ = first_dtype;
             result.data_ = tensors[0].data_;
             result.data_owner_ = tensors[0].data_owner_; // Share ownership
+            result.storage_meta_ = tensors[0].storage_meta_;
             result.state_ = std::make_shared<Tensor::TensorState>(*tensors[0].state_);
             result.state_->capacity = tensors[0].capacity();
             result.state_->logical_size = total_size_along_dim;
@@ -2113,6 +2263,9 @@ namespace lfs::core {
         auto result = Tensor::empty(TensorShape(result_dims), first_device, first_dtype);
         LOG_DEBUG("  Created new tensor: id={}, data_ptr={}, capacity={}",
                   result.id_, result.data_ptr(), result.capacity());
+
+        if (result.numel() == 0)
+            return result;
 
         size_t element_size = dtype_size(first_dtype);
 
@@ -2243,6 +2396,7 @@ namespace lfs::core {
         const auto first_dtype = tensors[0].dtype();
 
         // Validate all tensors have same shape, device, and dtype
+        bool has_non_contiguous_input = !tensors[0].is_contiguous();
         for (size_t i = 1; i < tensors.size(); ++i) {
             tensor_contract::require_valid(
                 tensors[i], "stack", "input", LFS_SOURCE_SITE_CURRENT());
@@ -2252,8 +2406,21 @@ namespace lfs::core {
             tensor_contract::require_same_device(
                 tensors[0], tensors[i], "stack", "reference", "input",
                 LFS_SOURCE_SITE_CURRENT());
-            tensor_contract::require_dtype(
-                tensors[i], first_dtype, "stack", "input", LFS_SOURCE_SITE_CURRENT());
+            has_non_contiguous_input |= !tensors[i].is_contiguous();
+        }
+
+        if (auto promoted = promote_tensor_list(tensors)) {
+            return stack(*promoted, dim);
+        }
+
+        if (has_non_contiguous_input) {
+            std::vector<Tensor> materialized;
+            materialized.reserve(tensors.size());
+            for (const Tensor& tensor : tensors) {
+                Tensor storage;
+                materialized.push_back(tensor.contiguous_read(storage));
+            }
+            return stack(materialized, dim);
         }
 
         // Build output shape with new dimension inserted at 'dim'
@@ -2308,6 +2475,23 @@ namespace lfs::core {
         LFS_ASSERT_MSG(!std::isnan(min_val) && !std::isnan(max_val) && min_val <= max_val,
                        "clamp bounds must not be NaN and must be ordered");
 
+        Tensor input_materialized;
+        const Tensor& input = contiguous_read(input_materialized);
+        if (&input != this) {
+            return input.clamp(min_val, max_val);
+        }
+
+        if (dtype_ == DataType::Int32) {
+            const bool integer_bounds =
+                (min_val == -std::numeric_limits<float>::infinity() ||
+                 detail::is_exact_int32_scalar(min_val)) &&
+                (max_val == std::numeric_limits<float>::infinity() ||
+                 detail::is_exact_int32_scalar(max_val));
+            if (!integer_bounds) {
+                return to(DataType::Float32).clamp(min_val, max_val);
+            }
+        }
+
         if (numel() == 0) {
             return empty(shape_, device_, dtype_);
         }
@@ -2328,9 +2512,14 @@ namespace lfs::core {
                 LFS_CUDA_CHECK_MSG(
                     cudaMemcpy(result.data_, data_ptr(), bytes(), cudaMemcpyDeviceToDevice),
                     "Int32 clamp CUDA copy");
+                const int min_int = min_val == -std::numeric_limits<float>::infinity()
+                                        ? std::numeric_limits<int>::lowest()
+                                        : static_cast<int>(min_val);
+                const int max_int = max_val == std::numeric_limits<float>::infinity()
+                                        ? std::numeric_limits<int>::max()
+                                        : static_cast<int>(max_val);
                 tensor_ops::launch_clamp_scalar_int(result.ptr<int>(),
-                                                    static_cast<int>(min_val),
-                                                    static_cast<int>(max_val),
+                                                    min_int, max_int,
                                                     numel(), result.stream());
             }
         } else {
@@ -2344,8 +2533,12 @@ namespace lfs::core {
             } else if (dtype_ == DataType::Int32) {
                 const int* src = ptr<int>();
                 int* dst = result.ptr<int>();
-                int min_int = static_cast<int>(min_val);
-                int max_int = static_cast<int>(max_val);
+                const int min_int = min_val == -std::numeric_limits<float>::infinity()
+                                        ? std::numeric_limits<int>::lowest()
+                                        : static_cast<int>(min_val);
+                const int max_int = max_val == std::numeric_limits<float>::infinity()
+                                        ? std::numeric_limits<int>::max()
+                                        : static_cast<int>(max_val);
                 for (size_t i = 0; i < numel(); ++i) {
                     dst[i] = std::clamp(src[i], min_int, max_int);
                 }

--- a/src/core/tensor/tensor_utils.cpp
+++ b/src/core/tensor/tensor_utils.cpp
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/logger.hpp"
+#include "internal/cuda_stream_context.hpp"
 #include "internal/tensor_impl.hpp"
 #include "internal/tensor_ops.hpp"
 #include <algorithm>
@@ -29,9 +30,11 @@ namespace lfs::core {
 
         // Generate on CPU first
         std::vector<float> data(steps);
-        float step = (end - start) / (steps - 1);
+        const float step = (end - start) / static_cast<float>(steps - 1);
         for (size_t i = 0; i < steps; ++i) {
-            data[i] = start + i * step;
+            data[i] = i < steps / 2
+                          ? start + step * static_cast<float>(i)
+                          : end - step * static_cast<float>(steps - i - 1);
         }
 
         if (device == Device::CUDA) {
@@ -52,6 +55,12 @@ namespace lfs::core {
         LFS_ASSERT_MSG(diagonal.dtype() == DataType::Float32,
                        "diag currently supports only Float32");
 
+        Tensor materialized;
+        const Tensor& dense_diagonal = diagonal.contiguous_read(materialized);
+        if (&dense_diagonal != &diagonal) {
+            return diag(dense_diagonal);
+        }
+
         size_t n = diagonal.numel();
         auto result = Tensor::zeros({n, n}, diagonal.device());
         if (n == 0) {
@@ -59,8 +68,9 @@ namespace lfs::core {
         }
 
         if (diagonal.device() == Device::CUDA) {
+            prepare_inputs_for_stream({&dense_diagonal}, result.stream());
             LFS_CUDA_CHECK(cudaGetLastError());
-            tensor_ops::launch_diag(diagonal.ptr<float>(), result.ptr<float>(), n, result.stream());
+            tensor_ops::launch_diag(dense_diagonal.ptr<float>(), result.ptr<float>(), n, result.stream());
             LFS_CUDA_CHECK(cudaGetLastError());
             // No sync - returns tensor
         } else {

--- a/src/core/tensor/tensor_warp_reduce.cu
+++ b/src/core/tensor/tensor_warp_reduce.cu
@@ -13,6 +13,7 @@
  */
 
 #include "core/cuda_error.hpp"
+#include "core/logger.hpp"
 #include "internal/gpu_config.hpp"
 #include "internal/packed128.cuh"
 #include "internal/tensor_functors.hpp"
@@ -222,10 +223,10 @@ namespace lfs::core::tensor_ops {
 
             if (use_vectorized && idx + 3 < n) {
                 const float4 vals = reinterpret_cast<const float4*>(input)[vec_idx];
-                val = fmaxf(val, fmaxf(fmaxf(vals.x, vals.y), fmaxf(vals.z, vals.w)));
+                val = ops::max_reduce_op{}(val, ops::max_reduce_op{}(ops::max_reduce_op{}(vals.x, vals.y), ops::max_reduce_op{}(vals.z, vals.w)));
             } else if (idx < n) {
                 for (size_t i = idx; i < n && i < idx + VECTOR_SIZE; ++i) {
-                    val = fmaxf(val, input[i]);
+                    val = ops::max_reduce_op{}(val, input[i]);
                 }
             }
         }
@@ -238,7 +239,7 @@ namespace lfs::core::tensor_ops {
             int assumed;
             do {
                 assumed = old;
-                const float new_val = fmaxf(__int_as_float(assumed), val);
+                const float new_val = ops::max_reduce_op{}(__int_as_float(assumed), val);
                 old = atomicCAS(output_as_int, assumed, __float_as_int(new_val));
             } while (assumed != old);
         }
@@ -261,10 +262,10 @@ namespace lfs::core::tensor_ops {
 
             if (use_vectorized && idx + 3 < n) {
                 const float4 vals = reinterpret_cast<const float4*>(input)[vec_idx];
-                val = fminf(val, fminf(fminf(vals.x, vals.y), fminf(vals.z, vals.w)));
+                val = ops::min_reduce_op{}(val, ops::min_reduce_op{}(ops::min_reduce_op{}(vals.x, vals.y), ops::min_reduce_op{}(vals.z, vals.w)));
             } else if (idx < n) {
                 for (size_t i = idx; i < n && i < idx + VECTOR_SIZE; ++i) {
-                    val = fminf(val, input[i]);
+                    val = ops::min_reduce_op{}(val, input[i]);
                 }
             }
         }
@@ -277,7 +278,7 @@ namespace lfs::core::tensor_ops {
             int assumed;
             do {
                 assumed = old;
-                const float new_val = fminf(__int_as_float(assumed), val);
+                const float new_val = ops::min_reduce_op{}(__int_as_float(assumed), val);
                 old = atomicCAS(output_as_int, assumed, __float_as_int(new_val));
             } while (assumed != old);
         }
@@ -442,12 +443,12 @@ namespace lfs::core::tensor_ops {
                     size_t idx = base + lane;
                     if (idx < num_float4s) {
                         float4 v = reinterpret_cast<const float4*>(segment_start)[idx];
-                        val = fmaxf(val, fmaxf(fmaxf(v.x, v.y), fmaxf(v.z, v.w)));
+                        val = ops::max_reduce_op{}(val, ops::max_reduce_op{}(ops::max_reduce_op{}(v.x, v.y), ops::max_reduce_op{}(v.z, v.w)));
                     }
                 }
             } else {
                 for (size_t i = lane; i < segment_size; i += 32) {
-                    val = fmaxf(val, segment_start[i]);
+                    val = ops::max_reduce_op{}(val, segment_start[i]);
                 }
             }
 
@@ -484,12 +485,12 @@ namespace lfs::core::tensor_ops {
                     size_t idx = base + lane;
                     if (idx < num_float4s) {
                         float4 v = reinterpret_cast<const float4*>(segment_start)[idx];
-                        val = fminf(val, fminf(fminf(v.x, v.y), fminf(v.z, v.w)));
+                        val = ops::min_reduce_op{}(val, ops::min_reduce_op{}(ops::min_reduce_op{}(v.x, v.y), ops::min_reduce_op{}(v.z, v.w)));
                     }
                 }
             } else {
                 for (size_t i = lane; i < segment_size; i += 32) {
-                    val = fminf(val, segment_start[i]);
+                    val = ops::min_reduce_op{}(val, segment_start[i]);
                 }
             }
 
@@ -647,7 +648,7 @@ namespace lfs::core::tensor_ops {
             float max_val = -CUDA_INFINITY;
 #pragma unroll 8
             for (size_t i = 0; i < segment_size; ++i) {
-                max_val = fmaxf(max_val, segment_start[i]);
+                max_val = ops::max_reduce_op{}(max_val, segment_start[i]);
             }
 
             output[seg_idx] = max_val;
@@ -671,7 +672,7 @@ namespace lfs::core::tensor_ops {
             float min_val = CUDA_INFINITY;
 #pragma unroll 8
             for (size_t i = 0; i < segment_size; ++i) {
-                min_val = fminf(min_val, segment_start[i]);
+                min_val = ops::min_reduce_op{}(min_val, segment_start[i]);
             }
 
             output[seg_idx] = min_val;
@@ -858,20 +859,20 @@ namespace lfs::core::tensor_ops {
                     float v7 = input[base_idx + (r + 7) * inner_size];
 
                     // Balanced tree reduction
-                    float m01 = fmaxf(v0, v1);
-                    float m23 = fmaxf(v2, v3);
-                    float m45 = fmaxf(v4, v5);
-                    float m67 = fmaxf(v6, v7);
-                    float m0123 = fmaxf(m01, m23);
-                    float m4567 = fmaxf(m45, m67);
-                    max_val = fmaxf(max_val, fmaxf(m0123, m4567));
+                    float m01 = ops::max_reduce_op{}(v0, v1);
+                    float m23 = ops::max_reduce_op{}(v2, v3);
+                    float m45 = ops::max_reduce_op{}(v4, v5);
+                    float m67 = ops::max_reduce_op{}(v6, v7);
+                    float m0123 = ops::max_reduce_op{}(m01, m23);
+                    float m4567 = ops::max_reduce_op{}(m45, m67);
+                    max_val = ops::max_reduce_op{}(max_val, ops::max_reduce_op{}(m0123, m4567));
                 }
             }
 
 // Handle remainder
 #pragma unroll 4
             for (; r < reduce_size; ++r) {
-                max_val = fmaxf(max_val, input[base_idx + r * inner_size]);
+                max_val = ops::max_reduce_op{}(max_val, input[base_idx + r * inner_size]);
             }
 
             output[out_idx] = max_val;
@@ -969,23 +970,63 @@ namespace lfs::core::tensor_ops {
                     float v7 = input[base_idx + (r + 7) * inner_size];
 
                     // Balanced tree reduction
-                    float m01 = fminf(v0, v1);
-                    float m23 = fminf(v2, v3);
-                    float m45 = fminf(v4, v5);
-                    float m67 = fminf(v6, v7);
-                    float m0123 = fminf(m01, m23);
-                    float m4567 = fminf(m45, m67);
-                    min_val = fminf(min_val, fminf(m0123, m4567));
+                    float m01 = ops::min_reduce_op{}(v0, v1);
+                    float m23 = ops::min_reduce_op{}(v2, v3);
+                    float m45 = ops::min_reduce_op{}(v4, v5);
+                    float m67 = ops::min_reduce_op{}(v6, v7);
+                    float m0123 = ops::min_reduce_op{}(m01, m23);
+                    float m4567 = ops::min_reduce_op{}(m45, m67);
+                    min_val = ops::min_reduce_op{}(min_val, ops::min_reduce_op{}(m0123, m4567));
                 }
             }
 
 // Handle remainder
 #pragma unroll 4
             for (; r < reduce_size; ++r) {
-                min_val = fminf(min_val, input[base_idx + r * inner_size]);
+                min_val = ops::min_reduce_op{}(min_val, input[base_idx + r * inner_size]);
             }
 
             output[out_idx] = min_val;
+        }
+    }
+
+    __global__ void warp_strided_reduce_prod_kernel(
+        const float* __restrict__ input,
+        float* __restrict__ output,
+        size_t outer_size,
+        size_t reduce_size,
+        size_t inner_size) {
+        const size_t output_elements = outer_size * inner_size;
+        const size_t stride = blockDim.x * gridDim.x;
+
+        for (size_t out_idx = blockIdx.x * blockDim.x + threadIdx.x;
+             out_idx < output_elements;
+             out_idx += stride) {
+            const size_t outer_idx = out_idx / inner_size;
+            const size_t inner_idx = out_idx % inner_size;
+            const size_t base_idx = outer_idx * reduce_size * inner_size + inner_idx;
+
+            float product = 1.0f;
+            size_t r = 0;
+            if (reduce_size >= 8) {
+#pragma unroll 2
+                for (; r + 7 < reduce_size; r += 8) {
+                    product *= input[base_idx + (r + 0) * inner_size] *
+                               input[base_idx + (r + 1) * inner_size] *
+                               input[base_idx + (r + 2) * inner_size] *
+                               input[base_idx + (r + 3) * inner_size] *
+                               input[base_idx + (r + 4) * inner_size] *
+                               input[base_idx + (r + 5) * inner_size] *
+                               input[base_idx + (r + 6) * inner_size] *
+                               input[base_idx + (r + 7) * inner_size];
+                }
+            }
+#pragma unroll 4
+            for (; r < reduce_size; ++r) {
+                product *= input[base_idx + r * inner_size];
+            }
+
+            output[out_idx] = product;
         }
     }
 
@@ -1066,7 +1107,8 @@ namespace lfs::core::tensor_ops {
                 input, output, n, is_aligned);
             break;
         default:
-            break;
+            LFS_ASSERT_MSG(false,
+                           "two-stage warp reduction encountered an unsupported operation");
         }
 
         // Free partial buffer if we allocated it
@@ -1122,7 +1164,8 @@ namespace lfs::core::tensor_ops {
                 input, output, n, is_aligned);
             break;
         default:
-            break;
+            LFS_ASSERT_MSG(false,
+                           "full warp reduction encountered an unsupported operation");
         }
     }
 
@@ -1182,7 +1225,8 @@ namespace lfs::core::tensor_ops {
                     input, output, num_segments, segment_size);
                 break;
             default:
-                break;
+                LFS_ASSERT_MSG(false,
+                               "tiny segmented reduction encountered an unsupported operation");
             }
             return;
         }
@@ -1220,7 +1264,8 @@ namespace lfs::core::tensor_ops {
                     input, output, num_segments, segment_size);
                 break;
             default:
-                break;
+                LFS_ASSERT_MSG(false,
+                               "medium segmented reduction encountered an unsupported operation");
             }
             return;
         }
@@ -1253,7 +1298,8 @@ namespace lfs::core::tensor_ops {
                 input, output, num_segments, segment_size);
             break;
         default:
-            break;
+            LFS_ASSERT_MSG(false,
+                           "segmented reduction encountered an unsupported operation");
         }
     }
 
@@ -1307,128 +1353,35 @@ namespace lfs::core::tensor_ops {
             warp_strided_reduce_min_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
                 input, output, outer_size, reduce_size, inner_size);
             break;
-        default:
+        case ReduceOp::Prod:
+            warp_strided_reduce_prod_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
+                input, output, outer_size, reduce_size, inner_size);
             break;
+        default:
+            LFS_ASSERT_MSG(false,
+                           "warp strided reduction encountered an unsupported operation");
         }
     }
 
-    /**
-     * @brief Multi-axis reduction kernel for contiguous axes
-     *
-     * When reducing multiple contiguous axes, we can treat it as a single-axis
-     * reduction with a larger reduce_size. This is much faster than the generic
-     * multi-axis kernel.
-     *
-     * Example: sum({0, 1}) on [256, 256, 64] reduces 256*256=65536 elements
-     *          to produce each of the 64 output values.
-     *
-     * Each block processes one output element using warp reductions.
-     */
-    __global__ void warp_multi_axis_reduce_sum_kernel(
-        const float* __restrict__ input,
-        float* __restrict__ output,
-        size_t output_size,
-        size_t reduce_count) {
-        size_t out_idx = blockIdx.x;
-        if (out_idx >= output_size)
-            return;
-
-        // Each output element requires summing reduce_count input elements
-        const float* segment_start = input + out_idx * reduce_count;
-
-        // Use vectorized segment reduction
-        float result = warp_ops::vectorized_segment_reduce_sum(segment_start, reduce_count);
-
-        if (threadIdx.x == 0) {
-            output[out_idx] = result;
-        }
-    }
-
-    /**
-     * @brief Multi-axis max reduction kernel for contiguous axes
-     */
-    __global__ void warp_multi_axis_reduce_max_kernel(
-        const float* __restrict__ input,
-        float* __restrict__ output,
-        size_t output_size,
-        size_t reduce_count) {
-        size_t out_idx = blockIdx.x;
-        if (out_idx >= output_size)
-            return;
-
-        const float* segment_start = input + out_idx * reduce_count;
-        float result = warp_ops::vectorized_segment_reduce_max(segment_start, reduce_count);
-
-        if (threadIdx.x == 0) {
-            output[out_idx] = result;
-        }
-    }
-
-    /**
-     * @brief Multi-axis min reduction kernel for contiguous axes
-     */
-    __global__ void warp_multi_axis_reduce_min_kernel(
-        const float* __restrict__ input,
-        float* __restrict__ output,
-        size_t output_size,
-        size_t reduce_count) {
-        size_t out_idx = blockIdx.x;
-        if (out_idx >= output_size)
-            return;
-
-        const float* segment_start = input + out_idx * reduce_count;
-        float result = warp_ops::vectorized_segment_reduce_min(segment_start, reduce_count);
-
-        if (threadIdx.x == 0) {
-            output[out_idx] = result;
-        }
-    }
-
-    /**
-     * @brief Launch optimized multi-axis warp reduction
-     *
-     * This is for reducing multiple contiguous axes. Much faster than the generic
-     * multi-axis kernel which has poor index computation overhead.
-     *
-     * @param input Input tensor data
-     * @param output Output array
-     * @param output_size Number of output elements
-     * @param reduce_count Number of elements to reduce per output
-     * @param op Reduction operation
-     * @param stream CUDA stream
-     */
     void launch_warp_multi_axis_reduce(
         const float* input,
         float* output,
-        size_t output_size,
+        size_t outer_size,
         size_t reduce_count,
+        size_t inner_size,
         ReduceOp op,
         cudaStream_t stream) {
-        if (output_size == 0 || reduce_count == 0)
+        if (outer_size == 0 || reduce_count == 0 || inner_size == 0)
             return;
 
-        // Each block processes one output element
-        // 256 threads per block for good warp utilization
-        constexpr int BLOCK_SIZE = 256;
-        int grid_size = output_size;
-
-        switch (op) {
-        case ReduceOp::Sum:
-        case ReduceOp::Mean: // Mean handled as sum, then divided by caller
-            warp_multi_axis_reduce_sum_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
-                input, output, output_size, reduce_count);
-            break;
-        case ReduceOp::Max:
-            warp_multi_axis_reduce_max_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
-                input, output, output_size, reduce_count);
-            break;
-        case ReduceOp::Min:
-            warp_multi_axis_reduce_min_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
-                input, output, output_size, reduce_count);
-            break;
-        default:
-            break;
+        if (inner_size == 1) {
+            launch_warp_segmented_reduce(
+                input, output, outer_size, reduce_count, op, stream);
+            return;
         }
+
+        launch_warp_strided_reduce(
+            input, output, outer_size, reduce_count, inner_size, op, stream);
     }
 
     // Column reduction for 2D matrices [M, N] -> [N]
@@ -1475,7 +1428,7 @@ namespace lfs::core::tensor_ops {
 
         float val = -FLT_MAX;
         for (size_t row = row_start; row < row_end; row++) {
-            val = fmaxf(val, input[row * N + col]);
+            val = ops::max_reduce_op{}(val, input[row * N + col]);
         }
 
         if (gridDim.y == 1) {
@@ -1485,7 +1438,7 @@ namespace lfs::core::tensor_ops {
             int old = *out_int, assumed;
             do {
                 assumed = old;
-                old = atomicCAS(out_int, assumed, __float_as_int(fmaxf(__int_as_float(assumed), val)));
+                old = atomicCAS(out_int, assumed, __float_as_int(ops::max_reduce_op{}(__int_as_float(assumed), val)));
             } while (assumed != old);
         }
     }
@@ -1503,7 +1456,7 @@ namespace lfs::core::tensor_ops {
 
         float val = FLT_MAX;
         for (size_t row = row_start; row < row_end; row++) {
-            val = fminf(val, input[row * N + col]);
+            val = ops::min_reduce_op{}(val, input[row * N + col]);
         }
 
         if (gridDim.y == 1) {
@@ -1513,7 +1466,7 @@ namespace lfs::core::tensor_ops {
             int old = *out_int, assumed;
             do {
                 assumed = old;
-                old = atomicCAS(out_int, assumed, __float_as_int(fminf(__int_as_float(assumed), val)));
+                old = atomicCAS(out_int, assumed, __float_as_int(ops::min_reduce_op{}(__int_as_float(assumed), val)));
             } while (assumed != old);
         }
     }
@@ -1559,7 +1512,8 @@ namespace lfs::core::tensor_ops {
             column_reduce_min_kernel<<<grid, BLOCK, 0, stream>>>(input, output, M, N);
             break;
         default:
-            break;
+            LFS_ASSERT_MSG(false,
+                           "column reduction encountered an unsupported operation");
         }
     }
 

--- a/src/python/lfs/py_rendering.cpp
+++ b/src/python/lfs/py_rendering.cpp
@@ -67,7 +67,7 @@ namespace lfs::python {
             if (layout == rendering::ImageLayout::Unknown)
                 return std::nullopt;
             if (layout == rendering::ImageLayout::CHW) {
-                image = image.permute({1, 2, 0});
+                image = rendering::flipImageVertical(image, layout).permute({1, 2, 0}).contiguous();
             } else {
                 image = image.contiguous();
             }
@@ -1719,7 +1719,8 @@ namespace lfs::python {
                     return static_cast<float>(self.height) / self.ortho_scale;
                 },
                 "Vertical view extent in world units (Blender-compatible orthographic scale). Larger when zoomed out, smaller when zoomed in.")
-            .def_prop_ro("position", [](const PyViewInfo& self) -> std::tuple<float, float, float> {
+            .def_prop_ro(
+                "position", [](const PyViewInfo& self) -> std::tuple<float, float, float> {
                     auto t = self.translation.tensor().cpu();
                     auto acc = t.accessor<float, 1>();
                     return {acc(0), acc(1), acc(2)}; }, "Camera position as (x, y, z) tuple");

--- a/src/python/lfs/py_tensor.cpp
+++ b/src/python/lfs/py_tensor.cpp
@@ -304,12 +304,8 @@ namespace lfs::python {
 
     nb::object PyTensor::numpy(bool copy) const {
         validate();
-        Tensor cpu_tensor = tensor_.device() == Device::CUDA ? tensor_.cpu() : tensor_;
-
-        // Ensure contiguous
-        if (!cpu_tensor.is_contiguous()) {
-            cpu_tensor = cpu_tensor.contiguous();
-        }
+        Tensor host = tensor_.device() == Device::CUDA ? tensor_.cpu() : tensor_;
+        Tensor cpu_tensor = host.is_contiguous() ? std::move(host) : host.contiguous();
 
         const auto& dims = cpu_tensor.shape().dims();
         size_t elem_size = 4;
@@ -469,10 +465,8 @@ namespace lfs::python {
 
     nb::object PyTensor::tolist() const {
         validate();
-        Tensor cpu_tensor = tensor_.device() == Device::CUDA ? tensor_.cpu() : tensor_;
-        if (!cpu_tensor.is_contiguous()) {
-            cpu_tensor = cpu_tensor.contiguous();
-        }
+        Tensor host = tensor_.device() == Device::CUDA ? tensor_.cpu() : tensor_;
+        Tensor cpu_tensor = host.is_contiguous() ? std::move(host) : host.contiguous();
 
         const auto& dims = cpu_tensor.shape().dims();
         size_t offset = 0;
@@ -1712,25 +1706,32 @@ namespace lfs::python {
                     return self.iadd(other);
                 },
                 nb::rv_policy::reference, "In-place add tensor")
-            .def("__iadd__", [](PyTensor& self, float scalar) -> PyTensor& { return self.iadd_scalar(scalar); }, nb::rv_policy::reference, "In-place add scalar")
+            .def(
+                "__iadd__", [](PyTensor& self, float scalar) -> PyTensor& { return self.iadd_scalar(scalar); }, nb::rv_policy::reference, "In-place add scalar")
 
             .def("__sub__", &PyTensor::sub, "Subtract tensor")
             .def("__sub__", &PyTensor::sub_scalar, "Subtract scalar")
             .def("__rsub__", &PyTensor::rsub_scalar, "Reverse subtract scalar")
-            .def("__isub__", [](PyTensor& self, const PyTensor& other) -> PyTensor& { return self.isub(other); }, nb::rv_policy::reference, "In-place subtract tensor")
-            .def("__isub__", [](PyTensor& self, float scalar) -> PyTensor& { return self.isub_scalar(scalar); }, nb::rv_policy::reference, "In-place subtract scalar")
+            .def(
+                "__isub__", [](PyTensor& self, const PyTensor& other) -> PyTensor& { return self.isub(other); }, nb::rv_policy::reference, "In-place subtract tensor")
+            .def(
+                "__isub__", [](PyTensor& self, float scalar) -> PyTensor& { return self.isub_scalar(scalar); }, nb::rv_policy::reference, "In-place subtract scalar")
 
             .def("__mul__", &PyTensor::mul, "Multiply tensor")
             .def("__mul__", &PyTensor::mul_scalar, "Multiply scalar")
             .def("__rmul__", &PyTensor::mul_scalar, "Reverse multiply scalar")
-            .def("__imul__", [](PyTensor& self, const PyTensor& other) -> PyTensor& { return self.imul(other); }, nb::rv_policy::reference, "In-place multiply tensor")
-            .def("__imul__", [](PyTensor& self, float scalar) -> PyTensor& { return self.imul_scalar(scalar); }, nb::rv_policy::reference, "In-place multiply scalar")
+            .def(
+                "__imul__", [](PyTensor& self, const PyTensor& other) -> PyTensor& { return self.imul(other); }, nb::rv_policy::reference, "In-place multiply tensor")
+            .def(
+                "__imul__", [](PyTensor& self, float scalar) -> PyTensor& { return self.imul_scalar(scalar); }, nb::rv_policy::reference, "In-place multiply scalar")
 
             .def("__truediv__", &PyTensor::div, "Divide tensor")
             .def("__truediv__", &PyTensor::div_scalar, "Divide scalar")
             .def("__rtruediv__", &PyTensor::rdiv_scalar, "Reverse divide scalar")
-            .def("__itruediv__", [](PyTensor& self, const PyTensor& other) -> PyTensor& { return self.idiv(other); }, nb::rv_policy::reference, "In-place divide tensor")
-            .def("__itruediv__", [](PyTensor& self, float scalar) -> PyTensor& { return self.idiv_scalar(scalar); }, nb::rv_policy::reference, "In-place divide scalar")
+            .def(
+                "__itruediv__", [](PyTensor& self, const PyTensor& other) -> PyTensor& { return self.idiv(other); }, nb::rv_policy::reference, "In-place divide tensor")
+            .def(
+                "__itruediv__", [](PyTensor& self, float scalar) -> PyTensor& { return self.idiv_scalar(scalar); }, nb::rv_policy::reference, "In-place divide scalar")
 
             .def("fill_", &PyTensor::fill_, nb::rv_policy::reference, "Fill tensor with value in-place")
             .def("zero_", &PyTensor::zero_, nb::rv_policy::reference, "Zero tensor in-place")
@@ -1880,11 +1881,12 @@ namespace lfs::python {
 
             // __array__ protocol for zero-copy NumPy interop (CPU only)
             // Allows: np.asarray(tensor) for zero-copy when tensor is CPU + contiguous
-            .def("__array__", [](PyTensor& self, nb::object dtype) -> nb::object {
-                (void)dtype;              // We return our native dtype, ignore requested dtype
-                return self.numpy(false); // Zero-copy
-            },
-                 nb::arg("dtype") = nb::none(), "Return numpy array view (zero-copy for CPU contiguous tensors)");
+            .def(
+                "__array__", [](PyTensor& self, nb::object dtype) -> nb::object {
+                    (void)dtype;              // We return our native dtype, ignore requested dtype
+                    return self.numpy(false); // Zero-copy
+                },
+                nb::arg("dtype") = nb::none(), "Return numpy array view (zero-copy for CPU contiguous tensors)");
     }
 
 } // namespace lfs::python

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,6 +218,8 @@ set(TEST_FILES
     test_tensor_stream.cpp
     test_cuda_event_pool.cpp
     test_tensor_multistream.cpp
+    test_tensor_discovery.cpp
+    test_tensor_discovery_fuzz.cpp
     test_mcmc_multinomial.cpp
     test_arena_metrics_contention.cpp
     test_tensor_memory_planner.cpp
@@ -333,6 +335,47 @@ target_compile_options(lichtfeld_tests PRIVATE
     $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
 )
 
+# Tensor-library hardening is intentionally isolated from the default test
+# tiers.  During the hardening phases these oracle tests are expected to expose
+# known failures, and crash-prone reproducers must not terminate the monolithic
+# test process before unrelated tests run.
+add_executable(tensor_hardening_tests
+    test_main.cpp
+    tensor_hardening_cuda_utils.cu
+    test_tensor_hardening_theme_a.cpp
+    test_tensor_hardening_theme_b.cpp
+    test_tensor_hardening_theme_c.cpp
+    test_tensor_hardening_theme_d.cpp
+    test_tensor_hardening_theme_e.cpp
+    test_tensor_hardening_theme_f.cpp
+)
+
+set_target_properties(tensor_hardening_tests PROPERTIES
+    CUDA_STANDARD 20
+    CUDA_STANDARD_REQUIRED ON
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON
+)
+
+target_include_directories(tensor_hardening_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/tests
+    ${CUDAToolkit_INCLUDE_DIRS}
+)
+
+target_link_libraries(tensor_hardening_tests PRIVATE
+    lfs_core
+    GTest::gtest
+    ${TORCH_LIBRARIES}
+    CUDA::cudart
+    CUDA::curand
+)
+
+target_compile_options(tensor_hardening_tests PRIVATE
+    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
+    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
+)
+
 # =============================================================================
 # CTest registration
 # =============================================================================
@@ -398,7 +441,7 @@ string(CONCAT LFS_SLOW_TEST_FILTER
 )
 
 set(LFS_NON_FAST_TEST_FILTER
-    "${LFS_SLOW_TEST_FILTER}:${LFS_NIGHTLY_TEST_FILTER}")
+    "${LFS_SLOW_TEST_FILTER}:${LFS_NIGHTLY_TEST_FILTER}:DiscoveryFuzz.*:DiscoverySweep.*")
 
 add_test(NAME lichtfeld.fast
     COMMAND $<TARGET_FILE:lichtfeld_tests>
@@ -430,6 +473,28 @@ add_test(NAME lichtfeld.nightly
 set_tests_properties(lichtfeld.nightly PROPERTIES
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     LABELS "nightly;gpu"
+    TIMEOUT 1800
+)
+
+add_test(NAME tensor.hardening
+    COMMAND $<TARGET_FILE:tensor_hardening_tests>
+        --gtest_color=no
+        --gtest_death_test_style=threadsafe
+)
+set_tests_properties(tensor.hardening PROPERTIES
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    LABELS "hardening;gpu"
+    TIMEOUT 900
+)
+
+add_test(NAME lichtfeld.discovery
+    COMMAND $<TARGET_FILE:lichtfeld_tests>
+        "--gtest_filter=DiscoveryFuzz.*:DiscoverySweep.*"
+        --gtest_color=no
+)
+set_tests_properties(lichtfeld.discovery PROPERTIES
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    LABELS "discovery;gpu"
     TIMEOUT 1800
 )
 

--- a/tests/tensor_hardening_cuda_utils.cu
+++ b/tests/tensor_hardening_cuda_utils.cu
@@ -1,0 +1,22 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <cstdint>
+
+#include <cuda_runtime.h>
+
+namespace tensor_hardening {
+    namespace {
+        __global__ void delay_kernel(const uint64_t cycles) {
+            const uint64_t start = clock64();
+            while (clock64() - start < cycles) {
+                __nanosleep(100);
+            }
+        }
+    } // namespace
+
+    cudaError_t launch_delay_kernel(const cudaStream_t stream, const uint64_t cycles) {
+        delay_kernel<<<1, 1, 0, stream>>>(cycles);
+        return cudaGetLastError();
+    }
+} // namespace tensor_hardening

--- a/tests/tensor_hardening_test_utils.hpp
+++ b/tests/tensor_hardening_test_utils.hpp
@@ -1,0 +1,239 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include "core/tensor.hpp"
+#include "core/tensor/internal/memory_pool.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+namespace tensor_hardening {
+
+    using lfs::core::DataType;
+    using lfs::core::Device;
+    using lfs::core::Tensor;
+    using lfs::core::TensorShape;
+
+    cudaError_t launch_delay_kernel(cudaStream_t stream, uint64_t cycles);
+
+    inline bool has_cuda_device() {
+        int count = 0;
+        return cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+    }
+
+    class CudaTest : public ::testing::Test {
+    protected:
+        void SetUp() override {
+            if (!has_cuda_device()) {
+                GTEST_SKIP() << "CUDA device required";
+            }
+            ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+        }
+    };
+
+    inline void destroy_stream_safely(cudaStream_t stream) {
+        if (stream == nullptr) {
+            return;
+        }
+        lfs::core::CudaMemoryPool::instance().release_stream(stream);
+        EXPECT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+    }
+
+    inline std::vector<int64_t> torch_shape(const Tensor& tensor) {
+        std::vector<int64_t> result;
+        result.reserve(tensor.shape().rank());
+        for (const size_t dim : tensor.shape().dims()) {
+            result.push_back(static_cast<int64_t>(dim));
+        }
+        return result;
+    }
+
+    inline void expect_shape_matches(const Tensor& actual, const torch::Tensor& expected,
+                                     const std::string& context) {
+        ASSERT_EQ(actual.shape().rank(), static_cast<size_t>(expected.dim()))
+            << context << ": rank mismatch; ours=" << actual.shape().str()
+            << ", torch=" << expected.sizes();
+        for (size_t dim = 0; dim < actual.shape().rank(); ++dim) {
+            EXPECT_EQ(actual.shape()[dim], static_cast<size_t>(expected.size(dim)))
+                << context << ": dimension " << dim << " mismatch; ours="
+                << actual.shape().str() << ", torch=" << expected.sizes();
+        }
+    }
+
+    inline std::vector<float> lfs_values_as_float(const Tensor& input) {
+        Tensor materialized = input.is_contiguous() ? input : input.contiguous();
+        if (materialized.dtype() != DataType::Float32) {
+            materialized = materialized.to(DataType::Float32);
+        }
+        return materialized.cpu().to_vector();
+    }
+
+    inline std::vector<float> torch_values_as_float(const torch::Tensor& input) {
+        const auto materialized = input.detach().to(torch::kCPU).to(torch::kFloat32).contiguous().flatten();
+        const auto* values = materialized.data_ptr<float>();
+        return {values, values + materialized.numel()};
+    }
+
+    inline void expect_float_values_match(const Tensor& actual, const torch::Tensor& expected,
+                                          const std::string& context,
+                                          const float rtol = 1e-5f,
+                                          const float atol = 1e-6f) {
+        expect_shape_matches(actual, expected, context);
+        const auto ours = lfs_values_as_float(actual);
+        const auto torch_values = torch_values_as_float(expected);
+        ASSERT_EQ(ours.size(), torch_values.size()) << context << ": element count mismatch";
+
+        size_t mismatch_count = 0;
+        std::ostringstream mismatch_sample;
+        for (size_t i = 0; i < ours.size(); ++i) {
+            const float lhs = ours[i];
+            const float rhs = torch_values[i];
+            bool matches = false;
+            if (std::isnan(rhs)) {
+                matches = std::isnan(lhs);
+            } else if (std::isinf(rhs)) {
+                matches = std::isinf(lhs) && std::signbit(lhs) == std::signbit(rhs);
+            } else {
+                matches = std::abs(lhs - rhs) <= atol + rtol * std::abs(rhs);
+            }
+            if (!matches) {
+                if (mismatch_count < 8) {
+                    mismatch_sample << "\n  index " << i << ": expected=" << rhs
+                                    << ", actual=" << lhs;
+                }
+                ++mismatch_count;
+            }
+        }
+        EXPECT_EQ(mismatch_count, 0u)
+            << context << ": " << mismatch_count << " mismatched element(s); sample:"
+            << mismatch_sample.str();
+    }
+
+    inline void expect_int_values_match(const Tensor& actual, const torch::Tensor& expected,
+                                        const std::string& context) {
+        expect_shape_matches(actual, expected, context);
+        Tensor materialized = actual.is_contiguous() ? actual : actual.contiguous();
+        const auto torch_values = expected.detach().to(torch::kCPU).to(torch::kInt64).contiguous().flatten();
+        ASSERT_EQ(materialized.numel(), static_cast<size_t>(torch_values.numel()))
+            << context << ": element count mismatch";
+
+        std::vector<int64_t> ours;
+        if (materialized.dtype() == DataType::Int64) {
+            ours = materialized.cpu().to_vector_int64();
+        } else {
+            const auto ints = materialized.cpu().to_vector_int();
+            ours.assign(ints.begin(), ints.end());
+        }
+        const auto* reference = torch_values.data_ptr<int64_t>();
+        size_t mismatch_count = 0;
+        std::ostringstream mismatch_sample;
+        for (size_t i = 0; i < ours.size(); ++i) {
+            if (ours[i] != reference[i]) {
+                if (mismatch_count < 8) {
+                    mismatch_sample << "\n  index " << i << ": expected=" << reference[i]
+                                    << ", actual=" << ours[i];
+                }
+                ++mismatch_count;
+            }
+        }
+        EXPECT_EQ(mismatch_count, 0u)
+            << context << ": " << mismatch_count << " mismatched element(s); sample:"
+            << mismatch_sample.str();
+    }
+
+    inline void expect_bool_values_match(const Tensor& actual, const torch::Tensor& expected,
+                                         const std::string& context) {
+        expect_shape_matches(actual, expected, context);
+        Tensor materialized = actual.is_contiguous() ? actual : actual.contiguous();
+        const auto ours = materialized.cpu().to_vector_bool();
+        const auto torch_values = expected.detach().to(torch::kCPU).to(torch::kBool).contiguous().flatten();
+        ASSERT_EQ(ours.size(), static_cast<size_t>(torch_values.numel()))
+            << context << ": element count mismatch";
+        const auto* reference = torch_values.data_ptr<bool>();
+        size_t mismatch_count = 0;
+        std::ostringstream mismatch_sample;
+        for (size_t i = 0; i < ours.size(); ++i) {
+            if (ours[i] != reference[i]) {
+                if (mismatch_count < 8) {
+                    mismatch_sample << "\n  index " << i << ": expected=" << reference[i]
+                                    << ", actual=" << ours[i];
+                }
+                ++mismatch_count;
+            }
+        }
+        EXPECT_EQ(mismatch_count, 0u)
+            << context << ": " << mismatch_count << " mismatched element(s); sample:"
+            << mismatch_sample.str();
+    }
+
+    inline Tensor lfs_float_tensor(const std::vector<float>& values,
+                                   const std::initializer_list<size_t> shape,
+                                   const Device device) {
+        return Tensor::from_vector(values, TensorShape(shape), device);
+    }
+
+    inline Tensor lfs_int_tensor(const std::vector<int>& values,
+                                 const std::initializer_list<size_t> shape,
+                                 const Device device) {
+        return Tensor::from_vector(values, TensorShape(shape), device);
+    }
+
+    inline Tensor lfs_bool_tensor(const std::vector<bool>& values,
+                                  const std::initializer_list<size_t> shape,
+                                  const Device device) {
+        return Tensor::from_vector(values, TensorShape(shape), device);
+    }
+
+    // A stream blocked behind a short GPU delay. It widens ordering windows
+    // without a blocking host callback, which can serialize CUDA API calls.
+    class GateStream {
+    public:
+        GateStream() {
+            EXPECT_EQ(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking), cudaSuccess);
+            EXPECT_EQ(cudaStreamCreateWithFlags(&gate_holder_, cudaStreamNonBlocking), cudaSuccess);
+            EXPECT_EQ(cudaEventCreateWithFlags(&gate_, cudaEventDisableTiming), cudaSuccess);
+        }
+
+        GateStream(const GateStream&) = delete;
+        GateStream& operator=(const GateStream&) = delete;
+
+        ~GateStream() {
+            if (stream_ != nullptr) {
+                lfs::core::CudaMemoryPool::instance().release_stream(stream_);
+                cudaStreamDestroy(stream_);
+            }
+            if (gate_holder_ != nullptr) {
+                cudaStreamDestroy(gate_holder_);
+            }
+            if (gate_ != nullptr) {
+                cudaEventDestroy(gate_);
+            }
+        }
+
+        void close() {
+            EXPECT_EQ(launch_delay_kernel(gate_holder_, 100'000'000), cudaSuccess);
+            EXPECT_EQ(cudaEventRecord(gate_, gate_holder_), cudaSuccess);
+            EXPECT_EQ(cudaStreamWaitEvent(stream_, gate_, 0), cudaSuccess);
+        }
+
+        [[nodiscard]] cudaStream_t get() const { return stream_; }
+
+    private:
+        cudaStream_t stream_ = nullptr;
+        cudaStream_t gate_holder_ = nullptr;
+        cudaEvent_t gate_ = nullptr;
+    };
+
+} // namespace tensor_hardening

--- a/tests/test_assert_hardening.cpp
+++ b/tests/test_assert_hardening.cpp
@@ -119,10 +119,13 @@ namespace {
         EXPECT_THROW((void)lhs.all_close(rhs), std::runtime_error);
     }
 
-    TEST_F(AssertHardeningExpectedFailTest, RejectsUnimplementedArgmaxDispatch) {
+    TEST_F(AssertHardeningExpectedFailTest, ArgmaxDispatchMatchesTorch) {
         const auto values = Tensor::from_vector({1.0f, 3.0f, 2.0f}, {3}, Device::CPU);
 
-        EXPECT_THROW((void)values.argmax(), std::runtime_error);
+        const auto result = values.argmax();
+        EXPECT_EQ(result.dtype(), DataType::Int64);
+        EXPECT_EQ(result.ndim(), 0);
+        EXPECT_EQ(result.item<int64_t>(), 1);
     }
 
     TEST_F(AssertHardeningExpectedFailTest, RejectsDuplicatePlyVertexProperties) {

--- a/tests/test_python_integration.cpp
+++ b/tests/test_python_integration.cpp
@@ -215,9 +215,9 @@ namespace {
         constexpr size_t width = 2;
         constexpr size_t height = 2;
 
-        // Simulate raw bottom-left-origin readback: the logical bottom row is bright.
+        // Simulate raw bottom-left-origin readback: the logical top row is stored last.
         for (size_t col = 0; col < width; ++col) {
-            ptr[0 * height * width + col * height + 0] = 10.0f;
+            ptr[0 * height * width + (height - 1) * width + col] = 10.0f;
         }
 
         return std::make_shared<lfs::core::Tensor>(std::move(image));

--- a/tests/test_tensor_discovery.cpp
+++ b/tests/test_tensor_discovery.cpp
@@ -1,0 +1,1610 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/tensor.hpp"
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string_view>
+#include <vector>
+
+using namespace lfs::core;
+
+namespace {
+
+    std::vector<float> torch_float_values(const torch::Tensor& tensor) {
+        const auto cpu = tensor.detach().to(torch::kCPU).to(torch::kFloat32).contiguous();
+        const auto* data = cpu.data_ptr<float>();
+        return {data, data + cpu.numel()};
+    }
+
+    std::vector<int64_t> torch_int64_values(const torch::Tensor& tensor) {
+        const auto cpu = tensor.detach().to(torch::kCPU).to(torch::kInt64).contiguous();
+        const auto* data = cpu.data_ptr<int64_t>();
+        return {data, data + cpu.numel()};
+    }
+
+    std::vector<uint8_t> torch_uint8_values(const torch::Tensor& tensor) {
+        const auto cpu = tensor.detach().to(torch::kCPU).to(torch::kUInt8).contiguous();
+        const auto* data = cpu.data_ptr<uint8_t>();
+        return {data, data + cpu.numel()};
+    }
+
+    std::vector<float> lfs_float_values(const Tensor& tensor) {
+        return tensor.cpu().to(DataType::Float32).contiguous().to_vector();
+    }
+
+    void expect_shape(const Tensor& actual, const torch::Tensor& expected,
+                      const std::string_view context) {
+        ASSERT_EQ(actual.ndim(), static_cast<size_t>(expected.dim())) << context;
+        for (size_t dim = 0; dim < actual.ndim(); ++dim) {
+            EXPECT_EQ(actual.size(dim), static_cast<size_t>(expected.size(dim)))
+                << context << " at dimension " << dim;
+        }
+    }
+
+    void expect_float_tensor(const Tensor& actual, const torch::Tensor& expected,
+                             const std::string_view context,
+                             const float rtol = 1e-5f,
+                             const float atol = 1e-6f) {
+        expect_shape(actual, expected, context);
+        const auto actual_values = lfs_float_values(actual);
+        const auto expected_values = torch_float_values(expected);
+        ASSERT_EQ(actual_values.size(), expected_values.size()) << context;
+        for (size_t i = 0; i < actual_values.size(); ++i) {
+            const float a = actual_values[i];
+            const float e = expected_values[i];
+            if (std::isnan(e)) {
+                EXPECT_TRUE(std::isnan(a))
+                    << context << " at flat index " << i << ": actual=" << a;
+            } else if (std::isinf(e)) {
+                EXPECT_EQ(a, e)
+                    << context << " at flat index " << i;
+            } else {
+                EXPECT_LE(std::abs(a - e), atol + rtol * std::abs(e))
+                    << context << " at flat index " << i
+                    << ": actual=" << a << ", expected=" << e;
+            }
+        }
+    }
+
+    void expect_int64_tensor(const Tensor& actual, const torch::Tensor& expected,
+                             const std::string_view context) {
+        expect_shape(actual, expected, context);
+        const auto actual_values = actual.cpu().contiguous().to_vector_int64();
+        const auto expected_values = torch_int64_values(expected);
+        EXPECT_EQ(actual_values, expected_values) << context;
+    }
+
+} // namespace
+
+TEST(DiscoverySweep, PartialStdAndVarWithoutKeepdimMatchTorch) {
+    const std::vector<float> data = {0.0f, 1.0f, 2.0f,
+                                     3.0f, 4.0f, 5.0f};
+    const auto input = Tensor::from_vector(data, {2, 3}, Device::CPU);
+    const auto reference = torch::tensor(data, torch::kFloat32).reshape({2, 3});
+    const auto expected_std = reference.std(c10::IntArrayRef{1}, false, false);
+    const auto expected_var = reference.var(c10::IntArrayRef{1}, false, false);
+
+    try {
+        const auto actual_std = input.std(1, false, false);
+        expect_float_tensor(actual_std, expected_std,
+                            "std(dim=1, keepdim=false, unbiased=false)");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << "std unexpectedly threw: " << error.what();
+    }
+
+    try {
+        const auto actual_var = input.var(1, false, false);
+        expect_float_tensor(actual_var, expected_var,
+                            "var(dim=1, keepdim=false, unbiased=false)");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << "var unexpectedly threw: " << error.what();
+    }
+}
+
+TEST(DiscoverySweep, UnbiasedSingletonStdAndVarProduceNaN) {
+    const auto input = Tensor::from_vector({5.0f}, {1}, Device::CPU);
+    const auto reference = torch::tensor({5.0f}, torch::kFloat32);
+
+    const float expected_std = reference.std(true).item<float>();
+    const float expected_var = reference.var(true).item<float>();
+    ASSERT_TRUE(std::isnan(expected_std));
+    ASSERT_TRUE(std::isnan(expected_var));
+
+    EXPECT_TRUE(std::isnan(input.std_scalar(true)))
+        << "Torch's correction=1 estimate is undefined for one sample";
+    EXPECT_TRUE(std::isnan(input.var_scalar(true)))
+        << "Torch's correction=1 estimate is undefined for one sample";
+}
+
+TEST(DiscoverySweep, EmptyReductionSemanticsMatchTorch) {
+    const auto input = Tensor::empty({0}, Device::CPU, DataType::Float32);
+    const auto reference = torch::empty({0}, torch::kFloat32);
+    ASSERT_TRUE(std::isnan(reference.mean().item<float>()));
+
+    EXPECT_TRUE(std::isnan(input.mean().item()))
+        << "mean(empty) must be NaN, not an additive identity";
+    EXPECT_THROW({
+        const auto ignored = input.max();
+        (void)ignored;
+    },
+                 std::runtime_error);
+    EXPECT_THROW({
+        const auto ignored = input.min();
+        (void)ignored;
+    },
+                 std::runtime_error);
+}
+
+TEST(DiscoverySweep, BoolReductionDtypesAndDomainsMatchTorch) {
+    const auto input = Tensor::from_vector(
+        std::vector<bool>{true, false, true}, {3}, Device::CPU);
+    const auto reference = torch::tensor(
+                               std::vector<int>{1, 0, 1}, torch::kInt32)
+                               .to(torch::kBool);
+
+    EXPECT_THROW({
+        const auto ignored = reference.mean();
+        (void)ignored;
+    },
+                 c10::Error);
+    EXPECT_THROW({
+        const auto ignored = input.mean();
+        (void)ignored;
+    },
+                 std::runtime_error);
+
+    const auto expected_max = reference.max();
+    const auto expected_min = reference.min();
+    ASSERT_EQ(expected_max.scalar_type(), torch::kBool);
+    ASSERT_EQ(expected_min.scalar_type(), torch::kBool);
+    EXPECT_EQ(input.max().dtype(), DataType::Bool);
+    EXPECT_EQ(input.min().dtype(), DataType::Bool);
+}
+
+TEST(DiscoverySweep, AccessorRejectsDtypeMismatchLikeTorch) {
+    auto input = Tensor::from_vector(
+        std::vector<int>{1, 2, 3}, {3}, Device::CPU);
+    auto reference = torch::tensor(
+        std::vector<int>{1, 2, 3}, torch::kInt32);
+
+    EXPECT_THROW((reference.accessor<float, 1>()), c10::Error);
+    EXPECT_THROW((input.accessor<float, 1>()), std::runtime_error)
+        << "accessor<T> must not reinterpret storage of a different dtype";
+}
+
+TEST(DiscoverySweep, ScalarNormZeroAndNegativeInfinityMatchTorch) {
+    const std::vector<float> data = {0.0f, 2.0f, -3.0f};
+    const auto input = Tensor::from_vector(data, {3}, Device::CPU);
+    const auto reference = torch::tensor(data, torch::kFloat32);
+
+    const float expected_zero = reference.norm(0).item<float>();
+    const float expected_negative_infinity =
+        reference.norm(-std::numeric_limits<double>::infinity()).item<float>();
+
+    EXPECT_FLOAT_EQ(input.norm(0.0f), expected_zero);
+    EXPECT_FLOAT_EQ(input.norm(-std::numeric_limits<float>::infinity()),
+                    expected_negative_infinity);
+}
+
+TEST(DiscoverySweep, SortOrdersNaNsLikeTorch) {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const std::vector<float> data = {nan, -2.0f};
+    const auto input = Tensor::from_vector(data, {2}, Device::CPU);
+    const auto reference = torch::tensor(data, torch::kFloat32);
+
+    const auto [actual_values, actual_indices] = input.sort(0, false);
+    const auto [expected_values, expected_indices] = reference.sort(0, false);
+    expect_float_tensor(actual_values, expected_values, "ascending sort values with NaN");
+    expect_int64_tensor(actual_indices, expected_indices, "ascending sort indices with NaN");
+}
+
+TEST(DiscoverySweep, RoundUsesTiesToEvenLikeTorch) {
+    const std::vector<float> data = {0.5f, 1.5f, 2.5f, -0.5f, -1.5f, -2.5f};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::from_vector(data, {data.size()}, device);
+        auto reference = torch::tensor(data, torch::kFloat32);
+        if (device == Device::CUDA)
+            reference = reference.cuda();
+        expect_float_tensor(input.round(), reference.round(),
+                            "round must use IEEE ties-to-even");
+    }
+}
+
+TEST(DiscoverySweep, NumericCastsToUInt8MatchTorch) {
+    const std::vector<float> data = {-1.2f, 0.9f, 1.9f, 255.9f, 256.0f};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::from_vector(data, {data.size()}, device);
+        auto reference = torch::tensor(data, torch::kFloat32);
+        if (device == Device::CUDA)
+            reference = reference.cuda();
+
+        const auto actual = input.to(DataType::UInt8).cpu().to_vector_uint8();
+        const auto expected = torch_uint8_values(reference);
+        EXPECT_EQ(actual, expected)
+            << "numeric to(UInt8) must use cast truncation/wrapping semantics";
+    }
+}
+
+TEST(DiscoverySweep, SortAcceptsAnEmptyDimension) {
+    const auto input = Tensor::empty({0}, Device::CPU, DataType::Float32);
+    const auto reference = torch::empty({0}, torch::kFloat32);
+
+    std::optional<std::pair<Tensor, Tensor>> actual;
+    ASSERT_NO_THROW(actual.emplace(input.sort(0, false)));
+    const auto [expected_values, expected_indices] = reference.sort(0, false);
+    expect_float_tensor(actual->first, expected_values, "empty sort values");
+    expect_int64_tensor(actual->second, expected_indices, "empty sort indices");
+}
+
+TEST(DiscoverySweep, MinMaxWithIndicesAcceptEmptyOuterDimensions) {
+    const auto input = Tensor::empty({0, 3}, Device::CPU, DataType::Float32);
+    const auto reference = torch::empty({0, 3}, torch::kFloat32);
+
+    const auto [expected_min, expected_min_indices] = reference.min(1, false);
+    try {
+        const auto actual_min = input.min_with_indices(1, false);
+        expect_float_tensor(actual_min.first, expected_min, "empty outer min values");
+        expect_int64_tensor(actual_min.second, expected_min_indices, "empty outer min indices");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << "min_with_indices unexpectedly threw: " << error.what();
+    }
+
+    const auto [expected_max, expected_max_indices] = reference.max(1, false);
+    try {
+        const auto actual_max = input.max_with_indices(1, false);
+        expect_float_tensor(actual_max.first, expected_max, "empty outer max values");
+        expect_int64_tensor(actual_max.second, expected_max_indices, "empty outer max indices");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << "max_with_indices unexpectedly threw: " << error.what();
+    }
+}
+
+TEST(DiscoverySweep, SortUsesLogicalViewValues) {
+    const std::vector<float> data = {4.0f, 1.0f, 3.0f,
+                                     2.0f, 6.0f, 5.0f};
+    const auto input = Tensor::from_vector(data, {2, 3}, Device::CPU).transpose(0, 1);
+    const auto reference = torch::tensor(data, torch::kFloat32)
+                               .reshape({2, 3})
+                               .transpose(0, 1);
+
+    const auto [actual_values, actual_indices] = input.sort(1, false);
+    const auto [expected_values, expected_indices] = reference.sort(1, false);
+    expect_float_tensor(actual_values, expected_values, "sort values from a transposed view");
+    expect_int64_tensor(actual_indices, expected_indices,
+                        "sort indices from a transposed view");
+}
+
+TEST(DiscoverySweep, NonzeroSplitReturnsOneCoordinateTensorPerAxis) {
+    const std::vector<float> data = {1.0f, 0.0f,
+                                     0.0f, 2.0f};
+    const auto input = Tensor::from_vector(data, {2, 2}, Device::CPU);
+    const auto reference = torch::tensor(data, torch::kFloat32).reshape({2, 2});
+
+    const auto actual = input.nonzero_split();
+    const auto expected = reference.nonzero().unbind(1);
+    ASSERT_EQ(actual.size(), expected.size())
+        << "nonzero_split must mirror nonzero(as_tuple=true)";
+    for (size_t axis = 0; axis < actual.size(); ++axis) {
+        expect_int64_tensor(actual[axis], expected[axis], "nonzero_split coordinate axis");
+    }
+}
+
+TEST(DiscoverySweep, NoOpViewTransformsPreserveAliasing) {
+    {
+        const std::vector<float> data = {1.0f, 2.0f,
+                                         3.0f, 4.0f};
+        auto actual_base = Tensor::from_vector(data, {2, 2}, Device::CPU);
+        auto expected_base = torch::tensor(data, torch::kFloat32).reshape({2, 2});
+
+        auto actual_view = actual_base.squeeze(0); // dimension 0 is not singleton
+        auto expected_view = expected_base.squeeze(0);
+        actual_view.add_(10.0f);
+        expected_view.add_(10.0f);
+        expect_float_tensor(actual_base, expected_base,
+                            "squeeze(non-singleton) must remain an alias");
+    }
+
+    {
+        const std::vector<float> data = {1.0f, 2.0f, 3.0f};
+        auto actual_base = Tensor::from_vector(data, {3}, Device::CPU);
+        auto expected_base = torch::tensor(data, torch::kFloat32);
+
+        auto actual_view = actual_base.t();
+        auto expected_view = expected_base.t();
+        actual_view.mul_(2.0f);
+        expected_view.mul_(2.0f);
+        expect_float_tensor(actual_base, expected_base,
+                            "t() on a vector must remain an alias");
+    }
+}
+
+TEST(DiscoverySweep, RowProxyTensorConversionPreservesAliasing) {
+    const std::vector<float> data = {1.0f, 2.0f,
+                                     3.0f, 4.0f};
+    auto actual_base = Tensor::from_vector(data, {2, 2}, Device::CPU);
+    auto expected_base = torch::tensor(data, torch::kFloat32).reshape({2, 2});
+
+    Tensor actual_row = actual_base[0];
+    auto expected_row = expected_base[0];
+    actual_row.add_(10.0f);
+    expected_row.add_(10.0f);
+
+    expect_float_tensor(actual_base, expected_base,
+                        "Tensor converted from tensor[row] must alias the parent row");
+}
+
+TEST(DiscoverySweep, CdistMaterializesTheLeftView) {
+    const std::vector<float> lhs_data = {1.0f, 2.0f, 3.0f,
+                                         4.0f, 5.0f, 6.0f};
+    const std::vector<float> rhs_data = {0.0f, 0.0f};
+    const auto lhs = Tensor::from_vector(lhs_data, {2, 3}, Device::CPU).transpose(0, 1);
+    const auto rhs = Tensor::from_vector(rhs_data, {1, 2}, Device::CPU);
+    const auto reference_lhs = torch::tensor(lhs_data, torch::kFloat32)
+                                   .reshape({2, 3})
+                                   .transpose(0, 1);
+    const auto reference_rhs = torch::tensor(rhs_data, torch::kFloat32).reshape({1, 2});
+    const auto expected = (reference_lhs.unsqueeze(1) - reference_rhs.unsqueeze(0))
+                              .square()
+                              .sum(2)
+                              .sqrt();
+
+    expect_float_tensor(lhs.cdist(rhs, 2.0f), expected,
+                        "cdist with a non-contiguous left input");
+}
+
+TEST(DiscoverySweep, CdistSupportsZeroAndInfinityNorms) {
+    const std::vector<float> lhs_data = {0.0f, 2.0f, 3.0f};
+    const std::vector<float> rhs_data = {0.0f, 5.0f, 1.0f};
+    const auto lhs = Tensor::from_vector(lhs_data, {1, 3}, Device::CPU);
+    const auto rhs = Tensor::from_vector(rhs_data, {1, 3}, Device::CPU);
+    const auto reference_lhs = torch::tensor(lhs_data, torch::kFloat32).reshape({1, 3});
+    const auto reference_rhs = torch::tensor(rhs_data, torch::kFloat32).reshape({1, 3});
+
+    for (const float p : {0.0f, std::numeric_limits<float>::infinity()}) {
+        SCOPED_TRACE(::testing::Message() << "p=" << p);
+        const auto expected = torch::cdist(reference_lhs, reference_rhs, p);
+        std::optional<Tensor> actual;
+        ASSERT_NO_THROW(actual.emplace(lhs.cdist(rhs, p)));
+        expect_float_tensor(*actual, expected, "cdist norm domain");
+    }
+}
+
+TEST(DiscoverySweep, MaxPool2dPreservesNonFiniteMaxima) {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const std::vector<float> data = {1.0f, nan, 2.0f, 3.0f};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::from_vector(data, {1, 1, 2, 2}, device);
+        auto reference = torch::tensor(data, torch::kFloat32).reshape({1, 1, 2, 2});
+        if (device == Device::CUDA) {
+            reference = reference.cuda();
+        }
+        expect_float_tensor(input.max_pool2d(2, 2),
+                            torch::max_pool2d(reference, {2, 2}, {2, 2}),
+                            "max_pool2d NaN propagation");
+
+        const std::vector<float> negative_infinity = {
+            -std::numeric_limits<float>::infinity()};
+        const auto inf_input = Tensor::from_vector(negative_infinity, {1, 1, 1, 1}, device);
+        auto inf_reference = torch::tensor(negative_infinity, torch::kFloat32)
+                                 .reshape({1, 1, 1, 1});
+        if (device == Device::CUDA)
+            inf_reference = inf_reference.cuda();
+        expect_float_tensor(inf_input.max_pool2d(1, 1),
+                            torch::max_pool2d(inf_reference, {1, 1}, {1, 1}),
+                            "max_pool2d negative-infinity propagation");
+    }
+}
+
+TEST(DiscoverySweep, MaxPool2dRejectsZeroSizedOutput) {
+    const std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::from_vector(data, {1, 1, 2, 2}, device);
+        auto reference = torch::tensor(data, torch::kFloat32).reshape({1, 1, 2, 2});
+        if (device == Device::CUDA) {
+            reference = reference.cuda();
+        }
+
+        EXPECT_THROW(torch::max_pool2d(reference, {3, 3}, {2, 2}), std::exception);
+        EXPECT_THROW(input.max_pool2d(3, 2), std::exception);
+    }
+}
+
+TEST(DiscoverySweep, ClampMaterializesItsInputView) {
+    const std::vector<float> data = {1.0f, 2.0f, 3.0f,
+                                     4.0f, 5.0f, 6.0f};
+    const auto input = Tensor::from_vector(data, {2, 3}, Device::CPU).transpose(0, 1);
+    const auto reference = torch::tensor(data, torch::kFloat32)
+                               .reshape({2, 3})
+                               .transpose(0, 1);
+
+    expect_float_tensor(input.clamp(2.5f, 4.5f), reference.clamp(2.5f, 4.5f),
+                        "clamp on a transposed view");
+}
+
+TEST(DiscoverySweep, LazyPointwiseOnOffsetSliceMatchesTorch) {
+    const std::vector<float> data = {0.0f, 0.0f, 0.0f, 0.0f,
+                                     0.0f, 0.0f, 0.0f, 0.0f,
+                                     0.0f, 3.0f, 0.0f, 0.0f};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::from_vector(data, {1, 3, 4}, device).slice(2, 1, 2);
+        auto reference = torch::tensor(data, torch::kFloat32)
+                             .reshape({1, 3, 4})
+                             .slice(2, 1, 2);
+        if (device == Device::CUDA)
+            reference = reference.cuda();
+
+        const auto actual_pointwise = input.mul(3.0f);
+        const auto expected_pointwise = reference.mul(3.0f);
+        const auto actual_fused_reduce = input.mul(3.0f).mean();
+        const auto expected_fused_reduce = reference.mul(3.0f).mean();
+        expect_float_tensor(actual_fused_reduce, expected_fused_reduce,
+                            "reduction directly consuming deferred scalar multiplication");
+        expect_float_tensor(actual_pointwise, expected_pointwise,
+                            "deferred scalar multiplication on an offset slice");
+        expect_float_tensor(actual_pointwise.mean(), expected_pointwise.mean(),
+                            "reduction after deferred scalar multiplication on an offset slice");
+    }
+}
+
+TEST(DiscoverySweep, InPlaceMatchesOutOfPlaceOnContiguousInputs) {
+    const std::vector<float> data = {-2.0f, 0.0f, 3.0f, 5.0f};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto actual = Tensor::from_vector(data, {2, 2}, device);
+        actual.add_(2.0f);
+        auto reference = torch::tensor(data, torch::kFloat32).reshape({2, 2});
+        if (device == Device::CUDA)
+            reference = reference.cuda();
+        expect_float_tensor(actual, reference.add(2.0f),
+                            "in-place add equals out-of-place add");
+    }
+}
+
+TEST(DiscoverySweep, NonzeroUsesLogicalViewOrder) {
+    const std::vector<float> data = {0.0f, 1.0f, 0.0f,
+                                     0.0f, 0.0f, 2.0f};
+    const auto input = Tensor::from_vector(data, {2, 3}, Device::CPU).transpose(0, 1);
+    const auto reference = torch::tensor(data, torch::kFloat32)
+                               .reshape({2, 3})
+                               .transpose(0, 1);
+
+    expect_int64_tensor(input.nonzero(), reference.nonzero(),
+                        "nonzero on a transposed view");
+}
+
+TEST(DiscoverySweep, MinMaxWithIndicesPropagateNaNs) {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const std::vector<float> data = {1.0f, nan, -1.0f};
+    const auto input = Tensor::from_vector(data, {1, 3}, Device::CPU);
+    const auto reference = torch::tensor(data, torch::kFloat32).reshape({1, 3});
+
+    const auto [actual_min, actual_min_index] = input.min_with_indices(1, false);
+    const auto [expected_min, expected_min_index] = reference.min(1, false);
+    expect_float_tensor(actual_min, expected_min, "min_with_indices NaN value");
+    expect_int64_tensor(actual_min_index, expected_min_index, "min_with_indices NaN index");
+
+    const auto [actual_max, actual_max_index] = input.max_with_indices(1, false);
+    const auto [expected_max, expected_max_index] = reference.max(1, false);
+    expect_float_tensor(actual_max, expected_max, "max_with_indices NaN value");
+    expect_int64_tensor(actual_max_index, expected_max_index, "max_with_indices NaN index");
+}
+
+TEST(DiscoverySweep, ReassigningLazyPointwiseOnExpandedSliceMatchesTorch) {
+    const std::vector<float> data = {0.0f, 5.0f};
+    const auto input = Tensor::from_vector(data, {2}, Device::CPU)
+                           .unsqueeze(1)
+                           .expand({2, 3})
+                           .slice(1, 0, 1);
+    const auto reference = torch::tensor(data, torch::kFloat32)
+                               .unsqueeze(1)
+                               .expand({2, 3})
+                               .slice(1, 0, 1);
+
+    auto actual = input;
+    actual = actual.mul(2.0f);
+    actual = actual.mul(-2.0f);
+    auto expected = reference;
+    expected = expected.mul(2.0f);
+    expected = expected.mul(-2.0f);
+
+    expect_float_tensor(actual.sum(), expected.sum(),
+                        "sum consuming a pointwise chain on an expanded slice");
+    expect_float_tensor(actual, expected, "reassigned pointwise result on an expanded slice");
+}
+
+TEST(DiscoverySweep, ArgMinAndArgMaxPublicApisMatchTorch) {
+    const std::vector<float> data = {3.0f, -2.0f, 7.0f, 1.0f};
+    const auto input = Tensor::from_vector(data, {4}, Device::CPU);
+    const auto reference = torch::tensor(data, torch::kFloat32);
+
+    try {
+        expect_int64_tensor(input.argmax(), reference.argmax(), "argmax public API");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << "argmax unexpectedly threw: " << error.what();
+    }
+    try {
+        expect_int64_tensor(input.argmin(), reference.argmin(), "argmin public API");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << "argmin unexpectedly threw: " << error.what();
+    }
+}
+
+TEST(DiscoverySweep, IntegerClampBoundsMatchTorch) {
+    const std::vector<int> data = {-3, -1, 0, 1, 3};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto input = Tensor::from_vector(data, {data.size()}, Device::CPU);
+        auto reference = torch::tensor(data, torch::kInt32);
+        if (device == Device::CUDA) {
+            input = input.cuda();
+            reference = reference.cuda();
+        }
+
+        const auto actual_unbounded = input.clamp(
+            -std::numeric_limits<float>::infinity(),
+            std::numeric_limits<float>::infinity());
+        const auto expected_unbounded = reference.clamp(
+            -std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::infinity());
+        expect_float_tensor(actual_unbounded, expected_unbounded,
+                            "Int32 clamp with infinite bounds");
+
+        const auto actual_fractional = input.clamp(-0.5f, 1.5f);
+        const auto expected_fractional = reference.clamp(-0.5, 1.5);
+        expect_float_tensor(actual_fractional, expected_fractional,
+                            "Int32 clamp with fractional bounds");
+        EXPECT_EQ(actual_fractional.dtype(),
+                  expected_fractional.scalar_type() == torch::kFloat32
+                      ? DataType::Float32
+                      : DataType::Int32);
+    }
+}
+
+TEST(DiscoverySweep, FullShapeBooleanIndexingMatchesTorch) {
+    const std::vector<float> data = {1.0f, 2.0f, 3.0f,
+                                     4.0f, 5.0f, 6.0f};
+    const std::vector<bool> mask_data = {true, false, true,
+                                         false, true, false};
+    const auto reference = torch::tensor(data, torch::kFloat32).reshape({2, 3});
+    const auto reference_mask = torch::tensor(
+                                    std::vector<int>{1, 0, 1, 0, 1, 0}, torch::kInt32)
+                                    .reshape({2, 3})
+                                    .to(torch::kBool);
+    const auto expected = reference.index({reference_mask});
+
+    auto mutable_input = Tensor::from_vector(data, {2, 3}, Device::CPU);
+    const auto mutable_mask = Tensor::from_vector(mask_data, {2, 3}, Device::CPU);
+    try {
+        const Tensor actual = mutable_input[mutable_mask];
+        expect_float_tensor(actual, expected, "mutable full-shape Bool operator[]");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << "mutable full-shape Bool indexing unexpectedly threw: "
+                      << error.what();
+    }
+
+    const auto const_input = Tensor::from_vector(data, {2, 3}, Device::CPU);
+    const auto const_mask = Tensor::from_vector(mask_data, {2, 3}, Device::CPU);
+    try {
+        const Tensor actual = const_input[const_mask];
+        expect_float_tensor(actual, expected, "const full-shape Bool operator[]");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << "const full-shape Bool indexing unexpectedly threw: "
+                      << error.what();
+    }
+}
+
+TEST(DiscoverySweep, MaskedOpsBroadcastMasksLikeTorch) {
+    const std::vector<float> data = {1.0f, 2.0f, 3.0f,
+                                     4.0f, 5.0f, 6.0f};
+    const std::vector<bool> mask_data = {true, false, true};
+    const auto reference = torch::tensor(data, torch::kFloat32).reshape({2, 3});
+    const auto reference_mask = torch::tensor(
+                                    std::vector<int>{1, 0, 1}, torch::kInt32)
+                                    .reshape({1, 3})
+                                    .to(torch::kBool);
+
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto input = Tensor::from_vector(data, {2, 3}, Device::CPU);
+        auto mask = Tensor::from_vector(mask_data, {1, 3}, Device::CPU);
+        auto torch_input = reference;
+        auto torch_mask = reference_mask;
+        if (device == Device::CUDA) {
+            input = input.cuda();
+            mask = mask.cuda();
+            torch_input = torch_input.cuda();
+            torch_mask = torch_mask.cuda();
+        }
+
+        try {
+            const auto actual = input.masked_select(mask);
+            expect_float_tensor(actual, torch_input.masked_select(torch_mask),
+                                "masked_select with broadcast mask");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "masked_select unexpectedly rejected a broadcast mask: "
+                          << error.what();
+        }
+
+        try {
+            const auto actual = input.masked_fill(mask, -9.0f);
+            expect_float_tensor(actual, torch_input.masked_fill(torch_mask, -9.0),
+                                "masked_fill with broadcast mask");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "masked_fill unexpectedly rejected a broadcast mask: "
+                          << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, MaskedFillAcceptsNonFiniteFloatValues) {
+    const std::vector<float> data = {1.0f, 2.0f, 3.0f};
+    const std::vector<bool> mask_data = {false, true, false};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto input = Tensor::from_vector(data, {3}, Device::CPU);
+        auto mask = Tensor::from_vector(mask_data, {3}, Device::CPU);
+        auto reference = torch::tensor(data, torch::kFloat32);
+        auto reference_mask = torch::tensor(
+                                  std::vector<int>{0, 1, 0}, torch::kInt32)
+                                  .to(torch::kBool);
+        if (device == Device::CUDA) {
+            input = input.cuda();
+            mask = mask.cuda();
+            reference = reference.cuda();
+            reference_mask = reference_mask.cuda();
+        }
+
+        for (const float value : {
+                 -std::numeric_limits<float>::infinity(),
+                 std::numeric_limits<float>::quiet_NaN()}) {
+            SCOPED_TRACE(std::isnan(value) ? "NaN" : "-Inf");
+            try {
+                const auto actual = input.masked_fill(mask, value);
+                expect_float_tensor(actual, reference.masked_fill(reference_mask, value),
+                                    "masked_fill non-finite Float32 scalar");
+            } catch (const std::exception& error) {
+                ADD_FAILURE() << "masked_fill unexpectedly rejected a non-finite "
+                                 "Float32 scalar: "
+                              << error.what();
+            }
+        }
+    }
+}
+
+TEST(DiscoverySweep, BoolMaskedFillUsesScalarTruthiness) {
+    const std::vector<bool> mask_data = {true, false, true};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto mask = Tensor::from_vector(mask_data, {3}, device);
+        const auto input = Tensor::zeros_bool({3}, device);
+        auto reference_mask = torch::tensor(
+                                  std::vector<int>{1, 0, 1}, torch::kInt32)
+                                  .to(torch::kBool);
+        auto reference = torch::zeros({3}, torch::kBool);
+        if (device == Device::CUDA) {
+            reference_mask = reference_mask.cuda();
+            reference = reference.cuda();
+        }
+        const auto expected = reference.masked_fill(reference_mask, -1.0);
+
+        try {
+            const auto actual = input.masked_fill(mask, -1.0f);
+            expect_shape(actual, expected, "Bool masked_fill scalar truthiness");
+            EXPECT_EQ(actual.cpu().to(DataType::UInt8).to_vector_uint8(),
+                      torch_uint8_values(expected));
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "Bool masked_fill unexpectedly rejected a truthy scalar: "
+                          << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, NormalAllowsZeroStandardDeviation) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto options = torch::TensorOptions().dtype(torch::kFloat32);
+        if (device == Device::CUDA)
+            options = options.device(torch::kCUDA);
+        auto expected = torch::empty({4}, options);
+        ASSERT_NO_THROW(expected.normal_(2.5, 0.0));
+
+        try {
+            const auto actual = Tensor::normal({4}, 2.5f, 0.0f, device);
+            expect_float_tensor(actual, expected, "normal with std=0");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "normal unexpectedly rejected std=0: " << error.what();
+        }
+
+        auto actual_in_place = Tensor::empty({4}, device, DataType::Float32);
+        try {
+            actual_in_place.normal_(2.5f, 0.0f);
+            expect_float_tensor(actual_in_place, expected, "normal_ with std=0");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "normal_ unexpectedly rejected std=0: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, MixedNormalApisAdvanceCudaGenerator) {
+    constexpr uint64_t seed = 0x12345;
+    constexpr size_t count = 8;
+
+    torch::manual_seed(seed);
+    const auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+    const auto torch_first = torch::randn({static_cast<int64_t>(count)}, options);
+    auto torch_second = torch::empty({static_cast<int64_t>(count)}, options);
+    torch_second.normal_();
+    EXPECT_FALSE(torch::equal(torch_first, torch_second))
+        << "Torch's sequential normal APIs must advance their shared generator";
+
+    Tensor::manual_seed(seed);
+    const auto first = Tensor::normal({count}, 0.0f, 1.0f, Device::CUDA);
+    auto second = Tensor::empty({count}, Device::CUDA, DataType::Float32);
+    second.normal_(0.0f, 1.0f);
+    EXPECT_NE(lfs_float_values(first), lfs_float_values(second))
+        << "static normal followed by normal_ reused the same CUDA subsequence";
+}
+
+TEST(DiscoverySweep, BatchedMatmulBroadcastsSingletonBatch) {
+    const std::vector<float> left_data = {1.0f, 2.0f, 3.0f,
+                                          4.0f, 5.0f, 6.0f};
+    std::vector<float> right_data(4 * 3 * 2);
+    for (size_t i = 0; i < right_data.size(); ++i) {
+        right_data[i] = static_cast<float>(static_cast<int>(i % 5) - 2);
+    }
+
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto left = Tensor::from_vector(left_data, {1, 2, 3}, Device::CPU);
+        auto right = Tensor::from_vector(right_data, {4, 3, 2}, Device::CPU);
+        auto torch_left = torch::tensor(left_data, torch::kFloat32).reshape({1, 2, 3});
+        auto torch_right = torch::tensor(right_data, torch::kFloat32).reshape({4, 3, 2});
+        if (device == Device::CUDA) {
+            left = left.cuda();
+            right = right.cuda();
+            torch_left = torch_left.cuda();
+            torch_right = torch_right.cuda();
+        }
+
+        try {
+            const auto actual = left.matmul(right);
+            expect_float_tensor(actual, torch::matmul(torch_left, torch_right),
+                                "rank-3 matmul singleton batch broadcast");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "matmul unexpectedly rejected broadcastable batch dimensions: "
+                          << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, FullMinMaxReductionsPropagateNaNs) {
+    const std::vector<float> data = {1.0f, std::numeric_limits<float>::quiet_NaN(), -2.0f};
+
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto input = Tensor::from_vector(data, {3}, Device::CPU);
+        auto reference = torch::tensor(data, torch::kFloat32);
+        if (device == Device::CUDA) {
+            input = input.cuda();
+            reference = reference.cuda();
+        }
+
+        expect_float_tensor(input.max(), reference.max(), "full max with a later NaN");
+        expect_float_tensor(input.min(), reference.min(), "full min with a later NaN");
+    }
+}
+
+TEST(DiscoverySweep, UniformFactoryAllowsDegenerateInterval) {
+    constexpr float value = 2.5f;
+
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto expected = torch::empty({4}, torch::TensorOptions().dtype(torch::kFloat32));
+        if (device == Device::CUDA) {
+            expected = expected.cuda();
+        }
+        expected.uniform_(value, value);
+
+        auto inplace = Tensor::empty({4}, device, DataType::Float32);
+        inplace.uniform_(value, value);
+        expect_float_tensor(inplace, expected, "uniform_ with equal bounds");
+
+        try {
+            const auto factory = Tensor::uniform({4}, value, value, device, DataType::Float32);
+            expect_float_tensor(factory, expected, "uniform factory with equal bounds");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "uniform factory unexpectedly rejected equal bounds: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, ArangeDoesNotIncludeFloatingEndpoint) {
+    const auto actual = Tensor::arange(0.0f, 0.3f, 0.1f);
+    const auto expected = torch::arange(
+        0.0f, 0.3f, 0.1f,
+        torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
+    expect_float_tensor(actual, expected, "floating-point arange endpoint exclusion");
+}
+
+TEST(DiscoverySweep, SplitBatchPreservesEmptyInput) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::empty({0, 3}, device, DataType::Float32);
+        const auto actual = Tensor::split_batch(input, 2);
+        const auto reference = torch::empty(
+            {0, 3}, torch::TensorOptions().dtype(torch::kFloat32).device(device == Device::CUDA ? torch::kCUDA : torch::kCPU));
+        const auto expected = reference.split(2, 0);
+
+        EXPECT_EQ(actual.size(), expected.size());
+        for (size_t i = 0; i < std::min(actual.size(), expected.size()); ++i) {
+            expect_shape(actual[i], expected[i], "empty split_batch chunk");
+        }
+    }
+}
+
+TEST(DiscoverySweep, AdaptiveAvgPoolRejectsEmptySpatialInput) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto input = Tensor::empty({1, 1, 0, 3}, device, DataType::Float32);
+        auto reference = torch::empty({1, 1, 0, 3}, torch::TensorOptions().dtype(torch::kFloat32));
+        if (device == Device::CUDA) {
+            reference = reference.cuda();
+        }
+
+        EXPECT_THROW(torch::adaptive_avg_pool2d(reference, {2, 2}), c10::Error);
+        EXPECT_THROW(static_cast<void>(input.adaptive_avg_pool2d(2, 2)), std::exception);
+    }
+}
+
+TEST(DiscoverySweep, FullUInt8ScalarDomainMatchesTorch) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        for (const float value : {-1.0f, -0.5f, 255.5f, 256.0f}) {
+            SCOPED_TRACE(value);
+            bool torch_threw = false;
+            std::vector<uint8_t> expected;
+            try {
+                auto reference = torch::full(
+                    {1}, value,
+                    torch::TensorOptions().dtype(torch::kUInt8).device(device == Device::CUDA ? torch::kCUDA : torch::kCPU));
+                expected = torch_uint8_values(reference);
+            } catch (const std::exception&) {
+                torch_threw = true;
+            }
+
+            bool lfs_threw = false;
+            std::vector<uint8_t> actual;
+            try {
+                actual = Tensor::full({1}, value, device, DataType::UInt8)
+                             .cpu()
+                             .to_vector_uint8();
+            } catch (const std::exception&) {
+                lfs_threw = true;
+            }
+
+            EXPECT_EQ(lfs_threw, torch_threw);
+            if (!torch_threw && !lfs_threw) {
+                EXPECT_EQ(actual, expected);
+            }
+        }
+    }
+}
+
+TEST(DiscoverySweep, MaximumMinimumPreserveSignedZero) {
+    const std::vector<float> left_data = {-0.0f, 0.0f};
+    const std::vector<float> right_data = {0.0f, -0.0f};
+
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto left = Tensor::from_vector(left_data, {2}, device);
+        auto right = Tensor::from_vector(right_data, {2}, device);
+        auto torch_left = torch::tensor(left_data, torch::kFloat32);
+        auto torch_right = torch::tensor(right_data, torch::kFloat32);
+        if (device == Device::CUDA) {
+            torch_left = torch_left.cuda();
+            torch_right = torch_right.cuda();
+        }
+
+        const auto actual_max = lfs_float_values(left.maximum(right));
+        const auto actual_min = lfs_float_values(left.minimum(right));
+        const auto expected_max = torch_float_values(torch::maximum(torch_left, torch_right));
+        const auto expected_min = torch_float_values(torch::minimum(torch_left, torch_right));
+        ASSERT_EQ(actual_max.size(), expected_max.size());
+        ASSERT_EQ(actual_min.size(), expected_min.size());
+        for (size_t i = 0; i < actual_max.size(); ++i) {
+            EXPECT_EQ(std::signbit(actual_max[i]), std::signbit(expected_max[i]))
+                << "maximum signed zero at index " << i;
+            EXPECT_EQ(std::signbit(actual_min[i]), std::signbit(expected_min[i]))
+                << "minimum signed zero at index " << i;
+        }
+
+        const auto reduced_max = lfs_float_values(left.max());
+        const auto reduced_min = lfs_float_values(right.min());
+        const auto expected_reduced_max = torch_float_values(torch_left.max());
+        const auto expected_reduced_min = torch_float_values(torch_right.min());
+        EXPECT_EQ(std::signbit(reduced_max.front()),
+                  std::signbit(expected_reduced_max.front()))
+            << "full maximum signed zero";
+        EXPECT_EQ(std::signbit(reduced_min.front()),
+                  std::signbit(expected_reduced_min.front()))
+            << "full minimum signed zero";
+    }
+}
+
+TEST(DiscoverySweep, ElementwiseMaximumMinimumPropagateNaNs) {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const std::vector<float> left_data = {1.0f, nan};
+    const std::vector<float> right_data = {nan, 1.0f};
+
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto left = Tensor::from_vector(left_data, {2}, device);
+        const auto right = Tensor::from_vector(right_data, {2}, device);
+        auto torch_left = torch::tensor(left_data, torch::kFloat32);
+        auto torch_right = torch::tensor(right_data, torch::kFloat32);
+        if (device == Device::CUDA) {
+            torch_left = torch_left.cuda();
+            torch_right = torch_right.cuda();
+        }
+
+        expect_float_tensor(left.maximum(right),
+                            torch::maximum(torch_left, torch_right),
+                            "elementwise maximum NaN propagation");
+        expect_float_tensor(left.minimum(right),
+                            torch::minimum(torch_left, torch_right),
+                            "elementwise minimum NaN propagation");
+    }
+}
+
+TEST(DiscoverySweep, RowProxyAssignmentAcceptsNonFiniteFloatValues) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        for (const float value : {std::numeric_limits<float>::infinity(),
+                                  std::numeric_limits<float>::quiet_NaN()}) {
+            auto actual = Tensor::zeros({1}, device, DataType::Float32);
+            auto expected = torch::full(
+                {1}, value,
+                torch::TensorOptions().dtype(torch::kFloat32).device(device == Device::CUDA ? torch::kCUDA : torch::kCPU));
+            try {
+                actual[0] = value;
+                expect_float_tensor(actual, expected, "row-proxy non-finite scalar assignment");
+            } catch (const std::exception& error) {
+                ADD_FAILURE() << "row proxy unexpectedly rejected a representable Float32 value: "
+                              << error.what();
+            }
+        }
+    }
+}
+
+TEST(DiscoverySweep, FillAcceptsNonFiniteFloatValues) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        for (const float value : {-std::numeric_limits<float>::infinity(),
+                                  std::numeric_limits<float>::quiet_NaN()}) {
+            auto actual = Tensor::zeros({3}, device, DataType::Float32);
+            auto expected = torch::zeros(
+                {3}, torch::TensorOptions().dtype(torch::kFloat32).device(device == Device::CUDA ? torch::kCUDA : torch::kCPU));
+            expected.fill_(value);
+            try {
+                actual.fill_(value);
+                expect_float_tensor(actual, expected, "fill_ with non-finite Float32 value");
+            } catch (const std::exception& error) {
+                ADD_FAILURE() << "fill_ unexpectedly rejected a representable Float32 value: "
+                              << error.what();
+            }
+        }
+    }
+}
+
+TEST(DiscoverySweep, IntegerFillRejectsOutOfRangeValuesLikeTorch) {
+    constexpr float out_of_range = std::numeric_limits<float>::max();
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto actual = Tensor::zeros({2}, device, DataType::Int32);
+        auto expected = torch::zeros(
+            {2}, torch::TensorOptions().dtype(torch::kInt32).device(device == Device::CUDA ? torch::kCUDA : torch::kCPU));
+
+        EXPECT_THROW(expected.fill_(out_of_range), std::exception);
+        EXPECT_THROW(actual.fill_(out_of_range), std::exception);
+    }
+}
+
+TEST(DiscoverySweep, ScalarMathAcceptsNonFiniteOperands) {
+    const std::vector<float> data = {0.0f, 1.0f};
+    const float infinity = std::numeric_limits<float>::infinity();
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        auto input = Tensor::from_vector(data, {2}, device);
+        auto reference = torch::tensor(data, torch::kFloat32);
+        if (device == Device::CUDA) {
+            reference = reference.cuda();
+        }
+
+        try {
+            expect_float_tensor(input.add(infinity), reference.add(infinity),
+                                "scalar addition with infinity");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar arithmetic unexpectedly rejected infinity: " << error.what();
+        }
+
+        try {
+            const auto actual = input.eq(nan);
+            const auto expected = reference.eq(nan);
+            expect_shape(actual, expected, "scalar equality with NaN");
+            EXPECT_EQ(actual.cpu().to(DataType::UInt8).to_vector_uint8(),
+                      torch_uint8_values(expected))
+                << "scalar equality with NaN";
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar comparison unexpectedly rejected NaN: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, ScalarWhereSupportsZeroDimensionalInputs) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+
+        const auto condition = Tensor::full_bool({}, true, device);
+        const auto x = Tensor::full({}, 2.0f, device);
+        const auto y = Tensor::full({}, -3.0f, device);
+
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto expected = torch::where(
+            torch::scalar_tensor(true, torch::TensorOptions().dtype(torch::kBool).device(torch_device)),
+            torch::scalar_tensor(2.0f, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device)),
+            torch::scalar_tensor(-3.0f, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device)));
+
+        try {
+            const auto actual = Tensor::where(condition, x, y);
+            expect_float_tensor(actual, expected, "scalar where");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar where unexpectedly threw: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, CatAndStackPromoteMixedDtypesLikeTorch) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+
+        const auto ints = Tensor::from_vector(
+            std::vector<int>{1, 2}, {2}, device);
+        const auto floats = Tensor::from_vector(
+            std::vector<float>{0.5f, 1.5f}, {2}, device);
+
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto torch_ints = torch::tensor(
+            {1, 2}, torch::TensorOptions().dtype(torch::kInt32).device(torch_device));
+        const auto torch_floats = torch::tensor(
+            {0.5f, 1.5f}, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+        const auto expected_cat = torch::cat({torch_ints, torch_floats});
+        const auto expected_stack = torch::stack({torch_ints, torch_floats});
+        ASSERT_EQ(expected_cat.scalar_type(), torch::kFloat32);
+        ASSERT_EQ(expected_stack.scalar_type(), torch::kFloat32);
+
+        try {
+            const auto actual = Tensor::cat({ints, floats});
+            EXPECT_EQ(actual.dtype(), DataType::Float32);
+            expect_float_tensor(actual, expected_cat, "mixed-dtype cat");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "mixed-dtype cat unexpectedly threw: " << error.what();
+        }
+
+        try {
+            const auto actual = Tensor::stack({ints, floats});
+            EXPECT_EQ(actual.dtype(), DataType::Float32);
+            expect_float_tensor(actual, expected_stack, "mixed-dtype stack");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "mixed-dtype stack unexpectedly threw: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, ScalarReductionsAcceptDimZeroLikeTorch) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+
+        const auto input = Tensor::full({}, 6.0f, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto reference = torch::scalar_tensor(
+            6.0f, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+
+        const auto expected_sum = reference.sum(/*dim=*/0, /*keepdim=*/false);
+        const auto expected_mean = reference.mean(/*dim=*/0, /*keepdim=*/false);
+        const auto expected_prod = reference.prod(/*dim=*/0, /*keepdim=*/false);
+
+        try {
+            expect_float_tensor(input.sum(0), expected_sum, "scalar sum(dim=0)");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar sum(dim=0) unexpectedly threw: " << error.what();
+        }
+        try {
+            expect_float_tensor(input.mean(0), expected_mean, "scalar mean(dim=0)");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar mean(dim=0) unexpectedly threw: " << error.what();
+        }
+        try {
+            expect_float_tensor(input.prod(0), expected_prod, "scalar prod(dim=0)");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar prod(dim=0) unexpectedly threw: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, IntegerPowScalarOverloadRejectsNegativeIntegerExponent) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+
+        const auto input = Tensor::from_vector(
+            std::vector<int>{2, -2}, {2}, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto torch_input = torch::tensor(
+            {2, -2}, torch::TensorOptions().dtype(torch::kInt32).device(torch_device));
+
+        EXPECT_THROW((void)torch::pow(torch_input, -1), c10::Error);
+
+        EXPECT_THROW({
+            const auto result = input.pow(-1);
+            (void)result.cpu().to_vector_int();
+        },
+                     std::runtime_error);
+    }
+}
+
+TEST(DiscoverySweep, IntegerModuloByZeroThrowsInsteadOfCrashing) {
+    const auto reference = torch::tensor({7}, torch::kInt32);
+    const auto zero = torch::tensor({0}, torch::kInt32);
+    EXPECT_THROW(static_cast<void>(torch::remainder(reference, zero)), c10::Error);
+
+    EXPECT_EXIT(
+        {
+            try {
+                const auto input = Tensor::from_vector(
+                    std::vector<int>{7}, {1}, Device::CPU);
+                const auto divisor = Tensor::from_vector(
+                    std::vector<int>{0}, {1}, Device::CPU);
+                const auto values = input.mod(divisor).to_vector_int();
+                (void)values;
+                std::_Exit(2);
+            } catch (const std::exception&) {
+                std::_Exit(0);
+            }
+        },
+        ::testing::ExitedWithCode(0),
+        "");
+}
+
+TEST(DiscoverySweep, LargeNormalInplaceCallsDoNotReuseSubsequence) {
+    constexpr size_t offset_step = 1'000'000;
+    constexpr size_t tail_size = 8;
+    constexpr uint64_t seed = 0x12345678ULL;
+
+    Tensor::manual_seed(seed);
+    auto first = Tensor::empty(
+        {offset_step + tail_size}, Device::CUDA, DataType::Float32);
+    auto second = Tensor::empty(
+        {offset_step + tail_size}, Device::CUDA, DataType::Float32);
+    first.normal_();
+    second.normal_();
+
+    const auto first_tail = lfs_float_values(
+        first.slice(0, offset_step, offset_step + tail_size));
+    const auto second_head = lfs_float_values(second.slice(0, 0, tail_size));
+
+    torch::manual_seed(seed);
+    auto torch_first = torch::empty(
+        {static_cast<int64_t>(offset_step + tail_size)},
+        torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
+    auto torch_second = torch::empty_like(torch_first);
+    torch_first.normal_();
+    torch_second.normal_();
+    ASSERT_FALSE(torch::equal(
+        torch_first.slice(0, offset_step, offset_step + tail_size),
+        torch_second.slice(0, 0, tail_size)))
+        << "Torch consumes disjoint generator state across consecutive calls";
+
+    EXPECT_NE(first_tail, second_head)
+        << "consecutive normal_ calls reused the first call's millionth-value subsequence";
+}
+
+TEST(DiscoverySweep, ScatterMinMaxPropagateNaNsLikeTorch) {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const auto indices = Tensor::from_vector(
+        std::vector<int>{0}, {1}, Device::CPU);
+    const auto source = Tensor::from_vector(
+        std::vector<float>{nan}, {1}, Device::CPU);
+    const auto torch_indices = torch::tensor({0}, torch::kInt64);
+    const auto torch_source = torch::tensor({nan}, torch::kFloat32);
+
+    for (const auto [mode, reduce] : {
+             std::pair{ScatterMode::Max, std::string_view{"amax"}},
+             std::pair{ScatterMode::Min, std::string_view{"amin"}}}) {
+        auto actual = Tensor::from_vector(
+            std::vector<float>{1.0f}, {1}, Device::CPU);
+        const auto expected = torch::tensor({1.0f}, torch::kFloat32)
+                                  .scatter_reduce(0, torch_indices, torch_source,
+                                                  reduce, /*include_self=*/true);
+        ASSERT_TRUE(std::isnan(expected.item<float>()));
+
+        actual.scatter_(0, indices, source, mode);
+        EXPECT_TRUE(std::isnan(actual.item<float>()))
+            << reduce << " scatter reduction suppressed the source NaN";
+    }
+}
+
+TEST(DiscoverySweep, MaxPool2dRejectsInvalidStrideAndPaddingLikeTorch) {
+    const std::vector<float> values = {
+        1.0f, 2.0f, 3.0f, 4.0f,
+        5.0f, 6.0f, 7.0f, 8.0f,
+        9.0f, 10.0f, 11.0f, 12.0f,
+        13.0f, 14.0f, 15.0f, 16.0f};
+
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::from_vector(values, {1, 1, 4, 4}, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto reference = torch::tensor(
+                                   values, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device))
+                                   .reshape({1, 1, 4, 4});
+
+        EXPECT_THROW(
+            (void)torch::max_pool2d(reference, {2, 2}, {1, 1}, {-1, -1}),
+            c10::Error);
+        EXPECT_THROW((void)input.max_pool2d(2, 1, -1), std::runtime_error)
+            << "negative padding must not return a cropped-looking value";
+
+        EXPECT_THROW(
+            (void)torch::max_pool2d(reference, {2, 2}, {0, 0}),
+            c10::Error);
+        EXPECT_THROW((void)input.max_pool2d(2, 0), std::runtime_error)
+            << "an explicit zero stride must not silently become kernel_size";
+    }
+}
+
+TEST(DiscoverySweep, SqueezeProducesZeroDimensionalScalarsLikeTorch) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::full({1, 1}, 7.0f, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto reference = torch::full(
+            {1, 1}, 7.0f,
+            torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+
+        const auto expected_all = reference.squeeze();
+        const auto expected_dim = reference.squeeze(0).squeeze(0);
+        ASSERT_EQ(expected_all.dim(), 0);
+        ASSERT_EQ(expected_dim.dim(), 0);
+
+        expect_float_tensor(input.squeeze(), expected_all,
+                            "squeeze all singleton dimensions");
+        expect_float_tensor(input.squeeze(0).squeeze(0), expected_dim,
+                            "squeeze singleton dimensions explicitly");
+
+        const auto scalar = Tensor::full({}, 7.0f, device);
+        const auto torch_scalar = torch::scalar_tensor(
+            7.0f, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+        try {
+            expect_float_tensor(scalar.squeeze(0), torch_scalar.squeeze(0),
+                                "squeeze(dim=0) on a scalar");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar squeeze(dim=0) unexpectedly threw: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, FlattenAcceptsZeroDimensionalScalarsLikeTorch) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::full({}, 7.0f, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto reference = torch::scalar_tensor(
+            7.0f, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+        const auto expected = reference.flatten();
+        ASSERT_EQ(expected.dim(), 1);
+        ASSERT_EQ(expected.size(0), 1);
+
+        try {
+            expect_float_tensor(input.flatten(), expected,
+                                "flatten() on a scalar");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar flatten unexpectedly threw: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, IntegerListReshapeCanProduceScalarsLikeTorch) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::full({1}, 7.0f, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto reference = torch::full(
+            {1}, 7.0f,
+            torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+        const auto expected = reference.reshape(c10::IntArrayRef{});
+        ASSERT_EQ(expected.dim(), 0);
+
+        try {
+            const auto actual = input.reshape(std::initializer_list<int>{});
+            expect_float_tensor(actual, expected,
+                                "reshape({}) through the integer-list overload");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "reshape({}) unexpectedly threw: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, TransposeAcceptsScalarDimensionAliasesLikeTorch) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::full({}, 7.0f, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto reference = torch::scalar_tensor(
+            7.0f, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+        const auto expected = reference.transpose(0, 0);
+        ASSERT_EQ(expected.dim(), 0);
+
+        try {
+            expect_float_tensor(input.transpose(0, 0), expected,
+                                "transpose(0, 0) on a scalar");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar transpose unexpectedly threw: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, SerializationRoundTripsSupportedHighRankTensor) {
+    const auto input = Tensor::full(
+        {1, 1, 1, 1, 1, 1, 1, 1}, 3.0f,
+        Device::CPU, DataType::Float32);
+    ASSERT_EQ(input.ndim(), MAX_TENSOR_RANK);
+
+    std::stringstream stream;
+    ASSERT_NO_THROW(stream << input);
+
+    Tensor loaded;
+    try {
+        stream >> loaded;
+        expect_float_tensor(
+            loaded,
+            torch::full({1, 1, 1, 1, 1, 1, 1, 1}, 3.0f, torch::kFloat32),
+            "maximum supported rank serialization round trip");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << "the serializer emitted a tensor its reader rejected: "
+                      << error.what();
+    }
+
+    // Round 3 deliberately made MAX_TENSOR_RANK a fail-loud library contract.
+    // Serialization therefore tests the maximum supported rank, while rank 9
+    // must be rejected before a writer can emit an unreadable tensor.
+    EXPECT_ANY_THROW((void)Tensor::full(
+        {1, 1, 1, 1, 1, 1, 1, 1, 1}, 3.0f,
+        Device::CPU, DataType::Float32));
+}
+
+TEST(DiscoverySweep, UnaryOnViewMatchesMaterializedLogicalValues) {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const std::vector<float> values = {0.0f, 0.0f, 0.0f, 0.0f,
+                                       0.0f, 0.0f, nan, 0.0f};
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::from_vector(values, {4, 2}, device).transpose(0, 1);
+        auto reference = torch::tensor(values, torch::kFloat32).reshape({4, 2}).transpose(0, 1);
+        if (device == Device::CUDA) {
+            reference = reference.cuda();
+        }
+        expect_float_tensor(input.neg(), reference.neg(),
+                            "neg on a transposed view");
+    }
+}
+
+TEST(DiscoverySweep, CatAcceptsZeroElementCudaInputsLikeTorch) {
+    const auto input = Tensor::empty(
+        {0, 1, 1}, Device::CUDA, DataType::Float32);
+    const auto reference = torch::empty(
+        {0, 1, 1},
+        torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
+    const auto expected = torch::cat({reference, reference}, 2);
+
+    try {
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+        const auto actual = Tensor::cat({input, input}, 2);
+        const auto status = cudaGetLastError();
+        ASSERT_EQ(status, cudaSuccess)
+            << "empty cat left a CUDA launch error: "
+            << cudaGetErrorString(status);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        expect_float_tensor(actual, expected,
+                            "CUDA cat with zero outer rows");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << "valid empty CUDA cat unexpectedly failed: " << error.what();
+    }
+}
+
+TEST(DiscoverySweep, SquareThenCumsumOnSliceMatchesMaterializedValues) {
+    const std::vector<float> values = {
+        4.0f, 1.0f,
+        -3.0f, -3.0f,
+        5.0f, 0.0f,
+        -1.0f, 4.0f};
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::from_vector(values, {4, 2}, device).slice(1, 1, 2);
+        auto reference = torch::tensor(values, torch::kFloat32)
+                             .reshape({4, 2})
+                             .slice(1, 1, 2);
+        if (device == Device::CUDA) {
+            reference = reference.cuda();
+        }
+
+        const auto squared = input.square();
+        const auto expected_squared = reference.square();
+        expect_float_tensor(squared, expected_squared,
+                            "square on a sliced column");
+        expect_float_tensor(squared.cumsum(-1), expected_squared.cumsum(-1),
+                            "cumsum after square on a sliced column");
+    }
+}
+
+TEST(DiscoverySweep, CudaColumnReductionsAcceptZeroWidthOutputsLikeTorch) {
+    const auto input = Tensor::empty({1, 0}, Device::CUDA, DataType::Float32);
+    const auto reference = torch::empty(
+        {1, 0}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
+
+    const auto check = [&](const char* name, const auto& lfs_reduce,
+                           const auto& torch_reduce) {
+        SCOPED_TRACE(name);
+        static_cast<void>(cudaGetLastError());
+        const auto actual = lfs_reduce();
+        const auto expected = torch_reduce();
+        expect_shape(actual, expected, name);
+        const cudaError_t status = cudaGetLastError();
+        EXPECT_EQ(status, cudaSuccess)
+            << name << " left CUDA error " << static_cast<int>(status)
+            << " (" << cudaGetErrorString(status) << ")";
+    };
+
+    check(
+        "sum(dim=0)", [&] { return input.sum(0); },
+        [&] { return reference.sum(0); });
+    check(
+        "mean(dim=0)", [&] { return input.mean(0); },
+        [&] { return reference.mean(0); });
+    check(
+        "max(dim=0)", [&] { return input.max(0); },
+        [&] { return std::get<0>(reference.max(0)); });
+    check(
+        "min(dim=0)", [&] { return input.min(0); },
+        [&] { return std::get<0>(reference.min(0)); });
+}
+
+TEST(DiscoverySweep, LinspacePreservesSubnormalEndpointLikeTorch) {
+    constexpr float low = 0.0f;
+    const float high = std::numeric_limits<float>::denorm_min();
+
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto actual = Tensor::linspace(low, high, 3, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto expected = torch::linspace(
+            low, high, 3,
+            torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+        expect_float_tensor(actual, expected,
+                            "linspace ending at the smallest Float32 subnormal");
+        const auto actual_values = lfs_float_values(actual);
+        const auto expected_values = torch_float_values(expected);
+        ASSERT_EQ(expected_values.back(), high);
+        EXPECT_EQ(actual_values.back(), expected_values.back())
+            << "linspace must preserve its explicitly requested endpoint exactly";
+    }
+}
+
+TEST(DiscoverySweep, ScalarCumsumAcceptsDimZeroLikeTorch) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::full({}, 7.0f, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto reference = torch::scalar_tensor(
+            7.0f, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+
+        try {
+            expect_float_tensor(input.cumsum(0), reference.cumsum(0),
+                                "scalar cumsum(dim=0)");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar cumsum(dim=0) unexpectedly threw: " << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, ScalarAdvancedOpsAcceptDimZeroLikeTorch) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::full({}, 7.0f, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto reference = torch::scalar_tensor(
+            7.0f, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+
+        try {
+            const auto [actual_values, actual_indices] = input.sort(0);
+            const auto [expected_values, expected_indices] = reference.sort(0);
+            expect_float_tensor(actual_values, expected_values, "scalar sort values");
+            expect_int64_tensor(actual_indices, expected_indices, "scalar sort indices");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar sort(dim=0) unexpectedly threw: " << error.what();
+        }
+
+        try {
+            const auto [actual_values, actual_indices] = input.min_with_indices(0);
+            const auto [expected_values, expected_indices] = reference.min(0);
+            expect_float_tensor(actual_values, expected_values,
+                                "scalar min_with_indices values");
+            expect_int64_tensor(actual_indices, expected_indices,
+                                "scalar min_with_indices indices");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar min_with_indices(dim=0) unexpectedly threw: "
+                          << error.what();
+        }
+
+        try {
+            const auto [actual_values, actual_indices] = input.max_with_indices(0);
+            const auto [expected_values, expected_indices] = reference.max(0);
+            expect_float_tensor(actual_values, expected_values,
+                                "scalar max_with_indices values");
+            expect_int64_tensor(actual_indices, expected_indices,
+                                "scalar max_with_indices indices");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar max_with_indices(dim=0) unexpectedly threw: "
+                          << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, ScalarDimensionalNormAcceptsDimZeroLikeTorch) {
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        SCOPED_TRACE(device == Device::CPU ? "CPU" : "CUDA");
+        const auto input = Tensor::full({}, -7.0f, device);
+        const auto torch_device = device == Device::CPU ? torch::kCPU : torch::kCUDA;
+        const auto reference = torch::scalar_tensor(
+            -7.0f, torch::TensorOptions().dtype(torch::kFloat32).device(torch_device));
+        const std::array<int64_t, 1> axes = {0};
+        const auto expected = at::linalg_vector_norm(
+            reference, 2.0, c10::IntArrayRef(axes), false);
+
+        try {
+            expect_float_tensor(input.norm(2.0f, 0), expected,
+                                "scalar norm(p=2, dim=0)");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "scalar norm(p=2, dim=0) unexpectedly threw: "
+                          << error.what();
+        }
+    }
+}
+
+TEST(DiscoverySweep, StackWritesContiguousInputsAlongInnerDimensions) {
+    const auto input = Tensor::from_vector(
+        std::vector<float>{4.0f}, {1, 1}, Device::CPU);
+    const auto reference = torch::tensor(
+                               std::vector<float>{4.0f}, torch::kFloat32)
+                               .reshape({1, 1});
+
+    expect_float_tensor(Tensor::stack({input, input}, 2),
+                        torch::stack({reference, reference}, 2),
+                        "CPU stack along an inserted inner dimension");
+}

--- a/tests/test_tensor_discovery_fuzz.cpp
+++ b/tests/test_tensor_discovery_fuzz.cpp
@@ -1,0 +1,1251 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/tensor.hpp"
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace lfs::core;
+
+namespace {
+
+    enum class ViewKind {
+        Transpose,
+        Permute,
+        Slice,
+        Unsqueeze,
+        Squeeze,
+        Expand,
+    };
+
+    struct ViewStep {
+        ViewKind kind{};
+        int first = 0;
+        int second = 0;
+        int64_t start = 0;
+        int64_t end = 0;
+        std::vector<int64_t> dimensions;
+    };
+
+    enum class PointwiseKind {
+        AddScalar,
+        MulScalar,
+        Abs,
+        Neg,
+        Clamp,
+        Square,
+    };
+
+    struct PointwiseStep {
+        PointwiseKind kind{};
+        float scalar = 0.0f;
+    };
+
+    enum class TerminalOp {
+        Identity,
+        Cast,
+        AddScalar,
+        MulScalar,
+        Abs,
+        Neg,
+        Clamp,
+        CompareScalar,
+        SumAll,
+        SumDim,
+        SumAxes,
+        MeanAll,
+        MeanDim,
+        StdDim,
+        VarDim,
+        Cumsum,
+        Nonzero,
+        Sort,
+        InplaceAdd,
+        BroadcastAdd,
+        MaskedSelect,
+        IndexSelect,
+        Cat,
+        Stack,
+        Matmul,
+        MinWithIndices,
+        MaxWithIndices,
+        SerializeRoundTrip,
+    };
+
+    struct FuzzProgram {
+        uint64_t seed = 0;
+        size_t iteration = 0;
+        DataType dtype = DataType::Float32;
+        Device device = Device::CPU;
+        std::vector<int64_t> base_shape;
+        std::vector<float> values;
+        std::vector<ViewStep> views;
+        std::vector<PointwiseStep> pointwise;
+        TerminalOp terminal = TerminalOp::Identity;
+        DataType cast_dtype = DataType::Float32;
+        int dim = 0;
+        std::vector<int> axes;
+        float scalar = 1.0f;
+        bool keepdim = false;
+        bool unbiased = false;
+        bool descending = false;
+    };
+
+    struct LfsRun {
+        std::vector<Tensor> outputs;
+        std::string exception;
+    };
+
+    struct TorchRun {
+        std::vector<torch::Tensor> outputs;
+        std::string exception;
+    };
+
+    constexpr std::array<DataType, 6> kDtypes = {
+        DataType::Float32,
+        DataType::Float16,
+        DataType::Int32,
+        DataType::Int64,
+        DataType::UInt8,
+        DataType::Bool,
+    };
+
+    std::string_view terminal_name(const TerminalOp op) {
+        switch (op) {
+        case TerminalOp::Identity: return "identity";
+        case TerminalOp::Cast: return "cast";
+        case TerminalOp::AddScalar: return "add_scalar";
+        case TerminalOp::MulScalar: return "mul_scalar";
+        case TerminalOp::Abs: return "abs";
+        case TerminalOp::Neg: return "neg";
+        case TerminalOp::Clamp: return "clamp";
+        case TerminalOp::CompareScalar: return "compare_scalar";
+        case TerminalOp::SumAll: return "sum_all";
+        case TerminalOp::SumDim: return "sum_dim";
+        case TerminalOp::SumAxes: return "sum_axes";
+        case TerminalOp::MeanAll: return "mean_all";
+        case TerminalOp::MeanDim: return "mean_dim";
+        case TerminalOp::StdDim: return "std_dim";
+        case TerminalOp::VarDim: return "var_dim";
+        case TerminalOp::Cumsum: return "cumsum";
+        case TerminalOp::Nonzero: return "nonzero";
+        case TerminalOp::Sort: return "sort";
+        case TerminalOp::InplaceAdd: return "inplace_add";
+        case TerminalOp::BroadcastAdd: return "broadcast_add";
+        case TerminalOp::MaskedSelect: return "masked_select";
+        case TerminalOp::IndexSelect: return "index_select";
+        case TerminalOp::Cat: return "cat";
+        case TerminalOp::Stack: return "stack";
+        case TerminalOp::Matmul: return "matmul";
+        case TerminalOp::MinWithIndices: return "min_with_indices";
+        case TerminalOp::MaxWithIndices: return "max_with_indices";
+        case TerminalOp::SerializeRoundTrip: return "serialize_round_trip";
+        }
+        return "unknown";
+    }
+
+    std::string_view view_name(const ViewKind kind) {
+        switch (kind) {
+        case ViewKind::Transpose: return "transpose";
+        case ViewKind::Permute: return "permute";
+        case ViewKind::Slice: return "slice/narrow";
+        case ViewKind::Unsqueeze: return "unsqueeze";
+        case ViewKind::Squeeze: return "squeeze";
+        case ViewKind::Expand: return "expand";
+        }
+        return "unknown";
+    }
+
+    std::string_view pointwise_name(const PointwiseKind kind) {
+        switch (kind) {
+        case PointwiseKind::AddScalar: return "add";
+        case PointwiseKind::MulScalar: return "mul";
+        case PointwiseKind::Abs: return "abs";
+        case PointwiseKind::Neg: return "neg";
+        case PointwiseKind::Clamp: return "clamp";
+        case PointwiseKind::Square: return "square";
+        }
+        return "unknown";
+    }
+
+    torch::ScalarType torch_dtype(const DataType dtype) {
+        switch (dtype) {
+        case DataType::Float32: return torch::kFloat32;
+        case DataType::Float16: return torch::kFloat16;
+        case DataType::Int32: return torch::kInt32;
+        case DataType::Int64: return torch::kInt64;
+        case DataType::UInt8: return torch::kUInt8;
+        case DataType::Bool: return torch::kBool;
+        }
+        throw std::runtime_error("unsupported fuzz dtype");
+    }
+
+    DataType lfs_dtype(const torch::ScalarType dtype) {
+        switch (dtype) {
+        case torch::kFloat32: return DataType::Float32;
+        case torch::kFloat16: return DataType::Float16;
+        case torch::kInt32: return DataType::Int32;
+        case torch::kInt64: return DataType::Int64;
+        case torch::kUInt8: return DataType::UInt8;
+        case torch::kBool: return DataType::Bool;
+        default: throw std::runtime_error("unsupported Torch result dtype");
+        }
+    }
+
+    size_t shape_numel(const std::vector<int64_t>& shape) {
+        size_t result = 1;
+        for (const int64_t extent : shape) {
+            if (extent == 0) {
+                return 0;
+            }
+            result *= static_cast<size_t>(extent);
+        }
+        return result;
+    }
+
+    std::vector<size_t> lfs_shape(const std::vector<int64_t>& shape) {
+        std::vector<size_t> result;
+        result.reserve(shape.size());
+        for (const int64_t extent : shape) {
+            result.push_back(static_cast<size_t>(extent));
+        }
+        return result;
+    }
+
+    torch::Tensor make_torch_base_cpu(const FuzzProgram& program) {
+        auto source = torch::tensor(program.values, torch::kFloat32).reshape(program.base_shape);
+        return source.to(torch_dtype(program.dtype));
+    }
+
+    torch::Tensor make_torch_base(const FuzzProgram& program) {
+        auto result = make_torch_base_cpu(program);
+        return program.device == Device::CUDA ? result.cuda() : result;
+    }
+
+    Tensor make_lfs_base(const FuzzProgram& program) {
+        auto result = Tensor::from_vector(
+            program.values, TensorShape(lfs_shape(program.base_shape)), Device::CPU);
+        if (program.dtype != DataType::Float32) {
+            result = result.to(program.dtype);
+        }
+        return program.device == Device::CUDA ? result.cuda() : result;
+    }
+
+    torch::Tensor apply_view(torch::Tensor tensor, const ViewStep& step) {
+        switch (step.kind) {
+        case ViewKind::Transpose:
+            return tensor.transpose(step.first, step.second);
+        case ViewKind::Permute:
+            return tensor.permute(step.dimensions);
+        case ViewKind::Slice:
+            return tensor.slice(step.first, step.start, step.end);
+        case ViewKind::Unsqueeze:
+            return tensor.unsqueeze(step.first);
+        case ViewKind::Squeeze:
+            return tensor.squeeze(step.first);
+        case ViewKind::Expand:
+            return tensor.expand(step.dimensions);
+        }
+        throw std::runtime_error("unknown Torch view step");
+    }
+
+    Tensor apply_view(Tensor tensor, const ViewStep& step) {
+        switch (step.kind) {
+        case ViewKind::Transpose:
+            return tensor.transpose(step.first, step.second);
+        case ViewKind::Permute: {
+            std::vector<int> dimensions(step.dimensions.begin(), step.dimensions.end());
+            return tensor.permute(dimensions);
+        }
+        case ViewKind::Slice:
+            return tensor.slice(static_cast<size_t>(step.first),
+                                static_cast<size_t>(step.start),
+                                static_cast<size_t>(step.end));
+        case ViewKind::Unsqueeze:
+            return tensor.unsqueeze(step.first);
+        case ViewKind::Squeeze:
+            return tensor.squeeze(step.first);
+        case ViewKind::Expand: {
+            std::vector<int> dimensions(step.dimensions.begin(), step.dimensions.end());
+            return tensor.expand(dimensions);
+        }
+        }
+        throw std::runtime_error("unknown LFS view step");
+    }
+
+    torch::Tensor apply_views(torch::Tensor tensor, const FuzzProgram& program) {
+        for (const auto& step : program.views) {
+            tensor = apply_view(std::move(tensor), step);
+        }
+        return tensor;
+    }
+
+    Tensor apply_views(Tensor tensor, const FuzzProgram& program) {
+        std::optional<Tensor> current;
+        current.emplace(std::move(tensor));
+        for (const auto& step : program.views) {
+            Tensor next = apply_view(std::move(*current), step);
+            current.reset();
+            current.emplace(std::move(next));
+        }
+        return std::move(*current);
+    }
+
+    torch::Tensor apply_pointwise(torch::Tensor tensor, const FuzzProgram& program) {
+        for (const auto& step : program.pointwise) {
+            switch (step.kind) {
+            case PointwiseKind::AddScalar: tensor = tensor.add(step.scalar); break;
+            case PointwiseKind::MulScalar: tensor = tensor.mul(step.scalar); break;
+            case PointwiseKind::Abs: tensor = tensor.abs(); break;
+            case PointwiseKind::Neg: tensor = tensor.neg(); break;
+            case PointwiseKind::Clamp: tensor = tensor.clamp(-2.0f, 2.0f); break;
+            case PointwiseKind::Square: tensor = tensor.square(); break;
+            }
+        }
+        return tensor;
+    }
+
+    Tensor apply_pointwise(Tensor tensor, const FuzzProgram& program) {
+        std::optional<Tensor> current;
+        current.emplace(std::move(tensor));
+        for (const auto& step : program.pointwise) {
+            Tensor next = [&]() -> Tensor {
+                switch (step.kind) {
+                case PointwiseKind::AddScalar: return current->add(step.scalar);
+                case PointwiseKind::MulScalar: return current->mul(step.scalar);
+                case PointwiseKind::Abs: return current->abs();
+                case PointwiseKind::Neg: return current->neg();
+                case PointwiseKind::Clamp: return current->clamp(-2.0f, 2.0f);
+                case PointwiseKind::Square: return current->square();
+                }
+                throw std::runtime_error("unknown LFS pointwise step");
+            }();
+            current.reset();
+            current.emplace(std::move(next));
+        }
+        return std::move(*current);
+    }
+
+    Tensor make_lfs_rhs(const Tensor& input, const size_t rows, const size_t columns) {
+        std::vector<float> data(rows * columns);
+        for (size_t i = 0; i < data.size(); ++i) {
+            data[i] = static_cast<float>(static_cast<int>(i % 7) - 3);
+        }
+        auto result = Tensor::from_vector(data, {rows, columns}, Device::CPU);
+        return input.device() == Device::CUDA ? result.cuda() : result;
+    }
+
+    torch::Tensor make_torch_rhs(const torch::Tensor& input,
+                                 const int64_t rows,
+                                 const int64_t columns) {
+        auto result = torch::arange(rows * columns, torch::kFloat32)
+                          .remainder(7)
+                          .sub(3)
+                          .reshape({rows, columns});
+        return input.is_cuda() ? result.cuda() : result;
+    }
+
+    LfsRun run_lfs(const FuzzProgram& program) {
+        try {
+            Tensor input = apply_pointwise(
+                apply_views(make_lfs_base(program), program), program);
+            switch (program.terminal) {
+            case TerminalOp::Identity:
+                return {{input}, {}};
+            case TerminalOp::Cast:
+                return {{input.to(program.cast_dtype)}, {}};
+            case TerminalOp::AddScalar:
+                return program.dtype == DataType::Int32
+                           ? LfsRun{{input.add(static_cast<int>(program.scalar))}, {}}
+                           : LfsRun{{input.add(program.scalar)}, {}};
+            case TerminalOp::MulScalar:
+                return program.dtype == DataType::Int32
+                           ? LfsRun{{input.mul(static_cast<int>(program.scalar))}, {}}
+                           : LfsRun{{input.mul(program.scalar)}, {}};
+            case TerminalOp::Abs:
+                return {{input.abs()}, {}};
+            case TerminalOp::Neg:
+                return {{input.neg()}, {}};
+            case TerminalOp::Clamp:
+                return {{input.clamp(-1, 2)}, {}};
+            case TerminalOp::CompareScalar:
+                return program.dtype == DataType::Float32
+                           ? LfsRun{{input.gt(program.scalar)}, {}}
+                           : LfsRun{{input.gt(static_cast<int>(program.scalar))}, {}};
+            case TerminalOp::SumAll:
+                return {{input.sum()}, {}};
+            case TerminalOp::SumDim:
+                return {{input.sum(program.dim, program.keepdim)}, {}};
+            case TerminalOp::SumAxes:
+                return {{input.sum(program.axes, program.keepdim)}, {}};
+            case TerminalOp::MeanAll:
+                return {{input.mean()}, {}};
+            case TerminalOp::MeanDim:
+                return {{input.mean(program.dim, program.keepdim)}, {}};
+            case TerminalOp::StdDim:
+                return {{input.std(program.dim, program.keepdim, program.unbiased)}, {}};
+            case TerminalOp::VarDim:
+                return {{input.var(program.dim, program.keepdim, program.unbiased)}, {}};
+            case TerminalOp::Cumsum:
+                return {{input.cumsum(program.dim)}, {}};
+            case TerminalOp::Nonzero:
+                return {{input.nonzero()}, {}};
+            case TerminalOp::Sort: {
+                auto [values, indices] = input.sort(program.dim, program.descending);
+                return {{std::move(values), std::move(indices)}, {}};
+            }
+            case TerminalOp::InplaceAdd:
+                if (program.dtype == DataType::Int32) {
+                    input.add_(static_cast<int>(program.scalar));
+                } else {
+                    input.add_(program.scalar);
+                }
+                return {{input}, {}};
+            case TerminalOp::BroadcastAdd: {
+                std::vector<size_t> shape(input.ndim(), 1);
+                const auto rhs = Tensor::full(TensorShape(shape), program.scalar,
+                                              input.device(), input.dtype());
+                return {{input.add(rhs)}, {}};
+            }
+            case TerminalOp::MaskedSelect: {
+                const auto mask = input.gt(program.scalar);
+                return {{input.masked_select(mask)}, {}};
+            }
+            case TerminalOp::IndexSelect: {
+                const int resolved_dim = program.dim < 0
+                                             ? program.dim + static_cast<int>(input.ndim())
+                                             : program.dim;
+                const size_t extent = input.size(static_cast<size_t>(resolved_dim));
+                std::vector<int> indices(extent);
+                for (size_t i = 0; i < extent; ++i) {
+                    indices[i] = static_cast<int>(extent - i - 1);
+                }
+                auto index = Tensor::from_vector(indices, {indices.size()}, Device::CPU)
+                                 .to(DataType::Int64);
+                if (input.device() == Device::CUDA) {
+                    index = index.cuda();
+                }
+                return {{input.index_select(program.dim, index)}, {}};
+            }
+            case TerminalOp::Cat:
+                return {{Tensor::cat({input, input}, program.dim)}, {}};
+            case TerminalOp::Stack:
+                return {{Tensor::stack({input, input}, program.dim)}, {}};
+            case TerminalOp::Matmul: {
+                const size_t rows = input.size(1);
+                const auto rhs = make_lfs_rhs(input, rows, 2);
+                return {{input.matmul(rhs)}, {}};
+            }
+            case TerminalOp::MinWithIndices: {
+                auto [values, indices] = input.min_with_indices(program.dim, program.keepdim);
+                return {{std::move(values), std::move(indices)}, {}};
+            }
+            case TerminalOp::MaxWithIndices: {
+                auto [values, indices] = input.max_with_indices(program.dim, program.keepdim);
+                return {{std::move(values), std::move(indices)}, {}};
+            }
+            case TerminalOp::SerializeRoundTrip: {
+                std::stringstream stream;
+                stream << input;
+                Tensor loaded;
+                stream >> loaded;
+                return {{std::move(loaded)}, {}};
+            }
+            }
+        } catch (const std::exception& error) {
+            return {{}, error.what()};
+        } catch (...) {
+            return {{}, "non-standard exception"};
+        }
+        return {{}, "unreachable terminal"};
+    }
+
+    TorchRun run_torch(const FuzzProgram& program) {
+        try {
+            auto input = apply_pointwise(
+                apply_views(make_torch_base(program), program), program);
+            switch (program.terminal) {
+            case TerminalOp::Identity:
+                return {{input}, {}};
+            case TerminalOp::Cast:
+                return {{input.to(torch_dtype(program.cast_dtype))}, {}};
+            case TerminalOp::AddScalar:
+                return program.dtype == DataType::Int32
+                           ? TorchRun{{input.add(static_cast<int64_t>(program.scalar))}, {}}
+                           : TorchRun{{input.add(program.scalar)}, {}};
+            case TerminalOp::MulScalar:
+                return program.dtype == DataType::Int32
+                           ? TorchRun{{input.mul(static_cast<int64_t>(program.scalar))}, {}}
+                           : TorchRun{{input.mul(program.scalar)}, {}};
+            case TerminalOp::Abs:
+                return {{input.abs()}, {}};
+            case TerminalOp::Neg:
+                return {{input.neg()}, {}};
+            case TerminalOp::Clamp:
+                return {{input.clamp(-1, 2)}, {}};
+            case TerminalOp::CompareScalar:
+                return program.dtype == DataType::Float32
+                           ? TorchRun{{input.gt(program.scalar)}, {}}
+                           : TorchRun{{input.gt(static_cast<int64_t>(program.scalar))}, {}};
+            case TerminalOp::SumAll:
+                return {{input.sum()}, {}};
+            case TerminalOp::SumDim:
+                return {{input.sum(program.dim, program.keepdim)}, {}};
+            case TerminalOp::SumAxes: {
+                std::vector<int64_t> axes(program.axes.begin(), program.axes.end());
+                return {{input.sum(axes, program.keepdim)}, {}};
+            }
+            case TerminalOp::MeanAll:
+                return {{input.mean()}, {}};
+            case TerminalOp::MeanDim:
+                return {{input.mean(program.dim, program.keepdim)}, {}};
+            case TerminalOp::StdDim:
+                return {{input.std(c10::IntArrayRef{program.dim},
+                                   program.unbiased, program.keepdim)},
+                        {}};
+            case TerminalOp::VarDim:
+                return {{input.var(c10::IntArrayRef{program.dim},
+                                   program.unbiased, program.keepdim)},
+                        {}};
+            case TerminalOp::Cumsum:
+                return {{input.cumsum(program.dim)}, {}};
+            case TerminalOp::Nonzero:
+                return {{input.nonzero()}, {}};
+            case TerminalOp::Sort: {
+                auto [values, indices] = input.sort(program.dim, program.descending);
+                return {{std::move(values), std::move(indices)}, {}};
+            }
+            case TerminalOp::InplaceAdd:
+                if (program.dtype == DataType::Int32) {
+                    input.add_(static_cast<int64_t>(program.scalar));
+                } else {
+                    input.add_(program.scalar);
+                }
+                return {{input}, {}};
+            case TerminalOp::BroadcastAdd: {
+                std::vector<int64_t> shape(static_cast<size_t>(input.dim()), 1);
+                const auto rhs = torch::full(shape, program.scalar, input.options());
+                return {{input.add(rhs)}, {}};
+            }
+            case TerminalOp::MaskedSelect: {
+                const auto mask = input.gt(program.scalar);
+                return {{input.masked_select(mask)}, {}};
+            }
+            case TerminalOp::IndexSelect: {
+                const int64_t extent = input.size(program.dim);
+                auto index = torch::arange(extent - 1, -1, -1,
+                                           torch::TensorOptions().dtype(torch::kInt64));
+                if (input.is_cuda()) {
+                    index = index.cuda();
+                }
+                return {{input.index_select(program.dim, index)}, {}};
+            }
+            case TerminalOp::Cat:
+                return {{torch::cat({input, input}, program.dim)}, {}};
+            case TerminalOp::Stack:
+                return {{torch::stack({input, input}, program.dim)}, {}};
+            case TerminalOp::Matmul: {
+                const auto rhs = make_torch_rhs(input, input.size(1), 2);
+                return {{input.matmul(rhs)}, {}};
+            }
+            case TerminalOp::MinWithIndices: {
+                auto [values, indices] = input.min(program.dim, program.keepdim);
+                return {{std::move(values), std::move(indices)}, {}};
+            }
+            case TerminalOp::MaxWithIndices: {
+                auto [values, indices] = input.max(program.dim, program.keepdim);
+                return {{std::move(values), std::move(indices)}, {}};
+            }
+            case TerminalOp::SerializeRoundTrip:
+                return {{input.cpu().contiguous()}, {}};
+            }
+        } catch (const std::exception& error) {
+            return {{}, error.what()};
+        } catch (...) {
+            return {{}, "non-standard exception"};
+        }
+        return {{}, "unreachable terminal"};
+    }
+
+    std::optional<std::string> compare_output(const Tensor& actual,
+                                              const torch::Tensor& expected,
+                                              const size_t output_index) {
+        if (actual.ndim() != static_cast<size_t>(expected.dim())) {
+            return "shape: output " + std::to_string(output_index) + " rank " +
+                   std::to_string(actual.ndim()) + " versus " +
+                   std::to_string(expected.dim());
+        }
+        for (size_t dim = 0; dim < actual.ndim(); ++dim) {
+            if (actual.size(dim) != static_cast<size_t>(expected.size(dim))) {
+                return "shape: output " + std::to_string(output_index) + " dimension " +
+                       std::to_string(dim) + " is " + std::to_string(actual.size(dim)) +
+                       " versus " + std::to_string(expected.size(dim));
+            }
+        }
+        const DataType expected_dtype = lfs_dtype(expected.scalar_type());
+        if (actual.dtype() != expected_dtype) {
+            return "dtype: output " + std::to_string(output_index) + " is " +
+                   std::string(dtype_name(actual.dtype())) + " versus " +
+                   std::string(dtype_name(expected_dtype));
+        }
+        if (actual.numel() != static_cast<size_t>(expected.numel())) {
+            return "shape: output element count differs";
+        }
+
+        const bool exact = expected_dtype == DataType::Int32 ||
+                           expected_dtype == DataType::Int64 ||
+                           expected_dtype == DataType::UInt8 ||
+                           expected_dtype == DataType::Bool;
+        if (exact) {
+            const auto actual_values = actual.cpu()
+                                           .contiguous()
+                                           .to(DataType::Int64)
+                                           .to_vector_int64();
+            const auto expected_cpu = expected.detach()
+                                          .to(torch::kCPU)
+                                          .contiguous()
+                                          .to(torch::kInt64);
+            const auto* expected_data = expected_cpu.data_ptr<int64_t>();
+            for (size_t index = 0; index < actual_values.size(); ++index) {
+                if (actual_values[index] != expected_data[index]) {
+                    return "value: exact output " + std::to_string(output_index) +
+                           " index " + std::to_string(index) + " is " +
+                           std::to_string(actual_values[index]) + " versus " +
+                           std::to_string(expected_data[index]);
+                }
+            }
+            return std::nullopt;
+        }
+
+        const auto actual_values = actual.cpu()
+                                       .contiguous()
+                                       .to(DataType::Float32)
+                                       .to_vector();
+        const auto expected_cpu = expected.detach()
+                                      .to(torch::kCPU)
+                                      .contiguous()
+                                      .to(torch::kFloat32);
+        const auto* expected_data = expected_cpu.data_ptr<float>();
+        const float rtol = expected_dtype == DataType::Float16 ? 3e-3f : 2e-4f;
+        const float atol = expected_dtype == DataType::Float16 ? 3e-3f : 2e-5f;
+        for (size_t index = 0; index < actual_values.size(); ++index) {
+            const float a = actual_values[index];
+            const float e = expected_data[index];
+            if (std::isnan(e)) {
+                if (!std::isnan(a)) {
+                    return "value: output " + std::to_string(output_index) +
+                           " index " + std::to_string(index) + " expected NaN, got " +
+                           std::to_string(a);
+                }
+            } else if (std::isinf(e)) {
+                if (a != e) {
+                    return "value: output " + std::to_string(output_index) +
+                           " index " + std::to_string(index) + " expected infinity";
+                }
+            } else if (!std::isfinite(a) ||
+                       std::abs(a - e) > atol + rtol * std::abs(e)) {
+                return "value: output " + std::to_string(output_index) +
+                       " index " + std::to_string(index) + " is " +
+                       std::to_string(a) + " versus " + std::to_string(e);
+            }
+        }
+        return std::nullopt;
+    }
+
+    std::optional<std::string> mismatch_for(const FuzzProgram& program) {
+        auto actual = run_lfs(program);
+        if (program.device == Device::CUDA) {
+            const cudaError_t status = cudaDeviceSynchronize();
+            const cudaError_t launch_status = cudaGetLastError();
+            const cudaError_t failure = status != cudaSuccess ? status : launch_status;
+            if (failure != cudaSuccess && actual.exception.empty()) {
+                actual.exception = std::string("CUDA synchronization failed: ") +
+                                   cudaGetErrorString(failure);
+            }
+        }
+        const auto expected = run_torch(program);
+        if (!actual.exception.empty() || !expected.exception.empty()) {
+            if (actual.exception.empty() != expected.exception.empty()) {
+                return "exception-asymmetry: LFS=" +
+                       (actual.exception.empty() ? std::string("none") : actual.exception) +
+                       "; Torch=" +
+                       (expected.exception.empty() ? std::string("none") : expected.exception);
+            }
+            return std::nullopt;
+        }
+        if (actual.outputs.size() != expected.outputs.size()) {
+            return "shape: output count is " + std::to_string(actual.outputs.size()) +
+                   " versus " + std::to_string(expected.outputs.size());
+        }
+        for (size_t index = 0; index < actual.outputs.size(); ++index) {
+            if (auto mismatch = compare_output(actual.outputs[index], expected.outputs[index], index)) {
+                return mismatch;
+            }
+        }
+        return std::nullopt;
+    }
+
+    std::string describe_program(const FuzzProgram& program) {
+        std::ostringstream description;
+        description << "seed=0x" << std::hex << program.seed << std::dec
+                    << " iteration=" << program.iteration
+                    << " device=" << (program.device == Device::CPU ? "CPU" : "CUDA")
+                    << " dtype=" << dtype_name(program.dtype)
+                    << " shape=[";
+        for (size_t i = 0; i < program.base_shape.size(); ++i) {
+            if (i != 0)
+                description << ',';
+            description << program.base_shape[i];
+        }
+        description << "] values=[";
+        for (size_t i = 0; i < std::min<size_t>(program.values.size(), 12); ++i) {
+            if (i != 0)
+                description << ',';
+            if (std::isnan(program.values[i]))
+                description << "nan";
+            else if (std::isinf(program.values[i]))
+                description << (program.values[i] > 0 ? "inf" : "-inf");
+            else
+                description << program.values[i];
+        }
+        if (program.values.size() > 12)
+            description << ",...";
+        description << "] views=";
+        if (program.views.empty())
+            description << "none";
+        for (size_t i = 0; i < program.views.size(); ++i) {
+            if (i != 0)
+                description << "->";
+            const auto& view = program.views[i];
+            description << view_name(view.kind) << '(';
+            switch (view.kind) {
+            case ViewKind::Transpose:
+                description << view.first << ',' << view.second;
+                break;
+            case ViewKind::Permute:
+            case ViewKind::Expand:
+                for (size_t dim = 0; dim < view.dimensions.size(); ++dim) {
+                    if (dim != 0)
+                        description << ',';
+                    description << view.dimensions[dim];
+                }
+                break;
+            case ViewKind::Slice:
+                description << view.first << ',' << view.start << ',' << view.end;
+                break;
+            case ViewKind::Unsqueeze:
+            case ViewKind::Squeeze:
+                description << view.first;
+                break;
+            }
+            description << ')';
+        }
+        description << " terminal=" << terminal_name(program.terminal)
+                    << " dim=" << program.dim
+                    << " keepdim=" << program.keepdim
+                    << " unbiased=" << program.unbiased
+                    << " scalar=" << program.scalar;
+        description << " chain=";
+        if (program.pointwise.empty())
+            description << "none";
+        for (size_t i = 0; i < program.pointwise.size(); ++i) {
+            if (i != 0)
+                description << "->";
+            description << pointwise_name(program.pointwise[i].kind);
+            if (program.pointwise[i].kind == PointwiseKind::AddScalar ||
+                program.pointwise[i].kind == PointwiseKind::MulScalar) {
+                description << '(' << program.pointwise[i].scalar << ')';
+            }
+        }
+        return description.str();
+    }
+
+    std::string mismatch_class(const TerminalOp terminal, const std::string& mismatch) {
+        const size_t separator = mismatch.find(':');
+        std::string category =
+            mismatch.substr(0, separator == std::string::npos ? mismatch.size() : separator);
+        if (mismatch.find("slice range") != std::string::npos)
+            category += "-slice-contract";
+        if (mismatch.find("broadcast_to does not support") != std::string::npos)
+            category += "-expand-dtype";
+        if (mismatch.find("squeeze dimension") != std::string::npos)
+            category += "-squeeze";
+        if (mismatch.find("broadcast-compatible") != std::string::npos ||
+            mismatch.find("Cannot broadcast") != std::string::npos)
+            category += "-broadcast";
+        return std::string(terminal_name(terminal)) + '|' + category;
+    }
+
+    FuzzProgram minimize(FuzzProgram program) {
+        const auto initial_mismatch = mismatch_for(program);
+        if (!initial_mismatch)
+            return program;
+        const std::string target_class = mismatch_class(program.terminal, *initial_mismatch);
+        size_t attempts = 0;
+        constexpr size_t kMaxAttempts = 96;
+        auto still_fails = [&](const FuzzProgram& candidate) {
+            if (++attempts > kMaxAttempts)
+                return false;
+            const auto mismatch = mismatch_for(candidate);
+            return mismatch && mismatch_class(candidate.terminal, *mismatch) == target_class;
+        };
+
+        for (size_t index = 0; index < program.views.size() && attempts < kMaxAttempts;) {
+            auto candidate = program;
+            candidate.views.erase(candidate.views.begin() + static_cast<std::ptrdiff_t>(index));
+            if (still_fails(candidate)) {
+                program = std::move(candidate);
+            } else {
+                ++index;
+            }
+        }
+
+        for (size_t index = 0; index < program.pointwise.size() && attempts < kMaxAttempts;) {
+            auto candidate = program;
+            candidate.pointwise.erase(
+                candidate.pointwise.begin() + static_cast<std::ptrdiff_t>(index));
+            if (still_fails(candidate)) {
+                program = std::move(candidate);
+            } else {
+                ++index;
+            }
+        }
+
+        for (size_t index = 0; index < program.values.size() && attempts < kMaxAttempts; ++index) {
+            if (program.values[index] == 0.0f)
+                continue;
+            auto candidate = program;
+            candidate.values[index] = 0.0f;
+            if (still_fails(candidate)) {
+                program = std::move(candidate);
+            }
+        }
+
+        for (size_t dim = 0; dim < program.base_shape.size() && attempts < kMaxAttempts; ++dim) {
+            if (program.base_shape[dim] <= 1)
+                continue;
+            auto candidate = program;
+            candidate.base_shape[dim] = 1;
+            candidate.values.resize(shape_numel(candidate.base_shape), 0.0f);
+            if (still_fails(candidate)) {
+                program = std::move(candidate);
+            }
+        }
+
+        if (program.device == Device::CUDA && attempts < kMaxAttempts) {
+            auto candidate = program;
+            candidate.device = Device::CPU;
+            if (still_fails(candidate)) {
+                program = std::move(candidate);
+            }
+        }
+        return program;
+    }
+
+    template <typename Generator>
+    size_t random_index(Generator& generator, const size_t size) {
+        return std::uniform_int_distribution<size_t>(0, size - 1)(generator);
+    }
+
+    template <typename Generator>
+    bool random_bool(Generator& generator) {
+        return std::uniform_int_distribution<int>(0, 1)(generator) != 0;
+    }
+
+    template <typename Generator>
+    FuzzProgram generate_program(Generator& generator,
+                                 const uint64_t seed,
+                                 const size_t iteration,
+                                 const std::string_view device_mode) {
+        FuzzProgram program;
+        program.seed = seed;
+        program.iteration = iteration;
+        program.dtype = kDtypes[random_index(generator, kDtypes.size())];
+        if (device_mode == "cpu") {
+            program.device = Device::CPU;
+        } else if (device_mode == "cuda") {
+            program.device = Device::CUDA;
+        } else {
+            program.device = random_bool(generator) ? Device::CPU : Device::CUDA;
+        }
+
+        const int shape_class = std::uniform_int_distribution<int>(0, 9)(generator);
+        if (shape_class == 0) {
+            program.base_shape = {};
+        } else if (shape_class <= 2) {
+            const int rank = std::uniform_int_distribution<int>(1, 3)(generator);
+            program.base_shape.assign(static_cast<size_t>(rank), 1);
+            program.base_shape[random_index(generator, program.base_shape.size())] = 0;
+            for (int dim = 0; dim < rank; ++dim) {
+                if (program.base_shape[static_cast<size_t>(dim)] != 0) {
+                    program.base_shape[static_cast<size_t>(dim)] =
+                        std::uniform_int_distribution<int>(1, 3)(generator);
+                }
+            }
+        } else {
+            const int rank = std::uniform_int_distribution<int>(1, 3)(generator);
+            for (int dim = 0; dim < rank; ++dim) {
+                const bool singleton = std::uniform_int_distribution<int>(0, 2)(generator) == 0;
+                program.base_shape.push_back(singleton
+                                                 ? 1
+                                                 : std::uniform_int_distribution<int>(2, 4)(generator));
+            }
+        }
+
+        const size_t elements = shape_numel(program.base_shape);
+        program.values.resize(elements);
+        for (size_t index = 0; index < elements; ++index) {
+            if (program.dtype == DataType::Bool) {
+                program.values[index] = random_bool(generator) ? 1.0f : 0.0f;
+            } else if (program.dtype == DataType::UInt8) {
+                program.values[index] = static_cast<float>(
+                    std::uniform_int_distribution<int>(0, 5)(generator));
+            } else {
+                program.values[index] = static_cast<float>(
+                    std::uniform_int_distribution<int>(-3, 5)(generator));
+                if (program.dtype == DataType::Float32) {
+                    const int special = std::uniform_int_distribution<int>(0, 199)(generator);
+                    if (special == 0)
+                        program.values[index] = std::numeric_limits<float>::quiet_NaN();
+                    if (special == 1)
+                        program.values[index] = std::numeric_limits<float>::infinity();
+                    if (special == 2)
+                        program.values[index] = -std::numeric_limits<float>::infinity();
+                }
+            }
+        }
+
+        torch::Tensor planning = make_torch_base_cpu(program);
+        const int wanted_views = std::uniform_int_distribution<int>(0, 4)(generator);
+        for (int view_index = 0, tries = 0;
+             view_index < wanted_views && tries < wanted_views * 6 + 6;
+             ++tries) {
+            ViewStep step;
+            step.kind = static_cast<ViewKind>(std::uniform_int_distribution<int>(0, 5)(generator));
+            const int rank = static_cast<int>(planning.dim());
+            bool valid = true;
+            switch (step.kind) {
+            case ViewKind::Transpose:
+                if (rank < 2) {
+                    valid = false;
+                    break;
+                }
+                step.first = std::uniform_int_distribution<int>(0, rank - 1)(generator);
+                do {
+                    step.second = std::uniform_int_distribution<int>(0, rank - 1)(generator);
+                } while (step.second == step.first);
+                break;
+            case ViewKind::Permute:
+                if (rank < 2) {
+                    valid = false;
+                    break;
+                }
+                step.dimensions.resize(static_cast<size_t>(rank));
+                for (int dim = 0; dim < rank; ++dim)
+                    step.dimensions[static_cast<size_t>(dim)] = dim;
+                std::shuffle(step.dimensions.begin(), step.dimensions.end(), generator);
+                break;
+            case ViewKind::Slice: {
+                if (rank == 0) {
+                    valid = false;
+                    break;
+                }
+                step.first = std::uniform_int_distribution<int>(0, rank - 1)(generator);
+                const int64_t extent = planning.size(step.first);
+                if (extent == 0) {
+                    valid = false;
+                    break;
+                }
+                step.start = std::uniform_int_distribution<int64_t>(0, extent - 1)(generator);
+                step.end = std::uniform_int_distribution<int64_t>(step.start + 1, extent)(generator);
+                break;
+            }
+            case ViewKind::Unsqueeze:
+                if (rank >= 5) {
+                    valid = false;
+                    break;
+                }
+                step.first = std::uniform_int_distribution<int>(0, rank)(generator);
+                break;
+            case ViewKind::Squeeze:
+                if (rank == 0) {
+                    valid = false;
+                    break;
+                }
+                step.first = std::uniform_int_distribution<int>(0, rank - 1)(generator);
+                if (planning.size(step.first) != 1 || rank == 1)
+                    valid = false;
+                break;
+            case ViewKind::Expand: {
+                std::vector<int> singleton_dims;
+                for (int dim = 0; dim < rank; ++dim) {
+                    if (planning.size(dim) == 1)
+                        singleton_dims.push_back(dim);
+                }
+                if (program.dtype != DataType::Float32 ||
+                    singleton_dims.empty() || planning.numel() > 32) {
+                    valid = false;
+                    break;
+                }
+                step.dimensions = planning.sizes().vec();
+                const int dim = singleton_dims[random_index(generator, singleton_dims.size())];
+                step.dimensions[static_cast<size_t>(dim)] =
+                    std::uniform_int_distribution<int>(2, 3)(generator);
+                break;
+            }
+            }
+            if (!valid)
+                continue;
+            try {
+                planning = apply_view(std::move(planning), step);
+                program.views.push_back(std::move(step));
+                ++view_index;
+            } catch (...) {
+                // Generation only keeps view programs that Torch accepts.
+            }
+        }
+
+        std::vector<TerminalOp> terminals = {
+            TerminalOp::Identity,
+            TerminalOp::Cast,
+            TerminalOp::SerializeRoundTrip,
+        };
+        const bool float32 = program.dtype == DataType::Float32;
+        const bool int32 = program.dtype == DataType::Int32;
+        const int rank = static_cast<int>(planning.dim());
+        const bool nonempty = planning.numel() > 0;
+
+        if (float32) {
+            const int chain_length = std::uniform_int_distribution<int>(0, 3)(generator);
+            for (int i = 0; i < chain_length; ++i) {
+                PointwiseStep step;
+                step.kind = static_cast<PointwiseKind>(
+                    std::uniform_int_distribution<int>(0, 5)(generator));
+                step.scalar = static_cast<float>(
+                    std::uniform_int_distribution<int>(-2, 3)(generator));
+                if (step.kind == PointwiseKind::MulScalar && step.scalar == 0.0f) {
+                    step.scalar = 2.0f;
+                }
+                program.pointwise.push_back(step);
+            }
+        }
+
+        if (float32 || int32) {
+            terminals.insert(terminals.end(), {
+                                                  TerminalOp::AddScalar,
+                                                  TerminalOp::MulScalar,
+                                                  TerminalOp::Abs,
+                                                  TerminalOp::Neg,
+                                                  TerminalOp::Clamp,
+                                                  TerminalOp::CompareScalar,
+                                                  TerminalOp::BroadcastAdd,
+                                                  TerminalOp::MaskedSelect,
+                                              });
+            if (float32) {
+                terminals.push_back(TerminalOp::SumAll);
+                terminals.push_back(TerminalOp::InplaceAdd);
+            }
+        } else if (program.dtype == DataType::Bool) {
+            terminals.push_back(TerminalOp::CompareScalar);
+            terminals.push_back(TerminalOp::SumAll);
+        } else if (program.dtype == DataType::UInt8) {
+            terminals.push_back(TerminalOp::CompareScalar);
+        }
+        if (float32) {
+            terminals.push_back(TerminalOp::MeanAll);
+            terminals.push_back(TerminalOp::Cat);
+            terminals.push_back(TerminalOp::Stack);
+        }
+        if (float32 || int32 || program.dtype == DataType::Bool) {
+            terminals.push_back(TerminalOp::Nonzero);
+        }
+        if (rank > 0) {
+            terminals.push_back(TerminalOp::IndexSelect);
+            if (float32) {
+                terminals.insert(terminals.end(), {
+                                                      TerminalOp::SumDim,
+                                                      TerminalOp::SumAxes,
+                                                      TerminalOp::MeanDim,
+                                                      TerminalOp::StdDim,
+                                                      TerminalOp::VarDim,
+                                                      TerminalOp::Cumsum,
+                                                  });
+                if (nonempty) {
+                    terminals.push_back(TerminalOp::Sort);
+                    if (rank > 1) {
+                        terminals.push_back(TerminalOp::MinWithIndices);
+                        terminals.push_back(TerminalOp::MaxWithIndices);
+                    }
+                }
+            }
+        }
+        if (float32 && rank == 2 && nonempty && planning.size(1) > 0) {
+            terminals.push_back(TerminalOp::Matmul);
+        }
+
+        program.terminal = terminals[random_index(generator, terminals.size())];
+        program.scalar = static_cast<float>(std::uniform_int_distribution<int>(-2, 3)(generator));
+        if (program.dtype == DataType::Bool || program.dtype == DataType::UInt8) {
+            program.scalar = static_cast<float>(std::uniform_int_distribution<int>(0, 1)(generator));
+        }
+        if (program.scalar == 0.0f && program.terminal == TerminalOp::MulScalar) {
+            program.scalar = 2.0f;
+        }
+        program.keepdim = random_bool(generator);
+        program.unbiased = random_bool(generator);
+        program.descending = random_bool(generator);
+        if (rank > 0) {
+            program.dim = std::uniform_int_distribution<int>(0, rank - 1)(generator);
+            if (random_bool(generator))
+                program.dim -= rank;
+            const int positive_dim = program.dim < 0 ? program.dim + rank : program.dim;
+            program.axes = {positive_dim};
+            if (rank > 1 && random_bool(generator)) {
+                int second = std::uniform_int_distribution<int>(0, rank - 1)(generator);
+                if (second == positive_dim)
+                    second = (second + 1) % rank;
+                program.axes.push_back(second);
+                if (random_bool(generator))
+                    std::reverse(program.axes.begin(), program.axes.end());
+            }
+        }
+        program.cast_dtype = kDtypes[random_index(generator, kDtypes.size())];
+        if (program.cast_dtype == DataType::UInt8) {
+            program.cast_dtype = DataType::Int64;
+        }
+        if (program.terminal == TerminalOp::Cat) {
+            program.dim = rank == 0 ? 0 : std::uniform_int_distribution<int>(0, rank - 1)(generator);
+        } else if (program.terminal == TerminalOp::Stack) {
+            program.dim = std::uniform_int_distribution<int>(0, rank)(generator);
+        }
+        return program;
+    }
+
+    uint64_t env_uint64(const char* name, const uint64_t fallback) {
+        const char* value = std::getenv(name);
+        if (value == nullptr || *value == '\0')
+            return fallback;
+        char* end = nullptr;
+        const uint64_t parsed = std::strtoull(value, &end, 0);
+        return end != value && *end == '\0' ? parsed : fallback;
+    }
+
+    std::string env_string(const char* name, std::string fallback) {
+        const char* value = std::getenv(name);
+        return value == nullptr || *value == '\0' ? std::move(fallback) : std::string(value);
+    }
+
+} // namespace
+
+TEST(DiscoveryFuzz, RandomizedProgramsMatchTorch) {
+    ASSERT_TRUE(torch::cuda::is_available()) << "Discovery fuzzer requires CUDA";
+
+    const uint64_t seed = env_uint64("LFS_DISCOVERY_SEED", 0x5eedc0deULL);
+    const size_t start_iteration = static_cast<size_t>(
+        env_uint64("LFS_DISCOVERY_START", 0));
+    const size_t iterations = static_cast<size_t>(
+        env_uint64("LFS_DISCOVERY_ITERS", 512));
+    const std::string device_mode = env_string("LFS_DISCOVERY_DEVICE", "mixed");
+    const bool allow_mismatches = env_uint64("LFS_DISCOVERY_ALLOW_MISMATCHES", 0) != 0;
+    const bool emit_mismatches = env_uint64("LFS_DISCOVERY_EMIT_MISMATCHES", 1) != 0;
+    ASSERT_TRUE(device_mode == "mixed" || device_mode == "cpu" || device_mode == "cuda");
+
+    std::mt19937_64 generator(seed);
+    std::map<std::string, size_t> dtype_counts;
+    std::map<std::string, size_t> device_counts;
+    std::map<std::string, size_t> terminal_counts;
+    std::map<std::string, size_t> view_counts;
+    std::map<std::string, size_t> pointwise_counts;
+    std::map<std::string, size_t> mismatch_counts;
+    std::map<std::string, std::string> first_mismatches;
+    size_t mismatch_total = 0;
+
+    for (size_t iteration = 0; iteration < start_iteration + iterations; ++iteration) {
+        const auto program = generate_program(generator, seed, iteration, device_mode);
+        if (iteration < start_iteration)
+            continue;
+        ++dtype_counts[std::string(dtype_name(program.dtype))];
+        ++device_counts[program.device == Device::CPU ? "CPU" : "CUDA"];
+        ++terminal_counts[std::string(terminal_name(program.terminal))];
+        if (program.views.empty())
+            ++view_counts["none"];
+        for (const auto& view : program.views) {
+            ++view_counts[std::string(view_name(view.kind))];
+        }
+        for (const auto& step : program.pointwise) {
+            ++pointwise_counts[std::string(pointwise_name(step.kind))];
+        }
+
+        const auto mismatch = mismatch_for(program);
+        if (!mismatch)
+            continue;
+        ++mismatch_total;
+        const std::string signature = mismatch_class(program.terminal, *mismatch);
+        ++mismatch_counts[signature];
+        if (emit_mismatches && !first_mismatches.contains(signature)) {
+            const auto minimized = minimize(program);
+            const auto minimized_mismatch = mismatch_for(minimized).value_or(*mismatch);
+            std::ostringstream detail;
+            detail << *mismatch << "\n  original: " << describe_program(program)
+                   << "\n  minimized: " << describe_program(minimized)
+                   << "\n  minimized mismatch: " << minimized_mismatch;
+            first_mismatches.emplace(signature, detail.str());
+            std::cout << "DISCOVERY_FUZZ_MISMATCH signature=" << signature << '\n'
+                      << detail.str() << '\n';
+        }
+    }
+
+    auto print_counts = [](const std::string_view label,
+                           const std::map<std::string, size_t>& counts) {
+        std::cout << label << '=';
+        bool first = true;
+        for (const auto& [name, count] : counts) {
+            if (!first)
+                std::cout << ',';
+            first = false;
+            std::cout << name << ':' << count;
+        }
+        std::cout << '\n';
+    };
+
+    std::cout << "DISCOVERY_FUZZ_SUMMARY seed=0x" << std::hex << seed << std::dec
+              << " start=" << start_iteration
+              << " iterations=" << iterations
+              << " mismatches=" << mismatch_total
+              << " signatures=" << mismatch_counts.size() << '\n';
+    print_counts("DISCOVERY_FUZZ_DTYPES", dtype_counts);
+    print_counts("DISCOVERY_FUZZ_DEVICES", device_counts);
+    print_counts("DISCOVERY_FUZZ_TERMINALS", terminal_counts);
+    print_counts("DISCOVERY_FUZZ_VIEWS", view_counts);
+    print_counts("DISCOVERY_FUZZ_POINTWISE", pointwise_counts);
+    print_counts("DISCOVERY_FUZZ_SIGNATURES", mismatch_counts);
+
+    if (!allow_mismatches && mismatch_total != 0) {
+        std::ostringstream failures;
+        failures << mismatch_total << " mismatches in " << mismatch_counts.size()
+                 << " signatures";
+        for (const auto& [signature, detail] : first_mismatches) {
+            failures << "\n[" << signature << "] " << detail;
+        }
+        FAIL() << failures.str();
+    }
+}

--- a/tests/test_tensor_hardening_theme_a.cpp
+++ b/tests/test_tensor_hardening_theme_a.cpp
@@ -1,0 +1,528 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "tensor_hardening_test_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <numeric>
+
+using namespace lfs::core;
+using namespace tensor_hardening;
+
+namespace {
+
+    template <typename CustomMutation, typename TorchMutation>
+    void check_view_mutation(const Device device, CustomMutation&& custom_mutation,
+                             TorchMutation&& torch_mutation, const std::string& context) {
+        const std::vector<float> values = {
+            1.0f, 2.0f, 3.0f, 4.0f,
+            5.0f, 6.0f, 7.0f, 8.0f,
+            9.0f, 10.0f, 11.0f, 12.0f,
+            13.0f, 14.0f, 15.0f, 16.0f};
+        auto ours = lfs_float_tensor(values, {4, 4}, device);
+        auto theirs = torch::tensor(values, torch::TensorOptions().dtype(torch::kFloat32))
+                          .reshape({4, 4});
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+        }
+
+        custom_mutation(ours);
+        torch_mutation(theirs);
+        expect_float_values_match(ours, theirs, context);
+    }
+
+    std::vector<bool> changed_from_zero(const Tensor& tensor) {
+        const auto values = lfs_values_as_float(tensor);
+        std::vector<bool> changed;
+        changed.reserve(values.size());
+        for (const float value : values) {
+            changed.push_back(value != 0.0f);
+        }
+        return changed;
+    }
+
+    std::vector<bool> changed_from_zero(const torch::Tensor& tensor) {
+        const auto values = torch_values_as_float(tensor);
+        std::vector<bool> changed;
+        changed.reserve(values.size());
+        for (const float value : values) {
+            changed.push_back(value != 0.0f);
+        }
+        return changed;
+    }
+
+} // namespace
+
+TEST_F(CudaTest, A1_NonContiguousZeroFollowsViewStrides_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        check_view_mutation(
+            device,
+            [](Tensor& base) { base.slice(0, 0, 2).slice(1, 0, 2).zero_(); },
+            [](torch::Tensor& base) { base.slice(0, 0, 2).slice(1, 0, 2).zero_(); },
+            device == Device::CPU ? "A1 zero CPU" : "A1 zero CUDA");
+    }
+}
+
+TEST_F(CudaTest, A1_NonContiguousScalarInPlaceFollowsViewStrides_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        check_view_mutation(
+            device,
+            [](Tensor& base) { base.slice(1, 1, 2).squeeze(1).add_(10.0f); },
+            [](torch::Tensor& base) { base.slice(1, 1, 2).squeeze(1).add_(10.0f); },
+            device == Device::CPU ? "A1 scalar add CPU" : "A1 scalar add CUDA");
+    }
+}
+
+TEST_F(CudaTest, A1_NonContiguousBinaryInPlaceFollowsViewStrides_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        check_view_mutation(
+            device,
+            [device](Tensor& base) {
+                auto view = base.slice(1, 1, 2).squeeze(1);
+                view.add_(Tensor::full({4}, 10.0f, device));
+            },
+            [](torch::Tensor& base) {
+                auto view = base.slice(1, 1, 2).squeeze(1);
+                view.add_(torch::full({4}, 10.0f, base.options()));
+            },
+            device == Device::CPU ? "A1 binary add CPU" : "A1 binary add CUDA");
+    }
+}
+
+TEST_F(CudaTest, A1_NonContiguousClampFollowsViewStrides_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        check_view_mutation(
+            device,
+            [](Tensor& base) { base.slice(1, 1, 2).squeeze(1).clamp_(6.0f, 10.0f); },
+            [](torch::Tensor& base) { base.slice(1, 1, 2).squeeze(1).clamp_(6.0f, 10.0f); },
+            device == Device::CPU ? "A1 clamp CPU" : "A1 clamp CUDA");
+    }
+}
+
+TEST(HardeningThemeA_Strided, A2_CPUCopyFromWritesLogicalDestinationCells) {
+    auto base = Tensor::zeros({2, 2}, Device::CPU);
+    auto destination = base.transpose(0, 1);
+    auto source = lfs_float_tensor({1.0f, 2.0f, 3.0f, 4.0f}, {2, 2}, Device::CPU);
+    destination.copy_from(source);
+
+    auto torch_base = torch::zeros({2, 2});
+    auto torch_destination = torch_base.transpose(0, 1);
+    torch_destination.copy_(torch::tensor({{1.0f, 2.0f}, {3.0f, 4.0f}}));
+    expect_float_values_match(base, torch_base, "A2 CPU copy_from");
+}
+
+TEST(HardeningThemeA_Strided, A3_ViewCopyAssignmentUsesBothTensorStrides) {
+    auto base = Tensor::zeros({3, 3}, Device::CPU);
+    auto destination = base.slice(1, 0, 1);
+    const auto source = Tensor::full({3, 1}, 9.0f, Device::CPU);
+    destination = source;
+
+    auto torch_base = torch::zeros({3, 3});
+    torch_base.slice(1, 0, 1).copy_(torch::full({3, 1}, 9.0f));
+    expect_float_values_match(base, torch_base, "A3 copy assignment");
+}
+
+TEST(HardeningThemeA_Strided, A3_ViewMoveAssignmentUsesBothTensorStrides) {
+    auto base = Tensor::zeros({3, 3}, Device::CPU);
+    auto destination = base.slice(1, 0, 1);
+    destination = Tensor::full({3, 1}, 7.0f, Device::CPU);
+
+    auto torch_base = torch::zeros({3, 3});
+    torch_base.slice(1, 0, 1).copy_(torch::full({3, 1}, 7.0f));
+    expect_float_values_match(base, torch_base, "A3 move assignment");
+}
+
+TEST(HardeningThemeA_Strided, A4_RangeSlicePreservesExistingStorageOffset) {
+    auto ours = Tensor::arange(10.0f).to(Device::CPU);
+    auto ours_result = ours.slice(0, 2, 8).slice({{1, 3}});
+
+    auto theirs = torch::arange(10.0f);
+    auto torch_result = theirs.slice(0, 2, 8).slice(0, 1, 3);
+    expect_float_values_match(ours_result, torch_result, "A4 chained range slice");
+}
+
+TEST(HardeningThemeA_Strided, A4_RangeSlicePreservesSourceStrides) {
+    const std::vector<float> values = {1, 2, 3, 4, 5, 6};
+    auto ours = lfs_float_tensor(values, {2, 3}, Device::CPU).transpose(0, 1);
+    auto ours_result = ours.slice({{1, 3}, {0, 2}});
+
+    auto theirs = torch::tensor(values).reshape({2, 3}).transpose(0, 1);
+    auto torch_result = theirs.slice(0, 1, 3).slice(1, 0, 2);
+    expect_float_values_match(ours_result, torch_result, "A4 range slice of transpose");
+}
+
+TEST(HardeningThemeA_Strided, A5_Int32VectorExportUsesLogicalOrder) {
+    auto ours = lfs_int_tensor({1, 2, 3, 4}, {2, 2}, Device::CPU).transpose(0, 1);
+    const std::vector<int> expected = {1, 3, 2, 4};
+    EXPECT_EQ(ours.to_vector_int(), expected);
+}
+
+TEST(HardeningThemeA_Strided, A5_Int64VectorExportUsesLogicalOrder) {
+    auto ours = lfs_int_tensor({1, 2, 3, 4}, {2, 2}, Device::CPU)
+                    .to(DataType::Int64)
+                    .transpose(0, 1);
+    const std::vector<int64_t> expected = {1, 3, 2, 4};
+    EXPECT_EQ(ours.to_vector_int64(), expected);
+}
+
+TEST(HardeningThemeA_Strided, A5_BoolAndUInt8VectorExportsUseLogicalOrder) {
+    auto bool_view = lfs_bool_tensor({true, false, true, true}, {2, 2}, Device::CPU)
+                         .transpose(0, 1);
+    const std::vector<bool> expected_bool = {true, true, false, true};
+    EXPECT_EQ(bool_view.to_vector_bool(), expected_bool);
+
+    auto byte_view = lfs_int_tensor({1, 2, 3, 4}, {2, 2}, Device::CPU)
+                         .to(DataType::UInt8)
+                         .transpose(0, 1);
+    const std::vector<uint8_t> expected_bytes = {1, 3, 2, 4};
+    EXPECT_EQ(byte_view.to_vector_uint8(), expected_bytes);
+}
+
+TEST(HardeningThemeA_Strided, A6_CPUAllCloseComparesLogicalOrder) {
+    auto transposed = lfs_float_tensor({1, 2, 3, 4}, {2, 2}, Device::CPU).transpose(0, 1);
+    auto dense_physical_order = lfs_float_tensor({1, 2, 3, 4}, {2, 2}, Device::CPU);
+
+    const auto torch_transposed = torch::tensor({{1.0f, 2.0f}, {3.0f, 4.0f}}).transpose(0, 1);
+    const auto torch_dense = torch::tensor({{1.0f, 2.0f}, {3.0f, 4.0f}});
+    EXPECT_EQ(transposed.all_close(dense_physical_order),
+              torch::allclose(torch_transposed, torch_dense));
+}
+
+TEST_F(CudaTest, A7_CUDASpecialValueScansFollowViewStrides) {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    auto base = lfs_float_tensor({0, 0, 0, 0, 0, 0, nan, 0, 0}, {3, 3}, Device::CUDA);
+    auto view = base.slice(1, 0, 1).squeeze(1);
+    auto torch_base = torch::tensor({0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, nan, 0.0f, 0.0f},
+                                    torch::TensorOptions().device(torch::kCUDA))
+                          .reshape({3, 3});
+    auto torch_view = torch_base.slice(1, 0, 1).squeeze(1);
+    EXPECT_EQ(view.has_nan(), torch_view.isnan().any().item<bool>());
+
+    auto inf_base = lfs_float_tensor(
+        {0, 0, 0, 0, 0, 0, std::numeric_limits<float>::infinity(), 0, 0},
+        {3, 3}, Device::CUDA);
+    auto inf_view = inf_base.slice(1, 0, 1).squeeze(1);
+    auto torch_inf = torch::tensor(
+                         {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                          std::numeric_limits<float>::infinity(), 0.0f, 0.0f},
+                         torch::TensorOptions().device(torch::kCUDA))
+                         .reshape({3, 3})
+                         .slice(1, 0, 1)
+                         .squeeze(1);
+    EXPECT_EQ(inf_view.has_inf(), torch_inf.isinf().any().item<bool>());
+}
+
+TEST(HardeningThemeA_Strided, A8_ReserveOnOffsetViewPreservesLogicalValues) {
+    auto base = lfs_float_tensor({1, 2, 3, 4, 5, 6}, {3, 2}, Device::CPU);
+    auto view = base.slice(0, 1, 3);
+    const auto torch_reference = torch::tensor({{3.0f, 4.0f}, {5.0f, 6.0f}});
+    view.reserve(4);
+    expect_float_values_match(view, torch_reference, "A8 reserve view");
+}
+
+TEST_F(CudaTest, A9_CatReadsNonContiguousOperands_CPUAndCUDA) {
+    const std::vector<float> values = {1, 2, 3, 4, 5, 6};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto ours = lfs_float_tensor(values, {2, 3}, device).transpose(0, 1);
+        auto theirs = torch::tensor(values).reshape({2, 3}).transpose(0, 1);
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+        }
+        expect_float_values_match(Tensor::cat({ours, ours}, 0),
+                                  torch::cat({theirs, theirs}, 0),
+                                  device == Device::CPU ? "A9 cat CPU" : "A9 cat CUDA");
+    }
+}
+
+TEST_F(CudaTest, A9_StackReadsNonContiguousOperands_CPUAndCUDA) {
+    const std::vector<float> values = {1, 2, 3, 4, 5, 6};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto ours = lfs_float_tensor(values, {2, 3}, device).transpose(0, 1);
+        auto theirs = torch::tensor(values).reshape({2, 3}).transpose(0, 1);
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+        }
+        expect_float_values_match(Tensor::stack({ours, ours}, 0),
+                                  torch::stack({theirs, theirs}, 0),
+                                  device == Device::CPU ? "A9 stack CPU" : "A9 stack CUDA");
+    }
+}
+
+TEST_F(CudaTest, A10_MaskedSelectReadsLogicalViewOrder_CPUAndCUDA) {
+    const std::vector<float> values = {1, 2, 3, 4, 5, 6};
+    const std::vector<bool> mask_values = {false, false, false, true, false, false};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto ours = lfs_float_tensor(values, {2, 3}, device).transpose(0, 1);
+        const auto mask = lfs_bool_tensor(mask_values, {3, 2}, device);
+        auto theirs = torch::tensor(values).reshape({2, 3}).transpose(0, 1);
+        auto torch_mask = torch::tensor(
+                              {false, false, false, true, false, false},
+                              torch::TensorOptions().dtype(torch::kBool))
+                              .reshape({3, 2});
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+            torch_mask = torch_mask.cuda();
+        }
+        expect_float_values_match(ours.masked_select(mask), theirs.masked_select(torch_mask),
+                                  device == Device::CPU ? "A10 select CPU" : "A10 select CUDA");
+    }
+}
+
+TEST_F(CudaTest, A10_MaskedFillWritesLogicalViewCells_CPUAndCUDA) {
+    const std::vector<float> values = {1, 2, 3, 4, 5, 6};
+    const std::vector<bool> mask_values = {false, false, false, true, false, false};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        auto ours_base = lfs_float_tensor(values, {2, 3}, device);
+        auto ours_view = ours_base.transpose(0, 1);
+        const auto mask = lfs_bool_tensor(mask_values, {3, 2}, device);
+        ours_view.masked_fill_(mask, 99.0f);
+
+        auto torch_base = torch::tensor(values).reshape({2, 3});
+        auto torch_mask = torch::tensor(
+                              {false, false, false, true, false, false},
+                              torch::TensorOptions().dtype(torch::kBool))
+                              .reshape({3, 2});
+        if (device == Device::CUDA) {
+            torch_base = torch_base.cuda();
+            torch_mask = torch_mask.cuda();
+        }
+        torch_base.transpose(0, 1).masked_fill_(torch_mask, 99.0f);
+        expect_float_values_match(ours_base, torch_base,
+                                  device == Device::CPU ? "A10 fill CPU" : "A10 fill CUDA");
+    }
+}
+
+TEST_F(CudaTest, A11_IndexPutOnOffsetViewWritesLogicalCells_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        auto ours_base = Tensor::zeros({6}, device);
+        auto ours_view = ours_base.slice(0, 2, 5);
+        const auto index = lfs_int_tensor({1}, {1}, device);
+        const auto value = lfs_float_tensor({9.0f}, {1}, device);
+        ours_view.index_put_(index, value);
+
+        auto torch_base = torch::zeros({6}, torch::TensorOptions().device(
+                                                device == Device::CUDA ? torch::kCUDA : torch::kCPU));
+        auto torch_view = torch_base.slice(0, 2, 5);
+        auto torch_index = torch::tensor({1}, torch::TensorOptions().dtype(torch::kInt64).device(torch_base.device()));
+        torch_view.index_put_({torch_index}, torch::tensor({9.0f}, torch_base.options()));
+        expect_float_values_match(ours_base, torch_base,
+                                  device == Device::CPU ? "A11 index_put CPU" : "A11 index_put CUDA");
+    }
+}
+
+TEST_F(CudaTest, A12_LinearReadsStridedBias) {
+    const auto input = lfs_float_tensor({1, 2, 3, 4}, {2, 2}, Device::CUDA);
+    const auto weight = lfs_float_tensor({1, 0, 0, 1}, {2, 2}, Device::CUDA);
+    const auto bias_base = lfs_float_tensor({10, 99, 20, 99}, {2, 2}, Device::CUDA);
+    const auto bias = bias_base.transpose(0, 1).slice(0, 0, 1).squeeze(0);
+
+    const auto torch_input = torch::tensor({{1.0f, 2.0f}, {3.0f, 4.0f}}, torch::kCUDA);
+    const auto torch_weight = torch::eye(2, torch::TensorOptions().device(torch::kCUDA));
+    const auto torch_bias_base = torch::tensor({{10.0f, 99.0f}, {20.0f, 99.0f}}, torch::kCUDA);
+    const auto torch_bias = torch_bias_base.transpose(0, 1).slice(0, 0, 1).squeeze(0);
+    expect_float_values_match(input.linear(weight, bias),
+                              torch::linear(torch_input, torch_weight, torch_bias),
+                              "A12 linear strided bias");
+}
+
+TEST_F(CudaTest, A13_LinearOutWritesLogicalOutputLayout) {
+    const auto input = lfs_float_tensor({1, 2, 3, 4}, {2, 2}, Device::CUDA);
+    const auto weight = lfs_float_tensor({1, 0, 0, 1}, {2, 2}, Device::CUDA);
+    Tensor no_bias;
+    auto output_base = Tensor::zeros({2, 2}, Device::CUDA);
+    auto output_view = output_base.transpose(0, 1);
+    input.linear_out(weight, no_bias, output_view);
+
+    const auto torch_input = torch::tensor({{1.0f, 2.0f}, {3.0f, 4.0f}}, torch::kCUDA);
+    const auto torch_expected = torch_input.clone();
+    expect_float_values_match(output_view, torch_expected, "A13 linear_out view");
+}
+
+TEST_F(CudaTest, A14_GatherReadsStridedInt32Indices) {
+    const auto input = lfs_float_tensor({10, 20, 30}, {3}, Device::CUDA);
+    const auto index_base = lfs_int_tensor({2, 0, 1, 0, 0, 0}, {3, 2}, Device::CUDA);
+    const auto index = index_base.slice(1, 0, 1).squeeze(1);
+
+    const auto torch_input = torch::tensor({10.0f, 20.0f, 30.0f}, torch::kCUDA);
+    const auto torch_index_base = torch::tensor({{2, 0}, {1, 0}, {0, 0}},
+                                                torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA));
+    const auto torch_index = torch_index_base.slice(1, 0, 1).squeeze(1);
+    expect_float_values_match(input.gather(0, index), torch_input.gather(0, torch_index),
+                              "A14 strided gather index");
+}
+
+TEST_F(CudaTest, A15_IndexSelectReadsLogicalSourceAndIndices) {
+    const auto input = lfs_float_tensor({1, 2, 3, 4, 5, 6}, {2, 3}, Device::CUDA)
+                           .transpose(0, 1);
+    const auto index_base = lfs_int_tensor({1, 0, 2, 0}, {2, 2}, Device::CUDA);
+    const auto index = index_base.slice(1, 0, 1).squeeze(1);
+
+    const auto torch_input = torch::tensor({{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}}, torch::kCUDA)
+                                 .transpose(0, 1);
+    const auto torch_index = torch::tensor({1, 2},
+                                           torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA));
+    expect_float_values_match(input.index_select(0, index),
+                              torch_input.index_select(0, torch_index),
+                              "A15 index_select source/index");
+}
+
+TEST_F(CudaTest, A15_TakeFlattensLogicalOrder) {
+    const auto input = lfs_float_tensor({1, 2, 3, 4, 5, 6}, {2, 3}, Device::CUDA)
+                           .transpose(0, 1);
+    const auto index = lfs_int_tensor({1, 4}, {2}, Device::CUDA);
+    const auto torch_input = torch::tensor({{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}}, torch::kCUDA)
+                                 .transpose(0, 1);
+    const auto torch_index = torch::tensor({1, 4},
+                                           torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA));
+    expect_float_values_match(input.take(index), torch::take(torch_input, torch_index),
+                              "A15 take logical flatten");
+}
+
+TEST_F(CudaTest, A15_IndexSelectIntoWritesLogicalOutputLayout) {
+    const auto input = lfs_float_tensor({1, 2, 3, 4}, {2, 2}, Device::CUDA);
+    const auto index = lfs_int_tensor({1, 0}, {2}, Device::CUDA);
+    auto output_base = Tensor::zeros({2, 2}, Device::CUDA);
+    auto output_view = output_base.transpose(0, 1);
+    input.index_select_into(output_view, 0, index, BoundaryMode::Assert);
+
+    const auto torch_input = torch::tensor({{1.0f, 2.0f}, {3.0f, 4.0f}}, torch::kCUDA);
+    const auto torch_index = torch::tensor({1, 0},
+                                           torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA));
+    expect_float_values_match(output_view, torch_input.index_select(0, torch_index),
+                              "A15 index_select_into output");
+}
+
+TEST_F(CudaTest, A16_ScatterWritesStridedDestination) {
+    auto ours_base = Tensor::zeros({3, 2}, Device::CUDA);
+    auto ours_view = ours_base.slice(1, 0, 1).squeeze(1);
+    const auto index = lfs_int_tensor({2, 0, 1}, {3}, Device::CUDA);
+    const auto source = lfs_float_tensor({7, 8, 9}, {3}, Device::CUDA);
+    ours_view.scatter_(0, index, source);
+
+    auto torch_base = torch::zeros({3, 2}, torch::TensorOptions().device(torch::kCUDA));
+    auto torch_view = torch_base.slice(1, 0, 1).squeeze(1);
+    const auto torch_index = torch::tensor({2, 0, 1},
+                                           torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA));
+    torch_view.scatter_(0, torch_index, torch::tensor({7.0f, 8.0f, 9.0f}, torch::kCUDA));
+    expect_float_values_match(ours_base, torch_base, "A16 scatter destination");
+}
+
+TEST_F(CudaTest, A16_IndexCopyReadsAndWritesStridedOperands) {
+    auto ours_base = Tensor::zeros({3, 2}, Device::CUDA);
+    auto ours_view = ours_base.slice(1, 0, 1).squeeze(1);
+    const auto index = lfs_int_tensor({2, 0, 1}, {3}, Device::CUDA);
+    const auto source_base = lfs_float_tensor({7, -1, 8, -1, 9, -1}, {3, 2}, Device::CUDA);
+    const auto source = source_base.slice(1, 0, 1).squeeze(1);
+    ours_view.index_copy_(0, index, source);
+
+    auto torch_base = torch::zeros({3, 2}, torch::TensorOptions().device(torch::kCUDA));
+    auto torch_view = torch_base.slice(1, 0, 1).squeeze(1);
+    const auto torch_index = torch::tensor({2, 0, 1},
+                                           torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA));
+    const auto torch_source = torch::tensor({{7.0f, -1.0f}, {8.0f, -1.0f}, {9.0f, -1.0f}}, torch::kCUDA)
+                                  .slice(1, 0, 1)
+                                  .squeeze(1);
+    torch_view.index_copy_(0, torch_index, torch_source);
+    expect_float_values_match(ours_base, torch_base, "A16 index_copy operands");
+}
+
+TEST_F(CudaTest, A16_IndexAddReadsAndWritesStridedOperands) {
+    auto ours_base = Tensor::zeros({3, 2}, Device::CUDA);
+    auto ours_view = ours_base.slice(1, 0, 1).squeeze(1);
+    const auto index = lfs_int_tensor({2, 0, 1}, {3}, Device::CUDA);
+    const auto source_base = lfs_float_tensor({7, -1, 8, -1, 9, -1}, {3, 2}, Device::CUDA);
+    const auto source = source_base.slice(1, 0, 1).squeeze(1);
+    ours_view.index_add_(0, index, source);
+
+    auto torch_base = torch::zeros({3, 2}, torch::TensorOptions().device(torch::kCUDA));
+    auto torch_view = torch_base.slice(1, 0, 1).squeeze(1);
+    const auto torch_index = torch::tensor({2, 0, 1},
+                                           torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA));
+    const auto torch_source = torch::tensor({{7.0f, -1.0f}, {8.0f, -1.0f}, {9.0f, -1.0f}}, torch::kCUDA)
+                                  .slice(1, 0, 1)
+                                  .squeeze(1);
+    torch_view.index_add_(0, torch_index, torch_source);
+    expect_float_values_match(ours_base, torch_base, "A16 index_add operands");
+}
+
+TEST_F(CudaTest, A17_UniformTouchesOnlyLogicalViewCells_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        auto ours_base = Tensor::zeros({3, 4}, device);
+        auto ours_view = ours_base.slice(1, 1, 3);
+        ours_view.uniform_(2.0f, 4.0f);
+
+        auto torch_base = torch::zeros({3, 4}, torch::TensorOptions().device(
+                                                   device == Device::CUDA ? torch::kCUDA : torch::kCPU));
+        torch_base.slice(1, 1, 3).uniform_(2.0, 4.0);
+        EXPECT_EQ(changed_from_zero(ours_base), changed_from_zero(torch_base))
+            << (device == Device::CPU ? "A17 uniform CPU" : "A17 uniform CUDA");
+    }
+}
+
+TEST_F(CudaTest, A17_NormalTouchesOnlyLogicalViewCells_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        auto ours_base = Tensor::zeros({3, 4}, device);
+        auto ours_view = ours_base.slice(1, 1, 3);
+        ours_view.normal_(10.0f, 0.01f);
+
+        auto torch_base = torch::zeros({3, 4}, torch::TensorOptions().device(
+                                                   device == Device::CUDA ? torch::kCUDA : torch::kCPU));
+        torch_base.slice(1, 1, 3).normal_(10.0, 0.01);
+        EXPECT_EQ(changed_from_zero(ours_base), changed_from_zero(torch_base))
+            << (device == Device::CPU ? "A17 normal CPU" : "A17 normal CUDA");
+    }
+}
+
+TEST_F(CudaTest, A18_RankOneGatherBroadcastsAcrossOuterDimensions) {
+    const auto ours = lfs_float_tensor({10, 11, 12, 20, 21, 22}, {2, 3}, Device::CUDA);
+    const auto index = lfs_int_tensor({2, 0}, {2}, Device::CUDA);
+    const auto theirs = torch::tensor({{10.0f, 11.0f, 12.0f}, {20.0f, 21.0f, 22.0f}}, torch::kCUDA);
+    const auto torch_index = torch::tensor({2, 0},
+                                           torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA));
+    expect_float_values_match(ours.gather(1, index), theirs.index_select(1, torch_index),
+                              "A18 rank-one gather");
+}
+
+TEST_F(CudaTest, A19_MaskedScatterTreatsUInt8MaskAsTruthValues) {
+    auto ours = Tensor::zeros({2}, Device::CUDA);
+    const auto mask = lfs_int_tensor({2, 1}, {2}, Device::CUDA).to(DataType::UInt8);
+    const auto source = lfs_float_tensor({10, 20}, {2}, Device::CUDA);
+    ours[mask] = source;
+
+    auto theirs = torch::zeros({2}, torch::TensorOptions().device(torch::kCUDA));
+    const auto torch_mask = torch::tensor({true, true},
+                                          torch::TensorOptions().dtype(torch::kBool).device(torch::kCUDA));
+    theirs.masked_scatter_(torch_mask, torch::tensor({10.0f, 20.0f}, torch::kCUDA));
+    expect_float_values_match(ours, theirs, "A19 UInt8 masked scatter");
+}
+
+TEST_F(CudaTest, A20_MultinomialSamplesLogicalStridedWeights) {
+    const auto base = lfs_float_tensor({1, 100, 0, 0}, {2, 2}, Device::CUDA);
+    const auto weights = base.transpose(0, 1).slice(0, 0, 1).squeeze(0);
+    const auto torch_base = torch::tensor({{1.0f, 100.0f}, {0.0f, 0.0f}}, torch::kCUDA);
+    const auto torch_weights = torch_base.transpose(0, 1).slice(0, 0, 1).squeeze(0);
+
+    const auto ours = Tensor::multinomial(weights, 512, true);
+    const auto theirs = torch::multinomial(torch_weights, 512, true);
+    const auto ours_values = ours.cpu().to_vector_int64();
+    const auto torch_cpu = theirs.cpu().contiguous();
+    const auto* torch_values = torch_cpu.data_ptr<int64_t>();
+    EXPECT_EQ(std::count(ours_values.begin(), ours_values.end(), 0),
+              std::count(torch_values, torch_values + torch_cpu.numel(), int64_t{0}));
+}
+
+TEST_F(CudaTest, A21_DiagReadsRankOneStride_CPUAndCUDA) {
+    const std::vector<float> values = {1, 2, 3, 4};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto base = lfs_float_tensor(values, {2, 2}, device);
+        const auto diagonal = base.transpose(0, 1).slice(0, 0, 1).squeeze(0);
+        auto torch_base = torch::tensor(values).reshape({2, 2});
+        if (device == Device::CUDA) {
+            torch_base = torch_base.cuda();
+        }
+        const auto torch_diagonal = torch_base.transpose(0, 1).slice(0, 0, 1).squeeze(0);
+        expect_float_values_match(Tensor::diag(diagonal), torch::diag(torch_diagonal),
+                                  device == Device::CPU ? "A21 diag CPU" : "A21 diag CUDA");
+    }
+}

--- a/tests/test_tensor_hardening_theme_b.cpp
+++ b/tests/test_tensor_hardening_theme_b.cpp
@@ -1,0 +1,100 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "tensor_hardening_test_utils.hpp"
+
+#include <numeric>
+
+using namespace lfs::core;
+using namespace tensor_hardening;
+
+TEST_F(CudaTest, B1_Float16TransposeContiguousDispatchesAKernel) {
+    const std::vector<float> values = {1, 2, 3, 4, 5, 6};
+    const auto ours = lfs_float_tensor(values, {2, 3}, Device::CUDA)
+                          .to(DataType::Float16)
+                          .transpose(0, 1)
+                          .contiguous();
+    const auto theirs = torch::tensor(values, torch::TensorOptions().device(torch::kCUDA))
+                            .reshape({2, 3})
+                            .to(torch::kFloat16)
+                            .transpose(0, 1)
+                            .contiguous();
+    expect_float_values_match(ours, theirs, "B1 CUDA half contiguous");
+}
+
+TEST_F(CudaTest, B1_Float16StridedCPUUploadDispatchesAKernel) {
+    const std::vector<float> values = {1, 2, 3, 4, 5, 6};
+    const auto ours = lfs_float_tensor(values, {2, 3}, Device::CPU)
+                          .to(DataType::Float16)
+                          .transpose(0, 1)
+                          .cuda();
+    const auto theirs = torch::tensor(values)
+                            .reshape({2, 3})
+                            .to(torch::kFloat16)
+                            .transpose(0, 1)
+                            .cuda();
+    expect_float_values_match(ours, theirs, "B1 CPU half strided upload");
+}
+
+TEST_F(CudaTest, B2_HWCToCHWInt32UploadFallsBackToGenericDispatch) {
+    std::vector<int> values(12);
+    std::iota(values.begin(), values.end(), 1);
+    const auto ours = lfs_int_tensor(values, {2, 2, 3}, Device::CPU)
+                          .permute({2, 0, 1})
+                          .cuda();
+    const auto theirs = torch::tensor(values, torch::TensorOptions().dtype(torch::kInt32))
+                            .reshape({2, 2, 3})
+                            .permute({2, 0, 1})
+                            .cuda();
+    expect_int_values_match(ours, theirs, "B2 HWC Int32 upload");
+}
+
+TEST_F(CudaTest, B2_HWCToCHWBoolUploadFallsBackToGenericDispatch) {
+    const std::vector<bool> values = {
+        true, false, true, false, true, false,
+        false, true, false, true, false, true};
+    const auto ours = lfs_bool_tensor(values, {2, 2, 3}, Device::CPU)
+                          .permute({2, 0, 1})
+                          .cuda();
+    const auto theirs = torch::tensor(
+                            {true, false, true, false, true, false,
+                             false, true, false, true, false, true},
+                            torch::TensorOptions().dtype(torch::kBool))
+                            .reshape({2, 2, 3})
+                            .permute({2, 0, 1})
+                            .cuda();
+    expect_bool_values_match(ours, theirs, "B2 HWC Bool upload");
+}
+
+TEST_F(CudaTest, B2_HWCToCHWInt64UploadFallsBackToGenericDispatch) {
+    std::vector<int> values(12);
+    std::iota(values.begin(), values.end(), 1);
+    const auto ours = lfs_int_tensor(values, {2, 2, 3}, Device::CPU)
+                          .to(DataType::Int64)
+                          .permute({2, 0, 1})
+                          .cuda();
+    const auto theirs = torch::tensor(values, torch::TensorOptions().dtype(torch::kInt64))
+                            .reshape({2, 2, 3})
+                            .permute({2, 0, 1})
+                            .cuda();
+    expect_int_values_match(ours, theirs, "B2 HWC Int64 upload");
+}
+
+TEST_F(CudaTest, B3_MultiAxisProdWritesEveryOutputElement) {
+    const auto ours = Tensor::full({2, 2, 2}, 2.0f, Device::CUDA).prod({0, 1});
+    const auto theirs = torch::full({2, 2, 2}, 2.0f,
+                                    torch::TensorOptions().device(torch::kCUDA))
+                            .prod(0)
+                            .prod(0);
+    expect_float_values_match(ours, theirs, "B3 multi-axis prod dispatch");
+}
+
+TEST(HardeningThemeB_DtypeDispatch, B4_CPUInt32PartialReductionWritesAndPromotes) {
+    const auto ours = lfs_int_tensor({1, 2, 3, 4}, {2, 2}, Device::CPU).sum({0});
+    const auto theirs = torch::tensor({1, 2, 3, 4}, torch::TensorOptions().dtype(torch::kInt32))
+                            .reshape({2, 2})
+                            .sum(0);
+    EXPECT_EQ(ours.dtype(), DataType::Int64)
+        << "B4 torch promotes Int32 sum to Int64";
+    expect_int_values_match(ours, theirs, "B4 CPU Int32 partial sum");
+}

--- a/tests/test_tensor_hardening_theme_c.cpp
+++ b/tests/test_tensor_hardening_theme_c.cpp
@@ -1,0 +1,103 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "tensor_hardening_test_utils.hpp"
+
+#include <limits>
+#include <numeric>
+
+using namespace lfs::core;
+using namespace tensor_hardening;
+
+TEST_F(CudaTest, C1_NonSuffixMultiAxisSumUsesLogicalReductionAxes) {
+    std::vector<float> values(8);
+    std::iota(values.begin(), values.end(), 1.0f);
+    const auto ours = lfs_float_tensor(values, {2, 2, 2}, Device::CUDA).sum({0, 1});
+    const std::vector<int64_t> axes = {0, 1};
+    const auto theirs = torch::tensor(values, torch::TensorOptions().device(torch::kCUDA))
+                            .reshape({2, 2, 2})
+                            .sum(axes);
+    expect_float_values_match(ours, theirs, "C1 non-suffix multi-axis sum");
+}
+
+TEST_F(CudaTest, C2_SuffixMultiAxisMeanNormalizesExactlyOnce) {
+    std::vector<float> values(24);
+    std::iota(values.begin(), values.end(), 1.0f);
+    const auto ours = lfs_float_tensor(values, {2, 3, 4}, Device::CUDA).mean({1, 2});
+    const std::vector<int64_t> axes = {1, 2};
+    const auto theirs = torch::tensor(values, torch::TensorOptions().device(torch::kCUDA))
+                            .reshape({2, 3, 4})
+                            .mean(axes);
+    expect_float_values_match(ours, theirs, "C2 suffix multi-axis mean");
+}
+
+TEST_F(CudaTest, C3_RGBAlphaCatReadsProvidedAlphaTensor) {
+    const auto rgb = lfs_float_tensor({0.1f, 0.2f, 0.3f,
+                                       0.4f, 0.5f, 0.6f},
+                                      {2, 3}, Device::CUDA);
+    const auto alpha = lfs_float_tensor({0.2f, 0.7f}, {2, 1}, Device::CUDA);
+    const auto torch_rgb = torch::tensor({0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f},
+                                         torch::TensorOptions().device(torch::kCUDA))
+                               .reshape({2, 3});
+    const auto torch_alpha = torch::tensor({0.2f, 0.7f},
+                                           torch::TensorOptions().device(torch::kCUDA))
+                                 .reshape({2, 1});
+    expect_float_values_match(Tensor::cat({rgb, alpha}, -1),
+                              torch::cat({torch_rgb, torch_alpha}, -1),
+                              "C3 RGB plus alpha cat");
+}
+
+TEST_F(CudaTest, C4_Int32FullSumPromotesAndDoesNotOverflow_CPUAndCUDA) {
+    const std::vector<int> values = {std::numeric_limits<int>::max(), 1};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto ours = lfs_int_tensor(values, {2}, device).sum();
+        auto theirs = torch::tensor(values, torch::TensorOptions().dtype(torch::kInt32));
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+        }
+        const auto torch_sum = theirs.sum();
+        EXPECT_EQ(ours.dtype(), DataType::Int64)
+            << (device == Device::CPU ? "C4 CPU result dtype" : "C4 CUDA result dtype");
+        expect_int_values_match(ours, torch_sum,
+                                device == Device::CPU ? "C4 CPU sum" : "C4 CUDA sum");
+    }
+}
+
+TEST_F(CudaTest, C5_IntegerMeanRejectsLikeTorch_CPUAndCUDA) {
+    const std::vector<int> values = {1, 2, 3, 4};
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        auto theirs = torch::tensor(values, torch::TensorOptions().dtype(torch::kInt32));
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+        }
+        EXPECT_THROW(theirs.mean(), c10::Error);
+
+        const auto ours = lfs_int_tensor(values, {2, 2}, device);
+        EXPECT_THROW(static_cast<void>(ours.mean()), std::exception)
+            << (device == Device::CPU ? "C5 CPU integer mean" : "C5 CUDA integer mean");
+    }
+}
+
+TEST_F(CudaTest, C6_TransposeBeforeReduceRestoresKeepdimAxisOrder) {
+    std::vector<float> values(2 * 3 * 256);
+    std::iota(values.begin(), values.end(), 1.0f);
+    const auto ours = lfs_float_tensor(values, {2, 3, 256}, Device::CUDA).sum({1}, true);
+    const std::vector<int64_t> axis = {1};
+    const auto theirs = torch::tensor(values, torch::TensorOptions().device(torch::kCUDA))
+                            .reshape({2, 3, 256})
+                            .sum(axis, true);
+    expect_float_values_match(ours, theirs, "C6 keepdim axis restoration");
+}
+
+TEST_F(CudaTest, C7_EmptyDimensionalNormWritesIdentityValues_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto ours = Tensor::empty({0, 3}, device).norm(2.0f, {0});
+        auto theirs = torch::empty({0, 3});
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+        }
+        const auto torch_norm = theirs.norm(2, 0);
+        expect_float_values_match(ours, torch_norm,
+                                  device == Device::CPU ? "C7 CPU empty norm" : "C7 CUDA empty norm");
+    }
+}

--- a/tests/test_tensor_hardening_theme_d.cpp
+++ b/tests/test_tensor_hardening_theme_d.cpp
@@ -1,0 +1,369 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "tensor_hardening_test_utils.hpp"
+
+#include "core/tensor/internal/cuda_stream_context.hpp"
+
+#include <algorithm>
+#include <optional>
+
+using namespace lfs::core;
+using namespace tensor_hardening;
+namespace {
+
+    cudaStream_t make_consumer_stream() {
+        cudaStream_t stream = nullptr;
+        EXPECT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+        return stream;
+    }
+
+    template <typename Callback>
+    void invoke_while_producer_is_gated(GateStream&, const cudaStream_t consumer,
+                                        Callback&& callback) {
+        CUDAStreamGuard guard(consumer);
+        callback();
+    }
+
+} // namespace
+
+TEST_F(CudaTest, D1_CloneWaitsForGatedProducer) {
+    GateStream producer;
+    const cudaStream_t consumer = make_consumer_stream();
+
+    Tensor source;
+    {
+        CUDAStreamGuard guard(producer.get());
+        source = Tensor::zeros({1 << 20}, Device::CUDA);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    producer.close();
+    source.fill_(3.0f, producer.get());
+
+    Tensor result;
+    invoke_while_producer_is_gated(producer, consumer, [&] { result = source.clone(); });
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+
+    expect_float_values_match(
+        result, torch::full({1 << 20}, 3.0f, torch::TensorOptions().device(torch::kCUDA)),
+        "D1 clone producer ordering");
+    destroy_stream_safely(consumer);
+}
+
+TEST_F(CudaTest, D1_ContiguousWaitsForGatedProducer) {
+    GateStream producer;
+    const cudaStream_t consumer = make_consumer_stream();
+
+    Tensor base;
+    {
+        CUDAStreamGuard guard(producer.get());
+        base = Tensor::zeros({1024, 1024}, Device::CUDA);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    const auto view = base.transpose(0, 1);
+    producer.close();
+    base.fill_(4.0f, producer.get());
+
+    Tensor result;
+    invoke_while_producer_is_gated(producer, consumer, [&] { result = view.contiguous(); });
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+
+    expect_float_values_match(
+        result, torch::full({1024, 1024}, 4.0f, torch::TensorOptions().device(torch::kCUDA)),
+        "D1 contiguous producer ordering");
+    destroy_stream_safely(consumer);
+}
+
+TEST_F(CudaTest, D1_DtypeConversionWaitsForGatedProducer) {
+    GateStream producer;
+    const cudaStream_t consumer = make_consumer_stream();
+
+    Tensor source;
+    {
+        CUDAStreamGuard guard(producer.get());
+        source = Tensor::zeros({1 << 20}, Device::CUDA);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    producer.close();
+    source.fill_(5.0f, producer.get());
+
+    Tensor result;
+    invoke_while_producer_is_gated(
+        producer, consumer, [&] { result = source.to(DataType::Int32); });
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+
+    expect_int_values_match(
+        result, torch::full({1 << 20}, 5, torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA)),
+        "D1 dtype conversion producer ordering");
+    destroy_stream_safely(consumer);
+}
+
+TEST_F(CudaTest, D1_CopyFromWaitsForGatedProducer) {
+    GateStream producer;
+    const cudaStream_t consumer = make_consumer_stream();
+
+    Tensor source;
+    Tensor destination;
+    {
+        CUDAStreamGuard guard(producer.get());
+        source = Tensor::zeros({1 << 20}, Device::CUDA);
+    }
+    {
+        CUDAStreamGuard guard(consumer);
+        destination = Tensor::zeros({1 << 20}, Device::CUDA);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    producer.close();
+    source.fill_(6.0f, producer.get());
+
+    invoke_while_producer_is_gated(
+        producer, consumer, [&] { destination.copy_from(source); });
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+
+    expect_float_values_match(
+        destination, torch::full({1 << 20}, 6.0f, torch::TensorOptions().device(torch::kCUDA)),
+        "D1 copy_from producer ordering");
+    destroy_stream_safely(consumer);
+}
+
+TEST_F(CudaTest, D1_BinaryInPlaceWaitsForGatedProducer) {
+    GateStream producer;
+    const cudaStream_t consumer = make_consumer_stream();
+
+    Tensor source;
+    Tensor destination;
+    {
+        CUDAStreamGuard guard(producer.get());
+        source = Tensor::zeros({1 << 20}, Device::CUDA);
+    }
+    {
+        CUDAStreamGuard guard(consumer);
+        destination = Tensor::ones({1 << 20}, Device::CUDA);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    producer.close();
+    source.fill_(2.0f, producer.get());
+
+    invoke_while_producer_is_gated(
+        producer, consumer, [&] { destination.add_(source); });
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+
+    expect_float_values_match(
+        destination, torch::full({1 << 20}, 3.0f, torch::TensorOptions().device(torch::kCUDA)),
+        "D1 in-place producer ordering");
+    destroy_stream_safely(consumer);
+}
+
+TEST_F(CudaTest, D2_MMWaitsForGatedProducer) {
+    GateStream producer;
+    const cudaStream_t consumer = make_consumer_stream();
+    constexpr int size = 256;
+
+    Tensor input;
+    {
+        CUDAStreamGuard guard(producer.get());
+        input = Tensor::zeros({size, size}, Device::CUDA);
+    }
+    const auto identity = Tensor::eye(size, Device::CUDA);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(nullptr), cudaSuccess);
+    producer.close();
+    input.fill_(2.0f, producer.get());
+
+    Tensor result;
+    invoke_while_producer_is_gated(producer, consumer, [&] { result = input.mm(identity); });
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    expect_float_values_match(
+        result, torch::full({size, size}, 2.0f, torch::TensorOptions().device(torch::kCUDA)),
+        "D2 mm producer ordering");
+    destroy_stream_safely(consumer);
+}
+
+TEST_F(CudaTest, D2_DotWaitsForGatedProducer) {
+    GateStream producer;
+    const cudaStream_t consumer = make_consumer_stream();
+    constexpr int count = 1 << 20;
+
+    Tensor input;
+    {
+        CUDAStreamGuard guard(producer.get());
+        input = Tensor::zeros({count}, Device::CUDA);
+    }
+    const auto ones = Tensor::ones({count}, Device::CUDA);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(nullptr), cudaSuccess);
+    producer.close();
+    input.fill_(2.0f, producer.get());
+
+    Tensor result;
+    invoke_while_producer_is_gated(producer, consumer, [&] { result = input.dot(ones); });
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    expect_float_values_match(
+        result, torch::tensor(static_cast<float>(count * 2), torch::TensorOptions().device(torch::kCUDA)),
+        "D2 dot producer ordering");
+    destroy_stream_safely(consumer);
+}
+
+TEST_F(CudaTest, D2_DiagWaitsForGatedProducer) {
+    GateStream producer;
+    const cudaStream_t consumer = make_consumer_stream();
+    constexpr int count = 1024;
+
+    Tensor input;
+    {
+        CUDAStreamGuard guard(producer.get());
+        input = Tensor::zeros({count}, Device::CUDA);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    producer.close();
+    input.fill_(7.0f, producer.get());
+
+    Tensor result;
+    invoke_while_producer_is_gated(producer, consumer, [&] { result = Tensor::diag(input); });
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    expect_float_values_match(
+        result, torch::diag(torch::full({count}, 7.0f, torch::TensorOptions().device(torch::kCUDA))),
+        "D2 diag producer ordering");
+    destroy_stream_safely(consumer);
+}
+
+TEST_F(CudaTest, D2_MultinomialWaitsForGatedProducer) {
+    GateStream producer;
+    const cudaStream_t consumer = make_consumer_stream();
+
+    Tensor weights;
+    {
+        CUDAStreamGuard guard(producer.get());
+        weights = Tensor::zeros({2}, Device::CUDA);
+    }
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+    producer.close();
+    weights.fill_(1.0f, producer.get());
+
+    std::optional<Tensor> result;
+    invoke_while_producer_is_gated(
+        producer, consumer, [&] { result = Tensor::multinomial(weights, 4096, true); });
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(producer.get()), cudaSuccess);
+
+    const auto values = result->cpu().to_vector_int64();
+    ASSERT_EQ(values.size(), 4096u);
+    EXPECT_TRUE(std::all_of(values.begin(), values.end(), [](const int64_t value) {
+        return value == 0 || value == 1;
+    }));
+    EXPECT_NE(std::count(values.begin(), values.end(), 0), 0);
+    EXPECT_NE(std::count(values.begin(), values.end(), 1), 0);
+    destroy_stream_safely(consumer);
+}
+
+TEST_F(CudaTest, D3_WhereMetadataIsNotReusedAcrossConcurrentStreams) {
+    cudaStream_t first_stream = make_consumer_stream();
+    cudaStream_t second_stream = make_consumer_stream();
+
+    const auto first_condition = Tensor::ones({2048, 1}, Device::CUDA, DataType::Bool);
+    const auto first_x = Tensor::ones({1, 2048}, Device::CUDA);
+    const auto first_y = Tensor::zeros({2048, 2048}, Device::CUDA);
+    const auto second_condition = Tensor::zeros({1, 8, 1}, Device::CUDA, DataType::Bool);
+    const auto second_x = Tensor::ones({4, 1, 16}, Device::CUDA);
+    const auto second_y = Tensor::full({4, 8, 16}, 2.0f, Device::CUDA);
+    ASSERT_EQ(cudaStreamSynchronize(nullptr), cudaSuccess);
+
+    for (int iteration = 0; iteration < 20; ++iteration) {
+        Tensor first_result;
+        Tensor second_result;
+        {
+            CUDAStreamGuard guard(first_stream);
+            first_result = Tensor::where(first_condition, first_x, first_y);
+        }
+        {
+            CUDAStreamGuard guard(second_stream);
+            second_result = Tensor::where(second_condition, second_x, second_y);
+        }
+        ASSERT_EQ(cudaStreamSynchronize(first_stream), cudaSuccess);
+        ASSERT_EQ(cudaStreamSynchronize(second_stream), cudaSuccess);
+
+        const auto first_values = first_result.cpu().to_vector();
+        ASSERT_EQ(first_values.size(), static_cast<size_t>(2048 * 2048));
+        EXPECT_FLOAT_EQ(first_values.front(), 1.0f) << "iteration " << iteration;
+        EXPECT_FLOAT_EQ(first_values[first_values.size() / 2], 1.0f) << "iteration " << iteration;
+        EXPECT_FLOAT_EQ(first_values.back(), 1.0f) << "iteration " << iteration;
+        const auto second_values = second_result.cpu().to_vector();
+        EXPECT_TRUE(std::all_of(second_values.begin(), second_values.end(), [](const float value) {
+            return value == 2.0f;
+        })) << "iteration "
+            << iteration;
+    }
+
+    destroy_stream_safely(second_stream);
+    destroy_stream_safely(first_stream);
+}
+
+TEST_F(CudaTest, D4_OverlappingTransposeCopyUsesSnapshotSemantics) {
+    const std::vector<float> values = {1, 2, 3, 4,
+                                       5, 6, 7, 8,
+                                       9, 10, 11, 12,
+                                       13, 14, 15, 16};
+    for (int iteration = 0; iteration < 100; ++iteration) {
+        auto ours = lfs_float_tensor(values, {4, 4}, Device::CUDA);
+        auto destination = ours.transpose(0, 1);
+        destination.copy_from(ours);
+
+        const auto theirs = torch::tensor(values, torch::TensorOptions().device(torch::kCUDA))
+                                .reshape({4, 4})
+                                .transpose(0, 1)
+                                .contiguous();
+        expect_float_values_match(ours, theirs,
+                                  "D4 transpose copy iteration " + std::to_string(iteration));
+    }
+}
+
+TEST_F(CudaTest, D4_OverlappingIndexSelectIntoUsesSnapshotSemantics) {
+    const auto index = lfs_int_tensor({1, 0}, {2}, Device::CUDA);
+    for (int iteration = 0; iteration < 100; ++iteration) {
+        auto ours = lfs_float_tensor({1, 2, 3, 4}, {2, 2}, Device::CUDA);
+        ours.index_select_into(ours, 0, index, BoundaryMode::Assert);
+        const auto theirs = torch::tensor({3.0f, 4.0f, 1.0f, 2.0f},
+                                          torch::TensorOptions().device(torch::kCUDA))
+                                .reshape({2, 2});
+        expect_float_values_match(ours, theirs,
+                                  "D4 index_select_into iteration " + std::to_string(iteration));
+    }
+}
+
+TEST_F(CudaTest, D5_AliasedScatterMatchesTorchOverlapContract) {
+    const auto index = lfs_int_tensor({1, 2, 0}, {3}, Device::CUDA);
+    auto ours = lfs_float_tensor({1, 2, 3}, {3}, Device::CUDA);
+    bool ours_threw = false;
+    try {
+        ours.scatter_(0, index, ours);
+    } catch (const std::exception&) {
+        ours_threw = true;
+    }
+
+    auto theirs = torch::tensor({1.0f, 2.0f, 3.0f},
+                                torch::TensorOptions().device(torch::kCUDA));
+    const auto torch_index = torch::tensor({1, 2, 0},
+                                           torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA));
+    bool torch_threw = false;
+    try {
+        theirs.scatter_(0, torch_index, theirs);
+    } catch (const c10::Error&) {
+        torch_threw = true;
+    }
+
+    EXPECT_EQ(ours_threw, torch_threw);
+    if (!torch_threw) {
+        expect_float_values_match(ours, theirs, "D5 aliased scatter");
+    }
+}

--- a/tests/test_tensor_hardening_theme_e.cpp
+++ b/tests/test_tensor_hardening_theme_e.cpp
@@ -1,0 +1,335 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "tensor_hardening_test_utils.hpp"
+
+#include "core/tensor/internal/lazy_executor.hpp"
+#include "core/tensor/internal/lazy_ir.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <optional>
+#include <set>
+
+using namespace lfs::core;
+using namespace tensor_hardening;
+
+namespace {
+
+    class LazyStateGuard {
+    public:
+        explicit LazyStateGuard(const bool enable_fusion = true) {
+            internal::clear_lazy_ir_for_testing();
+            internal::lazy_executor_clear_registry_for_testing();
+            internal::lazy_executor_reset_diagnostics_for_testing();
+            internal::lazy_executor_set_size_heuristic_override_for_testing(false);
+            internal::lazy_executor_set_size_threshold_override_for_testing(std::nullopt);
+            internal::lazy_executor_set_pointwise_fusion_override_for_testing(enable_fusion);
+        }
+
+        ~LazyStateGuard() {
+            internal::clear_lazy_ir_for_testing();
+            internal::lazy_executor_clear_registry_for_testing();
+            internal::lazy_executor_reset_diagnostics_for_testing();
+            internal::lazy_executor_set_pointwise_fusion_override_for_testing(std::nullopt);
+            internal::lazy_executor_set_size_heuristic_override_for_testing(std::nullopt);
+            internal::lazy_executor_set_size_threshold_override_for_testing(std::nullopt);
+        }
+    };
+
+    std::vector<int64_t> int64_values(const Tensor& tensor) {
+        return tensor.cpu().to_vector_int64();
+    }
+
+} // namespace
+
+TEST(HardeningThemeE_Numerical, E1_AllCloseUsesTorchNaNPolicy) {
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const auto ours_nan = lfs_float_tensor({nan}, {1}, Device::CPU);
+    const auto ours_zero = lfs_float_tensor({0.0f}, {1}, Device::CPU);
+    const auto torch_nan = torch::tensor({nan});
+    const auto torch_zero = torch::tensor({0.0f});
+
+    EXPECT_EQ(ours_nan.all_close(ours_zero), torch::allclose(torch_nan, torch_zero));
+    EXPECT_EQ(ours_nan.all_close(ours_nan), torch::allclose(torch_nan, torch_nan));
+}
+
+TEST_F(CudaTest, E2_IntegerTensorTrueDivisionPromotesLikeTorch_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto lhs = lfs_int_tensor({3}, {1}, device);
+        const auto rhs = lfs_int_tensor({2}, {1}, device);
+        const auto ours = lhs.div(rhs);
+        auto torch_lhs = torch::tensor({3}, torch::TensorOptions().dtype(torch::kInt32));
+        auto torch_rhs = torch::tensor({2}, torch::TensorOptions().dtype(torch::kInt32));
+        if (device == Device::CUDA) {
+            torch_lhs = torch_lhs.cuda();
+            torch_rhs = torch_rhs.cuda();
+        }
+        const auto theirs = torch_lhs / torch_rhs;
+        EXPECT_EQ(ours.dtype(), DataType::Float32);
+        expect_float_values_match(ours, theirs,
+                                  device == Device::CPU ? "E2 tensor div CPU" : "E2 tensor div CUDA");
+    }
+}
+
+TEST_F(CudaTest, E2_IntegerScalarTrueDivisionPromotesLikeTorch_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto ours = lfs_int_tensor({3}, {1}, device).div(2.0f);
+        auto theirs = torch::tensor({3}, torch::TensorOptions().dtype(torch::kInt32));
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+        }
+        theirs = theirs / 2.0f;
+        EXPECT_EQ(ours.dtype(), DataType::Float32);
+        expect_float_values_match(ours, theirs,
+                                  device == Device::CPU ? "E2 scalar div CPU" : "E2 scalar div CUDA");
+    }
+}
+
+TEST_F(CudaTest, E3_Int32ScalarArithmeticPreservesValuesBeyondFloatMantissa) {
+    constexpr int scalar = 16'777'217;
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto ours = lfs_int_tensor({0}, {1}, device).add(scalar);
+        auto theirs = torch::tensor({0}, torch::TensorOptions().dtype(torch::kInt32));
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+        }
+        theirs = theirs + scalar;
+        expect_int_values_match(ours, theirs,
+                                device == Device::CPU ? "E3 scalar add CPU" : "E3 scalar add CUDA");
+    }
+}
+
+TEST_F(CudaTest, E3_Int32ScalarComparisonPreservesValuesBeyondFloatMantissa) {
+    constexpr int scalar = 16'777'217;
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto ours = lfs_int_tensor({16'777'216}, {1}, device).eq(scalar);
+        auto theirs = torch::tensor({16'777'216}, torch::TensorOptions().dtype(torch::kInt32));
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+        }
+        theirs = theirs.eq(scalar);
+        expect_bool_values_match(ours, theirs,
+                                 device == Device::CPU ? "E3 scalar compare CPU" : "E3 scalar compare CUDA");
+    }
+}
+
+TEST_F(CudaTest, E4_IntegerSqrtPromotesLikeTorch_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto ours = lfs_int_tensor({2}, {1}, device).sqrt();
+        auto theirs = torch::tensor({2}, torch::TensorOptions().dtype(torch::kInt32));
+        if (device == Device::CUDA) {
+            theirs = theirs.cuda();
+        }
+        theirs = theirs.sqrt();
+        EXPECT_EQ(ours.dtype(), DataType::Float32);
+        expect_float_values_match(ours, theirs,
+                                  device == Device::CPU ? "E4 sqrt CPU" : "E4 sqrt CUDA");
+    }
+}
+
+TEST_F(CudaTest, E4_IntegerReciprocalAndExpPromoteLikeTorch_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        const auto input = lfs_int_tensor({2}, {1}, device);
+        auto torch_input = torch::tensor({2}, torch::TensorOptions().dtype(torch::kInt32));
+        if (device == Device::CUDA) {
+            torch_input = torch_input.cuda();
+        }
+
+        const auto reciprocal = input.reciprocal();
+        EXPECT_EQ(reciprocal.dtype(), DataType::Float32);
+        expect_float_values_match(reciprocal, torch_input.reciprocal(),
+                                  device == Device::CPU ? "E4 reciprocal CPU" : "E4 reciprocal CUDA");
+
+        const auto exponential = input.exp();
+        EXPECT_EQ(exponential.dtype(), DataType::Float32);
+        expect_float_values_match(exponential, torch_input.exp(),
+                                  device == Device::CPU ? "E4 exp CPU" : "E4 exp CUDA");
+    }
+}
+
+TEST_F(CudaTest, E5_AffineFoldingPreservesSequentialOverflowSemantics) {
+    LazyStateGuard guard;
+    const float maximum = std::numeric_limits<float>::max();
+    const auto ours = Tensor::full({1024}, maximum, Device::CUDA).mul(2.0f).div(2.0f);
+    const auto theirs = torch::full({1024}, maximum,
+                                    torch::TensorOptions().device(torch::kCUDA))
+                            .mul(2.0f)
+                            .div(2.0f);
+    expect_float_values_match(ours, theirs, "E5 affine overflow folding");
+}
+
+TEST_F(CudaTest, E5_AffineFoldingPreservesSequentialDivisionByZeroSemantics) {
+    LazyStateGuard guard;
+    const auto ours = Tensor::zeros({1024}, Device::CUDA).add(1.0f).div(0.0f);
+    const auto theirs = torch::zeros({1024}, torch::TensorOptions().device(torch::kCUDA))
+                            .add(1.0f)
+                            .div(0.0f);
+    expect_float_values_match(ours, theirs, "E5 affine division by zero folding");
+}
+
+TEST_F(CudaTest, E6_FusedMaxMinUseInfiniteIdentities) {
+    LazyStateGuard guard;
+    const float maximum = std::numeric_limits<float>::max();
+
+    const auto ours_max = Tensor::full({2048}, -maximum, Device::CUDA).mul(2.0f).max();
+    const auto torch_max = torch::full({2048}, -maximum,
+                                       torch::TensorOptions().device(torch::kCUDA))
+                               .mul(2.0f)
+                               .max();
+    expect_float_values_match(ours_max, torch_max, "E6 fused max identity");
+
+    const auto ours_min = Tensor::full({2048}, maximum, Device::CUDA).mul(2.0f).min();
+    const auto torch_min = torch::full({2048}, maximum,
+                                       torch::TensorOptions().device(torch::kCUDA))
+                               .mul(2.0f)
+                               .min();
+    expect_float_values_match(ours_min, torch_min, "E6 fused min identity");
+}
+
+TEST_F(CudaTest, E6_FusedMaxMinPropagateAllNaNInputs) {
+    LazyStateGuard guard;
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const auto ours_max = Tensor::full({2048}, nan, Device::CUDA).mul(1.0f).max();
+    const auto ours_min = Tensor::full({2048}, nan, Device::CUDA).mul(1.0f).min();
+    const auto torch_input = torch::full({2048}, nan,
+                                         torch::TensorOptions().device(torch::kCUDA));
+    expect_float_values_match(ours_max, torch_input.mul(1.0f).max(), "E6 all-NaN max");
+    expect_float_values_match(ours_min, torch_input.mul(1.0f).min(), "E6 all-NaN min");
+}
+
+TEST_F(CudaTest, E7_CUDAReluPropagatesNaNLikeTorch) {
+    LazyStateGuard guard;
+    std::vector<float> values(1024, -1.0f);
+    values[0] = std::numeric_limits<float>::quiet_NaN();
+    const auto ours = lfs_float_tensor(values, {1024}, Device::CUDA).relu();
+    const auto theirs = torch::tensor(values, torch::TensorOptions().device(torch::kCUDA)).relu();
+    expect_float_values_match(ours, theirs, "E7 CUDA relu NaN");
+}
+
+TEST_F(CudaTest, E7_CUDALogSqrtAndRsqrtFollowTorchDomainSemantics) {
+    LazyStateGuard guard;
+    std::vector<float> values(1024, 4.0f);
+    values[0] = std::numeric_limits<float>::quiet_NaN();
+    values[1] = -1.0f;
+    values[2] = 0.0f;
+    const auto ours = lfs_float_tensor(values, {1024}, Device::CUDA);
+    const auto theirs = torch::tensor(values, torch::TensorOptions().device(torch::kCUDA));
+    expect_float_values_match(ours.log(), theirs.log(), "E7 CUDA log domain");
+    expect_float_values_match(ours.sqrt(), theirs.sqrt(), "E7 CUDA sqrt domain");
+    expect_float_values_match(ours.rsqrt(), theirs.rsqrt(), "E7 CUDA rsqrt domain");
+}
+
+TEST_F(CudaTest, E8_WideRangeRandintDoesNotCollapseDistribution) {
+    constexpr int count = 8192;
+    const auto ours = Tensor::randint({count}, std::numeric_limits<int>::min(),
+                                      std::numeric_limits<int>::max(), Device::CUDA,
+                                      DataType::Int32)
+                          .cpu()
+                          .to_vector_int();
+    const auto theirs_tensor = torch::randint(
+        std::numeric_limits<int>::min(), std::numeric_limits<int>::max(), {count},
+        torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA));
+    const auto theirs_cpu = theirs_tensor.cpu().contiguous();
+    const auto* theirs_data = theirs_cpu.data_ptr<int>();
+    const std::set<int> ours_unique(ours.begin(), ours.end());
+    const std::set<int> torch_unique(theirs_data, theirs_data + count);
+    ASSERT_GT(torch_unique.size(), 8000u);
+    EXPECT_GT(ours_unique.size(), 8000u)
+        << "torch unique=" << torch_unique.size() << ", ours unique=" << ours_unique.size();
+}
+
+TEST_F(CudaTest, E9_MultinomialLargeFiniteWeightsMatchesTorch) {
+    constexpr int samples = 20'000;
+    const float maximum = std::numeric_limits<float>::max();
+    const auto weights = lfs_float_tensor({maximum, maximum}, {2}, Device::CUDA);
+    const auto ours = int64_values(Tensor::multinomial(weights, samples, true));
+    // LibTorch 2.7.1 overflows its Float32 cumulative sum for
+    // {FLT_MAX, FLT_MAX}: CUDA asserts and CPU collapses to the last bucket.
+    // Multinomial probabilities are scale invariant, so normalized {1, 1}
+    // supplies the torch-compatible semantic oracle without oracle overflow.
+    const auto torch_weights = torch::tensor({1.0f, 1.0f});
+    const auto theirs = torch::multinomial(torch_weights, samples, true);
+    const auto* torch_data = theirs.data_ptr<int64_t>();
+
+    const double ours_zero_fraction =
+        static_cast<double>(std::count(ours.begin(), ours.end(), 0)) / samples;
+    const double torch_zero_fraction =
+        static_cast<double>(std::count(torch_data, torch_data + samples, int64_t{0})) / samples;
+    EXPECT_NEAR(ours_zero_fraction, torch_zero_fraction, 0.05)
+        << "ours zero fraction=" << ours_zero_fraction
+        << ", torch CPU zero fraction=" << torch_zero_fraction;
+}
+
+TEST_F(CudaTest, E10_SparseNoReplacementMultinomialMatchesTorchContract) {
+    const auto weights = lfs_float_tensor({1.0f, 0.0f}, {2}, Device::CUDA);
+    const auto torch_cpu_weights = torch::tensor({1.0f, 0.0f});
+    const auto torch_cuda_weights = torch_cpu_weights.cuda();
+
+    bool ours_threw = false;
+    bool torch_cpu_threw = false;
+    bool torch_cuda_threw = false;
+    std::vector<int64_t> ours_values;
+    std::vector<int64_t> torch_cpu_values;
+    std::vector<int64_t> torch_cuda_values;
+
+    try {
+        ours_values = int64_values(Tensor::multinomial(weights, 2, false));
+    } catch (const std::exception&) {
+        ours_threw = true;
+    }
+    try {
+        const auto result = torch::multinomial(torch_cpu_weights, 2, false).contiguous();
+        const auto* values = result.data_ptr<int64_t>();
+        torch_cpu_values.assign(values, values + result.numel());
+    } catch (const c10::Error&) {
+        torch_cpu_threw = true;
+    }
+    try {
+        const auto result = torch::multinomial(torch_cuda_weights, 2, false).cpu().contiguous();
+        const auto* values = result.data_ptr<int64_t>();
+        torch_cuda_values.assign(values, values + result.numel());
+    } catch (const c10::Error&) {
+        torch_cuda_threw = true;
+    }
+
+    EXPECT_EQ(torch_cpu_threw, torch_cuda_threw);
+    EXPECT_EQ(ours_threw, torch_cuda_threw);
+    if (!ours_threw && !torch_cuda_threw) {
+        std::sort(ours_values.begin(), ours_values.end());
+        std::sort(torch_cpu_values.begin(), torch_cpu_values.end());
+        std::sort(torch_cuda_values.begin(), torch_cuda_values.end());
+        EXPECT_EQ(torch_cpu_values, torch_cuda_values);
+        EXPECT_EQ(ours_values, torch_cuda_values);
+    }
+}
+
+TEST(HardeningThemeE_Numerical, E11_LinspaceMatchesTorchWideRangeOverflow) {
+    const float maximum = std::numeric_limits<float>::max();
+    const auto ours = Tensor::linspace(-maximum, maximum, 3, Device::CPU);
+    const auto theirs = torch::linspace(-maximum, maximum, 3,
+                                        torch::TensorOptions().dtype(torch::kFloat32));
+    // LibTorch 2.7.1 computes a Float32 step and fills from both endpoints. The
+    // overflowing step makes this observable result {NaN, -Inf, NaN}; it is
+    // the compatibility contract here rather than a higher-precision alternative.
+    const auto* torch_values = theirs.data_ptr<float>();
+    ASSERT_TRUE(std::isnan(torch_values[0]));
+    ASSERT_TRUE(std::isinf(torch_values[1]) && std::signbit(torch_values[1]));
+    ASSERT_TRUE(std::isnan(torch_values[2]));
+    expect_float_values_match(ours, theirs, "E11 linspace wide-range overflow");
+}
+
+TEST_F(CudaTest, E12_RandomEndpointStressMatchesTorchIntervalContracts) {
+    // The bad cuRAND endpoint has probability about 2^-32 per draw.  This is a
+    // bounded runtime probe; a pass is not proof and is reported as unverified.
+    constexpr int count = 1 << 20;
+    const auto uniform = Tensor::uniform({count}, 2.0f, 4.0f, Device::CUDA).cpu().to_vector();
+    EXPECT_TRUE(std::all_of(uniform.begin(), uniform.end(), [](const float value) {
+        return value >= 2.0f && value < 4.0f;
+    }));
+
+    const auto bernoulli = Tensor::bernoulli({count}, 1.0f, Device::CUDA).cpu().to_vector();
+    EXPECT_TRUE(std::all_of(bernoulli.begin(), bernoulli.end(), [](const float value) {
+        return value == 1.0f;
+    }));
+}

--- a/tests/test_tensor_hardening_theme_f.cpp
+++ b/tests/test_tensor_hardening_theme_f.cpp
@@ -1,0 +1,189 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "tensor_hardening_test_utils.hpp"
+
+#include "core/pinned_memory_allocator.hpp"
+#include "core/tensor/internal/lazy_executor.hpp"
+#include "core/tensor/internal/lazy_ir.hpp"
+
+#include <limits>
+#include <optional>
+
+using namespace lfs::core;
+using namespace tensor_hardening;
+
+namespace {
+
+    class LazyStateGuard {
+    public:
+        LazyStateGuard() {
+            internal::clear_lazy_ir_for_testing();
+            internal::lazy_executor_clear_registry_for_testing();
+            internal::lazy_executor_reset_diagnostics_for_testing();
+            internal::lazy_executor_set_size_heuristic_override_for_testing(false);
+            internal::lazy_executor_set_size_threshold_override_for_testing(std::nullopt);
+        }
+
+        ~LazyStateGuard() {
+            internal::clear_lazy_ir_for_testing();
+            internal::lazy_executor_clear_registry_for_testing();
+            internal::lazy_executor_reset_diagnostics_for_testing();
+            internal::lazy_executor_set_size_heuristic_override_for_testing(std::nullopt);
+            internal::lazy_executor_set_size_threshold_override_for_testing(std::nullopt);
+        }
+    };
+
+    class PinnedFallbackGuard {
+    public:
+        PinnedFallbackGuard() {
+            auto& allocator = PinnedMemoryAllocator::instance();
+            allocator.set_enabled(true);
+            allocator.set_force_fallback_for_testing(true);
+        }
+
+        ~PinnedFallbackGuard() {
+            PinnedMemoryAllocator::instance().set_force_fallback_for_testing(false);
+        }
+    };
+
+} // namespace
+
+TEST_F(CudaTest, F1_DeferredExpressionSnapshotsSourceBeforeMutation_CPUAndCUDA) {
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        LazyStateGuard guard;
+        auto source = Tensor::ones({1024}, device);
+        const auto deferred = source.add(1.0f);
+        ASSERT_TRUE(deferred.has_lazy_expr());
+        source.fill_(5.0f);
+
+        auto torch_source = torch::ones({1024});
+        if (device == Device::CUDA) {
+            torch_source = torch_source.cuda();
+        }
+        const auto torch_result = torch_source.add(1.0f);
+        torch_source.fill_(5.0f);
+        expect_float_values_match(
+            deferred, torch_result,
+            device == Device::CPU ? "F1 deferred source CPU" : "F1 deferred source CUDA");
+    }
+}
+
+TEST_F(CudaTest, F2_CUDARowReferencesDoNotAliasReusableStaging) {
+    auto ours = lfs_float_tensor({1.0f, 2.0f}, {1, 2}, Device::CUDA);
+    {
+        auto row = ours[0];
+        float& first = row[0];
+        float& second = row[1];
+        static_cast<void>(second);
+        first = 5.0f;
+    }
+
+    auto theirs = torch::tensor({1.0f, 2.0f}, torch::TensorOptions().device(torch::kCUDA))
+                      .reshape({1, 2});
+    theirs.index_put_({0, 0}, 5.0f);
+    expect_float_values_match(ours, theirs, "F2 CUDA row proxy references");
+}
+
+TEST(HardeningThemeF_Misc, F3_Rank11WhereDoesNotOverwriteFixedMetadataArrays) {
+    const auto torch_result = torch::where(
+        torch::ones({1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2},
+                    torch::TensorOptions().dtype(torch::kBool)),
+        torch::ones({1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2},
+                    torch::TensorOptions()),
+        torch::zeros({1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2}));
+    ASSERT_TRUE(torch_result.eq(1.0f).all().item<bool>());
+
+    EXPECT_THROW(
+        static_cast<void>(TensorShape(
+            {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2})),
+        std::exception);
+}
+
+TEST(HardeningThemeF_Misc, F3_Rank11GatherDoesNotOverwriteFixedMetadataArrays) {
+    EXPECT_THROW(
+        static_cast<void>(Tensor::ones(
+            {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2}, Device::CPU)),
+        std::exception);
+}
+
+TEST_F(CudaTest, F4_UnpinnedFallbackStridedUploadStagesSafely) {
+    const auto torch_result = torch::tensor({1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f})
+                                  .reshape({2, 3})
+                                  .transpose(0, 1)
+                                  .cuda()
+                                  .contiguous();
+    ASSERT_EQ(torch_result.numel(), 6);
+    const std::vector<float> expected = {1, 4, 2, 5, 3, 6};
+
+    PinnedFallbackGuard fallback_guard;
+    const auto input = Tensor::from_vector(
+        std::vector<float>{1, 2, 3, 4, 5, 6}, {2, 3}, Device::CPU);
+    const auto values = input.transpose(0, 1).cuda().cpu().to_vector();
+    EXPECT_EQ(values, expected);
+}
+
+TEST_F(CudaTest, F5_NegativeScatterIndicesMatchAcrossCPUCUDAAndTorch) {
+    const auto torch_index = torch::tensor({-1}, torch::TensorOptions().dtype(torch::kInt64));
+    const auto torch_source = torch::tensor({7.0f});
+    auto torch_expected = torch::zeros({3});
+    bool torch_threw = false;
+    try {
+        torch_expected.scatter_(0, torch_index, torch_source);
+    } catch (const c10::Error&) {
+        torch_threw = true;
+    }
+
+    for (const Device device : {Device::CPU, Device::CUDA}) {
+        auto ours = Tensor::zeros({3}, device);
+        const auto index = lfs_int_tensor({-1}, {1}, device);
+        const auto source = lfs_float_tensor({7.0f}, {1}, device);
+        bool ours_threw = false;
+        try {
+            ours.scatter_(0, index, source);
+        } catch (const std::exception&) {
+            ours_threw = true;
+        }
+        EXPECT_EQ(ours_threw, torch_threw)
+            << (device == Device::CPU ? "F5 CPU exception contract" : "F5 CUDA exception contract");
+        if (!torch_threw) {
+            auto expected = torch_expected;
+            if (device == Device::CUDA) {
+                expected = expected.cuda();
+            }
+            expect_float_values_match(
+                ours, expected,
+                device == Device::CPU ? "F5 negative scatter CPU" : "F5 negative scatter CUDA");
+        }
+    }
+}
+
+TEST(HardeningThemeF_Misc, F6_IncompatibleEmptyBroadcastRejectsLikeTorch) {
+    const auto torch_input = torch::empty({0, 2});
+    EXPECT_THROW(static_cast<void>(torch_input.expand({3, 4})), c10::Error);
+    const auto ours_input = Tensor::empty({0, 2}, Device::CPU);
+    EXPECT_THROW(static_cast<void>(ours_input.broadcast_to(TensorShape({3, 4}))),
+                 std::exception);
+}
+
+TEST(HardeningThemeF_Misc, F7_Rank9BroadcastDoesNotOverwriteFixedMetadataArrays) {
+    const auto torch_result = torch::ones(
+                                  {1, 1, 1, 1, 1, 1, 1, 2, 2})
+                                  .expand({2, 1, 1, 1, 1, 1, 1, 2, 2});
+    ASSERT_TRUE(torch_result.eq(1.0f).all().item<bool>());
+
+    EXPECT_THROW(
+        static_cast<void>(TensorShape(
+            {2, 1, 1, 1, 1, 1, 1, 2, 2})),
+        std::exception);
+}
+
+TEST_F(CudaTest, F8_GenericBroadcastUsesInlineMetadataAndWritesResult) {
+    const auto ours = Tensor::ones({2, 1, 3, 1}, Device::CUDA)
+                          .add(Tensor::ones({1, 4, 1, 5}, Device::CUDA));
+    const auto theirs = torch::ones(
+                            {2, 1, 3, 1}, torch::TensorOptions().device(torch::kCUDA))
+                            .add(torch::ones(
+                                {1, 4, 1, 5}, torch::TensorOptions().device(torch::kCUDA)));
+    expect_float_values_match(ours, theirs, "F8 generic broadcast inline metadata");
+}

--- a/tests/test_tensor_hardening_theme_f.cpp
+++ b/tests/test_tensor_hardening_theme_f.cpp
@@ -38,13 +38,19 @@ namespace {
     public:
         PinnedFallbackGuard() {
             auto& allocator = PinnedMemoryAllocator::instance();
+            previous_enabled_ = allocator.is_enabled();
             allocator.set_enabled(true);
             allocator.set_force_fallback_for_testing(true);
         }
 
         ~PinnedFallbackGuard() {
-            PinnedMemoryAllocator::instance().set_force_fallback_for_testing(false);
+            auto& allocator = PinnedMemoryAllocator::instance();
+            allocator.set_force_fallback_for_testing(false);
+            allocator.set_enabled(previous_enabled_);
         }
+
+    private:
+        bool previous_enabled_ = false;
     };
 
 } // namespace

--- a/tests/test_tensor_reduction.cpp
+++ b/tests/test_tensor_reduction.cpp
@@ -150,16 +150,13 @@ TEST_F(TensorReductionTest, Mean) {
     EXPECT_FLOAT_EQ(custom_mean, 6.0f);
 }
 
-TEST_F(TensorReductionTest, Int32MeanPreservesDtypeAndTruncates) {
+TEST_F(TensorReductionTest, Int32MeanRejectsLikeTorch) {
     for (const auto device : {Device::CPU, Device::CUDA}) {
         const auto values = Tensor::from_vector(
                                 std::vector<int>{1, 2, 3, 4}, {4}, Device::CPU)
                                 .to(device);
 
-        const auto mean = values.mean();
-
-        EXPECT_EQ(mean.dtype(), DataType::Int32) << device_name(device);
-        EXPECT_EQ(mean.item<int>(), 2) << device_name(device);
+        EXPECT_THROW(static_cast<void>(values.mean()), std::exception) << device_name(device);
     }
 }
 

--- a/tests/test_tensor_serialization.cpp
+++ b/tests/test_tensor_serialization.cpp
@@ -220,7 +220,7 @@ TEST_F(TensorSerializationTest, RejectsExcessiveRankBeforeReadingDimensions) {
         .version = TENSOR_FILE_VERSION,
         .dtype = static_cast<uint8_t>(DataType::Float32),
         .device = static_cast<uint8_t>(Device::CPU),
-        .rank = static_cast<uint16_t>(MAX_SERIALIZED_TENSOR_RANK + 1),
+        .rank = static_cast<uint16_t>(MAX_TENSOR_RANK + 1),
         .numel = 1,
     };
     ss.write(reinterpret_cast<const char*>(&header), sizeof(header));

--- a/tests/test_tensor_views.cpp
+++ b/tests/test_tensor_views.cpp
@@ -592,15 +592,11 @@ TEST_F(TensorViewTest, SqueezeEdgeCases) {
     auto squeezed_custom = all_ones_custom.squeeze();
     auto squeezed_torch = all_ones_torch.squeeze();
 
-    // Known difference: Custom implementation keeps at least rank 1,
-    // PyTorch goes to rank 0 (scalar tensor)
-    EXPECT_EQ(squeezed_custom.ndim(), 1); // Custom: shape {1}
-    EXPECT_EQ(squeezed_torch.dim(), 0);   // PyTorch: 0-D scalar
+    EXPECT_EQ(squeezed_custom.ndim(), 0);
+    EXPECT_EQ(squeezed_torch.dim(), 0);
 
     // Values should still match
     EXPECT_FLOAT_EQ(squeezed_custom.item(), squeezed_torch.item<float>());
-
-    std::cout << "WARNING: squeeze() on all-1 dims keeps rank 1, PyTorch goes to rank 0 (known difference)\n";
 
     // No dimensions of size 1
     auto [no_ones_custom, no_ones_torch] = create_test_tensors({2, 3, 4});


### PR DESCRIPTION
Every fix is runtime-verified against a libtorch oracle and covered by a regression test that failed before the fix (labels: hardening, discovery; 158 tests plus a 512-program differential fuzzer, all green; memcheck and racecheck clean).

Root-cause clusters, each fixed by a shared mechanism instead of per-site patches:

- Dtype dispatch: one exhaustive fail-loud dispatcher; no silent default: branches. Float16 contiguous(), HWC->CHW uploads, multi-axis Prod and Int32 CPU partial reductions previously returned unwritten memory.
- Strided views: materialization firewall normalizes non-contiguous read operands; in-place ops write stride-aware to view destinations (zero_, masked_fill_, index_put_, uniform_, scatter family, cat/stack, NN bias).
- Reductions: single ownership point for result dtype and normalization; arbitrary multi-axis sets, mean normalized exactly once, Int64 accumulation for integer sums, empty-reduction identities.
- Streams: specialized launchers (clone/contiguous/copy_from, mm, dot, diag, multinomial, scatter) route through one input-stream preparation helper; per-launch metadata travels by value.
- IEEE semantics: NaN propagation in fused extrema/relu/sqrt/log, no algebraic folding that changes user-visible FP results, overflow-safe randint/multinomial; torch is the reference throughout.
- Lazy eval: deferred expressions take copy-on-write snapshots; zero copies unless a source mutates between defer and evaluation.
- CUDA RNG: one generator owner shares offset state across factory and in-place APIs; fixes sequence reuse, including >1M-element draws.
- Rank-0/scalar dimension policy, torch-style promotion for mixed-dtype cat/stack, argmin/argmax reachability, integer mod-by-zero no longer raises SIGFPE, rank>8 fails loudly, pinned-fallback uploads stage through GPU-addressable memory.

Deliberate contract changes: integer mean rejects like torch, maximum tensor rank is 8, overlapping scatter destinations are rejected.

Performance: 7k-iteration bicycle/mcmc train at 31.4s vs 32.36s on master, identical splat trajectory (1,293,710 final splats), peak RSS parity. Contiguous fast paths unchanged; the interim regression was profiled and eliminated (cuRAND offset-reset syncs, eager snapshot copies, per-tensor metadata allocations).