### PR TITLE
fix: add libgtk-3-dev to Dockerfile (#1554)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
         libxcursor-dev \
         xorg-dev \
         libglu1-mesa-dev \
+        libgtk-3-dev \
         vim \
         nano \
         htop \


### PR DESCRIPTION
## Problem

CMake build inside the Docker container fails because \libgtk-3-dev\ (GTK3 development files) is missing from the container environment.

\\\
CMake Error at cmake/SetupNativeFileDialog.cmake:49 (message):
  nativefiledialog-extended (Linux) requires GTK3 development files.
  pkg-config could not locate \gtk+-3.0\. Install the dev headers and re-run CMake.
    Debian/Ubuntu:  sudo apt install libgtk-3-dev
\\\

## Fix

Added \libgtk-3-dev\ to the apt-get dependencies in \docker/Dockerfile\.

nativefiledialog-extended requires GTK3 on Linux for reliable file/folder picker behavior (the xdg-desktop-portal backend often ignores \current_folder\ on GNOME).

## Related

Fixes #1554