### PR TITLE
fix(core): include Windows API before PSAPI

### DIFF
--- a/src/core/host_metrics.cpp
+++ b/src/core/host_metrics.cpp
@@ -14,8 +14,10 @@
 #include <vector>
 
 #ifdef _WIN32
-#include <psapi.h>
+// clang-format off: windows.h must precede psapi.h.
 #include <windows.h>
+#include <psapi.h>
+// clang-format on
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
Fix the Windows build of `host_metrics.cpp` by including `windows.h` before `psapi.h`.

`psapi.h` depends on Win32 types and calling-convention macros such as `BOOL`, `DWORD`, and `WINAPI`. The Linux include path remains unchanged.