### PR TITLE
theme: tokenise close button hover highlight

### DIFF
--- a/src/visualizer/gui/rmlui/resources/components.rcss
+++ b/src/visualizer/gui/rmlui/resources/components.rcss
@@ -69,9 +69,6 @@ body.docked-panel {
     cursor: pointer;
 }
 
-#close-btn:hover {
-    background-color: rgba(255, 255, 255, 18);
-}
 
 #content-wrap {
     display: flex;

--- a/src/visualizer/gui/rmlui/resources/components.theme.rcss
+++ b/src/visualizer/gui/rmlui/resources/components.theme.rcss
@@ -43,6 +43,7 @@ body.floating-panel {
 
 #close-btn:hover {
     color: @{error};
+    background-color: @{alpha(text,0.07)};
 }
 
 .panel-title,


### PR DESCRIPTION
## Summary

Moves the close button hover highlight from the shared base stylesheet into the themed component stylesheet.

## Why

The base rule used a hard-coded white RGBA value, which made the hover state ignore the active theme. The replacement derives the highlight from the existing `text` token.

## Impact

The close button hover treatment now adapts to each shipped theme while preserving the subtle highlight treatment.

Fixes #1446.

## Validation

- Verified the branch diff changes only `components.rcss` and `components.theme.rcss` (1 addition, 3 deletions).
- Verified the raw close-button hover rule is absent from the base stylesheet and the themed token rule is present.
- The full local C++ test suite was not run because this environment could not complete the repository checkout; please rely on the repository CI for the final build validation.
