### PR TITLE
Fix group merge deleting splats when merging to a single PLY

### DIFF
--- a/src/app/mcp_gui_tools.cpp
+++ b/src/app/mcp_gui_tools.cpp
@@ -2747,6 +2747,10 @@ namespace lfs::app {
 
                     core::events::cmd::MergeGroupById{.node_id = group->id}.emit();
 
+                    if (const auto* const merged = scene.getNode(name);
+                        merged && merged->type == core::NodeType::SPLAT)
+                        return json{{"success", true}, {"node", node_summary_json(scene, *merged)}};
+
                     for (const auto* const node : scene.getNodes()) {
                         if (node && !before.contains(node->name))
                             return json{{"success", true}, {"node", node_summary_json(scene, *node)}};

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -2491,11 +2491,21 @@ namespace lfs::core {
             return "";
         }
 
-        Transaction txn(*this);
-        removeNode(group_name, false);
-        addSplat(group_name, std::move(merged), parent_id);
+        std::string merged_name = makeUniqueNodeName(name_to_id_, group_name + " Merged");
+        NodeId merged_id = NULL_NODE;
+        {
+            Transaction txn(*this);
+            merged_id = addSplat(merged_name, std::move(merged), parent_id);
+            if (merged_id == NULL_NODE) {
+                return "";
+            }
+            removeNode(group_name, false);
+            if (renameNode(merged_id, group_name)) {
+                merged_name = group_name;
+            }
+        }
 
-        return group_name;
+        return merged_name;
     }
 
     std::unique_ptr<lfs::core::SplatData> Scene::createMergedModelWithTransforms() const {

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -4188,12 +4188,22 @@ namespace lfs::vis {
             scene_.setCombinedModelAllocator(std::move(allocator));
         }
 
+        std::string merged_name = makeUniqueNodeName(scene_, name + " Merged");
+        core::NodeId merged_id = core::NULL_NODE;
         {
             core::Scene::Transaction txn(scene_);
+            merged_id = scene_.addSplat(merged_name, std::move(merged_model), parent_id);
+            if (merged_id == core::NULL_NODE) {
+                LOG_ERROR("Failed to add merged group '{}' as '{}'", name, merged_name);
+                return {};
+            }
             scene_.removeNode(name, false);
-            scene_.addSplat(name, std::move(merged_model), parent_id);
+            if (scene_.renameNode(merged_id, name)) {
+                merged_name = name;
+            } else {
+                LOG_ERROR("Failed to rename merged group '{}' back to '{}'", merged_name, name);
+            }
         }
-        const std::string merged_name = name;
         selection_.invalidateNodeMask();
 
         // Emit PLYRemoved for all original children and the group

--- a/tests/test_error_envelope.cpp
+++ b/tests/test_error_envelope.cpp
@@ -123,7 +123,7 @@ TEST(ErrorEnvelopeTest, InvalidUtf8DetailPathSerializesUnderStrictDump) {
         .domain = lfs::ErrorDomain::IO,
         .user_message = "Load failed",
         .detection = LFS_SOURCE_SITE_CURRENT(),
-        .fields = lfs::SmallFields{}.add("path", std::string("/data/sc\xff\x80ene.ply")),
+        .fields = lfs::SmallFields{}.add("path", std::string("/data/sc\xff\x80" "ene.ply")),
     });
 
     const nlohmann::json envelope = lfs::core::to_wire_envelope(error);

--- a/tests/test_scene_validity.cpp
+++ b/tests/test_scene_validity.cpp
@@ -1055,6 +1055,37 @@ namespace lfs::python {
                 EXPECT_NEAR(world_before[col][row], world_after[col][row], 1e-4f);
     }
 
+    TEST_F(SceneValidityTest, MergeGroupAfterDuplicatingAndMovingSplatsKeepsMergedNode) {
+        const auto original = dummy_scene_.addSplat("Model", make_test_splat(3));
+        ASSERT_NE(original, core::NULL_NODE);
+
+        const std::string copy_name = dummy_scene_.duplicateNode("Model");
+        ASSERT_FALSE(copy_name.empty());
+        const auto copy = dummy_scene_.getNodeIdByName(copy_name);
+        ASSERT_NE(copy, core::NULL_NODE);
+
+        glm::mat4 copy_transform(1.0f);
+        copy_transform[3] = glm::vec4(2.0f, 0.0f, 0.0f, 1.0f);
+        dummy_scene_.setNodeTransform(copy_name, copy_transform);
+
+        const auto group = dummy_scene_.addGroup("Group");
+        ASSERT_NE(group, core::NULL_NODE);
+        ASSERT_TRUE(dummy_scene_.moveNode(original, group, -1));
+        ASSERT_TRUE(dummy_scene_.moveNode(copy, group, -1));
+
+        const std::string merged_name = dummy_scene_.mergeGroup("Group");
+
+        EXPECT_EQ(merged_name, "Group");
+        const auto* merged = dummy_scene_.getNode("Group");
+        ASSERT_NE(merged, nullptr);
+        EXPECT_EQ(merged->type, core::NodeType::SPLAT);
+        ASSERT_TRUE(merged->model != nullptr);
+        EXPECT_EQ(merged->model->size(), 6);
+        EXPECT_EQ(dummy_scene_.getTotalGaussianCount(), 6u);
+        EXPECT_EQ(dummy_scene_.getNode("Model"), nullptr);
+        EXPECT_EQ(dummy_scene_.getNode(copy_name), nullptr);
+        EXPECT_EQ(dummy_scene_.getNodeCount(), 1u);
+    }
     TEST_F(SceneValidityTest, SceneManagerMoveNodeReparentsIntoGroup) {
         lfs::vis::SceneManager sm;
         auto& scene = sm.getScene();
@@ -1084,6 +1115,43 @@ namespace lfs::python {
         EXPECT_TRUE(scene.getNodeById(group)->children.empty());
     }
 
+    TEST_F(SceneValidityTest, SceneManagerMergeGroupAfterDuplicatingAndMovingSplatsKeepsMergedNode) {
+        lfs::vis::SceneManager sm;
+        auto& scene = sm.getScene();
+        const auto original = scene.addSplat("Model", make_test_splat(3));
+        ASSERT_NE(original, core::NULL_NODE);
+
+        const std::string copy_name = scene.duplicateNode("Model");
+        ASSERT_FALSE(copy_name.empty());
+        const auto copy = scene.getNodeIdByName(copy_name);
+        ASSERT_NE(copy, core::NULL_NODE);
+
+        glm::mat4 copy_transform(1.0f);
+        copy_transform[3] = glm::vec4(2.0f, 0.0f, 0.0f, 1.0f);
+        scene.setNodeTransform(copy_name, copy_transform);
+
+        const std::string group_name = sm.addGroupNode("Group", core::NULL_NODE);
+        ASSERT_EQ(group_name, "Group");
+        const auto group = scene.getNodeIdByName(group_name);
+        ASSERT_NE(group, core::NULL_NODE);
+        ASSERT_TRUE(sm.moveNode(original, group, -1));
+        ASSERT_TRUE(sm.moveNode(copy, group, -1));
+        sm.selectNodesById({group});
+
+        const std::string merged_name = sm.mergeGroupNode(group_name);
+
+        EXPECT_EQ(merged_name, group_name);
+        const auto* merged = scene.getNode(group_name);
+        ASSERT_NE(merged, nullptr);
+        EXPECT_EQ(merged->type, core::NodeType::SPLAT);
+        ASSERT_TRUE(merged->model != nullptr);
+        EXPECT_EQ(merged->model->size(), 6);
+        EXPECT_EQ(scene.getTotalGaussianCount(), 6u);
+        EXPECT_EQ(scene.getNode("Model"), nullptr);
+        EXPECT_EQ(scene.getNode(copy_name), nullptr);
+        ASSERT_EQ(sm.getSelectedNodeNames().size(), 1u);
+        EXPECT_EQ(sm.getSelectedNodeNames()[0], group_name);
+    }
     TEST_F(SceneValidityTest, SceneManagerBlocksActiveCameraSubtreeAndAllowsInactiveCameraRemoval) {
         const ScopedServicesClear services_scope;
         lfs::vis::SceneManager sm;


### PR DESCRIPTION
Fixes #1458 

## Summary

This patch fixes the group merge flow used by **Scene Navigation -> Merge to Single PLY**. The merge operation now safely replaces a group with the merged splat node without leaving the scene in a deleted/intermediate state, and the MCP `scene.merge_group` tool now correctly reports success when the merged node keeps the original group name.

## Observed Symptoms
Original issue: https://github.com/MrNeRF/LichtFeld-Studio/issues/1458

## Replication Steps From The Original Issue

1. Load a `.ply` model.
2. Duplicate the `.ply`.
3. Move the duplicated `.ply` so both models are visible separately.
4. In scene navigation, right-click `Models` and add a new group.
5. Drag both models into the new group.
6. Right-click the group and choose `Merge to Single PLY`.
7. Before this patch, the splats and the group could disappear instead of being replaced by one merged splat node.

## Root Cause

The merge implementation built the merged model first, then replaced the group with this sequence:

1. Remove the group and all of its children.
2. Add a new splat node using the original group name.

That meant the scene briefly went through a removal-only state, and the code did not verify that the replacement `addSplat` actually succeeded before continuing with selection, history, and scene update handling. If the replacement path failed or downstream observers reacted to the delete side before the replacement was visible, the operation could appear as if it deleted the models.

A related MCP tool issue made this more confusing: `scene.merge_group` checked only for newly added node names after merge. Since the intended merged node reuses the original group name, the tool could report failure even when the scene contained the merged replacement.

## What This Patch Fixes

- Changes core `Scene::mergeGroup` to add the merged splat under a temporary unique name before removing the original group.
- Applies the same safe replacement sequence in `SceneManager::mergeGroupNode`, which is the path used by the scene navigation context menu.
- Renames the temporary merged node back to the original group name after the group has been removed.
- Checks replacement insertion before deleting the original group, so a failed insert no longer turns into data loss.
- Keeps the merged node under the temporary name if the final rename unexpectedly fails, preferring data preservation over exact naming.
- Updates MCP `scene.merge_group` success detection so same-name replacements are treated as successful merges.
- Adds regression coverage for the duplicate, move, group, and merge flow at both core scene and scene-manager levels.

## Why The Issue Showed Up

The repro uses a group replacement pattern: two existing splat nodes are reparented into a group, then the group is replaced by one merged splat with the same name. That is exactly the case where remove-then-add is fragile, because the old group name disappears before the new splat with that same name exists.

The duplication and move steps also make the bug more visible because there are clearly two separate models before merge. When the replacement does not appear, it looks like both original splats were deleted.

