### PR TITLE
Fix NVCC dllimport/dllexport conflict in memory arena diagnostics check

### DIFF
--- a/src/core/cuda/memory_arena.hpp
+++ b/src/core/cuda/memory_arena.hpp
@@ -295,8 +295,8 @@ namespace lfs::core {
         void reconfigure_for_testing(RasterizerMemoryArena::Config config);
 
     private:
-        friend GlobalArenaManager& global_arena_manager();
-        friend void shutdown_global_arena_manager();
+        friend LFS_CORE_API GlobalArenaManager& global_arena_manager();
+        friend LFS_CORE_API void shutdown_global_arena_manager();
 
         GlobalArenaManager() = default;
         ~GlobalArenaManager() = default;


### PR DESCRIPTION
## Description

This PR fixes the Windows NVCC warning emitted while compiling the CUDA diagnostics check:

```text
warning #1397-D: dllexport/dllimport conflict with
lfs::core::global_arena_manager