### PR TITLE
Reduce rebuilds caused by Git version metadata

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -6,9 +6,6 @@
 #define PROJECT_VERSION_PATCH @PROJECT_VERSION_PATCH@
 #define PROJECT_VERSION_STRING "@PROJECT_VERSION@"
 
-// Git version (generated at build time)
-#include "git_version.h"
-
 // Platform detection
 #if defined(_WIN32) || defined(_WIN64)
 #define PLATFORM_WINDOWS

--- a/src/mcp/mcp_server.cpp
+++ b/src/mcp/mcp_server.cpp
@@ -7,6 +7,7 @@
 #include "core/error.hpp"
 #include "core/error_envelope.hpp"
 #include "core/event_bridge/command_center_bridge.hpp"
+#include "git_version.h"
 
 #include <cassert>
 

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -64,6 +64,7 @@
 
 #include "config.h"
 #include "core/checkpoint_format.hpp"
+#include "git_version.h"
 #include "input/input_controller.hpp"
 #include "python/runner.hpp"
 #include "rendering/rendering_manager.hpp"

--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -51,6 +51,7 @@
 #include "visualizer/training/training_manager.hpp"
 
 #include "config.h"
+#include "git_version.h"
 
 #include "visualizer/input/key_codes.hpp"
 

--- a/tests/test_mcp_protocol.cpp
+++ b/tests/test_mcp_protocol.cpp
@@ -9,6 +9,7 @@
 
 #include "config.h"
 #include "core/event_bridge/command_center_bridge.hpp"
+#include "git_version.h"
 #include "mcp/mcp_http_server.hpp"
 #include "mcp/mcp_protocol.hpp"
 #include "mcp/mcp_server.hpp"


### PR DESCRIPTION
## Summary

Decouples dynamic Git version metadata from the shared `config.h` header.

`config.h` now contains only stable project and platform configuration. Files that actually expose Git version information include `git_version.h` directly.

## Motivation

`git_version.h` changes only when the repository moves between clean and dirty states. Once the working tree is already dirty, further edits do not change it again.

Previously, each clean-to-dirty transition propagated through the widely included `config.h` header and triggered recompilation of **46 object files**. With the dependency limited to actual version consumers, the same update rebuilds only **5 application object files** (plus the MCP protocol test when tests are built).

This preserves Git tag, commit, and dirty-state reporting while preventing the broad rebuild fan-out.