### PR TITLE
Remove dead no-op event handlers from VisualizerImpl

### DIFF
--- a/src/core/include/core/events.hpp
+++ b/src/core/include/core/events.hpp
@@ -57,7 +57,6 @@ namespace lfs::core {
             EVENT(ResumeTraining, );
             EVENT(StopTraining, );
             EVENT(ResetTraining, );
-            EVENT(SwitchToLatestCheckpoint, );
             EVENT(SaveCheckpoint, std::optional<int> iteration;);
             EVENT(LoadFile, std::filesystem::path path; bool is_dataset; std::filesystem::path output_path; std::filesystem::path init_path; std::string centralize_dataset; std::optional<int> max_width; std::optional<int> min_track_length; bool apply_auto_crop = false;);
             EVENT(LoadCheckpointForTraining, std::filesystem::path checkpoint_path; std::filesystem::path dataset_path; std::filesystem::path output_path;);

--- a/src/python/lfs/notification_bridge.cpp
+++ b/src/python/lfs/notification_bridge.cpp
@@ -106,8 +106,6 @@ namespace lfs::python {
                     if (clicked == edit_label)
                         cmd::SwitchToEditMode{}.emit();
                 });
-
-            cmd::SwitchToLatestCheckpoint{}.emit();
         });
     }
 

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -1192,10 +1192,6 @@ namespace lfs::vis {
         });
 
         // File loading commands
-        cmd::LoadFile::when([this](const auto& cmd) {
-            handleLoadFileCommand(cmd);
-        });
-
         cmd::LoadConfigFile::when([this](const auto& cmd) {
             handleLoadConfigFile(cmd.path);
         });
@@ -1209,10 +1205,6 @@ namespace lfs::vis {
             if (window_manager_) {
                 window_manager_->requestClose();
             }
-        });
-
-        cmd::SwitchToLatestCheckpoint::when([this](const auto&) {
-            handleSwitchToLatestCheckpoint();
         });
 
         // Signal bridge event handlers
@@ -1614,11 +1606,7 @@ namespace lfs::vis {
                                         std::max(kTooltipRevealMinWaitSeconds, *tooltip_wait));
         }
 
-        if (is_training) {
-            window_manager_->waitEvents(wait_seconds); // Training tick is capped at ~10 Hz when no resize settle is due.
-        } else {
-            window_manager_->waitEvents(wait_seconds);
-        }
+        window_manager_->waitEvents(wait_seconds);
     }
 
     void VisualizerImpl::render() {
@@ -2210,10 +2198,6 @@ namespace lfs::vis {
         restore_camera();
     }
 
-    void VisualizerImpl::handleLoadFileCommand([[maybe_unused]] const lfs::core::events::cmd::LoadFile& cmd) {
-        // File loading is handled by the data_loader_ service
-    }
-
     void VisualizerImpl::handleLoadConfigFile(const std::filesystem::path& path) {
         auto result = lfs::core::param::read_optim_params_from_json(path);
         if (!result) {
@@ -2285,11 +2269,6 @@ namespace lfs::vis {
             window_manager_->requestClose();
         }
         wakeMainLoop();
-    }
-
-    void VisualizerImpl::handleSwitchToLatestCheckpoint() {
-        // This event is emitted by the training flow even when no project/checkpoint manager is active.
-        // In the plain dataset workflow there is nothing to switch, so treat it as a no-op.
     }
 
 } // namespace lfs::vis

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -178,14 +178,12 @@ namespace lfs::vis {
         void setupEventHandlers();
         void setupComponentConnections();
         void handleTrainingCompleted(const lfs::core::events::state::TrainingCompleted& event);
-        void handleLoadFileCommand(const lfs::core::events::cmd::LoadFile& cmd);
         void handleLoadConfigFile(const std::filesystem::path& path);
         void handleNewProject();
         void performNewProject();
         void schedulePendingTrainingAction();
         void performPendingTrainingAction();
         void requestApplicationClose();
-        void handleSwitchToLatestCheckpoint();
         void performReset();
         void resetProjectState();
 


### PR DESCRIPTION
Three pure deletions found while reading `visualizer_impl.cpp`. No behaviour change.

## What was dead

**`VisualizerImpl::handleLoadFileCommand`** — an empty no-op whose body was a single comment. The real `cmd::LoadFile` subscribers are `DataLoadingService` (`data_loading_service.cpp:45`) and `AsyncTaskManager` (`async_task_manager.cpp:708`); both are untouched. The subscription here only added an event-bus hop that did nothing.

**`cmd::SwitchToLatestCheckpoint`** — emitted unconditionally from `notification_bridge.cpp` on every training completion, with exactly one subscriber, also a no-op. The event had no effect anywhere in the build, so the whole chain is gone: the emit, the `EVENT(...)` declaration in `events.hpp`, the subscription, and the handler. The sibling `cmd::SwitchToEditMode` emit in the same lambda has a real subscriber and stays.

**Identical branch in `waitForNextEvent`** — `if (is_training)` and its `else` both called `waitEvents(wait_seconds)` with the same argument, so the branch decided nothing. Collapsed to one call. `is_training` is still used for the `is_training ? 0.1 : 0.5` wait above, which is where the ~10 Hz training cap actually lives; the trailing comment claiming otherwise on the shared line would have been misleading.

Net: -27 lines, +1.

## How this was checked

- build clean
- `clang-format` clean on all four touched files. `events.hpp` reports three violations around lines 158/311/312, but they reproduce identically on an unmodified master checkout, so they are pre-existing and left alone
- `grep -rn "SwitchToLatestCheckpoint" src/` and `grep -rn "VisualizerImpl::handleLoadFileCommand" src/` both return nothing
- 32 targeted gtests pass (`Visualizer*`, `*Event*`)
- ran the viewer on a 5M splat PLY: loads and renders, clean shutdown, zero errors and zero criticals in the log