### PR TITLE
Remove misleading video frame orientation helper

### DIFF
--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -332,12 +332,6 @@ namespace lfs::vis::gui {
         return state.cached_environment_resolved_path;
     }
 
-    lfs::core::Tensor orientVideoExportFrameForEncoder(const lfs::core::Tensor& image) {
-        if (!image.is_valid() || image.ndim() != 3) {
-            return image;
-        }
-        return image.contiguous();
-    }
     [[nodiscard]] const VideoExportCropBoxSnapshot* activeVideoExportPointCloudCropBox(
         const VideoExportSceneSnapshot& snapshot) {
         const VideoExportCropBoxSnapshot* selected = nullptr;
@@ -1954,7 +1948,7 @@ namespace lfs::vis::gui {
                         break;
                     }
 
-                    auto export_frame = orientVideoExportFrameForEncoder(*frame_tensor);
+                    auto export_frame = frame_tensor->contiguous();
                     auto image_hwc = export_frame.permute({1, 2, 0}).contiguous();
 
                     if (frame == 0) {


### PR DESCRIPTION
Closes #1546.

`orientVideoExportFrameForEncoder` no longer performed any orientation work—it only made the tensor contiguous. This removes the misleading helper and keeps that behavior at the export call site.

Checked with `clang-format --dry-run --Werror src/visualizer/gui/async_task_manager.cpp` and `git diff --check`.