### PR TITLE
Preserve explicit training iterations; clean up auto-scale marker sync

### DIFF
--- a/src/python/lfs_plugins/training_panel.py
+++ b/src/python/lfs_plugins/training_panel.py
@@ -411,7 +411,6 @@ class TrainingPanel(Panel):
         self._new_save_step = 7000
         self._auto_scaled_for_cameras = 0
         self._auto_scale_steps_locked = True
-        self._auto_scale_scene_generation = RuntimeState.scene_generation.value
         self._auto_scale_dataset_path = ""
         self._last_state = ""
         self._last_save_steps = None
@@ -1322,20 +1321,12 @@ class TrainingPanel(Panel):
         )
         self._reactive_binding.set_handle(self._handle).watch(*native_signals)
 
-    def _sync_auto_scale_scene_generation(self):
+    def _sync_auto_scale_markers(self):
         d = lf.dataset_params()
-        dataset_path = str(d.data_path) if d and d.has_params() else ""
+        dataset_path = d.data_path if d and d.has_params() else ""
         if dataset_path != self._auto_scale_dataset_path:
             self._auto_scale_dataset_path = dataset_path
             self._auto_scaled_for_cameras = 0
-            self._auto_scale_scene_generation = RuntimeState.scene_generation.value
-            return True
-
-        scene_generation = RuntimeState.scene_generation.value
-        if scene_generation == self._auto_scale_scene_generation:
-            return False
-        self._auto_scale_scene_generation = scene_generation
-        return False
 
     def _unsubscribe_reactive_state(self):
         self._reactive_binding.close()
@@ -1399,7 +1390,7 @@ class TrainingPanel(Panel):
         if not self._handle:
             return False
         self._sync_panel_label()
-        self._sync_auto_scale_scene_generation()
+        self._sync_auto_scale_markers()
 
         dirty = False
         state = RuntimeState.trainer_state.value
@@ -2361,7 +2352,7 @@ class TrainingPanel(Panel):
         params.remove_eval_step(step)
 
     def _try_auto_scale_steps(self, params):
-        self._sync_auto_scale_scene_generation()
+        self._sync_auto_scale_markers()
         if not self._auto_scale_steps_locked:
             return False
         scene = lf.get_scene()

--- a/src/python/lfs_plugins/training_panel.py
+++ b/src/python/lfs_plugins/training_panel.py
@@ -411,6 +411,7 @@ class TrainingPanel(Panel):
         self._new_save_step = 7000
         self._auto_scaled_for_cameras = 0
         self._auto_scale_steps_locked = True
+        self._auto_scale_user_override = False
         self._auto_scale_dataset_path = ""
         self._last_state = ""
         self._last_save_steps = None
@@ -1327,6 +1328,7 @@ class TrainingPanel(Panel):
         if dataset_path != self._auto_scale_dataset_path:
             self._auto_scale_dataset_path = dataset_path
             self._auto_scaled_for_cameras = 0
+            self._auto_scale_user_override = False
 
     def _unsubscribe_reactive_state(self):
         self._reactive_binding.close()
@@ -1784,7 +1786,10 @@ class TrainingPanel(Panel):
 
         try:
             if prop == "steps_scaler":
+                current_scaler = float(getattr(params, "steps_scaler", 1.0))
                 params.apply_step_scaling(val)
+                if abs(val - current_scaler) > 0.005:
+                    self._auto_scale_user_override = True
                 if self._handle:
                     self._sync_text_bufs()
                     self._handle.dirty_all()
@@ -1816,6 +1821,7 @@ class TrainingPanel(Panel):
         if self._handle:
             self._sync_text_bufs()
             self._handle.dirty_all()
+        self._auto_scale_user_override = True
         return True
 
     def _set_ppisp_activation_step(self, val_str):
@@ -2353,7 +2359,7 @@ class TrainingPanel(Panel):
 
     def _try_auto_scale_steps(self, params):
         self._sync_auto_scale_markers()
-        if not self._auto_scale_steps_locked:
+        if not self._auto_scale_steps_locked or self._auto_scale_user_override:
             return False
         scene = lf.get_scene()
         if scene is None:
@@ -2373,6 +2379,7 @@ class TrainingPanel(Panel):
 
         if locked:
             self._auto_scaled_for_cameras = 0
+            self._auto_scale_user_override = False
             params = lf.optimization_params()
             if params and params.has_params() and self._try_auto_scale_steps(params):
                 self._sync_text_bufs()

--- a/tests/python/test_training_panel_regressions.py
+++ b/tests/python/test_training_panel_regressions.py
@@ -102,6 +102,7 @@ class _ParamsStub:
         self.eval_steps = []
         self.bg_color = (0.0, 0.0, 0.0)
         self.bg_image_path = ""
+        self.auto_scaled_for = None
 
     def has_params(self):
         return True
@@ -114,8 +115,8 @@ class _ParamsStub:
         self.stop_refine = int(self.stop_refine * scale)
         self.grow_until_iter = int(self.grow_until_iter * scale)
 
-    def auto_scale_steps(self, _camera_count):
-        pass
+    def auto_scale_steps(self, camera_count):
+        self.auto_scaled_for = camera_count
 
     def set(self, prop, value):
         setattr(self, prop, value)
@@ -150,25 +151,49 @@ def test_auto_scale_marker_survives_reset_but_not_dataset_change(
 ):
     dataset = _DatasetStub()
     scene = SimpleNamespace(active_camera_count=600)
-    monkeypatch.setattr(
-        training_panel_module,
-        "RuntimeState",
-        SimpleNamespace(scene_generation=_make_signal(0)),
-    )
     monkeypatch.setattr(training_panel_module.lf, "dataset_params", lambda: dataset)
     monkeypatch.setattr(training_panel_module.lf, "get_scene", lambda: scene)
     panel = training_panel_module.TrainingPanel()
     params = _ParamsStub()
 
     assert panel._try_auto_scale_steps(params) is True
+    assert params.auto_scaled_for == 600
 
-    # Reset re-loads the same dataset and bumps the scene generation.
-    training_panel_module.RuntimeState.scene_generation.value = 1
+    # Reset re-enters with the same dataset path.
+    params.auto_scaled_for = None
     assert panel._try_auto_scale_steps(params) is False
+    assert params.auto_scaled_for is None
 
     dataset.data_path = "/data/scene_b"
-    training_panel_module.RuntimeState.scene_generation.value = 2
     assert panel._try_auto_scale_steps(params) is True
+    assert params.auto_scaled_for == 600
+
+
+def test_auto_scale_user_override_survives_camera_change_until_relocked(
+    training_panel_module, monkeypatch
+):
+    dataset = _DatasetStub()
+    scene = SimpleNamespace(active_camera_count=900)
+    monkeypatch.setattr(training_panel_module.lf, "dataset_params", lambda: dataset)
+    monkeypatch.setattr(training_panel_module.lf, "get_scene", lambda: scene)
+    params = _ParamsStub()
+    monkeypatch.setattr(training_panel_module.lf, "optimization_params", lambda: params)
+    panel = training_panel_module.TrainingPanel()
+
+    assert panel._try_auto_scale_steps(params) is True
+    assert params.auto_scaled_for == 900
+
+    assert panel._set_iterations(params, 50000) is True
+    assert params.iterations == 50000
+
+    scene.active_camera_count = 800
+    assert panel._try_auto_scale_steps(params) is False
+    assert params.auto_scaled_for == 900
+    assert params.iterations == 50000
+
+    panel._set_auto_scale_steps_locked(False)
+    panel._set_auto_scale_steps_locked(True)
+    assert params.auto_scaled_for == 800
 
 
 def test_training_panel_progress_updates_bound_value(training_panel_module, monkeypatch):

--- a/tests/python/test_training_panel_regressions.py
+++ b/tests/python/test_training_panel_regressions.py
@@ -114,6 +114,9 @@ class _ParamsStub:
         self.stop_refine = int(self.stop_refine * scale)
         self.grow_until_iter = int(self.grow_until_iter * scale)
 
+    def auto_scale_steps(self, _camera_count):
+        pass
+
     def set(self, prop, value):
         setattr(self, prop, value)
 
@@ -126,6 +129,7 @@ class _ParamsStub:
 
 class _DatasetStub:
     def __init__(self):
+        self.data_path = "/data/scene_a"
         self.max_width = 2048
         self.test_every = 8
 
@@ -139,6 +143,32 @@ class _ModelStub:
 
     def bind(self, name, getter, setter):
         self.bindings[name] = (getter, setter)
+
+
+def test_auto_scale_marker_survives_reset_but_not_dataset_change(
+    training_panel_module, monkeypatch
+):
+    dataset = _DatasetStub()
+    scene = SimpleNamespace(active_camera_count=600)
+    monkeypatch.setattr(
+        training_panel_module,
+        "RuntimeState",
+        SimpleNamespace(scene_generation=_make_signal(0)),
+    )
+    monkeypatch.setattr(training_panel_module.lf, "dataset_params", lambda: dataset)
+    monkeypatch.setattr(training_panel_module.lf, "get_scene", lambda: scene)
+    panel = training_panel_module.TrainingPanel()
+    params = _ParamsStub()
+
+    assert panel._try_auto_scale_steps(params) is True
+
+    # Reset re-loads the same dataset and bumps the scene generation.
+    training_panel_module.RuntimeState.scene_generation.value = 1
+    assert panel._try_auto_scale_steps(params) is False
+
+    dataset.data_path = "/data/scene_b"
+    training_panel_module.RuntimeState.scene_generation.value = 2
+    assert panel._try_auto_scale_steps(params) is True
 
 
 def test_training_panel_progress_updates_bound_value(training_panel_module, monkeypatch):


### PR DESCRIPTION
Follow-up to #1443, two commits.

**Cleanup.** The auto-scale re-run is keyed on the dataset path now, so `_auto_scale_scene_generation` was write-only and the sync helper's return value was unused (and inverted with respect to its name). Renamed it to `_sync_auto_scale_markers`, dropped the dead state and returns, removed a redundant `str()` on an already-`str` binding.

**Camera-count fix.** #1443 only covered the reset-on-the-same-dataset case. Auto-scaling still overwrote an explicitly typed iteration count whenever the active camera count moved — disabling cameras for training, or a reset re-enabling them:

```
load dataset (900 cams)   iters 30000 -> 90000   scaler 1.000 -> 3.000
user types 50000          iters 50000            scaler 1.667
disable 100 cameras       iters 50000 -> 80000   scaler 1.667 -> 2.667   wrong
reset                     iters 80000 -> 90000   scaler 2.667 -> 3.000   wrong
```

The lock button sits inside the iterations row and only disables the *dependent* step params, so Auto means "you set iterations and the rest follows" — the camera count seeds the value, it is not an invariant. Auto-scaling now stops once the user edits iterations or the steps scaler for the current dataset. Loading another dataset re-seeds; toggling the lock off and back on re-derives from the camera count.

The override latches only on a real change (`_on_number_input_blur` commits on every blur, edit or not) and only after the edit succeeds, and the steps-scaler comparison uses a tolerance wider than its `%.2f` display rounding.

Two regression tests. Verified in the GUI on `data/bicycle`: clean load, `Auto-scaled steps for 194 images: scaler=1.00`, no errors.
