### PR TITLE
Fix RmlUI warning from uninitialized status message color

### DIFF
--- a/src/visualizer/gui/rml_status_bar.cpp
+++ b/src/visualizer/gui/rml_status_bar.cpp
@@ -291,6 +291,7 @@ namespace lfs::vis::gui {
         model_.lfs_mem_color = colorToRml(palette.info);
         model_.gpu_mem_color = colorToRml(palette.text);
         model_.fps_color = colorToRml(palette.success);
+        model_.status_message_color = colorToRml(palette.info);
 
         rml_context_ = rml_manager_->createContext("status_bar", 800, 22);
         if (!rml_context_) {


### PR DESCRIPTION
## Summary

Initializes the status message color when the RmlUI status bar is created.

This prevents RmlUI from parsing an empty inline style declaration (`color: ;`) before the first status message is shown, removing the startup warning.