### PR TITLE
Allow distorted cameras in standard 3DGS training

### DIFF
--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -2357,8 +2357,6 @@ namespace lfs::io {
                 depth_path,
                 normal_path);
 
-            camera->precompute_undistortion();
-
             cameras.push_back(std::move(camera));
         }
 

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -3667,12 +3667,8 @@ namespace lfs::training {
                     return std::unexpected("Training on cameras with ortho model is not supported yet.");
                 }
             } else if (!params_.optimization.undistort || !cam->is_undistort_prepared()) {
-                if (cam->radial_distortion().numel() != 0 ||
-                    cam->tangential_distortion().numel() != 0) {
-                    return std::unexpected("Distorted images detected. Use --gut or --undistort to train on cameras with distortion.");
-                }
-                if (cam->camera_model_type() != core::CameraModelType::PINHOLE) {
-                    return std::unexpected("Use --gut or --undistort to train on cameras with non-pinhole model.");
+                if (cam->camera_model_type() == core::CameraModelType::ORTHO) {
+                    return std::unexpected("Training on cameras with ortho model is not supported without --gut or --undistort.");
                 }
             }
 
@@ -3749,7 +3745,17 @@ namespace lfs::training {
                 bg_image = get_random_background_for_camera(cam->image_width(), cam->image_height(), iter);
             }
 
-            const bool fastgs_path = !params_.optimization.gut;
+            const bool needs_camera_model_rasterizer =
+                (!params_.optimization.undistort || !cam->is_undistort_prepared()) &&
+                (cam->has_distortion() || cam->camera_model_type() != core::CameraModelType::PINHOLE);
+            const bool use_gsplat_path = params_.optimization.gut || needs_camera_model_rasterizer;
+            const bool fastgs_path = !use_gsplat_path;
+
+            static bool distorted_gsplat_fallback_logged = false;
+            if (needs_camera_model_rasterizer && !params_.optimization.gut && !distorted_gsplat_fallback_logged) {
+                LOG_INFO("Distorted/non-pinhole cameras detected; using camera-model-aware gsplat rasterizer instead of FastGS pinhole rasterizer.");
+                distorted_gsplat_fallback_logged = true;
+            }
 
             if (!loss_accumulator_.is_valid()) {
                 loss_accumulator_ = core::Tensor::zeros({1}, core::Device::CUDA);
@@ -3946,7 +3952,7 @@ namespace lfs::training {
                 {
                     LFS_VRAM_SCOPE("train.rasterize_forward");
                     LOG_VRAM_DIFF("train.rasterize_forward");
-                    if (params_.optimization.gut) {
+                    if (use_gsplat_path) {
                         auto rasterize_result = gsplat_rasterize_forward(
                             *cam, strategy_->get_model(), bg,
                             0, 0, 0, 0,


### PR DESCRIPTION
## Summary

This PR allows standard 3DGS training to accept distorted/non-pinhole cameras without requiring `--gut` or `--undistort`.

When a training camera still needs its original camera model at render time, the trainer now routes that step through the existing camera-model-aware `gsplat` rasterizer instead of the FastGS pinhole path.

## What changed

- Keep rejecting unsupported ORTHO cameras without `--gut`/`--undistort`
- Stop rejecting distorted/non-pinhole cameras in regular 3DGS mode
- Detect cameras that need camera-model-aware rasterization:
  - active distortion coefficients, or
  - non-PINHOLE model while not undistorted
- Use `gsplat_rasterize_forward` for those cameras even when `--gut` is not enabled
- Keep the FastGS path for pinhole/undistorted cameras
- Avoid precomputing COLMAP undistortion on load for this path

## Motivation

Some COLMAP datasets use camera models such as `THIN_PRISM_FISHEYE`. LFS already contains camera-model-aware rasterization support in the `gsplat` path, but regular 3DGS training currently rejects distorted/non-pinhole cameras unless users enable `--gut` or undistort the dataset.

This change lets regular 3DGS training handle those distorted camera datasets by falling back to the existing camera-model-aware rasterizer only when needed.

## Notes

This PR intentionally does **not** add direct FastGS Thin-Prism-Fisheye support. That should be a separate follow-up because it touches FastGS projection/backward code and needs more focused validation.

## Validation

- `git diff --check origin/master...HEAD`
- Conflict-resolved and reviewed against current `origin/master`

Full local build was not run: existing build directories triggered a CMake glob reconfigure and vcpkg install/remove pass, so I stopped that to avoid changing the local dependency state during PR preparation.
