### PR TITLE
Fix PPISP Checkpoint Resume Color Regularizer State

### DIFF
--- a/src/training/components/ppisp.cpp
+++ b/src/training/components/ppisp.cpp
@@ -148,6 +148,10 @@ namespace lfs::training {
                                             color_params_.ptr<float>(), crf_params_.ptr<float>(), num_cameras_,
                                             num_frames_, nullptr);
 
+        init_color_pinv_block_diag();
+    }
+
+    void PPISP::init_color_pinv_block_diag() {
         // ZCA pinv block-diagonal matrix for color mean regularization
         // 8x8 block-diagonal: [Blue 2x2, Red 2x2, Green 2x2, Neutral 2x2]
         // From Python: _COLOR_PINV_BLOCK_DIAG
@@ -1169,6 +1173,7 @@ namespace lfs::training {
         ctrl_bwd_rgb_h_ = 0;
         ctrl_bwd_rgb_w_ = 0;
 
+        init_color_pinv_block_diag();
         finalized_ = true;
     }
 
@@ -1208,7 +1213,6 @@ namespace lfs::training {
         uid_to_frame_idx_.swap(loaded.uid_to_frame_idx_);
         uid_to_camera_id_.swap(loaded.uid_to_camera_id_);
         std::swap(finalized_, loaded.finalized_);
-        std::swap(color_pinv_block_diag_, loaded.color_pinv_block_diag_);
     }
 
     void PPISP::serialize_inference(std::ostream& os) const {
@@ -1265,6 +1269,7 @@ namespace lfs::training {
             uid_to_frame_idx_[i] = i;
             uid_to_camera_id_[i] = 0;
         }
+        init_color_pinv_block_diag();
         finalized_ = true;
     }
 

--- a/src/training/components/ppisp.hpp
+++ b/src/training/components/ppisp.hpp
@@ -214,6 +214,7 @@ namespace lfs::training {
         int translate_frame(int uid) const;
 
         void allocate_tensors();
+        void init_color_pinv_block_diag();
 
         // Parameter tensors (all on GPU)
         // Exposure: [num_frames] - per-frame exposure in log-space

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -221,6 +221,7 @@ set(TEST_FILES
     test_ppisp_controller.cpp
     test_ppisp_regularization.cpp
     test_ppisp_sidecar.cpp
+    test_ppisp_checkpoint_roundtrip.cpp
     test_ppisp_cuda_vs_torch.cpp
     test_ppisp_banded_region.cpp
     test_export_env_composite.cpp

--- a/tests/test_ppisp_checkpoint_roundtrip.cpp
+++ b/tests/test_ppisp_checkpoint_roundtrip.cpp
@@ -64,15 +64,7 @@ namespace {
         return loss.cpu().item<float>();
     }
 
-    class PPISPCheckpointRoundtripTest : public ::testing::Test {
-    protected:
-        void SetUp() override {
-            if (!tensor_hardening::has_cuda_device()) {
-                GTEST_SKIP() << "CUDA device required";
-            }
-            ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
-        }
-    };
+    class PPISPCheckpointRoundtripTest : public tensor_hardening::CudaTest {};
 
     TEST_F(PPISPCheckpointRoundtripTest, AdoptCheckpointStatePreservesColorMeanRegularizer) {
         PPISPConfig config;

--- a/tests/test_ppisp_checkpoint_roundtrip.cpp
+++ b/tests/test_ppisp_checkpoint_roundtrip.cpp
@@ -1,0 +1,136 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "components/ppisp.hpp"
+#include "core/tensor.hpp"
+#include "tensor_hardening_test_utils.hpp"
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <vector>
+
+namespace {
+
+    using lfs::core::Device;
+    using lfs::core::Tensor;
+    using lfs::training::PPISP;
+    using lfs::training::PPISPConfig;
+
+    Tensor make_input(float base) {
+        std::vector<float> values(3 * 4 * 4);
+        for (size_t i = 0; i < values.size(); ++i) {
+            values[i] = base + 0.01f * static_cast<float>(i);
+        }
+        return Tensor::from_vector(values, {3, 4, 4}, Device::CUDA);
+    }
+
+    Tensor make_grad(float value) {
+        std::vector<float> values(3 * 4 * 4, value);
+        return Tensor::from_vector(values, {3, 4, 4}, Device::CUDA);
+    }
+
+    void register_test_frames(PPISP& ppisp) {
+        ppisp.register_frame(101, 20);
+        ppisp.register_frame(102, 20);
+        ppisp.register_frame(201, 30);
+        ppisp.finalize();
+    }
+
+    void update_ppisp(PPISP& ppisp, int camera_id, int uid, float input_base, float grad_value, int steps) {
+        for (int i = 0; i < steps; ++i) {
+            const auto input = make_input(input_base + static_cast<float>(i) * 0.05f);
+            const auto grad = make_grad(grad_value + static_cast<float>(i) * 0.01f);
+            (void)ppisp.apply(input, camera_id, uid);
+            (void)ppisp.backward(input, grad, camera_id, uid);
+            ppisp.optimizer_step();
+            ppisp.zero_grad();
+            ppisp.scheduler_step();
+        }
+    }
+
+    void train_nontrivial_state(PPISP& ppisp) {
+        update_ppisp(ppisp, 20, 101, 0.10f, 0.03f, 2);
+        update_ppisp(ppisp, 20, 102, 0.20f, 0.05f, 2);
+        update_ppisp(ppisp, 30, 201, 0.30f, 0.07f, 2);
+    }
+
+    float expect_loss_contract(PPISP& ppisp) {
+        const auto loss = ppisp.reg_loss_gpu();
+        EXPECT_TRUE(loss.is_valid());
+        EXPECT_EQ(loss.device(), Device::CUDA);
+        EXPECT_EQ(loss.ndim(), 1u);
+        EXPECT_EQ(loss.numel(), 1u);
+        return loss.cpu().item<float>();
+    }
+
+    class PPISPCheckpointRoundtripTest : public ::testing::Test {
+    protected:
+        void SetUp() override {
+            if (!tensor_hardening::has_cuda_device()) {
+                GTEST_SKIP() << "CUDA device required";
+            }
+            ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+        }
+    };
+
+    TEST_F(PPISPCheckpointRoundtripTest, AdoptCheckpointStatePreservesColorMeanRegularizer) {
+        PPISPConfig config;
+        config.lr = 1e-2;
+        config.warmup_steps = 0;
+        config.color_mean = 1.0f;
+
+        PPISP source(1000, config);
+        register_test_frames(source);
+        train_nontrivial_state(source);
+        const float expected = expect_loss_contract(source);
+        ASSERT_TRUE(std::isfinite(expected));
+
+        std::stringstream checkpoint;
+        source.serialize(checkpoint);
+        checkpoint.seekg(0);
+
+        PPISP live(1000, config);
+        register_test_frames(live);
+
+        PPISP loaded(1);
+        loaded.deserialize(checkpoint);
+        live.adopt_checkpoint_state(loaded);
+
+        EXPECT_TRUE(live.isFinalized());
+        EXPECT_EQ(live.get_step(), source.get_step());
+
+        float restored = 0.0f;
+        EXPECT_NO_THROW(restored = expect_loss_contract(live));
+        EXPECT_NEAR(restored, expected, 1e-5f);
+
+        EXPECT_NO_THROW(live.reg_backward());
+        live.optimizer_step();
+        const float after_step = expect_loss_contract(live);
+        EXPECT_TRUE(std::isfinite(after_step));
+        EXPECT_GT(std::abs(after_step - restored), 1e-9f);
+    }
+
+    TEST_F(PPISPCheckpointRoundtripTest, DeserializeInferencePreservesColorMeanRegularizer) {
+        PPISPConfig config;
+        config.lr = 1e-2;
+        config.warmup_steps = 0;
+        config.color_mean = 1.0f;
+
+        PPISP source(1000, config);
+        register_test_frames(source);
+        train_nontrivial_state(source);
+
+        std::stringstream inference_weights;
+        source.serialize_inference(inference_weights);
+        inference_weights.seekg(0);
+
+        PPISP restored(1);
+        restored.deserialize_inference(inference_weights);
+
+        float loss = 0.0f;
+        EXPECT_NO_THROW(loss = expect_loss_contract(restored));
+        EXPECT_TRUE(std::isfinite(loss));
+    }
+
+} // namespace


### PR DESCRIPTION
fixes #1469

## Summary

This patch fixes a crash when resuming a training checkpoint created with PPISP enabled. The non-serialized ZCA pseudo-inverse matrix used by PPISP color-mean regularization is now rebuilt on every construction/restore path, and checkpoint adoption no longer swaps that constant as if it were checkpoint state.

## Observed Symptoms

Resuming a `--ppisp` checkpoint loads successfully, then fails on the first optimizer commit step. The failure report shows:

```text
Failed expression: is_valid()
Context: device transfer requires a valid tensor
Tensor::to(Device, CUstream_st*) <- Tensor::cpu()
Training step failed: iteration=4726, step_phase=OptimizerCommit
```

Replication for the original issue:

1. Load a checkpoint trained with `--ppisp`.
2. Resume training.
3. Observe that the first step after resume enters PPISP regularization and crashes while reading `color_pinv_block_diag_.cpu()`.

## Root Cause

`PPISP::color_pinv_block_diag_` is a constant CUDA tensor used by the color-mean regularizer. It is initialized during `finalize()` via `allocate_tensors()`, but it is intentionally not serialized.

The checkpoint load path constructs a temporary `PPISP`, calls `deserialize()`, and then calls `adopt_checkpoint_state()` on the live finalized instance. Before this patch:

- `deserialize()` rebuilt gradients and scratch buffers, then set `finalized_ = true`, but never rebuilt `color_pinv_block_diag_`.
- `adopt_checkpoint_state()` swapped `color_pinv_block_diag_`, moving the live valid constant into the temporary object and moving the invalid default tensor into the active PPISP.
- `reg_loss_gpu()` and `reg_backward()` then attempted `color_pinv_block_diag_.cpu()` and hit the tensor validity assertion.

## What This Patch Fixes

- Adds `PPISP::init_color_pinv_block_diag()` to centralize the constant tensor initialization.
- Calls the helper from `allocate_tensors()` for fresh runs.
- Calls the helper from `deserialize()` before marking the object finalized.
- Calls the helper from `deserialize_inference()` before marking the object finalized.
- Removes the `color_pinv_block_diag_` swap from `adopt_checkpoint_state()` because the tensor is derived constant state, not checkpoint state.
- Adds `PPISPCheckpointRoundtripTest`, which serializes, deserializes, adopts checkpoint state into a live PPISP, and exercises both `reg_loss_gpu()` return behavior and `reg_backward()` side effects.

