### PR TITLE
remove const to match declaration in launch_delay_kernel

### DIFF
--- a/tests/tensor_hardening_cuda_utils.cu
+++ b/tests/tensor_hardening_cuda_utils.cu
@@ -15,7 +15,7 @@ namespace tensor_hardening {
         }
     } // namespace
 
-    cudaError_t launch_delay_kernel(const cudaStream_t stream, const uint64_t cycles) {
+    cudaError_t launch_delay_kernel(cudaStream_t stream, uint64_t cycles) {
         delay_kernel<<<1, 1, 0, stream>>>(cycles);
         return cudaGetLastError();
     }


### PR DESCRIPTION
In tensor_hardening_test_utils.hpp:
```
cudaError_t launch_delay_kernel(cudaStream_t stream, uint64_t cycles);
```
But in tensor_hardening_cuda_utils.cu
```
cudaError_t launch_delay_kernel(const cudaStream_t stream, const uint64_t cycles) {
```
remove the const so it compiles