### PR TITLE
lichtfeld_tests Link Fix

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -186,6 +186,7 @@ nanobind_add_module(
     lfs/py_packages.cpp
     lfs/py_params.cpp
     lfs/py_plugins.cpp
+    lfs/py_operator_properties.cpp
     lfs/py_ui.cpp
     lfs/py_ui_context.cpp
     lfs/py_ui_theme.cpp

--- a/src/python/lfs/py_operator_properties.cpp
+++ b/src/python/lfs/py_operator_properties.cpp
@@ -1,0 +1,30 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "py_ui.hpp"
+
+namespace lfs::python {
+
+    PyOperatorProperties::PyOperatorProperties(const std::string& operator_id)
+        : operator_id_(operator_id),
+          properties_(nb::dict()) {
+    }
+
+    void PyOperatorProperties::set_property(const std::string& name, nb::object value) {
+        properties_[nb::str(name.c_str())] = std::move(value);
+    }
+
+    nb::object PyOperatorProperties::get_property(const std::string& name) const {
+        auto key = nb::str(name.c_str());
+        if (properties_.contains(key)) {
+            return properties_[key];
+        }
+        return nb::none();
+    }
+
+    nb::dict PyOperatorProperties::get_properties() const {
+        return properties_;
+    }
+
+} // namespace lfs::python

--- a/src/python/lfs/py_ui_operators.cpp
+++ b/src/python/lfs/py_ui_operators.cpp
@@ -8,27 +8,6 @@
 
 namespace lfs::python {
 
-    PyOperatorProperties::PyOperatorProperties(const std::string& operator_id)
-        : operator_id_(operator_id),
-          properties_(nb::dict()) {
-    }
-
-    void PyOperatorProperties::set_property(const std::string& name, nb::object value) {
-        properties_[nb::str(name.c_str())] = std::move(value);
-    }
-
-    nb::object PyOperatorProperties::get_property(const std::string& name) const {
-        auto key = nb::str(name.c_str());
-        if (properties_.contains(key)) {
-            return properties_[key];
-        }
-        return nb::none();
-    }
-
-    nb::dict PyOperatorProperties::get_properties() const {
-        return properties_;
-    }
-
     void register_operator_return_value(nb::module_& m) {
         nb::class_<PyOperatorReturnValue>(m, "OperatorReturnValue")
             .def_ro("status", &PyOperatorReturnValue::status, "Result status string")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -276,7 +276,9 @@ set(TEST_SOURCES test_main.cpp ${TEST_FILES})
 
 # PyModalRegistry and its native-modal dispatch path for regression tests.
 list(APPEND TEST_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/python/lfs/py_error.cpp
     ${CMAKE_SOURCE_DIR}/src/python/lfs/py_modal_registry.cpp
+    ${CMAKE_SOURCE_DIR}/src/python/lfs/py_operator_properties.cpp
     ${CMAKE_SOURCE_DIR}/src/python/lfs/py_ui_modals.cpp
     ${CMAKE_SOURCE_DIR}/src/python/lfs/rml_im_mode_layout.cpp
     ${CMAKE_SOURCE_DIR}/src/app/mcp_sequencer_tools.cpp
@@ -359,6 +361,7 @@ target_link_libraries(lichtfeld_tests PRIVATE
 
     # System libraries
     spdlog::spdlog
+    SDL3::SDL3
 )
 
 target_link_libraries(lichtfeld_tests PRIVATE lfs_vulkan_rasterizer Vulkan::Vulkan)

--- a/tests/device_fault_cuda_utils.cu
+++ b/tests/device_fault_cuda_utils.cu
@@ -44,7 +44,7 @@ namespace device_fault_test {
                                        const bool trap_after_record,
                                        const int blocks,
                                        const int threads_per_block,
-                                       const cudaStream_t stream) {
+                                       cudaStream_t stream) {
         many_oob_record_kernel<<<blocks, threads_per_block, 0, stream>>>(
             fault, op_id, value, bound, trap_after_record);
         return cudaGetLastError();


### PR DESCRIPTION
## Summary

The `lichtfeld_tests` target failed at the final MSVC link step with unresolved
symbols from three areas:

- the CUDA device-fault test helper
- direct SDL3 calls in `test_visualizer_post_work.cpp`
- Python/RmlUi immediate-mode layout support code

The fixes make the test executable link the same native dependencies it already
uses, and keep the Python value-type dependency narrow enough that the tests do
not need to pull in the full Python operator registration path.

## Changes

### CUDA helper ABI mismatch

`tests/device_fault_cuda_utils.cu` exported
`device_fault_test::launch_many_oob_record`, but its final parameter was declared
as `const cudaStream_t stream` in the implementation.

On Windows, `cudaStream_t` is a pointer typedef. Adding `const` to the typedef
makes the exported MSVC symbol use `CUstream_st * const`, while callers from the
header expected `CUstream_st *`. Both files compiled, but the decorated linker
names did not match.

Fix:

- Removed `const` from the implementation parameter so it matches the header:
  `cudaStream_t stream`.

### SDL3 test dependency

`tests/test_visualizer_post_work.cpp` calls SDL3 functions directly:

- `SDL_Init`
- `SDL_FlushEvents`
- `SDL_HasEvents`

The test target included SDL headers through existing include/link surfaces, but
`lichtfeld_tests` did not link `SDL3::SDL3` directly. That left the executable
without the SDL import library at final link.

Fix:

- Added `SDL3::SDL3` to `target_link_libraries(lichtfeld_tests ...)`.

### Python/RmlUi layout symbols

`tests/CMakeLists.txt` compiles `src/python/lfs/rml_im_mode_layout.cpp` directly
for the Rml immediate-mode layout tests. That source depends on:

- `lfs::python::contain_python_callback`
- `lfs::python::PyOperatorProperties`

The test target already had a runtime dependency on `lfs_py`, but a runtime
dependency does not satisfy native symbols needed while linking
`lichtfeld_tests.exe`.

Fix:

- Added `src/python/lfs/py_error.cpp` to the test sources for
  `contain_python_callback`.
- Split `PyOperatorProperties` into a small new source file:
  `src/python/lfs/py_operator_properties.cpp`.
- Added that new source to both the production `lfs_py` module and the
  `lichtfeld_tests` sources.

The split avoids adding all of `py_ui_operators.cpp` to the test executable,
because that file also pulls in Python operator registry functionality such as
`get_python_operator_instance`.

## Files Changed

- `tests/device_fault_cuda_utils.cu`
- `tests/CMakeLists.txt`
- `src/python/CMakeLists.txt`
- `src/python/lfs/py_ui_operators.cpp`
- `src/python/lfs/py_operator_properties.cpp`

## Verification

The target was rebuilt from the Visual Studio x64 developer environment:

```powershell
cmake --build build-tests-release --target lichtfeld_tests
```

Result:

- `lichtfeld_tests` built successfully.
- The previous unresolved symbols for `launch_many_oob_record`, SDL3, and the
  Python/RmlUi layout helpers were resolved.
- The executable was produced at:
  `build-tests-release/tests/lichtfeld_tests.exe`
