### PR TITLE
perf(viewer): decouple tool-overlay cost from the splat raster hot path

### DIFF
--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -1703,8 +1703,16 @@ namespace lfs::core {
         {
             std::unique_lock lock(selection_mutex_);
             selection_mask_ = std::move(normalized);
-            has_selection_ = selection_mask_ && selection_mask_->is_valid();
+            // Match setSelectionMask: empty index lists must clear selection so a
+            // size-matched all-zero mask cannot keep has_selection_ stuck true.
+            const bool valid =
+                selection_mask_ && selection_mask_->is_valid() && selection_mask_->numel() > 0;
+            has_selection_ = valid && selected_count > 0;
             has_selection = has_selection_;
+            if (!has_selection_) {
+                selection_mask_.reset();
+                selected_count = 0;
+            }
             selection_group_counts_dirty_ = true;
         }
         events::state::SelectionChanged{

--- a/src/rendering/include/rendering/rendering.hpp
+++ b/src/rendering/include/rendering/rendering.hpp
@@ -164,6 +164,10 @@ namespace lfs::rendering {
         GaussianMarkerOverlayState markers;
         GaussianCursorOverlayState cursor;
         GaussianEmphasisOverlayState emphasis;
+        // Host-side non-empty committed selection for this frame snapshot.
+        // Independent of emphasis.mask pointer validity so an empty/stale mask
+        // tensor cannot keep the slow overlay raster path pinned.
+        bool has_selection = false;
         std::array<glm::vec4, kSelectionColorTableCount> selection_colors = defaultSelectionColorTable();
     };
 

--- a/src/rendering/rasterizer/vulkan/CMakeLists.txt
+++ b/src/rendering/rasterizer/vulkan/CMakeLists.txt
@@ -254,17 +254,18 @@ _vulkan_add_slang_shader(cumsum_scan_block_sums_indirect   cumsum.slang CUMSUM_P
 _vulkan_add_slang_shader(cumsum_add_block_offsets_indirect cumsum.slang CUMSUM_PHASE=3 CUMSUM_INDIRECT=1)
 _vulkan_add_slang_shader(prepare_tile_sort_visible    prepare_tile_sort.slang LFS_VISIBLE_BOUNDED=1)
 
-# HiGS macro-tile binning + raster/compose. The plain raster ships fp16
-# staging; the fp32 variant doubles as validation reference and overlay path.
+# HiGS macro-tile binning + raster/compose. Plain and overlay rasters each ship
+# an fp16 (default) and fp32 staging variant — overlays no longer force fp32.
 _vulkan_add_slang_shader(macro_coverage         macro_tile_shader.slang EXPORT_MODE=0 MACRO_ENTRY=1)
 _vulkan_add_slang_shader(generate_macro_keys_wave macro_tile_shader.slang EXPORT_MODE=0 MACRO_ENTRY=2)
 _vulkan_add_slang_shader(compute_macro_ranges   macro_tile_shader.slang EXPORT_MODE=0 MACRO_ENTRY=3)
 _vulkan_add_slang_shader(macro_batch_prepare    macro_tile_shader.slang EXPORT_MODE=0 MACRO_ENTRY=5)
 _vulkan_add_slang_shader(wave_partition         macro_tile_shader.slang EXPORT_MODE=0 MACRO_ENTRY=6)
 _vulkan_add_slang_shader(wave_partition_visible macro_tile_shader.slang EXPORT_MODE=0 MACRO_ENTRY=6 LFS_VISIBLE_BOUNDED=1)
-_vulkan_add_slang_shader(macro_raster           macro_raster.slang EXPORT_MODE=0)
-_vulkan_add_slang_shader(macro_raster_fp32      macro_raster.slang EXPORT_MODE=0 LFS_HIGS_FP32=1)
-_vulkan_add_slang_shader(macro_raster_overlays  macro_raster.slang EXPORT_MODE=0 LFS_HIGS_FP32=1 LFS_RASTER_OVERLAYS=1)
+_vulkan_add_slang_shader(macro_raster                  macro_raster.slang EXPORT_MODE=0)
+_vulkan_add_slang_shader(macro_raster_fp32             macro_raster.slang EXPORT_MODE=0 LFS_HIGS_FP32=1)
+_vulkan_add_slang_shader(macro_raster_overlays         macro_raster.slang EXPORT_MODE=0 LFS_RASTER_OVERLAYS=1)
+_vulkan_add_slang_shader(macro_raster_overlays_fp32    macro_raster.slang EXPORT_MODE=0 LFS_HIGS_FP32=1 LFS_RASTER_OVERLAYS=1)
 _vulkan_add_slang_shader(macro_compose          macro_compose.slang EXPORT_MODE=0)
 _vulkan_add_slang_shader(macro_compose_overlays macro_compose.slang EXPORT_MODE=0 LFS_RASTER_OVERLAYS=1)
 

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/alphablend_shader.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/alphablend_shader.slang
@@ -121,6 +121,11 @@ groupshared float4 collected_inv_cov_vs_opacity[TILE_SIZE];
 
 groupshared uint32_t active_subgroups[TILE_SIZE / SUBGROUP_SIZE];
 groupshared uint32_t collected_gauss_idx[TILE_SIZE];
+#if LFS_RASTER_OVERLAYS
+// Packed flags | selection_byte | preview_byte — one global load set per splat
+// per workgroup instead of per pixel.
+groupshared uint32_t collected_overlay[TILE_SIZE];
+#endif
 
 #if SUBTILE_SIZE > 0
 groupshared uint32_t subtile_overlap_bitmasks[TILE_SIZE];
@@ -313,6 +318,12 @@ void main(
 
     const int shared_memory_rounds = ((tile_idx_end - tile_idx_start + TILE_SIZE - 1) / TILE_SIZE);
 
+  #if LFS_RASTER_OVERLAYS
+    // Hoist uniform overlay scalars once per thread; hot loop never reloads
+    // overlay_params.
+    const OverlayUniformState overlay_state = load_overlay_uniform_state(overlay_params);
+  #endif
+
     int32_t num_cull = 0;  // for visualization
     int splats_left_to_process = tile_idx_end - tile_idx_start;
     for (int i = 0; i < shared_memory_rounds; i++)
@@ -351,6 +362,10 @@ void main(
             collected_xy_vs[thread_rank] = read_t2_float2(coll_id, xy_vs);
             collected_inv_cov_vs_opacity[thread_rank] = read_t4_float4(coll_id, inv_cov_vs_opacity);
             collected_gauss_idx[thread_rank] = coll_id;
+            #endif
+            #if LFS_RASTER_OVERLAYS
+            collected_overlay[thread_rank] = load_overlay_per_splat_pack(
+                coll_id, gaussian_overlay_flags, selection_mask, preview_mask, overlay_state);
             #endif
         }
         GroupMemoryBarrierWithGroupSync();
@@ -392,7 +407,8 @@ void main(
             #if SHARED_STRUCT
                 uint32_t splat_id = collected_gauss_idx[j];
               #if LFS_RASTER_OVERLAYS
-                uint flags = gaussian_overlay_flags[splat_id];
+                const uint overlay_pack = collected_overlay[j];
+                const uint flags = unpack_overlay_flags(overlay_pack);
               #endif
                 float splat_depth = read_t1_float(splat_id, depths);
                 float4 gauss_rgba;
@@ -436,7 +452,8 @@ void main(
 
                 uint32_t splat_id = collected_gauss_idx[j];
               #if LFS_RASTER_OVERLAYS
-                uint flags = gaussian_overlay_flags[splat_id];
+                const uint overlay_pack = collected_overlay[j];
+                const uint flags = unpack_overlay_flags(overlay_pack);
               #endif
                 float splat_depth = read_t1_float(splat_id, depths);
                 float3 splat_rgb = read_t3_float3(splat_id, rgb);
@@ -449,26 +466,28 @@ void main(
             #endif
 
             #if LFS_RASTER_OVERLAYS
-                uint sel_status = selection_status(overlay_splat.xy_vs,
-                                                   splat_id,
-                                                   flags,
-                                                   selection_mask,
-                                                   preview_mask,
-                                                   overlay_params);
+                const uint sel_status = selection_status(
+                    overlay_splat.xy_vs,
+                    splat_id,
+                    flags,
+                    unpack_overlay_selection_byte(overlay_pack),
+                    unpack_overlay_preview_byte(overlay_pack),
+                    overlay_state);
                 bool selectable = (flags & OVERLAY_FLAG_NONSELECTABLE) == 0u;
                 gauss_rgba = apply_projection_overlay_color(gauss_rgba,
                                                             overlay_splat.xy_vs,
                                                             flags,
-                                                            overlay_params);
+                                                            overlay_state);
                 gauss_rgba = apply_ring_overlay(gauss_rgba,
                                                 overlay_splat,
                                                 center_pix_coord,
                                                 sel_status,
                                                 flags,
-                                                overlay_params,
+                                                overlay_state.show_rings,
+                                                overlay_state.ring_width,
                                                 selection_colors);
 
-                if (overlay_enabled(overlay_params[OVERLAY_PARAM_MARKER_FLAGS].y) && selectable) {
+                if (overlay_state.show_center_markers && selectable) {
                     const float INNER_RADIUS_SQ = 2.25f;
                     const float OUTER_RADIUS_SQ = 6.25f;
                     const float OUTLINE_DARKEN = 0.4f;
@@ -490,7 +509,7 @@ void main(
                 }
 
                 gauss_rgba = apply_selection_overlay(gauss_rgba, sel_status, selection_colors);
-                gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_params);
+                gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_state.flash_intensity);
             #endif
 
                 float4 new_pixel_state = update_pixel_state(curr_pixel_state, gauss_rgba);

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/macro_compose.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/macro_compose.slang
@@ -61,7 +61,7 @@ void replay_batch(uint range_start,
                   float2 center_pix_coord,
                   bool spark_rad_opacity_path,
 #if LFS_RASTER_OVERLAYS
-                  bool markers_enabled,
+                  OverlayUniformState overlay_state,
 #endif
                   inout float4 curr_pixel_state,
                   inout float median_depth,
@@ -82,28 +82,36 @@ void replay_batch(uint range_start,
         const float splat_depth = read_t1_float(slot, depths);
 
       #if LFS_RASTER_OVERLAYS
+        // Replay streams from global (no cooperative stage). Hoisted uniforms
+        // still remove overlay_params traffic from the per-splat path.
+        // Flags are keyed by macro-sorted slot; selection masks by original id.
         const uint flags = gaussian_overlay_flags[slot];
         const uint sel_splat_id = uint(orig_ids[slot]);
+        const uint selection_byte = overlay_state.selection_mask_enabled
+            ? read_byte(selection_mask, sel_splat_id) : 0u;
+        const uint preview_byte = overlay_state.preview_mask_enabled
+            ? read_byte(preview_mask, sel_splat_id) : 0u;
         const uint sel_status = selection_status(g.xy_vs,
                                                  sel_splat_id,
                                                  flags,
-                                                 selection_mask,
-                                                 preview_mask,
-                                                 overlay_params);
+                                                 selection_byte,
+                                                 preview_byte,
+                                                 overlay_state);
         const bool selectable = (flags & OVERLAY_FLAG_NONSELECTABLE) == 0u;
         gauss_rgba = apply_projection_overlay_color(gauss_rgba,
                                                     g.xy_vs,
                                                     flags,
-                                                    overlay_params);
+                                                    overlay_state);
         gauss_rgba = apply_ring_overlay(gauss_rgba,
                                         g,
                                         center_pix_coord,
                                         sel_status,
                                         flags,
-                                        overlay_params,
+                                        overlay_state.show_rings,
+                                        overlay_state.ring_width,
                                         selection_colors);
 
-        if (markers_enabled && selectable) {
+        if (overlay_state.show_center_markers && selectable) {
             const float INNER_RADIUS_SQ = 2.25f;
             const float OUTER_RADIUS_SQ = 6.25f;
             const float OUTLINE_DARKEN = 0.4f;
@@ -125,7 +133,7 @@ void replay_batch(uint range_start,
         }
 
         gauss_rgba = apply_selection_overlay(gauss_rgba, sel_status, selection_colors);
-        gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_params);
+        gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_state.flash_intensity);
       #endif
 
         const float3 color = curr_pixel_state.rgb + gauss_rgba.rgb * curr_pixel_state.a;
@@ -170,7 +178,7 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
     const float2 center_pix_coord = float2(pix_coord);
     const bool spark_rad_opacity_path = (uniforms.lod_enabled & 4u) != 0u;
   #if LFS_RASTER_OVERLAYS
-    const bool markers_enabled = overlay_enabled(overlay_params[OVERLAY_PARAM_MARKER_FLAGS].y);
+    const OverlayUniformState overlay_state = load_overlay_uniform_state(overlay_params);
   #endif
 
     // The per-pixel blend state persists in the output buffers between waves;
@@ -221,7 +229,7 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
                              center_pix_coord,
                              spark_rad_opacity_path,
                           #if LFS_RASTER_OVERLAYS
-                             markers_enabled,
+                             overlay_state,
                           #endif
                              replay_state,
                              replay_median_depth,

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/macro_raster.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/macro_raster.slang
@@ -13,7 +13,9 @@
 // have, and alpha = opacity * exp2(-q).
 //
 // LFS_HIGS_FP32=1: float staging with the exact legacy evaluate_splat math;
-// used for validation and as the overlay/editor variant.
+// used for validation and for the spark-rad opacity path (host-routed).
+// Overlay data stages in separate uint arrays, so LFS_RASTER_OVERLAYS works
+// with either staging format; the fp16 overlay variant keeps the drain queue.
 
 #include "config.slang"
 
@@ -25,10 +27,6 @@ import utils;
 
 #ifndef LFS_RASTER_OVERLAYS
 #define LFS_RASTER_OVERLAYS 0
-#endif
-
-#if LFS_RASTER_OVERLAYS && !LFS_HIGS_FP32
-#error "overlay variant requires fp32 staging"
 #endif
 
 #define RASTER_THREAD_COUNT 320u
@@ -48,7 +46,13 @@ groupshared half4 shared_chol_thr[RASTER_BATCH_SIZE];    // {l00', l01', l11', t
 #endif
 groupshared half4 shared_rgb_opac[RASTER_BATCH_SIZE];    // {r, g, b, opacity}
 #if LFS_RASTER_OVERLAYS
+// Packed flags | selection_byte | preview_byte (selection id uses orig_ids).
+groupshared uint32_t shared_overlay_pack[RASTER_BATCH_SIZE];
+groupshared uint32_t shared_sel_id[RASTER_BATCH_SIZE];
+// Compact projection slot for rare ring inv_cov reloads (fp16 path only).
+#if !LFS_HIGS_FP32
 groupshared uint32_t shared_slot[RASTER_BATCH_SIZE];
+#endif
 #endif
 groupshared uint32_t shared_tile_masks[MINI_BATCHES * HIGS_MACRO_TILE_SIZE_TILES];
 #if !LFS_HIGS_FP32
@@ -161,6 +165,11 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
     const uint num_mini_batches = (splats_to_process + SUBGROUP_SIZE - 1u) / SUBGROUP_SIZE;
     const bool spark_rad_opacity_path = (uniforms.lod_enabled & 4u) != 0u;
 
+  #if LFS_RASTER_OVERLAYS
+    // Hoist uniform overlay scalars once per thread before the batch blend.
+    const OverlayUniformState overlay_state = load_overlay_uniform_state(overlay_params);
+  #endif
+
     // Phase 1: cooperative load + per-splat tile mask + ballot transpose. The
     // whole batch (positions, conics, colors) is staged once; render tiles
     // never re-read splat data from global memory.
@@ -194,7 +203,19 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
           #endif
             shared_rgb_opac[i] = half4(float4(g_rgb, g_ico.w));
           #if LFS_RASTER_OVERLAYS
+            // Selection masks are indexed by original gaussian id, not the
+            // macro-sorted slot (LOD may rematerialize).
+            const uint sel_splat_id = uint(orig_ids[slot]);
+            const uint flags = gaussian_overlay_flags[slot];
+            const uint selection_byte = overlay_state.selection_mask_enabled
+                ? read_byte(selection_mask, sel_splat_id) : 0u;
+            const uint preview_byte = overlay_state.preview_mask_enabled
+                ? read_byte(preview_mask, sel_splat_id) : 0u;
+            shared_overlay_pack[i] = pack_overlay_per_splat(flags, selection_byte, preview_byte);
+            shared_sel_id[i] = sel_splat_id;
+            #if !LFS_HIGS_FP32
             shared_slot[i] = slot;
+            #endif
           #endif
         }
         // One ballot per render tile transposes the per-splat tile masks into
@@ -277,15 +298,15 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
                 const float4 g_ico = shared_inv_cov_opac[i];
 
               #if LFS_RASTER_OVERLAYS
-                const uint32_t splat_slot = shared_slot[i];
-                const uint flags = gaussian_overlay_flags[splat_slot];
-                const uint sel_splat_id = uint(orig_ids[splat_slot]);
+                const uint overlay_pack = shared_overlay_pack[i];
+                const uint flags = unpack_overlay_flags(overlay_pack);
+                const uint sel_splat_id = shared_sel_id[i];
                 const uint sel_status = selection_status(g_xy,
                                                          sel_splat_id,
                                                          flags,
-                                                         selection_mask,
-                                                         preview_mask,
-                                                         overlay_params);
+                                                         unpack_overlay_selection_byte(overlay_pack),
+                                                         unpack_overlay_preview_byte(overlay_pack),
+                                                         overlay_state);
                 const bool selectable = (flags & OVERLAY_FLAG_NONSELECTABLE) == 0u;
                 const Splat_2D_AlphaBlend overlay_splat = { g_ico, g_xy, g_rgbo.rgb };
               #endif
@@ -316,16 +337,17 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
                     gauss_rgba = apply_projection_overlay_color(gauss_rgba,
                                                                 overlay_splat.xy_vs,
                                                                 flags,
-                                                                overlay_params);
+                                                                overlay_state);
                     gauss_rgba = apply_ring_overlay(gauss_rgba,
                                                     overlay_splat,
                                                     pixel_coord[p],
                                                     sel_status,
                                                     flags,
-                                                    overlay_params,
+                                                    overlay_state.show_rings,
+                                                    overlay_state.ring_width,
                                                     selection_colors);
 
-                    if (overlay_enabled(overlay_params[OVERLAY_PARAM_MARKER_FLAGS].y) && selectable) {
+                    if (overlay_state.show_center_markers && selectable) {
                         const float INNER_RADIUS_SQ = 2.25f;
                         const float OUTER_RADIUS_SQ = 6.25f;
                         const float OUTLINE_DARKEN = 0.4f;
@@ -346,7 +368,7 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
                     }
 
                     gauss_rgba = apply_selection_overlay(gauss_rgba, sel_status, selection_colors);
-                    gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_params);
+                    gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_state.flash_intensity);
                   #endif
 
                     const float3 color = pixel_state[p].rgb + gauss_rgba.rgb * pixel_state[p].a;
@@ -446,6 +468,32 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
                     const half2 thr2 = half2(g_chol.w, g_chol.w);
                     const half2 gy2 = half2(g_xy.y, g_xy.y);
 
+                  #if LFS_RASTER_OVERLAYS
+                    // Macro-relative half positions are the same representation
+                    // as the plain fp16 blend; reconstruct absolute pixel xy
+                    // for cursor/ring/marker tests (macro extent is tiny so
+                    // half tile-units stay exact).
+                    const float2 g_xy_abs =
+                        float2(g_xy) * float2(float(HIGS_TILE_WIDTH), float(HIGS_TILE_HEIGHT)) +
+                        macro_origin;
+                    const uint overlay_pack = shared_overlay_pack[i];
+                    const uint flags = unpack_overlay_flags(overlay_pack);
+                    const uint sel_splat_id = shared_sel_id[i];
+                    const uint sel_status = selection_status(g_xy_abs,
+                                                             sel_splat_id,
+                                                             flags,
+                                                             unpack_overlay_selection_byte(overlay_pack),
+                                                             unpack_overlay_preview_byte(overlay_pack),
+                                                             overlay_state);
+                    const bool selectable = (flags & OVERLAY_FLAG_NONSELECTABLE) == 0u;
+                    // Ring math needs full inv_cov; reload only when rings are on.
+                    const float4 g_ico_overlay = overlay_state.show_rings
+                        ? inv_cov_vs_opacity[shared_slot[i]]
+                        : float4(0.0f, 0.0f, 0.0f, 0.0f);
+                    const Splat_2D_AlphaBlend overlay_splat =
+                        { g_ico_overlay, g_xy_abs, float3(g_rgbo.xyz) };
+                  #endif
+
                     [unroll]
                     for (uint k = 0u; k < PIXEL_PAIRS; ++k) {
                         const half2 dy2 = pix_y2[k] - gy2;
@@ -455,11 +503,76 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
                         half2 alpha2 = min(g_rgbo.w * exp2(-q2), alpha_cap2);
                         alpha2 = select(q2 <= thr2, alpha2, zero2);
                         alpha2 = select(alpha2 >= alpha_min2, alpha2, zero2);
+
+                      #if LFS_RASTER_OVERLAYS
+                        // Keep the half2 quadratic/exp2; apply overlays and blend
+                        // per pixel so ring/marker absorb-all can kill one of the
+                        // pair without falling back to full fp32 staging.
+                        [unroll]
+                        for (uint pj = 0u; pj < 2u; ++pj) {
+                            const float a = float(alpha2[pj]);
+                            const float t = float(acc_t[k][pj]);
+                            if (a < ALPHA_THRESHOLD || t < 0.0001f)
+                                continue;
+
+                            const uint p = 2u * k + pj;
+                            const uint pixel_linear = lane_id + p * SUBGROUP_SIZE;
+                            const float2 pix_coord = float2(
+                                float(tile_origin.x + (pixel_linear % HIGS_TILE_WIDTH)),
+                                float(tile_origin.y + (pixel_linear / HIGS_TILE_WIDTH)));
+
+                            float4 gauss_rgba = float4(float3(g_rgbo.xyz) * a, a);
+                            gauss_rgba = apply_projection_overlay_color(gauss_rgba,
+                                                                        g_xy_abs,
+                                                                        flags,
+                                                                        overlay_state);
+                            gauss_rgba = apply_ring_overlay(gauss_rgba,
+                                                            overlay_splat,
+                                                            pix_coord,
+                                                            sel_status,
+                                                            flags,
+                                                            overlay_state.show_rings,
+                                                            overlay_state.ring_width,
+                                                            selection_colors);
+
+                            if (overlay_state.show_center_markers && selectable) {
+                                const float INNER_RADIUS_SQ = 2.25f;
+                                const float OUTER_RADIUS_SQ = 6.25f;
+                                const float OUTLINE_DARKEN = 0.4f;
+                                const float2 marker_delta = g_xy_abs - pix_coord;
+                                const float dist_sq = dot(marker_delta, marker_delta);
+                                // Marker mode renders dots only (matches the
+                                // legacy and fp32 paths): outside the dot the
+                                // splat contributes nothing.
+                                if (dist_sq > OUTER_RADIUS_SQ)
+                                    continue;
+
+                                float3 marker_color =
+                                    selection_overlay_target_color(sel_status, selection_colors);
+                                if (dist_sq > INNER_RADIUS_SQ)
+                                    marker_color *= OUTLINE_DARKEN;
+                                acc_r[k][pj] = half(marker_color.x);
+                                acc_g[k][pj] = half(marker_color.y);
+                                acc_b[k][pj] = half(marker_color.z);
+                                acc_t[k][pj] = half(0.0f);
+                                continue;
+                            }
+
+                            gauss_rgba = apply_selection_overlay(gauss_rgba, sel_status, selection_colors);
+                            gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_state.flash_intensity);
+
+                            acc_r[k][pj] = half(float(acc_r[k][pj]) + gauss_rgba.x * t);
+                            acc_g[k][pj] = half(float(acc_g[k][pj]) + gauss_rgba.y * t);
+                            acc_b[k][pj] = half(float(acc_b[k][pj]) + gauss_rgba.z * t);
+                            acc_t[k][pj] = half(t * (1.0f - gauss_rgba.w));
+                        }
+                      #else
                         const half2 w2 = alpha2 * acc_t[k];
                         acc_r[k] += g_rgbo.x * w2;
                         acc_g[k] += g_rgbo.y * w2;
                         acc_b[k] += g_rgbo.z * w2;
                         acc_t[k] *= one2 - alpha2;
+                      #endif
                     }
                 }
                 qcount = 0u;

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/tile_batch_shader.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/tile_batch_shader.slang
@@ -92,6 +92,8 @@ groupshared Splat_2D_AlphaBlend collected_splats[TILE_SIZE];
 groupshared uint32_t active_subgroups[TILE_SIZE / SUBGROUP_SIZE];
 #if LFS_RASTER_OVERLAYS
 groupshared uint32_t collected_gauss_idx[TILE_SIZE];
+// Packed flags | selection_byte | preview_byte per staged splat.
+groupshared uint32_t collected_overlay[TILE_SIZE];
 #endif
 
 layout(binding=0) StructuredBuffer<int32_t> sorted_gauss_idx;
@@ -136,6 +138,10 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
     uint shared_memory_rounds =
         (splats_to_process + TILE_SIZE - 1u) / TILE_SIZE;
 
+  #if LFS_RASTER_OVERLAYS
+    const OverlayUniformState overlay_state = load_overlay_uniform_state(overlay_params);
+  #endif
+
     for (uint round = 0u; round < shared_memory_rounds; ++round) {
         const uint subgroup_idx = thread_rank / SUBGROUP_SIZE;
         const uint32_t subgroup_has_active_thread =
@@ -161,6 +167,8 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
                 load_splat_alphablend(int32_t(splat_id), xy_vs, inv_cov_vs_opacity, rgb);
             #if LFS_RASTER_OVERLAYS
             collected_gauss_idx[thread_rank] = splat_id;
+            collected_overlay[thread_rank] = load_overlay_per_splat_pack(
+                splat_id, gaussian_overlay_flags, selection_mask, preview_mask, overlay_state);
             #endif
         }
         GroupMemoryBarrierWithGroupSync();
@@ -177,27 +185,29 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
 
                 #if LFS_RASTER_OVERLAYS
                 uint32_t splat_id = collected_gauss_idx[j];
-                uint flags = gaussian_overlay_flags[splat_id];
+                const uint overlay_pack = collected_overlay[j];
+                const uint flags = unpack_overlay_flags(overlay_pack);
                 uint sel_status = selection_status(g.xy_vs,
                                                    splat_id,
                                                    flags,
-                                                   selection_mask,
-                                                   preview_mask,
-                                                   overlay_params);
+                                                   unpack_overlay_selection_byte(overlay_pack),
+                                                   unpack_overlay_preview_byte(overlay_pack),
+                                                   overlay_state);
                 bool selectable = (flags & OVERLAY_FLAG_NONSELECTABLE) == 0u;
                 gauss_rgba = apply_projection_overlay_color(gauss_rgba,
                                                             g.xy_vs,
                                                             flags,
-                                                            overlay_params);
+                                                            overlay_state);
                 gauss_rgba = apply_ring_overlay(gauss_rgba,
                                                 g,
                                                 center_pix_coord,
                                                 sel_status,
                                                 flags,
-                                                overlay_params,
+                                                overlay_state.show_rings,
+                                                overlay_state.ring_width,
                                                 selection_colors);
 
-                if (overlay_enabled(overlay_params[OVERLAY_PARAM_MARKER_FLAGS].y) && selectable) {
+                if (overlay_state.show_center_markers && selectable) {
                     const float INNER_RADIUS_SQ = 2.25f;
                     const float OUTER_RADIUS_SQ = 6.25f;
                     const float OUTLINE_DARKEN = 0.4f;
@@ -216,7 +226,7 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
                 }
 
                 gauss_rgba = apply_selection_overlay(gauss_rgba, sel_status, selection_colors);
-                gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_params);
+                gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_state.flash_intensity);
                 #endif
 
                 float4 new_pixel_state = update_pixel_state(curr_pixel_state, gauss_rgba);
@@ -264,6 +274,9 @@ layout(binding=16) StructuredBuffer<float4> overlay_params;
 void replay_batch(uint range_start,
                   uint range_end,
                   float2 center_pix_coord,
+#if LFS_RASTER_OVERLAYS
+                  OverlayUniformState overlay_state,
+#endif
                   inout float4 curr_pixel_state,
                   inout float median_depth,
                   inout int32_t local_n_contrib,
@@ -281,27 +294,32 @@ void replay_batch(uint range_start,
         float splat_depth = read_t1_float(splat_id, depths);
 
         #if LFS_RASTER_OVERLAYS
-        uint flags = gaussian_overlay_flags[splat_id];
+        // Compose path streams splats (no cooperative stage); still use
+        // hoisted uniforms and a single packed per-splat load.
+        const uint overlay_pack = load_overlay_per_splat_pack(
+            splat_id, gaussian_overlay_flags, selection_mask, preview_mask, overlay_state);
+        const uint flags = unpack_overlay_flags(overlay_pack);
         uint sel_status = selection_status(g.xy_vs,
                                            splat_id,
                                            flags,
-                                           selection_mask,
-                                           preview_mask,
-                                           overlay_params);
+                                           unpack_overlay_selection_byte(overlay_pack),
+                                           unpack_overlay_preview_byte(overlay_pack),
+                                           overlay_state);
         bool selectable = (flags & OVERLAY_FLAG_NONSELECTABLE) == 0u;
         gauss_rgba = apply_projection_overlay_color(gauss_rgba,
                                                     g.xy_vs,
                                                     flags,
-                                                    overlay_params);
+                                                    overlay_state);
         gauss_rgba = apply_ring_overlay(gauss_rgba,
                                         g,
                                         center_pix_coord,
                                         sel_status,
                                         flags,
-                                        overlay_params,
+                                        overlay_state.show_rings,
+                                        overlay_state.ring_width,
                                         selection_colors);
 
-        if (overlay_enabled(overlay_params[OVERLAY_PARAM_MARKER_FLAGS].y) && selectable) {
+        if (overlay_state.show_center_markers && selectable) {
             const float INNER_RADIUS_SQ = 2.25f;
             const float OUTER_RADIUS_SQ = 6.25f;
             const float OUTLINE_DARKEN = 0.4f;
@@ -323,7 +341,7 @@ void replay_batch(uint range_start,
         }
 
         gauss_rgba = apply_selection_overlay(gauss_rgba, sel_status, selection_colors);
-        gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_params);
+        gauss_rgba = apply_flash_overlay(gauss_rgba, flags, overlay_state.flash_intensity);
         #endif
 
         float4 new_pixel_state = update_pixel_state(curr_pixel_state, gauss_rgba);
@@ -375,6 +393,10 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
     }
     bool thread_active = curr_pixel_state.a >= 0.0001f;
 
+  #if LFS_RASTER_OVERLAYS
+    const OverlayUniformState overlay_state = load_overlay_uniform_state(overlay_params);
+  #endif
+
     for (uint desc_idx = desc_begin; desc_idx < desc_end && thread_active; ++desc_idx) {
         uint partial_idx = desc_idx * TILE_SIZE + thread_rank;
         float4 partial_state = tile_batch_pixel_state[partial_idx];
@@ -392,6 +414,9 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
             replay_batch(descriptor.y,
                          descriptor.z,
                          center_pix_coord,
+                      #if LFS_RASTER_OVERLAYS
+                         overlay_state,
+                      #endif
                          curr_pixel_state,
                          median_depth,
                          local_n_contrib,
@@ -407,6 +432,9 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
             replay_batch(descriptor.y,
                          descriptor.z,
                          center_pix_coord,
+                      #if LFS_RASTER_OVERLAYS
+                         overlay_state,
+                      #endif
                          replay_state,
                          replay_median_depth,
                          replay_n_contrib,

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/utils.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/utils.slang
@@ -1125,12 +1125,100 @@ int read_int32(ByteAddressBuffer buffer, uint idx)
     return int(buffer.Load(idx * 4u));
 }
 
+// Uniform overlay scalars loaded once per thread (or workgroup) before any
+// per-splat/per-pixel loop. Keeps the hot raster loops free of overlay_params
+// buffer traffic.
+struct OverlayUniformState {
+    bool cursor_enabled;
+    bool saturation_preview;
+    float saturation_amount;
+    float ring_width;
+    bool show_rings;
+    bool show_center_markers;
+    float2 cursor_xy;
+    float cursor_radius;
+    bool cursor_selection_enabled;
+    bool selection_mask_enabled;
+    bool preview_mask_enabled;
+    bool add_mode;
+    int focused_gaussian_id;
+    float flash_intensity;
+};
+
 [ForceInline]
-bool overlay_cursor_hit(float2 gaussian_xy, StructuredBuffer<float4> overlay_params)
+OverlayUniformState load_overlay_uniform_state(StructuredBuffer<float4> overlay_params)
 {
-    float4 cursor = overlay_params[OVERLAY_PARAM_SELECTION_CURSOR];
-    float2 delta = gaussian_xy - cursor.xy;
-    return dot(delta, delta) <= cursor.z * cursor.z;
+    float4 cursor_flags = overlay_params[OVERLAY_PARAM_CURSOR_FLAGS];
+    float4 marker_flags = overlay_params[OVERLAY_PARAM_MARKER_FLAGS];
+    float4 selection_cursor = overlay_params[OVERLAY_PARAM_SELECTION_CURSOR];
+    float4 selection_flags = overlay_params[OVERLAY_PARAM_SELECTION_FLAGS];
+    float4 emphasis_flags = overlay_params[OVERLAY_PARAM_EMPHASIS_FLAGS];
+
+    OverlayUniformState state;
+    state.cursor_enabled = overlay_enabled(cursor_flags.x);
+    state.saturation_preview = overlay_enabled(cursor_flags.y);
+    state.saturation_amount = cursor_flags.z;
+    state.ring_width = cursor_flags.w;
+    state.show_rings = overlay_enabled(marker_flags.x);
+    state.show_center_markers = overlay_enabled(marker_flags.y);
+    state.cursor_xy = selection_cursor.xy;
+    state.cursor_radius = selection_cursor.z;
+    state.cursor_selection_enabled = overlay_enabled(selection_cursor.w);
+    state.selection_mask_enabled = overlay_enabled(selection_flags.x);
+    state.preview_mask_enabled = overlay_enabled(selection_flags.y);
+    state.add_mode = overlay_enabled(selection_flags.z);
+    state.focused_gaussian_id = overlay_int(selection_flags.w);
+    state.flash_intensity = emphasis_flags.w;
+    return state;
+}
+
+// Pack per-splat overlay payload for groupshared staging: flags | sel | preview.
+// Flags currently use 3 bits; 16 bits leave headroom without a second shared slot.
+[ForceInline]
+uint pack_overlay_per_splat(uint flags, uint selection_byte, uint preview_byte)
+{
+    return (flags & 0xffffu) |
+           ((selection_byte & 0xffu) << 16) |
+           ((preview_byte & 0xffu) << 24);
+}
+
+[ForceInline]
+uint unpack_overlay_flags(uint packed)
+{
+    return packed & 0xffffu;
+}
+
+[ForceInline]
+uint unpack_overlay_selection_byte(uint packed)
+{
+    return (packed >> 16) & 0xffu;
+}
+
+[ForceInline]
+uint unpack_overlay_preview_byte(uint packed)
+{
+    return (packed >> 24) & 0xffu;
+}
+
+[ForceInline]
+uint load_overlay_per_splat_pack(
+    uint splat_id,
+    StructuredBuffer<uint> gaussian_overlay_flags,
+    ByteAddressBuffer selection_mask,
+    ByteAddressBuffer preview_mask,
+    OverlayUniformState state)
+{
+    uint flags = gaussian_overlay_flags[splat_id];
+    uint selection_byte = state.selection_mask_enabled ? read_byte(selection_mask, splat_id) : 0u;
+    uint preview_byte = state.preview_mask_enabled ? read_byte(preview_mask, splat_id) : 0u;
+    return pack_overlay_per_splat(flags, selection_byte, preview_byte);
+}
+
+[ForceInline]
+bool overlay_cursor_hit(float2 gaussian_xy, float2 cursor_xy, float cursor_radius)
+{
+    float2 delta = gaussian_xy - cursor_xy;
+    return dot(delta, delta) <= cursor_radius * cursor_radius;
 }
 
 [ForceInline]
@@ -1145,35 +1233,36 @@ float3 unpremultiplied_color(float4 gauss_rgba)
     return gauss_rgba.a > eps ? gauss_rgba.rgb / gauss_rgba.a : float3(0.0f);
 }
 
+// selection_byte / preview_byte are the already-fetched mask values for splat_id
+// (from groupshared or a prior global load). No mask buffer access here.
 [ForceInline]
 uint selection_status(
     float2 gaussian_xy,
     uint splat_id,
     uint flags,
-    ByteAddressBuffer selection_mask,
-    ByteAddressBuffer preview_mask,
-    StructuredBuffer<float4> overlay_params)
+    uint selection_byte,
+    uint preview_byte,
+    OverlayUniformState state)
 {
-    if (overlay_enabled(overlay_params[OVERLAY_PARAM_CURSOR_FLAGS].y)) {
+    if (state.saturation_preview) {
         return 0u;
     }
     bool selectable = (flags & OVERLAY_FLAG_NONSELECTABLE) == 0u;
-    float4 selection_flags = overlay_params[OVERLAY_PARAM_SELECTION_FLAGS];
     uint group_id = 0;
-    if (overlay_enabled(selection_flags.x)) {
-        group_id = read_byte(selection_mask, splat_id) & SELECTION_GROUP_MASK;
+    if (state.selection_mask_enabled) {
+        group_id = selection_byte & SELECTION_GROUP_MASK;
     }
     bool is_committed = group_id > 0;
     bool is_in_preview = false;
-    if (overlay_enabled(selection_flags.y)) {
-        is_in_preview = read_byte(preview_mask, splat_id) != 0;
+    if (state.preview_mask_enabled) {
+        is_in_preview = preview_byte != 0;
     }
     bool under_brush = false;
-    if (overlay_enabled(overlay_params[OVERLAY_PARAM_SELECTION_CURSOR].w) && selectable) {
-        under_brush = overlay_cursor_hit(gaussian_xy, overlay_params);
+    if (state.cursor_selection_enabled && selectable) {
+        under_brush = overlay_cursor_hit(gaussian_xy, state.cursor_xy, state.cursor_radius);
     }
-    bool add_mode = overlay_enabled(selection_flags.z);
-    bool is_ring_highlight = selectable && overlay_int(selection_flags.w) == int(splat_id);
+    bool add_mode = state.add_mode;
+    bool is_ring_highlight = selectable && state.focused_gaussian_id == int(splat_id);
     bool is_preview = (is_in_preview && !is_committed && add_mode) ||
                       (is_in_preview && is_committed && !add_mode) ||
                       (under_brush && selectable && add_mode && !is_committed) ||
@@ -1188,15 +1277,14 @@ float4 apply_projection_overlay_color(
     float4 gauss_rgba,
     float2 gaussian_xy,
     uint flags,
-    StructuredBuffer<float4> overlay_params)
+    OverlayUniformState state)
 {
     float3 color = unpremultiplied_color(gauss_rgba);
     bool selectable = (flags & OVERLAY_FLAG_NONSELECTABLE) == 0u;
-    float4 cursor_flags = overlay_params[OVERLAY_PARAM_CURSOR_FLAGS];
-    if (overlay_enabled(cursor_flags.x) && overlay_enabled(cursor_flags.y) && selectable &&
-        overlay_cursor_hit(gaussian_xy, overlay_params)) {
+    if (state.cursor_enabled && state.saturation_preview && selectable &&
+        overlay_cursor_hit(gaussian_xy, state.cursor_xy, state.cursor_radius)) {
         float lum = 0.2126f * color.x + 0.7152f * color.y + 0.0722f * color.z;
-        float sat = 1.0f + cursor_flags.z;
+        float sat = 1.0f + state.saturation_amount;
         color = clamp(lum + sat * (color - lum), 0.0f, 1.0f);
     }
     if ((flags & OVERLAY_FLAG_DIM) != 0u) {
@@ -1224,6 +1312,8 @@ float3 selection_overlay_target_color(uint sel_status, StructuredBuffer<float4> 
     return selection_colors[0].xyz;
 }
 
+// show_rings / ring_width come from hoisted OverlayUniformState — no buffer
+// loads and no exp() until the cheap enable gates pass.
 [ForceInline]
 float4 apply_ring_overlay(
     float4 gauss_rgba,
@@ -1231,15 +1321,14 @@ float4 apply_ring_overlay(
     float2 pix_coord,
     uint sel_status,
     uint flags,
-    StructuredBuffer<float4> overlay_params,
+    bool show_rings,
+    float ring_width,
     StructuredBuffer<float4> selection_colors)
 {
-    bool show_rings = overlay_enabled(overlay_params[OVERLAY_PARAM_MARKER_FLAGS].x);
     bool selectable = (flags & OVERLAY_FLAG_NONSELECTABLE) == 0u;
     if (!show_rings || !selectable) {
         return gauss_rgba;
     }
-    float ring_width = overlay_params[OVERLAY_PARAM_CURSOR_FLAGS].w;
     float2 d = pix_coord - g.xy_vs;
     float3 inv_cov = g.inv_cov_vs_opacity.xyz;
     float sigma_over_2 = 0.5f * (inv_cov.x * d.x * d.x + inv_cov.z * d.y * d.y) + inv_cov.y * d.x * d.y;
@@ -1285,18 +1374,17 @@ float4 apply_selection_overlay(
 float4 apply_flash_overlay(
     float4 gauss_rgba,
     uint flags,
-    StructuredBuffer<float4> overlay_params)
+    float flash_intensity)
 {
     if ((flags & OVERLAY_FLAG_FLASH) == 0u) {
         return gauss_rgba;
     }
-    float intensity = overlay_params[OVERLAY_PARAM_EMPHASIS_FLAGS].w;
-    if (intensity <= 0.0f) {
+    if (flash_intensity <= 0.0f) {
         return gauss_rgba;
     }
     float3 color = unpremultiplied_color(gauss_rgba);
     const float3 flash_color = float3(1.0f, 0.95f, 0.6f);
-    color = lerp(color, flash_color, intensity * 0.5f);
+    color = lerp(color, flash_color, flash_intensity * 0.5f);
     return replace_unpremultiplied_color(gauss_rgba, color);
 }
 

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/vertex_shader.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/vertex_shader.slang
@@ -198,10 +198,13 @@ struct SplatActiveState {
     uint model_transform_base;
     bool model_transform_enabled;
 };
+// crop_flags must already be loaded; callers gate on the enable bit before
+// any transform/min/max loads (and skip whole slot groups when none are active).
 [ForceInline]
 void apply_crop_box_filter(
     StructuredBuffer<float4> overlay_params,
     uint flags_idx,
+    float4 crop_flags,
     bool node_data_enabled,
     int node_idx,
     float3 mean_ws,
@@ -209,7 +212,6 @@ void apply_crop_box_filter(
     inout uint overlay_flags)
 {
     if (!active) return;
-    float4 crop_flags = overlay_params[flags_idx];
     if (!overlay_enabled(crop_flags.x)) return;
 
     int parent_node_idx = overlay_int(crop_flags.w);
@@ -233,10 +235,12 @@ void apply_crop_box_filter(
     }
 }
 
+// ellipsoid_flags must already be loaded; enable is checked before radii/transform.
 [ForceInline]
 void apply_ellipsoid_filter(
     StructuredBuffer<float4> overlay_params,
     uint flags_idx,
+    float4 ellipsoid_flags,
     bool node_data_enabled,
     int node_idx,
     float3 mean_ws,
@@ -244,7 +248,6 @@ void apply_ellipsoid_filter(
     inout uint overlay_flags)
 {
     if (!active) return;
-    float4 ellipsoid_flags = overlay_params[flags_idx];
     if (!overlay_enabled(ellipsoid_flags.x)) return;
 
     int parent_node_idx = overlay_int(ellipsoid_flags.w);
@@ -291,24 +294,45 @@ SplatActiveState compute_splat_active_state(
                          ? transform_point_rows(model_transforms, model_transform_base, xyz_ws_in)
                          : xyz_ws_in;
 
-    apply_crop_box_filter(overlay_params, OVERLAY_PARAM_CROP_FLAGS,
-                          node_data_enabled, node_idx, mean_ws,
-                          active, overlay_flags);
-    for (uint crop_i = 0u; crop_i < OVERLAY_PARAM_CROP_EXTRA_COUNT; ++crop_i) {
-        apply_crop_box_filter(overlay_params,
-                              OVERLAY_PARAM_CROP_EXTRA_BASE + crop_i * OVERLAY_PARAM_CROP_STRIDE,
-                              node_data_enabled, node_idx, mean_ws,
-                              active, overlay_flags);
+    // Host packs crop boxes densely: primary at CROP_FLAGS, then extras. If the
+    // primary enable bit is off, no crop is active — skip the whole 16-slot walk.
+    // When extras exist they are contiguous; stop at the first disabled slot.
+    {
+        float4 crop_flags = overlay_params[OVERLAY_PARAM_CROP_FLAGS];
+        if (overlay_enabled(crop_flags.x)) {
+            apply_crop_box_filter(overlay_params, OVERLAY_PARAM_CROP_FLAGS, crop_flags,
+                                  node_data_enabled, node_idx, mean_ws,
+                                  active, overlay_flags);
+            for (uint crop_i = 0u; crop_i < OVERLAY_PARAM_CROP_EXTRA_COUNT; ++crop_i) {
+                const uint flags_idx =
+                    OVERLAY_PARAM_CROP_EXTRA_BASE + crop_i * OVERLAY_PARAM_CROP_STRIDE;
+                float4 extra_flags = overlay_params[flags_idx];
+                if (!overlay_enabled(extra_flags.x))
+                    break;
+                apply_crop_box_filter(overlay_params, flags_idx, extra_flags,
+                                      node_data_enabled, node_idx, mean_ws,
+                                      active, overlay_flags);
+            }
+        }
     }
 
-    apply_ellipsoid_filter(overlay_params, OVERLAY_PARAM_ELLIPSOID_FLAGS,
-                           node_data_enabled, node_idx, mean_ws,
-                           active, overlay_flags);
-    for (uint ellipsoid_i = 0u; ellipsoid_i < OVERLAY_PARAM_ELLIPSOID_EXTRA_COUNT; ++ellipsoid_i) {
-        apply_ellipsoid_filter(overlay_params,
-                               OVERLAY_PARAM_ELLIPSOID_EXTRA_BASE + ellipsoid_i * OVERLAY_PARAM_ELLIPSOID_STRIDE,
-                               node_data_enabled, node_idx, mean_ws,
-                               active, overlay_flags);
+    {
+        float4 ellipsoid_flags = overlay_params[OVERLAY_PARAM_ELLIPSOID_FLAGS];
+        if (overlay_enabled(ellipsoid_flags.x)) {
+            apply_ellipsoid_filter(overlay_params, OVERLAY_PARAM_ELLIPSOID_FLAGS, ellipsoid_flags,
+                                   node_data_enabled, node_idx, mean_ws,
+                                   active, overlay_flags);
+            for (uint ellipsoid_i = 0u; ellipsoid_i < OVERLAY_PARAM_ELLIPSOID_EXTRA_COUNT; ++ellipsoid_i) {
+                const uint flags_idx =
+                    OVERLAY_PARAM_ELLIPSOID_EXTRA_BASE + ellipsoid_i * OVERLAY_PARAM_ELLIPSOID_STRIDE;
+                float4 extra_flags = overlay_params[flags_idx];
+                if (!overlay_enabled(extra_flags.x))
+                    break;
+                apply_ellipsoid_filter(overlay_params, flags_idx, extra_flags,
+                                       node_data_enabled, node_idx, mean_ws,
+                                       active, overlay_flags);
+            }
+        }
     }
 
     float4 view_flags = overlay_params[OVERLAY_PARAM_VIEW_FLAGS];

--- a/src/rendering/rasterizer/vulkan/src/gs_renderer.cpp
+++ b/src/rendering/rasterizer/vulkan/src/gs_renderer.cpp
@@ -1077,6 +1077,7 @@ void VulkanGSRenderer::initializeExternal(const std::map<std::string, std::strin
             create_optional(pipeline_macro_raster[i], "macro_raster");
             create_optional(pipeline_macro_raster_fp32[i], "macro_raster_fp32");
             create_optional(pipeline_macro_raster_overlays[i], "macro_raster_overlays");
+            create_optional(pipeline_macro_raster_overlays_fp32[i], "macro_raster_overlays_fp32");
             create_optional(pipeline_macro_compose[i], "macro_compose");
             create_optional(pipeline_macro_compose_overlays[i], "macro_compose_overlays");
         }
@@ -2931,9 +2932,12 @@ void VulkanGSRenderer::executeMacroDepthWaves(
                          _CEIL_DIV(_CEIL_DIV(alloc_macro_tiles, kCumsumBlock),
                                    kCumsumBlock)));
 
-    const bool use_fp32 = overlays_active || (uniforms.lod_enabled & 4u) != 0u;
+    // Spark-rad opacity (lod_enabled bit 2) still needs the fp32 blend math;
+    // overlays no longer force fp32 — pick the matching overlay/plain variant.
+    const bool use_fp32 = (uniforms.lod_enabled & 4u) != 0u;
     auto& raster_pipeline = overlays_active
-                                ? pipeline_macro_raster_overlays
+                                ? (use_fp32 ? pipeline_macro_raster_overlays_fp32
+                                            : pipeline_macro_raster_overlays)
                                 : (use_fp32 ? pipeline_macro_raster_fp32
                                             : pipeline_macro_raster);
     auto& compose_pipeline = overlays_active

--- a/src/rendering/rasterizer/vulkan/src/gs_renderer.h
+++ b/src/rendering/rasterizer/vulkan/src/gs_renderer.h
@@ -418,6 +418,7 @@ protected:
     _ComputePipelinePair pipeline_macro_raster = _ComputePipelinePair(8);
     _ComputePipelinePair pipeline_macro_raster_fp32 = _ComputePipelinePair(8);
     _ComputePipelinePair pipeline_macro_raster_overlays = _ComputePipelinePair(14);
+    _ComputePipelinePair pipeline_macro_raster_overlays_fp32 = _ComputePipelinePair(14);
     _ComputePipelinePair pipeline_macro_compose = _ComputePipelinePair(12);
     _ComputePipelinePair pipeline_macro_compose_overlays = _ComputePipelinePair(18);
     bool supports_float16_storage_ = false;

--- a/src/visualizer/rendering/viewport_request_builder.cpp
+++ b/src/visualizer/rendering/viewport_request_builder.cpp
@@ -331,7 +331,9 @@ namespace lfs::vis {
                       .flash_intensity = selection_overlay_enabled ? ctx.selection_flash_intensity : 0.0f,
                       .focused_gaussian_id = (selection_overlay_enabled && ring_selection_mode && overlay_visible)
                                                  ? ctx.cursor_preview.focused_gaussian_id
-                                                 : -1}},
+                                                 : -1},
+                 // Same FrameContext snapshot as emphasis.mask — no cross-frame lag.
+                 .has_selection = selection_overlay_enabled && ctx.scene_state.has_selection},
             .transparent_background = environmentBackgroundUsesTransparentViewerCompositing(ctx.settings),
             .depth_view = ctx.settings.depth_view,
             .depth_view_min = ctx.settings.depth_view_min,

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -786,6 +786,8 @@ namespace lfs::vis {
                 {"macro_raster", (root / "generated/macro_raster.spv").string()},
                 {"macro_raster_fp32", (root / "generated/macro_raster_fp32.spv").string()},
                 {"macro_raster_overlays", (root / "generated/macro_raster_overlays.spv").string()},
+                {"macro_raster_overlays_fp32",
+                 (root / "generated/macro_raster_overlays_fp32.spv").string()},
                 {"macro_compose", (root / "generated/macro_compose.spv").string()},
                 {"macro_compose_overlays", (root / "generated/macro_compose_overlays.spv").string()},
             };
@@ -4085,8 +4087,13 @@ namespace lfs::vis {
         // selection flicker seen with a detached upload stream.
         auto& slot = cuda_overlays_[ring_slot];
 
+        // Gate on both tensor presence and the host non-empty selection flag from
+        // the same request snapshot. A stale all-zero mask must not pin the slow
+        // overlay raster path; preview/cursor still engage via preview_enabled /
+        // cursor.enabled independently of has_selection.
         const bool selection_enabled =
             !request.overlay.cursor.saturation_preview &&
+            request.overlay.has_selection &&
             hasOverlayTensor(request.overlay.emphasis.mask, num_splats);
         const bool preview_enabled =
             !request.overlay.cursor.saturation_preview &&

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -3305,7 +3305,11 @@ namespace lfs::vis {
             state.selection_mask->numel() != render_splat_count) {
             state.selection_mask.reset();
         }
-        state.has_selection = state.selection_mask && state.selection_mask->is_valid();
+        // Authoritative non-empty selection (Scene::has_selection_ / hasSelection()).
+        // Mask pointer validity alone is not enough: a size-matched all-zero tensor
+        // must not report has_selection (see uploadOverlayBindings gate).
+        state.has_selection = scene_.hasSelection() && state.selection_mask &&
+                              state.selection_mask->is_valid();
 
         // Get cropboxes (before lock — no selection dependency)
         state.cropboxes = scene_.getRenderableCropBoxes();

--- a/tests/test_vksplat_tagged_dispatch.cpp
+++ b/tests/test_vksplat_tagged_dispatch.cpp
@@ -1004,6 +1004,7 @@ namespace {
             forge_pair(pipeline_macro_raster, 0x5610);
             forge_pair(pipeline_macro_raster_fp32, 0x5620);
             forge_pair(pipeline_macro_raster_overlays, 0x5630);
+            forge_pair(pipeline_macro_raster_overlays_fp32, 0x5638);
             forge_pair(pipeline_macro_compose, 0x5640);
             forge_pair(pipeline_macro_compose_overlays, 0x5650);
             forge_pair(pipeline_rasterize_forward, 0x5660);


### PR DESCRIPTION
Fixes #1579.

With an editing tool open, the splat raster paid a large overhead even where the overlay changed nothing on screen. Three changes:

- Overlay uniforms (cursor, rings, markers, flash, mask enables) are loaded once per thread into a small struct instead of being re-read from the params buffer inside the per-splat/per-pixel loops. Per-splat overlay flags and selection/preview mask bytes are staged into groupshared during the cooperative load. Projection skips the 16+16 crop/ellipsoid slot walk when no region is active.
- The HiGS macro raster overlay variant now runs on fp16 staging with the warp drain queue intact. Before, any active overlay forced the fp32 variant, which doubles groupshared and loses the drain optimization. The fp32 overlay variant stays for the spark-rad opacity path.
- The render request carries `has_selection` from the scene in the same frame snapshot as the mask tensor, so a stale or all-zero selection mask cannot keep the slow overlay raster active. `Scene::setSelection` with an empty index list clears mask state eagerly, matching `setSelectionMask`.

Measured on RTX 4080 (classroom scene, 3.34M splats, orbiting camera, mean GPU time of the rasterize pass per frame from the Vulkan timestamp profiler):

| Config | master | this PR |
|---|---|---|
| no selection | 0.743 ms | 0.733 ms |
| 50% of splats selected | 2.076 ms | 1.373 ms |
| selection emptied again | 0.743 ms | 0.730 ms |

Overlay-active raster cost drops 34%; overhead over the no-overlay path goes from 2.8x to 1.9x. Baseline is unchanged.

Build is clean; selection/scene/vksplat test suites pass (282 tests).
