### PR TITLE
Suppress CUDA failure-report flood when the runtime is unloading at process exit

### DIFF
--- a/src/core/cuda_error.cpp
+++ b/src/core/cuda_error.cpp
@@ -378,6 +378,22 @@ namespace lfs::core {
             finish_cuda_check(result, state, expression_copy.c_str(), message, location);
             return;
         }
+        if (result == cudaErrorCudartUnloading) {
+            // Process exit: the CUDA runtime has already shut itself down, so
+            // failed frees are expected and the OS reclaims the memory anyway.
+            // Log once instead of flooding the shutdown log.
+            static std::once_flag logged_once;
+            try {
+                std::call_once(logged_once, [] {
+                    Logger::get().log_internal(
+                        LogLevel::Debug, LFS_SOURCE_SITE_CURRENT(),
+                        "CUDA runtime is unloading (process exit); suppressing CUDA teardown failure reports.");
+                });
+            } catch (...) {
+            }
+            cudaGetLastError(); // clear the sticky error
+            return;
+        }
         try {
             const std::string expression_copy(expression);
             emit_cuda_failure_report(


### PR DESCRIPTION
After a successful headless training run, exiting the process floods the log with `LFS FAILURE REPORT` blocks, all with `cudaErrorCudartUnloading (4): driver shutting down`, coming from the allocator destructors (`SizeBucketedPool::trim_cache`, `GPUSlabAllocator::cleanup`, `PinnedMemoryAllocator::Block::~Block`).

Cause: the CUDA runtime shuts itself down before those static singletons are destroyed, so their frees can only fail with that error. 

Fix: in the `LogOnly` branch of `ensure_cuda_success`, treat `cudaErrorCudartUnloading` as benign — one debug line, clear the sticky error, no failure report. `Throw` behavior is unchanged, and `LogOnly` is only used on teardown/recovery paths, so real mid-run failures are unaffected.

Tested on Windows 11 (CUDA 12.8, driver 13.3), now training completes and saves as before, and exit is now clean.