### PR TITLE
Fix GPU running at 100% when no scene is loaded

### DIFF
--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -2702,7 +2702,15 @@ namespace lfs::python {
 
         // Hot-reload redraw request functions
         m.def(
-            "request_redraw", []() { lfs::python::request_redraw(); }, "Request a UI redraw on next frame");
+            "request_redraw",
+            [](double delay) {
+                if (delay <= 0.0)
+                    lfs::python::request_redraw();
+                else
+                    lfs::python::request_redraw_after(delay);
+            },
+            nb::arg("delay") = 0.0,
+            "Request a UI redraw; with delay > 0, schedule it no later than that many seconds from now.");
         m.def(
             "consume_redraw_request", []() {
                 return lfs::python::consume_redraw_request();

--- a/src/python/lfs/rml_im_mode_panel_adapter.cpp
+++ b/src/python/lfs/rml_im_mode_panel_adapter.cpp
@@ -245,6 +245,18 @@ namespace lfs::vis::gui {
         return ops.needs_animation ? ops.needs_animation(host_) : false;
     }
 
+    std::optional<double> RmlImModePanelAdapter::nextScheduledAnimationDelay() const {
+        if (!host_)
+            return std::nullopt;
+        const auto& ops = lfs::python::get_rml_panel_host_ops();
+        if (!ops.next_scheduled_update_delay)
+            return std::nullopt;
+        double host_delay = 0.0;
+        if (!ops.next_scheduled_update_delay(host_, &host_delay))
+            return std::nullopt;
+        return host_delay;
+    }
+
     void RmlImModePanelAdapter::reloadRmlResources() {
         if (!host_)
             return;

--- a/src/python/lfs/rml_im_mode_panel_adapter.hpp
+++ b/src/python/lfs/rml_im_mode_panel_adapter.hpp
@@ -39,6 +39,7 @@ namespace lfs::vis::gui {
         void setForcedHeight(float h) override;
         void setPanelSpace(PanelSpace space) override;
         bool needsAnimationFrame() const override;
+        std::optional<double> nextScheduledAnimationDelay() const override;
         void reloadRmlResources() override;
 
     private:

--- a/src/python/lfs/rml_python_panel_adapter.cpp
+++ b/src/python/lfs/rml_python_panel_adapter.cpp
@@ -621,6 +621,37 @@ namespace lfs::vis::gui {
         return ops.needs_animation ? ops.needs_animation(host_) : false;
     }
 
+    std::optional<double> RmlPythonPanelAdapter::nextScheduledAnimationDelay() const {
+        std::optional<double> min_delay;
+
+        if (host_) {
+            const auto& ops = lfs::python::get_rml_panel_host_ops();
+            if (ops.next_scheduled_update_delay) {
+                double host_delay = 0.0;
+                if (ops.next_scheduled_update_delay(host_, &host_delay))
+                    min_delay = host_delay;
+            }
+        }
+
+        // Interval-policy panels: remaining time until next_update_at_ when it is
+        // still in the future. When unset/expired, needsAnimationFrame() is true.
+        if (!dirty_driven_updates_) {
+            if (next_update_at_ != std::chrono::steady_clock::time_point{}) {
+                const auto now = std::chrono::steady_clock::now();
+                if (now < next_update_at_) {
+                    const double remaining =
+                        std::chrono::duration<double>(next_update_at_ - now).count();
+                    if (remaining > 0.0) {
+                        if (!min_delay || remaining < *min_delay)
+                            min_delay = remaining;
+                    }
+                }
+            }
+        }
+
+        return min_delay;
+    }
+
     void RmlPythonPanelAdapter::setForeground(bool fg) {
         foreground_ = fg;
         if (host_) {

--- a/src/python/lfs/rml_python_panel_adapter.hpp
+++ b/src/python/lfs/rml_python_panel_adapter.hpp
@@ -46,6 +46,7 @@ namespace lfs::vis::gui {
         void setForcedHeight(float h) override;
         bool wantsKeyboard() const override;
         bool needsAnimationFrame() const override;
+        std::optional<double> nextScheduledAnimationDelay() const override;
         bool wantsExternalFloatingShadow() const override { return !foreground_; }
         void setPanelSpace(PanelSpace space) override;
         void reloadRmlResources() override;

--- a/src/python/lfs_plugins/overlays/__init__.py
+++ b/src/python/lfs_plugins/overlays/__init__.py
@@ -36,6 +36,7 @@ _GAP_LENGTH = 8.0
 _BORDER_THICKNESS = 2.0
 _ICON_SIZE = 48.0
 _ANIM_SPEED = 30.0
+_EMPTY_STATE_REDRAW_INTERVAL = 1.0 / 15.0  # marching-ants pacing; ~2px/frame at _ANIM_SPEED=30
 _MIN_VIEWPORT_SIZE = 200.0
 _AUTO_DISMISS_DELAY = 3.0
 
@@ -430,7 +431,7 @@ def _draw_empty_state_overlay(layout):
     layout.draw_window_text(center_x - hint_w * 0.5, center_y + 70.0, hint, hint_color)
 
     layout.end_window()
-    lf.ui.request_redraw()
+    lf.ui.request_redraw(delay=_EMPTY_STATE_REDRAW_INTERVAL)
 
 
 def _draw_drag_drop_overlay(layout):

--- a/src/python/python_runtime.cpp
+++ b/src/python/python_runtime.cpp
@@ -11,7 +11,10 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
+#include <cstdint>
+#include <limits>
 #include <mutex>
+#include <optional>
 #include <stdexcept>
 #include <unordered_set>
 
@@ -172,13 +175,22 @@ namespace lfs::python {
         std::atomic<bool> g_has_selection{false};
         std::atomic<bool> g_is_training{false};
 
-        // Redraw request flag
+        // Redraw request: immediate flag + optional deadline (steady_clock ns since epoch).
+        // Sentinel max() means no scheduled deadline. CAS-min keeps the earliest deadline.
+        constexpr int64_t kNoRedrawDeadlineNs = std::numeric_limits<int64_t>::max();
         std::atomic<bool> g_redraw_requested{false};
+        std::atomic<int64_t> g_redraw_deadline_ns{kNoRedrawDeadlineNs};
         std::atomic<uint64_t> g_redraw_generation{0};
         std::atomic<uint64_t> g_pre_scene_panel_sync_generation{0};
         MainLoopWakeCallback g_main_loop_wake_callback = nullptr;
         std::mutex g_startup_plugin_load_status_mutex;
         StartupPluginLoadStatus g_startup_plugin_load_status;
+
+        [[nodiscard]] int64_t steady_now_ns() {
+            return std::chrono::duration_cast<std::chrono::nanoseconds>(
+                       std::chrono::steady_clock::now().time_since_epoch())
+                .count();
+        }
     } // namespace
 
     // Bridge API
@@ -222,12 +234,79 @@ namespace lfs::python {
             g_main_loop_wake_callback();
     }
 
+    void request_redraw_after(double delay_seconds) {
+        if (delay_seconds <= 0.0) {
+            request_redraw();
+            return;
+        }
+
+        const double delay_ns_d = delay_seconds * 1'000'000'000.0;
+        const int64_t delay_ns =
+            delay_ns_d >= static_cast<double>(std::numeric_limits<int64_t>::max())
+                ? std::numeric_limits<int64_t>::max()
+                : static_cast<int64_t>(delay_ns_d);
+        const int64_t now = steady_now_ns();
+        // Saturating add to avoid overflow on far-future delays.
+        const int64_t target =
+            (delay_ns > kNoRedrawDeadlineNs - now) ? kNoRedrawDeadlineNs : (now + delay_ns);
+
+        // CAS-min: keep the earlier of any pending deadline and this one.
+        int64_t current = g_redraw_deadline_ns.load(std::memory_order_acquire);
+        bool installed_earlier = false;
+        while (target < current) {
+            if (g_redraw_deadline_ns.compare_exchange_weak(
+                    current, target, std::memory_order_acq_rel, std::memory_order_acquire)) {
+                installed_earlier = true;
+                break;
+            }
+        }
+
+        g_redraw_generation.fetch_add(1, std::memory_order_acq_rel);
+        // Wake so waitForNextEvent re-mins against the new deadline (worker-thread safe).
+        if (installed_earlier && g_main_loop_wake_callback)
+            g_main_loop_wake_callback();
+    }
+
     bool has_redraw_request() {
-        return g_redraw_requested.load(std::memory_order_acquire);
+        if (g_redraw_requested.load(std::memory_order_acquire))
+            return true;
+        const int64_t deadline = g_redraw_deadline_ns.load(std::memory_order_acquire);
+        if (deadline == kNoRedrawDeadlineNs)
+            return false;
+        return deadline <= steady_now_ns();
     }
 
     bool consume_redraw_request() {
-        return g_redraw_requested.exchange(false, std::memory_order_acq_rel);
+        // Clear immediate flag. A future (not-yet-due) deadline must survive: consume
+        // can run on mouse-motion-filtered wakes without rendering a GUI frame.
+        const bool immediate = g_redraw_requested.exchange(false, std::memory_order_acq_rel);
+
+        bool due = false;
+        int64_t deadline = g_redraw_deadline_ns.load(std::memory_order_acquire);
+        const int64_t now = steady_now_ns();
+        while (deadline != kNoRedrawDeadlineNs && deadline <= now) {
+            if (g_redraw_deadline_ns.compare_exchange_weak(
+                    deadline, kNoRedrawDeadlineNs, std::memory_order_acq_rel,
+                    std::memory_order_acquire)) {
+                due = true;
+                break;
+            }
+            // deadline reloaded by CAS failure; re-check against a fresh now only if needed
+            if (deadline != kNoRedrawDeadlineNs && deadline > steady_now_ns())
+                break;
+        }
+
+        return immediate || due;
+    }
+
+    std::optional<double> seconds_until_scheduled_redraw() {
+        const int64_t deadline = g_redraw_deadline_ns.load(std::memory_order_acquire);
+        if (deadline == kNoRedrawDeadlineNs)
+            return std::nullopt;
+        const int64_t now = steady_now_ns();
+        if (deadline <= now)
+            return std::nullopt; // already due — reported via has_redraw_request()
+        return static_cast<double>(deadline - now) * 1e-9;
     }
 
     uint64_t redraw_request_generation() {

--- a/src/python/python_runtime.cpp
+++ b/src/python/python_runtime.cpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <mutex>
@@ -235,7 +236,7 @@ namespace lfs::python {
     }
 
     void request_redraw_after(double delay_seconds) {
-        if (delay_seconds <= 0.0) {
+        if (std::isnan(delay_seconds) || delay_seconds <= 0.0) {
             request_redraw();
             return;
         }

--- a/src/python/python_runtime.hpp
+++ b/src/python/python_runtime.hpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -95,9 +96,14 @@ namespace lfs::python {
     LFS_PYTHON_RUNTIME_API const PyContext& context();
 
     // UI redraw request mechanism
+    // request_redraw / request_redraw_after: "render a GUI frame no later than now + delay"
+    // (delay 0 = immediate). Multiple scheduled deadlines keep the earliest.
     LFS_PYTHON_RUNTIME_API void request_redraw();
+    LFS_PYTHON_RUNTIME_API void request_redraw_after(double delay_seconds);
     LFS_PYTHON_RUNTIME_API bool has_redraw_request();
     LFS_PYTHON_RUNTIME_API bool consume_redraw_request();
+    // Remaining seconds until a future scheduled redraw; nullopt if none or already due.
+    LFS_PYTHON_RUNTIME_API std::optional<double> seconds_until_scheduled_redraw();
     LFS_PYTHON_RUNTIME_API uint64_t redraw_request_generation();
     LFS_PYTHON_RUNTIME_API void request_pre_scene_panel_sync();
     LFS_PYTHON_RUNTIME_API uint64_t pre_scene_panel_sync_generation();
@@ -703,6 +709,9 @@ namespace lfs::python {
         void (*set_input)(void* host, const void* input);
         void (*set_forced_height)(void* host, float h);
         bool (*needs_animation)(void* host);
+        // Returns true and writes delay when the host has a finite scheduled
+        // update delay > 0 seconds; false for continuous demand or idle.
+        bool (*next_scheduled_update_delay)(void* host, double* out_seconds);
     };
 
     LFS_PYTHON_RUNTIME_API void set_rml_panel_host_ops(const RmlPanelHostOps& ops);

--- a/src/python/stubs/lichtfeld/ui/__init__.pyi
+++ b/src/python/stubs/lichtfeld/ui/__init__.pyi
@@ -905,8 +905,10 @@ def input_dialog(title: str, message: str, default_value: str = '', callback: ob
 def message_dialog(title: str, message: str, style: str = 'info', callback: object | None = None) -> None:
     """Show a message dialog (style: 'info', 'warning', or 'error')"""
 
-def request_redraw() -> None:
-    """Request a UI redraw on next frame"""
+def request_redraw(delay: float = 0.0) -> None:
+    """
+    Request a UI redraw; with delay > 0, schedule it no later than that many seconds from now.
+    """
 
 def consume_redraw_request() -> bool:
     """Consume and return pending redraw request flag"""

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -3443,6 +3443,14 @@ namespace lfs::vis::gui {
         ops.needs_animation = [](void* host) -> bool {
             return static_cast<RmlPanelHost*>(host)->needsAnimationFrame();
         };
+        ops.next_scheduled_update_delay = [](void* host, double* out_seconds) -> bool {
+            const auto delay =
+                static_cast<RmlPanelHost*>(host)->nextScheduledUpdateDelay();
+            if (!delay || !out_seconds)
+                return false;
+            *out_seconds = *delay;
+            return true;
+        };
         lfs::python::set_rml_panel_host_ops(ops);
 
         registerNativePanels();
@@ -6622,6 +6630,44 @@ namespace lfs::vis::gui {
             }))
             return true;
         return false;
+    }
+
+    std::optional<double> GuiManager::secondsUntilNextAnimationFrame() const {
+        auto min_delay = [](std::optional<double> a, std::optional<double> b) -> std::optional<double> {
+            if (!a)
+                return b;
+            if (!b)
+                return a;
+            return std::min(*a, *b);
+        };
+
+        std::optional<double> result;
+
+        if (!python::is_plugin_preload_running()) {
+            result = min_delay(result,
+                               PanelRegistry::instance().nextScheduledAnimationDelayForVisiblePanels({
+                                   .active_main_tab = panel_layout_.getActiveTab(),
+                                   .ui_visible = !ui_hidden_,
+                                   .right_panel_visible = show_main_panel_ && !ui_hidden_,
+                                   .bottom_dock_visible = panel_layout_.isBottomDockVisible(),
+                               }));
+        }
+
+        result = min_delay(result, rml_viewport_overlay_.nextScheduledUpdateDelay());
+
+        // VRAM HUD cadence: when armed and not yet due, wake at the publish deadline.
+        if (isVramHudOverlayVisible()) {
+            const auto now = std::chrono::steady_clock::now();
+            if (next_vram_hud_publish_ != std::chrono::steady_clock::time_point{} &&
+                now < next_vram_hud_publish_) {
+                const double remaining =
+                    std::chrono::duration<double>(next_vram_hud_publish_ - now).count();
+                if (remaining > 0.0)
+                    result = min_delay(result, remaining);
+            }
+        }
+
+        return result;
     }
 
     bool GuiManager::isViewportExportLocked() const {

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -100,6 +100,9 @@ namespace lfs::vis {
 
             // State queries
             bool needsAnimationFrame() const;
+            // Min finite scheduled GUI animation/update delay (seconds). Used by the
+            // idle wait path so CSS transitions / timers wake on time without spinning.
+            [[nodiscard]] std::optional<double> secondsUntilNextAnimationFrame() const;
             [[nodiscard]] bool isViewportExportLocked() const;
 
             // Window visibility

--- a/src/visualizer/gui/panel_registry.cpp
+++ b/src/visualizer/gui/panel_registry.cpp
@@ -1185,59 +1185,95 @@ namespace lfs::vis::gui {
         return false;
     }
 
-    PanelAnimationDemand PanelRegistry::animationDemandForVisiblePanels(
-        const PanelAnimationVisibility visibility) const {
-        auto mark_visible_demand = [&](PanelAnimationDemand& demand, const PanelInfo& p) {
+    namespace {
+        // Shared visibility predicate for animation demand and scheduled delays.
+        // Must stay in lockstep: a mismatch causes either pinned frames or stalled wakes.
+        [[nodiscard]] bool isPanelVisibleForAnimation(
+            const PanelInfo& p, const PanelAnimationVisibility& visibility) {
             if (!p.parent_id.empty()) {
-                if (visibility.right_panel_visible &&
-                    std::string_view(p.parent_id) == visibility.active_main_tab)
-                    demand.main_panel_tab = true;
+                return visibility.right_panel_visible &&
+                       std::string_view(p.parent_id) == visibility.active_main_tab;
+            }
+
+            switch (p.space) {
+            case PanelSpace::Floating:
+                return visibility.ui_visible;
+            case PanelSpace::SidePanel:
+                return visibility.ui_visible;
+            case PanelSpace::StatusBar:
+                return visibility.ui_visible;
+            case PanelSpace::ViewportOverlay:
+                return true;
+            case PanelSpace::SceneHeader:
+                return visibility.right_panel_visible;
+            case PanelSpace::MainPanelTab:
+                return visibility.right_panel_visible &&
+                       std::string_view(p.id) == visibility.active_main_tab;
+            case PanelSpace::BottomDock:
+                return visibility.ui_visible && visibility.bottom_dock_visible;
+            case PanelSpace::LeftDock:
+                return visibility.ui_visible && visibility.left_dock_visible;
+            }
+            return false;
+        }
+
+        void markVisibleAnimationDemand(PanelAnimationDemand& demand, const PanelInfo& p,
+                                        const PanelAnimationVisibility& visibility) {
+            if (!isPanelVisibleForAnimation(p, visibility))
+                return;
+
+            if (!p.parent_id.empty()) {
+                demand.main_panel_tab = true;
                 return;
             }
 
             switch (p.space) {
             case PanelSpace::Floating:
-                if (visibility.ui_visible)
-                    demand.floating = true;
+                demand.floating = true;
                 return;
             case PanelSpace::SidePanel:
-                if (visibility.ui_visible)
-                    demand.side_panel = true;
+                demand.side_panel = true;
                 return;
             case PanelSpace::StatusBar:
-                if (visibility.ui_visible)
-                    demand.status_bar = true;
+                demand.status_bar = true;
                 return;
             case PanelSpace::ViewportOverlay:
                 demand.viewport_overlay = true;
                 return;
             case PanelSpace::SceneHeader:
-                if (visibility.right_panel_visible)
-                    demand.scene_header = true;
+                demand.scene_header = true;
                 return;
             case PanelSpace::MainPanelTab:
-                if (visibility.right_panel_visible &&
-                    std::string_view(p.id) == visibility.active_main_tab)
-                    demand.main_panel_tab = true;
+                demand.main_panel_tab = true;
                 return;
             case PanelSpace::BottomDock:
-                if (visibility.ui_visible && visibility.bottom_dock_visible)
-                    demand.bottom_dock = true;
+                demand.bottom_dock = true;
                 return;
             case PanelSpace::LeftDock:
-                if (visibility.ui_visible && visibility.left_dock_visible)
-                    demand.left_dock = true;
+                demand.left_dock = true;
                 return;
             }
-        };
+        }
 
+        [[nodiscard]] std::optional<double> minOptionalDelay(std::optional<double> a,
+                                                             std::optional<double> b) {
+            if (!a)
+                return b;
+            if (!b)
+                return a;
+            return std::min(*a, *b);
+        }
+    } // namespace
+
+    PanelAnimationDemand PanelRegistry::animationDemandForVisiblePanels(
+        const PanelAnimationVisibility visibility) const {
         PanelAnimationDemand demand;
         std::lock_guard lock(mutex_);
         for (const auto& p : panels_) {
             if (!p.enabled || p.error_disabled || !p.panel)
                 continue;
             if (p.panel->needsAnimationFrame())
-                mark_visible_demand(demand, p);
+                markVisibleAnimationDemand(demand, p, visibility);
         }
         return demand;
     }
@@ -1245,6 +1281,20 @@ namespace lfs::vis::gui {
     bool PanelRegistry::needsAnimationFrameForVisiblePanels(
         const PanelAnimationVisibility visibility) const {
         return animationDemandForVisiblePanels(visibility).any();
+    }
+
+    std::optional<double> PanelRegistry::nextScheduledAnimationDelayForVisiblePanels(
+        const PanelAnimationVisibility visibility) const {
+        std::optional<double> min_delay;
+        std::lock_guard lock(mutex_);
+        for (const auto& p : panels_) {
+            if (!p.enabled || p.error_disabled || !p.panel)
+                continue;
+            if (!isPanelVisibleForAnimation(p, visibility))
+                continue;
+            min_delay = minOptionalDelay(min_delay, p.panel->nextScheduledAnimationDelay());
+        }
+        return min_delay;
     }
 
     bool PanelRegistry::set_panel_label(const std::string& id, const std::string& new_label) {

--- a/src/visualizer/gui/panel_registry.hpp
+++ b/src/visualizer/gui/panel_registry.hpp
@@ -128,6 +128,9 @@ namespace lfs::vis::gui {
         virtual void setForcedHeight(float h) { (void)h; }
         virtual bool wantsKeyboard() const { return false; }
         virtual bool needsAnimationFrame() const { return false; }
+        // Finite scheduled animation/update delay in seconds (> 0). nullopt means
+        // no scheduled wake (either continuous demand via needsAnimationFrame or idle).
+        virtual std::optional<double> nextScheduledAnimationDelay() const { return std::nullopt; }
         virtual bool wantsExternalFloatingShadow() const { return true; }
         virtual void setPanelSpace(PanelSpace space) { (void)space; }
         virtual void reloadRmlResources() {}
@@ -327,6 +330,10 @@ namespace lfs::vis::gui {
         PanelAnimationDemand animationDemandForVisiblePanels(
             PanelAnimationVisibility visibility) const;
         bool needsAnimationFrameForVisiblePanels(PanelAnimationVisibility visibility) const;
+        // Min finite scheduled delay across visible panels (same visibility rules as
+        // needsAnimationFrameForVisiblePanels). nullopt if none are scheduled.
+        std::optional<double> nextScheduledAnimationDelayForVisiblePanels(
+            PanelAnimationVisibility visibility) const;
         bool set_panel_label(const std::string& id, const std::string& new_label);
         bool set_panel_order(const std::string& id, int new_order);
         bool set_panel_space(const std::string& id, PanelSpace new_space);

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1830,6 +1830,7 @@
     "secondary_view": "Sekundäre Ansicht",
     "split": "Teilung:",
     "gpu": "GPU",
+    "ui_fps": "UI FPS",
     "strategy_default": "Standard"
   },
   "plugin_manager": {

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1762,6 +1762,7 @@
     "secondary_view": "Secondary View",
     "split": "Split:",
     "gpu": "GPU",
+    "ui_fps": "UI FPS",
     "strategy_default": "Default"
   },
   "plugin_manager": {

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -1762,6 +1762,7 @@
     "secondary_view": "Vista Secundaria",
     "split": "División:",
     "gpu": "GPU",
+    "ui_fps": "UI FPS",
     "strategy_default": "Predeterminado"
   },
   "plugin_manager": {

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1830,6 +1830,7 @@
     "secondary_view": "Vue secondaire",
     "split": "Division :",
     "gpu": "GPU",
+    "ui_fps": "UI FPS",
     "strategy_default": "Défaut"
   },
   "plugin_manager": {

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1830,6 +1830,7 @@
     "secondary_view": "Vista secondaria",
     "split": "Divisione:",
     "gpu": "GPU",
+    "ui_fps": "UI FPS",
     "strategy_default": "Predefinito"
   },
   "plugin_manager": {

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1830,6 +1830,7 @@
     "secondary_view": "セカンダリビュー",
     "split": "分割:",
     "gpu": "GPU",
+    "ui_fps": "UI FPS",
     "strategy_default": "デフォルト"
   },
   "plugin_manager": {

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1830,6 +1830,7 @@
     "secondary_view": "보조 보기",
     "split": "분할:",
     "gpu": "GPU",
+    "ui_fps": "UI FPS",
     "strategy_default": "기본값"
   },
   "plugin_manager": {

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1830,6 +1830,7 @@
     "secondary_view": "Secundaire weergave",
     "split": "Splitsing:",
     "gpu": "GPU",
+    "ui_fps": "UI FPS",
     "strategy_default": "Standaard"
   },
   "plugin_manager": {

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1830,6 +1830,7 @@
     "secondary_view": "Widok pomocniczy",
     "split": "Podział:",
     "gpu": "GPU",
+    "ui_fps": "UI FPS",
     "strategy_default": "Domyślny"
   },
   "plugin_manager": {

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -1769,6 +1769,7 @@
     "secondary_view": "副视图",
     "split": "分割：",
     "gpu": "GPU",
+    "ui_fps": "UI FPS",
     "strategy_default": "默认"
   },
   "plugin_manager": {

--- a/src/visualizer/gui/rml_status_bar.cpp
+++ b/src/visualizer/gui/rml_status_bar.cpp
@@ -1215,14 +1215,22 @@ namespace lfs::vis::gui {
                        std::format("{} {:.2f}/{:.2f} GiB", LOC("status_bar.gpu"), used_gib, total_gib));
         setModelString("gpu_mem_color", model_.gpu_mem_color, colorToRml(mem_color));
 
-        // FPS
-        float fps = reactive_fps_available_ ? reactive_fps_value_
-                                            : (rm ? rm->getAverageFPS() : 0.0f);
-        ThemeColor fps_col = fps >= 30.0f ? p.success : (fps >= 15.0f ? p.warning : p.error);
+        // FPS: prefer scene-render rate when scene frames are in the measurement
+        // window; when only GUI frames are presented, show that rate as ui-fps
+        // so a GUI-only spin is not invisible. True idle (no samples) stays 0.
+        const float scene_fps = reactive_fps_available_ ? reactive_fps_value_
+                                                        : (rm ? rm->getAverageFPS() : 0.0f);
+        const float presented_fps = rm ? rm->getPresentedAverageFPS() : 0.0f;
+        const bool ui_only_fps = scene_fps <= 0.0f && presented_fps > 0.0f;
+        const float fps = ui_only_fps ? presented_fps : scene_fps;
+        ThemeColor fps_col = ui_only_fps
+                                 ? p.text_dim
+                                 : (fps >= 30.0f ? p.success : (fps >= 15.0f ? p.warning : p.error));
         setModelString("fps_value", model_.fps_value, std::format("{:.0f}", fps));
         setModelString("fps_color", model_.fps_color, colorToRml(fps_col));
         setModelString("fps_label", model_.fps_label,
-                       std::format(" {}", LOC(lichtfeld::Strings::Status::FPS)));
+                       ui_only_fps ? std::format(" {}", LOC("status_bar.ui_fps"))
+                                   : std::format(" {}", LOC(lichtfeld::Strings::Status::FPS)));
         setModelString("git_commit", model_.git_commit, GIT_COMMIT_HASH_SHORT);
 
         section_signature_ =

--- a/src/visualizer/gui/rml_viewport_overlay.cpp
+++ b/src/visualizer/gui/rml_viewport_overlay.cpp
@@ -21,7 +21,9 @@
 #include <RmlUi/Core/Input.h>
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <format>
+#include <limits>
 #include <vector>
 
 namespace lfs::vis::gui {
@@ -1000,7 +1002,9 @@ namespace lfs::vis::gui {
             rml_context_->SetDimensions(Rml::Vector2i(w, h));
             rml_context_->Update();
             queueCachedVulkanContext(true);
-            animation_active_ = (rml_context_->GetNextUpdateDelay() == 0);
+            const double next_delay = rml_context_->GetNextUpdateDelay();
+            next_update_delay_ = next_delay;
+            animation_active_ = (next_delay == 0.0);
             return;
         }
         const bool can_reuse = theme_current && !render_needed_ && !animation_active_ &&
@@ -1117,12 +1121,20 @@ namespace lfs::vis::gui {
         queueCachedVulkanContext(true);
         {
             LOG_TIMER_THRESHOLD("gui_render.rml_viewport_overlay.render.update.next_delay", 0.25);
-            animation_active_ = (rml_context_->GetNextUpdateDelay() == 0);
+            const double next_delay = rml_context_->GetNextUpdateDelay();
+            next_update_delay_ = next_delay;
+            animation_active_ = (next_delay == 0.0);
         }
         render_needed_ = false;
         render_reason_bits_ = 0;
         last_render_w_ = w;
         last_render_h_ = h;
+    }
+
+    std::optional<double> RmlViewportOverlay::nextScheduledUpdateDelay() const {
+        if (std::isfinite(next_update_delay_) && next_update_delay_ > 0.0)
+            return next_update_delay_;
+        return std::nullopt;
     }
 
 } // namespace lfs::vis::gui

--- a/src/visualizer/gui/rml_viewport_overlay.hpp
+++ b/src/visualizer/gui/rml_viewport_overlay.hpp
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <glm/glm.hpp>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -99,6 +100,9 @@ namespace lfs::vis::gui {
             return render_needed_ || document_sync_dirty_ || animation_active_ || tooltip_.revealDue() ||
                    (vram_hud_ && vram_hud_->needsAnimationFrame());
         }
+        // Finite RmlUi scheduled update delay (seconds) when > 0; nullopt for
+        // continuous demand (0) or idle (infinity).
+        [[nodiscard]] std::optional<double> nextScheduledUpdateDelay() const;
         [[nodiscard]] bool blocksPointer(double screen_x, double screen_y) const;
 
     private:
@@ -173,6 +177,7 @@ namespace lfs::vis::gui {
         bool document_sync_dirty_ = true;
         bool data_model_binding_dirty_ = true;
         bool animation_active_ = false;
+        double next_update_delay_ = std::numeric_limits<double>::infinity();
         bool hovered_interactive_ = false;
         Rml::Element* last_hover_element_ = nullptr;
         bool mouse_pos_valid_ = false;

--- a/src/visualizer/gui/rmlui/rml_panel_host.cpp
+++ b/src/visualizer/gui/rmlui/rml_panel_host.cpp
@@ -29,6 +29,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <format>
+#include <limits>
 #include <string_view>
 #include <unordered_set>
 
@@ -587,7 +588,9 @@ namespace lfs::vis::gui {
         if (height_mode_ != PanelHeightMode::Content)
             last_content_height_ = display_h;
 
-        animation_active_ = (rml_context_->GetNextUpdateDelay() == 0);
+        const double next_delay = rml_context_->GetNextUpdateDelay();
+        next_update_delay_ = next_delay;
+        animation_active_ = (next_delay == 0.0);
         last_fbo_w_ = pw;
         last_fbo_h_ = ph;
         last_fbo_padding_ = padding;
@@ -602,11 +605,30 @@ namespace lfs::vis::gui {
                 last_content_el_height_ = content_el_->GetOffsetHeight();
 
             if (std::abs(actual_content_h - prev_content_h) > 2.0f) {
-                content_dirty_ = true;
-                direct_cache_dirty_ = true;
-                last_measure_w_ = 0;
+                ++content_height_rearm_count_;
+                if (content_height_rearm_count_ > 8) {
+                    if (!content_height_rearm_warned_) {
+                        content_height_rearm_warned_ = true;
+                        LOG_WARN("RmlPanelHost '{}': content-height settle exceeded 8 re-arms "
+                                 "(pw={}, ph={}, prev_h={:.1f}, actual_h={:.1f}); skipping re-arm",
+                                 context_name_, pw, ph, prev_content_h, actual_content_h);
+                    }
+                } else {
+                    content_dirty_ = true;
+                    direct_cache_dirty_ = true;
+                    last_measure_w_ = 0;
+                }
+            } else {
+                content_height_rearm_count_ = 0;
+                content_height_rearm_warned_ = false;
             }
         }
+    }
+
+    std::optional<double> RmlPanelHost::nextScheduledUpdateDelay() const {
+        if (std::isfinite(next_update_delay_) && next_update_delay_ > 0.0)
+            return next_update_delay_;
+        return std::nullopt;
     }
 
     void RmlPanelHost::draw(const PanelDrawContext& ctx) {

--- a/src/visualizer/gui/rmlui/rml_panel_host.hpp
+++ b/src/visualizer/gui/rmlui/rml_panel_host.hpp
@@ -64,6 +64,7 @@ namespace lfs::vis::gui {
         void markContentDirty() {
             content_dirty_ = true;
             direct_cache_dirty_ = true;
+            content_height_rearm_count_ = 0;
         }
         void setForeground(bool fg) { foreground_ = fg; }
         void setFloating(bool floating);
@@ -74,6 +75,9 @@ namespace lfs::vis::gui {
         bool needsAnimationFrame() const {
             return render_needed_ || content_dirty_ || animation_active_ || tooltip_.revealDue();
         }
+        // Finite RmlUi scheduled update delay (seconds) when > 0; nullopt for
+        // continuous demand (0, use needsAnimationFrame) or idle (infinity).
+        [[nodiscard]] std::optional<double> nextScheduledUpdateDelay() const;
 
         Rml::ElementDocument* getDocument() { return document_; }
         Rml::Context* getContext() { return rml_context_; }
@@ -136,6 +140,9 @@ namespace lfs::vis::gui {
 
         bool render_needed_ = true;
         bool animation_active_ = false;
+        double next_update_delay_ = std::numeric_limits<double>::infinity();
+        int content_height_rearm_count_ = 0;
+        bool content_height_rearm_warned_ = false;
         std::uint64_t localized_language_generation_ = std::numeric_limits<std::uint64_t>::max();
         bool direct_cache_dirty_ = true;
         CachedVulkanContextRender direct_cache_;

--- a/src/visualizer/gui/rmlui/rmlui_manager.cpp
+++ b/src/visualizer/gui/rmlui/rmlui_manager.cpp
@@ -770,16 +770,30 @@ namespace lfs::vis::gui {
                         lfs::core::ScopedTimer timer(
                             timer_name + ".cache_refresh", 0.25,
                             lfs::core::LogLevel::Performance, LFS_SOURCE_SITE_CURRENT());
-                        if (command.cache->texture != 0)
+                        // Same capture extent → reuse the existing image (copy into it).
+                        // Extent change → deferred-delete the old image and allocate fresh.
+                        const Rml::TextureHandle reuse_texture =
+                            (command.cache->texture != 0 && command.cache->width == vis_w &&
+                             command.cache->height == vis_h)
+                                ? command.cache->texture
+                                : Rml::TextureHandle{};
+                        if (command.cache->texture != 0 && reuse_texture == 0)
                             releaseCachedVulkanContext(*command.cache);
 
                         vulkan_render_interface_->ResetContextRenderState();
+                        vulkan_render_interface_->BeginCacheCapture(left, top, vis_w, vis_h);
+                        vulkan_render_interface_->SetContextOffset(command.offset_x, command.offset_y);
+                        vulkan_render_interface_->SetContextClipRect(fleft, ftop, fright, fbottom);
                         const Rml::LayerHandle layer = vulkan_render_interface_->PushLayer();
                         if (layer != 0) {
-                            vulkan_render_interface_->SetContextOffset(command.offset_x, command.offset_y);
-                            vulkan_render_interface_->SetContextClipRect(fleft, ftop, fright, fbottom);
                             command.context->Render();
-                            command.cache->texture = vulkan_render_interface_->SaveLayerAsTexture();
+                            const Rml::TextureHandle saved_texture =
+                                vulkan_render_interface_->SaveLayerAsTexture(reuse_texture);
+                            if (reuse_texture != 0 && saved_texture != 0 && saved_texture != reuse_texture)
+                                vulkan_render_interface_->ReleaseTexture(reuse_texture);
+                            // On save failure keep a still-valid reuse handle (avoid leaking it).
+                            command.cache->texture =
+                                saved_texture != 0 ? saved_texture : reuse_texture;
                             vulkan_render_interface_->SetTextureDebugName(command.cache->texture,
                                                                           command.context_name);
                             vulkan_render_interface_->PopLayer();
@@ -794,6 +808,7 @@ namespace lfs::vis::gui {
                             command.cache->clip_y2 = fbottom;
                             recordPreviewDependency(*command.cache, saved);
                         }
+                        vulkan_render_interface_->EndCacheCapture();
                     }
 
                     if (command.cache->texture != 0) {
@@ -835,19 +850,31 @@ namespace lfs::vis::gui {
                     lfs::core::ScopedTimer timer(
                         timer_name + ".cache_refresh", 0.25,
                         lfs::core::LogLevel::Performance, LFS_SOURCE_SITE_CURRENT());
-                    if (command.cache->texture != 0)
+                    const Rml::TextureHandle reuse_texture =
+                        (command.cache->texture != 0 && command.cache->width == command.cache_width &&
+                         command.cache->height == command.cache_height)
+                            ? command.cache->texture
+                            : Rml::TextureHandle{};
+                    if (command.cache->texture != 0 && reuse_texture == 0)
                         releaseCachedVulkanContext(*command.cache);
 
                     vulkan_render_interface_->ResetContextRenderState();
+                    vulkan_render_interface_->BeginCacheCapture(0, 0, command.cache_width, command.cache_height);
+                    vulkan_render_interface_->SetContextOffset(0.0f, 0.0f);
+                    vulkan_render_interface_->SetContextClipRect(0.0f,
+                                                                 0.0f,
+                                                                 static_cast<float>(command.cache_width),
+                                                                 static_cast<float>(command.cache_height));
                     const Rml::LayerHandle layer = vulkan_render_interface_->PushLayer();
                     if (layer != 0) {
-                        vulkan_render_interface_->SetContextOffset(0.0f, 0.0f);
-                        vulkan_render_interface_->SetContextClipRect(0.0f,
-                                                                     0.0f,
-                                                                     static_cast<float>(command.cache_width),
-                                                                     static_cast<float>(command.cache_height));
                         command.context->Render();
-                        command.cache->texture = vulkan_render_interface_->SaveLayerAsTexture();
+                        const Rml::TextureHandle saved_texture =
+                            vulkan_render_interface_->SaveLayerAsTexture(reuse_texture);
+                        if (reuse_texture != 0 && saved_texture != 0 && saved_texture != reuse_texture)
+                            vulkan_render_interface_->ReleaseTexture(reuse_texture);
+                        // On save failure keep a still-valid reuse handle (avoid leaking it).
+                        command.cache->texture =
+                            saved_texture != 0 ? saved_texture : reuse_texture;
                         vulkan_render_interface_->SetTextureDebugName(command.cache->texture,
                                                                       command.context_name);
                         vulkan_render_interface_->PopLayer();
@@ -856,6 +883,7 @@ namespace lfs::vis::gui {
                         command.cache->height = saved ? command.cache_height : 0;
                         recordPreviewDependency(*command.cache, saved);
                     }
+                    vulkan_render_interface_->EndCacheCapture();
                 }
 
                 if (command.cache->texture != 0) {

--- a/src/visualizer/gui/rmlui/rmlui_vk_backend.cpp
+++ b/src/visualizer/gui/rmlui/rmlui_vk_backend.cpp
@@ -482,7 +482,7 @@ void RenderInterface_VK::EnableScissorRegion(bool enable) {
     if (m_is_use_scissor_specified == false) {
         m_is_transformed_scissor_enabled = false;
         m_is_apply_to_regular_geometry_stencil = m_is_clip_mask_enabled;
-        m_scissor = ContextClipScissor();
+        m_scissor = ClampToCacheCaptureArea(ContextClipScissor());
         vkCmdSetScissor(m_p_current_command_buffer, 0, 1, &m_scissor);
     }
 }
@@ -500,7 +500,7 @@ void RenderInterface_VK::SetScissorRegion(Rml::Rectanglei region) {
             int indices[6] = {0, 2, 1, 0, 3, 2};
 
             m_is_use_stencil_pipeline = true;
-            m_scissor = ContextClipScissor();
+            m_scissor = ClampToCacheCaptureArea(ContextClipScissor());
             vkCmdSetScissor(m_p_current_command_buffer, 0, 1, &m_scissor);
 
 #ifdef RMLUI_VK_DEBUG
@@ -527,8 +527,10 @@ void RenderInterface_VK::SetScissorRegion(Rml::Rectanglei region) {
 
             VkClearRect clear_rect = {};
             clear_rect.layerCount = 1;
-            clear_rect.rect.extent.width = m_width;
-            clear_rect.rect.extent.height = m_height;
+            clear_rect.rect = ClampToCacheCaptureArea(VkRect2D{
+                {0, 0},
+                {static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height)},
+            });
 
             vkCmdClearAttachments(m_p_current_command_buffer, 1, &clear_attachment, 1, &clear_rect);
 
@@ -541,7 +543,7 @@ void RenderInterface_VK::SetScissorRegion(Rml::Rectanglei region) {
 
             m_is_transformed_scissor_enabled = true;
             m_is_apply_to_regular_geometry_stencil = true;
-            m_scissor = ContextClipScissor();
+            m_scissor = ClampToCacheCaptureArea(ContextClipScissor());
             vkCmdSetScissor(m_p_current_command_buffer, 0, 1, &m_scissor);
         } else {
             m_is_transformed_scissor_enabled = false;
@@ -559,7 +561,7 @@ void RenderInterface_VK::SetScissorRegion(Rml::Rectanglei region) {
             m_scissor.offset.y = top;
             m_scissor.extent.width = static_cast<uint32_t>(std::max(0, right - left));
             m_scissor.extent.height = static_cast<uint32_t>(std::max(0, bottom - top));
-            m_scissor = IntersectContextClip(m_scissor);
+            m_scissor = ClampToCacheCaptureArea(IntersectContextClip(m_scissor));
 
 #ifdef RMLUI_VK_DEBUG
             VkDebugUtilsLabelEXT info{};
@@ -598,8 +600,10 @@ void RenderInterface_VK::RenderToClipMask(Rml::ClipMaskOperation operation, Rml:
 
     VkClearRect clear_rect = {};
     clear_rect.layerCount = 1;
-    clear_rect.rect.extent.width = m_width;
-    clear_rect.rect.extent.height = m_height;
+    clear_rect.rect = ClampToCacheCaptureArea(VkRect2D{
+        {0, 0},
+        {static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height)},
+    });
 
     // Match RmlUi's legacy compatibility behavior for intersect until the Vulkan renderer has
     // stencil increment/decrement pipelines for true nested clip-mask intersections.
@@ -702,6 +706,10 @@ void RenderInterface_VK::PopLayer() {
 }
 
 Rml::TextureHandle RenderInterface_VK::SaveLayerAsTexture() {
+    return SaveLayerAsTexture({});
+}
+
+Rml::TextureHandle RenderInterface_VK::SaveLayerAsTexture(Rml::TextureHandle reuse_texture) {
     if (m_p_current_command_buffer == nullptr || m_render_layer_stack_size <= 0)
         return {};
 
@@ -713,6 +721,7 @@ Rml::TextureHandle RenderInterface_VK::SaveLayerAsTexture() {
 
     VkRect2D bounds = m_is_use_scissor_specified ? m_scissor : ContextClipScissor();
     bounds = IntersectContextClip(bounds);
+    bounds = ClampToCacheCaptureArea(bounds);
     bounds.offset.x = Rml::Math::Clamp(bounds.offset.x, 0, source_layer->width);
     bounds.offset.y = Rml::Math::Clamp(bounds.offset.y, 0, source_layer->height);
     if (bounds.offset.x + static_cast<int>(bounds.extent.width) > source_layer->width)
@@ -724,79 +733,102 @@ Rml::TextureHandle RenderInterface_VK::SaveLayerAsTexture() {
 
     EndActiveRendering();
 
-    auto* texture = new texture_data_t{};
-    const VkFormat format = m_swapchain_format.format;
+    const int capture_w = static_cast<int>(bounds.extent.width);
+    const int capture_h = static_cast<int>(bounds.extent.height);
     const VkExtent3D extent{bounds.extent.width, bounds.extent.height, 1};
 
-    VkImageCreateInfo image_info{};
-    image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    image_info.imageType = VK_IMAGE_TYPE_2D;
-    image_info.format = format;
-    image_info.extent = extent;
-    image_info.mipLevels = 1;
-    image_info.arrayLayers = 1;
-    image_info.samples = VK_SAMPLE_COUNT_1_BIT;
-    image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-    image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VmaAllocationCreateInfo allocation_info{};
-    allocation_info.usage = VMA_MEMORY_USAGE_GPU_ONLY;
-
-    VmaAllocationInfo allocation_stats{};
-    VkResult status = vmaCreateImage(m_p_allocator,
-                                     &image_info,
-                                     &allocation_info,
-                                     &texture->m_p_vk_image,
-                                     &texture->m_p_vma_allocation,
-                                     &allocation_stats);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to create saved RmlUi layer texture");
-    if (status != VK_SUCCESS) {
-        delete texture;
-        return {};
+    texture_data_t* texture = nullptr;
+    bool reusing = false;
+    if (reuse_texture != 0) {
+        auto* candidate = reinterpret_cast<texture_data_t*>(reuse_texture);
+        if (candidate && candidate->m_p_vk_image != VK_NULL_HANDLE && candidate->m_p_vk_image_view != VK_NULL_HANDLE &&
+            candidate->m_width == capture_w && candidate->m_height == capture_h) {
+            texture = candidate;
+            reusing = true;
+        }
     }
-    (void)m_debug_name_writer.set(VK_OBJECT_TYPE_IMAGE,
-                                  (uint64_t)texture->m_p_vk_image,
-                                  "rmlui.saved-layer.image");
-    texture->m_barrier_generation = ++m_image_barrier_generation;
-    texture->m_vram_scope = "vulkan.rmlui.saved_layer_texture";
-    texture->m_vram_label = TextureVramLabel("saved_layer",
-                                             "clip",
-                                             static_cast<int>(bounds.extent.width),
-                                             static_cast<int>(bounds.extent.height),
-                                             texture);
-    texture->m_vram_allocation_size = allocation_stats.size;
-    RecordRmlUiVram(texture->m_vram_scope, texture->m_vram_label, texture->m_vram_allocation_size);
 
-    VkImageViewCreateInfo view_info{};
-    view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-    view_info.image = texture->m_p_vk_image;
-    view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    view_info.format = format;
-    view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    view_info.subresourceRange.baseMipLevel = 0;
-    view_info.subresourceRange.levelCount = 1;
-    view_info.subresourceRange.baseArrayLayer = 0;
-    view_info.subresourceRange.layerCount = 1;
-    status = vkCreateImageView(m_p_device, &view_info, nullptr, &texture->m_p_vk_image_view);
-    RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to create saved RmlUi layer texture view");
-    if (status != VK_SUCCESS) {
-        if (!texture->m_vram_scope.empty() && !texture->m_vram_label.empty())
-            RecordRmlUiVram(texture->m_vram_scope, texture->m_vram_label, 0);
-        vmaDestroyImage(m_p_allocator, texture->m_p_vk_image, texture->m_p_vma_allocation);
-        delete texture;
-        return {};
+    if (!reusing) {
+        texture = new texture_data_t{};
+        const VkFormat format = m_swapchain_format.format;
+
+        VkImageCreateInfo image_info{};
+        image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        image_info.imageType = VK_IMAGE_TYPE_2D;
+        image_info.format = format;
+        image_info.extent = extent;
+        image_info.mipLevels = 1;
+        image_info.arrayLayers = 1;
+        image_info.samples = VK_SAMPLE_COUNT_1_BIT;
+        image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+        image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+        VmaAllocationCreateInfo allocation_info{};
+        allocation_info.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+
+        VmaAllocationInfo allocation_stats{};
+        VkResult status = vmaCreateImage(m_p_allocator,
+                                         &image_info,
+                                         &allocation_info,
+                                         &texture->m_p_vk_image,
+                                         &texture->m_p_vma_allocation,
+                                         &allocation_stats);
+        RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to create saved RmlUi layer texture");
+        if (status != VK_SUCCESS) {
+            delete texture;
+            return {};
+        }
+        (void)m_debug_name_writer.set(VK_OBJECT_TYPE_IMAGE,
+                                      (uint64_t)texture->m_p_vk_image,
+                                      "rmlui.saved-layer.image");
+        texture->m_barrier_generation = ++m_image_barrier_generation;
+        texture->m_width = capture_w;
+        texture->m_height = capture_h;
+        texture->m_vram_scope = "vulkan.rmlui.saved_layer_texture";
+        texture->m_vram_label = TextureVramLabel("saved_layer",
+                                                 "clip",
+                                                 capture_w,
+                                                 capture_h,
+                                                 texture);
+        texture->m_vram_allocation_size = allocation_stats.size;
+        RecordRmlUiVram(texture->m_vram_scope, texture->m_vram_label, texture->m_vram_allocation_size);
+
+        VkImageViewCreateInfo view_info{};
+        view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        view_info.image = texture->m_p_vk_image;
+        view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        view_info.format = format;
+        view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        view_info.subresourceRange.baseMipLevel = 0;
+        view_info.subresourceRange.levelCount = 1;
+        view_info.subresourceRange.baseArrayLayer = 0;
+        view_info.subresourceRange.layerCount = 1;
+        status = vkCreateImageView(m_p_device, &view_info, nullptr, &texture->m_p_vk_image_view);
+        RMLUI_VK_ASSERTMSG(status == VK_SUCCESS, "failed to create saved RmlUi layer texture view");
+        if (status != VK_SUCCESS) {
+            if (!texture->m_vram_scope.empty() && !texture->m_vram_label.empty())
+                RecordRmlUiVram(texture->m_vram_scope, texture->m_vram_label, 0);
+            vmaDestroyImage(m_p_allocator, texture->m_p_vk_image, texture->m_p_vma_allocation);
+            delete texture;
+            return {};
+        }
+        (void)m_debug_name_writer.set(VK_OBJECT_TYPE_IMAGE_VIEW,
+                                      (uint64_t)texture->m_p_vk_image_view,
+                                      "rmlui.saved-layer.view");
+        texture->m_p_vk_sampler = m_p_sampler_linear;
     }
-    (void)m_debug_name_writer.set(VK_OBJECT_TYPE_IMAGE_VIEW,
-                                  (uint64_t)texture->m_p_vk_image_view,
-                                  "rmlui.saved-layer.view");
-    texture->m_p_vk_sampler = m_p_sampler_linear;
 
     TransitionImageLayout(source_layer->m_color.m_p_vk_image, source_layer->m_color.m_barrier_generation, VK_IMAGE_ASPECT_COLOR_BIT, source_layer->m_color_layout,
                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
     source_layer->m_color_layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
 
-    TransitionImageLayout(texture->m_p_vk_image, texture->m_barrier_generation, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    // Fresh images: UNDEFINED → TRANSFER_DST (discard). Reused cache textures were last in
+    // SHADER_READ_ONLY after composite sampling; WAR against those fragment reads on this queue.
+    const VkImageLayout dst_old_layout =
+        reusing ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
+    TransitionImageLayout(texture->m_p_vk_image, texture->m_barrier_generation, VK_IMAGE_ASPECT_COLOR_BIT, dst_old_layout,
+                          VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     VkImageCopy copy_region{};
     copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -819,7 +851,8 @@ Rml::TextureHandle RenderInterface_VK::SaveLayerAsTexture() {
 
     BeginLayerRendering(static_cast<Rml::LayerHandle>(m_render_layer_stack_size), false);
 
-    RegisterLiveTexture(texture);
+    if (!reusing)
+        RegisterLiveTexture(texture);
     return reinterpret_cast<Rml::TextureHandle>(texture);
 }
 
@@ -1429,12 +1462,41 @@ void RenderInterface_VK::SetContextOffset(float offset_x, float offset_y) {
     ApplyTransformState();
 }
 
+void RenderInterface_VK::BeginCacheCapture(const int x, const int y, const int width, const int height) {
+    if (width <= 0 || height <= 0) {
+        EndCacheCapture();
+        return;
+    }
+
+    const int left = Rml::Math::Clamp(x, 0, m_width);
+    const int top = Rml::Math::Clamp(y, 0, m_height);
+    const int right = Rml::Math::Clamp(x + width, 0, m_width);
+    const int bottom = Rml::Math::Clamp(y + height, 0, m_height);
+    if (right <= left || bottom <= top) {
+        EndCacheCapture();
+        return;
+    }
+
+    m_cache_capture_active = true;
+    m_cache_capture_render_area.offset.x = left;
+    m_cache_capture_render_area.offset.y = top;
+    m_cache_capture_render_area.extent.width = static_cast<uint32_t>(right - left);
+    m_cache_capture_render_area.extent.height = static_cast<uint32_t>(bottom - top);
+}
+
+void RenderInterface_VK::EndCacheCapture() {
+    m_cache_capture_active = false;
+    m_cache_capture_render_area = {};
+}
+
 void RenderInterface_VK::SetContextClipRect(float x1, float y1, float x2, float y2) {
     if (x2 <= x1 || y2 <= y1) {
         m_context_clip_enabled = true;
         m_context_clip_scissor = {};
-        if (m_p_current_command_buffer)
-            vkCmdSetScissor(m_p_current_command_buffer, 0, 1, &m_context_clip_scissor);
+        if (m_p_current_command_buffer) {
+            VkRect2D empty = ClampToCacheCaptureArea(m_context_clip_scissor);
+            vkCmdSetScissor(m_p_current_command_buffer, 0, 1, &empty);
+        }
         return;
     }
 
@@ -1448,8 +1510,10 @@ void RenderInterface_VK::SetContextClipRect(float x1, float y1, float x2, float 
     m_context_clip_scissor.offset.y = top;
     m_context_clip_scissor.extent.width = static_cast<uint32_t>(std::max(0, right - left));
     m_context_clip_scissor.extent.height = static_cast<uint32_t>(std::max(0, bottom - top));
-    if (m_p_current_command_buffer)
-        vkCmdSetScissor(m_p_current_command_buffer, 0, 1, &m_context_clip_scissor);
+    if (m_p_current_command_buffer) {
+        VkRect2D scissor = ClampToCacheCaptureArea(m_context_clip_scissor);
+        vkCmdSetScissor(m_p_current_command_buffer, 0, 1, &scissor);
+    }
 }
 
 void RenderInterface_VK::ApplyTransformState() {
@@ -1525,6 +1589,26 @@ VkRect2D RenderInterface_VK::IntersectContextClip(VkRect2D scissor) const noexce
     scissor.extent.width = static_cast<uint32_t>(std::max(0, right - left));
     scissor.extent.height = static_cast<uint32_t>(std::max(0, bottom - top));
     return scissor;
+}
+
+VkRect2D RenderInterface_VK::ClampToCacheCaptureArea(VkRect2D rect) const noexcept {
+    if (!m_cache_capture_active)
+        return rect;
+
+    const int left = std::max(rect.offset.x, m_cache_capture_render_area.offset.x);
+    const int top = std::max(rect.offset.y, m_cache_capture_render_area.offset.y);
+    const int right = std::min(rect.offset.x + static_cast<int>(rect.extent.width),
+                               m_cache_capture_render_area.offset.x +
+                                   static_cast<int>(m_cache_capture_render_area.extent.width));
+    const int bottom = std::min(rect.offset.y + static_cast<int>(rect.extent.height),
+                                m_cache_capture_render_area.offset.y +
+                                    static_cast<int>(m_cache_capture_render_area.extent.height));
+
+    rect.offset.x = left;
+    rect.offset.y = top;
+    rect.extent.width = static_cast<uint32_t>(std::max(0, right - left));
+    rect.extent.height = static_cast<uint32_t>(std::max(0, bottom - top));
+    return rect;
 }
 
 bool RenderInterface_VK::InitializeExternal(const ExternalContext& context) {
@@ -1651,6 +1735,7 @@ void RenderInterface_VK::BeginExternalFrame(const VkCommandBuffer command_buffer
     SetContextOffset(0.0f, 0.0f);
     SetTransform(nullptr);
     m_context_clip_enabled = false;
+    EndCacheCapture();
 }
 
 void RenderInterface_VK::EndExternalFrame() {
@@ -1666,6 +1751,7 @@ void RenderInterface_VK::EndExternalFrame() {
     m_external_swapchain_layout = VK_IMAGE_LAYOUT_UNDEFINED;
     m_active_render_target = active_render_target_t::None;
     m_p_current_command_buffer = nullptr;
+    EndCacheCapture();
 }
 
 void RenderInterface_VK::ResetContextRenderState() {
@@ -1680,8 +1766,11 @@ void RenderInterface_VK::ResetContextRenderState() {
     SetContextOffset(0.0f, 0.0f);
     SetTransform(nullptr);
     m_context_clip_enabled = false;
+    // Do not clear cache-capture mode here: manager may call Reset between
+    // BeginCacheCapture and PushLayer/Render.
     vkCmdSetViewport(m_p_current_command_buffer, 0, 1, &m_viewport);
-    vkCmdSetScissor(m_p_current_command_buffer, 0, 1, &m_scissor_original);
+    VkRect2D scissor = ClampToCacheCaptureArea(m_scissor_original);
+    vkCmdSetScissor(m_p_current_command_buffer, 0, 1, &scissor);
     vkCmdSetStencilReference(m_p_current_command_buffer, VK_STENCIL_FACE_FRONT_AND_BACK, 1);
 }
 
@@ -2423,7 +2512,7 @@ void RenderInterface_VK::ResetDynamicRenderState() {
         return;
     vkCmdSetViewport(m_p_current_command_buffer, 0, 1, &m_viewport);
     VkRect2D scissor = (m_is_use_scissor_specified && !m_is_transformed_scissor_enabled) ? m_scissor : ContextClipScissor();
-    scissor = IntersectContextClip(scissor);
+    scissor = ClampToCacheCaptureArea(IntersectContextClip(scissor));
     vkCmdSetScissor(m_p_current_command_buffer, 0, 1, &scissor);
     vkCmdSetStencilReference(m_p_current_command_buffer, VK_STENCIL_FACE_FRONT_AND_BACK, 1);
 }
@@ -2465,11 +2554,24 @@ void RenderInterface_VK::BeginLayerRendering(Rml::LayerHandle layer_handle, bool
     depth_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     depth_attachment.clearValue = depth_clear;
 
+    // Full-layer default; during cache capture, restrict renderArea so loadOp CLEAR
+    // only touches the panel region (scissors are clamped to the same rect).
+    VkRect2D render_area{};
+    render_area.offset = {0, 0};
+    render_area.extent = {static_cast<uint32_t>(layer->width), static_cast<uint32_t>(layer->height)};
+    if (m_cache_capture_active) {
+        render_area = ClampToCacheCaptureArea(render_area);
+        // Empty capture area would make begin-rendering illegal; fall back to full layer.
+        if (render_area.extent.width == 0 || render_area.extent.height == 0) {
+            render_area.offset = {0, 0};
+            render_area.extent = {static_cast<uint32_t>(layer->width),
+                                  static_cast<uint32_t>(layer->height)};
+        }
+    }
+
     VkRenderingInfo rendering_info{};
     rendering_info.sType = VK_STRUCTURE_TYPE_RENDERING_INFO;
-    rendering_info.renderArea.offset = {0, 0};
-    rendering_info.renderArea.extent = {static_cast<uint32_t>(layer->width),
-                                        static_cast<uint32_t>(layer->height)};
+    rendering_info.renderArea = render_area;
     rendering_info.layerCount = 1;
     rendering_info.colorAttachmentCount = 1;
     rendering_info.pColorAttachments = &color_attachment;

--- a/src/visualizer/gui/rmlui/rmlui_vk_backend.hpp
+++ b/src/visualizer/gui/rmlui/rmlui_vk_backend.hpp
@@ -81,6 +81,13 @@ public:
     void SetContextClipRect(float x1, float y1, float x2, float y2);
     void RenderTextureQuad(Rml::TextureHandle texture, float x, float y, float w, float h);
 
+    // Restrict layer render-pass area (and thus loadOp clears / scissor bounds) to the
+    // capture clip rect while recording a cached-panel refresh. Pair with EndCacheCapture.
+    // Nested PushLayer during the capture inherits the same restricted area. Normal
+    // (non-capture) layer usage is unaffected when capture is inactive.
+    void BeginCacheCapture(int x, int y, int width, int height);
+    void EndCacheCapture();
+
     // Build a Rml::Image src URL referencing an externally-owned VkImageView/VkSampler.
     // The view+sampler must remain alive while any element references this URL. The
     // returned URL form is "lfs-vk://?v=<view_hex>&s=<sampler_hex>&w=W&h=H".
@@ -128,6 +135,11 @@ public:
     void PopLayer() override;
     /// Called by RmlUi when it wants to capture the current layer as a texture.
     Rml::TextureHandle SaveLayerAsTexture() override;
+    /// Like SaveLayerAsTexture(), but when `reuse_texture` has the same extent as the
+    /// capture bounds, reuses that image (copy into it) instead of allocating a new one.
+    /// On extent mismatch or invalid handle, allocates a new texture (caller must release
+    /// the old one if it is no longer needed).
+    Rml::TextureHandle SaveLayerAsTexture(Rml::TextureHandle reuse_texture);
 
     /// Called by RmlUi when it wants to set the current transform matrix to a new matrix.
     void SetTransform(const Rml::Matrix4f* transform) override;
@@ -155,6 +167,8 @@ private:
         std::string m_vram_scope;
         std::string m_vram_label;
         VkDeviceSize m_vram_allocation_size = 0;
+        int m_width = 0;
+        int m_height = 0;
         bool m_is_async_preview = false;
         // Resource identity for VulkanImageBarrierTracker (#1478).
         std::uint64_t m_barrier_generation = 0;
@@ -574,6 +588,8 @@ private:
     void ApplyTransformState();
     VkRect2D ContextClipScissor() const noexcept;
     VkRect2D IntersectContextClip(VkRect2D scissor) const noexcept;
+    // Intersect with the active cache-capture render area when capture is active; no-op otherwise.
+    VkRect2D ClampToCacheCaptureArea(VkRect2D rect) const noexcept;
     void ResetDynamicRenderState();
     void RenderFullscreenTexture(texture_data_t& texture, Rml::BlendMode blend_mode);
 
@@ -639,6 +655,9 @@ private:
     VkRect2D m_context_clip_scissor{};
     bool m_context_clip_enabled = false;
     bool m_current_context_used_preview_texture = false;
+    // When true, layer render passes clear/draw only this sub-rect of the full-size layer.
+    bool m_cache_capture_active = false;
+    VkRect2D m_cache_capture_render_area{};
 
     Rml::Matrix4f m_projection;
     Rml::Vector<VkShaderModule> m_shaders;

--- a/src/visualizer/gui/scene_panel_native.cpp
+++ b/src/visualizer/gui/scene_panel_native.cpp
@@ -804,7 +804,11 @@ namespace lfs::vis::gui {
 
         if (logging_level_select_el_ &&
             logging_level_select_el_->GetSelection() != desired_selection) {
+            // Guard the Change listener so programmatic selection does not re-enter
+            // applyLogLevelSelection → setLoggingFeedback → dirty latch.
+            syncing_logging_selection_ = true;
             logging_level_select_el_->SetSelection(desired_selection);
+            syncing_logging_selection_ = false;
             changed = true;
         }
 
@@ -922,6 +926,11 @@ namespace lfs::vis::gui {
         if (type == "change") {
             const Rml::String current_id = current ? current->GetId() : "";
             if (current_id == "logging-level-select") {
+                // Ignore Change events raised by programmatic SetSelection during sync.
+                if (syncing_logging_selection_) {
+                    event.StopPropagation();
+                    return true;
+                }
                 applyLogLevelSelection();
                 event.StopPropagation();
                 return true;
@@ -1024,6 +1033,11 @@ namespace lfs::vis::gui {
 
         const core::LogLevel selected_level =
             logLevelFromSelection(logging_level_select_el_->GetSelection());
+        // No-op when the selection already matches the applied level — avoids
+        // re-dirtying via setLoggingFeedback on programmatic Change events.
+        if (selected_level == core::Logger::get().level())
+            return;
+
         core::Logger::get().set_level(selected_level);
         setLoggingFeedback(LOCF("runtime.log_level_set", logLevelLabel(selected_level)),
                            FeedbackTone::Success);
@@ -1079,6 +1093,8 @@ namespace lfs::vis::gui {
     }
 
     void NativeScenePanel::setLoggingFeedback(std::string message, const FeedbackTone tone) {
+        if (message == logging_feedback_text_ && tone == logging_feedback_tone_)
+            return;
         logging_feedback_text_ = std::move(message);
         logging_feedback_tone_ = tone;
         logging_feedback_dirty_ = true;

--- a/src/visualizer/gui/scene_panel_native.hpp
+++ b/src/visualizer/gui/scene_panel_native.hpp
@@ -11,6 +11,7 @@
 
 #include <RmlUi/Core/EventListener.h>
 #include <cstdint>
+#include <optional>
 #include <string>
 
 namespace Rml {
@@ -46,6 +47,9 @@ namespace lfs::vis::gui {
         }
         bool wantsKeyboard() const override { return host_.wantsKeyboard(); }
         bool needsAnimationFrame() const override { return host_.needsAnimationFrame(); }
+        std::optional<double> nextScheduledAnimationDelay() const override {
+            return host_.nextScheduledUpdateDelay();
+        }
         void reloadRmlResources() override;
         void releaseRendererResources() override { host_.releaseRendererResources(); }
 
@@ -169,6 +173,7 @@ namespace lfs::vis::gui {
         std::string logging_feedback_text_;
         FeedbackTone logging_feedback_tone_ = FeedbackTone::Info;
         bool logging_feedback_dirty_ = false;
+        bool syncing_logging_selection_ = false;
     };
 
 } // namespace lfs::vis::gui

--- a/src/visualizer/rendering/rendering_manager.hpp
+++ b/src/visualizer/rendering/rendering_manager.hpp
@@ -357,8 +357,13 @@ namespace lfs::vis {
 
         void clearLatestCameraMetrics();
 
-        // FPS monitoring
+        // FPS monitoring (scene renders vs. swapchain-presented GUI frames)
         float getAverageFPS() const { return framerate_controller_.getAverageFPS(); }
+        float getPresentedAverageFPS() const {
+            return presented_framerate_controller_.getAverageFPS();
+        }
+        // Measurement only — does not affect scene render pacing/limiting.
+        void notePresentedFrame() { presented_framerate_controller_.beginFrame(); }
 
         // Access to the auxiliary rendering engine used by point-cloud, mesh, and readback paths.
         lfs::rendering::RenderingEngine* getRenderingEngine();
@@ -738,6 +743,9 @@ namespace lfs::vis {
         std::unique_ptr<lfs::rendering::RenderingEngine> engine_;
         lfs::rendering::ScreenOverlayRenderer screen_overlay_renderer_;
         mutable FramerateController framerate_controller_;
+        // Parallel presented-frame counter (GUI-only frames included). Does not
+        // drive pacing — scene path still uses framerate_controller_ alone.
+        mutable FramerateController presented_framerate_controller_;
 
         std::shared_ptr<const lfs::core::Tensor> vulkan_viewport_image_;
         std::uint64_t vulkan_viewport_image_generation_ = 0;

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -100,6 +100,11 @@ namespace lfs::vis {
 
         constexpr double kResizeSettleMinWaitSeconds = 0.001;
         constexpr double kTooltipRevealMinWaitSeconds = 0.001;
+        constexpr double kScheduledRedrawMinWaitSeconds = 0.001;
+        constexpr double kGuiScheduledUpdateMinWaitSeconds = 0.001;
+        // Backstop cap for GUI-only continuous demand (python_redraw / gui_animation only).
+        // MAILBOX presents never block, so free-running would pin the GPU at full GUI cost.
+        constexpr double kGuiAnimationFrameInterval = 1.0 / 30.0;
 #if defined(__linux__)
         constexpr auto kWindowResizePaintDemandWindow = std::chrono::milliseconds(160);
 #endif
@@ -1613,11 +1618,21 @@ namespace lfs::vis {
 
         // Wake exactly when a pending tooltip is due so the reveal costs a single
         // frame instead of rendering continuously through the hover delay.
+        // Also min against RmlUi scheduled-update deadlines (CSS transitions, timers)
+        // so finite-delay panels wake on time without gui_animation spin.
         if (gui_manager_) {
             if (const auto tooltip_wait = gui_manager_->secondsUntilTooltipReveal())
                 wait_seconds = std::min(wait_seconds,
                                         std::max(kTooltipRevealMinWaitSeconds, *tooltip_wait));
+            if (const auto anim_wait = gui_manager_->secondsUntilNextAnimationFrame())
+                wait_seconds = std::min(wait_seconds,
+                                        std::max(kGuiScheduledUpdateMinWaitSeconds, *anim_wait));
         }
+
+        // Wake no later than a Python-scheduled redraw deadline (paced overlay animation).
+        if (const auto redraw_wait = python::seconds_until_scheduled_redraw())
+            wait_seconds = std::min(wait_seconds,
+                                    std::max(kScheduledRedrawMinWaitSeconds, *redraw_wait));
 
         window_manager_->waitEvents(wait_seconds);
     }
@@ -1820,6 +1835,12 @@ namespace lfs::vis {
             window_manager_->updateWindowSize("pre_gui_render");
             gui_manager_->render();
             window_manager_->refreshResizeCursor();
+            // Count presented frames (GUI-only included). Scene FPS still comes
+            // from framerate_controller_ inside renderVulkanFrame; this is
+            // measurement-only and does not affect pacing.
+            if (rendering_manager_) {
+                rendering_manager_->notePresentedFrame();
+            }
         } else {
             processRenderWorkQueue();
         }
@@ -1833,7 +1854,23 @@ namespace lfs::vis {
         // Render-on-demand: VSync handles frame pacing, waitEvents saves CPU when idle
         const FrameDemand next_demand = collectFrameDemand(viewport_export_locked, false, false);
 
-        LOG_PERF("loop_end needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} window_resize_paint_pending={} viewport_resize_deferring={} viewport_resize_settle_ready={}",
+        // Continuous demand that is only python_redraw and/or gui_animation — pace it
+        // so GUI-only animation does not free-run against a MAILBOX swapchain.
+        const bool gui_only_animation =
+            next_demand.needsContinuousLoop() &&
+            !python::is_plugin_preload_running() &&
+            !next_demand.scene_dirty && !next_demand.continuous_input &&
+            !next_demand.python_animation && !next_demand.python_overlay &&
+            !next_demand.input_event && !next_demand.posted_work &&
+            !next_demand.render_work && !next_demand.store_dirty &&
+            !next_demand.swapchain_resize_pending && !next_demand.swapchain_resize_ready &&
+            !next_demand.window_resize_paint_pending && !next_demand.viewport_resize_deferring &&
+            !next_demand.viewport_resize_settle_ready && !next_demand.viewport_export_locked;
+
+        const auto py_redraw_due = python::seconds_until_scheduled_redraw();
+        const double py_redraw_due_in = py_redraw_due ? *py_redraw_due : -1.0;
+
+        LOG_PERF("loop_end needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} window_resize_paint_pending={} viewport_resize_deferring={} viewport_resize_settle_ready={} gui_only_throttle={} py_redraw_due_in={:.4f}",
                  next_demand.scene_dirty,
                  next_demand.continuous_input,
                  next_demand.python_animation,
@@ -1848,10 +1885,25 @@ namespace lfs::vis {
                  next_demand.swapchain_resize_ready,
                  next_demand.window_resize_paint_pending,
                  next_demand.viewport_resize_deferring,
-                 next_demand.viewport_resize_settle_ready);
+                 next_demand.viewport_resize_settle_ready,
+                 gui_only_animation,
+                 py_redraw_due_in);
 
         if (next_demand.needsContinuousLoop()) {
-            window_manager_->pollEvents();
+            if (gui_only_animation) {
+                // GUI-only animation must not free-run against a MAILBOX swapchain.
+                // Cap at kGuiAnimationFrameInterval; waitEvents still wakes instantly on input.
+                const double elapsed = std::chrono::duration<double>(
+                                           std::chrono::high_resolution_clock::now() - last_frame_time_)
+                                           .count();
+                if (elapsed >= kGuiAnimationFrameInterval) {
+                    window_manager_->pollEvents();
+                } else {
+                    window_manager_->waitEvents(kGuiAnimationFrameInterval - elapsed);
+                }
+            } else {
+                window_manager_->pollEvents();
+            }
         } else {
             // Idle: wait to minimize CPU/GPU work. Mouse-motion-only viewport wakes
             // are filtered at the top of the next loop without presenting a GUI frame.


### PR DESCRIPTION
## Problem

Open the app with no scene and the GPU runs at 100% while doing nothing (reported by Miron on Discord, Windows 11, RTX 3060 Ti at 4K). The app itself showed 0 FPS, so it looked innocent.

The empty scene overlay asked for a new frame after every frame. The render loop never went to sleep. Each frame also paid a full scene panel rebuild and a full-screen clear just to refresh a small cached panel.

## What changed

- The empty scene overlay now redraws on a timer (15 fps), not every frame
- `lf.ui.request_redraw()` can now take a delay, so plugins can do the same
- UI animations tell the app when they need the next frame, and the app sleeps until then
- The scene panel no longer marks itself dirty every frame
- Panel cache updates reuse their texture and only clear the panel area, not the whole screen
- The status bar now shows the UI frame rate when no scene is drawn, so this can never hide again
- Safety net: UI-only redraw loops are capped at 30 fps

## Tested

- Before: empty scene, hands off — 1760 frames in 30 s, loop never idle, GPU 8-10% (100% on the reporter's 4K setup)
- After: same test — loop sleeps between timed 15 fps wakes, GPU 1-5%
- Full build clean, UI renders pixel-correct, panel and status bar tests pass