### PR TITLE
Fix Gaussian and mesh depth compositing in video export

### DIFF
--- a/src/rendering/include/rendering/video_composite_utils.hpp
+++ b/src/rendering/include/rendering/video_composite_utils.hpp
@@ -1,0 +1,16 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+namespace lfs::rendering::detail {
+
+    [[nodiscard]] constexpr bool meshFragmentPassesDepthTest(
+        const float alpha,
+        const float mesh_view_depth,
+        const float scene_view_depth) noexcept {
+        return alpha > 0.0f && mesh_view_depth > 0.0f && mesh_view_depth < scene_view_depth;
+    }
+
+} // namespace lfs::rendering::detail

--- a/src/rendering/raster_rendering_engine.cpp
+++ b/src/rendering/raster_rendering_engine.cpp
@@ -15,6 +15,7 @@
 #include "point_cloud_raster.cuh"
 #include "rendering/coordinate_conventions.hpp"
 #include "rendering/rendering.hpp"
+#include "rendering/video_composite_utils.hpp"
 #include "screen_overlay_renderer.hpp"
 #include <OpenImageIO/imageio.h>
 #include <algorithm>
@@ -675,20 +676,51 @@ namespace lfs::rendering {
                     }
                 }
 
-                if (primary_metadata && primary_metadata->primaryDepth() &&
-                    primary_metadata->primaryDepth()->is_valid()) {
-                    Tensor depth_cpu = primary_metadata->primaryDepth()->cpu().contiguous();
-                    if (depth_cpu.ndim() == 3 && depth_cpu.dtype() == lfs::core::DataType::Float32) {
+                if (primary_metadata) {
+                    const size_t panel_count = std::min(
+                        primary_metadata->depth_panel_count > 0
+                            ? primary_metadata->depth_panel_count
+                            : (primary_metadata->primaryDepth() ? size_t{1} : size_t{0}),
+                        primary_metadata->depth_panels.size());
+                    for (size_t panel_index = 0; panel_index < panel_count; ++panel_index) {
+                        const auto& panel = primary_metadata->depth_panels[panel_index];
+                        if (!panel.depth || !panel.depth->is_valid()) {
+                            continue;
+                        }
+                        Tensor depth_cpu = panel.depth->cpu().contiguous();
+                        if (depth_cpu.ndim() != 3 ||
+                            depth_cpu.size(0) != 1u ||
+                            depth_cpu.dtype() != lfs::core::DataType::Float32) {
+                            continue;
+                        }
+
+                        const int panel_start = std::clamp(
+                            static_cast<int>(std::lround(static_cast<float>(width) * panel.start_position)),
+                            0,
+                            width);
+                        const int panel_end = std::clamp(
+                            static_cast<int>(std::lround(static_cast<float>(width) * panel.end_position)),
+                            panel_start,
+                            width);
+                        const int panel_width = panel_end - panel_start;
+                        if (panel_width <= 0) {
+                            continue;
+                        }
+
                         const int depth_h = static_cast<int>(depth_cpu.size(1));
                         const int depth_w = static_cast<int>(depth_cpu.size(2));
+                        if (depth_h <= 0 || depth_w <= 0) {
+                            continue;
+                        }
                         const float* depth_src = depth_cpu.ptr<float>();
                         for (int y = 0; y < height; ++y) {
                             const int sy = std::clamp(static_cast<int>(
                                                           static_cast<float>(y) * depth_h / std::max(height, 1)),
                                                       0, depth_h - 1);
-                            for (int x = 0; x < width; ++x) {
+                            for (int x = panel_start; x < panel_end; ++x) {
+                                const int panel_x = x - panel_start;
                                 const int sx = std::clamp(static_cast<int>(
-                                                              static_cast<float>(x) * depth_w / std::max(width, 1)),
+                                                              static_cast<float>(panel_x) * depth_w / panel_width),
                                                           0, depth_w - 1);
                                 depth[static_cast<size_t>(y) * width + x] =
                                     depth_src[static_cast<size_t>(sy) * depth_w + sx];
@@ -719,8 +751,8 @@ namespace lfs::rendering {
                 const float* rgba = mesh_rgba.ptr<float>();
                 const float* view_depth = mesh_depth.ptr<float>();
                 for (size_t pixel = 0; pixel < pixel_count; ++pixel) {
-                    if (rgba[3u * pixel_count + pixel] > 0.0f &&
-                        view_depth[pixel] < depth[pixel]) {
+                    if (detail::meshFragmentPassesDepthTest(
+                            rgba[3u * pixel_count + pixel], view_depth[pixel], depth[pixel])) {
                         image[pixel] = rgba[pixel];
                         image[pixel_count + pixel] = rgba[pixel_count + pixel];
                         image[2u * pixel_count + pixel] = rgba[2u * pixel_count + pixel];

--- a/src/rendering/video_composite_utils.hpp
+++ b/src/rendering/video_composite_utils.hpp
@@ -10,7 +10,7 @@ namespace lfs::rendering::detail {
         const float alpha,
         const float mesh_view_depth,
         const float scene_view_depth) noexcept {
-        return alpha > 0.0f && mesh_view_depth > 0.0f && mesh_view_depth < scene_view_depth;
+        return alpha > 0.0f && mesh_view_depth < scene_view_depth;
     }
 
 } // namespace lfs::rendering::detail

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -512,13 +512,6 @@ namespace lfs::vis::gui {
         return frame.contiguous();
     }
 
-    rendering::FrameMetadata makeVideoExportFrameMetadata(const rendering::FrameView& frame_view) {
-        return rendering::FrameMetadata{
-            .valid = true,
-            .far_plane = frame_view.far_plane,
-            .orthographic = frame_view.orthographic};
-    }
-
     std::expected<lfs::core::Tensor, std::string> renderVideoExportFrame(
         RenderingManager& rendering_manager,
         rendering::RenderingEngine& engine,
@@ -572,26 +565,66 @@ namespace lfs::vis::gui {
             } else {
                 auto scene_state = makeVideoExportGaussianSceneState(snapshot);
                 const auto camera_rotation = glm::mat3_cast(cam_state.rotation);
-                auto preview_image = render_environment
-                                         ? rendering_manager.renderPreviewImageRgba8(
-                                               *snapshot.combined_model,
-                                               std::move(scene_state),
-                                               camera_rotation,
-                                               cam_state.position,
-                                               cam_state.focal_length_mm,
-                                               width,
-                                               height)
-                                         : rendering_manager.renderPreviewImage(
-                                               *snapshot.combined_model,
-                                               std::move(scene_state),
-                                               camera_rotation,
-                                               cam_state.position,
-                                               cam_state.focal_length_mm,
-                                               width,
-                                               height);
+                std::shared_ptr<lfs::core::Tensor> preview_image;
+                std::shared_ptr<lfs::core::Tensor> preview_depth;
+                if (!snapshot.meshes.empty()) {
+                    auto preview = render_environment
+                                       ? rendering_manager.renderPreviewImageRgba8AndDepth(
+                                             *snapshot.combined_model,
+                                             std::move(scene_state),
+                                             camera_rotation,
+                                             cam_state.position,
+                                             cam_state.focal_length_mm,
+                                             width,
+                                             height,
+                                             false,
+                                             frame_view.orthographic,
+                                             frame_view.ortho_scale)
+                                       : rendering_manager.renderPreviewImageAndDepth(
+                                             *snapshot.combined_model,
+                                             std::move(scene_state),
+                                             camera_rotation,
+                                             cam_state.position,
+                                             cam_state.focal_length_mm,
+                                             width,
+                                             height,
+                                             false,
+                                             std::nullopt,
+                                             frame_view.orthographic,
+                                             frame_view.ortho_scale);
+                    preview_image = std::move(preview.image);
+                    preview_depth = std::move(preview.depth);
+                } else {
+                    preview_image = render_environment
+                                        ? rendering_manager.renderPreviewImageRgba8(
+                                              *snapshot.combined_model,
+                                              std::move(scene_state),
+                                              camera_rotation,
+                                              cam_state.position,
+                                              cam_state.focal_length_mm,
+                                              width,
+                                              height,
+                                              frame_view.orthographic,
+                                              frame_view.ortho_scale)
+                                        : rendering_manager.renderPreviewImage(
+                                              *snapshot.combined_model,
+                                              std::move(scene_state),
+                                              camera_rotation,
+                                              cam_state.position,
+                                              cam_state.focal_length_mm,
+                                              width,
+                                              height,
+                                              std::nullopt,
+                                              frame_view.orthographic,
+                                              frame_view.ortho_scale);
+                }
                 auto video_frame = makeGaussianPreviewVideoFrame(preview_image);
                 if (!video_frame) {
                     return std::unexpected(video_frame.error());
+                }
+                if (!snapshot.meshes.empty() &&
+                    (!preview_depth || !preview_depth->is_valid())) {
+                    return std::unexpected("Failed to render Gaussian depth for mesh compositing");
                 }
 
                 if (!requires_composite_pass) {
@@ -601,7 +634,7 @@ namespace lfs::vis::gui {
                 auto frame_image = std::make_shared<lfs::core::Tensor>(std::move(*video_frame));
                 auto materialized = engine.materializeGpuFrame(
                     frame_image,
-                    makeVideoExportFrameMetadata(frame_view),
+                    makeVideoExportFrameMetadata(frame_view, preview_depth),
                     {width, height});
                 if (!materialized || !materialized->valid()) {
                     return std::unexpected(materialized ? LOC(lichtfeld::Strings::Runtime::RENDERED_GAUSSIAN_INVALID)

--- a/src/visualizer/gui/video_export_utils.cpp
+++ b/src/visualizer/gui/video_export_utils.cpp
@@ -199,4 +199,24 @@ namespace lfs::vis::gui {
         return options;
     }
 
+    lfs::rendering::FrameMetadata makeVideoExportFrameMetadata(
+        const lfs::rendering::FrameView& frame_view,
+        const std::shared_ptr<lfs::core::Tensor>& linear_depth) {
+        lfs::rendering::FrameMetadata metadata{
+            .valid = true,
+            .near_plane = frame_view.near_plane,
+            .far_plane = frame_view.far_plane,
+            .orthographic = frame_view.orthographic,
+        };
+        if (linear_depth && linear_depth->is_valid() && linear_depth->ndim() == 2) {
+            metadata.depth_panels[0] = lfs::rendering::FramePanelMetadata{
+                .depth = std::make_shared<lfs::core::Tensor>(linear_depth->unsqueeze(0).contiguous()),
+                .start_position = 0.0f,
+                .end_position = 1.0f,
+            };
+            metadata.depth_panel_count = 1;
+        }
+        return metadata;
+    }
+
 } // namespace lfs::vis::gui

--- a/src/visualizer/gui/video_export_utils.hpp
+++ b/src/visualizer/gui/video_export_utils.hpp
@@ -11,6 +11,7 @@
 #include "core/splat_data.hpp"
 #include "core/tensor.hpp"
 #include "io/video/video_export_options.hpp"
+#include "rendering/rendering.hpp"
 #include <expected>
 #include <glm/glm.hpp>
 #include <memory>
@@ -77,5 +78,9 @@ namespace lfs::vis::gui {
 
     LFS_VIS_API std::expected<lfs::io::video::VideoExportOptions, std::string> validateVideoExportOptions(
         lfs::io::video::VideoExportOptions options);
+
+    LFS_VIS_API lfs::rendering::FrameMetadata makeVideoExportFrameMetadata(
+        const lfs::rendering::FrameView& frame_view,
+        const std::shared_ptr<lfs::core::Tensor>& linear_depth = {});
 
 } // namespace lfs::vis::gui

--- a/src/visualizer/rendering/rendering_manager.hpp
+++ b/src/visualizer/rendering/rendering_manager.hpp
@@ -163,7 +163,8 @@ namespace lfs::vis {
 
         // Image + per-pixel linear depth from the same viewport render. When
         // expected_depth is true, depth is alpha-weighted expected depth instead
-        // of median depth. image is [H,W,3] and depth is [H,W], both CPU float32.
+        // of median depth. Image is CPU [H,W,C] (float RGB or uint8 RGBA depending
+        // on the entry point); depth is CPU float32 [H,W].
         struct PreviewRgbd {
             std::shared_ptr<lfs::core::Tensor> image;
             std::shared_ptr<lfs::core::Tensor> depth;
@@ -175,6 +176,25 @@ namespace lfs::vis {
                                                int width, int height,
                                                bool expected_depth = false,
                                                std::optional<glm::vec3> background_color_override = std::nullopt);
+        PreviewRgbd renderPreviewImageAndDepth(const lfs::core::SplatData& model,
+                                               SceneRenderState scene_state,
+                                               const glm::mat3& camera_rotation,
+                                               const glm::vec3& camera_position,
+                                               float focal_length_mm,
+                                               int width, int height,
+                                               bool expected_depth = false,
+                                               std::optional<glm::vec3> background_color_override = std::nullopt,
+                                               std::optional<bool> orthographic_override = std::nullopt,
+                                               std::optional<float> ortho_scale_override = std::nullopt);
+        PreviewRgbd renderPreviewImageRgba8AndDepth(const lfs::core::SplatData& model,
+                                                    SceneRenderState scene_state,
+                                                    const glm::mat3& camera_rotation,
+                                                    const glm::vec3& camera_position,
+                                                    float focal_length_mm,
+                                                    int width, int height,
+                                                    bool expected_depth = false,
+                                                    std::optional<bool> orthographic_override = std::nullopt,
+                                                    std::optional<float> ortho_scale_override = std::nullopt);
         std::shared_ptr<lfs::core::Tensor> renderPreviewImageRgba8(SceneManager* scene_manager,
                                                                    const glm::mat3& camera_rotation,
                                                                    const glm::vec3& camera_position,
@@ -642,7 +662,38 @@ namespace lfs::vis {
             bool expected_depth,
             std::optional<glm::vec3> background_color_override,
             std::optional<bool> orthographic_override,
-            std::optional<float> ortho_scale_override);
+            std::optional<float> ortho_scale_override,
+            std::optional<bool> transparent_background_override = std::nullopt);
+        PreviewRgbd renderPreviewImageAndDepthWithState(
+            SceneManager* scene_manager,
+            const lfs::core::SplatData& model,
+            SceneRenderState scene_state,
+            const glm::mat3& camera_rotation,
+            const glm::vec3& camera_position,
+            float focal_length_mm,
+            int width,
+            int height,
+            bool render_lock_held,
+            bool expected_depth,
+            std::optional<glm::vec3> background_color_override,
+            std::optional<bool> orthographic_override,
+            std::optional<float> ortho_scale_override,
+            PreviewImageReadback readback);
+        PreviewRgbd renderPreviewImageAndDepthTiledWithState(
+            SceneManager* scene_manager,
+            const lfs::core::SplatData& model,
+            SceneRenderState scene_state,
+            const glm::mat3& camera_rotation,
+            const glm::vec3& camera_position,
+            float focal_length_mm,
+            int width,
+            int height,
+            bool render_lock_held,
+            bool expected_depth,
+            std::optional<glm::vec3> background_color_override,
+            std::optional<bool> orthographic_override,
+            std::optional<float> ortho_scale_override,
+            PreviewImageReadback readback);
         std::shared_ptr<lfs::core::Tensor> renderPreviewImageTiledWithState(
             SceneManager* scene_manager,
             const lfs::core::SplatData& model,

--- a/src/visualizer/rendering/rendering_manager_viewport.cpp
+++ b/src/visualizer/rendering/rendering_manager_viewport.cpp
@@ -423,7 +423,8 @@ namespace lfs::vis {
         const bool expected_depth,
         std::optional<glm::vec3> background_color_override,
         std::optional<bool> orthographic_override,
-        std::optional<float> ortho_scale_override) {
+        std::optional<float> ortho_scale_override,
+        std::optional<bool> transparent_background_override) {
         if (width <= 0 || height <= 0) {
             return std::unexpected("invalid preview depth render dimensions");
         }
@@ -431,15 +432,9 @@ namespace lfs::vis {
             return std::unexpected("no renderable Gaussian model is available");
         }
         if (previewRenderNeedsTiling(width, height)) {
-            // Depth comes from the single per-frame pixel_depth scratch; a tiled
-            // render would need per-tile depth assembly, which isn't wired yet.
-            LOG_WARN("render_view depth unavailable for tiled preview size {}x{}", width, height);
-            return std::unexpected("preview depth render would require tiled depth assembly");
+            return std::unexpected("preview depth render requires tiled depth assembly");
         }
 
-        // The macro-tile (HiGS) chain only yields per-macro-tile median depth;
-        // force the legacy per-pixel chain for the depth-capture render so the
-        // readback matches the image resolution.
         if (!vksplat_viewport_renderer_) {
             vksplat_viewport_renderer_ = std::make_unique<VksplatViewportRenderer>();
         }
@@ -449,10 +444,10 @@ namespace lfs::vis {
             ~DepthCaptureModeGuard() { renderer->setDepthCaptureMode(false); }
         } depth_capture_guard{vksplat_viewport_renderer_.get()};
 
-        auto rendered = renderPreviewImageToPreviewSlotWithState(
+        return renderPreviewImageToPreviewSlotWithState(
             scene_manager,
             model,
-            scene_state,
+            std::move(scene_state),
             rotation,
             position,
             focal_length_mm,
@@ -465,8 +460,7 @@ namespace lfs::vis {
             orthographic_override,
             ortho_scale_override,
             background_color_override,
-            std::nullopt);
-        return rendered;
+            transparent_background_override);
     }
 
     RenderingManager::PreviewRgbd RenderingManager::renderPreviewImageAndDepth(
@@ -489,7 +483,7 @@ namespace lfs::vis {
             return result;
         }
 
-        auto rendered = renderDepthCaptureToPreviewSlotWithState(
+        return renderPreviewImageAndDepthWithState(
             scene_manager,
             *model,
             std::move(render_state),
@@ -502,30 +496,65 @@ namespace lfs::vis {
             expected_depth,
             background_color_override,
             std::nullopt,
-            std::nullopt);
-        if (!rendered) {
-            LOG_ERROR("Gaussian preview rgbd render failed: {}", rendered.error());
-            return result;
-        }
+            std::nullopt,
+            PreviewImageReadback::FloatRgb);
+    }
 
-        // image and depth are read from the same render: the Preview output slot
-        // and the pixel_depth scratch it just wrote (still resident — the Preview
-        // path uses private scratch, which render() does not release).
-        auto image = vksplat_viewport_renderer_->readOutputImage(
-            *last_vulkan_context_, VksplatViewportRenderer::OutputSlot::Preview);
-        if (!image) {
-            LOG_ERROR("Gaussian preview rgbd image readback failed: {}", image.error());
-            return result;
-        }
-        auto depth = vksplat_viewport_renderer_->readPreviewDepth(
-            *last_vulkan_context_, VksplatViewportRenderer::OutputSlot::Preview);
-        if (!depth) {
-            LOG_ERROR("Gaussian preview depth readback failed: {}", depth.error());
-            return result;
-        }
-        result.image = std::move(*image);
-        result.depth = std::move(*depth);
-        return result;
+    RenderingManager::PreviewRgbd RenderingManager::renderPreviewImageAndDepth(
+        const lfs::core::SplatData& model,
+        SceneRenderState scene_state,
+        const glm::mat3& rotation,
+        const glm::vec3& position,
+        const float focal_length_mm,
+        const int width,
+        const int height,
+        const bool expected_depth,
+        std::optional<glm::vec3> background_color_override,
+        std::optional<bool> orthographic_override,
+        std::optional<float> ortho_scale_override) {
+        return renderPreviewImageAndDepthWithState(
+            nullptr,
+            model,
+            std::move(scene_state),
+            rotation,
+            position,
+            focal_length_mm,
+            width,
+            height,
+            false,
+            expected_depth,
+            background_color_override,
+            orthographic_override,
+            ortho_scale_override,
+            PreviewImageReadback::FloatRgb);
+    }
+
+    RenderingManager::PreviewRgbd RenderingManager::renderPreviewImageRgba8AndDepth(
+        const lfs::core::SplatData& model,
+        SceneRenderState scene_state,
+        const glm::mat3& rotation,
+        const glm::vec3& position,
+        const float focal_length_mm,
+        const int width,
+        const int height,
+        const bool expected_depth,
+        std::optional<bool> orthographic_override,
+        std::optional<float> ortho_scale_override) {
+        return renderPreviewImageAndDepthWithState(
+            nullptr,
+            model,
+            std::move(scene_state),
+            rotation,
+            position,
+            focal_length_mm,
+            width,
+            height,
+            false,
+            expected_depth,
+            std::nullopt,
+            orthographic_override,
+            ortho_scale_override,
+            PreviewImageReadback::UInt8Rgba);
     }
 
     std::shared_ptr<lfs::core::Tensor> RenderingManager::renderPreviewImageRgb8(SceneManager* const scene_manager,
@@ -834,6 +863,259 @@ namespace lfs::vis {
         };
         return applyExportPostProcess(
             std::move(image), scene_manager, settings, getCurrentCameraId(), request.mode, view);
+    }
+
+    RenderingManager::PreviewRgbd RenderingManager::renderPreviewImageAndDepthWithState(
+        SceneManager* const scene_manager,
+        const lfs::core::SplatData& model,
+        SceneRenderState scene_state,
+        const glm::mat3& rotation,
+        const glm::vec3& position,
+        const float focal_length_mm,
+        const int width,
+        const int height,
+        const bool render_lock_held,
+        const bool expected_depth,
+        std::optional<glm::vec3> background_color_override,
+        std::optional<bool> orthographic_override,
+        std::optional<float> ortho_scale_override,
+        const PreviewImageReadback readback) {
+        if (width <= 0 || height <= 0) {
+            return {};
+        }
+        if (previewRenderNeedsTiling(width, height)) {
+            return renderPreviewImageAndDepthTiledWithState(
+                scene_manager,
+                model,
+                std::move(scene_state),
+                rotation,
+                position,
+                focal_length_mm,
+                width,
+                height,
+                render_lock_held,
+                expected_depth,
+                background_color_override,
+                orthographic_override,
+                ortho_scale_override,
+                readback);
+        }
+
+        const auto readback_config =
+            previewImageReadbackConfig(readback, background_color_override.has_value());
+        auto rendered = renderDepthCaptureToPreviewSlotWithState(
+            scene_manager,
+            model,
+            scene_state,
+            rotation,
+            position,
+            focal_length_mm,
+            width,
+            height,
+            render_lock_held,
+            expected_depth,
+            background_color_override,
+            orthographic_override,
+            ortho_scale_override,
+            readback_config.transparent_background_override);
+        if (!rendered) {
+            if (isTileInstanceOverflow(rendered.error()) &&
+                height > kMinPreviewSubdivisionHeight) {
+                return renderPreviewImageAndDepthTiledWithState(
+                    scene_manager,
+                    model,
+                    std::move(scene_state),
+                    rotation,
+                    position,
+                    focal_length_mm,
+                    width,
+                    height,
+                    render_lock_held,
+                    expected_depth,
+                    background_color_override,
+                    orthographic_override,
+                    ortho_scale_override,
+                    readback);
+            }
+            LOG_ERROR("Gaussian preview RGBD render failed: {}", rendered.error());
+            return {};
+        }
+
+        std::expected<std::shared_ptr<lfs::core::Tensor>, std::string> image =
+            std::unexpected("unsupported preview image readback format");
+        if (readback_config.dtype == lfs::core::DataType::UInt8 &&
+            readback_config.channels == 4) {
+            image = vksplat_viewport_renderer_->readOutputImageRgba8(
+                *last_vulkan_context_,
+                VksplatViewportRenderer::OutputSlot::Preview);
+        } else if (readback_config.dtype == lfs::core::DataType::UInt8) {
+            image = vksplat_viewport_renderer_->readOutputImageRgb8(
+                *last_vulkan_context_,
+                VksplatViewportRenderer::OutputSlot::Preview);
+        } else {
+            image = vksplat_viewport_renderer_->readOutputImage(
+                *last_vulkan_context_,
+                VksplatViewportRenderer::OutputSlot::Preview);
+        }
+        if (!image) {
+            LOG_ERROR("Gaussian preview RGBD image readback failed: {}", image.error());
+            return {};
+        }
+
+        auto depth = vksplat_viewport_renderer_->readPreviewDepth(
+            *last_vulkan_context_,
+            VksplatViewportRenderer::OutputSlot::Preview);
+        if (!depth) {
+            LOG_ERROR("Gaussian preview RGBD depth readback failed: {}", depth.error());
+            return {};
+        }
+        return PreviewRgbd{
+            .image = std::move(*image),
+            .depth = std::move(*depth),
+        };
+    }
+
+    RenderingManager::PreviewRgbd RenderingManager::renderPreviewImageAndDepthTiledWithState(
+        SceneManager* const scene_manager,
+        const lfs::core::SplatData& model,
+        SceneRenderState scene_state,
+        const glm::mat3& rotation,
+        const glm::vec3& position,
+        const float focal_length_mm,
+        const int width,
+        const int height,
+        const bool render_lock_held,
+        const bool expected_depth,
+        std::optional<glm::vec3> background_color_override,
+        std::optional<bool> orthographic_override,
+        std::optional<float> ortho_scale_override,
+        const PreviewImageReadback readback) {
+        PreviewRgbd result{};
+        if (width <= 0 || height <= 0) {
+            return result;
+        }
+
+        const auto readback_config =
+            previewImageReadbackConfig(readback, background_color_override.has_value());
+        const int tile_height_limit = previewTileHeightForWidth(width);
+        if (tile_height_limit <= 0) {
+            return result;
+        }
+
+        auto image = lfs::core::Tensor::empty(
+            {static_cast<std::size_t>(height),
+             static_cast<std::size_t>(width),
+             static_cast<std::size_t>(readback_config.channels)},
+            lfs::core::Device::CPU,
+            readback_config.dtype);
+        auto depth = lfs::core::Tensor::empty(
+            {static_cast<std::size_t>(height), static_cast<std::size_t>(width)},
+            lfs::core::Device::CPU,
+            lfs::core::DataType::Float32);
+        if (!image.is_valid() || !depth.is_valid()) {
+            LOG_TRACE("Gaussian preview tiled RGBD render failed to allocate output tensors");
+            return result;
+        }
+
+        if (!vksplat_viewport_renderer_) {
+            vksplat_viewport_renderer_ = std::make_unique<VksplatViewportRenderer>();
+        }
+        vksplat_viewport_renderer_->setDepthCaptureMode(true, expected_depth);
+        struct DepthCaptureModeGuard {
+            VksplatViewportRenderer* renderer;
+            ~DepthCaptureModeGuard() { renderer->setDepthCaptureMode(false); }
+        } depth_capture_guard{vksplat_viewport_renderer_.get()};
+
+        int band_height_limit = tile_height_limit;
+        for (int tile_y = 0; tile_y < height;) {
+            int tile_height = std::min(band_height_limit, height - tile_y);
+            const auto intrinsics = previewTileIntrinsics(width, height, focal_length_mm);
+            while (true) {
+                auto rendered = renderPreviewImageToPreviewSlotWithState(
+                    scene_manager,
+                    model,
+                    scene_state,
+                    rotation,
+                    position,
+                    focal_length_mm,
+                    width,
+                    tile_height,
+                    render_lock_held,
+                    intrinsics,
+                    {0, tile_y},
+                    {width, height},
+                    orthographic_override,
+                    ortho_scale_override,
+                    background_color_override,
+                    readback_config.transparent_background_override);
+                if (rendered) {
+                    break;
+                }
+                if (!isTileInstanceOverflow(rendered.error()) ||
+                    tile_height <= kMinPreviewSubdivisionHeight) {
+                    LOG_TRACE("Gaussian preview tiled RGBD render failed at tile y={} height={}: {}",
+                              tile_y,
+                              tile_height,
+                              rendered.error());
+                    return {};
+                }
+                tile_height = std::max(kMinPreviewSubdivisionHeight, tile_height / 2);
+                band_height_limit = tile_height;
+            }
+
+            auto color_ticket = vksplat_viewport_renderer_->submitReadOutputImageIntoCpuHwcTicket(
+                *last_vulkan_context_,
+                VksplatViewportRenderer::OutputSlot::Preview,
+                image,
+                0,
+                tile_y);
+            if (!color_ticket) {
+                LOG_TRACE("Gaussian preview tiled RGBD color readback failed at tile y={}: {}",
+                          tile_y,
+                          color_ticket.error());
+                return {};
+            }
+
+            auto tile_depth = vksplat_viewport_renderer_->readPreviewDepth(
+                *last_vulkan_context_,
+                VksplatViewportRenderer::OutputSlot::Preview);
+            if (!tile_depth) {
+                vksplat_viewport_renderer_->abandonReadbackTicket(*color_ticket);
+                LOG_TRACE("Gaussian preview tiled RGBD depth readback failed at tile y={}: {}",
+                          tile_y,
+                          tile_depth.error());
+                return {};
+            }
+            if (const auto waited = vksplat_viewport_renderer_->waitReadbackTicket(*color_ticket);
+                !waited) {
+                LOG_TRACE("Gaussian preview tiled RGBD color wait failed at tile y={}: {}",
+                          tile_y,
+                          waited.error());
+                return {};
+            }
+            if (!(*tile_depth)->is_valid() ||
+                (*tile_depth)->device() != lfs::core::Device::CPU ||
+                (*tile_depth)->dtype() != lfs::core::DataType::Float32 ||
+                (*tile_depth)->ndim() != 2 ||
+                static_cast<int>((*tile_depth)->size(0)) != tile_height ||
+                static_cast<int>((*tile_depth)->size(1)) != width ||
+                !(*tile_depth)->is_contiguous()) {
+                LOG_TRACE("Gaussian preview tiled RGBD depth shape mismatch at tile y={}", tile_y);
+                return {};
+            }
+
+            const std::size_t tile_pixels =
+                static_cast<std::size_t>(tile_height) * static_cast<std::size_t>(width);
+            std::copy_n(
+                (*tile_depth)->ptr<float>(),
+                tile_pixels,
+                depth.ptr<float>() + static_cast<std::size_t>(tile_y) * width);
+            tile_y += tile_height;
+        }
+
+        result.image = std::make_shared<lfs::core::Tensor>(std::move(image));
+        result.depth = std::make_shared<lfs::core::Tensor>(std::move(depth));
+        return result;
     }
 
     std::shared_ptr<lfs::core::Tensor> RenderingManager::renderPreviewImageWithState(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -186,6 +186,7 @@ set(TEST_FILES
     test_mcp_sequencer_tools.cpp
     test_tcp_publisher.cpp
     test_view_info_json.cpp
+    test_video_export_composite.cpp
     test_video_export_utils.cpp
     test_video_frame_extractor_naming.cpp
     test_video_hdr_logic.cpp

--- a/tests/test_video_export_composite.cpp
+++ b/tests/test_video_export_composite.cpp
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/tensor.hpp"
+#include "rendering/mesh_offscreen_renderer.hpp"
 #include "rendering/rendering.hpp"
 #include "rendering/video_composite_utils.hpp"
 
+#include <glm/gtc/matrix_transform.hpp>
 #include <gtest/gtest.h>
 #include <memory>
 #include <optional>
@@ -30,6 +32,14 @@ namespace {
         const std::vector<float>& values,
         const lfs::core::TensorShape& shape) {
         return Tensor::from_vector(values, shape, Device::CUDA);
+    }
+
+    [[nodiscard]] float projectedMeshDepth(const float view_depth, const bool orthographic) {
+        const glm::mat4 projection = orthographic
+                                         ? glm::ortho(-2.0f, 2.0f, -2.0f, 2.0f, 0.25f, FAR_PLANE)
+                                         : glm::perspective(glm::radians(55.0f), 1.0f, 0.25f, FAR_PLANE);
+        const glm::vec4 clip = projection * glm::vec4(0.0f, 0.0f, -view_depth, 1.0f);
+        return lfs::vis::linearizeMeshViewDepth(clip.z / clip.w, projection);
     }
 
     [[nodiscard]] VideoCompositeFrameRequest makeRequest(
@@ -95,7 +105,6 @@ namespace {
 
         EXPECT_TRUE(meshFragmentPassesDepthTest(1.0f, 2.0f, 5.0f));
         EXPECT_FALSE(meshFragmentPassesDepthTest(0.0f, 2.0f, 5.0f));
-        EXPECT_FALSE(meshFragmentPassesDepthTest(1.0f, -2.0f, 5.0f));
         EXPECT_FALSE(meshFragmentPassesDepthTest(1.0f, 5.0f, 2.0f));
         EXPECT_FALSE(meshFragmentPassesDepthTest(1.0f, 5.0f, 5.0f));
     }
@@ -109,7 +118,10 @@ namespace {
                  0.0f, 0.0f,
                  1.0f, 0.0f},
                 {4, HEIGHT, WIDTH}),
-            .view_depth = makeTensor({1.0f, 1.0f}, {HEIGHT, WIDTH}),
+            .view_depth = makeTensor(
+                {projectedMeshDepth(1.0f, orthographic()),
+                 projectedMeshDepth(1.0f, orthographic())},
+                {HEIGHT, WIDTH}),
         };
 
         expectFramePixels(
@@ -170,7 +182,12 @@ namespace {
                  1.0f, 1.0f, 0.0f, 1.0f,
                  1.0f, 1.0f, 0.0f, 1.0f},
                 {4, HEIGHT, WIDTH}),
-            .view_depth = makeTensor({1.0f, 5.0f, 0.5f, 8.0f}, {HEIGHT, WIDTH}),
+            .view_depth = makeTensor(
+                {projectedMeshDepth(1.0f, orthographic()),
+                 projectedMeshDepth(5.0f, orthographic()),
+                 projectedMeshDepth(0.5f, orthographic()),
+                 projectedMeshDepth(9.0f, orthographic())},
+                {HEIGHT, WIDTH}),
         };
 
         expectFramePixels(
@@ -183,24 +200,24 @@ namespace {
     }
 
     TEST_P(VideoExportCompositePathTest, SplitViewUsesEachPanelsDepth) {
-        constexpr int WIDTH = 4;
+        constexpr int WIDTH = 7;
         const std::vector<float> primary_colors{
-            1.0f, 1.0f, 0.0f, 0.0f,
-            0.0f, 0.0f, 0.0f, 0.0f,
-            0.0f, 0.0f, 1.0f, 1.0f};
+            1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
         auto left_depth = std::make_shared<Tensor>(
-            makeTensor({2.0f, 2.0f}, {1, HEIGHT, 2}));
+            makeTensor({2.0f}, {1, HEIGHT, 1}));
         auto right_depth = std::make_shared<Tensor>(
-            makeTensor({8.0f, 8.0f}, {1, HEIGHT, 2}));
+            makeTensor({8.0f, 2.0f, 8.0f}, {1, HEIGHT, 3}));
         FrameMetadata metadata{
             .depth_panels =
                 {FramePanelMetadata{
                      .depth = std::move(left_depth),
                      .start_position = 0.0f,
-                     .end_position = 0.5f},
+                     .end_position = 0.3f},
                  FramePanelMetadata{
                      .depth = std::move(right_depth),
-                     .start_position = 0.5f,
+                     .start_position = 0.3f,
                      .end_position = 1.0f}},
             .depth_panel_count = 2,
             .valid = true,
@@ -212,21 +229,23 @@ namespace {
 
         MeshLayer mesh{
             .rgba = makeTensor(
-                {0.0f, 0.0f, 0.0f, 0.0f,
-                 1.0f, 1.0f, 1.0f, 1.0f,
-                 0.0f, 0.0f, 0.0f, 0.0f,
-                 1.0f, 1.0f, 1.0f, 1.0f},
+                {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+                 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f},
                 {4, HEIGHT, WIDTH}),
-            .view_depth = makeTensor({5.0f, 5.0f, 5.0f, 5.0f}, {HEIGHT, WIDTH}),
+            .view_depth = makeTensor(
+                std::vector<float>(WIDTH, projectedMeshDepth(5.0f, orthographic())),
+                {HEIGHT, WIDTH}),
         };
 
         expectFramePixels(
             engine_->renderVideoCompositeFrame(
                 primary,
                 makeRequest(WIDTH, orthographic(), &mesh)),
-            {1.0f, 1.0f, 0.0f, 0.0f,
-             0.0f, 0.0f, 1.0f, 1.0f,
-             0.0f, 0.0f, 0.0f, 0.0f});
+            {1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+             0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+             0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f});
     }
 
     INSTANTIATE_TEST_SUITE_P(

--- a/tests/test_video_export_composite.cpp
+++ b/tests/test_video_export_composite.cpp
@@ -1,0 +1,240 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/tensor.hpp"
+#include "rendering/rendering.hpp"
+#include "rendering/video_composite_utils.hpp"
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+    using lfs::core::Device;
+    using lfs::core::Tensor;
+    using lfs::rendering::FrameMetadata;
+    using lfs::rendering::FramePanelMetadata;
+    using lfs::rendering::MeshLayer;
+    using lfs::rendering::RenderingEngine;
+    using lfs::rendering::VideoCompositeFrameRequest;
+
+    constexpr int HEIGHT = 1;
+    constexpr float FAR_PLANE = 100.0f;
+
+    [[nodiscard]] Tensor makeTensor(
+        const std::vector<float>& values,
+        const lfs::core::TensorShape& shape) {
+        return Tensor::from_vector(values, shape, Device::CUDA);
+    }
+
+    [[nodiscard]] VideoCompositeFrameRequest makeRequest(
+        const int width,
+        const bool orthographic,
+        const MeshLayer* mesh = nullptr,
+        const glm::vec3 background = glm::vec3(0.0f)) {
+        return VideoCompositeFrameRequest{
+            .viewport = {.size = {width, HEIGHT}, .orthographic = orthographic},
+            .frame_view =
+                {.size = {width, HEIGHT},
+                 .far_plane = FAR_PLANE,
+                 .orthographic = orthographic,
+                 .background_color = background},
+            .background_color = background,
+            .prerendered_meshes = mesh,
+        };
+    }
+
+    void expectFramePixels(
+        const lfs::rendering::Result<Tensor>& result,
+        const std::vector<float>& expected) {
+        ASSERT_TRUE(result.has_value()) << result.error();
+        const auto actual = result->cpu().to_vector();
+        ASSERT_EQ(actual.size(), expected.size());
+        for (size_t i = 0; i < expected.size(); ++i) {
+            EXPECT_FLOAT_EQ(actual[i], expected[i]) << "channel-major value " << i;
+        }
+    }
+
+    class VideoExportCompositePathTest : public testing::TestWithParam<bool> {
+    protected:
+        void SetUp() override {
+            engine_ = RenderingEngine::create();
+            ASSERT_NE(engine_, nullptr);
+            const auto initialized = engine_->initialize();
+            ASSERT_TRUE(initialized.has_value()) << initialized.error();
+        }
+
+        [[nodiscard]] bool orthographic() const {
+            return GetParam();
+        }
+
+        [[nodiscard]] std::optional<lfs::rendering::GpuFrame> materialize(
+            const std::vector<float>& color,
+            const int width,
+            FrameMetadata metadata) {
+            auto image = std::make_shared<Tensor>(
+                makeTensor(color, {3, static_cast<size_t>(HEIGHT), static_cast<size_t>(width)}));
+            auto frame = engine_->materializeGpuFrame(image, metadata, {width, HEIGHT});
+            EXPECT_TRUE(frame.has_value()) << frame.error();
+            if (!frame) {
+                return std::nullopt;
+            }
+            return *frame;
+        }
+
+        std::unique_ptr<RenderingEngine> engine_;
+    };
+
+    TEST(VideoCompositeDepthTest, MeshFragmentMustBeOpaqueAndCloser) {
+        using lfs::rendering::detail::meshFragmentPassesDepthTest;
+
+        EXPECT_TRUE(meshFragmentPassesDepthTest(1.0f, 2.0f, 5.0f));
+        EXPECT_FALSE(meshFragmentPassesDepthTest(0.0f, 2.0f, 5.0f));
+        EXPECT_FALSE(meshFragmentPassesDepthTest(1.0f, -2.0f, 5.0f));
+        EXPECT_FALSE(meshFragmentPassesDepthTest(1.0f, 5.0f, 2.0f));
+        EXPECT_FALSE(meshFragmentPassesDepthTest(1.0f, 5.0f, 5.0f));
+    }
+
+    TEST_P(VideoExportCompositePathTest, MeshOnlyUsesBackgroundOutsideTheMesh) {
+        constexpr int WIDTH = 2;
+        MeshLayer mesh{
+            .rgba = makeTensor(
+                {1.0f, 0.0f,
+                 0.0f, 1.0f,
+                 0.0f, 0.0f,
+                 1.0f, 0.0f},
+                {4, HEIGHT, WIDTH}),
+            .view_depth = makeTensor({1.0f, 1.0f}, {HEIGHT, WIDTH}),
+        };
+
+        expectFramePixels(
+            engine_->renderVideoCompositeFrame(
+                std::nullopt,
+                makeRequest(WIDTH, orthographic(), &mesh, {0.1f, 0.2f, 0.3f})),
+            {1.0f, 0.1f,
+             0.0f, 0.2f,
+             0.0f, 0.3f});
+    }
+
+    TEST_P(VideoExportCompositePathTest, SplatOnlyPreservesThePrimaryFrame) {
+        constexpr int WIDTH = 2;
+        const std::vector<float> colors{
+            1.0f, 0.0f,
+            0.0f, 1.0f,
+            0.0f, 0.5f};
+        FrameMetadata metadata{
+            .valid = true,
+            .far_plane = FAR_PLANE,
+            .orthographic = orthographic(),
+        };
+        const auto primary = materialize(colors, WIDTH, std::move(metadata));
+        ASSERT_TRUE(primary.has_value());
+
+        expectFramePixels(
+            engine_->renderVideoCompositeFrame(
+                primary,
+                makeRequest(WIDTH, orthographic())),
+            colors);
+    }
+
+    TEST_P(VideoExportCompositePathTest, SplatAndMeshUseLinearViewDepth) {
+        constexpr int WIDTH = 4;
+        const std::vector<float> primary_colors{
+            1.0f, 0.0f, 0.0f, 1.0f,
+            0.0f, 1.0f, 0.0f, 1.0f,
+            0.0f, 0.0f, 1.0f, 0.0f};
+        auto primary_depth = std::make_shared<Tensor>(
+            makeTensor({2.0f, 4.0f, 6.0f, 8.0f}, {1, HEIGHT, WIDTH}));
+        FrameMetadata metadata{
+            .depth_panels = {FramePanelMetadata{
+                .depth = std::move(primary_depth),
+                .start_position = 0.0f,
+                .end_position = 1.0f}},
+            .depth_panel_count = 1,
+            .valid = true,
+            .far_plane = FAR_PLANE,
+            .orthographic = orthographic(),
+        };
+        const auto primary = materialize(primary_colors, WIDTH, std::move(metadata));
+        ASSERT_TRUE(primary.has_value());
+
+        MeshLayer mesh{
+            .rgba = makeTensor(
+                {0.0f, 1.0f, 1.0f, 1.0f,
+                 1.0f, 0.0f, 0.0f, 0.0f,
+                 1.0f, 1.0f, 0.0f, 1.0f,
+                 1.0f, 1.0f, 0.0f, 1.0f},
+                {4, HEIGHT, WIDTH}),
+            .view_depth = makeTensor({1.0f, 5.0f, 0.5f, 8.0f}, {HEIGHT, WIDTH}),
+        };
+
+        expectFramePixels(
+            engine_->renderVideoCompositeFrame(
+                primary,
+                makeRequest(WIDTH, orthographic(), &mesh)),
+            {0.0f, 0.0f, 0.0f, 1.0f,
+             1.0f, 1.0f, 0.0f, 1.0f,
+             1.0f, 0.0f, 1.0f, 0.0f});
+    }
+
+    TEST_P(VideoExportCompositePathTest, SplitViewUsesEachPanelsDepth) {
+        constexpr int WIDTH = 4;
+        const std::vector<float> primary_colors{
+            1.0f, 1.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 1.0f, 1.0f};
+        auto left_depth = std::make_shared<Tensor>(
+            makeTensor({2.0f, 2.0f}, {1, HEIGHT, 2}));
+        auto right_depth = std::make_shared<Tensor>(
+            makeTensor({8.0f, 8.0f}, {1, HEIGHT, 2}));
+        FrameMetadata metadata{
+            .depth_panels =
+                {FramePanelMetadata{
+                     .depth = std::move(left_depth),
+                     .start_position = 0.0f,
+                     .end_position = 0.5f},
+                 FramePanelMetadata{
+                     .depth = std::move(right_depth),
+                     .start_position = 0.5f,
+                     .end_position = 1.0f}},
+            .depth_panel_count = 2,
+            .valid = true,
+            .far_plane = FAR_PLANE,
+            .orthographic = orthographic(),
+        };
+        const auto primary = materialize(primary_colors, WIDTH, std::move(metadata));
+        ASSERT_TRUE(primary.has_value());
+
+        MeshLayer mesh{
+            .rgba = makeTensor(
+                {0.0f, 0.0f, 0.0f, 0.0f,
+                 1.0f, 1.0f, 1.0f, 1.0f,
+                 0.0f, 0.0f, 0.0f, 0.0f,
+                 1.0f, 1.0f, 1.0f, 1.0f},
+                {4, HEIGHT, WIDTH}),
+            .view_depth = makeTensor({5.0f, 5.0f, 5.0f, 5.0f}, {HEIGHT, WIDTH}),
+        };
+
+        expectFramePixels(
+            engine_->renderVideoCompositeFrame(
+                primary,
+                makeRequest(WIDTH, orthographic(), &mesh)),
+            {1.0f, 1.0f, 0.0f, 0.0f,
+             0.0f, 0.0f, 1.0f, 1.0f,
+             0.0f, 0.0f, 0.0f, 0.0f});
+    }
+
+    INSTANTIATE_TEST_SUITE_P(
+        PerspectiveAndOrthographic,
+        VideoExportCompositePathTest,
+        testing::Values(false, true),
+        [](const testing::TestParamInfo<bool>& info) {
+            return info.param ? std::string("Orthographic") : std::string("Perspective");
+        });
+
+} // namespace

--- a/tests/test_video_export_utils.cpp
+++ b/tests/test_video_export_utils.cpp
@@ -237,6 +237,44 @@ TEST(VideoExportUtilsTest, CaptureSnapshotSupportsMeshOnlyScenes) {
     expect_visualizer_translation_from_data(snapshot.meshes[0].transform, {-1.5f, 0.0f, 4.0f});
 }
 
+TEST(VideoExportUtilsTest, FrameMetadataCarriesLinearDepthAndProjection) {
+    auto depth = std::make_shared<Tensor>(Tensor::from_vector(
+        {2.0f, 4.0f, 6.0f, 8.0f},
+        {size_t{2}, size_t{2}},
+        Device::CPU));
+    const lfs::rendering::FrameView frame_view{
+        .size = {2, 2},
+        .near_plane = 0.25f,
+        .far_plane = 80.0f,
+        .orthographic = true,
+    };
+
+    const auto metadata = lfs::vis::gui::makeVideoExportFrameMetadata(frame_view, depth);
+
+    EXPECT_TRUE(metadata.valid);
+    EXPECT_FLOAT_EQ(metadata.near_plane, 0.25f);
+    EXPECT_FLOAT_EQ(metadata.far_plane, 80.0f);
+    EXPECT_TRUE(metadata.orthographic);
+    ASSERT_EQ(metadata.depth_panel_count, 1u);
+    ASSERT_TRUE(metadata.primaryDepth());
+    EXPECT_EQ(metadata.primaryDepth()->shape(), lfs::core::TensorShape({1, 2, 2}));
+    EXPECT_EQ(metadata.primaryDepth()->to_vector(), std::vector<float>({2.0f, 4.0f, 6.0f, 8.0f}));
+}
+
+TEST(VideoExportUtilsTest, FrameMetadataOmitsUnavailableDepth) {
+    const lfs::rendering::FrameView frame_view{
+        .size = {2, 2},
+        .near_plane = 0.1f,
+        .far_plane = 100.0f,
+    };
+
+    const auto metadata = lfs::vis::gui::makeVideoExportFrameMetadata(frame_view);
+
+    EXPECT_TRUE(metadata.valid);
+    EXPECT_EQ(metadata.depth_panel_count, 0u);
+    EXPECT_FALSE(metadata.primaryDepth());
+}
+
 TEST(VideoExportUtilsTest, ValidateVideoExportOptionsRejectsInvalidValues) {
     EXPECT_FALSE(lfs::vis::gui::validateVideoExportOptions({.width = 0,
                                                             .height = 1080,


### PR DESCRIPTION
## Summary

- capture Gaussian color and linear depth from the same preview render whenever mesh compositing is required
- carry that depth through frame metadata so meshes are correctly occluded by Gaussians
- preserve the same behavior for perspective, orthographic, environment-background, and tiled high-resolution exports
- use each split-view panel's own depth tensor during compositing
- add known-pixel coverage for mesh-only, splat-only, splat+mesh, and uneven split-view cases

Addresses #1548.

## Validation

- built `lichtfeld_tests` successfully on Windows with CUDA 12.8
- `lichtfeld_tests.exe --gtest_filter=VideoCompositeDepthTest.*:*VideoExportCompositePathTest*:VideoExportUtilsTest.*:MeshOffscreenDepthTest.*` (21 passed)
