### PR TITLE
Fix Empty-Name Group Merge When Merging To Single PLY

### DIFF
--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -596,8 +596,10 @@ namespace lfs::vis {
 
         cmd::MergeGroupById::when([this](const auto& cmd) {
             const auto* node = scene_.getNodeById(static_cast<core::NodeId>(cmd.node_id));
-            if (node)
-                mergeGroupNode(node->name);
+            if (node) {
+                const std::string node_name = node->name;
+                mergeGroupNode(node_name);
+            }
         });
 
         // Handle node selection from scene panel (both PLYs and Groups)
@@ -4120,13 +4122,14 @@ namespace lfs::vis {
     }
 
     std::string SceneManager::mergeGroupNode(const std::string& name) {
-        const auto* group = scene_.getNode(name);
+        const std::string group_name = name;
+        const auto* group = scene_.getNode(group_name);
         if (!group || group->type != core::NodeType::GROUP) {
             return {};
         }
 
         const auto history_options = sceneGraphCaptureOptions(true, false);
-        auto history_before = op::SceneGraphPatchEntry::captureState(*this, {name}, history_options);
+        auto history_before = op::SceneGraphPatchEntry::captureState(*this, {group_name}, history_options);
         const core::NodeId group_id = group->id;
         const core::NodeId parent_id = group->parent_id;
 
@@ -4140,7 +4143,7 @@ namespace lfs::vis {
         // Check if the group being merged is currently selected
         bool was_selected = false;
         {
-            const core::NodeId group_nid = scene_.getNodeIdByName(name);
+            const core::NodeId group_nid = scene_.getNodeIdByName(group_name);
             if (group_nid != core::NULL_NODE && selection_.isNodeSelected(group_nid)) {
                 was_selected = true;
                 selection_.removeFromSelection(group_nid);
@@ -4174,14 +4177,14 @@ namespace lfs::vis {
 
         auto merged_model = core::Scene::mergeSplatsWithTransforms(splats);
         if (!merged_model) {
-            LOG_WARN("Failed to merge group '{}'", name);
+            LOG_WARN("Failed to merge group '{}'", group_name);
             return {};
         }
 
         if (auto allocator = makeExternalSplatAllocator()) {
             if (auto migrated = lfs::io::migrateSplatTensorsToAllocator(*merged_model, allocator); !migrated) {
                 LOG_ERROR("Failed to prepare merged group '{}' for rendering: {}",
-                          name,
+                          group_name,
                           migrated.error().format());
                 return {};
             }
@@ -4190,10 +4193,10 @@ namespace lfs::vis {
 
         {
             core::Scene::Transaction txn(scene_);
-            scene_.removeNode(name, false);
-            scene_.addSplat(name, std::move(merged_model), parent_id);
+            scene_.removeNode(group_name, false);
+            scene_.addSplat(group_name, std::move(merged_model), parent_id);
         }
-        const std::string merged_name = name;
+        const std::string merged_name = group_name;
         selection_.invalidateNodeMask();
 
         // Emit PLYRemoved for all original children and the group
@@ -4208,7 +4211,7 @@ namespace lfs::vis {
         }
 
         state::PLYRemoved{
-            .name = name,
+            .name = group_name,
             .children_kept = false,
             .parent_of_removed = {},
             .from_history = false,
@@ -4243,7 +4246,7 @@ namespace lfs::vis {
             }
         }
 
-        LOG_INFO("Merged group '{}' -> '{}'", name, merged_name);
+        LOG_INFO("Merged group '{}' -> '{}'", group_name, merged_name);
         pushSceneGraphHistoryEntry(*this, "Merge Group", std::move(history_before), {merged_name}, history_options);
         return merged_name;
     }

--- a/tests/test_error_envelope.cpp
+++ b/tests/test_error_envelope.cpp
@@ -123,7 +123,7 @@ TEST(ErrorEnvelopeTest, InvalidUtf8DetailPathSerializesUnderStrictDump) {
         .domain = lfs::ErrorDomain::IO,
         .user_message = "Load failed",
         .detection = LFS_SOURCE_SITE_CURRENT(),
-        .fields = lfs::SmallFields{}.add("path", std::string("/data/sc\xff\x80ene.ply")),
+        .fields = lfs::SmallFields{}.add("path", std::string("/data/sc\xff\x80" "ene.ply")),
     });
 
     const nlohmann::json envelope = lfs::core::to_wire_envelope(error);

--- a/tests/test_undo_history.cpp
+++ b/tests/test_undo_history.cpp
@@ -1898,6 +1898,46 @@ TEST_F(UndoHistoryTest, DeleteKeepChildrenRestoresHierarchyOnUndo) {
     EXPECT_EQ(child->parent_id, lfs::core::NULL_NODE);
 }
 
+TEST_F(UndoHistoryTest, MergeGroupNodeHandlesNameReferenceFromGroupNode) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    auto& scene = scene_manager->getScene();
+    const auto group_id = scene.addGroup("group");
+    ASSERT_NE(group_id, lfs::core::NULL_NODE);
+    const auto child_a_id = scene.addSplat("child_a", make_test_splat({0.0f, 0.0f, 0.0f}), group_id);
+    const auto child_b_id = scene.addSplat(
+        "child_b",
+        make_test_splat({
+            1.0f,
+            0.0f,
+            0.0f,
+            2.0f,
+            0.0f,
+            0.0f,
+        }),
+        group_id);
+    ASSERT_NE(child_a_id, lfs::core::NULL_NODE);
+    ASSERT_NE(child_b_id, lfs::core::NULL_NODE);
+    scene_manager->changeContentType(lfs::vis::SceneManager::ContentType::SplatFiles);
+
+    const auto* group = scene.getNodeById(group_id);
+    ASSERT_NE(group, nullptr);
+
+    const auto merged_name = scene_manager->mergeGroupNode(group->name);
+
+    EXPECT_EQ(merged_name, "group");
+    const auto* merged = scene.getNode("group");
+    ASSERT_NE(merged, nullptr);
+    EXPECT_EQ(merged->type, lfs::core::NodeType::SPLAT);
+    EXPECT_EQ(scene.getNodeById(child_a_id), nullptr);
+    EXPECT_EQ(scene.getNodeById(child_b_id), nullptr);
+    EXPECT_EQ(merged->gaussian_count.load(std::memory_order_acquire), 3u);
+    EXPECT_EQ(scene.getTotalGaussianCount(), 3u);
+}
+
 TEST_F(UndoHistoryTest, DeleteResultHonorsTrainingRemovalPolicy) {
     auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
     auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();


### PR DESCRIPTION
Fixes #1458  

## Summary

This patch fixes the Scene Navigation `Merge to Single PLY` path for groups. The merge code now keeps a stable copy of the group name before removing the original group node, so the replacement splat is created with the intended name instead of sometimes using an invalid string.

It also adds a focused regression test that reproduces the original failure mode by passing the group node's own `name` reference into `SceneManager::mergeGroupNode()`.

Original issue: https://github.com/MrNeRF/LichtFeld-Studio/issues/1458

## Observed Symptoms

When merging a group into a single PLY, the operation could appear to delete the group and its splat children instead of replacing them with one merged splat.

The repro log showed the merge attempting to create a node with an empty name:

```text
[01:27:29.869] [warn] scene.cpp:171  Cannot add node with empty name
[01:27:29.871] [info] scene_manager.cpp:4246  Merged group '' -> ''
```

That log is the important clue: the merge was not failing because of a duplicate name. It was losing the group name during the merge.

## Replication Steps For The Original Issue

1. Load a `.ply` model.
2. Duplicate the `.ply`.
3. Move the duplicate so both models are visible separately.
4. In Scene Navigation, create a new group.
5. Move both splat nodes into that group.
6. Right-click the group and choose `Merge to Single PLY`.
7. Before this patch, the group and children could disappear, with the log showing `Cannot add node with empty name` and `Merged group '' -> ''`.

## What This Patch Fixes

- Copies `node->name` before dispatching `MergeGroupById` to avoid passing a scene-node-owned string reference into merge logic.
- Copies the `mergeGroupNode()` input into a local `group_name` immediately and uses that stable copy for lookup, history capture, removal, replacement insertion, events, logging, and return value.
- Adds `UndoHistoryTest.MergeGroupNodeHandlesNameReferenceFromGroupNode`, which intentionally passes `group->name` directly to reproduce the dangerous path.
- Keeps the small MSVC test-build fix for `tests/test_error_envelope.cpp`, splitting a hex escape so `\x80` is not parsed together with following hex-looking characters.

## Root Cause

`MergeGroupById` looked up the group node by id and called:

```cpp
mergeGroupNode(node->name);
```

`mergeGroupNode()` accepted that as `const std::string& name`. If the reference pointed to the group node's own `name` member, the function later removed that same group node:

```cpp
scene_.removeNode(name, false);
scene_.addSplat(name, std::move(merged_model), parent_id);
```

Removing the group destroys the string object backing `name`. Every later use of `name` is then a dangling reference. In the observed run, that dangling reference read back as an empty string, so `addSplat()` tried to add a node named `""` and failed with `Cannot add node with empty name`.

## Why The Issue Showed Up

The UI context-menu flow uses `MergeGroupById`, so it naturally passes through the id-to-node lookup path. That made it possible for the merge function's `name` parameter to alias the very node being removed.

Tests or callers that passed an independent `std::string` copy did not expose the bug, which is why the earlier happy-path merge tests could pass while the UI action still failed.

## Verification

The new regression test failed before the fix with the same symptom as the user log:

```text
Cannot add node with empty name
Merged group '' -> ''
```

After the fix:

```text
UndoHistoryTest.MergeGroupNodeHandlesNameReferenceFromGroupNode passed
Merged group 'group' -> 'group'
```

