### PR TITLE
docs: centralize source build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ Thanks for your interest in contributing!
    - Not sure where to start? Ask on [Discord](https://discord.gg/TbxJST2BbC)
 
 2. **Setup**
-   - Follow the repo-local [source build guide](docs/building_and_distribution.md) for toolchain setup, the pre-commit hook, and test commands
+   - Installation and user documentation are available in the [Wiki](https://github.com/MrNeRF/LichtFeld-Studio/wiki)
+   - Developers should follow the repo-local [source build guide](docs/building_and_distribution.md) for toolchain setup, the pre-commit hook, and test commands
 
 3. **Make Your Changes**
    - Apply `clang-format` before committing
@@ -67,6 +68,7 @@ requests and pushes to `master`; the identical-value audit remains opt-in.
 ## Need Help?
 
 - Join our [Discord](https://discord.gg/TbxJST2BbC) for questions and discussions
+- Check the [Wiki](https://github.com/MrNeRF/LichtFeld-Studio/wiki) for user documentation
 - Check the [source build guide](docs/building_and_distribution.md) for build and test documentation
 - Look at the [FAQ](https://github.com/MrNeRF/LichtFeld-Studio/wiki/Frequently-Asked-Questions)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,7 @@ Thanks for your interest in contributing!
    - Not sure where to start? Ask on [Discord](https://discord.gg/TbxJST2BbC)
 
 2. **Setup**
-   - Installation instructions are in the [Wiki](https://github.com/MrNeRF/LichtFeld-Studio/wiki)
-   - Install the pre-commit hook: `cp tools/pre-commit .git/hooks/`
+   - Follow the repo-local [source build guide](docs/building_and_distribution.md) for toolchain setup, the pre-commit hook, and test commands
 
 3. **Make Your Changes**
    - Apply `clang-format` before committing
@@ -68,7 +67,7 @@ requests and pushes to `master`; the identical-value audit remains opt-in.
 ## Need Help?
 
 - Join our [Discord](https://discord.gg/TbxJST2BbC) for questions and discussions
-- Check the [Wiki](https://github.com/MrNeRF/LichtFeld-Studio/wiki) for documentation
+- Check the [source build guide](docs/building_and_distribution.md) for build and test documentation
 - Look at the [FAQ](https://github.com/MrNeRF/LichtFeld-Studio/wiki/Frequently-Asked-Questions)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ LichtFeld Studio lets you train new scenes from COLMAP datasets, resume checkpoi
 [![Donorbox](https://img.shields.io/badge/Donorbox-Support-27A9E1)](https://donorbox.org/lichtfeld-studio)
 
 [**Download Windows**](https://github.com/MrNeRF/LichtFeld-Studio/releases) •
-[**Build From Source**](https://github.com/MrNeRF/LichtFeld-Studio/wiki/) •
+[**Build From Source**](docs/building_and_distribution.md) •
 [**Plugin System**](docs/plugin-system.md) •
 [**MCP Guide**](docs/docs/development/mcp/index.md) •
 [**Support Development**](#support-development) •
@@ -79,7 +79,8 @@ LichtFeld Studio is free and open source. If it is useful in your research, prod
 
 Windows binaries are now available through the Lichtfeld Portal. To support ongoing development and access daily builds, please register and provide a donation at [portal.lichtfeld.io](https://portal.lichtfeld.io/). Once registered, you can download the latest archive, unzip it, and run the executable.
 
-For building from source and platform-specific notes, see the [Wiki](https://github.com/MrNeRF/LichtFeld-Studio/wiki/) and the repo-local docs in [docs/README.md](docs/README.md).
+For building from source and platform-specific notes, see the repo-local
+[source build guide](docs/building_and_distribution.md).
 
 Current project notes:
 
@@ -92,6 +93,7 @@ Current project notes:
 
 - [Project Wiki](https://github.com/MrNeRF/LichtFeld-Studio/wiki/)
 - [FAQ](https://github.com/MrNeRF/LichtFeld-Studio/wiki/Frequently-Asked-Questions)
+- [Source Build Guide](docs/building_and_distribution.md)
 - [Plugin System](docs/plugin-system.md)
 - [Plugin Developer Guide](docs/plugins/getting-started.md)
 - [MCP Guide](docs/docs/development/mcp/index.md)
@@ -112,7 +114,7 @@ Getting started:
 
 - Check issues labeled `good first issue`
 - Join the [Discord](https://discord.gg/TbxJST2BbC) if you want to discuss implementation details before opening a larger change
-- Install the pre-commit hook with `cp tools/pre-commit .git/hooks/`
+- Follow the [source build guide](docs/building_and_distribution.md) for toolchain setup, the pre-commit hook, and test commands
 
 ## Corporate Sponsors
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ LichtFeld Studio is free and open source. If it is useful in your research, prod
 
 Windows binaries are now available through the Lichtfeld Portal. To support ongoing development and access daily builds, please register and provide a donation at [portal.lichtfeld.io](https://portal.lichtfeld.io/). Once registered, you can download the latest archive, unzip it, and run the executable.
 
-For building from source and platform-specific notes, see the repo-local
+For building from source and platform-specific notes, see the
+[Wiki](https://github.com/MrNeRF/LichtFeld-Studio/wiki/). Developers can find
+contributor setup and test commands in the repo-local
 [source build guide](docs/building_and_distribution.md).
 
 Current project notes:

--- a/docs/building_and_distribution.md
+++ b/docs/building_and_distribution.md
@@ -30,6 +30,18 @@ set CUDNN_ROOT_DIR=C:\Program Files\NVIDIA\CUDNN\v9.24
 For unusual layouts, pass `-DLFS_CUDNN_BIN_DIR=...` directly to the cuDNN DLL
 directory, for example `...\bin\<cuda-version>\x64`.
 
+## Contributor Setup
+
+Install the repository's pre-commit hook after cloning:
+
+```bash
+cp tools/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+The hook applies `clang-format` to staged C, C++, and CUDA source files outside
+`external/` before each commit.
+
 ## Linux Prerequisites
 
 On Linux, LichtFeld Studio requires SDL3 to be built with at least one windowing backend (`x11` or `wayland`).
@@ -77,6 +89,45 @@ cmake --install build --prefix ./dist
 # Example training run
 ./dist/bin/run_lichtfeld.sh -d /path/to/data -o /path/to/output
 ```
+
+## Tests
+
+Tests are a separate opt-in build:
+
+```bash
+cmake -S . -B build/tests -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_TESTS=ON
+cmake --build build/tests \
+  --target lichtfeld_tests tensor_hardening_tests \
+  -j6
+```
+
+Run the CTest label that matches the subsystem and cost of the change:
+
+| Label | Use it for |
+|---|---|
+| `fast` | Default developer loop: core unit tests, fast Python tests, focused GPU contracts, and some real-data loader checks |
+| `slow` | Dataset loaders, training, interop, and other multi-second integration paths |
+| `nightly` | Stress, large-tensor, real-data, and optional-codec coverage |
+| `hardening` | Isolated tensor hardening and crash-prone oracle tests |
+| `discovery` | Discovery fuzzing and parameter sweeps |
+| `gpu` | All registered tests that require GPU execution |
+
+For example:
+
+```bash
+ctest --test-dir build/tests --output-on-failure -L fast
+ctest --test-dir build/tests --output-on-failure -L slow
+ctest --test-dir build/tests --output-on-failure -L nightly
+```
+
+The repository intentionally ignores `data/`, but several fast, slow, nightly,
+and GPU tests read real files from `data/bicycle` or `data/garden`. Populate
+those paths with compatible real datasets before running the affected tiers.
+Synthetic placeholder input is not a substitute: loader, training, image-codec,
+and checkpoint tests assert the expected images, masks, COLMAP files, or point
+cloud exist on disk.
 
 ## What's the Difference?
 

--- a/docs/docs/development/build.md
+++ b/docs/docs/development/build.md
@@ -128,12 +128,7 @@ CUDA: native (native)
 
 ## Tests
 
-Tests remain opt-in and have their own manifest dependency feature:
-
-```sh
-cmake -S . -B build/tests -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
-cmake --build build/tests --target lichtfeld_tests -j6
-```
-
-This keeps test-only package restore and target generation out of the normal
-application loop without changing any shipped feature.
+Tests remain opt-in, keeping test-only package restore and target generation
+out of the normal application loop without changing any shipped feature. The
+canonical [source build guide](../../building_and_distribution.md#tests)
+documents the test build targets, CTest tiers, and required real-data layout.


### PR DESCRIPTION
## Summary

- make `docs/building_and_distribution.md` the repo-local developer source-build authority
- retain and link the Wiki as the user-facing documentation surface
- link the developer guide from the README and contributing documentation
- document contributor hook setup, test build targets, CTest tiers, and real-data requirements
- point the existing repository development build page at the canonical test section to avoid drift

## Verification

- `git diff --check`
- `python3 tools/check_locale_completeness.py` — 1770 English keys passed
- validated documented targets and labels against `tests/CMakeLists.txt`
- validated hook setup against `tools/pre-commit`
- validated real-data requirements against the affected tests and ignored `data/` layout
- independently reviewed the documentation links and maintainer-requested Wiki preservation

Closes #1493
