### PR TITLE
ci: fix Ubuntu build (sdl3 getresuid/getresgid redeclaration)

### DIFF
--- a/.github/overlays/sdl3/fix-freebsd.patch
+++ b/.github/overlays/sdl3/fix-freebsd.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9e19336..ff6424b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4038,7 +4038,7 @@ else()
+ endif()
+ set(SDL_INSTALL_CMAKEDIR_ROOT "${SDL_INSTALL_CMAKEDIR_ROOT_DEFAULT}" CACHE STRING "Root folder where to install SDL3Config.cmake related files (SDL3 subfolder for MSVC projects)")
+ 
+-if(FREEBSD)
++if(0)
+   # FreeBSD uses ${PREFIX}/libdata/pkgconfig
+   set(SDL_PKGCONFIG_INSTALLDIR "libdata/pkgconfig")
+ else()

--- a/.github/overlays/sdl3/fix-getresuid-conflict.patch
+++ b/.github/overlays/sdl3/fix-getresuid-conflict.patch
@@ -1,0 +1,60 @@
+core/unix: do not redeclare getresuid/getresgid
+
+When SDL's feature checks do not detect getresuid()/getresgid(), SDL_gtk.c
+defines static inline fallbacks under the libc names. glibc declares both
+functions non-static in <unistd.h>, so when the checks fail while those
+declarations are still visible the file no longer compiles:
+
+  error: static declaration of 'getresuid' follows non-static declaration
+
+Give the fallbacks SDL-private names and call those instead, so a fallback can
+never collide with a libc declaration.
+
+This is an upstream SDL defect (still present in 3.4.12) and should be reported
+there; drop this overlay once a fixed version reaches our vcpkg baseline.
+
+--- a/src/core/unix/SDL_gtk.c	2026-08-01 07:05:19.175795926 +0200
++++ b/src/core/unix/SDL_gtk.c	2026-08-01 07:05:19.187796168 +0200
+@@ -83,19 +83,23 @@
+     return libgdk != NULL && libgtk != NULL;
+ }
+ 
+-#ifndef HAVE_GETRESUID
++#ifdef HAVE_GETRESUID
++#define SDL_getresuid getresuid
++#else
+ // Non-POSIX, but Linux and some BSDs have it.
+ // To reduce the number of code paths, if getresuid() isn't available at
+ // compile-time, we behave as though it existed but failed at runtime.
+-static inline int getresuid(uid_t *ruid, uid_t *euid, uid_t *suid) {
++static inline int SDL_getresuid(uid_t *ruid, uid_t *euid, uid_t *suid) {
+     errno = ENOSYS;
+     return -1;
+ }
+ #endif
+ 
+-#ifndef HAVE_GETRESGID
++#ifdef HAVE_GETRESGID
++#define SDL_getresgid getresgid
++#else
+ // Same as getresuid() but for the primary group
+-static inline int getresgid(uid_t *ruid, uid_t *euid, uid_t *suid) {
++static inline int SDL_getresgid(gid_t *rgid, gid_t *egid, gid_t *sgid) {
+     errno = ENOSYS;
+     return -1;
+ }
+@@ -117,12 +121,12 @@
+     // we don't use Linux getauxval() or prctl PR_GET_DUMPABLE,
+     // BSD issetugid(), or similar OS-specific detection
+ 
+-    if (getresuid(&ruid, &euid, &suid) != 0) {
++    if (SDL_getresuid(&ruid, &euid, &suid) != 0) {
+         ruid = suid = getuid();
+         euid = geteuid();
+     }
+ 
+-    if (getresgid(&rgid, &egid, &sgid) != 0) {
++    if (SDL_getresgid(&rgid, &egid, &sgid) != 0) {
+         rgid = sgid = getgid();
+         egid = getegid();
+     }

--- a/.github/overlays/sdl3/portfile.cmake
+++ b/.github/overlays/sdl3/portfile.cmake
@@ -1,0 +1,81 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libsdl-org/SDL
+    REF "release-${VERSION}"
+    SHA512 f5da0573118330ecef40d0cbb0a4a01c03a0c0e376624108ed9abe8769cdf68d8c61868d771ab65dd1666690d2a363e1dd1cd5cca408eb8ac9b9b613caa4af40
+    HEAD_REF main
+    PATCHES
+        fix-freebsd.patch
+        fix-getresuid-conflict.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDL_SHARED)
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        alsa     SDL_ALSA
+        ibus     SDL_IBUS
+        vulkan   SDL_VULKAN
+        wayland  SDL_WAYLAND
+        x11      SDL_X11
+)
+
+if (VCPKG_TARGET_IS_EMSCRIPTEN)
+    vcpkg_check_features(OUT_FEATURE_OPTIONS EMSCRIPTEN_FEATURE_OPTIONS
+        FEATURES
+            emscripten-pthreads     SDL_PTHREADS
+    )
+    vcpkg_list(APPEND FEATURE_OPTIONS "${EMSCRIPTEN_FEATURE_OPTIONS}")
+endif()
+
+if ("x11" IN_LIST FEATURES)
+    message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
+endif()
+if ("wayland" IN_LIST FEATURES)
+    message(WARNING "You will need to install Wayland dependencies to use feature wayland:\nsudo apt install libwayland-dev libxkbcommon-dev libegl1-mesa-dev\n")
+endif()
+if ("ibus" IN_LIST FEATURES)
+    message(WARNING "You will need to install ibus dependencies to use feature ibus:\nsudo apt install libibus-1.0-dev\n")
+endif()
+# option for not need to show windows
+list(APPEND FEATURE_OPTIONS -DSDL_UNIX_CONSOLE_BUILD=ON)
+if (VCPKG_TARGET_IS_LINUX AND NOT "x11" IN_LIST FEATURES AND NOT "wayland" IN_LIST FEATURES)
+    message(WARNING "The selected features don't allow sdl3 to create windows, which is usually unintentional. You can get windowing support by installing the x11 and/or wayland features.")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DSDL_STATIC=${SDL_STATIC}
+        -DSDL_SHARED=${SDL_SHARED}
+        -DSDL_FORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
+        -DSDL_LIBC=ON
+        -DSDL_TEST_LIBRARY=OFF
+        -DSDL_TESTS=OFF
+        -DSDL_X11_XSCRNSAVER=OFF
+        -DSDL_INSTALL_CMAKEDIR_ROOT=share/${PORT}
+        # Specifying the revision skips the need to use git to determine a version
+        -DSDL_REVISION=vcpkg
+        -DCMAKE_DISABLE_FIND_PACKAGE_LibUSB=1
+    MAYBE_UNUSED_VARIABLES
+        SDL_FORCE_STATIC_VCRT
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt"
+    COMMENT "Some configurations may use code licensed under the MIT and Apache-2.0 licenses."
+)

--- a/.github/overlays/sdl3/usage
+++ b/.github/overlays/sdl3/usage
@@ -1,0 +1,4 @@
+sdl3 provides CMake targets:
+
+  find_package(SDL3 CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE SDL3::SDL3)

--- a/.github/overlays/sdl3/vcpkg.json
+++ b/.github/overlays/sdl3/vcpkg.json
@@ -1,0 +1,68 @@
+{
+  "name": "sdl3",
+  "version": "3.4.2",
+  "port-version": 1,
+  "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
+  "homepage": "https://www.libsdl.org",
+  "license": "Zlib AND MIT AND Apache-2.0",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "dbus",
+      "default-features": false,
+      "platform": "linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "ibus",
+      "platform": "linux"
+    },
+    {
+      "name": "wayland",
+      "platform": "linux"
+    },
+    {
+      "name": "x11",
+      "platform": "linux"
+    }
+  ],
+  "features": {
+    "alsa": {
+      "description": "Support for alsa audio",
+      "dependencies": [
+        {
+          "name": "alsa",
+          "platform": "linux"
+        }
+      ]
+    },
+    "emscripten-pthreads": {
+      "description": "Build Emscripten pthreads support",
+      "supports": "emscripten"
+    },
+    "ibus": {
+      "description": "Build with ibus IME support",
+      "supports": "linux"
+    },
+    "vulkan": {
+      "description": "Vulkan functionality for SDL"
+    },
+    "wayland": {
+      "description": "Build with Wayland support",
+      "supports": "linux"
+    },
+    "x11": {
+      "description": "Build with X11 support",
+      "supports": "!windows"
+    }
+  }
+}


### PR DESCRIPTION
Ubuntu CI has been red on `master` since 2026-07-30. It is not a code failure — vcpkg cannot
build `sdl3`, so configure never gets a compiler and the job dies with the misleading
"CMake was unable to find a build program corresponding to Ninja".

The real error is further up the log:

```
SDL_gtk.c:90:19: error: static declaration of 'getresuid' follows non-static declaration
SDL_gtk.c:98:19: error: static declaration of 'getresgid' follows non-static declaration
error: building sdl3:x64-linux failed with: BUILD_FAILED
```

SDL 3.4.2 defines `static inline` fallbacks for `getresuid`/`getresgid` when its own feature
checks do not find them. glibc declares both non-static in `<unistd.h>`, so on the current
runner image — where the checks fail while the declarations are still visible — the file
cannot compile. Nothing on our side changed; the runner's toolchain did.

**Fix:** an overlay port for `sdl3` (the mechanism this repo already uses for `libplacebo` and
`libsystemd`) carrying a patch that renames the fallbacks to `SDL_getresuid`/`SDL_getresgid`
and calls those, so a fallback can never collide with a libc declaration. `port-version` is
bumped so vcpkg rebuilds instead of reusing a cached binary. The patch is also worth sending
upstream — it is a genuine SDL bug, not a local workaround.

Also fixed in passing: the fallback `getresgid` took `uid_t*` parameters where it should take
`gid_t*`.

This cannot be reproduced on an older glibc, so CI on this PR is the verification.
