### PR TITLE
fix(vksplat): render external float SH data

### DIFF
--- a/src/training/rasterization/fastgs/optimizer/include/adam_kernels.cuh
+++ b/src/training/rasterization/fastgs/optimizer/include/adam_kernels.cuh
@@ -664,11 +664,11 @@ namespace fast_lfs::optimizer::kernels::adam {
         float4* mm_ptr = reinterpret_cast<float4*>(bounds + 4 * bidx);
         const float4 old_mm = *mm_ptr;
         const float4 new_mm = joint_expand_bounds_include_zero(old_mm);
-        const uint slots = static_cast<uint>(slots_per_primitive);
-        constexpr uint R = 32u;
+        const uint32_t slots = static_cast<uint32_t>(slots_per_primitive);
+        constexpr uint32_t R = 32u;
 
-        auto sh_cell = [&](const uint p, const uint k, const int c) -> int64_t {
-            const uint slot = (p / R) * (slots * R) + k * R + (p % R);
+        auto sh_cell = [&](const uint32_t p, const uint32_t k, const int c) -> int64_t {
+            const uint32_t slot = (p / R) * (slots * R) + k * R + (p % R);
             return static_cast<int64_t>(slot) * 4 + c;
         };
 
@@ -677,9 +677,9 @@ namespace fast_lfs::optimizer::kernels::adam {
             const int block_end = (n_prims > 0) ? min(block_begin + 256, n_prims)
                                                 : (block_begin + 256);
             for (int p = block_begin; p < block_end; ++p) {
-                for (uint k = 0; k < slots; ++k) {
+                for (uint32_t k = 0; k < slots; ++k) {
                     for (int c = 0; c < 4; ++c) {
-                        const int64_t cell = sh_cell(static_cast<uint>(p), k, c);
+                        const int64_t cell = sh_cell(static_cast<uint32_t>(p), k, c);
                         const float2 us = C::decode_us(packed, cell, old_mm);
                         C::encode_us(packed, cell, us.x, us.y, new_mm);
                     }
@@ -687,9 +687,9 @@ namespace fast_lfs::optimizer::kernels::adam {
             }
             *mm_ptr = new_mm;
         }
-        for (uint k = 0; k < slots; ++k) {
+        for (uint32_t k = 0; k < slots; ++k) {
             for (int c = 0; c < 4; ++c) {
-                C::encode_us(packed, sh_cell(static_cast<uint>(prim), k, c),
+                C::encode_us(packed, sh_cell(static_cast<uint32_t>(prim), k, c),
                              0.0f, 0.0f, new_mm);
             }
         }

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -4825,12 +4825,14 @@ namespace lfs::vis {
             means_storage && sh0_storage && rotations_storage && scaling_storage;
         // q16-throughout: shN must be exportable pad-dropped codes (+ bounds) for
         // zero-copy. A mid-densify float workspace is excluded by render_mutex_;
-        // if a reader ever observes float shN, fall through to copy upload rather
-        // than binding a non-exportable rest buffer.
+        // if a reader observes a non-external float shN tensor, fall through to
+        // copy upload rather than binding a transient workspace. Static PLY models
+        // legitimately keep float shN in Vulkan-external storage and can bind it.
         const bool shN_float_workspace =
             splat_data.shN_raw().is_valid() &&
             splat_data.shN_raw().dtype() == lfs::core::DataType::Float32 &&
-            !splat_data.shN_value_quantized();
+            !splat_data.shN_value_quantized() &&
+            !shN_storage;
         // Generation-checked q16 pair (same machinery as FastGS bind). Required
         // before the viewer installs zero-copy codes+bounds descriptors.
         const lfs::core::Q16BindPtrs q16_bind =
@@ -4919,6 +4921,9 @@ namespace lfs::vis {
         }
         if (!can_bind_external && has_deleted_mask) {
             input_copy_reasons.emplace_back("soft_deleted_mask");
+        }
+        if (shN_float_workspace) {
+            input_copy_reasons.emplace_back("non_external_float_shN_workspace");
         }
         std::string input_copy_reason = "unknown";
         if (!input_copy_reasons.empty()) {


### PR DESCRIPTION
## Summary

Fix VkSplat rendering for static PLY models whose Float32 spherical harmonics tensors already use Vulkan-external storage.

## Problem

Loading a valid SH3 PLY succeeded, but the viewport remained empty and VkSplat entered degraded mode:

`VkSplat refusing full input-copy fallback; model tensors must use Vulkan-external storage (unknown)`

The tensors were already backed by Vulkan-external storage. However, every non-quantized Float32 `shN` tensor was classified as a transient training workspace, causing the external zero-copy path to be rejected.

## Fix

- Accept Float32 `shN` tensors when they are backed by Vulkan-external storage.
- Continue rejecting non-external Float32 tensors that may represent transient training workspaces.
- Report `non_external_float_shN_workspace` instead of the generic `unknown` reason when that condition occurs.

## Impact

Static PLY models with Float32 SH data can now use the Vulkan zero-copy rendering path without enabling the prohibited full-input copy fallback.
