### PR TITLE
Stop hidden left dock from driving animation frame demand

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -4648,18 +4648,11 @@ namespace lfs::vis::gui {
         const bool has_floating_panels = reg.has_panels(PanelSpace::Floating);
         const bool has_status_bar_panels = reg.has_panels(PanelSpace::StatusBar);
         const bool has_viewport_overlay_panels = reg.has_panels(PanelSpace::ViewportOverlay);
-        const bool right_panel_visible = show_main_panel_ && !ui_hidden_;
         PanelAnimationDemand panel_animation_demand;
         {
             LOG_TIMER_THRESHOLD("gui_render.panel_animation_demand", 0.01);
             panel_animation_demand =
-                reg.animationDemandForVisiblePanels({
-                    .active_main_tab = panel_layout_.getActiveTab(),
-                    .ui_visible = !ui_hidden_,
-                    .right_panel_visible = right_panel_visible,
-                    .bottom_dock_visible = panel_layout_.isBottomDockVisible(),
-                    .left_dock_visible = panel_layout_.isLeftDockVisible(),
-                });
+                reg.animationDemandForVisiblePanels(panelAnimationVisibility());
         }
         const bool panel_registry_needs_animation = panel_animation_demand.any();
         const bool right_panel_registry_needs_animation = panel_animation_demand.rightPanel();
@@ -6754,14 +6747,20 @@ namespace lfs::vis::gui {
         if (rml_right_panel_.needsAnimationFrame())
             return true;
         if (!python::is_plugin_preload_running() &&
-            PanelRegistry::instance().needsAnimationFrameForVisiblePanels({
-                .active_main_tab = panel_layout_.getActiveTab(),
-                .ui_visible = !ui_hidden_,
-                .right_panel_visible = show_main_panel_ && !ui_hidden_,
-                .bottom_dock_visible = panel_layout_.isBottomDockVisible(),
-            }))
+            PanelRegistry::instance().needsAnimationFrameForVisiblePanels(
+                panelAnimationVisibility()))
             return true;
         return false;
+    }
+
+    PanelAnimationVisibility GuiManager::panelAnimationVisibility() const {
+        return {
+            .active_main_tab = panel_layout_.getActiveTab(),
+            .ui_visible = !ui_hidden_,
+            .right_panel_visible = show_main_panel_ && !ui_hidden_,
+            .bottom_dock_visible = panel_layout_.isBottomDockVisible(),
+            .left_dock_visible = panel_layout_.isLeftDockVisible(),
+        };
     }
 
     std::optional<double> GuiManager::secondsUntilNextAnimationFrame() const {
@@ -6777,12 +6776,8 @@ namespace lfs::vis::gui {
 
         if (!python::is_plugin_preload_running()) {
             result = min_delay(result,
-                               PanelRegistry::instance().nextScheduledAnimationDelayForVisiblePanels({
-                                   .active_main_tab = panel_layout_.getActiveTab(),
-                                   .ui_visible = !ui_hidden_,
-                                   .right_panel_visible = show_main_panel_ && !ui_hidden_,
-                                   .bottom_dock_visible = panel_layout_.isBottomDockVisible(),
-                               }));
+                               PanelRegistry::instance().nextScheduledAnimationDelayForVisiblePanels(
+                                   panelAnimationVisibility()));
         }
 
         result = min_delay(result, rml_viewport_overlay_.nextScheduledUpdateDelay());

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -207,6 +207,7 @@ namespace lfs::vis {
 
             [[nodiscard]] bool isVramHudOverlayVisible() const;
             [[nodiscard]] bool isVramHudPublishDue(std::chrono::steady_clock::time_point now) const;
+            [[nodiscard]] PanelAnimationVisibility panelAnimationVisibility() const;
             [[nodiscard]] bool drainVulkanFramesForInteractiveTransition(
                 lfs::vis::WindowManager& window_manager,
                 const char* transition_name);

--- a/src/visualizer/gui/panel_layout.cpp
+++ b/src/visualizer/gui/panel_layout.cpp
@@ -664,7 +664,7 @@ namespace lfs::vis::gui {
         auto& reg = PanelRegistry::instance();
         if (!show_main_panel || ui_hidden || screen.work_size.x <= 0 || screen.work_size.y <= 0 ||
             !reg.has_panels(PanelSpace::LeftDock)) {
-            drawLeftDockResizeIndicator(draw_ctx, 1.0f, false, false);
+            drawLeftDockResizeIndicator(draw_ctx, lfs::python::get_shared_dpi_scale(), false, false);
             left_dock_hovering_edge_ = false;
             left_dock_resizing_ = false;
             left_dock_visible_ = false;
@@ -788,7 +788,7 @@ namespace lfs::vis::gui {
                                                   const PanelInputState& input,
                                                   const ScreenState& screen) {
         LOG_TIMER("gui_render.panel_layout.renderLeftDock.cached");
-        drawLeftDockResizeIndicator(draw_ctx, 1.0f, false, false);
+        drawLeftDockResizeIndicator(draw_ctx, lfs::python::get_shared_dpi_scale(), false, false);
         auto& reg = PanelRegistry::instance();
         if (!show_main_panel || ui_hidden || screen.work_size.x <= 0 || screen.work_size.y <= 0 ||
             !reg.has_panels(PanelSpace::LeftDock)) {

--- a/tests/test_panel_registry_animation_demand.cpp
+++ b/tests/test_panel_registry_animation_demand.cpp
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -17,7 +18,10 @@ namespace {
 
     class TestPanel final : public lfs::vis::gui::IPanel {
     public:
-        explicit TestPanel(bool animation) : animation_(animation) {}
+        explicit TestPanel(bool animation,
+                           std::optional<double> scheduled_delay = std::nullopt)
+            : animation_(animation),
+              scheduled_delay_(scheduled_delay) {}
 
         void draw(const lfs::vis::gui::PanelDrawContext&) override {}
 
@@ -25,8 +29,13 @@ namespace {
             return animation_;
         }
 
+        std::optional<double> nextScheduledAnimationDelay() const override {
+            return scheduled_delay_;
+        }
+
     private:
         bool animation_ = false;
+        std::optional<double> scheduled_delay_;
     };
 
     class RecordingPanel final : public lfs::vis::gui::IPanel {
@@ -91,14 +100,15 @@ namespace {
         static void registerPanel(std::string id,
                                   lfs::vis::gui::PanelSpace space,
                                   bool animation,
-                                  std::string parent_id = {}) {
+                                  std::string parent_id = {},
+                                  std::optional<double> scheduled_delay = std::nullopt) {
             lfs::vis::gui::PanelInfo info;
             info.id = std::move(id);
             info.label = info.id;
             info.space = space;
             info.parent_id = std::move(parent_id);
             info.is_native = false;
-            info.panel = std::make_shared<TestPanel>(animation);
+            info.panel = std::make_shared<TestPanel>(animation, scheduled_delay);
             ASSERT_TRUE(lfs::vis::gui::PanelRegistry::instance().register_panel(std::move(info)));
         }
 
@@ -114,6 +124,103 @@ namespace {
     };
 
 } // namespace
+
+TEST_F(PanelRegistryAnimationDemandTest, LeftDockDemandRespectsLeftDockVisibility) {
+    using namespace lfs::vis::gui;
+
+    registerPanel("test.left", PanelSpace::LeftDock, true);
+
+    const auto visible = PanelRegistry::instance().animationDemandForVisiblePanels({
+        .active_main_tab = "test.main",
+        .ui_visible = true,
+        .right_panel_visible = true,
+        .bottom_dock_visible = true,
+        .left_dock_visible = true,
+    });
+    EXPECT_TRUE(visible.left_dock);
+    EXPECT_TRUE(visible.any());
+    EXPECT_TRUE(PanelRegistry::instance().needsAnimationFrameForVisiblePanels({
+        .active_main_tab = "test.main",
+        .ui_visible = true,
+        .right_panel_visible = true,
+        .bottom_dock_visible = true,
+        .left_dock_visible = true,
+    }));
+
+    const auto left_hidden = PanelRegistry::instance().animationDemandForVisiblePanels({
+        .active_main_tab = "test.main",
+        .ui_visible = true,
+        .right_panel_visible = true,
+        .bottom_dock_visible = true,
+        .left_dock_visible = false,
+    });
+    EXPECT_FALSE(left_hidden.left_dock);
+    EXPECT_FALSE(left_hidden.any());
+    EXPECT_FALSE(PanelRegistry::instance().needsAnimationFrameForVisiblePanels({
+        .active_main_tab = "test.main",
+        .ui_visible = true,
+        .right_panel_visible = true,
+        .bottom_dock_visible = true,
+        .left_dock_visible = false,
+    }));
+
+    const auto ui_hidden = PanelRegistry::instance().animationDemandForVisiblePanels({
+        .active_main_tab = "test.main",
+        .ui_visible = false,
+        .right_panel_visible = true,
+        .bottom_dock_visible = true,
+        .left_dock_visible = true,
+    });
+    EXPECT_FALSE(ui_hidden.left_dock);
+    EXPECT_FALSE(ui_hidden.any());
+    EXPECT_FALSE(PanelRegistry::instance().needsAnimationFrameForVisiblePanels({
+        .active_main_tab = "test.main",
+        .ui_visible = false,
+        .right_panel_visible = true,
+        .bottom_dock_visible = true,
+        .left_dock_visible = true,
+    }));
+}
+
+TEST_F(PanelRegistryAnimationDemandTest, ScheduledDelaySkipsHiddenLeftDock) {
+    using namespace lfs::vis::gui;
+
+    registerPanel("test.left.scheduled", PanelSpace::LeftDock, false, {}, 0.25);
+
+    const auto visible_delay =
+        PanelRegistry::instance().nextScheduledAnimationDelayForVisiblePanels({
+            .active_main_tab = "test.main",
+            .ui_visible = true,
+            .right_panel_visible = true,
+            .bottom_dock_visible = true,
+            .left_dock_visible = true,
+        });
+    ASSERT_TRUE(visible_delay.has_value());
+    EXPECT_NEAR(*visible_delay, 0.25, 1e-9);
+
+    const auto hidden_delay =
+        PanelRegistry::instance().nextScheduledAnimationDelayForVisiblePanels({
+            .active_main_tab = "test.main",
+            .ui_visible = true,
+            .right_panel_visible = true,
+            .bottom_dock_visible = true,
+            .left_dock_visible = false,
+        });
+    EXPECT_FALSE(hidden_delay.has_value());
+}
+
+TEST_F(PanelRegistryAnimationDemandTest, DefaultLeftDockVisibleTrue) {
+    using namespace lfs::vis::gui;
+
+    // Callers must set left_dock_visible explicitly; the field defaults to true (#1597).
+    const PanelAnimationVisibility v{
+        .active_main_tab = "test.main",
+        .ui_visible = true,
+        .right_panel_visible = true,
+        .bottom_dock_visible = true,
+    };
+    EXPECT_TRUE(v.left_dock_visible);
+}
 
 TEST_F(PanelRegistryAnimationDemandTest, ViewportOverlayAnimationDoesNotMarkRightPanel) {
     using namespace lfs::vis::gui;


### PR DESCRIPTION
Fixes #1597.

## What

`GuiManager::needsAnimationFrame()` and `secondsUntilNextAnimationFrame()` built their `PanelAnimationVisibility` without setting `left_dock_visible`, which defaults to `true`. Panels docked in a hidden left dock kept reporting animation demand through both frame-pacing queries, so the GUI kept scheduling frames nobody could see. The per-frame demand path already passed the real dock state.

All three call sites now go through one private helper, `GuiManager::panelAnimationVisibility()`, that fills in every visibility field. The three sites cannot drift from each other again.

While validating this with a hidden dock I found a second waste source in the same area: two `drawLeftDockResizeIndicator` call sites in `panel_layout.cpp` passed a hardcoded `1.0f` dpi while the other sites pass the real dpi. At UI scale above 1.25 the thickness difference between the cached and full render paths (2.0 vs 2.6 px) defeats the 0.5 px change guard in `setLeftDockResizeIndicator`, so every frame re-marks the viewport overlay dirty and an idle window re-renders forever. Both sites now pass the real dpi.

## Tests

New registry tests in `test_panel_registry_animation_demand.cpp`:
- left dock animation demand is reported only while `left_dock_visible` and `ui_visible` are set,
- `nextScheduledAnimationDelayForVisiblePanels` skips hidden left dock panels,
- a regression guard documenting that `left_dock_visible` defaults to true, which is why callers must always set it.

All 16 tests in the touched GUI suites pass (`PanelRegistryAnimationDemandTest`, panel layout, status bar).

## Measurements

Repro: empty scene, a left-dock panel with a 16 ms interval update policy, left dock hidden by narrowing the window until the dock has no room (640 px at UI scale 1.3). Metric windows of 60 s, `--log-level perf` frame-loop counters, RTX 4080.

Demand leak (this issue):
- master: every rendered frame in the window reported `gui_anim=true` (61 of 61) and the loop never took an idle skip. The pacing queries claimed animation demand forever while nothing visible animated.
- fixed: `gui_anim=true` on 87 of 882 frames (transient RmlUi settle only) with 795 idle skips in the same window. The queries now report no demand for the hidden dock.

Indicator re-render loop (second fix):
- before: sustained ~59 fps GUI re-render at idle, `render_reasons sources=left_dock_resize` marked 450 times in the log, GPU around 7-8 %.
- after: 0 occurrences, GPU at idle baseline (~1 %).

The frame savings from the demand leak alone are small on this machine because the wait loop caps wakes, matching the low severity stated in the issue; the indicator loop was the larger waste and only shows up at UI scale > 1.25.