### PR TITLE
Fix inconsistent DLL linkage warnings in error.hpp

### DIFF
--- a/src/core/include/core/error.hpp
+++ b/src/core/include/core/error.hpp
@@ -255,8 +255,8 @@ namespace lfs {
 
         template <class>
         friend class Result;
-        friend Error make_error(ErrorInit init) noexcept;
-        friend Error make_immortal_error_for_testing(bool unknown_seed) noexcept;
+        friend LFS_CORE_API Error make_error(ErrorInit init) noexcept;
+        friend LFS_CORE_API Error make_immortal_error_for_testing(bool unknown_seed) noexcept;
     };
 
     static_assert(sizeof(Error) == sizeof(void*));


### PR DESCRIPTION
## Summary

Fixes MSVC C4273 `inconsistent dll linkage` warnings originating from
`error.hpp`.

The `make_error` and `make_immortal_error_for_testing` functions are
forward-declared with `LFS_CORE_API`, but their friend declarations inside
`Error` were missing the export macro. MSVC therefore treated the
declarations as having inconsistent DLL linkage.

## Changes

- Added `LFS_CORE_API` to the `make_error` friend declaration.
- Added `LFS_CORE_API` to the `make_immortal_error_for_testing` friend declaration.
- Keeps the friend declarations consistent with their existing exported declarations.

## Result

Eliminates the repeated C4273 warnings from every translation unit that
includes `error.hpp`, without changing the functions' intended API or behavior.