### PR TITLE
fix: pre-flight GPU check — refuse cards below SM 7.5 with clear message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,9 +329,6 @@ endif()
 # Minimum SM for PTX-only (75=Turing, 80=Ampere, 86=GA102, 89=Ada, 90=Hopper)
 set(BUILD_CUDA_MIN_SM "75" CACHE STRING "Minimum SM for PTX-only builds")
 
-# Bake the minimum SM into the binary so runtime can fail-fast on unsupported GPUs.
-add_compile_definitions(LFS_MIN_SM=${BUILD_CUDA_MIN_SM})
-
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CUDA_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -398,6 +395,7 @@ if(BUILD_CUDA_PTX_ONLY)
     endif()
 
     set(LichtFeld-Studio_CUDA_ARCH "${BUILD_CUDA_MIN_SM}-virtual")
+    set(LFS_RUNTIME_MIN_SM "${BUILD_CUDA_MIN_SM}")
 
     math(EXPR _maj "${BUILD_CUDA_MIN_SM}/10")
     math(EXPR _min "${BUILD_CUDA_MIN_SM}%10")
@@ -407,8 +405,16 @@ if(BUILD_CUDA_PTX_ONLY)
 else()
     # Native GPU only
     set(TORCH_CUDA_ARCH_LIST "${DETECTED_COMPUTE_CAP}" CACHE STRING "" FORCE)
+    string(REPLACE "." "" LFS_RUNTIME_MIN_SM "${DETECTED_COMPUTE_CAP}")
     message(STATUS "CUDA: native (${LichtFeld-Studio_CUDA_ARCH})")
 endif()
+
+if(NOT LFS_RUNTIME_MIN_SM MATCHES "^[0-9]+$")
+    message(WARNING "Could not derive a runtime SM floor from '${LFS_RUNTIME_MIN_SM}'; "
+        "falling back to 70. The startup GPU check will be permissive.")
+    set(LFS_RUNTIME_MIN_SM "70")
+endif()
+message(STATUS "Runtime GPU floor: SM ${LFS_RUNTIME_MIN_SM}")
 
 enable_language(CUDA)
 find_package(CUDAToolkit 12.8 REQUIRED)
@@ -644,6 +650,10 @@ add_executable(${PROJECT_NAME}
     src/app/converter.cpp
     resources/lichtfeld-studio.rc
 )
+
+# The binary only carries code for these architectures; the app refuses to start on anything
+# lower instead of dying inside the first kernel launch (#1540).
+target_compile_definitions(${PROJECT_NAME} PRIVATE LFS_MIN_SM=${LFS_RUNTIME_MIN_SM})
 
 foreach(_lfs_git_version_consumer IN ITEMS
         ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,9 @@ endif()
 # Minimum SM for PTX-only (75=Turing, 80=Ampere, 86=GA102, 89=Ada, 90=Hopper)
 set(BUILD_CUDA_MIN_SM "75" CACHE STRING "Minimum SM for PTX-only builds")
 
+# Bake the minimum SM into the binary so runtime can fail-fast on unsupported GPUs.
+add_compile_definitions(LFS_MIN_SM=${BUILD_CUDA_MIN_SM})
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CUDA_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -75,14 +75,6 @@ LichtFeld Studio is free and open source. If it is useful in your research, prod
 [![PayPal](https://img.shields.io/badge/PayPal-00457C?style=for-the-badge&logo=paypal&logoColor=white)](https://paypal.me/MrNeRF)
 [![Support on Donorbox](https://img.shields.io/badge/Donate-Donorbox-27A9E1?style=for-the-badge)](https://donorbox.org/lichtfeld-studio)
 
-## Requirements
-
-- NVIDIA RTX 20-series or newer (compute capability 7.5+)
-- NVIDIA driver 570+
-- Windows
-
-GTX 10-series and older, AMD, and Intel GPUs are not supported.
-
 ## Installation
 
 Windows binaries are now available through the Lichtfeld Portal. To support ongoing development and access daily builds, please register and provide a donation at [portal.lichtfeld.io](https://portal.lichtfeld.io/). Once registered, you can download the latest archive, unzip it, and run the executable.
@@ -95,9 +87,10 @@ contributor setup and test commands in the repo-local
 Current project notes:
 
 - Windows is the primary prebuilt distribution target today
-- LichtFeld Studio targets NVIDIA GPUs
+- LichtFeld Studio requires an NVIDIA GPU with compute capability 7.5 or newer (GTX 16-series,
+  RTX 20-series and up). GTX 10-series and older, AMD, and Intel GPUs are not supported
+- NVIDIA driver 570 or newer is required (CUDA 12.8+)
 - Source builds use modern C++23 and CUDA 12.8+ toolchains
-- Use a recent NVIDIA driver for current Windows builds
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ LichtFeld Studio is free and open source. If it is useful in your research, prod
 [![PayPal](https://img.shields.io/badge/PayPal-00457C?style=for-the-badge&logo=paypal&logoColor=white)](https://paypal.me/MrNeRF)
 [![Support on Donorbox](https://img.shields.io/badge/Donate-Donorbox-27A9E1?style=for-the-badge)](https://donorbox.org/lichtfeld-studio)
 
+## Requirements
+
+- NVIDIA RTX 20-series or newer (compute capability 7.5+)
+- NVIDIA driver 570+
+- Windows
+
+GTX 10-series and older, AMD, and Intel GPUs are not supported.
+
 ## Installation
 
 Windows binaries are now available through the Lichtfeld Portal. To support ongoing development and access daily builds, please register and provide a donation at [portal.lichtfeld.io](https://portal.lichtfeld.io/). Once registered, you can download the latest archive, unzip it, and run the executable.

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -49,6 +49,10 @@
 #include <windows.h>
 #endif
 
+#ifndef LFS_MIN_SM
+#define LFS_MIN_SM 75
+#endif
+
 namespace lfs::app {
 
     namespace {
@@ -513,7 +517,13 @@ namespace lfs::app {
 
             LOG_INFO("CUDA driver version: {}.{}", info.major, info.minor);
             if (!info.supported) {
-                LOG_WARN("CUDA {}.{} unsupported. Requires 12.8+ (driver 570+)", info.major, info.minor);
+                LOG_ERROR("CUDA driver too old. Requires 12.8+ (driver 570+)");
+#ifdef WIN32
+                MessageBoxW(NULL,
+                    L"NVIDIA driver too old. Please update to driver 570 or newer.",
+                    L"LichtFeld Studio - Incompatible Driver",
+                    MB_ICONERROR | MB_OK);
+#endif
                 return false;
             }
             return true;
@@ -531,6 +541,22 @@ namespace lfs::app {
             if (cudaGetDeviceProperties(&prop, 0) == cudaSuccess) {
                 LOG_INFO("GPU: {} (SM {}.{}, {} MB)", prop.name, prop.major, prop.minor,
                          prop.totalGlobalMem / (1024 * 1024));
+
+                const int device_sm = prop.major * 10 + prop.minor;
+                if (device_sm < LFS_MIN_SM) {
+                    std::string msg = std::format(
+                        "This PC's GPU ({}) doesn't meet the minimum requirement — an NVIDIA RTX 20-series card or newer is needed.",
+                        prop.name);
+#ifdef WIN32
+                    std::wstring wmsg(msg.begin(), msg.end());
+                    MessageBoxW(NULL, wmsg.c_str(),
+                        L"LichtFeld Studio - Incompatible GPU",
+                        MB_ICONERROR | MB_OK);
+#endif
+                    LOG_ERROR("{}", msg);
+                    std::exit(1);
+
+                }
             }
 
             LOG_INFO("Initializing CUDA...");
@@ -545,6 +571,21 @@ namespace lfs::app {
             if (cudaGetDeviceProperties(&prop, 0) == cudaSuccess) {
                 LOG_INFO("GPU: {} (SM {}.{}, {} MB)", prop.name, prop.major, prop.minor,
                          prop.totalGlobalMem / (1024 * 1024));
+
+                const int device_sm = prop.major * 10 + prop.minor;
+                if (device_sm < LFS_MIN_SM) {
+                    std::string msg = std::format(
+                        "This PC's GPU ({}) doesn't meet the minimum requirement — an NVIDIA RTX 20-series card or newer is needed.",
+                        prop.name);
+#ifdef WIN32
+                    std::wstring wmsg(msg.begin(), msg.end());
+                    MessageBoxW(NULL, wmsg.c_str(),
+                        L"LichtFeld Studio - Incompatible GPU",
+                        MB_ICONERROR | MB_OK);
+#endif
+                    LOG_ERROR("{}", msg);
+                    std::exit(1);
+                }
             }
 
             LOG_INFO("Initializing CUDA (async)...");

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -44,20 +44,19 @@
 #include <future>
 #include <mutex>
 #include <rasterization_api.h>
+#include <string_view>
 
 #ifdef WIN32
 #include <windows.h>
 #endif
 
 #ifndef LFS_MIN_SM
-#define LFS_MIN_SM 75
+#error "LFS_MIN_SM must be defined by the build (CMakeLists.txt)"
 #endif
 
 namespace lfs::app {
 
     namespace {
-
-        bool checkCudaDriverVersion();
 
         std::expected<core::param::TrainingParameters, std::string> loadCheckpointParams(const core::param::TrainingParameters& params, core::Scene& scene) {
             LOG_INFO("Resuming from checkpoint: {}", core::path_to_utf8(*params.resume_checkpoint));
@@ -116,7 +115,6 @@ namespace lfs::app {
                 return 1;
             }
 
-            checkCudaDriverVersion();
             lfs::event::CommandCenterBridge::instance().set(&lfs::training::CommandCenter::instance());
             HeadlessRunCoordinator coordinator;
 
@@ -267,7 +265,6 @@ namespace lfs::app {
                 return 1;
             }
 
-            checkCudaDriverVersion();
             lfs::event::CommandCenterBridge::instance().set(&lfs::training::CommandCenter::instance());
             HeadlessRunCoordinator coordinator;
 
@@ -381,8 +378,6 @@ namespace lfs::app {
         // Renders a sequencer camera path against a trained scene to a video file, headless.
         int runHeadlessRender(std::unique_ptr<lfs::core::param::TrainingParameters> params) {
             const auto& cfg = *params->render_path;
-
-            checkCudaDriverVersion();
 
             // Load the trained scene.
             std::shared_ptr<core::SplatData> model;
@@ -508,22 +503,71 @@ namespace lfs::app {
             return 0;
         }
 
-        bool checkCudaDriverVersion() {
+        // Only an accurate paraphrase of SM 7.5 — Turing also covers the GTX 16-series and T4,
+        // so this must not say "RTX only". Drop the hint if the floor ever moves.
+        constexpr std::string_view kMinGpuHint =
+            LFS_MIN_SM == 75 ? " Cards from the GTX 16-series, RTX 20-series and newer qualify." : "";
+
+        // English literals on purpose: this runs before the visualizer exists, so
+        // LocalizationManager has no catalog loaded yet. Do not convert to LOC(...).
+        void reportFatalStartupError(const std::string& title, const std::string& message,
+                                     const bool show_dialog) {
+            LOG_ERROR("{}", message);
+#ifdef WIN32
+            if (show_dialog) {
+                MessageBoxW(nullptr, core::utf8_to_wstring(message).c_str(),
+                            core::utf8_to_wstring(title).c_str(), MB_ICONERROR | MB_OK);
+            }
+#else
+            (void)title;
+            (void)show_dialog;
+#endif
+        }
+
+        // The binary only carries code for SM >= LFS_MIN_SM, so a lower card can never JIT our
+        // kernels. Without this gate the first launch inside warmup_kernels dies with no
+        // user-facing message (#1540). show_dialog is false for CLI-only modes: a modal in a
+        // non-interactive process blocks it forever.
+        bool preflightGpu(const bool show_dialog) {
             const auto info = lfs::core::check_cuda_version();
             if (info.query_failed) {
                 LOG_WARN("Failed to query CUDA driver version");
-                return true;
+            } else {
+                LOG_INFO("CUDA driver version: {}.{}", info.major, info.minor);
+                if (!info.supported) {
+                    reportFatalStartupError(
+                        "LichtFeld Studio - Incompatible driver",
+                        std::format("CUDA {}.{} is too old. LichtFeld Studio requires CUDA 12.8 or "
+                                    "newer, which needs NVIDIA driver 570 or newer.",
+                                    info.major, info.minor),
+                        show_dialog);
+                    return false;
+                }
             }
 
-            LOG_INFO("CUDA driver version: {}.{}", info.major, info.minor);
-            if (!info.supported) {
-                LOG_ERROR("CUDA driver too old. Requires 12.8+ (driver 570+)");
-#ifdef WIN32
-                MessageBoxW(NULL,
-                    L"NVIDIA driver too old. Please update to driver 570 or newer.",
-                    L"LichtFeld Studio - Incompatible Driver",
-                    MB_ICONERROR | MB_OK);
-#endif
+            cudaDeviceProp prop{};
+            if (const cudaError_t err = cudaGetDeviceProperties(&prop, 0); err != cudaSuccess) {
+                reportFatalStartupError(
+                    "LichtFeld Studio - No usable GPU",
+                    std::format("No usable NVIDIA GPU found ({}). LichtFeld Studio requires an "
+                                "NVIDIA GPU with compute capability {}.{} or newer.{}",
+                                cudaGetErrorString(err), LFS_MIN_SM / 10, LFS_MIN_SM % 10,
+                                kMinGpuHint),
+                    show_dialog);
+                return false;
+            }
+
+            LOG_INFO("GPU: {} (SM {}.{}, {} MB)", prop.name, prop.major, prop.minor,
+                     prop.totalGlobalMem / (1024 * 1024));
+
+            if (const int device_sm = prop.major * 10 + prop.minor; device_sm < LFS_MIN_SM) {
+                reportFatalStartupError(
+                    "LichtFeld Studio - Incompatible GPU",
+                    std::format("This PC's GPU ({}) has compute capability {}.{}, below the {}.{} "
+                                "this build requires.{}",
+                                prop.name, prop.major, prop.minor, LFS_MIN_SM / 10, LFS_MIN_SM % 10,
+                                kMinGpuHint),
+                    show_dialog);
                 return false;
             }
             return true;
@@ -534,60 +578,7 @@ namespace lfs::app {
             return fut;
         }
 
-        void warmupCudaSync() {
-            checkCudaDriverVersion();
-
-            cudaDeviceProp prop;
-            if (cudaGetDeviceProperties(&prop, 0) == cudaSuccess) {
-                LOG_INFO("GPU: {} (SM {}.{}, {} MB)", prop.name, prop.major, prop.minor,
-                         prop.totalGlobalMem / (1024 * 1024));
-
-                const int device_sm = prop.major * 10 + prop.minor;
-                if (device_sm < LFS_MIN_SM) {
-                    std::string msg = std::format(
-                        "This PC's GPU ({}) doesn't meet the minimum requirement — an NVIDIA RTX 20-series card or newer is needed.",
-                        prop.name);
-#ifdef WIN32
-                    std::wstring wmsg(msg.begin(), msg.end());
-                    MessageBoxW(NULL, wmsg.c_str(),
-                        L"LichtFeld Studio - Incompatible GPU",
-                        MB_ICONERROR | MB_OK);
-#endif
-                    LOG_ERROR("{}", msg);
-                    std::exit(1);
-
-                }
-            }
-
-            LOG_INFO("Initializing CUDA...");
-            fast_lfs::rasterization::warmup_kernels();
-            lfs::diagnostics::VramProfiler::instance().captureCudaWarmupDelta();
-        }
-
         void warmupCudaAsync() {
-            checkCudaDriverVersion();
-
-            cudaDeviceProp prop;
-            if (cudaGetDeviceProperties(&prop, 0) == cudaSuccess) {
-                LOG_INFO("GPU: {} (SM {}.{}, {} MB)", prop.name, prop.major, prop.minor,
-                         prop.totalGlobalMem / (1024 * 1024));
-
-                const int device_sm = prop.major * 10 + prop.minor;
-                if (device_sm < LFS_MIN_SM) {
-                    std::string msg = std::format(
-                        "This PC's GPU ({}) doesn't meet the minimum requirement — an NVIDIA RTX 20-series card or newer is needed.",
-                        prop.name);
-#ifdef WIN32
-                    std::wstring wmsg(msg.begin(), msg.end());
-                    MessageBoxW(NULL, wmsg.c_str(),
-                        L"LichtFeld Studio - Incompatible GPU",
-                        MB_ICONERROR | MB_OK);
-#endif
-                    LOG_ERROR("{}", msg);
-                    std::exit(1);
-                }
-            }
-
             LOG_INFO("Initializing CUDA (async)...");
             cudaWarmupFuture() = std::async(std::launch::async, [] {
                 fast_lfs::rasterization::warmup_kernels();
@@ -610,7 +601,8 @@ namespace lfs::app {
             // Warm up on every path, not just import/resume: warmup_kernels forces the
             // lazily-loaded cubins to upload so captureCudaWarmupDelta can attribute that
             // module memory (the cuda.modules row). Without it the modules land in the
-            // unattributed NVML residual. warmupCudaAsync runs checkCudaDriverVersion itself.
+            // unattributed NVML residual. The pre-flight gate in Application::run covers
+            // hardware compatibility before this warmup starts.
             warmupCudaAsync();
 
             lfs::event::CommandCenterBridge::instance().set(&lfs::training::CommandCenter::instance());
@@ -704,6 +696,15 @@ namespace lfs::app {
     } // namespace
 
     int Application::run(std::unique_ptr<lfs::core::param::TrainingParameters> params) {
+        // Refuse unsupported hardware before anything touches the GPU. --render-path is a
+        // CLI-only mode that does not set optimization.headless, so test it explicitly: a
+        // modal must never appear in a non-interactive run.
+        const bool interactive = !params->optimization.headless && !params->render_path;
+        if (!preflightGpu(interactive)) {
+            core::teardown_gpu_before_exit();
+            core::flush_and_exit(1);
+        }
+
         // Pre-initialize CacheLoader for the exe module.
         // On Windows, lfs_io (static lib) is linked into both the exe and
         // lfs_visualizer.dll, giving each its own CacheLoader singleton.


### PR DESCRIPTION
Fixes #1540

## Problem

Users on GTX 10-series (Pascal, SM 6.1) get a silent crash at startup - no window, no explanation. The app logs GPU: NVIDIA GeForce GTX 1070 (SM 6.1, 8191 MB) but never compares against the build's minimum SM 7.5, then dies later with no user-facing message.

## Changes

### CMakeLists.txt
- Bake BUILD_CUDA_MIN_SM into binary via add_compile_definitions(LFS_MIN_SM=...) so runtime can fail-fast on unsupported GPUs

### src/app/application.cpp
- After cudaGetDeviceProperties, compute device_sm = prop.major * 10 + prop.minor; if device_sm < LFS_MIN_SM, show a MessageBoxW dialog naming the GPU and exit immediately
- Replace LOG_WARN for old driver with blocking MessageBoxW dialog requiring driver 570+

### README.md
- Add Requirements section listing RTX 20-series+, driver 570+, Windows as minimums; explicitly note GTX 10-series/AMD/Intel are unsupported