### PR TITLE
Scene Graph Camera Group Active Count

### DIFF
--- a/src/core/include/core/scene.hpp
+++ b/src/core/include/core/scene.hpp
@@ -150,6 +150,11 @@ namespace lfs::core {
             bool has_selection = false;
         };
 
+        struct CameraTrainingCounts {
+            size_t enabled = 0;
+            size_t total = 0;
+        };
+
         enum class MutationType : uint32_t {
             NODE_ADDED = 1 << 0,
             NODE_REMOVED = 1 << 1,
@@ -373,6 +378,7 @@ namespace lfs::core {
         [[nodiscard]] std::vector<std::shared_ptr<lfs::core::Camera>> getAllCameras() const;
         [[nodiscard]] std::vector<std::shared_ptr<lfs::core::Camera>> getActiveCameras() const;
         [[nodiscard]] size_t getActiveCameraCount() const;
+        [[nodiscard]] CameraTrainingCounts getCameraTrainingCounts(NodeId camera_group_id) const;
         void setCameraTrainingEnabled(const std::string& name, bool enabled);
         void setCameraTrainingEnabled(NodeId id, bool enabled);
 

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -3546,6 +3546,24 @@ namespace lfs::core {
         return count;
     }
 
+    Scene::CameraTrainingCounts Scene::getCameraTrainingCounts(const NodeId camera_group_id) const {
+        const SceneNode* const group = getNodeById(camera_group_id);
+        if (!group || group->type != NodeType::CAMERA_GROUP)
+            return {};
+
+        CameraTrainingCounts counts;
+        for (const NodeId child_id : group->children) {
+            const SceneNode* const child = getNodeById(child_id);
+            if (!child || child->type != NodeType::CAMERA || !child->camera)
+                continue;
+
+            ++counts.total;
+            if (child->training_enabled)
+                ++counts.enabled;
+        }
+        return counts;
+    }
+
     void Scene::setCameraTrainingEnabled(const std::string& name, bool enabled) {
         const NodeId id = getNodeIdByName(name);
         if (id == NULL_NODE)

--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
@@ -82,8 +82,6 @@ namespace lfs::vis::gui {
         [[nodiscard]] std::string formatCameraGroupLabel(
             const std::string& name,
             const core::Scene::CameraTrainingCounts counts) {
-            if (counts.total == 0)
-                return name;
             if (counts.enabled == counts.total)
                 return std::format("{}  ({})", name, formatWithThousands(counts.total));
             return std::format("{}  ({}/{})",

--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
@@ -79,6 +79,19 @@ namespace lfs::vis::gui {
             return name;
         }
 
+        [[nodiscard]] std::string formatCameraGroupLabel(
+            const std::string& name,
+            const core::Scene::CameraTrainingCounts counts) {
+            if (counts.total == 0)
+                return name;
+            if (counts.enabled == counts.total)
+                return std::format("{}  ({})", name, formatWithThousands(counts.total));
+            return std::format("{}  ({}/{})",
+                               name,
+                               formatWithThousands(counts.enabled),
+                               formatWithThousands(counts.total));
+        }
+
         [[nodiscard]] std::string lowerCopy(std::string value) {
             std::ranges::transform(value, value.begin(), [](const unsigned char c) {
                 return static_cast<char>(std::tolower(c));
@@ -847,9 +860,9 @@ namespace lfs::vis::gui {
                 break;
             }
             case core::NodeType::CAMERA_GROUP:
-                snapshot.label = std::format("{}  ({})",
-                                             node->name,
-                                             formatWithThousands(node->children.size()));
+                snapshot.label = formatCameraGroupLabel(
+                    node->name,
+                    scene.getCameraTrainingCounts(node->id));
                 break;
             case core::NodeType::KEYFRAME:
                 if (node->keyframe)

--- a/tests/test_scene_validity.cpp
+++ b/tests/test_scene_validity.cpp
@@ -1098,6 +1098,48 @@ namespace lfs::python {
         EXPECT_TRUE(scene.getNodeById(group)->children.empty());
     }
 
+    TEST_F(SceneValidityTest, CameraGroupTrainingCountsTrackEnabledDirectChildren) {
+        lfs::vis::SceneManager sm;
+        auto& scene = sm.getScene();
+        const core::NodeId cameras = scene.addGroup("Cameras");
+        const core::NodeId training = scene.addCameraGroup("Training", cameras, 3);
+        const core::NodeId validation = scene.addCameraGroup("Validation", cameras, 1);
+        const core::NodeId non_camera_child = scene.addGroup("Nested", training);
+        const core::NodeId train_a = scene.addCamera("train_a.png", training, make_test_camera());
+        const core::NodeId train_b = scene.addCamera("train_b.png", training, make_test_camera());
+        const core::NodeId train_c = scene.addCamera("train_c.png", training, make_test_camera());
+        const core::NodeId val_a = scene.addCamera("val_a.png", validation, make_test_camera());
+        ASSERT_NE(non_camera_child, core::NULL_NODE);
+        ASSERT_NE(train_a, core::NULL_NODE);
+        ASSERT_NE(train_b, core::NULL_NODE);
+        ASSERT_NE(train_c, core::NULL_NODE);
+        ASSERT_NE(val_a, core::NULL_NODE);
+
+        auto counts = scene.getCameraTrainingCounts(training);
+        EXPECT_EQ(counts.enabled, 3u);
+        EXPECT_EQ(counts.total, 3u);
+        EXPECT_EQ(scene.getActiveCameraCount(), 4u);
+
+        scene.setCameraTrainingEnabled(train_b, false);
+
+        counts = scene.getCameraTrainingCounts(training);
+        EXPECT_EQ(counts.enabled, 2u);
+        EXPECT_EQ(counts.total, 3u);
+        EXPECT_EQ(scene.getActiveCameraCount(), 3u);
+
+        const auto validation_counts = scene.getCameraTrainingCounts(validation);
+        EXPECT_EQ(validation_counts.enabled, 1u);
+        EXPECT_EQ(validation_counts.total, 1u);
+
+        const auto invalid_counts = scene.getCameraTrainingCounts(core::NULL_NODE);
+        EXPECT_EQ(invalid_counts.enabled, 0u);
+        EXPECT_EQ(invalid_counts.total, 0u);
+
+        const auto non_camera_group_counts = scene.getCameraTrainingCounts(cameras);
+        EXPECT_EQ(non_camera_group_counts.enabled, 0u);
+        EXPECT_EQ(non_camera_group_counts.total, 0u);
+    }
+
     TEST_F(SceneValidityTest, SceneManagerBlocksActiveCameraSubtreeAndAllowsInactiveCameraRemoval) {
         const ScopedServicesClear services_scope;
         lfs::vis::SceneManager sm;


### PR DESCRIPTION
## Summary

When importing a dataset, the scene graph displays a camera group such as `Training (103)` using the total number of camera children. After disabling cameras for training, the row still displays `Training (103)`, making it look like all cameras are still active.

Camera group rows in the scene graph now show active training cameras (for example `Training (100/103)` when some cameras in the group are disabled. Fully enabled groups keep the existing compact total count.

## Reproduction Steps

1. Load a dataset with a camera group, for example `Training (103)`.
2. Disable one or more cameras for training from the scene graph context menu.
3. Observe that the camera group row still shows the original total count.

## Root Cause

The RmlUI scene graph label for `CAMERA_GROUP` nodes used `node->children.size()`. That counted direct child nodes but did not distinguish cameras enabled for training from cameras disabled for training. The core scene already tracked per-camera `training_enabled` state and exposed a whole-scene active camera count, but there was no per-camera-group active/total query for the scene tree label.

## What This Patch Fixes

- Adds `Scene::CameraTrainingCounts` and `Scene::getCameraTrainingCounts(NodeId)` to report enabled and total direct camera children for a camera group.
- Updates the scene graph camera-group label to display:
  - `Training (103)` when all direct cameras are enabled.
  - `Training (100/103)` when only 100 of 103 direct cameras are enabled.
- Ignores malformed non-camera direct children in camera group counts.
- Leaves CLI, Python API, and MCP behavior unchanged.

