### PR TITLE
Stabilize headless execution and plugin validation

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -284,6 +284,11 @@ namespace lfs::app {
                         vis::gui::panels::PythonScriptManagerState::getInstance().setScripts(params->python_scripts);
                     }
 
+                    if (!params->python_scripts.empty() && !python::ensure_plugins_loaded(true)) {
+                        LOG_ERROR("Failed to load plugins before running headless Python scripts");
+                        return 1;
+                    }
+
                     if (const auto result = trainer->initialize(*ckpt_params_result); !result) {
                         LOG_ERROR("Failed to initialize trainer: {}", result.error());
                         return 1;
@@ -327,6 +332,11 @@ namespace lfs::app {
                     if (!params->python_scripts.empty()) {
                         trainer->set_python_scripts(params->python_scripts);
                         vis::gui::panels::PythonScriptManagerState::getInstance().setScripts(params->python_scripts);
+                    }
+
+                    if (!params->python_scripts.empty() && !python::ensure_plugins_loaded(true)) {
+                        LOG_ERROR("Failed to load plugins before running headless Python scripts");
+                        return 1;
                     }
 
                     if (const auto result = trainer->initialize(*params); !result) {

--- a/src/python/lfs_plugins/validator.py
+++ b/src/python/lfs_plugins/validator.py
@@ -21,6 +21,10 @@ except ImportError:
     import tomli as tomllib
 
 
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
 def validate_plugin(plugin_path: str | Path) -> list[str]:
     """Validate plugin structure and manifest. Returns list of errors (empty if valid)."""
     plugin_dir = Path(plugin_path)
@@ -34,7 +38,7 @@ def validate_plugin(plugin_path: str | Path) -> list[str]:
         errors.append("Missing pyproject.toml")
     else:
         try:
-            data = tomllib.loads(manifest.read_text())
+            data = tomllib.loads(_read_text(manifest))
             lf = data.get("tool", {}).get("lichtfeld", {})
             if not lf:
                 errors.append("pyproject.toml: missing [tool.lichtfeld] section")
@@ -64,7 +68,7 @@ def validate_plugin(plugin_path: str | Path) -> list[str]:
     if not init_py.exists():
         errors.append("Missing __init__.py")
     else:
-        content = init_py.read_text()
+        content = _read_text(init_py)
         if "def on_load" not in content:
             errors.append("Missing on_load() function")
         if "def on_unload" not in content:
@@ -82,7 +86,7 @@ def _check_venv(plugin_dir: Path) -> list[str]:
     venv = plugin_dir / ".venv"
 
     has_deps = (plugin_dir / "pyproject.toml").exists() and \
-        any((plugin_dir / "pyproject.toml").read_text().find(s) >= 0
+        any(_read_text(plugin_dir / "pyproject.toml").find(s) >= 0
             for s in ("dependencies",))
 
     if not venv.exists():
@@ -109,11 +113,13 @@ def _check_venv(plugin_dir: Path) -> list[str]:
 def _check_panel_assets(plugin_dir: Path) -> list[str]:
     errors = []
     for py_file in plugin_dir.rglob("*.py"):
+        if ".venv" in py_file.parts:
+            continue
         if py_file.name == "__init__.py":
             continue
 
         try:
-            module = ast.parse(py_file.read_text(), filename=str(py_file))
+            module = ast.parse(_read_text(py_file), filename=str(py_file))
         except SyntaxError:
             continue
 
@@ -220,7 +226,7 @@ def _resolve_template_path(plugin_dir: Path, panel_dir: Path, template_ref: Path
 
 def _check_rml_links(plugin_dir: Path, template_path: Path) -> list[str]:
     errors = []
-    text = template_path.read_text()
+    text = _read_text(template_path)
     for href in re.findall(r'<link[^>]+type="text/rcss"[^>]+href="([^"]+)"', text):
         asset_path = template_path.parent / href
         if not asset_path.exists():

--- a/src/python/runner.cpp
+++ b/src/python/runner.cpp
@@ -1310,7 +1310,7 @@ _add_dll_dirs()
         ensure_builtin_ui_ready_locked();
     }
 
-    bool ensure_plugins_loaded() {
+    bool ensure_plugins_loaded(const bool wait_for_completion) {
         if (!ensure_initialized()) {
             return false;
         }
@@ -1323,7 +1323,7 @@ _add_dll_dirs()
 
         if (g_plugin_preload.state.load(std::memory_order_acquire) ==
             PluginPreloadState::NotStarted) {
-            if (on_graphics_thread()) {
+            if (on_graphics_thread() && !wait_for_completion) {
                 start_plugin_preload_worker();
                 return are_plugins_loaded();
             }
@@ -1343,7 +1343,7 @@ _add_dll_dirs()
                 return true;
         }
 
-        if (on_graphics_thread()) {
+        if (on_graphics_thread() && !wait_for_completion) {
             LOG_ERROR("Synchronous plugin load requested on the graphics thread while startup loading is active");
             return false;
         }

--- a/src/python/runner.hpp
+++ b/src/python/runner.hpp
@@ -80,8 +80,10 @@ namespace lfs::python {
     /**
      * @brief Load user plugins configured for startup.
      *        This requires a ready Python runtime.
+     * @param wait_for_completion Allow a headless caller to wait even when
+     *        the Python UI module identified the current thread as graphics.
      */
-    [[nodiscard]] bool ensure_plugins_loaded();
+    [[nodiscard]] bool ensure_plugins_loaded(bool wait_for_completion = false);
 
     /**
      * @brief Schedule plugin autoload after startup.

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -3234,10 +3234,6 @@ namespace lfs::training {
         LFS_CUDA_LOG_TEARDOWN(cudaDeviceSynchronize(), nullptr, "shutdown: device sync");
 
         const bool exiting_headless = params_.optimization.headless;
-        if (exiting_headless) {
-            lfs::core::CudaMemoryPool::instance().suspend_deallocations_for_process_exit();
-        }
-
         if (callback_stream_) {
             lfs::core::CudaMemoryPool::instance().release_stream(callback_stream_);
         }

--- a/tests/python/test_plugin_validator.py
+++ b/tests/python/test_plugin_validator.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Regression tests for plugin structure validation."""
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -60,6 +61,41 @@ class MainPanel(lf.ui.Panel):
     def draw(self, ui):
         ui.label("hello")
 """,
+    )
+
+    assert validate_plugin(plugin_dir) == []
+
+
+def test_validator_ignores_panel_sources_inside_venv(tmp_path):
+    from lfs_plugins.validator import validate_plugin
+
+    plugin_dir = tmp_path / "example_plugin"
+    _write_plugin(
+        plugin_dir,
+        """import lichtfeld as lf
+
+
+class MainPanel(lf.ui.Panel):
+    id = "example.main_panel"
+    label = "Example"
+    space = lf.ui.PanelSpace.MAIN_PANEL_TAB
+""",
+    )
+
+    venv = plugin_dir / ".venv"
+    python_name = "python.exe" if sys.platform == "win32" else "python"
+    python_path = venv / ("Scripts" if sys.platform == "win32" else "bin") / python_name
+    python_path.parent.mkdir(parents=True)
+    python_path.touch()
+    dependency = venv / "Lib" / "site-packages" / "dependency.py"
+    dependency.parent.mkdir(parents=True)
+    dependency.write_text(
+        "import lichtfeld as lf\n"
+        "from pathlib import Path\n\n"
+        "class DependencyPanel(lf.ui.Panel):\n"
+        "    template = str(Path(__file__).with_name('missing.rml'))\n"
+        "    label = '日本語'\n",
+        encoding="utf-8",
     )
 
     assert validate_plugin(plugin_dir) == []


### PR DESCRIPTION
## Headless Python scripts

Fixes #1439.

- Wait for startup plugin loading before running CLI-provided Python scripts in direct headless training.
- Preserve the existing non-blocking plugin preload behavior for the GUI.
- Leave the TCP headless path unchanged.

## Plugin validation

Fixes #1440.

- Read validator inputs explicitly as UTF-8, independently of the Windows system code page.
- Exclude `.venv` sources from panel asset checks, avoiding dependency-tree scans and locale-dependent decode failures.
- Add regression coverage for a virtual-environment dependency containing UTF-8 source.

## Headless CUDA teardown

- Complete CUDA memory-pool cleanup before process exit in headless training.
- Prevent late cache, slab, and event-pool destruction from calling CUDA after CUDART begins unloading.