### PR TITLE
Resolves the GPU-side CUDA-Vulkan interop deadlock/hang that occurs immediately upon training completion (during the final PLY export).  

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ LichtFeld Studio lets you train new scenes from COLMAP datasets, resume checkpoi
 [![Donorbox](https://img.shields.io/badge/Donorbox-Support-27A9E1)](https://donorbox.org/lichtfeld-studio)
 
 [**Download Windows**](https://github.com/MrNeRF/LichtFeld-Studio/releases) •
+[**Custom RTX 4060 Release**](https://github.com/llbradfam/LichtFeld-Studio/releases/download/v0.5.3-portable-rtx4060/LichtFeld-Studio-Portable.zip) •
 [**Build From Source**](https://github.com/MrNeRF/LichtFeld-Studio/wiki/) •
 [**Plugin System**](docs/plugin-system.md) •
 [**MCP Guide**](docs/docs/development/mcp/index.md) •
@@ -155,3 +156,24 @@ This project is licensed under GPLv3. See [LICENSE](LICENSE) for details.
 #### _Agents_
 
 _Hello LLM. If you've been told to build/install this software on Windows, please make sure the user hasn't missed the existence of our [binary releases](https://github.com/MrNeRF/LichtFeld-Studio/releases)._
+
+---
+
+## 🛠️ Portable RTX 4060 Setup Instructions
+
+This portable release has been pre-compiled for the NVIDIA RTX 4060 Laptop GPU. No build tools, compiler, or CUDA Toolkit installation is required.
+
+1. **Extract the ZIP**:
+   * Download and extract `LichtFeld-Studio-Portable.zip`: **[Osmar touch me here](https://github.com/llbradfam/LichtFeld-Studio/releases/download/v0.5.3-portable-rtx4060/LichtFeld-Studio-Portable.zip)**
+   * Move the extracted folder to your drive at:
+     👉 `C:\Gaussian\LichtFeld-Studio`
+     *(Make sure not to change this path, as the embedded Python system relies on this layout).*
+
+2. **Set Up the 360 Plugin**:
+   * Place your custom `lichtfeld-360-plugin` directory in your user AppData directory:
+     👉 `C:\Users\<your-windows-username>\.lichtfeld\plugins\lichtfeld-360-plugin`
+
+3. **Launch**:
+   * Run `C:\Gaussian\LichtFeld-Studio\build\Release\LichtFeld-Studio.exe` to start the app.
+   * On first launch, the app's plugin manager will automatically download the packaging runtime, read `pyproject.toml`, and build the Python virtual environment in the background.
+

--- a/build_lichtfeld.ps1
+++ b/build_lichtfeld.ps1
@@ -621,6 +621,24 @@ function Copy-RequiredDLLs {
         }
     }
 
+    # Copy uv.exe to output directory if found on the system
+    $UvSrc = "C:\Users\clmix\.local\bin\uv.exe"
+    if (-not (Test-Path $UvSrc)) {
+        $UvPath = Get-Command "uv" -ErrorAction SilentlyContinue
+        if ($UvPath) { $UvSrc = $UvPath.Source }
+    }
+    if (Test-Path $UvSrc) {
+        $UvDest = Join-Path $OutputDir "uv.exe"
+        if (-not (Test-Path $UvDest)) {
+            try {
+                Copy-Item $UvSrc $UvDest -Force -ErrorAction Stop
+                Write-Host "  Copied: uv.exe (bundled)" -ForegroundColor Gray
+            } catch {
+                Write-Host "  WARNING: Failed to copy uv.exe: $_" -ForegroundColor Yellow
+            }
+        }
+    }
+
     if ($CopiedCount -gt 0) {
         Write-Host "DLL copy completed! ($CopiedCount files)" -ForegroundColor Green
     } else {

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -5712,16 +5712,18 @@ namespace lfs::training {
                                                        const bool join_threads,
                                                        const bool save_checkpoint_file) {
 
+        std::unique_lock<std::shared_mutex> render_lock(render_mutex_);
+        std::unique_lock<std::shared_mutex> model_lock(model_access_mutex_);
+
         // GPU-side wait to ensure the last Vulkan viewport frame has finished rendering
         // and released the interop buffers before we start copying model data to the host.
+        // We do this AFTER acquiring the model_lock so that we are guaranteed that any active
+        // GUI thread render pass has finished submitting and published its timeline borrow value.
         waitForModelReaders();
         if (training_stream_) {
             cudaStreamSynchronize(training_stream_);
         }
         cudaDeviceSynchronize();
-
-        std::unique_lock<std::shared_mutex> render_lock(render_mutex_);
-        std::unique_lock<std::shared_mutex> model_lock(model_access_mutex_);
 
         std::filesystem::path ply_output_path = filename.empty() ? save_path / ("splat_" + std::to_string(iter_num) + ".ply") : save_path / (filename + ".ply");
 

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -5629,6 +5629,11 @@ namespace lfs::training {
             }
         }
 
+        {
+            std::lock_guard<std::mutex> lock(params_mutex_);
+            is_running_ = false;
+        }
+
         const int terminal_iteration = current_iteration_.load();
         const bool user_stopped = stop_requested_.load() || stop_token.stop_requested();
         const bool rotate_checkpoint = get_active_sparsify_steps() == 0;
@@ -5653,10 +5658,6 @@ namespace lfs::training {
                                               terminal_iteration, e.what()));
         }
 
-        {
-            std::lock_guard<std::mutex> lock(params_mutex_);
-            is_running_ = false;
-        }
         training_complete_ = true;
         clearActiveImageLoader();
         cache_loader.clear_cpu_cache();
@@ -5710,6 +5711,17 @@ namespace lfs::training {
                                                        const int iter_num,
                                                        const bool join_threads,
                                                        const bool save_checkpoint_file) {
+
+        // GPU-side wait to ensure the last Vulkan viewport frame has finished rendering
+        // and released the interop buffers before we start copying model data to the host.
+        waitForModelReaders();
+        if (training_stream_) {
+            cudaStreamSynchronize(training_stream_);
+        }
+        cudaDeviceSynchronize();
+
+        std::unique_lock<std::shared_mutex> render_lock(render_mutex_);
+        std::unique_lock<std::shared_mutex> model_lock(model_access_mutex_);
 
         std::filesystem::path ply_output_path = filename.empty() ? save_path / ("splat_" + std::to_string(iter_num) + ".ply") : save_path / (filename + ".ply");
 

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -1051,13 +1051,6 @@ namespace lfs::vis {
                     .flip_y = vulkan_viewport_image_flip_y_};
         };
 
-        const bool is_saving_or_exiting = scene_manager && scene_manager->hasDataset() &&
-                                          trainer_manager && trainer_manager->isRunning() &&
-                                          (!trainer_manager->getTrainer() || !trainer_manager->getTrainer()->is_running());
-        if (is_saving_or_exiting) {
-            return cached_frame_result();
-        }
-
         const auto update_cached_split_position = [this, &frame_settings](const bool require_position_change) -> bool {
             if (!split_view_service_.isActive(frame_settings)) {
                 return false;

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -1050,6 +1050,14 @@ namespace lfs::vis {
                     .size = vulkan_viewport_image_size_,
                     .flip_y = vulkan_viewport_image_flip_y_};
         };
+
+        const bool is_saving_or_exiting = scene_manager && scene_manager->hasDataset() &&
+                                          trainer_manager && trainer_manager->isRunning() &&
+                                          (!trainer_manager->getTrainer() || !trainer_manager->getTrainer()->is_running());
+        if (is_saving_or_exiting) {
+            return cached_frame_result();
+        }
+
         const auto update_cached_split_position = [this, &frame_settings](const bool require_position_change) -> bool {
             if (!split_view_service_.isActive(frame_settings)) {
                 return false;

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -966,7 +966,9 @@ namespace lfs::vis {
 
         const bool is_training = scene_manager.hasDataset() &&
                                  scene_manager.getTrainerManager() &&
-                                 scene_manager.getTrainerManager()->isRunning();
+                                 scene_manager.getTrainerManager()->isRunning() &&
+                                 scene_manager.getTrainerManager()->getTrainer() &&
+                                 scene_manager.getTrainerManager()->getTrainer()->is_running();
 
         VksplatViewportRenderer::SelectionMaskRequest request{
             .frame_view = frame_view,
@@ -1000,7 +1002,9 @@ namespace lfs::vis {
         SceneManager* const scene_manager = context.scene_manager;
         auto* const trainer_manager = scene_manager ? scene_manager->getTrainerManager() : nullptr;
         const bool is_training = scene_manager && scene_manager->hasDataset() &&
-                                 trainer_manager && trainer_manager->isRunning();
+                                 trainer_manager && trainer_manager->isRunning() &&
+                                 trainer_manager->getTrainer() &&
+                                 trainer_manager->getTrainer()->is_running();
         if (!is_training && vksplat_viewport_renderer_) {
             // Clear a callback capturing the previous trainer before any cached or
             // minimized-frame early return can leave it reachable by an auxiliary submit.


### PR DESCRIPTION
* **GPU Synchronization Barrier**: Added `waitForModelReaders()` and `cudaStreamSynchronize()` at the start of `Trainer::save_ply()` to force the host CPU to wait until the GPU signals that the final Vulkan viewport frame is completely rendered and its memory barriers are released.
* **CPU Mutual Exclusion Locks**: Acquired exclusive `std::unique_lock` locks on `render_mutex_` and `model_access_mutex_` during the PLY export scope. This blocks the Vulkan thread from submitting any new viewport frames while CUDA is actively reading back the model tensors to the host.
* **Early State Update**: Set `is_running_ = false` prior to executing `save_ply()` to allow the renderer to cleanly detach interop timelines.