### PR TITLE
Start LichtFeld Studio on demand from the MCP bridge, and shut it down again

### DIFF
--- a/scripts/lichtfeld_mcp_bridge.py
+++ b/scripts/lichtfeld_mcp_bridge.py
@@ -6,8 +6,10 @@
 
 from __future__ import annotations
 
+import atexit
 import json
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -25,7 +27,11 @@ except ImportError:  # pragma: no cover - Windows fallback.
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_ENDPOINT = os.environ.get("LFS_MCP_ENDPOINT", "http://127.0.0.1:45677/mcp")
 DEFAULT_START_TIMEOUT_S = float(os.environ.get("LFS_MCP_START_TIMEOUT_S", "90"))
+CHILD_SHUTDOWN_GRACE_S = float(os.environ.get("LFS_MCP_SHUTDOWN_GRACE_S", "5"))
 START_POLL_INTERVAL_S = 0.5
+DEFAULT_PROTOCOL_VERSION = "2024-11-05"
+BRIDGE_NAME = "lichtfeld-mcp-bridge"
+BRIDGE_VERSION = "1.0.0"
 LOG_PATH = Path(
     os.environ.get(
         "LFS_MCP_BRIDGE_LOG",
@@ -38,6 +44,16 @@ LOCK_PATH = Path(
         str(Path.home() / ".codex" / "log" / "lichtfeld-mcp-bridge.lock"),
     )
 )
+TOOLS_CACHE_PATH = Path(
+    os.environ.get(
+        "LFS_MCP_TOOLS_CACHE",
+        str(Path.home() / ".codex" / "log" / "lichtfeld-mcp-tools.json"),
+    )
+)
+
+_spawned_processes: list[tuple[subprocess.Popen[Any], int | None]] = []
+_attached_to_existing_instance = False
+_cleanup_in_progress = False
 
 
 def log(message: str) -> None:
@@ -128,6 +144,158 @@ def launch_environment(command: list[str]) -> dict[str, str]:
     return env
 
 
+def bridge_spawn_is_running() -> bool:
+    return any(process.poll() is None for process, _ in _spawned_processes)
+
+
+def record_existing_attachment() -> None:
+    global _attached_to_existing_instance
+
+    if bridge_spawn_is_running() or _attached_to_existing_instance:
+        return
+
+    _attached_to_existing_instance = True
+    log(f"Attached to existing LichtFeld MCP endpoint at {DEFAULT_ENDPOINT}.")
+
+
+def track_spawned_process(process: subprocess.Popen[Any]) -> None:
+    process_group_id: int | None = None
+    if os.name != "nt":
+        try:
+            process_group_id = os.getpgid(process.pid)
+        except (ProcessLookupError, PermissionError):
+            process_group_id = process.pid
+
+    _spawned_processes.append((process, process_group_id))
+
+
+def process_group_exists(process_group_id: int) -> bool:
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def terminate_posix_process_group(
+    process: subprocess.Popen[Any],
+    process_group_id: int | None,
+) -> None:
+    try:
+        process_group_id = os.getpgid(process.pid)
+    except ProcessLookupError:
+        pass
+    except PermissionError:
+        log(f"Permission denied while resolving process group for child {process.pid}.")
+
+    if process_group_id is None:
+        process_group_id = process.pid
+
+    try:
+        os.killpg(process_group_id, signal.SIGTERM)
+    except ProcessLookupError:
+        process.poll()
+        log(f"Bridge-spawned child {process.pid} had already exited.")
+        return
+    except PermissionError:
+        log(f"Permission denied while terminating process group {process_group_id}.")
+        return
+
+    deadline = time.monotonic() + CHILD_SHUTDOWN_GRACE_S
+    while time.monotonic() < deadline:
+        process.poll()
+        if not process_group_exists(process_group_id):
+            log(f"Terminated bridge-spawned process group {process_group_id}.")
+            return
+        time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+
+    try:
+        os.killpg(process_group_id, signal.SIGKILL)
+    except ProcessLookupError:
+        process.poll()
+        log(f"Terminated bridge-spawned process group {process_group_id}.")
+        return
+    except PermissionError:
+        log(f"Permission denied while killing process group {process_group_id}.")
+        return
+
+    try:
+        process.wait(timeout=1.0)
+    except (subprocess.TimeoutExpired, ProcessLookupError, PermissionError):
+        pass
+    log(f"Terminated bridge-spawned process group {process_group_id} with SIGKILL.")
+
+
+def terminate_windows_process(process: subprocess.Popen[Any]) -> None:
+    if process.poll() is not None:
+        log(f"Bridge-spawned child {process.pid} had already exited.")
+        return
+
+    try:
+        process.terminate()
+    except ProcessLookupError:
+        log(f"Bridge-spawned child {process.pid} had already exited.")
+        return
+    except PermissionError:
+        log(f"Permission denied while terminating child {process.pid}.")
+        return
+
+    try:
+        process.wait(timeout=CHILD_SHUTDOWN_GRACE_S)
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            log(f"Permission denied while killing child {process.pid}.")
+            return
+        try:
+            process.wait(timeout=1.0)
+        except (subprocess.TimeoutExpired, ProcessLookupError, PermissionError):
+            pass
+
+    log(f"Terminated bridge-spawned child {process.pid}.")
+
+
+def cleanup_spawned_processes() -> None:
+    global _cleanup_in_progress
+
+    if _cleanup_in_progress or not _spawned_processes:
+        return
+
+    _cleanup_in_progress = True
+    processes = list(reversed(_spawned_processes))
+    _spawned_processes.clear()
+    try:
+        for process, process_group_id in processes:
+            log(f"Cleaning up bridge-spawned child {process.pid}.")
+            if os.name == "nt":
+                terminate_windows_process(process)
+            else:
+                terminate_posix_process_group(process, process_group_id)
+    finally:
+        _cleanup_in_progress = False
+
+
+def handle_shutdown_signal(signum: int, _frame: Any) -> None:
+    log(f"Bridge received signal {signum}; cleaning up.")
+    cleanup_spawned_processes()
+    raise SystemExit(128 + signum)
+
+
+def install_signal_handlers() -> None:
+    for signal_name in ("SIGTERM", "SIGINT", "SIGHUP"):
+        shutdown_signal = getattr(signal, signal_name, None)
+        if shutdown_signal is not None:
+            signal.signal(shutdown_signal, handle_shutdown_signal)
+
+
+atexit.register(cleanup_spawned_processes)
+
+
 class StartupLock:
     def __enter__(self) -> "StartupLock":
         LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -151,16 +319,17 @@ def tail_log(limit: int = 20) -> str:
 
 def ensure_server_ready() -> None:
     if endpoint_ready():
+        record_existing_attachment()
         return
 
     with StartupLock():
         if endpoint_ready():
+            record_existing_attachment()
             return
 
         command = pick_launch_command()
         env = launch_environment(command)
 
-        log(f"Starting LichtFeld Studio: {' '.join(command)}")
         with LOG_PATH.open("a", encoding="utf-8") as handle:
             process = subprocess.Popen(
                 command,
@@ -171,6 +340,8 @@ def ensure_server_ready() -> None:
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
             )
+        track_spawned_process(process)
+        log(f"Spawned LichtFeld Studio child {process.pid}: {' '.join(command)}")
 
         deadline = time.monotonic() + DEFAULT_START_TIMEOUT_S
         while time.monotonic() < deadline:
@@ -243,45 +414,144 @@ def error_response(message: Any, error_text: str) -> dict[str, Any]:
     }
 
 
+def success_response(message: dict[str, Any], result: Any) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message["id"],
+        "result": result,
+    }
+
+
+def initialize_response(message: dict[str, Any]) -> dict[str, Any]:
+    protocol_version = DEFAULT_PROTOCOL_VERSION
+    params = message.get("params")
+    if isinstance(params, dict) and "protocolVersion" in params:
+        protocol_version = params["protocolVersion"]
+
+    return success_response(
+        message,
+        {
+            "protocolVersion": protocol_version,
+            "capabilities": {"tools": {}},
+            "serverInfo": {
+                "name": BRIDGE_NAME,
+                "version": BRIDGE_VERSION,
+            },
+        },
+    )
+
+
+def normalize_tools_manifest(payload: Any) -> dict[str, Any]:
+    manifest = payload
+    if isinstance(payload, dict) and "result" in payload:
+        manifest = payload["result"]
+    if isinstance(manifest, list):
+        manifest = {"tools": manifest}
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("tools"), list):
+        raise ValueError("tools manifest must contain a tools list")
+    return manifest
+
+
+def read_tools_cache() -> dict[str, Any] | None:
+    try:
+        payload = json.loads(TOOLS_CACHE_PATH.read_text(encoding="utf-8"))
+        return normalize_tools_manifest(payload)
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        log(f"Ignoring invalid tools cache at {TOOLS_CACHE_PATH}: {exc}")
+        return None
+
+
+def write_tools_cache(response: Any) -> None:
+    try:
+        manifest = normalize_tools_manifest(response)
+    except ValueError as exc:
+        log(f"Not caching invalid live tools/list response: {exc}")
+        return
+
+    temporary_path = TOOLS_CACHE_PATH.with_name(
+        f".{TOOLS_CACHE_PATH.name}.{os.getpid()}.tmp"
+    )
+    try:
+        TOOLS_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temporary_path, TOOLS_CACHE_PATH)
+    except OSError as exc:
+        log(f"Failed to refresh tools cache at {TOOLS_CACHE_PATH}: {exc}")
+        try:
+            temporary_path.unlink()
+        except (FileNotFoundError, PermissionError):
+            pass
+        return
+
+    log(f"Refreshed tools cache from live app at {TOOLS_CACHE_PATH}.")
+
+
 def forward_message(message: Any) -> Any:
     return post_json(message, timeout_s=30.0)
 
 
 def main() -> int:
+    install_signal_handlers()
     try:
-        ensure_server_ready()
-    except Exception as exc:  # pragma: no cover - exercised in live startup.
-        log(f"Startup failed: {exc}")
-        print(f"lichtfeld-mcp-bridge: {exc}", file=sys.stderr)
-        return 1
-
-    while True:
-        try:
-            message = read_message()
-        except Exception as exc:
-            log(f"Failed to read MCP message: {exc}")
-            print(f"lichtfeld-mcp-bridge: {exc}", file=sys.stderr)
-            return 1
-
-        if message is None:
-            return 0
-
-        try:
-            response = forward_message(message)
-        except Exception as exc:
-            log(f"HTTP forward failed, retrying after startup check: {exc}")
+        while True:
             try:
-                ensure_server_ready()
-                response = forward_message(message)
-            except Exception as retry_exc:
-                if is_notification(message):
-                    log(f"Dropping notification after transport failure: {retry_exc}")
-                    continue
-                write_message(error_response(message, f"LichtFeld transport error: {retry_exc}"))
+                message = read_message()
+            except Exception as exc:
+                log(f"Failed to read MCP message: {exc}")
+                print(f"lichtfeld-mcp-bridge: {exc}", file=sys.stderr)
+                return 1
+
+            if message is None:
+                return 0
+
+            if is_notification(message):
+                method = message.get("method") if isinstance(message, dict) else None
+                log(f"Dropped MCP notification locally: {method or '<unknown>'}.")
                 continue
 
-        if not is_notification(message):
+            method = message.get("method") if isinstance(message, dict) else None
+            if method == "initialize":
+                log("Served MCP initialize locally.")
+                write_message(initialize_response(message))
+                continue
+
+            if method == "ping":
+                log("Served MCP ping locally.")
+                write_message(success_response(message, {}))
+                continue
+
+            if method == "tools/list":
+                cached_manifest = read_tools_cache()
+                if cached_manifest is not None:
+                    log(f"Served tools/list from cache at {TOOLS_CACHE_PATH}.")
+                    write_message(success_response(message, cached_manifest))
+                    continue
+                log(f"tools/list cache miss at {TOOLS_CACHE_PATH}; querying live app.")
+
+            try:
+                response = forward_message(message)
+                record_existing_attachment()
+            except Exception as exc:
+                log(f"HTTP forward failed, retrying after startup check: {exc}")
+                try:
+                    ensure_server_ready()
+                    response = forward_message(message)
+                except Exception as retry_exc:
+                    write_message(
+                        error_response(message, f"LichtFeld transport error: {retry_exc}")
+                    )
+                    continue
+
+            if method == "tools/list":
+                write_tools_cache(response)
             write_message(response)
+    finally:
+        cleanup_spawned_processes()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The MCP bridge launched the app at every session start and never cleaned it up. Two separate bugs.

**It started eagerly.** `main()` called `ensure_server_ready()` before reading a single MCP message. Claude Code and Codex both start the bridge when they connect, so the GUI launched every session even when no lichtfeld tool was ever used. Codex has this server in `~/.codex/config.toml` too, so every `codex exec` did it as well.

**It never cleaned up.** The child was spawned with `start_new_session=True` and nothing ever terminated it, so it reparented to `systemd --user` and outlived the bridge, the session, and every later session. Instances accumulated - I had two orphans 1.5 hours apart, and one of them had already failed to open a window (`Failed to initialize SDL: No available video device`) and was just sitting there.

## What changed

**The handshake no longer touches the app.** `initialize`, `ping` and notifications are answered by the bridge itself. `tools/list` is served from a cached manifest (`~/.codex/log/lichtfeld-mcp-tools.json`, override with `LFS_MCP_TOOLS_CACHE`), refreshed whenever a live response comes back so it self-heals when tools change. Only a real call - `tools/call`, or `tools/list` with no cache yet - starts anything.

**Whatever the bridge spawns, the bridge kills.** Every spawned process is tracked and its process group terminated on stdin EOF, normal exit, unhandled exception, and SIGTERM/SIGINT/SIGHUP, with a 5s grace period before SIGKILL. `start_new_session=True` stays, because it is what makes the group kill clean.

**An instance you opened yourself is left alone.** If the endpoint already answers when the bridge starts, it records that it attached rather than spawned, and never terminates it.

## Testing

| case | result |
|---|---|
| `initialize` + `notifications/initialized` + `tools/list` over stdio | 0 GUI instances before, during and after; bridge exits 0 |
| spawned child, bridge hits stdin EOF | child and process group gone |
| spawned child, bridge gets SIGTERM | child and process group gone |
| pre-existing endpoint, bridge exits | not killed, still answering |
| cache refresh + relaunch-after-transport-failure cleanup | pass |

I ran the handshake test myself against a seeded cache: `protocolVersion` echoed back correctly, tools served from cache, nothing spawned.