### PR TITLE
Video Frame Extractor Source Frame Numbering

### DIFF
--- a/src/io/video_frame_extractor.cpp
+++ b/src/io/video_frame_extractor.cpp
@@ -36,6 +36,7 @@ extern "C" {
 #include <limits>
 #include <stdexcept>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 namespace lfs::io {
@@ -1328,6 +1329,7 @@ namespace lfs::io {
                     double sharpness_score;
                 };
                 std::vector<FrameSaveInfo> saved_frames;
+                std::unordered_set<std::filesystem::path> emitted_filenames;
 
                 const bool seek_timestamps_available =
                     std::isfinite(time_base) && time_base > 0.0 && std::isfinite(video_duration) &&
@@ -1395,6 +1397,29 @@ namespace lfs::io {
                     return params.output_dir / (formatFrameFilenameStem(params.filename_pattern, frame_num) + ext);
                 };
 
+                const auto source_frame_for_time = [&](const double frame_time) {
+                    return std::max(
+                        1, static_cast<int>(std::llround(frame_time * video_fps)) + 1);
+                };
+
+                auto reserve_output_filename = [&](const std::filesystem::path& filename,
+                                                   const int source_frame) {
+                    if (emitted_filenames.insert(filename).second)
+                        return true;
+                    LOG_WARN("Skipping duplicate source frame {} output: {}",
+                             source_frame, lfs::core::path_to_utf8(filename));
+                    return false;
+                };
+
+                auto finish_selected_frame = [&]() {
+                    saved_count++;
+
+                    if (params.progress_callback) {
+                        params.progress_callback(saved_count + skipped_count, estimated_total, skipped_count);
+                    }
+                    throw_if_cancelled();
+                };
+
                 auto should_extract_frame = [&](const double frame_time) {
                     bool should_extract = false;
                     if (params.mode == ExtractionMode::FPS) {
@@ -1420,6 +1445,12 @@ namespace lfs::io {
                             return a.score < b.score;
                         });
                     std::filesystem::path fname = generate_filename(best->source_frame);
+                    if (!reserve_output_filename(fname, best->source_frame)) {
+                        finish_selected_frame();
+                        window_candidates.clear();
+                        window_skip_counter = 0;
+                        return;
+                    }
                     // Apply rotation to the best window frame before writing
                     int write_w = out_width;
                     int write_h = out_height;
@@ -1467,12 +1498,9 @@ namespace lfs::io {
                                                     best->score});
                         }
                     }
-                    ++saved_count;
-                    if (params.progress_callback)
-                        params.progress_callback(saved_count, estimated_total, skipped_count);
+                    finish_selected_frame();
                     window_candidates.clear();
                     window_skip_counter = 0;
-                    throw_if_cancelled();
                 };
 
                 auto process_frame_hw = [&](AVFrame* hw_frame) {
@@ -1529,6 +1557,11 @@ namespace lfs::io {
                                     params.progress_callback(saved_count + skipped_count, estimated_total, skipped_count);
                                 return;
                             }
+                        }
+
+                        if (!reserve_output_filename(filename, current_src_frame)) {
+                            finish_selected_frame();
+                            return;
                         }
 
                         const int rot = params.rotation;
@@ -1614,6 +1647,11 @@ namespace lfs::io {
                             }
                         }
                         // --- End sharpness ---
+
+                        if (!reserve_output_filename(filename, current_src_frame)) {
+                            finish_selected_frame();
+                            return;
+                        }
 
                         // --- Rotation (hybrid HW path) ---
                         int hw_rot_w = out_width;
@@ -1729,6 +1767,12 @@ namespace lfs::io {
                     }
                     // --- End sharpness ---
 
+                    std::filesystem::path filename = generate_filename(current_src_frame);
+                    if (!reserve_output_filename(filename, current_src_frame)) {
+                        finish_selected_frame();
+                        return;
+                    }
+
                     // --- Rotation (SW path) ---
                     int sw_rot_w = out_width;
                     int sw_rot_h = out_height;
@@ -1763,8 +1807,6 @@ namespace lfs::io {
                                     static_cast<size_t>(out_width) * out_height * 3);
                     }
                     // --- End rotation ---
-
-                    std::filesystem::path filename = generate_filename(current_src_frame);
 
                     if (gpu_encoding_enabled) {
                         if (batch_encode_w == 0) {
@@ -1801,12 +1843,7 @@ namespace lfs::io {
                         LOG_WARN("Failed to write extracted frame: {}", lfs::core::path_to_utf8(filename));
                     }
 
-                    saved_count++;
-
-                    if (params.progress_callback) {
-                        params.progress_callback(saved_count + skipped_count, estimated_total, skipped_count);
-                    }
-                    throw_if_cancelled();
+                    finish_selected_frame();
                 };
 
                 if (params.mode == ExtractionMode::FPS) {
@@ -1838,8 +1875,7 @@ namespace lfs::io {
                 const auto process_selected_frame = [&](AVFrame* const selected_frame,
                                                         const double frame_time) {
                     current_frame_time = frame_time;
-                    current_src_frame = std::max(
-                        1, static_cast<int>(std::llround(frame_time * video_fps)) + 1);
+                    current_src_frame = source_frame_for_time(frame_time);
                     if (using_hw_decode)
                         process_frame_hw(selected_frame);
                     else
@@ -1869,7 +1905,7 @@ namespace lfs::io {
                     }
 
                     current_frame_time = frame_time;
-                    current_src_frame = decoded_frame_count;
+                    current_src_frame = source_frame_for_time(frame_time);
                     if (params.sharpness.enabled && params.sharpness.window_mode) {
                         const int window_index = params.mode == ExtractionMode::FPS
                                                      ? static_cast<int>(std::floor(

--- a/src/io/video_frame_extractor.cpp
+++ b/src/io/video_frame_extractor.cpp
@@ -1419,8 +1419,7 @@ namespace lfs::io {
                         [](const CandidateFrame& a, const CandidateFrame& b) {
                             return a.score < b.score;
                         });
-                    std::filesystem::path fname = generate_filename(
-                        written_count + 1);
+                    std::filesystem::path fname = generate_filename(best->source_frame);
                     // Apply rotation to the best window frame before writing
                     int write_w = out_width;
                     int write_h = out_height;
@@ -1478,7 +1477,7 @@ namespace lfs::io {
 
                 auto process_frame_hw = [&](AVFrame* hw_frame) {
                     throw_if_cancelled();
-                    std::filesystem::path filename = generate_filename(saved_count + 1);
+                    std::filesystem::path filename = generate_filename(current_src_frame);
 
                     const AVPixelFormat hw_sw_format = hardwareFrameSoftwareFormat(hw_frame);
                     if (decoded_software_format == AV_PIX_FMT_NONE &&
@@ -1765,7 +1764,7 @@ namespace lfs::io {
                     }
                     // --- End rotation ---
 
-                    std::filesystem::path filename = generate_filename(saved_count + 1);
+                    std::filesystem::path filename = generate_filename(current_src_frame);
 
                     if (gpu_encoding_enabled) {
                         if (batch_encode_w == 0) {

--- a/src/io/video_frame_extractor.hpp
+++ b/src/io/video_frame_extractor.hpp
@@ -82,7 +82,7 @@ namespace lfs::io {
             int custom_height = 0;
 
             // Output naming
-            std::string filename_pattern = "frame_%d"; // %d = frame number
+            std::string filename_pattern = "frame_%d"; // %d = 1-based source video frame number
             bool generate_metadata = false;
             int rotation = 0; // 0, 90, 180, 270
             bool convert_hdr_to_sdr = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -157,6 +157,7 @@ set(TEST_FILES
     test_tcp_publisher.cpp
     test_view_info_json.cpp
     test_video_export_utils.cpp
+    test_video_frame_extractor_naming.cpp
     test_video_hdr_logic.cpp
     test_visualizer_post_work.cpp
     test_panel_registry_animation_demand.cpp

--- a/tests/test_video_frame_extractor_naming.cpp
+++ b/tests/test_video_frame_extractor_naming.cpp
@@ -1,0 +1,231 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "io/video/video_encoder.hpp"
+#include "io/video_frame_extractor.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+namespace {
+
+    using lfs::io::ExtractionMode;
+    using lfs::io::VideoFrameExtractor;
+
+    constexpr int kWidth = 16;
+    constexpr int kHeight = 16;
+    constexpr int kChannels = 3;
+
+    struct TempDir {
+        explicit TempDir(const std::string_view label) {
+            const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+            path = std::filesystem::temp_directory_path() /
+                   ("lfs_video_extract_" + std::string(label) + "_" + std::to_string(now));
+            std::filesystem::create_directories(path);
+        }
+
+        ~TempDir() {
+            std::error_code ec;
+            std::filesystem::remove_all(path, ec);
+        }
+
+        std::filesystem::path path;
+    };
+
+    struct CudaFloatBuffer {
+        explicit CudaFloatBuffer(const std::size_t count) {
+            status = cudaMalloc(reinterpret_cast<void**>(&ptr), count * sizeof(float));
+        }
+
+        ~CudaFloatBuffer() {
+            if (ptr)
+                cudaFree(ptr);
+        }
+
+        float* ptr = nullptr;
+        cudaError_t status = cudaSuccess;
+    };
+
+    bool cudaAvailable() {
+        int device_count = 0;
+        return cudaGetDeviceCount(&device_count) == cudaSuccess && device_count > 0;
+    }
+
+    bool writeEncodedVideo(const std::filesystem::path& video_path,
+                           const int frame_count,
+                           const int framerate,
+                           std::string& error) {
+        lfs::io::video::VideoExportOptions options;
+        options.preset = lfs::io::video::VideoPreset::CUSTOM;
+        options.width = kWidth;
+        options.height = kHeight;
+        options.framerate = framerate;
+        options.crf = 23;
+
+        lfs::io::video::VideoEncoder encoder;
+        if (const auto opened = encoder.open(video_path, options); !opened) {
+            error = opened.error();
+            return false;
+        }
+
+        std::vector<float> frame(static_cast<std::size_t>(kWidth) * kHeight * kChannels);
+        CudaFloatBuffer device_frame(frame.size());
+        if (device_frame.status != cudaSuccess) {
+            error = cudaGetErrorString(device_frame.status);
+            return false;
+        }
+
+        for (int frame_index = 0; frame_index < frame_count; ++frame_index) {
+            const float red = static_cast<float>(frame_index + 1) /
+                              static_cast<float>(frame_count);
+            for (int y = 0; y < kHeight; ++y) {
+                for (int x = 0; x < kWidth; ++x) {
+                    const std::size_t offset =
+                        (static_cast<std::size_t>(y) * kWidth + x) * kChannels;
+                    frame[offset + 0] = red;
+                    frame[offset + 1] = static_cast<float>(x) / static_cast<float>(kWidth - 1);
+                    frame[offset + 2] = static_cast<float>(y) / static_cast<float>(kHeight - 1);
+                }
+            }
+
+            const cudaError_t copy_status = cudaMemcpy(
+                device_frame.ptr, frame.data(), frame.size() * sizeof(float), cudaMemcpyHostToDevice);
+            if (copy_status != cudaSuccess) {
+                error = cudaGetErrorString(copy_status);
+                return false;
+            }
+
+            if (const auto written = encoder.writeFrameGpu(device_frame.ptr, kWidth, kHeight); !written) {
+                error = written.error();
+                return false;
+            }
+        }
+
+        if (const auto closed = encoder.close(); !closed) {
+            error = closed.error();
+            return false;
+        }
+        return true;
+    }
+
+    VideoFrameExtractor::Params extractionParams(
+        const std::filesystem::path& video_path,
+        const std::filesystem::path& output_dir) {
+        VideoFrameExtractor::Params params;
+        params.video_path = video_path;
+        params.output_dir = output_dir;
+        params.mode = ExtractionMode::INTERVAL;
+        params.frame_interval = 1;
+        params.format = lfs::io::ImageFormat::PNG;
+        params.generate_metadata = true;
+        return params;
+    }
+
+    std::size_t countPngFiles(const std::filesystem::path& output_dir) {
+        std::size_t count = 0;
+        for (const auto& entry : std::filesystem::directory_iterator{output_dir}) {
+            if (entry.is_regular_file() && entry.path().extension() == ".png")
+                ++count;
+        }
+        return count;
+    }
+
+    nlohmann::json readMetadata(const std::filesystem::path& output_dir) {
+        std::ifstream file(output_dir / "extraction_metadata.json");
+        return nlohmann::json::parse(file);
+    }
+
+} // namespace
+
+TEST(VideoFrameExtractorOutputNaming, IntervalUsesSourceFrameNumbers) {
+    if (!cudaAvailable())
+        GTEST_SKIP() << "CUDA device required for VideoEncoder-based fixture";
+
+    TempDir temp("interval");
+    const std::filesystem::path video_path = temp.path / "source.mp4";
+    const std::filesystem::path output_dir = temp.path / "frames";
+    std::filesystem::create_directories(output_dir);
+
+    std::string error;
+    ASSERT_TRUE(writeEncodedVideo(video_path, 5, 10, error)) << error;
+
+    auto params = extractionParams(video_path, output_dir);
+    params.frame_interval = 2;
+
+    VideoFrameExtractor extractor;
+    ASSERT_TRUE(extractor.extract(params, error)) << error;
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_1.png"));
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_3.png"));
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_5.png"));
+    EXPECT_FALSE(std::filesystem::exists(output_dir / "frame_2.png"));
+    EXPECT_EQ(3u, countPngFiles(output_dir));
+}
+
+TEST(VideoFrameExtractorOutputNaming, TrimmedRangeKeepsOriginalSourceFrameNumbers) {
+    if (!cudaAvailable())
+        GTEST_SKIP() << "CUDA device required for VideoEncoder-based fixture";
+
+    TempDir temp("trim");
+    const std::filesystem::path video_path = temp.path / "source.mp4";
+    const std::filesystem::path output_dir = temp.path / "frames";
+    std::filesystem::create_directories(output_dir);
+
+    std::string error;
+    ASSERT_TRUE(writeEncodedVideo(video_path, 40, 10, error)) << error;
+
+    auto params = extractionParams(video_path, output_dir);
+    params.start_time = 2.3;
+    params.end_time = 2.41;
+
+    VideoFrameExtractor extractor;
+    ASSERT_TRUE(extractor.extract(params, error)) << error;
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_24.png"));
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_25.png"));
+    EXPECT_FALSE(std::filesystem::exists(output_dir / "frame_4.png"));
+    EXPECT_EQ(2u, countPngFiles(output_dir));
+}
+
+TEST(VideoFrameExtractorOutputNaming, RepeatedSourceFramesAreWrittenOnce) {
+    if (!cudaAvailable())
+        GTEST_SKIP() << "CUDA device required for VideoEncoder-based fixture";
+
+    TempDir temp("duplicates");
+    const std::filesystem::path video_path = temp.path / "source.mp4";
+    const std::filesystem::path output_dir = temp.path / "frames";
+    std::filesystem::create_directories(output_dir);
+
+    std::string error;
+    ASSERT_TRUE(writeEncodedVideo(video_path, 5, 10, error)) << error;
+
+    auto params = extractionParams(video_path, output_dir);
+    params.mode = ExtractionMode::FPS;
+    params.fps = 30.0;
+    params.start_time = 0.0;
+    params.end_time = 0.5;
+
+    VideoFrameExtractor extractor;
+    ASSERT_TRUE(extractor.extract(params, error)) << error;
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_1.png"));
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_2.png"));
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_3.png"));
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_4.png"));
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_5.png"));
+    EXPECT_EQ(5u, countPngFiles(output_dir));
+
+    const nlohmann::json metadata = readMetadata(output_dir);
+    ASSERT_TRUE(metadata.contains("frames"));
+    EXPECT_EQ(5u, metadata["frames"].size());
+    EXPECT_EQ(5, metadata["performance"]["written_frames"].get<int>());
+}

--- a/tests/test_video_hdr_logic.cpp
+++ b/tests/test_video_hdr_logic.cpp
@@ -3,7 +3,6 @@
 
 #include "io/hdr_tonemap.hpp"
 #include "io/video_frame_extractor.hpp"
-#include "io/video/video_encoder.hpp"
 
 extern "C" {
 #include <libavutil/pixfmt.h>
@@ -11,17 +10,9 @@ extern "C" {
 
 #include <gtest/gtest.h>
 
-#include <cuda_runtime.h>
-
 #include <array>
-#include <chrono>
-#include <cstdint>
-#include <filesystem>
 #include <limits>
 #include <string>
-#include <string_view>
-#include <system_error>
-#include <vector>
 
 namespace {
 
@@ -30,111 +21,6 @@ namespace {
     using lfs::io::ResolutionMode;
     using lfs::io::VideoFrameExtractor;
 
-    struct TempDir {
-        explicit TempDir(const std::string_view label) {
-            const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
-            path = std::filesystem::temp_directory_path() /
-                   ("lfs_video_extract_" + std::string(label) + "_" + std::to_string(now));
-            std::filesystem::create_directories(path);
-        }
-
-        ~TempDir() {
-            std::error_code ec;
-            std::filesystem::remove_all(path, ec);
-        }
-
-        std::filesystem::path path;
-    };
-
-    struct CudaFloatBuffer {
-        explicit CudaFloatBuffer(const std::size_t count) {
-            status = cudaMalloc(reinterpret_cast<void**>(&ptr), count * sizeof(float));
-        }
-
-        ~CudaFloatBuffer() {
-            if (ptr)
-                cudaFree(ptr);
-        }
-
-        float* ptr = nullptr;
-        cudaError_t status = cudaSuccess;
-    };
-
-    void skipIfCudaUnavailable() {
-        int device_count = 0;
-        if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count <= 0)
-            GTEST_SKIP() << "CUDA device required for VideoEncoder-based fixture";
-    }
-
-    bool writeTinyEncodedVideo(const std::filesystem::path& video_path, std::string& error) {
-        constexpr int width = 16;
-        constexpr int height = 16;
-        constexpr int frame_count = 5;
-        constexpr int channels = 3;
-
-        lfs::io::video::VideoExportOptions options;
-        options.preset = lfs::io::video::VideoPreset::CUSTOM;
-        options.width = width;
-        options.height = height;
-        options.framerate = 10;
-        options.crf = 23;
-
-        lfs::io::video::VideoEncoder encoder;
-        if (const auto opened = encoder.open(video_path, options); !opened) {
-            error = opened.error();
-            return false;
-        }
-
-        std::vector<float> frame(static_cast<std::size_t>(width) * height * channels);
-        CudaFloatBuffer device_frame(frame.size());
-        if (device_frame.status != cudaSuccess) {
-            error = cudaGetErrorString(device_frame.status);
-            return false;
-        }
-
-        for (int frame_index = 0; frame_index < frame_count; ++frame_index) {
-            const float red = static_cast<float>(frame_index + 1) / static_cast<float>(frame_count);
-            for (int y = 0; y < height; ++y) {
-                for (int x = 0; x < width; ++x) {
-                    const std::size_t offset = (static_cast<std::size_t>(y) * width + x) * channels;
-                    frame[offset + 0] = red;
-                    frame[offset + 1] = static_cast<float>(x) / static_cast<float>(width - 1);
-                    frame[offset + 2] = static_cast<float>(y) / static_cast<float>(height - 1);
-                }
-            }
-
-            const cudaError_t copy_status = cudaMemcpy(
-                device_frame.ptr, frame.data(), frame.size() * sizeof(float), cudaMemcpyHostToDevice);
-            if (copy_status != cudaSuccess) {
-                error = cudaGetErrorString(copy_status);
-                return false;
-            }
-
-            if (const auto written = encoder.writeFrameGpu(device_frame.ptr, width, height); !written) {
-                error = written.error();
-                return false;
-            }
-        }
-
-        if (const auto closed = encoder.close(); !closed) {
-            error = closed.error();
-            return false;
-        }
-        return true;
-    }
-
-    VideoFrameExtractor::Params extractionParams(
-        const std::filesystem::path& video_path,
-        const std::filesystem::path& output_dir) {
-        VideoFrameExtractor::Params params;
-        params.video_path = video_path;
-        params.output_dir = output_dir;
-        params.mode = ExtractionMode::INTERVAL;
-        params.frame_interval = 1;
-        params.format = lfs::io::ImageFormat::PNG;
-        params.generate_metadata = true;
-        return params;
-    }
     VideoFrameExtractor::Params validParams() {
         VideoFrameExtractor::Params params;
         params.mode = ExtractionMode::FPS;
@@ -296,48 +182,4 @@ TEST(VideoFrameExtractorParams, RejectsInvalidRangesAndDimensions) {
     params.custom_height = 1;
     EXPECT_FALSE(VideoFrameExtractor::validateParams(
         params, 1920, 1080, 1.0 / 90000.0, layout, error));
-}
-
-TEST(VideoFrameExtractorOutputNaming, IntervalUsesSourceFrameNumbers) {
-    skipIfCudaUnavailable();
-
-    TempDir temp("interval");
-    const std::filesystem::path video_path = temp.path / "source.mp4";
-    const std::filesystem::path output_dir = temp.path / "frames";
-    std::filesystem::create_directories(output_dir);
-
-    std::string error;
-    ASSERT_TRUE(writeTinyEncodedVideo(video_path, error)) << error;
-
-    auto params = extractionParams(video_path, output_dir);
-    params.frame_interval = 2;
-
-    VideoFrameExtractor extractor;
-    EXPECT_TRUE(extractor.extract(params, error)) << error;
-    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_1.png"));
-    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_3.png"));
-    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_5.png"));
-    EXPECT_FALSE(std::filesystem::exists(output_dir / "frame_2.png"));
-}
-
-TEST(VideoFrameExtractorOutputNaming, TrimmedRangeKeepsOriginalSourceFrameNumbers) {
-    skipIfCudaUnavailable();
-
-    TempDir temp("trim");
-    const std::filesystem::path video_path = temp.path / "source.mp4";
-    const std::filesystem::path output_dir = temp.path / "frames";
-    std::filesystem::create_directories(output_dir);
-
-    std::string error;
-    ASSERT_TRUE(writeTinyEncodedVideo(video_path, error)) << error;
-
-    auto params = extractionParams(video_path, output_dir);
-    params.start_time = 0.19;
-    params.end_time = 0.31;
-
-    VideoFrameExtractor extractor;
-    EXPECT_TRUE(extractor.extract(params, error)) << error;
-    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_3.png"));
-    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_4.png"));
-    EXPECT_FALSE(std::filesystem::exists(output_dir / "frame_1.png"));
 }

--- a/tests/test_video_hdr_logic.cpp
+++ b/tests/test_video_hdr_logic.cpp
@@ -60,6 +60,12 @@ namespace {
         cudaError_t status = cudaSuccess;
     };
 
+    void skipIfCudaUnavailable() {
+        int device_count = 0;
+        if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count <= 0)
+            GTEST_SKIP() << "CUDA device required for VideoEncoder-based fixture";
+    }
+
     bool writeTinyEncodedVideo(const std::filesystem::path& video_path, std::string& error) {
         constexpr int width = 16;
         constexpr int height = 16;
@@ -293,6 +299,8 @@ TEST(VideoFrameExtractorParams, RejectsInvalidRangesAndDimensions) {
 }
 
 TEST(VideoFrameExtractorOutputNaming, IntervalUsesSourceFrameNumbers) {
+    skipIfCudaUnavailable();
+
     TempDir temp("interval");
     const std::filesystem::path video_path = temp.path / "source.mp4";
     const std::filesystem::path output_dir = temp.path / "frames";
@@ -313,6 +321,8 @@ TEST(VideoFrameExtractorOutputNaming, IntervalUsesSourceFrameNumbers) {
 }
 
 TEST(VideoFrameExtractorOutputNaming, TrimmedRangeKeepsOriginalSourceFrameNumbers) {
+    skipIfCudaUnavailable();
+
     TempDir temp("trim");
     const std::filesystem::path video_path = temp.path / "source.mp4";
     const std::filesystem::path output_dir = temp.path / "frames";

--- a/tests/test_video_hdr_logic.cpp
+++ b/tests/test_video_hdr_logic.cpp
@@ -3,6 +3,7 @@
 
 #include "io/hdr_tonemap.hpp"
 #include "io/video_frame_extractor.hpp"
+#include "io/video/video_encoder.hpp"
 
 extern "C" {
 #include <libavutil/pixfmt.h>
@@ -10,9 +11,17 @@ extern "C" {
 
 #include <gtest/gtest.h>
 
+#include <cuda_runtime.h>
+
 #include <array>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
 #include <limits>
 #include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
 
 namespace {
 
@@ -21,6 +30,105 @@ namespace {
     using lfs::io::ResolutionMode;
     using lfs::io::VideoFrameExtractor;
 
+    struct TempDir {
+        explicit TempDir(const std::string_view label) {
+            const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+            path = std::filesystem::temp_directory_path() /
+                   ("lfs_video_extract_" + std::string(label) + "_" + std::to_string(now));
+            std::filesystem::create_directories(path);
+        }
+
+        ~TempDir() {
+            std::error_code ec;
+            std::filesystem::remove_all(path, ec);
+        }
+
+        std::filesystem::path path;
+    };
+
+    struct CudaFloatBuffer {
+        explicit CudaFloatBuffer(const std::size_t count) {
+            status = cudaMalloc(reinterpret_cast<void**>(&ptr), count * sizeof(float));
+        }
+
+        ~CudaFloatBuffer() {
+            if (ptr)
+                cudaFree(ptr);
+        }
+
+        float* ptr = nullptr;
+        cudaError_t status = cudaSuccess;
+    };
+
+    bool writeTinyEncodedVideo(const std::filesystem::path& video_path, std::string& error) {
+        constexpr int width = 16;
+        constexpr int height = 16;
+        constexpr int frame_count = 5;
+        constexpr int channels = 3;
+
+        lfs::io::video::VideoExportOptions options;
+        options.preset = lfs::io::video::VideoPreset::CUSTOM;
+        options.width = width;
+        options.height = height;
+        options.framerate = 10;
+        options.crf = 23;
+
+        lfs::io::video::VideoEncoder encoder;
+        if (const auto opened = encoder.open(video_path, options); !opened) {
+            error = opened.error();
+            return false;
+        }
+
+        std::vector<float> frame(static_cast<std::size_t>(width) * height * channels);
+        CudaFloatBuffer device_frame(frame.size());
+        if (device_frame.status != cudaSuccess) {
+            error = cudaGetErrorString(device_frame.status);
+            return false;
+        }
+
+        for (int frame_index = 0; frame_index < frame_count; ++frame_index) {
+            const float red = static_cast<float>(frame_index + 1) / static_cast<float>(frame_count);
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    const std::size_t offset = (static_cast<std::size_t>(y) * width + x) * channels;
+                    frame[offset + 0] = red;
+                    frame[offset + 1] = static_cast<float>(x) / static_cast<float>(width - 1);
+                    frame[offset + 2] = static_cast<float>(y) / static_cast<float>(height - 1);
+                }
+            }
+
+            const cudaError_t copy_status = cudaMemcpy(
+                device_frame.ptr, frame.data(), frame.size() * sizeof(float), cudaMemcpyHostToDevice);
+            if (copy_status != cudaSuccess) {
+                error = cudaGetErrorString(copy_status);
+                return false;
+            }
+
+            if (const auto written = encoder.writeFrameGpu(device_frame.ptr, width, height); !written) {
+                error = written.error();
+                return false;
+            }
+        }
+
+        if (const auto closed = encoder.close(); !closed) {
+            error = closed.error();
+            return false;
+        }
+        return true;
+    }
+
+    VideoFrameExtractor::Params extractionParams(
+        const std::filesystem::path& video_path,
+        const std::filesystem::path& output_dir) {
+        VideoFrameExtractor::Params params;
+        params.video_path = video_path;
+        params.output_dir = output_dir;
+        params.mode = ExtractionMode::INTERVAL;
+        params.frame_interval = 1;
+        params.format = lfs::io::ImageFormat::PNG;
+        params.generate_metadata = true;
+        return params;
+    }
     VideoFrameExtractor::Params validParams() {
         VideoFrameExtractor::Params params;
         params.mode = ExtractionMode::FPS;
@@ -182,4 +290,44 @@ TEST(VideoFrameExtractorParams, RejectsInvalidRangesAndDimensions) {
     params.custom_height = 1;
     EXPECT_FALSE(VideoFrameExtractor::validateParams(
         params, 1920, 1080, 1.0 / 90000.0, layout, error));
+}
+
+TEST(VideoFrameExtractorOutputNaming, IntervalUsesSourceFrameNumbers) {
+    TempDir temp("interval");
+    const std::filesystem::path video_path = temp.path / "source.mp4";
+    const std::filesystem::path output_dir = temp.path / "frames";
+    std::filesystem::create_directories(output_dir);
+
+    std::string error;
+    ASSERT_TRUE(writeTinyEncodedVideo(video_path, error)) << error;
+
+    auto params = extractionParams(video_path, output_dir);
+    params.frame_interval = 2;
+
+    VideoFrameExtractor extractor;
+    EXPECT_TRUE(extractor.extract(params, error)) << error;
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_1.png"));
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_3.png"));
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_5.png"));
+    EXPECT_FALSE(std::filesystem::exists(output_dir / "frame_2.png"));
+}
+
+TEST(VideoFrameExtractorOutputNaming, TrimmedRangeKeepsOriginalSourceFrameNumbers) {
+    TempDir temp("trim");
+    const std::filesystem::path video_path = temp.path / "source.mp4";
+    const std::filesystem::path output_dir = temp.path / "frames";
+    std::filesystem::create_directories(output_dir);
+
+    std::string error;
+    ASSERT_TRUE(writeTinyEncodedVideo(video_path, error)) << error;
+
+    auto params = extractionParams(video_path, output_dir);
+    params.start_time = 0.19;
+    params.end_time = 0.31;
+
+    VideoFrameExtractor extractor;
+    EXPECT_TRUE(extractor.extract(params, error)) << error;
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_3.png"));
+    EXPECT_TRUE(std::filesystem::exists(output_dir / "frame_4.png"));
+    EXPECT_FALSE(std::filesystem::exists(output_dir / "frame_1.png"));
 }


### PR DESCRIPTION
## Summary

This patch changes video frame extractor output naming so the numeric token in the filename pattern represents the 1-based source video frame number, not the sequence number of the extracted output image.

For the default `frame_%d` pattern, extracting every other frame from a five-frame source now writes names such as `frame_1.png`, `frame_3.png`, and `frame_5.png`. A trimmed extraction keeps numbering relative to the original video, so a trim that starts at source frame 3 writes `frame_3.png` rather than restarting at `frame_1.png`.

## Observed Symptoms

The extractor's default filename pattern is `frame_%d`. Users reasonably interpret `%d` as the actual video frame number, but the implementation passed extraction counters into the formatter. As a result, skipped frames and trimmed ranges produced compact output sequences that did not match the source video frame numbers.

Example replication steps for the original issue:

1. Open the Extract Frames from Video panel.
2. Use the default `frame_%d` filename pattern.
3. Extract every 2nd frame from a video.
4. Observe that the output files are named `frame_1`, `frame_2`, `frame_3`, even though they correspond to source frames 1, 3, and 5.
5. Repeat with a trimmed range starting later in the video and observe that numbering restarts at 1 instead of preserving the original source frame index.

## Root Cause

`formatFrameFilenameStem()` already formats the number it receives correctly. The bug was in the extraction write paths: they passed `saved_count + 1` or `written_count + 1`, which are output/extraction counters, while the extractor already tracked the selected source frame as `current_src_frame` and stored it in metadata as `source_frame`.

Sharpness window mode had the same issue through `written_count + 1`, even though the winning candidate already carried its `source_frame`.

## What This Patch Fixes

- Normal hardware decode writes now generate filenames from `current_src_frame`.
- Normal software decode writes now generate filenames from `current_src_frame`.
- Sharpness window writes now generate filenames from the selected candidate's `source_frame`.
- The `VideoFrameExtractor::Params::filename_pattern` comment now documents that `%d` means the 1-based source video frame number.
- Added deployed-path coverage that creates a tiny encoded video through the existing video encoder, runs the real extractor, and checks full interval and trimmed-range filename side effects together with the extractor return contract.

## Impact Check

- GUI: The existing video extractor dialog passes the filename pattern through unchanged, so the GUI inherits the corrected naming behavior. No new user-facing strings were added.
- CLI: No direct CLI extractor surface was found in the inspected code.
- Python API/plugin: The Python file menu operator only opens the native video extractor panel, so it inherits the GUI behavior without API changes.
- MCP: No direct video frame extraction MCP tool was found in the inspected app/MCP surfaces.
- Metadata: Existing metadata `source_frame` values are unchanged; filenames now align with those values.

