### PR TITLE
Remove Edit mode from training-stopped dialog, suppress it on New Project/close

### DIFF
--- a/src/core/include/core/events.hpp
+++ b/src/core/include/core/events.hpp
@@ -170,7 +170,7 @@ namespace lfs::core {
             EVENT(TrainingProgress, int iteration; float loss; int num_gaussians; bool is_refining = false;);
             EVENT(TrainingPaused, int iteration;);
             EVENT(TrainingResumed, int iteration;);
-            EVENT(TrainingCompleted, int iteration; float final_loss; float elapsed_seconds; bool success; bool user_stopped; std::optional<std::string> error; bool resource_exhausted = false; std::optional<core::WireError> error_info;);
+            EVENT(TrainingCompleted, int iteration; float final_loss; float elapsed_seconds; bool success; bool user_stopped; std::optional<std::string> error; bool resource_exhausted = false; std::optional<core::WireError> error_info; bool suppress_notification = false;);
             EVENT(TrainingStopped, int iteration; bool user_requested;);
 
             // Scene state

--- a/src/python/lfs/notification_bridge.cpp
+++ b/src/python/lfs/notification_bridge.cpp
@@ -69,6 +69,8 @@ namespace lfs::python {
         state::TrainingCompleted::when([](const auto& e) {
             if (!e.success)
                 return; // failures surface via the native ErrorBus bridge
+            if (e.suppress_notification)
+                return; // stop was part of New Project / app close / reset — no modal (issue #1604)
 
             namespace Str = lichtfeld::Strings::Training::Button;
 
@@ -99,14 +101,22 @@ namespace lfs::python {
                 }
             }
 
-            const std::string edit_label = LOC(Str::SWITCH_EDIT_MODE);
-            PyModalRegistry::instance().show_confirm(
-                e.user_stopped ? "Training Stopped" : "Training Complete", message,
-                {edit_label, "OK"},
-                [edit_label](const std::string& clicked) {
-                    if (clicked == edit_label)
-                        cmd::SwitchToEditMode{}.emit();
-                });
+            if (e.user_stopped) {
+                // Stopped by user: OK only — Edit mode is nonsensical when scene may be clearing (issue #1604)
+                PyModalRegistry::instance().show_confirm(
+                    "Training Stopped", message,
+                    {"OK"},
+                    [](const std::string&) {});
+            } else {
+                const std::string edit_label = LOC(Str::SWITCH_EDIT_MODE);
+                PyModalRegistry::instance().show_confirm(
+                    "Training Complete", message,
+                    {edit_label, "OK"},
+                    [edit_label](const std::string& clicked) {
+                        if (clicked == edit_label)
+                            cmd::SwitchToEditMode{}.emit();
+                    });
+            }
         });
     }
 

--- a/src/visualizer/training/training_manager.cpp
+++ b/src/visualizer/training/training_manager.cpp
@@ -775,6 +775,7 @@ namespace lfs::vis {
 
         training_start_time_ = std::chrono::steady_clock::now();
         accumulated_training_time_ = std::chrono::steady_clock::duration{0};
+        suppress_completion_notification_.store(false, std::memory_order_relaxed);
 
         state::TrainingStarted{.total_iterations = getTotalIterations()}.emit();
 
@@ -1033,6 +1034,7 @@ namespace lfs::vis {
     }
 
     void TrainerManager::launchTrainingThread() {
+        suppress_completion_notification_.store(false, std::memory_order_relaxed);
         {
             std::lock_guard lock(completion_mutex_);
             training_joined_ = false;
@@ -1113,7 +1115,8 @@ namespace lfs::vis {
                 .resource_exhausted = completion.resource_exhausted,
                 .error_info = completion.typed_error
                                   ? std::optional(core::to_wire_error(*completion.typed_error))
-                                  : std::nullopt}
+                                  : std::nullopt,
+                .suppress_notification = suppress_completion_notification_.exchange(false, std::memory_order_relaxed)}
                 .emit();
         };
 

--- a/src/visualizer/training/training_manager.hpp
+++ b/src/visualizer/training/training_manager.hpp
@@ -66,6 +66,9 @@ namespace lfs::vis {
         void pauseTraining();
         void resumeTraining();
         void stopTraining();
+        // Suppress the completion notification modal for the next TrainingCompleted
+        // dispatch (stop initiated by New Project / app close / reset, issue #1604).
+        void suppressCompletionNotification() { suppress_completion_notification_.store(true, std::memory_order_relaxed); }
         void requestSaveCheckpoint();
 
         // Temporary pause for short synchronization-sensitive operations; does not change UI state.
@@ -247,6 +250,7 @@ namespace lfs::vis {
         bool training_joined_ = true;
         std::optional<TrainingCompletionData> pending_completion_;
         std::atomic<bool> completion_pending_{false};
+        std::atomic<bool> suppress_completion_notification_{false};
 
         static constexpr int COMPLETION_TIMEOUT_SEC = 30;
         static constexpr int MAX_LOSS_POINTS = 200;

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -1120,6 +1120,7 @@ namespace lfs::vis {
             }
             if (trainer_manager_ &&
                 (trainer_manager_->isTrainingActive() || trainer_manager_->isCompletionPending())) {
+                trainer_manager_->suppressCompletionNotification();
                 if (pending_training_action_ == PendingTrainingAction::None) {
                     pending_training_action_ = PendingTrainingAction::Reset;
                 }
@@ -1921,6 +1922,7 @@ namespace lfs::vis {
                 (!trainer_manager_->isTrainingActive() && !trainer_manager_->isCompletionPending())) {
                 return false;
             }
+            trainer_manager_->suppressCompletionNotification();
             pending_training_action_ = PendingTrainingAction::Close;
             if (trainer_manager_->canStop()) {
                 trainer_manager_->stopTraining();
@@ -2113,6 +2115,7 @@ namespace lfs::vis {
             (!trainer_manager_->canPerform(TrainingAction::ClearScene) ||
              trainer_manager_->isCompletionPending())) {
             pending_training_action_ = PendingTrainingAction::NewProject;
+            trainer_manager_->suppressCompletionNotification();
             if (trainer_manager_->canStop()) {
                 trainer_manager_->stopTraining();
             }


### PR DESCRIPTION
The Training Stopped modal offered an "Edit mode" button even when training was stopped as a side effect of File > New Project or closing the app — where the scene is being torn down — and flashed briefly during close.

- User-stopped dialog now shows only **OK**; natural training completion keeps {Edit mode, OK}.
- New `suppress_notification` flag on `TrainingCompleted`, set by the pending-action stop paths (New Project, app close, reset), skips the modal entirely — no more flash on close.
- Flag is cleared in `launchTrainingThread()` so a stale value can never suppress a later legitimate dialog (covers checkpoint resume).
- Verified: TCP wire JSON byte-identical, error notifications unaffected, headless + TCP training paths exercised end-to-end, zero-warning build.

Closes #1604

🤖 Generated with [Claude Code](https://claude.com/claude-code)