### PR TITLE
Fix CommandCenter singleton linkage

### DIFF
--- a/src/core/event_bridge/CMakeLists.txt
+++ b/src/core/event_bridge/CMakeLists.txt
@@ -7,6 +7,7 @@
 add_library(lfs_event_bridge SHARED
     event_bridge.cpp
     control_boundary.cpp
+    command_center.cpp
     command_center_bridge.cpp
     scoped_handler.cpp
     localization_manager.cpp

--- a/src/core/event_bridge/command_center.cpp
+++ b/src/core/event_bridge/command_center.cpp
@@ -1,0 +1,78 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "training/control/command_api.hpp"
+
+namespace lfs::training {
+
+    CommandCenter& CommandCenter::instance() {
+        // lfs_training is linked into multiple modules, so the singleton storage
+        // must stay in this shared library.
+        static CommandCenter inst;
+        return inst;
+    }
+
+    CommandCenter::CommandCenter() {
+        ops_.push_back({.name = "set_attribute",
+                        .target = CommandTarget::Model,
+                        .selectors = {SelectionKind::All, SelectionKind::Range, SelectionKind::Indices},
+                        .args = {{"attribute", ArgType::String, true, "Attribute name (means, scaling, rotation, opacity, sh0, shN)"},
+                                 {"value", ArgType::Float, false, "Scalar value"},
+                                 {"values", ArgType::FloatList, false, "Vector value (broadcast)"}},
+                        .description = "Set attribute values for selected splats (scalar or per-dim vector)."});
+
+        ops_.push_back({.name = "scale_attribute",
+                        .target = CommandTarget::Model,
+                        .selectors = {SelectionKind::All, SelectionKind::Range, SelectionKind::Indices},
+                        .args = {{"attribute", ArgType::String, true, "Attribute name"},
+                                 {"factor", ArgType::Float, true, "Multiplicative scale"}},
+                        .description = "Scale attribute by factor for selected splats."});
+
+        ops_.push_back({.name = "clamp_attribute",
+                        .target = CommandTarget::Model,
+                        .selectors = {SelectionKind::All, SelectionKind::Range, SelectionKind::Indices},
+                        .args = {{"attribute", ArgType::String, true, "Attribute name"},
+                                 {"min", ArgType::Float, false, "Optional min"},
+                                 {"max", ArgType::Float, false, "Optional max"}},
+                        .description = "Clamp attribute values for selected splats."});
+
+        ops_.push_back({.name = "set_lr",
+                        .target = CommandTarget::Optimizer,
+                        .selectors = {SelectionKind::All},
+                        .args = {{"value", ArgType::Float, true, "Learning rate"}},
+                        .description = "Set global learning rate."});
+
+        ops_.push_back({.name = "scale_lr",
+                        .target = CommandTarget::Optimizer,
+                        .selectors = {SelectionKind::All},
+                        .args = {{"factor", ArgType::Float, true, "Scale factor"}},
+                        .description = "Scale global learning rate."});
+
+        ops_.push_back({.name = "pause",
+                        .target = CommandTarget::Session,
+                        .selectors = {SelectionKind::All},
+                        .args = {},
+                        .description = "Request pause."});
+
+        ops_.push_back({.name = "resume",
+                        .target = CommandTarget::Session,
+                        .selectors = {SelectionKind::All},
+                        .args = {},
+                        .description = "Request resume."});
+
+        ops_.push_back({.name = "request_stop",
+                        .target = CommandTarget::Session,
+                        .selectors = {SelectionKind::All},
+                        .args = {},
+                        .description = "Request graceful stop."});
+
+        // Mutable fields
+        mutable_fields_.push_back({"means", CommandTarget::Model, "[N,3]", "Gaussian means", true});
+        mutable_fields_.push_back({"scaling", CommandTarget::Model, "[N,3]", "Log scaling", true});
+        mutable_fields_.push_back({"rotation", CommandTarget::Model, "[N,4]", "Quaternion rotation", true});
+        mutable_fields_.push_back({"opacity", CommandTarget::Model, "[N]", "Opacity logits", true});
+        mutable_fields_.push_back({"sh0", CommandTarget::Model, "[N,3]", "SH0 coefficients", true});
+        mutable_fields_.push_back({"shN", CommandTarget::Model, "[N,?]", "Higher-order SH coefficients", true});
+    }
+
+} // namespace lfs::training

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -67,6 +67,7 @@
 #include "input/input_controller.hpp"
 #include "python/runner.hpp"
 #include "rendering/rendering_manager.hpp"
+#include "training/optimizer/adam_optimizer.hpp"
 #include "training/strategies/istrategy.hpp"
 #include "training/trainer.hpp"
 #include "training/training_state.hpp"

--- a/src/training/control/command_api.cpp
+++ b/src/training/control/command_api.cpp
@@ -4,6 +4,10 @@
 #include "command_api.hpp"
 
 #include "core/logger.hpp"
+#include "core/splat_data.hpp"
+#include "core/tensor.hpp"
+#include "training/optimizer/adam_optimizer.hpp"
+#include "training/trainer.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -108,74 +112,6 @@ namespace lfs::training {
             return std::nullopt;
         }
     } // namespace
-
-    CommandCenter& CommandCenter::instance() {
-        static CommandCenter inst;
-        return inst;
-    }
-
-    CommandCenter::CommandCenter() {
-        ops_.push_back({.name = "set_attribute",
-                        .target = CommandTarget::Model,
-                        .selectors = {SelectionKind::All, SelectionKind::Range, SelectionKind::Indices},
-                        .args = {{"attribute", ArgType::String, true, "Attribute name (means, scaling, rotation, opacity, sh0, shN)"},
-                                 {"value", ArgType::Float, false, "Scalar value"},
-                                 {"values", ArgType::FloatList, false, "Vector value (broadcast)"}},
-                        .description = "Set attribute values for selected splats (scalar or per-dim vector)."});
-
-        ops_.push_back({.name = "scale_attribute",
-                        .target = CommandTarget::Model,
-                        .selectors = {SelectionKind::All, SelectionKind::Range, SelectionKind::Indices},
-                        .args = {{"attribute", ArgType::String, true, "Attribute name"},
-                                 {"factor", ArgType::Float, true, "Multiplicative scale"}},
-                        .description = "Scale attribute by factor for selected splats."});
-
-        ops_.push_back({.name = "clamp_attribute",
-                        .target = CommandTarget::Model,
-                        .selectors = {SelectionKind::All, SelectionKind::Range, SelectionKind::Indices},
-                        .args = {{"attribute", ArgType::String, true, "Attribute name"},
-                                 {"min", ArgType::Float, false, "Optional min"},
-                                 {"max", ArgType::Float, false, "Optional max"}},
-                        .description = "Clamp attribute values for selected splats."});
-
-        ops_.push_back({.name = "set_lr",
-                        .target = CommandTarget::Optimizer,
-                        .selectors = {SelectionKind::All},
-                        .args = {{"value", ArgType::Float, true, "Learning rate"}},
-                        .description = "Set global learning rate."});
-
-        ops_.push_back({.name = "scale_lr",
-                        .target = CommandTarget::Optimizer,
-                        .selectors = {SelectionKind::All},
-                        .args = {{"factor", ArgType::Float, true, "Scale factor"}},
-                        .description = "Scale global learning rate."});
-
-        ops_.push_back({.name = "pause",
-                        .target = CommandTarget::Session,
-                        .selectors = {SelectionKind::All},
-                        .args = {},
-                        .description = "Request pause."});
-
-        ops_.push_back({.name = "resume",
-                        .target = CommandTarget::Session,
-                        .selectors = {SelectionKind::All},
-                        .args = {},
-                        .description = "Request resume."});
-
-        ops_.push_back({.name = "request_stop",
-                        .target = CommandTarget::Session,
-                        .selectors = {SelectionKind::All},
-                        .args = {},
-                        .description = "Request graceful stop."});
-
-        // Mutable fields
-        mutable_fields_.push_back({"means", CommandTarget::Model, "[N,3]", "Gaussian means", true});
-        mutable_fields_.push_back({"scaling", CommandTarget::Model, "[N,3]", "Log scaling", true});
-        mutable_fields_.push_back({"rotation", CommandTarget::Model, "[N,4]", "Quaternion rotation", true});
-        mutable_fields_.push_back({"opacity", CommandTarget::Model, "[N]", "Opacity logits", true});
-        mutable_fields_.push_back({"sh0", CommandTarget::Model, "[N,3]", "SH0 coefficients", true});
-        mutable_fields_.push_back({"shN", CommandTarget::Model, "[N,?]", "Higher-order SH coefficients", true});
-    }
 
     void CommandCenter::set_phase(TrainingPhase phase) {
         phase_.store(phase, std::memory_order_relaxed);

--- a/src/training/control/command_api.hpp
+++ b/src/training/control/command_api.hpp
@@ -3,18 +3,21 @@
 #pragma once
 
 #include "control_boundary.hpp"
-#include "core/splat_data.hpp"
 #include "core/tensor.hpp"
-#include "training/optimizer/adam_optimizer.hpp"
-#include "training/trainer.hpp"
 
 #include <atomic>
+#include <cstddef>
 #include <expected>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
 #include <variant>
 #include <vector>
+
+namespace lfs::core {
+    class SplatData;
+} // namespace lfs::core
 
 namespace lfs::training {
 
@@ -101,7 +104,7 @@ namespace lfs::training {
 
     class CommandCenter {
     public:
-        static CommandCenter& instance();
+        static LFS_BRIDGE_API CommandCenter& instance();
 
         void set_phase(TrainingPhase phase);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,7 @@ set(TEST_FILES
     test_logger.cpp
     test_parameter_manager.cpp
     test_mcp_protocol.cpp
+    test_mcp_training_state.cpp
     test_mcp_app_utils.cpp
     test_mcp_shared_scene_tools.cpp
     test_mcp_sequencer_tools.cpp

--- a/tests/test_mcp_training_state.cpp
+++ b/tests/test_mcp_training_state.cpp
@@ -1,0 +1,114 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/event_bridge/command_center_bridge.hpp"
+#include "core/event_bridge/event_bridge.hpp"
+#include "mcp/mcp_tools.hpp"
+#include "training/control/command_api.hpp"
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+namespace {
+
+    class McpTrainingStateTest : public testing::Test {
+    protected:
+        void SetUp() override {
+            lfs::event::EventBridge::instance().clear_all();
+
+            auto& command_center = lfs::training::CommandCenter::instance();
+            command_center.clear_snapshot(command_center.snapshot().trainer);
+            command_center.clear_loss_history();
+            lfs::event::CommandCenterBridge::instance().set(&command_center);
+        }
+
+        void TearDown() override {
+            auto& registry = lfs::mcp::ToolRegistry::instance();
+            for (const auto* name : registered_tool_names_) {
+                registry.unregister_tool(name);
+            }
+
+            auto& command_center = lfs::training::CommandCenter::instance();
+            command_center.clear_snapshot(command_center.snapshot().trainer);
+            command_center.clear_loss_history();
+            lfs::event::CommandCenterBridge::instance().set(nullptr);
+            lfs::event::EventBridge::instance().clear_all();
+        }
+
+        static void populate_snapshot() {
+            auto& command_center = lfs::training::CommandCenter::instance();
+            const lfs::training::HookContext context{
+                .iteration = kIteration,
+                .loss = kLoss,
+                .num_gaussians = kNumGaussians,
+                .is_refining = true,
+                .trainer = reinterpret_cast<lfs::training::Trainer*>(0x1)};
+
+            command_center.update_snapshot(
+                context,
+                kMaxIterations,
+                true,
+                true,
+                false,
+                lfs::training::TrainingPhase::OptimizerStep);
+            command_center.set_phase(lfs::training::TrainingPhase::OptimizerStep);
+        }
+
+        static constexpr int kIteration = 137;
+        static constexpr int kMaxIterations = 30'000;
+        static constexpr float kLoss = 0.625f;
+        static constexpr std::size_t kNumGaussians = 42'000;
+
+        static constexpr std::array registered_tool_names_{
+            "training.get_state",
+            "training.list_operations",
+            "training.get_loss_history",
+            "model.set_attribute",
+            "model.scale_attribute",
+            "model.clamp_attribute",
+            "optimizer.set_lr",
+            "optimizer.scale_lr",
+            "session.pause",
+            "session.resume",
+            "session.request_stop",
+        };
+    };
+
+    TEST_F(McpTrainingStateTest, BridgeReadsTheProcessWideCommandCenterSnapshot) {
+        populate_snapshot();
+
+        auto* const bridged_command_center = lfs::event::command_center();
+        ASSERT_NE(bridged_command_center, nullptr);
+        EXPECT_EQ(bridged_command_center, &lfs::training::CommandCenter::instance());
+
+        const auto bridged_snapshot = bridged_command_center->snapshot();
+        EXPECT_EQ(bridged_snapshot.iteration, kIteration);
+        EXPECT_EQ(bridged_snapshot.max_iterations, kMaxIterations);
+        EXPECT_FLOAT_EQ(bridged_snapshot.loss, kLoss);
+        EXPECT_EQ(bridged_snapshot.num_gaussians, kNumGaussians);
+        EXPECT_TRUE(bridged_snapshot.is_refining);
+        EXPECT_TRUE(bridged_snapshot.is_paused);
+        EXPECT_TRUE(bridged_snapshot.is_running);
+        EXPECT_FALSE(bridged_snapshot.stop_requested);
+        EXPECT_EQ(bridged_snapshot.phase, lfs::training::TrainingPhase::OptimizerStep);
+        EXPECT_NE(bridged_snapshot.trainer, nullptr);
+    }
+
+    TEST_F(McpTrainingStateTest, TrainingGetStateReturnsTheProcessWideSnapshot) {
+        populate_snapshot();
+        lfs::mcp::register_core_tools();
+
+        const auto result = lfs::mcp::ToolRegistry::instance().call_tool(
+            "training.get_state", nlohmann::json::object());
+
+        EXPECT_EQ(result.at("iteration"), kIteration);
+        EXPECT_EQ(result.at("max_iterations"), kMaxIterations);
+        EXPECT_FLOAT_EQ(result.at("loss").get<float>(), kLoss);
+        EXPECT_EQ(result.at("num_gaussians"), kNumGaussians);
+        EXPECT_TRUE(result.at("is_refining").get<bool>());
+        EXPECT_TRUE(result.at("is_paused").get<bool>());
+        EXPECT_TRUE(result.at("is_running").get<bool>());
+    }
+
+} // namespace


### PR DESCRIPTION
`CommandCenter` was a singleton inside the static `lfs_training` library. On Windows the exe, `lfs_visualizer.dll` and `lfs_mcp.dll` each got their own copy: the trainer wrote one copy while MCP read another. So `training.get_state` returned zeros during GUI training, and the session/model/optimizer MCP ops acted on the wrong instance. Linux hides this because the dynamic linker collapses the copies.

The singleton storage now lives in the shared `lfs_event_bridge` (same pattern as `EventBridge`), so the whole process uses one instance. No behavior changes otherwise. New tests pin the single instance and a populated `training.get_state`.

Verified on Linux at link level (exactly one exported definition, all modules import it) plus unit tests. The behavioral fix needs a Windows run to confirm, since the bug only shows there.

Fixes #1431
