### PR TITLE
Remove the unused standalone Vulkan path from the RmlUi backend

### DIFF
--- a/src/visualizer/gui/rmlui/rmlui_vk_backend.cpp
+++ b/src/visualizer/gui/rmlui/rmlui_vk_backend.cpp
@@ -10,12 +10,10 @@
 #include "gui/rmlui/vulkan/rmlui_shaders_spv.hpp"
 #include "internal/resource_paths.hpp"
 #include "python/python_runtime.hpp"
-#include "rendering/vulkan_wait.hpp"
 #include <RmlUi/Core/Core.h>
 #include <RmlUi/Core/FileInterface.h>
 #include <RmlUi/Core/Log.h>
 #include <RmlUi/Core/Math.h>
-#include <RmlUi/Core/Platform.h>
 #include <RmlUi/Core/Profiling.h>
 #include <algorithm>
 #include <charconv>
@@ -28,7 +26,6 @@
 #include <optional>
 #include <semaphore>
 #include <stb_image.h>
-#include <stop_token>
 #include <string.h>
 #include <string>
 #include <string_view>
@@ -40,13 +37,6 @@ template <typename T>
 static T AlignUp(T val, T alignment) {
     return (val + alignment - (T)1) & ~(alignment - (T)1);
 }
-
-VkValidationFeaturesEXT debug_validation_features_ext = {};
-VkValidationFeatureEnableEXT debug_validation_features_ext_requested[] = {
-    VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT,
-    VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT,
-    VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT,
-};
 
 static bool SupportsHostImageCopyDestinationLayout(VkPhysicalDevice physical_device,
                                                    VkImageLayout layout) {
@@ -75,25 +65,6 @@ static Rml::String FormatByteSize(VkDeviceSize size) noexcept {
     else if (size < K * K)
         return Rml::CreateString("%g KB", double(size) / double(K));
     return Rml::CreateString("%g MB", double(size) / double(K * K));
-}
-
-static VKAPI_ATTR VkBool32 VKAPI_CALL MyDebugReportCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severityFlags,
-                                                            VkDebugUtilsMessageTypeFlagsEXT /*messageTypeFlags*/, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* /*pUserData*/) {
-    if (severityFlags & VkDebugUtilsMessageSeverityFlagBitsEXT::VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) {
-        return VK_FALSE;
-    }
-
-#ifdef RMLUI_PLATFORM_WIN32
-    if (severityFlags & VkDebugUtilsMessageSeverityFlagBitsEXT::VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
-        // some logs are not passed to our UI, because of early calling for explicity I put native log output
-        OutputDebugString(TEXT("\n"));
-        OutputDebugStringA(pCallbackData->pMessage);
-    }
-#endif
-
-    Rml::Log::Message(Rml::Log::LT_ERROR, "[Vulkan][VALIDATION] %s ", pCallbackData->pMessage);
-
-    return VK_FALSE;
 }
 
 static void InsertDebugUtilsLabel(VkDevice device, VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT& label) noexcept {
@@ -285,17 +256,10 @@ RenderInterface_VK::RenderInterface_VK() : m_is_transform_enabled{false},
                                            m_is_use_stencil_pipeline{false},
                                            m_width{},
                                            m_height{},
-                                           m_queue_index_present{},
                                            m_queue_index_graphics{},
-                                           m_queue_index_compute{},
-                                           m_semaphore_index{},
-                                           m_semaphore_index_previous{},
-                                           m_image_index{},
                                            m_p_instance{},
                                            m_p_device{},
                                            m_p_physical_device{},
-                                           m_p_surface{},
-                                           m_p_swapchain{},
                                            m_p_pipeline_cache{},
                                            m_p_allocator{},
                                            m_p_current_command_buffer{},
@@ -313,15 +277,9 @@ RenderInterface_VK::RenderInterface_VK() : m_is_transform_enabled{false},
                                            m_scissor{},
                                            m_scissor_original{},
                                            m_viewport{},
-                                           m_p_queue_present{},
                                            m_p_queue_graphics{},
-                                           m_p_queue_compute{},
-#ifdef RMLUI_VK_DEBUG
-                                           m_debug_messenger{},
-#endif
                                            m_swapchain_format{},
                                            m_depth_stencil_format{},
-                                           m_texture_depthstencil{},
                                            m_pending_for_deletion_textures_by_frames{},
                                            m_live_textures{},
                                            m_render_layers{},
@@ -329,7 +287,6 @@ RenderInterface_VK::RenderInterface_VK() : m_is_transform_enabled{false},
                                            m_external_swapchain_image_view{},
                                            m_external_depth_stencil_image_view{},
                                            m_external_swapchain_layout{VK_IMAGE_LAYOUT_UNDEFINED},
-                                           m_depth_stencil_layout{VK_IMAGE_LAYOUT_UNDEFINED},
                                            m_active_render_target{active_render_target_t::None},
                                            m_active_layer{},
                                            m_render_layer_stack_size{} {
@@ -1567,151 +1524,6 @@ VkRect2D RenderInterface_VK::IntersectContextClip(VkRect2D scissor) const noexce
     return scissor;
 }
 
-void RenderInterface_VK::BeginFrame() {
-    // AMB-C1 soft-fail minimum: non-Ready acquire/fence skips the frame.
-    if (!Wait()) {
-        return;
-    }
-
-    m_reclaim_resource_slot = m_semaphore_index_previous;
-    m_resource_slot = m_semaphore_index;
-    FreeTransientShaderAllocations(m_reclaim_resource_slot);
-    Update_PendingForDeletion_Textures_By_Frame(m_reclaim_resource_slot);
-    Update_PendingForDeletion_Geometries(m_reclaim_resource_slot);
-    ProcessAsyncPreviewUploads();
-
-    m_command_buffer_ring.OnBeginFrame();
-    m_p_current_command_buffer = m_command_buffer_ring.GetCommandBufferForActiveFrame(CommandBufferName::Primary);
-
-    VkCommandBufferBeginInfo info = {};
-
-    info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-    info.pInheritanceInfo = nullptr;
-    info.pNext = nullptr;
-    info.flags = VkCommandBufferUsageFlagBits::VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-
-    auto status = vkBeginCommandBuffer(m_p_current_command_buffer, &info);
-
-    RMLUI_VK_ASSERTMSG(status == VkResult::VK_SUCCESS, "failed to vkBeginCommandBuffer");
-
-    BeginSwapchainRendering(VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_LOAD_OP_CLEAR);
-
-    m_active_render_target = active_render_target_t::Swapchain;
-    m_active_layer = {};
-    m_render_layer_stack_size = 0;
-    m_is_clip_mask_enabled = false;
-    m_is_transformed_scissor_enabled = false;
-    m_is_use_scissor_specified = false;
-    m_is_use_stencil_pipeline = false;
-    m_is_apply_to_regular_geometry_stencil = false;
-    m_current_context_used_preview_texture = false;
-    SetContextOffset(0.0f, 0.0f);
-    SetTransform(nullptr);
-    m_context_clip_enabled = false;
-}
-
-void RenderInterface_VK::EndFrame() {
-    if (m_p_current_command_buffer == nullptr)
-        return;
-
-    EndActiveRendering();
-    if (!m_external_context && m_image_index < m_swapchain_images.size()) {
-        TransitionImageLayout(m_swapchain_images[m_image_index],
-                              VK_IMAGE_ASPECT_COLOR_BIT,
-                              m_swapchain_image_layouts[m_image_index],
-                              VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
-        m_swapchain_image_layouts[m_image_index] = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    }
-
-    auto status = vkEndCommandBuffer(m_p_current_command_buffer);
-
-    RMLUI_VK_ASSERTMSG(status == VkResult::VK_SUCCESS, "failed to vkEndCommandBuffer");
-
-    Submit();
-    Present();
-
-    m_p_current_command_buffer = nullptr;
-}
-
-void RenderInterface_VK::SetViewport(int width, int height) {
-    WaitForSubmittedFrames();
-
-    if (width > 0 && height > 0) {
-        m_width = width;
-        m_height = height;
-    }
-
-    if (m_p_swapchain) {
-        Destroy_Swapchain();
-        DestroyResourcesDependentOnSize();
-        m_p_swapchain = {};
-    }
-
-    VkExtent2D window_extent = GetValidSurfaceExtent();
-    if (window_extent.width == 0 || window_extent.height == 0)
-        return;
-
-#ifdef RMLUI_VK_DEBUG
-    Rml::Log::Message(Rml::Log::Type::LT_DEBUG, "Rml width: %d height: %d | Vulkan width: %d height: %d", m_width, m_height, window_extent.width,
-                      window_extent.height);
-#endif
-
-    //  we need to sync the data from Vulkan so we can't use native Rml's data about width and height so be careful otherwise we create framebuffer
-    //  with Rml's width and height but they're different to what Vulkan determines for our window (e.g. device/swapchain)
-    m_width = window_extent.width;
-    m_height = window_extent.height;
-
-    Initialize_Swapchain(window_extent);
-    CreateResourcesDependentOnSize(window_extent);
-}
-
-bool RenderInterface_VK::IsSwapchainValid() {
-    return m_p_swapchain != nullptr;
-}
-
-void RenderInterface_VK::RecreateSwapchain() {
-    SetViewport(m_width, m_height);
-}
-
-bool RenderInterface_VK::Initialize(Rml::Vector<const char*> required_extensions, CreateSurfaceCallback create_surface_callback) {
-    RMLUI_ZoneScopedN("Vulkan - Initialize");
-
-    Initialize_Instance(std::move(required_extensions));
-
-    VkPhysicalDeviceProperties physical_device_properties = {};
-    Initialize_PhysicalDevice(physical_device_properties);
-
-    Initialize_Surface(create_surface_callback);
-    Initialize_QueueIndecies();
-    Initialize_Device();
-
-    Initialize_Queues();
-    Initialize_SyncPrimitives();
-    Initialize_Allocator();
-    Initialize_Resources(physical_device_properties);
-
-    return true;
-}
-
-void RenderInterface_VK::Shutdown() {
-    RMLUI_ZoneScopedN("Vulkan - Shutdown");
-
-    auto status = vkDeviceWaitIdle(m_p_device);
-
-    RMLUI_VK_ASSERTMSG(status == VkResult::VK_SUCCESS, "you must have a valid status here");
-
-    m_async_preview_textures.clear();
-    DestroyResourcesDependentOnSize();
-    Destroy_Resources();
-    Destroy_Allocator();
-    Destroy_SyncPrimitives();
-    Destroy_Swapchain();
-    Destroy_Surface();
-    Destroy_Device();
-    Destroy_ReportDebugCallback();
-    Destroy_Instance();
-}
-
 bool RenderInterface_VK::InitializeExternal(const ExternalContext& context) {
     RMLUI_ZoneScopedN("Vulkan - InitializeExternal");
 
@@ -1744,11 +1556,7 @@ bool RenderInterface_VK::InitializeExternal(const ExternalContext& context) {
                           "[Vulkan] Host image copies do not support the RmlUi shader-read layout; using staging uploads.");
     }
     m_p_queue_graphics = context.graphics_queue;
-    m_p_queue_present = context.graphics_queue;
-    m_p_queue_compute = context.graphics_queue;
     m_queue_index_graphics = context.graphics_queue_family;
-    m_queue_index_present = context.graphics_queue_family;
-    m_queue_index_compute = context.graphics_queue_family;
     m_swapchain_format.format = context.color_format;
     m_depth_stencil_format = context.depth_stencil_format;
     m_width = static_cast<int>(context.extent.width);
@@ -1790,8 +1598,6 @@ void RenderInterface_VK::ShutdownExternal() {
     m_p_physical_device = VK_NULL_HANDLE;
     m_p_device = VK_NULL_HANDLE;
     m_p_queue_graphics = VK_NULL_HANDLE;
-    m_p_queue_present = VK_NULL_HANDLE;
-    m_p_queue_compute = VK_NULL_HANDLE;
     m_external_swapchain_image = VK_NULL_HANDLE;
     m_external_swapchain_image_view = VK_NULL_HANDLE;
     m_external_depth_stencil_image_view = VK_NULL_HANDLE;
@@ -1814,9 +1620,6 @@ void RenderInterface_VK::BeginExternalFrame(const VkCommandBuffer command_buffer
         m_height = static_cast<int>(extent.height);
         UpdateViewportState(extent);
     }
-
-    m_semaphore_index_previous = m_semaphore_index;
-    m_semaphore_index = ((m_semaphore_index + 1) % kSwapchainBackBufferCount);
 
     m_resource_slot = static_cast<uint32_t>(frame_slot % kSwapchainBackBufferCount);
     m_reclaim_resource_slot = m_resource_slot;
@@ -1878,307 +1681,7 @@ void RenderInterface_VK::ResetContextRenderState() {
     vkCmdSetStencilReference(m_p_current_command_buffer, VK_STENCIL_FACE_FRONT_AND_BACK, 1);
 }
 
-void RenderInterface_VK::Initialize_Instance(Rml::Vector<const char*> required_extensions) noexcept {
-    uint32_t required_version = GetRequiredVersionAndValidateMachine();
-
-    VkApplicationInfo info = {};
-    info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-    info.pNext = nullptr;
-    info.pApplicationName = "RmlUi Shell";
-    info.applicationVersion = 50;
-    info.pEngineName = "RmlUi";
-    info.apiVersion = required_version;
-
-    Rml::Vector<const char*> instance_layer_names;
-    Rml::Vector<const char*> instance_extension_names = std::move(required_extensions);
-    CreatePropertiesFor_Instance(instance_layer_names, instance_extension_names);
-
-    VkInstanceCreateInfo info_instance = {};
-    info_instance.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-    info_instance.pNext = &debug_validation_features_ext;
-    info_instance.flags = 0;
-    info_instance.pApplicationInfo = &info;
-    info_instance.enabledExtensionCount = static_cast<uint32_t>(instance_extension_names.size());
-    info_instance.ppEnabledExtensionNames = instance_extension_names.data();
-    info_instance.enabledLayerCount = static_cast<uint32_t>(instance_layer_names.size());
-    info_instance.ppEnabledLayerNames = instance_layer_names.data();
-
-    VkResult status = vkCreateInstance(&info_instance, nullptr, &m_p_instance);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkCreateInstance");
-
-    CreateReportDebugCallback();
-}
-
-void RenderInterface_VK::Initialize_Device() noexcept {
-    ExtensionPropertiesList device_extension_properties;
-    CreatePropertiesFor_Device(device_extension_properties);
-
-    Rml::Vector<const char*> device_extension_names;
-    AddExtensionToDevice(device_extension_names, device_extension_properties, VK_KHR_SWAPCHAIN_EXTENSION_NAME);
-    AddExtensionToDevice(device_extension_names, device_extension_properties, VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
-
-#ifdef RMLUI_VK_DEBUG
-    AddExtensionToDevice(device_extension_names, device_extension_properties, VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-#endif
-
-    float queue_priorities[1] = {0.0f};
-
-    VkDeviceQueueCreateInfo info_queue[2] = {};
-
-    info_queue[0].sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    info_queue[0].pNext = nullptr;
-    info_queue[0].queueCount = 1;
-    info_queue[0].pQueuePriorities = queue_priorities;
-    info_queue[0].queueFamilyIndex = m_queue_index_graphics;
-
-    info_queue[1].sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    info_queue[1].pNext = nullptr;
-    info_queue[1].queueCount = 1;
-    info_queue[1].pQueuePriorities = queue_priorities;
-    info_queue[1].queueFamilyIndex = m_queue_index_compute;
-
-    VkPhysicalDeviceFeatures features_physical_device = {};
-
-    features_physical_device.fillModeNonSolid = true;
-    features_physical_device.pipelineStatisticsQuery = true;
-    features_physical_device.fragmentStoresAndAtomics = true;
-    features_physical_device.vertexPipelineStoresAndAtomics = true;
-    features_physical_device.shaderImageGatherExtended = true;
-    features_physical_device.wideLines = true;
-
-    VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR shader_subgroup_extended_type = {};
-
-    shader_subgroup_extended_type.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES_KHR;
-    shader_subgroup_extended_type.pNext = nullptr;
-    shader_subgroup_extended_type.shaderSubgroupExtendedTypes = VK_TRUE;
-
-    VkPhysicalDeviceFeatures2 features_physical_device2 = {};
-
-    features_physical_device2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    features_physical_device2.features = features_physical_device;
-    features_physical_device2.pNext = &shader_subgroup_extended_type;
-
-    VkDeviceCreateInfo info_device = {};
-
-    info_device.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-    info_device.pNext = &features_physical_device2;
-    info_device.queueCreateInfoCount = m_queue_index_compute != m_queue_index_graphics ? 2 : 1;
-    info_device.pQueueCreateInfos = info_queue;
-    info_device.enabledExtensionCount = static_cast<uint32_t>(device_extension_names.size());
-    info_device.ppEnabledExtensionNames = info_device.enabledExtensionCount ? device_extension_names.data() : nullptr;
-    info_device.pEnabledFeatures = nullptr;
-
-    VkResult status = vkCreateDevice(m_p_physical_device, &info_device, nullptr, &m_p_device);
-
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkCreateDevice");
-    m_debug_name_writer.initialize(m_p_device);
-}
-
-void RenderInterface_VK::Initialize_PhysicalDevice(VkPhysicalDeviceProperties& out_physical_device_properties) noexcept {
-    PhysicalDeviceWrapperList physical_devices;
-    CollectPhysicalDevices(physical_devices);
-
-    const PhysicalDeviceWrapper* selected_physical_device =
-        ChoosePhysicalDevice(physical_devices, VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
-
-    if (!selected_physical_device) {
-        Rml::Log::Message(Rml::Log::LT_WARNING, "Failed to pick the discrete gpu, now trying to pick integrated GPU");
-        selected_physical_device = ChoosePhysicalDevice(physical_devices, VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU);
-
-        if (!selected_physical_device) {
-            Rml::Log::Message(Rml::Log::LT_WARNING, "Failed to pick the integrated gpu, now trying to pick the CPU");
-            selected_physical_device = ChoosePhysicalDevice(physical_devices, VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_CPU);
-        }
-    }
-
-    RMLUI_VK_ASSERTMSG(selected_physical_device, "there's no suitable physical device for rendering, abort this application");
-
-    m_p_physical_device = selected_physical_device->m_p_physical_device;
-    vkGetPhysicalDeviceProperties(m_p_physical_device, &out_physical_device_properties);
-
-#ifdef RMLUI_VK_DEBUG
-    const auto& properties = selected_physical_device->m_physical_device_properties;
-    Rml::Log::Message(Rml::Log::LT_DEBUG, "Picked physical device: %s", properties.deviceName);
-#endif
-}
-
-void RenderInterface_VK::Initialize_Swapchain(VkExtent2D window_extent) noexcept {
-    m_swapchain_format = ChooseSwapchainFormat();
-
-    VkSwapchainCreateInfoKHR info = {};
-    info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
-    info.pNext = nullptr;
-    info.surface = m_p_surface;
-    info.imageFormat = m_swapchain_format.format;
-    info.minImageCount = Choose_SwapchainImageCount();
-    info.imageColorSpace = m_swapchain_format.colorSpace;
-    info.imageExtent = window_extent;
-    info.preTransform = CreatePretransformSwapchain();
-    info.compositeAlpha = ChooseSwapchainCompositeAlpha();
-    info.imageArrayLayers = 1;
-    info.presentMode = GetPresentMode();
-    info.oldSwapchain = nullptr;
-    info.clipped = true;
-    info.imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    info.queueFamilyIndexCount = 0;
-    info.pQueueFamilyIndices = nullptr;
-
-    uint32_t queue_family_index_present = m_queue_index_present;
-    uint32_t queue_family_index_graphics = m_queue_index_graphics;
-
-    if (queue_family_index_graphics != queue_family_index_present) {
-        uint32_t p_indecies[2] = {queue_family_index_graphics, queue_family_index_present};
-
-        info.imageSharingMode = VK_SHARING_MODE_CONCURRENT;
-        info.queueFamilyIndexCount = sizeof(p_indecies) / sizeof(p_indecies[0]);
-        info.pQueueFamilyIndices = p_indecies;
-    }
-
-    VkResult status = vkCreateSwapchainKHR(m_p_device, &info, nullptr, &m_p_swapchain);
-
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkCreateSwapchainKHR");
-}
-
-void RenderInterface_VK::Initialize_Surface(CreateSurfaceCallback create_surface_callback) noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_instance, "you must initialize your VkInstance");
-
-    bool result = create_surface_callback(m_p_instance, &m_p_surface);
-    RMLUI_VK_ASSERTMSG(result && m_p_surface, "failed to call create_surface_callback");
-}
-
-void RenderInterface_VK::Initialize_QueueIndecies() noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_physical_device, "you must initialize your physical device");
-    RMLUI_VK_ASSERTMSG(m_p_surface, "you must initialize VkSurfaceKHR before calling this method");
-
-    uint32_t queue_family_count = 0;
-
-    vkGetPhysicalDeviceQueueFamilyProperties(m_p_physical_device, &queue_family_count, nullptr);
-
-    RMLUI_VK_ASSERTMSG(queue_family_count >= 1, "failed to vkGetPhysicalDeviceQueueFamilyProperties (getting count)");
-
-    Rml::Vector<VkQueueFamilyProperties> queue_props;
-    queue_props.resize(queue_family_count);
-
-    vkGetPhysicalDeviceQueueFamilyProperties(m_p_physical_device, &queue_family_count, queue_props.data());
-
-    RMLUI_VK_ASSERTMSG(queue_family_count >= 1, "failed to vkGetPhysicalDeviceQueueFamilyProperties (filling vector of VkQueueFamilyProperties)");
-
-    constexpr uint32_t kUint32Undefined = uint32_t(-1);
-
-    m_queue_index_compute = kUint32Undefined;
-    m_queue_index_graphics = kUint32Undefined;
-    m_queue_index_present = kUint32Undefined;
-
-    for (uint32_t i = 0; i < queue_family_count; ++i) {
-        if ((queue_props[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0) {
-            if (m_queue_index_graphics == kUint32Undefined)
-                m_queue_index_graphics = i;
-
-            VkBool32 is_support_present;
-
-            vkGetPhysicalDeviceSurfaceSupportKHR(m_p_physical_device, i, m_p_surface, &is_support_present);
-
-            // User's videocard may have same index for two queues like graphics and present
-
-            if (is_support_present == VK_TRUE) {
-                m_queue_index_graphics = i;
-                m_queue_index_present = m_queue_index_graphics;
-                break;
-            }
-        }
-    }
-
-    if (m_queue_index_present == static_cast<uint32_t>(-1)) {
-        Rml::Log::Message(Rml::Log::LT_WARNING, "[Vulkan] User doesn't have one index for two queues, so we need to find for present queue index");
-
-        for (uint32_t i = 0; i < queue_family_count; ++i) {
-            VkBool32 is_support_present;
-
-            vkGetPhysicalDeviceSurfaceSupportKHR(m_p_physical_device, i, m_p_surface, &is_support_present);
-
-            if (is_support_present == VK_TRUE) {
-                m_queue_index_present = i;
-                break;
-            }
-        }
-    }
-
-    for (uint32_t i = 0; i < queue_family_count; ++i) {
-        if ((queue_props[i].queueFlags & VK_QUEUE_COMPUTE_BIT) != 0) {
-            if (m_queue_index_compute == kUint32Undefined)
-                m_queue_index_compute = i;
-
-            if (i != m_queue_index_graphics) {
-                m_queue_index_compute = i;
-                break;
-            }
-        }
-    }
-
-#ifdef RMLUI_VK_DEBUG
-    Rml::Log::Message(Rml::Log::LT_DEBUG, "[Vulkan] User family queues indecies: Graphics[%d] Present[%d] Compute[%d]", m_queue_index_graphics,
-                      m_queue_index_present, m_queue_index_compute);
-#endif
-}
-
-void RenderInterface_VK::Initialize_Queues() noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_device, "you must initialize VkDevice before using this method");
-
-    vkGetDeviceQueue(m_p_device, m_queue_index_graphics, 0, &m_p_queue_graphics);
-
-    if (m_queue_index_graphics == m_queue_index_present) {
-        m_p_queue_present = m_p_queue_graphics;
-    } else {
-        vkGetDeviceQueue(m_p_device, m_queue_index_present, 0, &m_p_queue_present);
-    }
-
-    constexpr uint32_t kUint32Undefined = uint32_t(-1);
-
-    if (m_queue_index_compute != kUint32Undefined) {
-        vkGetDeviceQueue(m_p_device, m_queue_index_compute, 0, &m_p_queue_compute);
-    }
-}
-
-void RenderInterface_VK::Initialize_SyncPrimitives() noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_device, "you must initialize your device");
-
-    m_executed_fences.resize(kSwapchainBackBufferCount);
-    m_semaphores_finished_render.resize(kSwapchainBackBufferCount);
-    m_semaphores_image_available.resize(kSwapchainBackBufferCount);
-
-    VkResult status = VK_SUCCESS;
-
-    for (uint32_t i = 0; i < kSwapchainBackBufferCount; ++i) {
-        VkFenceCreateInfo info_fence = {};
-
-        info_fence.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-        info_fence.pNext = nullptr;
-        info_fence.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-
-        status = vkCreateFence(m_p_device, &info_fence, nullptr, &m_executed_fences[i]);
-
-        RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkCreateFence");
-
-        VkSemaphoreCreateInfo info_semaphore = {};
-
-        info_semaphore.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-        info_semaphore.pNext = nullptr;
-        info_semaphore.flags = 0;
-
-        status = vkCreateSemaphore(m_p_device, &info_semaphore, nullptr, &m_semaphores_image_available[i]);
-
-        RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkCreateSemaphore");
-
-        status = vkCreateSemaphore(m_p_device, &info_semaphore, nullptr, &m_semaphores_finished_render[i]);
-
-        RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkCreateSemaphore");
-    }
-}
-
 void RenderInterface_VK::Initialize_Resources(const VkPhysicalDeviceProperties& physical_device_properties) noexcept {
-    m_command_buffer_ring.Initialize(m_p_device, m_queue_index_graphics);
-
     const VkDeviceSize min_buffer_alignment = physical_device_properties.limits.minUniformBufferOffsetAlignment;
     m_memory_pool.Initialize(kVideoMemoryForAllocation, min_buffer_alignment, m_p_allocator, m_p_device);
 
@@ -2215,41 +1718,7 @@ void RenderInterface_VK::Initialize_Allocator() noexcept {
         m_p_allocator = VK_NULL_HANDLE;
 }
 
-void RenderInterface_VK::Destroy_Instance() noexcept {
-    vkDestroyInstance(m_p_instance, nullptr);
-}
-
-void RenderInterface_VK::Destroy_Device() noexcept {
-    m_debug_name_writer.reset();
-    vkDestroyDevice(m_p_device, nullptr);
-}
-
-void RenderInterface_VK::Destroy_Swapchain() noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_device, "you must initialize device");
-
-    vkDestroySwapchainKHR(m_p_device, m_p_swapchain, nullptr);
-}
-
-void RenderInterface_VK::Destroy_Surface() noexcept {
-    vkDestroySurfaceKHR(m_p_instance, m_p_surface, nullptr);
-}
-
-void RenderInterface_VK::Destroy_SyncPrimitives() noexcept {
-    for (auto& p_fence : m_executed_fences) {
-        vkDestroyFence(m_p_device, p_fence, nullptr);
-    }
-
-    for (auto& p_semaphore : m_semaphores_image_available) {
-        vkDestroySemaphore(m_p_device, p_semaphore, nullptr);
-    }
-
-    for (auto& p_semaphore : m_semaphores_finished_render) {
-        vkDestroySemaphore(m_p_device, p_semaphore, nullptr);
-    }
-}
-
 void RenderInterface_VK::Destroy_Resources() noexcept {
-    m_command_buffer_ring.Shutdown();
     m_upload_manager.Shutdown();
 
     if (m_p_descriptor_set) {
@@ -2277,491 +1746,6 @@ void RenderInterface_VK::Destroy_Allocator() noexcept {
     if (m_p_allocator != VK_NULL_HANDLE)
         vmaDestroyAllocator(m_p_allocator);
     m_p_allocator = VK_NULL_HANDLE;
-}
-
-void RenderInterface_VK::QueryInstanceLayers(LayerPropertiesList& result) noexcept {
-    uint32_t instance_layer_properties_count = 0;
-    VkResult status = vkEnumerateInstanceLayerProperties(&instance_layer_properties_count, nullptr);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateInstanceLayerProperties (getting count)");
-
-    if (instance_layer_properties_count) {
-        result.resize(instance_layer_properties_count);
-        status = vkEnumerateInstanceLayerProperties(&instance_layer_properties_count, result.data());
-        RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateInstanceLayerProperties (filling vector of VkLayerProperties)");
-    }
-}
-
-void RenderInterface_VK::QueryInstanceExtensions(ExtensionPropertiesList& result, const LayerPropertiesList& instance_layer_properties) noexcept {
-    uint32_t instance_extension_property_count = 0;
-    VkResult status = vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_property_count, nullptr);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateInstanceExtensionProperties (getting count)");
-
-    if (instance_extension_property_count) {
-        result.resize(instance_extension_property_count);
-        status = vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_property_count, result.data());
-
-        RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateInstanceExtensionProperties (filling vector of VkExtensionProperties)");
-    }
-
-    uint32_t count = 0;
-
-    // without first argument in vkEnumerateInstanceExtensionProperties
-    // it doesn't collect information well so we need brute-force
-    // and pass through everything what use has
-    for (const auto& layer_property : instance_layer_properties) {
-        status = vkEnumerateInstanceExtensionProperties(layer_property.layerName, &count, nullptr);
-
-        if (status == VK_SUCCESS) {
-            if (count) {
-                ExtensionPropertiesList props;
-                props.resize(count);
-                status = vkEnumerateInstanceExtensionProperties(layer_property.layerName, &count, props.data());
-
-                if (status == VK_SUCCESS) {
-#ifdef RMLUI_VK_DEBUG
-                    Rml::Log::Message(Rml::Log::LT_DEBUG, "[Vulkan] obtained extensions for layer: %s, count: %zu", layer_property.layerName,
-                                      props.size());
-#endif
-
-                    for (const auto& extension : props) {
-                        if (IsExtensionPresent(result, extension.extensionName) == false) {
-#ifdef RMLUI_VK_DEBUG
-                            Rml::Log::Message(Rml::Log::LT_DEBUG, "[Vulkan] new extension is added: %s", extension.extensionName);
-#endif
-
-                            result.push_back(extension);
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-bool RenderInterface_VK::AddLayerToInstance(Rml::Vector<const char*>& result, const LayerPropertiesList& instance_layer_properties,
-                                            const char* p_instance_layer_name) noexcept {
-    if (p_instance_layer_name == nullptr) {
-        RMLUI_VK_ASSERTMSG(p_instance_layer_name, "you have an invalid layer");
-        return false;
-    }
-
-    if (IsLayerPresent(instance_layer_properties, p_instance_layer_name)) {
-        result.push_back(p_instance_layer_name);
-        return true;
-    }
-
-    Rml::Log::Message(Rml::Log::LT_WARNING, "[Vulkan] can't add layer %s", p_instance_layer_name);
-
-    return false;
-}
-
-bool RenderInterface_VK::AddExtensionToInstance(Rml::Vector<const char*>& result, const ExtensionPropertiesList& instance_extension_properties,
-                                                const char* p_instance_extension_name) noexcept {
-    if (p_instance_extension_name == nullptr) {
-        RMLUI_VK_ASSERTMSG(p_instance_extension_name, "you have an invalid extension");
-        return false;
-    }
-
-    if (IsExtensionPresent(instance_extension_properties, p_instance_extension_name)) {
-        result.push_back(p_instance_extension_name);
-        return true;
-    }
-
-    Rml::Log::Message(Rml::Log::LT_WARNING, "[Vulkan] can't add extension %s", p_instance_extension_name);
-
-    return false;
-}
-
-void RenderInterface_VK::CreatePropertiesFor_Instance(Rml::Vector<const char*>& instance_layer_names,
-                                                      Rml::Vector<const char*>& instance_extension_names) noexcept {
-    ExtensionPropertiesList instance_extension_properties;
-    LayerPropertiesList instance_layer_properties;
-
-    QueryInstanceLayers(instance_layer_properties);
-    QueryInstanceExtensions(instance_extension_properties, instance_layer_properties);
-
-    AddExtensionToInstance(instance_extension_names, instance_extension_properties, "VK_EXT_debug_utils");
-    AddExtensionToInstance(instance_extension_names, instance_extension_properties, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-
-#ifdef RMLUI_VK_DEBUG
-    AddLayerToInstance(instance_layer_names, instance_layer_properties, "VK_LAYER_LUNARG_monitor");
-
-    bool is_cpu_validation = AddLayerToInstance(instance_layer_names, instance_layer_properties, "VK_LAYER_KHRONOS_validation") &&
-                             AddExtensionToInstance(instance_extension_names, instance_extension_properties, VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
-
-    if (is_cpu_validation) {
-        Rml::Log::Message(Rml::Log::LT_DEBUG, "[Vulkan] CPU validation is enabled");
-
-        Rml::Array<const char*, 1> requested_extensions_for_gpu = {VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME};
-
-        for (const auto& extension_name : requested_extensions_for_gpu) {
-            AddExtensionToInstance(instance_extension_names, instance_extension_properties, extension_name);
-        }
-
-        debug_validation_features_ext.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
-        debug_validation_features_ext.pNext = nullptr;
-        debug_validation_features_ext.enabledValidationFeatureCount =
-            sizeof(debug_validation_features_ext_requested) / sizeof(debug_validation_features_ext_requested[0]);
-        debug_validation_features_ext.pEnabledValidationFeatures = debug_validation_features_ext_requested;
-    }
-
-#else
-    (void)instance_layer_names;
-
-#endif
-}
-
-bool RenderInterface_VK::IsLayerPresent(const LayerPropertiesList& properties, const char* p_layer_name) noexcept {
-    if (properties.empty())
-        return false;
-
-    if (p_layer_name == nullptr)
-        return false;
-
-    return std::find_if(properties.cbegin(), properties.cend(),
-                        [p_layer_name](const VkLayerProperties& prop) -> bool { return strcmp(prop.layerName, p_layer_name) == 0; }) != properties.cend();
-}
-
-bool RenderInterface_VK::IsExtensionPresent(const ExtensionPropertiesList& properties, const char* p_extension_name) noexcept {
-    if (properties.empty())
-        return false;
-
-    if (p_extension_name == nullptr)
-        return false;
-
-    return std::find_if(properties.cbegin(), properties.cend(), [p_extension_name](const VkExtensionProperties& prop) -> bool {
-               return strcmp(prop.extensionName, p_extension_name) == 0;
-           }) != properties.cend();
-}
-
-bool RenderInterface_VK::AddExtensionToDevice(Rml::Vector<const char*>& result, const ExtensionPropertiesList& device_extension_properties,
-                                              const char* p_device_extension_name) noexcept {
-    if (IsExtensionPresent(device_extension_properties, p_device_extension_name)) {
-        result.push_back(p_device_extension_name);
-        return true;
-    }
-
-    return false;
-}
-
-void RenderInterface_VK::CreatePropertiesFor_Device(ExtensionPropertiesList& result) noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_physical_device, "you must initialize your physical device. Call InitializePhysicalDevice first");
-
-    uint32_t extension_count = 0;
-    VkResult status = vkEnumerateDeviceExtensionProperties(m_p_physical_device, nullptr, &extension_count, nullptr);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateDeviceExtensionProperties (getting count)");
-
-    result.resize(extension_count);
-    status = vkEnumerateDeviceExtensionProperties(m_p_physical_device, nullptr, &extension_count, result.data());
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateDeviceExtensionProperties (filling vector of VkExtensionProperties)");
-
-    uint32_t instance_layer_property_count = 0;
-    status = vkEnumerateInstanceLayerProperties(&instance_layer_property_count, nullptr);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateInstanceLayerProperties (getting count)");
-
-    LayerPropertiesList layers;
-    layers.resize(instance_layer_property_count);
-
-    // On different OS Vulkan acts strange, so we can't get our extensions to just iterate through default functions
-    // We need to deeply analyze our layers and get specified extensions which pass user
-    // So we collect all extensions that are presented in physical device
-    // And add when they exist to extension_names so we don't pass properties
-
-    if (instance_layer_property_count) {
-        status = vkEnumerateInstanceLayerProperties(&instance_layer_property_count, layers.data());
-        RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateInstanceLayerProperties (filling vector of VkLayerProperties)");
-
-        for (const auto& layer : layers) {
-            extension_count = 0;
-            status = vkEnumerateDeviceExtensionProperties(m_p_physical_device, layer.layerName, &extension_count, nullptr);
-            RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateDeviceExtensionProperties (getting count)");
-
-            if (extension_count) {
-                ExtensionPropertiesList new_extensions;
-                new_extensions.resize(extension_count);
-
-                status = vkEnumerateDeviceExtensionProperties(m_p_physical_device, layer.layerName, &extension_count, new_extensions.data());
-                RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateDeviceExtensionProperties (filling vector of VkExtensionProperties)");
-
-                for (const auto& extension : new_extensions) {
-                    if (IsExtensionPresent(result, extension.extensionName) == false) {
-#ifdef RMLUI_VK_DEBUG
-                        Rml::Log::Message(Rml::Log::LT_DEBUG, "[Vulkan] obtained new device extension from layer[%s]: %s", layer.layerName,
-                                          extension.extensionName);
-#endif
-
-                        result.push_back(extension);
-                    }
-                }
-            }
-        }
-    }
-}
-
-void RenderInterface_VK::CreateReportDebugCallback() noexcept {
-#ifdef RMLUI_VK_DEBUG
-    VkDebugUtilsMessengerCreateInfoEXT info = {};
-
-    info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
-    info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
-                           VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
-    info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
-                       VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
-    info.pfnUserCallback = MyDebugReportCallback;
-
-    PFN_vkCreateDebugUtilsMessengerEXT p_callback_creation = VK_NULL_HANDLE;
-
-    p_callback_creation = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(vkGetInstanceProcAddr(m_p_instance, "vkCreateDebugUtilsMessengerEXT"));
-    VkResult status = p_callback_creation(m_p_instance, &info, nullptr, &m_debug_messenger);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkCreateDebugUtilsMessengerEXT");
-#endif
-}
-
-void RenderInterface_VK::Destroy_ReportDebugCallback() noexcept {
-#ifdef RMLUI_VK_DEBUG
-    PFN_vkDestroyDebugUtilsMessengerEXT p_destroy_callback =
-        reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(vkGetInstanceProcAddr(m_p_instance, "vkDestroyDebugUtilsMessengerEXT"));
-
-    if (m_debug_messenger) {
-        p_destroy_callback(m_p_instance, m_debug_messenger, nullptr);
-        m_debug_messenger = VK_NULL_HANDLE;
-    }
-#endif
-}
-
-uint32_t RenderInterface_VK::GetUserAPIVersion() const noexcept {
-    uint32_t result = RMLUI_VK_API_VERSION;
-
-#if defined VK_VERSION_1_1
-    VkResult status = vkEnumerateInstanceVersion(&result);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumerateInstanceVersion, See Status");
-#endif
-
-    return result;
-}
-
-uint32_t RenderInterface_VK::GetRequiredVersionAndValidateMachine() noexcept {
-    constexpr uint32_t kRequiredVersion = RMLUI_VK_API_VERSION;
-    const uint32_t user_version = GetUserAPIVersion();
-
-    RMLUI_VK_ASSERTMSG(kRequiredVersion <= user_version, "Your machine doesn't support Vulkan");
-
-    return kRequiredVersion;
-}
-
-void RenderInterface_VK::CollectPhysicalDevices(PhysicalDeviceWrapperList& out_physical_devices) noexcept {
-    uint32_t gpu_count = 1;
-    Rml::Vector<VkPhysicalDevice> temp_devices;
-
-    VkResult status = vkEnumeratePhysicalDevices(m_p_instance, &gpu_count, nullptr);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumeratePhysicalDevices (getting count)");
-
-    temp_devices.resize(gpu_count);
-    status = vkEnumeratePhysicalDevices(m_p_instance, &gpu_count, temp_devices.data());
-
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkEnumeratePhysicalDevices (filling the vector of VkPhysicalDevice)");
-    RMLUI_VK_ASSERTMSG(temp_devices.empty() == false, "you must have one videocard at least!");
-
-    out_physical_devices.resize(temp_devices.size());
-    for (size_t i = 0; i < out_physical_devices.size(); i++) {
-        out_physical_devices[i].m_p_physical_device = temp_devices[i];
-        vkGetPhysicalDeviceProperties(out_physical_devices[i].m_p_physical_device, &out_physical_devices[i].m_physical_device_properties);
-    }
-}
-
-const RenderInterface_VK::PhysicalDeviceWrapper* RenderInterface_VK::ChoosePhysicalDevice(const PhysicalDeviceWrapperList& physical_devices,
-                                                                                          VkPhysicalDeviceType device_type) noexcept {
-    RMLUI_VK_ASSERTMSG(physical_devices.empty() == false,
-                       "you must have one videocard at least or early calling of this method, try call this after CollectPhysicalDevices");
-
-    for (const auto& device : physical_devices) {
-        if (device.m_physical_device_properties.deviceType == device_type)
-            return &device;
-    }
-
-    return nullptr;
-}
-
-VkSurfaceFormatKHR RenderInterface_VK::ChooseSwapchainFormat() noexcept {
-    static constexpr VkFormat UNORM_FORMATS[] = {
-        VK_FORMAT_R4G4_UNORM_PACK8,
-        VK_FORMAT_R4G4B4A4_UNORM_PACK16,
-        VK_FORMAT_B4G4R4A4_UNORM_PACK16,
-        VK_FORMAT_R5G6B5_UNORM_PACK16,
-        VK_FORMAT_B5G6R5_UNORM_PACK16,
-        VK_FORMAT_R5G5B5A1_UNORM_PACK16,
-        VK_FORMAT_B5G5R5A1_UNORM_PACK16,
-        VK_FORMAT_A1R5G5B5_UNORM_PACK16,
-        VK_FORMAT_R8_UNORM,
-        VK_FORMAT_R8G8_UNORM,
-        VK_FORMAT_R8G8B8_UNORM,
-        VK_FORMAT_B8G8R8_UNORM,
-        VK_FORMAT_R8G8B8A8_UNORM,
-        VK_FORMAT_B8G8R8A8_UNORM,
-        VK_FORMAT_A8B8G8R8_UNORM_PACK32,
-        VK_FORMAT_A2R10G10B10_UNORM_PACK32,
-        VK_FORMAT_A2B10G10R10_UNORM_PACK32,
-        VK_FORMAT_R16_UNORM,
-        VK_FORMAT_R16G16_UNORM,
-        VK_FORMAT_R16G16B16_UNORM,
-        VK_FORMAT_R16G16B16A16_UNORM,
-        VK_FORMAT_D16_UNORM,
-        VK_FORMAT_X8_D24_UNORM_PACK32,
-        VK_FORMAT_D16_UNORM_S8_UINT,
-        VK_FORMAT_D24_UNORM_S8_UINT,
-        VK_FORMAT_BC1_RGB_UNORM_BLOCK,
-        VK_FORMAT_BC1_RGBA_UNORM_BLOCK,
-        VK_FORMAT_BC2_UNORM_BLOCK,
-        VK_FORMAT_BC3_UNORM_BLOCK,
-        VK_FORMAT_BC4_UNORM_BLOCK,
-        VK_FORMAT_BC5_UNORM_BLOCK,
-        VK_FORMAT_BC7_UNORM_BLOCK,
-        VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK,
-        VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK,
-        VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK,
-        VK_FORMAT_EAC_R11_UNORM_BLOCK,
-        VK_FORMAT_EAC_R11G11_UNORM_BLOCK,
-        VK_FORMAT_ASTC_4x4_UNORM_BLOCK,
-        VK_FORMAT_ASTC_5x4_UNORM_BLOCK,
-        VK_FORMAT_ASTC_5x5_UNORM_BLOCK,
-        VK_FORMAT_ASTC_6x5_UNORM_BLOCK,
-        VK_FORMAT_ASTC_6x6_UNORM_BLOCK,
-        VK_FORMAT_ASTC_8x5_UNORM_BLOCK,
-        VK_FORMAT_ASTC_8x6_UNORM_BLOCK,
-        VK_FORMAT_ASTC_8x8_UNORM_BLOCK,
-        VK_FORMAT_ASTC_10x5_UNORM_BLOCK,
-        VK_FORMAT_ASTC_10x6_UNORM_BLOCK,
-        VK_FORMAT_ASTC_10x8_UNORM_BLOCK,
-        VK_FORMAT_ASTC_10x10_UNORM_BLOCK,
-        VK_FORMAT_ASTC_12x10_UNORM_BLOCK,
-        VK_FORMAT_ASTC_12x12_UNORM_BLOCK,
-    };
-
-    RMLUI_VK_ASSERTMSG(m_p_physical_device, "you must initialize your physical device, before calling this method");
-    RMLUI_VK_ASSERTMSG(m_p_surface, "you must initialize your surface, before calling this method");
-
-    uint32_t surface_count = 0;
-    VkResult status = vkGetPhysicalDeviceSurfaceFormatsKHR(m_p_physical_device, m_p_surface, &surface_count, nullptr);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkGetPhysicalDeviceSurfaceFormatsKHR (getting count)");
-
-    Rml::Vector<VkSurfaceFormatKHR> formats(surface_count);
-    status = vkGetPhysicalDeviceSurfaceFormatsKHR(m_p_physical_device, m_p_surface, &surface_count, formats.data());
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkGetPhysicalDeviceSurfaceFormatsKHR (filling vector of VkSurfaceFormatKHR)");
-
-    // Prefer UNORM formats
-    for (auto& format : formats) {
-        for (auto ufmt : UNORM_FORMATS) {
-            if (ufmt == format.format)
-                return format;
-        }
-    }
-
-    return formats.front();
-}
-
-VkExtent2D RenderInterface_VK::GetValidSurfaceExtent() noexcept {
-    VkSurfaceCapabilitiesKHR caps = GetSurfaceCapabilities();
-    VkExtent2D result = {(uint32_t)m_width, (uint32_t)m_height};
-
-    /*
-        https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceCapabilitiesKHR.html
-    */
-    if (caps.currentExtent.width == 0xFFFFFFFF) {
-        result.width = Rml::Math::Clamp(result.width, caps.minImageExtent.width, caps.maxImageExtent.width);
-        result.height = Rml::Math::Clamp(result.height, caps.minImageExtent.height, caps.maxImageExtent.height);
-    } else {
-        result = caps.currentExtent;
-    }
-
-    return result;
-}
-
-VkSurfaceTransformFlagBitsKHR RenderInterface_VK::CreatePretransformSwapchain() noexcept {
-    auto caps = GetSurfaceCapabilities();
-
-    VkSurfaceTransformFlagBitsKHR result =
-        (caps.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) ? VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR : caps.currentTransform;
-
-    return result;
-}
-
-VkCompositeAlphaFlagBitsKHR RenderInterface_VK::ChooseSwapchainCompositeAlpha() noexcept {
-    auto caps = GetSurfaceCapabilities();
-
-    VkCompositeAlphaFlagBitsKHR result = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-
-    VkCompositeAlphaFlagBitsKHR composite_alpha_flags[4] = {VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR, VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR,
-                                                            VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR, VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR};
-
-    for (uint32_t i = 0; i < sizeof(composite_alpha_flags); ++i) {
-        if (caps.supportedCompositeAlpha & composite_alpha_flags[i]) {
-            result = composite_alpha_flags[i];
-            break;
-        }
-    }
-
-    return result;
-}
-
-int RenderInterface_VK::Choose_SwapchainImageCount(uint32_t user_swapchain_count_for_creation, bool if_failed_choose_min) noexcept {
-    auto caps = GetSurfaceCapabilities();
-
-    // don't worry if you get this assert just ignore it the method will fix the count ;)
-    RMLUI_VK_ASSERTMSG(user_swapchain_count_for_creation >= caps.minImageCount,
-                       "can't be, you must have a valid count that bounds from minImageCount to maxImageCount! Otherwise you will get a validation error that "
-                       "specifies that you created a swapchain with invalid image count");
-    RMLUI_VK_ASSERTMSG(user_swapchain_count_for_creation <= caps.maxImageCount,
-                       "can't be, you must have a valid count that bounds from minImageCount to maxImageCount! Otherwise you will get a validation error that "
-                       "specifies that you created a swapchain with invalid image count");
-
-    int result = 0;
-
-    if (user_swapchain_count_for_creation < caps.minImageCount || user_swapchain_count_for_creation > caps.maxImageCount)
-        result = if_failed_choose_min ? caps.minImageCount : caps.maxImageCount;
-    else
-        result = user_swapchain_count_for_creation;
-
-    return result;
-}
-
-// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentModeKHR.html
-// VK_PRESENT_MODE_FIFO_KHR system must support this mode at least so by default we want to use it otherwise user can specify his mode
-VkPresentModeKHR RenderInterface_VK::GetPresentMode(VkPresentModeKHR required) noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_device, "[Vulkan] you must initialize your device, before calling this method");
-    RMLUI_VK_ASSERTMSG(m_p_physical_device, "[Vulkan] you must initialize your physical device, before calling this method");
-    RMLUI_VK_ASSERTMSG(m_p_surface, "[Vulkan] you must initialize your surface, before calling this method");
-
-    VkPresentModeKHR result = required;
-
-    uint32_t present_modes_count = 0;
-    VkResult status = vkGetPhysicalDeviceSurfacePresentModesKHR(m_p_physical_device, m_p_surface, &present_modes_count, nullptr);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "[Vulkan] failed to vkGetPhysicalDeviceSurfacePresentModesKHR (getting count)");
-
-    Rml::Vector<VkPresentModeKHR> present_modes(present_modes_count);
-    status = vkGetPhysicalDeviceSurfacePresentModesKHR(m_p_physical_device, m_p_surface, &present_modes_count, present_modes.data());
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "[Vulkan] failed to vkGetPhysicalDeviceSurfacePresentModesKHR (filling vector of VkPresentModeKHR)");
-
-    for (const auto& mode : present_modes) {
-        if (mode == required)
-            return result;
-    }
-
-    Rml::Log::Message(Rml::Log::LT_WARNING,
-                      "[Vulkan] WARNING system can't detect your type of present mode so we choose the first from vector front");
-
-    return present_modes.front();
-}
-
-VkSurfaceCapabilitiesKHR RenderInterface_VK::GetSurfaceCapabilities() noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_device, "[Vulkan] you must initialize your device, before calling this method");
-    RMLUI_VK_ASSERTMSG(m_p_physical_device, "[Vulkan] you must initialize your physical device, before calling this method");
-    RMLUI_VK_ASSERTMSG(m_p_surface, "[Vulkan] you must initialize your surface, before calling this method");
-
-    VkSurfaceCapabilitiesKHR result;
-    VkResult status = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_p_physical_device, m_p_surface, &result);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "[Vulkan] failed to vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
-
-    return result;
 }
 
 void RenderInterface_VK::CreateShaders() noexcept {
@@ -3113,139 +2097,6 @@ void RenderInterface_VK::Create_Pipelines() noexcept {
 #endif
 }
 
-void RenderInterface_VK::CreateSwapchainImages() noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_device, "[Vulkan] you must initialize VkDevice before calling this method");
-    RMLUI_VK_ASSERTMSG(m_p_swapchain, "[Vulkan] you must initialize VkSwapchainKHR before calling this method");
-
-    uint32_t count = 0;
-    auto status = vkGetSwapchainImagesKHR(m_p_device, m_p_swapchain, &count, nullptr);
-
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "[Vulkan] failed to vkGetSwapchainImagesKHR (get count)");
-
-    m_swapchain_images.resize(count);
-
-    status = vkGetSwapchainImagesKHR(m_p_device, m_p_swapchain, &count, m_swapchain_images.data());
-
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "[Vulkan] failed to vkGetSwapchainImagesKHR (filling vector)");
-    m_swapchain_image_layouts.assign(count, VK_IMAGE_LAYOUT_UNDEFINED);
-}
-
-void RenderInterface_VK::CreateSwapchainImageViews() noexcept {
-    CreateSwapchainImages();
-
-    m_swapchain_image_views.resize(m_swapchain_images.size());
-
-    uint32_t index = 0;
-    VkImageViewCreateInfo info = {};
-    VkResult status = VkResult::VK_SUCCESS;
-
-    for (auto p_image : m_swapchain_images) {
-        info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-        info.pNext = nullptr;
-        info.format = m_swapchain_format.format;
-        info.components.r = VK_COMPONENT_SWIZZLE_R;
-        info.components.g = VK_COMPONENT_SWIZZLE_G;
-        info.components.b = VK_COMPONENT_SWIZZLE_B;
-        info.components.a = VK_COMPONENT_SWIZZLE_A;
-        info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        info.subresourceRange.baseMipLevel = 0;
-        info.subresourceRange.levelCount = 1;
-        info.subresourceRange.baseArrayLayer = 0;
-        info.subresourceRange.layerCount = 1;
-        info.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        info.flags = 0;
-        info.image = p_image;
-
-        status = vkCreateImageView(m_p_device, &info, nullptr, &m_swapchain_image_views[index]);
-        ++index;
-
-        RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "[Vulkan] failed to vkCreateImageView (creating swapchain views)");
-    }
-}
-
-void RenderInterface_VK::Create_DepthStencilImage() noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_device, "you must initialize your VkDevice here");
-    RMLUI_VK_ASSERTMSG(m_p_allocator, "you must initialize your VMA allcator");
-    RMLUI_VK_ASSERTMSG(m_texture_depthstencil.m_p_vk_image == nullptr, "you should delete texture before create it");
-
-    VkImageCreateInfo info = {};
-
-    info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    info.imageType = VK_IMAGE_TYPE_2D;
-    if (m_depth_stencil_format == VK_FORMAT_UNDEFINED)
-        m_depth_stencil_format = Get_SupportedDepthFormat();
-    info.format = m_depth_stencil_format;
-    info.extent = {static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1};
-    info.mipLevels = 1;
-    info.arrayLayers = 1;
-    info.samples = VK_SAMPLE_COUNT_1_BIT;
-    info.tiling = VK_IMAGE_TILING_OPTIMAL;
-    info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-
-    VmaAllocation p_allocation = {};
-    VkImage p_image = {};
-
-    VmaAllocationCreateInfo info_alloc = {};
-    auto p_commentary = "our depth stencil image";
-
-    info_alloc.usage = VMA_MEMORY_USAGE_GPU_ONLY;
-    info_alloc.flags = VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT;
-    info_alloc.pUserData = const_cast<char*>(p_commentary);
-
-    VmaAllocationInfo allocation_stats{};
-    VkResult status = vmaCreateImage(m_p_allocator, &info, &info_alloc, &p_image, &p_allocation, &allocation_stats);
-
-    RMLUI_VK_ASSERTMSG(status == VkResult::VK_SUCCESS, "failed to vmaCreateImage");
-
-    m_texture_depthstencil.m_p_vk_image = p_image;
-    m_texture_depthstencil.m_p_vma_allocation = p_allocation;
-    (void)m_debug_name_writer.set(VK_OBJECT_TYPE_IMAGE,
-                                  (uint64_t)m_texture_depthstencil.m_p_vk_image,
-                                  "rmlui.depth-stencil.image");
-    m_texture_depthstencil.m_vram_scope = "vulkan.rmlui.depth_stencil";
-    m_texture_depthstencil.m_vram_label = TextureVramLabel("depth_stencil",
-                                                           "swapchain",
-                                                           m_width,
-                                                           m_height,
-                                                           &m_texture_depthstencil);
-    m_texture_depthstencil.m_vram_allocation_size = allocation_stats.size;
-    RecordRmlUiVram(m_texture_depthstencil.m_vram_scope,
-                    m_texture_depthstencil.m_vram_label,
-                    m_texture_depthstencil.m_vram_allocation_size);
-    m_depth_stencil_layout = VK_IMAGE_LAYOUT_UNDEFINED;
-}
-
-void RenderInterface_VK::Create_DepthStencilImageViews() noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_device, "you must initialize your VkDevice here");
-    RMLUI_VK_ASSERTMSG(m_texture_depthstencil.m_p_vk_image_view == nullptr, "you should delete it before creating");
-    RMLUI_VK_ASSERTMSG(m_texture_depthstencil.m_p_vk_image, "you must initialize VkImage before create this");
-
-    VkImageViewCreateInfo info = {};
-
-    info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-    info.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    info.image = m_texture_depthstencil.m_p_vk_image;
-    if (m_depth_stencil_format == VK_FORMAT_UNDEFINED)
-        m_depth_stencil_format = Get_SupportedDepthFormat();
-    info.format = m_depth_stencil_format;
-    info.subresourceRange.baseMipLevel = 0;
-    info.subresourceRange.levelCount = 1;
-    info.subresourceRange.baseArrayLayer = 0;
-    info.subresourceRange.layerCount = 1;
-    info.subresourceRange.aspectMask = DepthStencilAspectMask();
-
-    VkImageView p_image_view = {};
-
-    VkResult status = vkCreateImageView(m_p_device, &info, nullptr, &p_image_view);
-
-    RMLUI_VK_ASSERTMSG(status == VkResult::VK_SUCCESS, "failed to vkCreateImageView");
-
-    m_texture_depthstencil.m_p_vk_image_view = p_image_view;
-    (void)m_debug_name_writer.set(VK_OBJECT_TYPE_IMAGE_VIEW,
-                                  (uint64_t)m_texture_depthstencil.m_p_vk_image_view,
-                                  "rmlui.depth-stencil.view");
-}
-
 void RenderInterface_VK::UpdateViewportState(const VkExtent2D& real_render_image_size) noexcept {
     m_viewport.height = static_cast<float>(real_render_image_size.height);
     m_viewport.width = static_cast<float>(real_render_image_size.width);
@@ -3271,15 +2122,6 @@ void RenderInterface_VK::UpdateViewportState(const VkExtent2D& real_render_image
     m_projection = correction_matrix * m_projection;
 
     SetTransform(nullptr);
-}
-
-void RenderInterface_VK::CreateResourcesDependentOnSize(const VkExtent2D& real_render_image_size) noexcept {
-    UpdateViewportState(real_render_image_size);
-
-    CreateSwapchainImageViews();
-    Create_DepthStencilImage();
-    Create_DepthStencilImageViews();
-    Create_Pipelines();
 }
 
 RenderInterface_VK::buffer_data_t RenderInterface_VK::CreateResource_StagingBuffer(VkDeviceSize size, VkBufferUsageFlags flags) noexcept {
@@ -3356,49 +2198,6 @@ uint32_t RenderInterface_VK::ActiveResourceSlot() const noexcept {
     return m_resource_slot % kSwapchainBackBufferCount;
 }
 
-void RenderInterface_VK::WaitForSubmittedFrames() noexcept {
-    if (!m_p_device || m_executed_fences.empty())
-        return;
-
-    Rml::Vector<VkFence> fences;
-    fences.reserve(m_executed_fences.size());
-    for (const VkFence fence : m_executed_fences) {
-        if (fence)
-            fences.push_back(fence);
-    }
-    if (fences.empty())
-        return;
-
-    // Bounded per-fence drain (API is single-fence). Soft-fail: no process abort;
-    // retain in-flight fences on non-Ready (AMB-4).
-    for (const VkFence fence : fences) {
-        lfs::rendering::WaitContext wait_ctx;
-        wait_ctx.fingerprint = "rmlui.wait_submitted_frames";
-        auto wait_outcome = lfs::rendering::wait_fence_bounded(
-            m_p_device,
-            fence,
-            std::stop_token{},
-            lfs::rendering::VulkanWaitPolicy{},
-            wait_ctx);
-        if (!wait_outcome.has_value() ||
-            *wait_outcome != lfs::rendering::WaitOutcome::Ready) {
-            LOG_ERROR(
-                "RmlUi WaitForSubmittedFrames did not reach Ready (fence={:#x}): {}",
-                lfs::rendering::vkHandleValue(fence),
-                wait_outcome.has_value()
-                    ? (*wait_outcome == lfs::rendering::WaitOutcome::Quarantined
-                           ? "Quarantined"
-                           : (*wait_outcome == lfs::rendering::WaitOutcome::Cancelled
-                                  ? "Cancelled"
-                                  : (*wait_outcome == lfs::rendering::WaitOutcome::Shutdown
-                                         ? "Shutdown"
-                                         : "non-Ready")))
-                    : wait_outcome.error().detail());
-            return;
-        }
-    }
-}
-
 void RenderInterface_VK::FreeTransientShaderAllocations(const uint32_t resource_slot) noexcept {
     auto& allocations = m_transient_shader_allocations_by_frame[resource_slot % kSwapchainBackBufferCount];
     for (VmaVirtualAllocation allocation : allocations)
@@ -3439,31 +2238,6 @@ void RenderInterface_VK::Destroy_Texture(const texture_data_t& texture) noexcept
     }
 }
 
-void RenderInterface_VK::DestroyResourcesDependentOnSize() noexcept {
-    DestroyRenderLayers();
-    Destroy_Pipelines();
-    DestroySwapchainImageViews();
-
-    Destroy_Texture(m_texture_depthstencil);
-    m_texture_depthstencil.m_p_vk_image = nullptr;
-    m_texture_depthstencil.m_p_vk_image_view = nullptr;
-    m_depth_stencil_layout = VK_IMAGE_LAYOUT_UNDEFINED;
-    m_image_barriers.reset();
-}
-
-void RenderInterface_VK::DestroySwapchainImageViews() noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_device, "[Vulkan] you must initialize VkDevice before calling this method");
-
-    m_swapchain_images.clear();
-    m_swapchain_image_layouts.clear();
-
-    for (auto p_view : m_swapchain_image_views) {
-        vkDestroyImageView(m_p_device, p_view, nullptr);
-    }
-
-    m_swapchain_image_views.clear();
-}
-
 void RenderInterface_VK::Destroy_Pipelines() noexcept {
     RMLUI_VK_ASSERTMSG(m_p_device, "must exist here");
 
@@ -3473,10 +2247,6 @@ void RenderInterface_VK::Destroy_Pipelines() noexcept {
     vkDestroyPipeline(m_p_device, m_p_pipeline_stencil_for_regular_geometry_that_applied_to_region_with_textures, nullptr);
     vkDestroyPipeline(m_p_device, m_p_pipeline_stencil_for_regular_geometry_that_applied_to_region_without_textures, nullptr);
 }
-
-void RenderInterface_VK::DestroyDescriptorSets() noexcept {}
-
-void RenderInterface_VK::DestroyPipelineLayout() noexcept {}
 
 void RenderInterface_VK::DestroySamplers() noexcept {
     RMLUI_VK_ASSERTMSG(m_p_device, "must exist here");
@@ -3722,23 +2492,6 @@ void RenderInterface_VK::BeginSwapchainRendering(VkAttachmentLoadOp color_load_o
                                   VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
             m_external_swapchain_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
         }
-    } else {
-        if (m_image_index >= m_swapchain_image_views.size() || m_image_index >= m_swapchain_images.size() ||
-            m_image_index >= m_swapchain_image_layouts.size()) {
-            return;
-        }
-        color_view = m_swapchain_image_views[m_image_index];
-        depth_view = m_texture_depthstencil.m_p_vk_image_view;
-        TransitionImageLayout(m_swapchain_images[m_image_index],
-                              VK_IMAGE_ASPECT_COLOR_BIT,
-                              m_swapchain_image_layouts[m_image_index],
-                              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-        m_swapchain_image_layouts[m_image_index] = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-        TransitionImageLayout(m_texture_depthstencil.m_p_vk_image,
-                              DepthStencilAspectMask(),
-                              m_depth_stencil_layout,
-                              VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-        m_depth_stencil_layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     }
 
     if (!color_view || !depth_view)
@@ -3878,83 +2631,6 @@ void RenderInterface_VK::DestroyRenderLayers() noexcept {
     m_active_layer = {};
 }
 
-bool RenderInterface_VK::Wait() noexcept {
-    RMLUI_VK_ASSERTMSG(m_p_device, "you must initialize device");
-    RMLUI_VK_ASSERTMSG(m_p_swapchain, "you must initialize swapchain");
-    if (!m_p_device || !m_p_swapchain) {
-        return false;
-    }
-
-    // B9 — bounded acquire (AMB-C1 soft-fail minimum; no new WSI recovery machine).
-    bool acquire_suboptimal = false;
-    lfs::rendering::WaitContext acquire_ctx;
-    acquire_ctx.fingerprint = "rmlui.frame.acquire";
-    auto acquire = lfs::rendering::acquire_next_image_bounded(
-        m_p_device,
-        m_p_swapchain,
-        m_semaphores_image_available[m_semaphore_index],
-        VK_NULL_HANDLE,
-        std::stop_token{},
-        lfs::rendering::VulkanWaitPolicy{},
-        acquire_ctx,
-        &acquire_suboptimal);
-    if (!acquire.has_value()) {
-        const auto& err = acquire.error();
-        // Existing RmlUi recreate path is available; OUT_OF_DATE uses it then
-        // soft-fails the frame (Present already recreated on OUT_OF_DATE/SUBOPTIMAL).
-        if (err.code() == lfs::ErrorCode::Unavailable &&
-            err.native().has_value() &&
-            static_cast<VkResult>(err.native()->code) == VK_ERROR_OUT_OF_DATE_KHR) {
-            RecreateSwapchain();
-            return false;
-        }
-        LOG_ERROR("RmlUi frame acquire soft-failed: {}", err.detail());
-        return false;
-    }
-    (void)acquire_suboptimal; // SUBOPTIMAL is success-with-flag; Present may recreate.
-    m_image_index = *acquire;
-
-    m_semaphore_index_previous = m_semaphore_index;
-    m_semaphore_index = ((m_semaphore_index + 1) % kSwapchainBackBufferCount);
-
-    // B10 — bounded image fence for the previous ring slot.
-    lfs::rendering::WaitContext fence_ctx;
-    fence_ctx.fingerprint = "rmlui.frame.image_fence";
-    auto fence_outcome = lfs::rendering::wait_fence_bounded(
-        m_p_device,
-        m_executed_fences[m_semaphore_index_previous],
-        std::stop_token{},
-        lfs::rendering::VulkanWaitPolicy{},
-        fence_ctx);
-    if (!fence_outcome.has_value() ||
-        *fence_outcome != lfs::rendering::WaitOutcome::Ready) {
-        LOG_ERROR(
-            "RmlUi frame image-fence wait soft-failed (slot={}): {}",
-            m_semaphore_index_previous,
-            fence_outcome.has_value()
-                ? (*fence_outcome == lfs::rendering::WaitOutcome::Quarantined
-                       ? "Quarantined"
-                       : (*fence_outcome == lfs::rendering::WaitOutcome::Cancelled
-                              ? "Cancelled"
-                              : (*fence_outcome == lfs::rendering::WaitOutcome::Shutdown
-                                     ? "Shutdown"
-                                     : "non-Ready")))
-                : fence_outcome.error().detail());
-        // Do not reset the fence while it may still be in-flight (AMB-4).
-        return false;
-    }
-
-    const VkResult status =
-        vkResetFences(m_p_device, 1, &m_executed_fences[m_semaphore_index_previous]);
-    if (status != VK_SUCCESS) {
-        LOG_ERROR("RmlUi frame fence reset failed: {} ({})",
-                  lfs::rendering::vkResultToString(status),
-                  static_cast<int>(status));
-        return false;
-    }
-    return true;
-}
-
 void RenderInterface_VK::Update_PendingForDeletion_Textures_By_Frame(const uint32_t resource_slot) noexcept {
     auto& textures_for_previous_frame = m_pending_for_deletion_textures_by_frames[resource_slot % kSwapchainBackBufferCount];
 
@@ -3974,151 +2650,6 @@ void RenderInterface_VK::Update_PendingForDeletion_Geometries(const uint32_t res
     }
 
     geometries.clear();
-}
-
-void RenderInterface_VK::Submit() noexcept {
-    const VkSemaphore p_semaphores_wait[] = {m_semaphores_image_available[m_semaphore_index_previous]};
-    const VkSemaphore p_semaphores_signal[] = {m_semaphores_finished_render[m_semaphore_index]};
-
-    VkFence p_fence = m_executed_fences[m_semaphore_index];
-
-    VkPipelineStageFlags submit_wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-
-    VkSubmitInfo info = {};
-
-    info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    info.pNext = nullptr;
-    info.waitSemaphoreCount = 1;
-    info.pWaitSemaphores = p_semaphores_wait;
-    info.pWaitDstStageMask = &submit_wait_stage;
-    info.signalSemaphoreCount = 1;
-    info.pSignalSemaphores = p_semaphores_signal;
-    info.commandBufferCount = 1;
-    info.pCommandBuffers = &m_p_current_command_buffer;
-
-    VkResult status = vkQueueSubmit(m_p_queue_graphics, 1, &info, p_fence);
-
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkQueueSubmit");
-}
-
-void RenderInterface_VK::Present() noexcept {
-    VkPresentInfoKHR info = {};
-
-    info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-    info.pNext = nullptr;
-    info.waitSemaphoreCount = 1;
-    info.pWaitSemaphores = &(m_semaphores_finished_render[m_semaphore_index]);
-    info.swapchainCount = 1;
-    info.pSwapchains = &m_p_swapchain;
-    info.pImageIndices = &m_image_index;
-    info.pResults = nullptr;
-
-    VkResult status = vkQueuePresentKHR(m_p_queue_present, &info);
-
-    if (!(status == VK_SUCCESS)) {
-        if (status == VK_ERROR_OUT_OF_DATE_KHR || status == VK_SUBOPTIMAL_KHR) {
-            RecreateSwapchain();
-        } else {
-            RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to vkQueuePresentKHR");
-        }
-    }
-}
-
-VkFormat RenderInterface_VK::Get_SupportedDepthFormat() {
-    RMLUI_VK_ASSERTMSG(m_p_physical_device, "you must initialize and pick physical device for your renderer");
-
-    Rml::Array<VkFormat, 5> formats = {VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D32_SFLOAT, VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D16_UNORM_S8_UINT,
-                                       VK_FORMAT_D16_UNORM};
-
-    VkFormatProperties properties;
-    for (const auto& format : formats) {
-        vkGetPhysicalDeviceFormatProperties(m_p_physical_device, format, &properties);
-
-        if (properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) {
-            return format;
-        }
-    }
-
-    return VkFormat::VK_FORMAT_UNDEFINED;
-}
-
-RenderInterface_VK::CommandBufferRing::CommandBufferRing() : m_p_device{},
-                                                             m_frame_index{},
-                                                             m_p_current_frame{},
-                                                             m_frames{} {}
-
-void RenderInterface_VK::CommandBufferRing::Initialize(VkDevice p_device, uint32_t queue_index_graphics) noexcept {
-    RMLUI_VK_ASSERTMSG(p_device, "you can't pass an invalid VkDevice here");
-    RMLUI_VK_ASSERTMSG(!m_p_device, "already initialized");
-
-    m_p_device = p_device;
-
-    for (CommandBuffersPerFrame& current_buffer : m_frames) {
-        for (uint32_t command_buffer_index = 0; command_buffer_index < kNumCommandBuffersPerFrame; ++command_buffer_index) {
-            VkCommandPoolCreateInfo info_pool = {};
-            info_pool.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-            info_pool.pNext = nullptr;
-            info_pool.queueFamilyIndex = queue_index_graphics;
-            info_pool.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
-
-            VkCommandPool p_pool = nullptr;
-            auto status = vkCreateCommandPool(p_device, &info_pool, nullptr, &p_pool);
-            RMLUI_VK_ASSERTMSG(status == VkResult::VK_SUCCESS, "can't create command pool");
-
-            current_buffer.m_command_pools[command_buffer_index] = p_pool;
-
-            VkCommandBufferAllocateInfo info_buffer = {};
-            info_buffer.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-            info_buffer.pNext = nullptr;
-            info_buffer.commandPool = p_pool;
-            info_buffer.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-            info_buffer.commandBufferCount = 1;
-
-            VkCommandBuffer p_buffer = nullptr;
-            status = vkAllocateCommandBuffers(p_device, &info_buffer, &p_buffer);
-            RMLUI_VK_ASSERTMSG(status == VkResult::VK_SUCCESS, "failed to fill command buffers");
-
-            current_buffer.m_command_buffers[command_buffer_index] = p_buffer;
-        }
-    }
-
-    m_frame_index = 0;
-    m_p_current_frame = &m_frames[m_frame_index];
-}
-
-void RenderInterface_VK::CommandBufferRing::Shutdown() {
-    RMLUI_VK_ASSERTMSG(m_p_device, "you can't have an uninitialized VkDevice");
-
-    for (CommandBuffersPerFrame& current_buffer : m_frames) {
-        for (uint32_t i = 0; i < kNumCommandBuffersPerFrame; ++i) {
-            vkFreeCommandBuffers(m_p_device, current_buffer.m_command_pools[i], 1, &current_buffer.m_command_buffers[i]);
-            vkDestroyCommandPool(m_p_device, current_buffer.m_command_pools[i], nullptr);
-        }
-    }
-}
-
-void RenderInterface_VK::CommandBufferRing::OnBeginFrame() {
-    m_frame_index = ((m_frame_index + 1) % kNumFramesToBuffer);
-    m_p_current_frame = &m_frames[m_frame_index];
-
-    // Reset all command pools of the current frame.
-    for (VkCommandPool command_pool : m_p_current_frame->m_command_pools) {
-        auto status = vkResetCommandPool(m_p_device, command_pool, 0);
-        RMLUI_VK_ASSERTMSG(status == VkResult::VK_SUCCESS, "failed to vkResetCommandPool");
-    }
-}
-
-VkCommandBuffer RenderInterface_VK::CommandBufferRing::GetCommandBufferForActiveFrame(CommandBufferName named_command_buffer) {
-    RMLUI_VK_ASSERTMSG(m_p_current_frame, "must be valid");
-    RMLUI_VK_ASSERTMSG(m_p_device, "you must initialize your VkDevice field with valid pointer or it's uninitialized field");
-    RMLUI_VK_ASSERTMSG((int)named_command_buffer < (int)CommandBufferName::Count, "overflow, please use one of the named command lists");
-
-    const uint32_t list_index = static_cast<uint32_t>(named_command_buffer);
-
-    VkCommandBuffer result = m_p_current_frame->m_command_buffers[list_index];
-    RMLUI_VK_ASSERTMSG(result, "your VkCommandBuffer must be valid otherwise debug your command list class for frame");
-
-    return result;
 }
 
 RenderInterface_VK::MemoryPool::MemoryPool() : m_memory_total_size{},

--- a/src/visualizer/gui/rmlui/rmlui_vk_backend.hpp
+++ b/src/visualizer/gui/rmlui/rmlui_vk_backend.hpp
@@ -11,16 +11,6 @@
 #include "rendering/vulkan_wait.hpp"
 #include "window/vulkan_image_barrier_tracker.hpp"
 
-#ifdef _WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#ifndef VK_USE_PLATFORM_WIN32_KHR
-#define VK_USE_PLATFORM_WIN32_KHR
-#endif
-#include <windows.h>
-#endif
-
 #ifndef VMA_STATIC_VULKAN_FUNCTIONS
 #define VMA_STATIC_VULKAN_FUNCTIONS 1
 #endif
@@ -64,8 +54,6 @@ public:
     RenderInterface_VK();
     ~RenderInterface_VK();
 
-    using CreateSurfaceCallback = bool (*)(VkInstance instance, VkSurfaceKHR* out_surface);
-
     struct ExternalContext {
         VkInstance instance = VK_NULL_HANDLE;
         VkPhysicalDevice physical_device = VK_NULL_HANDLE;
@@ -78,9 +66,6 @@ public:
         VkExtent2D extent{};
         bool host_image_copy = false;
     };
-
-    bool Initialize(Rml::Vector<const char*> required_extensions, CreateSurfaceCallback create_surface_callback);
-    void Shutdown();
 
     bool InitializeExternal(const ExternalContext& context);
     void ShutdownExternal();
@@ -95,13 +80,6 @@ public:
     void SetContextOffset(float offset_x, float offset_y);
     void SetContextClipRect(float x1, float y1, float x2, float y2);
     void RenderTextureQuad(Rml::TextureHandle texture, float x, float y, float w, float h);
-
-    void BeginFrame();
-    void EndFrame();
-
-    void SetViewport(int width, int height);
-    bool IsSwapchainValid();
-    void RecreateSwapchain();
 
     // Build a Rml::Image src URL referencing an externally-owned VkImageView/VkSampler.
     // The view+sampler must remain alive while any element references this URL. The
@@ -414,37 +392,6 @@ private:
         VmaVirtualBlock m_p_block;
     };
 
-    // If we need additional command buffers, we can add them to this list and retrieve them from the ring.
-    enum class CommandBufferName { Primary,
-                                   Count };
-
-    // The command buffer ring stores a unique set of named command buffers for each bufferd frame.
-    // Explanation of how to use Vulkan efficiently: https://vkguide.dev/docs/chapter-4/double_buffering/
-    class CommandBufferRing {
-    public:
-        static constexpr uint32_t kNumFramesToBuffer = kSwapchainBackBufferCount;
-        static constexpr uint32_t kNumCommandBuffersPerFrame = static_cast<uint32_t>(CommandBufferName::Count);
-
-        CommandBufferRing();
-
-        void Initialize(VkDevice p_device, uint32_t queue_index_graphics) noexcept;
-        void Shutdown();
-
-        void OnBeginFrame();
-        VkCommandBuffer GetCommandBufferForActiveFrame(CommandBufferName named_command_buffer);
-
-    private:
-        struct CommandBuffersPerFrame {
-            Rml::Array<VkCommandPool, kNumCommandBuffersPerFrame> m_command_pools;
-            Rml::Array<VkCommandBuffer, kNumCommandBuffersPerFrame> m_command_buffers;
-        };
-
-        VkDevice m_p_device;
-        uint32_t m_frame_index;
-        CommandBuffersPerFrame* m_p_current_frame;
-        Rml::Array<CommandBuffersPerFrame, kNumFramesToBuffer> m_frames;
-    };
-
     // Grows on demand: when a pool is exhausted (VK_ERROR_OUT_OF_POOL_MEMORY / VK_ERROR_FRAGMENTED_POOL)
     // a new identically-sized pool is created and the allocation retried. Each set remembers its owning
     // pool so Free_Descriptors returns it to the correct pool.
@@ -571,15 +518,6 @@ private:
         std::unordered_map<VkDescriptorSet, VkDescriptorPool> m_set_to_pool;
     };
 
-    struct PhysicalDeviceWrapper {
-        VkPhysicalDevice m_p_physical_device;
-        VkPhysicalDeviceProperties m_physical_device_properties;
-    };
-
-    using PhysicalDeviceWrapperList = Rml::Vector<PhysicalDeviceWrapper>;
-    using LayerPropertiesList = Rml::Vector<VkLayerProperties>;
-    using ExtensionPropertiesList = Rml::Vector<VkExtensionProperties>;
-
 private:
     Rml::TextureHandle CreateTexture(Rml::Span<const Rml::byte> source, Rml::Vector2i dimensions,
                                      const Rml::String& name, VkSampler sampler = VK_NULL_HANDLE);
@@ -589,57 +527,11 @@ private:
     void QueueTextureForDeferredDeletion(texture_data_t* texture);
     static async_preview_result_t DecodePreviewTexture(std::filesystem::path path, int max_size);
 
-    void Initialize_Instance(Rml::Vector<const char*> required_extensions) noexcept;
-    void Initialize_Device() noexcept;
-    void Initialize_PhysicalDevice(VkPhysicalDeviceProperties& out_physical_device_properties) noexcept;
-    void Initialize_Swapchain(VkExtent2D window_extent) noexcept;
-    void Initialize_Surface(CreateSurfaceCallback create_surface_callback) noexcept;
-    void Initialize_QueueIndecies() noexcept;
-    void Initialize_Queues() noexcept;
-    void Initialize_SyncPrimitives() noexcept;
     void Initialize_Resources(const VkPhysicalDeviceProperties& physical_device_properties) noexcept;
     void Initialize_Allocator() noexcept;
 
-    void Destroy_Instance() noexcept;
-    void Destroy_Device() noexcept;
-    void Destroy_Swapchain() noexcept;
-    void Destroy_Surface() noexcept;
-    void Destroy_SyncPrimitives() noexcept;
     void Destroy_Resources() noexcept;
     void Destroy_Allocator() noexcept;
-
-    void QueryInstanceLayers(LayerPropertiesList& result) noexcept;
-    void QueryInstanceExtensions(ExtensionPropertiesList& result, const LayerPropertiesList& instance_layer_properties) noexcept;
-    bool AddLayerToInstance(Rml::Vector<const char*>& result, const LayerPropertiesList& instance_layer_properties,
-                            const char* p_instance_layer_name) noexcept;
-    bool AddExtensionToInstance(Rml::Vector<const char*>& result, const ExtensionPropertiesList& instance_extension_properties,
-                                const char* p_instance_extension_name) noexcept;
-    void CreatePropertiesFor_Instance(Rml::Vector<const char*>& instance_layer_names, Rml::Vector<const char*>& instance_extension_names) noexcept;
-
-    bool IsLayerPresent(const LayerPropertiesList& properties, const char* p_layer_name) noexcept;
-    bool IsExtensionPresent(const ExtensionPropertiesList& properties, const char* p_extension_name) noexcept;
-
-    bool AddExtensionToDevice(Rml::Vector<const char*>& result, const ExtensionPropertiesList& device_extension_properties,
-                              const char* p_device_extension_name) noexcept;
-    void CreatePropertiesFor_Device(ExtensionPropertiesList& result) noexcept;
-
-    void CreateReportDebugCallback() noexcept;
-    void Destroy_ReportDebugCallback() noexcept;
-
-    uint32_t GetUserAPIVersion() const noexcept;
-    uint32_t GetRequiredVersionAndValidateMachine() noexcept;
-
-    void CollectPhysicalDevices(PhysicalDeviceWrapperList& out_physical_devices) noexcept;
-    const PhysicalDeviceWrapper* ChoosePhysicalDevice(const PhysicalDeviceWrapperList& physical_devices, VkPhysicalDeviceType device_type) noexcept;
-
-    VkSurfaceFormatKHR ChooseSwapchainFormat() noexcept;
-    VkSurfaceTransformFlagBitsKHR CreatePretransformSwapchain() noexcept;
-    VkCompositeAlphaFlagBitsKHR ChooseSwapchainCompositeAlpha() noexcept;
-    int Choose_SwapchainImageCount(uint32_t user_swapchain_count_for_creation = kSwapchainBackBufferCount, bool if_failed_choose_min = true) noexcept;
-    VkPresentModeKHR GetPresentMode(VkPresentModeKHR type = VkPresentModeKHR::VK_PRESENT_MODE_FIFO_KHR) noexcept;
-    VkSurfaceCapabilitiesKHR GetSurfaceCapabilities() noexcept;
-
-    VkExtent2D GetValidSurfaceExtent() noexcept;
 
     void CreateShaders() noexcept;
     void CreateDescriptorSetLayout() noexcept;
@@ -648,15 +540,7 @@ private:
     void CreateSamplers() noexcept;
     void Create_Pipelines() noexcept;
 
-    // This method is called in Views, so don't call it manually
-    void CreateSwapchainImages() noexcept;
-    void CreateSwapchainImageViews() noexcept;
-
-    void Create_DepthStencilImage() noexcept;
-    void Create_DepthStencilImageViews() noexcept;
-
     void UpdateViewportState(const VkExtent2D& real_render_image_size) noexcept;
-    void CreateResourcesDependentOnSize(const VkExtent2D& real_render_image_size) noexcept;
 
     buffer_data_t CreateResource_StagingBuffer(VkDeviceSize size, VkBufferUsageFlags flags) noexcept;
     void DestroyResource_StagingBuffer(const buffer_data_t& data) noexcept;
@@ -669,13 +553,9 @@ private:
     void RegisterLiveTexture(texture_data_t* texture);
     void UnregisterLiveTexture(texture_data_t* texture);
 
-    void DestroyResourcesDependentOnSize() noexcept;
-    void DestroySwapchainImageViews() noexcept;
     void DestroyRenderLayers() noexcept;
     void DestroyRenderLayer(render_layer_t& layer) noexcept;
     void Destroy_Pipelines() noexcept;
-    void DestroyDescriptorSets() noexcept;
-    void DestroyPipelineLayout() noexcept;
     void DestroySamplers() noexcept;
     void FreeTransientShaderAllocations(uint32_t resource_slot) noexcept;
     void FreeAllTransientShaderAllocations() noexcept;
@@ -695,19 +575,9 @@ private:
     void ResetDynamicRenderState();
     void RenderFullscreenTexture(texture_data_t& texture, Rml::BlendMode blend_mode);
 
-    // Bounded acquire + image-fence wait. Returns false on soft-fail (WSI out-of-date,
-    // quarantine, cancel, device-lost) so BeginFrame can skip the frame without aborting.
-    [[nodiscard]] bool Wait() noexcept;
-
     void Update_PendingForDeletion_Textures_By_Frame(uint32_t resource_slot) noexcept;
     void Update_PendingForDeletion_Geometries(uint32_t resource_slot) noexcept;
     uint32_t ActiveResourceSlot() const noexcept;
-    void WaitForSubmittedFrames() noexcept;
-
-    void Submit() noexcept;
-    void Present() noexcept;
-
-    VkFormat Get_SupportedDepthFormat();
 
 private:
     bool m_is_transform_enabled;
@@ -721,21 +591,14 @@ private:
     int m_width;
     int m_height;
 
-    uint32_t m_queue_index_present;
     uint32_t m_queue_index_graphics;
-    uint32_t m_queue_index_compute;
-    uint32_t m_semaphore_index;
-    uint32_t m_semaphore_index_previous;
     uint32_t m_resource_slot = 0;
     uint32_t m_reclaim_resource_slot = 0;
-    uint32_t m_image_index;
 
     VkInstance m_p_instance;
     VkDevice m_p_device;
     lfs::rendering::VulkanDebugNameWriter m_debug_name_writer;
     VkPhysicalDevice m_p_physical_device;
-    VkSurfaceKHR m_p_surface;
-    VkSwapchainKHR m_p_swapchain;
     VkPipelineCache m_p_pipeline_cache;
     VmaAllocator m_p_allocator;
     // VK_EXT_host_image_copy: when both pointers load (extension + feature
@@ -763,13 +626,7 @@ private:
     VkRect2D m_scissor_original;
     VkViewport m_viewport;
 
-    VkQueue m_p_queue_present;
     VkQueue m_p_queue_graphics;
-    VkQueue m_p_queue_compute;
-
-#ifdef RMLUI_VK_DEBUG
-    VkDebugUtilsMessengerEXT m_debug_messenger;
-#endif
 
     VkSurfaceFormatKHR m_swapchain_format;
     VkFormat m_depth_stencil_format = VK_FORMAT_UNDEFINED;
@@ -780,15 +637,8 @@ private:
     VkRect2D m_context_clip_scissor{};
     bool m_context_clip_enabled = false;
     bool m_current_context_used_preview_texture = false;
-    texture_data_t m_texture_depthstencil;
 
     Rml::Matrix4f m_projection;
-    Rml::Vector<VkFence> m_executed_fences;
-    Rml::Vector<VkSemaphore> m_semaphores_image_available;
-    Rml::Vector<VkSemaphore> m_semaphores_finished_render;
-    Rml::Vector<VkImage> m_swapchain_images;
-    Rml::Vector<VkImageView> m_swapchain_image_views;
-    Rml::Vector<VkImageLayout> m_swapchain_image_layouts;
     Rml::Vector<VkShaderModule> m_shaders;
     Rml::Array<Rml::Vector<texture_data_t*>, kSwapchainBackBufferCount> m_pending_for_deletion_textures_by_frames;
     std::unordered_set<texture_data_t*> m_live_textures;
@@ -805,7 +655,6 @@ private:
     VkImageView m_external_swapchain_image_view = VK_NULL_HANDLE;
     VkImageView m_external_depth_stencil_image_view = VK_NULL_HANDLE;
     VkImageLayout m_external_swapchain_layout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageLayout m_depth_stencil_layout = VK_IMAGE_LAYOUT_UNDEFINED;
     lfs::vis::VulkanImageBarrierTracker m_image_barriers;
     active_render_target_t m_active_render_target = active_render_target_t::None;
     Rml::LayerHandle m_active_layer = 0;
@@ -814,7 +663,6 @@ private:
     // vma handles that thing, so there's no need for frame splitting
     Rml::Array<Rml::Vector<geometry_handle_t*>, kSwapchainBackBufferCount> m_pending_for_deletion_geometries_by_frame;
 
-    CommandBufferRing m_command_buffer_ring;
     MemoryPool m_memory_pool;
     UploadResourceManager m_upload_manager;
     DescriptorPoolManager m_manager_descriptors;


### PR DESCRIPTION
`RenderInterface_VK` is the RmlUi Vulkan backend. Upstream it can run in two modes that exclude each other:

- **standalone** — it creates its own `VkInstance`, physical device, `VkDevice`, surface, swapchain, queues and sync primitives, and drives acquire/present itself. Entry points `Initialize()` / `Shutdown()`.
- **external** — it borrows instance, device and queue from the host renderer and records into a command buffer the host owns. Entry points `InitializeExternal()` / `ShutdownExternal()` / `BeginExternalFrame()` / `EndExternalFrame()`.

We only ever use the external mode. `rmlui_manager.cpp:92` calls `InitializeExternal(context)` and there is no other construction path. `RenderInterface_VK::Initialize(` has zero references anywhere in `src/`.

So the standalone half has been dead code the whole time. This removes it.

## What is gone

- **Lifecycle and frame loop:** `Initialize`, `Shutdown`, `BeginFrame`, `EndFrame`, `SetViewport`, `IsSwapchainValid`, `RecreateSwapchain`, `Wait`, `WaitForSubmittedFrames`, `Submit`, `Present`
- **Bootstrap and teardown:** the `Initialize_*` / `Destroy_*` pairs for instance, device, physical device, surface, swapchain, queues and sync primitives
- **Instance and device discovery:** layer and extension queries, `ChoosePhysicalDevice`, `CollectPhysicalDevices`, the API-version checks, the debug report callback
- **Swapchain and WSI resources:** format and present-mode selection, surface capabilities, swapchain images and image views, the depth/stencil image, `CreateResourcesDependentOnSize` / `DestroyResourcesDependentOnSize`
- **`CommandBufferRing`** and its per-frame command pools
- **Two empty leftovers:** `DestroyDescriptorSets` and `DestroyPipelineLayout` had no bodies and no callers
- The members those functions owned (surface, swapchain, present/compute queues, image-available and render-finished semaphores, frame fences, swapchain image lists, debug messenger, depth/stencil texture) and the types only they used (`CreateSurfaceCallback`, `CommandBufferRing`, `PhysicalDeviceWrapper`, the layer/extension list aliases)

## What stayed

Anything external mode touches. Worth naming the ones that look like they belong to the deleted code but do not:

- `Initialize_Allocator`, `Initialize_Resources`, `Destroy_Resources`, `Destroy_Allocator` — called by `InitializeExternal` / `ShutdownExternal`
- `m_swapchain_format` — the name is misleading, the value comes from the host context and live pipelines use it
- `kSwapchainBackBufferCount` — still drives deferred destruction and transient allocations
- `render_layer_t::m_depth_stencil_layout` — used by external render layers

## Size

| file | before | after | removed |
|---|---:|---:|---:|
| `rmlui_vk_backend.cpp` | 4,359 | 2,890 | 1,469 |
| `rmlui_vk_backend.hpp` | 821 | 669 | 152 |

The diff shows 24 added lines, but nothing was actually added — git just lines the hunks up that way. `CreateShaders` and `CreateDescriptorSetLayout` are byte-identical before and after.

## Testing

- `cmake --build build -j8` — clean, no new warnings
- `lichtfeld_tests --gtest_filter="*Rml*:*Theme*:*theme*:*rml*"` — 19/19 pass
- Ran the app **with Vulkan validation layers active** (`validation_layers=active, debug_utils=active`), loaded a 5M-Gaussian PLY, and let the UI render: menu bar, right panel, scene tree, status bar, gizmos and grid all draw normally at 26 FPS. **Zero errors, zero validation messages.** The only warning was an unrelated Python plugin load time.

Pure deletion. No behaviour change.
