### PR TITLE
#1475 Fix drifted parameter defaults in the property registry

### DIFF
--- a/src/python/lfs/py_params.cpp
+++ b/src/python/lfs/py_params.cpp
@@ -60,7 +60,7 @@ namespace lfs::python {
                         "Learning rate for spherical harmonics")
             .flags(PROP_LIVE_UPDATE)
             .float_prop(&OptimizationParameters::opacity_lr,
-                        "opacity_lr", "Opacity LR", 0.05f, 0.0f, 1.0f,
+                        "opacity_lr", "Opacity LR", 0.025f, 0.0f, 1.0f,
                         "Learning rate for opacity")
             .flags(PROP_LIVE_UPDATE)
             .float_prop(&OptimizationParameters::scaling_lr,
@@ -254,7 +254,7 @@ namespace lfs::python {
                        "mip_filter", "Mip Filter", false,
                        "Enable mip filtering (anti-aliasing)")
             .bool_prop(&OptimizationParameters::use_ppisp,
-                       "ppisp", "PPISP", true,
+                       "ppisp", "PPISP", false,
                        "Per-pixel image signal processing")
             .bool_prop(&OptimizationParameters::ppisp_use_controller,
                        "ppisp_use_controller", "Controller", false,
@@ -305,7 +305,7 @@ namespace lfs::python {
                         "prune_ratio", "Prune Ratio", 0.6f, 0.0f, 1.0f,
                         "Target pruning ratio for sparsification")
             .float_prop(&OptimizationParameters::init_rho,
-                        "init_rho", "Init Rho", 0.001f, 0.0f, 0.01f,
+                        "init_rho", "Init Rho", 0.0005f, 0.0f, 0.01f,
                         "Initial rho for sparsity optimization")
             .float_prop(&OptimizationParameters::steps_scaler,
                         "steps_scaler", "Steps Scaler", 1.0f, 0.0f, 10.0f,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,6 +121,7 @@ set(TEST_FILES
     test_sparsity_optimizer.cpp
     test_mcmc_tensor_ops.cpp
     test_training_cropbox_mask.cpp
+    test_training_parameters.cpp
     test_tensor_index_select_uint8.cpp
     test_tensor_uint8_inversion.cpp
     test_tensor_uint8_masking.cpp
@@ -285,6 +286,7 @@ list(APPEND TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/python/lfs/rml_im_mode_layout.cpp
     ${CMAKE_SOURCE_DIR}/src/app/mcp_sequencer_tools.cpp
     ${CMAKE_SOURCE_DIR}/src/app/converter.cpp
+    ${CMAKE_SOURCE_DIR}/src/python/lfs/py_params.cpp
 )
 
 # Create test executable

--- a/tests/test_training_parameters.cpp
+++ b/tests/test_training_parameters.cpp
@@ -1,0 +1,81 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/include/core/parameters.hpp"
+#include "core/include/core/property_registry.hpp"
+#include "python/lfs/py_params.hpp"
+#include <any>
+#include <gtest/gtest.h>
+#include <string>
+
+using lfs::core::prop::PropertyObjectRef;
+using lfs::core::prop::PropertyRegistry;
+using lfs::core::prop::PropType;
+
+namespace {
+
+    class TrainingParametersTest : public ::testing::Test {
+    protected:
+        void SetUp() override {
+            lfs::python::register_optimization_properties();
+        }
+
+        void TearDown() override {
+            PropertyRegistry::instance().unregister_group("optimization");
+        }
+    };
+
+    /* Registry defaults and OptimizationParameters member defaults are written
+    independently; reset serves the registry copy, so drift must fail here. */
+
+    TEST_F(TrainingParametersTest, RegistryDefaultsMatchStructDefaults) {
+        auto group = PropertyRegistry::instance().get_group("optimization");
+        ASSERT_NE(group, nullptr);
+        ASSERT_FALSE(group->properties.empty());
+
+        lfs::core::param::OptimizationParameters defaults;
+        const auto ref = PropertyObjectRef::cpp(&defaults);
+
+        for (const auto& meta : group->properties) {
+            SCOPED_TRACE(meta.id);
+
+            if (!meta.getter) {
+                ADD_FAILURE() << "property has no getter";
+                continue;
+            }
+            const std::any from_struct = meta.getter(ref);
+
+            switch (meta.type) {
+            case PropType::Float:
+                EXPECT_FLOAT_EQ(static_cast<float>(meta.default_value),
+                                std::any_cast<float>(from_struct));
+                break;
+            case PropType::Int:
+                EXPECT_EQ(static_cast<int>(meta.default_value),
+                          std::any_cast<int>(from_struct));
+                break;
+            case PropType::SizeT:
+                EXPECT_EQ(static_cast<size_t>(meta.default_value),
+                          std::any_cast<size_t>(from_struct));
+                break;
+            case PropType::Bool:
+                EXPECT_EQ(meta.default_value > 0.5,
+                          std::any_cast<bool>(from_struct));
+                break;
+            case PropType::String:
+                EXPECT_EQ(meta.default_string,
+                          std::any_cast<std::string>(from_struct));
+                break;
+            case PropType::Enum:
+                EXPECT_EQ(meta.default_enum,
+                          std::any_cast<int>(from_struct));
+                break;
+            default:
+                ADD_FAILURE() << "unhandled property type";
+                break;
+            }
+        }
+    }
+
+} // namespace


### PR DESCRIPTION
Fixes #1475

## Change
-  Fix three wrong defaults in `register_optimization_properties()`
  (`src/python/lfs/py_params.cpp`) so they match `OptimizationParameters`
  in `src/core/include/core/parameters.hpp`:

    | Parameter | Was | Now |
    |---|---|---|
    | `opacity_lr` | `0.05f` | `0.025f` |
    | `init_rho` | `0.001f` | `0.0005f` |
    | `use_ppisp` (id `"ppisp"`) | `true` | `false` |
- Add `tests/test_training_parameters.cpp`, which walks **every** property in the
  `optimization` group and asserts its registry default equals the corresponding
  member of a default-constructed `OptimizationParameters`.


**Note:** `OptimizationParameters` has 96 members, but only **82** are registered in the `optimization` property group — those are the ones the test covers. The other 14 have no registry entry:
`auto_train`, `bg_color`, `bg_image_path`, `config_file`, `debug_python`, `debug_python_port`, `enable_save_eval_images`, `eval_steps`, `no_splash`, `ppisp_lr`, `ppisp_reg_weight`, `ppisp_sidecar_path`, `ppisp_warmup_steps`, `save_steps`

## Verification
**Before the fix**
<img width="1117" height="484" alt="defaults_test_fail" src="https://github.com/user-attachments/assets/fa9db49f-446a-4056-a151-078b55e7d732" />

**After the fix:**
<img width="829" height="98" alt="defaults_test_pass" src="https://github.com/user-attachments/assets/a4f74aba-e1a1-4300-9323-170cb117b6d7" />
