### PR TITLE
Fix transforms.json loading: per-frame intrinsics and camera/point-cloud alignment

### DIFF
--- a/src/io/formats/transforms.cpp
+++ b/src/io/formats/transforms.cpp
@@ -19,8 +19,11 @@
 #include <limits>
 #include <nlohmann/json.hpp>
 #include <numbers>
+#include <set>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 namespace lfs::io {
 
@@ -40,7 +43,7 @@ namespace lfs::io {
         constexpr size_t MAX_TRANSFORMS_FRAMES = 1'000'000;
         constexpr size_t MAX_TRANSFORMS_PATH_BYTES = 4096;
         constexpr float MAX_TRANSFORM_COMPONENT = 1.0e12f;
-        constexpr float MAX_DISTORTION_MAGNITUDE = 1.0e4f;
+        constexpr float MAX_DISTORTION_MAGNITUDE = 1.0e8f;
         constexpr float MAX_INTRINSIC_DIMENSION_MULTIPLIER = 1.0e6f;
         constexpr double MIN_AFFINE_DETERMINANT = 1.0e-8;
         constexpr float AFFINE_ROW_TOLERANCE = 1.0e-4f;
@@ -50,16 +53,21 @@ namespace lfs::io {
             std::array<float, 16> matrix{};
         };
 
-        [[nodiscard]] float finite_json_float(
-            const nlohmann::json& object,
+        [[nodiscard]] float finite_json_float_value(
+            const nlohmann::json& value,
             const std::string_view key) {
-            const auto& value = object.at(std::string(key));
             if (!value.is_number())
                 throw std::runtime_error("Transforms field '" + std::string(key) + "' must be numeric");
             const double parsed = value.get<double>();
             if (!std::isfinite(parsed) || std::abs(parsed) > std::numeric_limits<float>::max())
                 throw std::runtime_error("Transforms field '" + std::string(key) + "' must be finite float32");
             return static_cast<float>(parsed);
+        }
+
+        [[nodiscard]] float finite_json_float(
+            const nlohmann::json& object,
+            const std::string_view key) {
+            return finite_json_float_value(object.at(std::string(key)), key);
         }
 
         [[nodiscard]] int positive_image_dimension(
@@ -199,31 +207,6 @@ namespace lfs::io {
         return 0.5f * (float)resolution / tanf(0.5f * fov_rad);
     }
 
-    // Function to create a 3x3 rotation matrix around Y-axis embeded in 4x4 matrix
-    lfs::core::Tensor createYRotationMatrix(float angle_radians) {
-        lfs::core::Tensor rotMat = lfs::core::Tensor::eye(4, Device::CPU);
-        float cos_angle = std::cos(angle_radians);
-        float sin_angle = std::sin(angle_radians);
-
-        // Rotation matrix around Y-axis by angle θ:
-        // [cos(θ)   0   sin(θ) 0]
-        // [  0      1     0    0]
-        // [-sin(θ)  0   cos(θ) 0]
-        // [0        0   0      1]
-
-        rotMat[0][0] = cos_angle;  // cos(θ)
-        rotMat[0][1] = 0.0f;       // 0
-        rotMat[0][2] = sin_angle;  // sin(θ)
-        rotMat[1][0] = 0.0f;       // 0
-        rotMat[1][1] = 1.0f;       // 1
-        rotMat[1][2] = 0.0f;       // 0
-        rotMat[2][0] = -sin_angle; // -sin(θ)
-        rotMat[2][1] = 0.0f;       // 0
-        rotMat[2][2] = cos_angle;  // cos(θ)
-
-        return rotMat;
-    }
-
     std::filesystem::path GetTransformImagePath(
         const std::filesystem::path& dir_path,
         const std::string& frame_file_path) {
@@ -244,6 +227,214 @@ namespace lfs::io {
         }
         return image_path;
     }
+
+    namespace {
+        // Resolved camera intrinsics for a single frame. Datasets exported by
+        // nerfstudio/Metashape store these per-frame instead of once at the root
+        // (each image may have a different sensor, resolution and distortion).
+        struct FrameIntrinsics {
+            int width = 0;
+            int height = 0;
+            float fl_x = -1.0f;
+            float fl_y = -1.0f;
+            float cx = -1.0f;
+            float cy = -1.0f;
+            float k1 = 0.0f;
+            float k2 = 0.0f;
+            float k3 = 0.0f;
+            float p1 = 0.0f;
+            float p2 = 0.0f;
+            bool is_distorted = false;
+            lfs::core::CameraModelType camera_model = lfs::core::CameraModelType::PINHOLE;
+        };
+
+        // Mutable load-scoped warning state so per-frame resolution can warn once.
+        struct IntrinsicsWarningState {
+            bool equirectangular_warned = false;
+            std::set<std::string> unknown_camera_models;
+            std::set<std::string> unsupported_distortion_keys;
+        };
+
+        // Look up an intrinsics field, preferring the per-frame value and falling
+        // back to the global (root) object. Returns nullptr when neither defines it.
+        [[nodiscard]] const nlohmann::json* find_intrinsic(
+            const nlohmann::json& frame,
+            const nlohmann::json& global,
+            const std::string_view key) {
+            const std::string name(key);
+            if (const auto it = frame.find(name); it != frame.end())
+                return &*it;
+            if (const auto it = global.find(name); it != global.end())
+                return &*it;
+            return nullptr;
+        }
+
+        // Resolve the pixel dimensions for a frame: per-frame w/h override the
+        // global w/h, which in turn fall back to reading the image header.
+        [[nodiscard]] std::pair<int, int> resolve_frame_dimensions(
+            const nlohmann::json& frame,
+            const int global_w,
+            const int global_h,
+            const std::filesystem::path& dir_path,
+            const std::string& file_path) {
+            int w = -1, h = -1;
+            const bool has_width = frame.contains("w");
+            const bool has_height = frame.contains("h");
+            if (has_width != has_height)
+                throw std::runtime_error("Transforms frame must specify both w and h or neither");
+            if (has_width) {
+                w = positive_image_dimension(frame, "w");
+                h = positive_image_dimension(frame, "h");
+            } else if (global_w > 0 && global_h > 0) {
+                w = global_w;
+                h = global_h;
+            } else {
+                const auto image_path = GetTransformImagePath(dir_path, file_path);
+                const auto info = lfs::core::get_image_info(image_path);
+                w = std::get<0>(info);
+                h = std::get<1>(info);
+            }
+            if (w <= 0 || h <= 0 ||
+                static_cast<uint64_t>(w) * static_cast<uint64_t>(h) > std::numeric_limits<int>::max())
+                throw std::runtime_error("Transforms image dimensions exceed the signed pixel-index budget");
+            return {w, h};
+        }
+
+        // Resolve intrinsics for a frame, preferring per-frame fields and falling
+        // back to the global object. Mirrors the historical global-only parsing so
+        // datasets that only carry root-level intrinsics behave identically.
+        [[nodiscard]] FrameIntrinsics resolve_frame_intrinsics(
+            const nlohmann::json& frame,
+            const nlohmann::json& global,
+            const int w,
+            const int h,
+            IntrinsicsWarningState& warnings) {
+            FrameIntrinsics intrinsics;
+            intrinsics.width = w;
+            intrinsics.height = h;
+
+            const auto find = [&](const std::string_view key) {
+                return find_intrinsic(frame, global, key);
+            };
+
+            // Camera model (nerfstudio/COLMAP naming). Pinhole variants (including
+            // OPENCV, which is pinhole + Brown-Conrady distortion) map to PINHOLE.
+            if (const auto* model_value = find("camera_model")) {
+                if (!model_value->is_string())
+                    throw std::runtime_error("Transforms camera_model must be a string");
+                const std::string model_str = model_value->get<std::string>();
+                if (model_str == "EQUIRECTANGULAR") {
+                    intrinsics.camera_model = lfs::core::CameraModelType::EQUIRECTANGULAR;
+                } else if (model_str == "FISHEYE" || model_str == "OPENCV_FISHEYE") {
+                    intrinsics.camera_model = lfs::core::CameraModelType::FISHEYE;
+                } else if (model_str != "PINHOLE" && model_str != "SIMPLE_PINHOLE" &&
+                           model_str != "OPENCV" && model_str != "FULL_OPENCV") {
+                    if (warnings.unknown_camera_models.insert(model_str).second)
+                        LOG_WARN("Unknown camera_model '{}', defaulting to PINHOLE", model_str);
+                }
+            }
+
+            const auto* fl_x_value = find("fl_x");
+            const auto* angle_x_value = find("camera_angle_x");
+            const auto* fl_y_value = find("fl_y");
+            const auto* angle_y_value = find("camera_angle_y");
+
+            float fl_x = -1.0f, fl_y = -1.0f;
+            if (fl_x_value) {
+                fl_x = finite_json_float_value(*fl_x_value, "fl_x");
+            } else if (angle_x_value) {
+                const float angle = finite_json_float_value(*angle_x_value, "camera_angle_x");
+                if (angle <= 0.0f || angle >= std::numbers::pi_v<float>)
+                    throw std::runtime_error("Transforms camera_angle_x must be in (0, pi)");
+                fl_x = fov_rad_to_focal_length(w, angle);
+            }
+
+            if (fl_y_value) {
+                fl_y = finite_json_float_value(*fl_y_value, "fl_y");
+            } else if (angle_y_value) {
+                const float angle = finite_json_float_value(*angle_y_value, "camera_angle_y");
+                if (angle <= 0.0f || angle >= std::numbers::pi_v<float>)
+                    throw std::runtime_error("Transforms camera_angle_y must be in (0, pi)");
+                fl_y = fov_rad_to_focal_length(h, angle);
+            } else {
+                const bool no_intrinsics = !fl_x_value && !angle_x_value && !fl_y_value && !angle_y_value;
+                if (no_intrinsics) {
+                    // Auto-detect equirectangular if not explicitly set
+                    if (intrinsics.camera_model != lfs::core::CameraModelType::EQUIRECTANGULAR) {
+                        if (!warnings.equirectangular_warned) {
+                            LOG_WARN("No camera intrinsics found, assuming equirectangular");
+                            warnings.equirectangular_warned = true;
+                        }
+                        intrinsics.camera_model = lfs::core::CameraModelType::EQUIRECTANGULAR;
+                    }
+                    fl_x = fl_y = EQUIRECTANGULAR_DUMMY_FOCAL;
+                } else {
+                    if (w != h)
+                        throw std::runtime_error("Transforms JSON is missing vertical intrinsics for a non-square image");
+                    fl_y = fl_x;
+                }
+            }
+
+            if (fl_x < 0.0f && fl_y > 0.0f) {
+                if (w != h)
+                    throw std::runtime_error("Transforms JSON is missing horizontal intrinsics for a non-square image");
+                fl_x = fl_y;
+            }
+            const float max_focal = static_cast<float>(std::max(w, h)) * MAX_INTRINSIC_DIMENSION_MULTIPLIER;
+            if (!std::isfinite(fl_x) || !std::isfinite(fl_y) || fl_x <= 0.0f || fl_y <= 0.0f ||
+                fl_x > max_focal || fl_y > max_focal) {
+                throw std::runtime_error("Transforms focal lengths must be positive bounded finite values");
+            }
+            intrinsics.fl_x = fl_x;
+            intrinsics.fl_y = fl_y;
+
+            if (const auto* cx_value = find("cx")) {
+                intrinsics.cx = finite_json_float_value(*cx_value, "cx");
+            } else {
+                intrinsics.cx = 0.5f * static_cast<float>(w);
+            }
+            if (const auto* cy_value = find("cy")) {
+                intrinsics.cy = finite_json_float_value(*cy_value, "cy");
+            } else {
+                intrinsics.cy = 0.5f * static_cast<float>(h);
+            }
+            const float max_center = static_cast<float>(std::max(w, h)) * MAX_INTRINSIC_DIMENSION_MULTIPLIER;
+            if (!std::isfinite(intrinsics.cx) || !std::isfinite(intrinsics.cy) ||
+                std::abs(intrinsics.cx) > max_center || std::abs(intrinsics.cy) > max_center)
+                throw std::runtime_error("Transforms principal point must be a bounded finite value");
+
+            if (const auto* value = find("k1"))
+                intrinsics.k1 = finite_json_float_value(*value, "k1");
+            if (const auto* value = find("k2"))
+                intrinsics.k2 = finite_json_float_value(*value, "k2");
+            if (const auto* value = find("k3"))
+                intrinsics.k3 = finite_json_float_value(*value, "k3");
+            if (const auto* value = find("p1"))
+                intrinsics.p1 = finite_json_float_value(*value, "p1");
+            if (const auto* value = find("p2"))
+                intrinsics.p2 = finite_json_float_value(*value, "p2");
+            for (const float coefficient : {intrinsics.k1, intrinsics.k2, intrinsics.k3, intrinsics.p1, intrinsics.p2}) {
+                if (std::abs(coefficient) > MAX_DISTORTION_MAGNITUDE)
+                    throw std::runtime_error("Transforms distortion coefficient exceeds the supported range");
+            }
+            intrinsics.is_distorted = (intrinsics.k1 != 0.0f) || (intrinsics.k2 != 0.0f) ||
+                                      (intrinsics.k3 != 0.0f) || (intrinsics.p1 != 0.0f) || (intrinsics.p2 != 0.0f);
+
+            // Metashape/nerfstudio may emit higher-order distortion terms we do not model.
+            static constexpr std::array<const char*, 5> unsupported_distortion_keys = {
+                "k4", "k5", "k6", "b1", "b2"};
+            for (const char* key : unsupported_distortion_keys) {
+                const auto* value = find(key);
+                if (!value || !value->is_number())
+                    continue;
+                const double parsed = value->get<double>();
+                if (std::isfinite(parsed) && parsed != 0.0)
+                    warnings.unsupported_distortion_keys.insert(key);
+            }
+
+            return intrinsics;
+        }
+    } // namespace
 
     std::tuple<std::vector<CameraData>, lfs::core::Tensor, std::optional<std::tuple<std::vector<std::string>, std::vector<std::string>>>> read_transforms_cameras_and_images(
         const std::filesystem::path& transPath,
@@ -272,7 +463,7 @@ namespace lfs::io {
 
         LOG_DEBUG("Reading transforms from: {}", lfs::core::path_to_utf8(transformsFile));
         std::ifstream trans_file;
-        if (!lfs::core::open_file_for_read(transformsFile, trans_file)) {
+        if (!lfs::core::open_file_for_read(transformsFile, std::ios::in | std::ios::binary, trans_file)) {
             throw std::runtime_error("Failed to open: " + lfs::core::path_to_utf8(transformsFile));
         }
 
@@ -296,144 +487,20 @@ namespace lfs::io {
             throw std::runtime_error("Transforms JSON root must be an object");
         const auto validated_frames = validated_transform_frames(transforms, options);
         throw_if_load_cancel_requested(options, "Transforms dataset parse cancelled");
-        int w = -1, h = -1;
+
+        // Global w/h are defaults; individual frames may override. nerfstudio/Metashape
+        // often store intrinsics only per-frame with no root-level dimensions.
+        int global_w = -1, global_h = -1;
         const bool has_width = transforms.contains("w");
         const bool has_height = transforms.contains("h");
         if (has_width != has_height)
             throw std::runtime_error("Transforms JSON must specify both w and h or neither");
-        if (!has_width) {
-
-            try {
-                LOG_DEBUG("Width/height not in transforms.json, reading from first image");
-                auto first_frame_img_path = GetTransformImagePath(dir_path, validated_frames.front().file_path);
-                auto result = lfs::core::get_image_info(first_frame_img_path);
-
-                w = std::get<0>(result);
-                h = std::get<1>(result);
-
-                LOG_DEBUG("Got image dimensions: {}x{}", w, h);
-            } catch (const std::exception& e) {
-                std::string error_msg = "Error while trying to read image dimensions: " + std::string(e.what());
-                LOG_ERROR("{}", error_msg);
-                throw std::runtime_error(error_msg);
-            } catch (...) {
-                std::string error_msg = "Unknown error while trying to read image dimensions";
-                LOG_ERROR("{}", error_msg);
-                throw std::runtime_error(error_msg);
-            }
-        } else {
-            w = positive_image_dimension(transforms, "w");
-            h = positive_image_dimension(transforms, "h");
-        }
-        if (w <= 0 || h <= 0 || static_cast<uint64_t>(w) * static_cast<uint64_t>(h) > std::numeric_limits<int>::max())
-            throw std::runtime_error("Transforms image dimensions exceed the signed pixel-index budget");
-
-        float fl_x = -1, fl_y = -1;
-        auto camera_model = lfs::core::CameraModelType::PINHOLE;
-
-        // Parse explicit camera_model field (nerfstudio format)
-        if (transforms.contains("camera_model")) {
-            if (!transforms["camera_model"].is_string())
-                throw std::runtime_error("Transforms camera_model must be a string");
-            const std::string model_str = transforms["camera_model"];
-            if (model_str == "EQUIRECTANGULAR") {
-                camera_model = lfs::core::CameraModelType::EQUIRECTANGULAR;
-            } else if (model_str == "FISHEYE" || model_str == "OPENCV_FISHEYE") {
-                camera_model = lfs::core::CameraModelType::FISHEYE;
-            } else if (model_str != "PINHOLE") {
-                LOG_WARN("Unknown camera_model '{}', defaulting to PINHOLE", model_str);
-            }
-            LOG_DEBUG("Camera model: {}", model_str);
-        }
-
-        if (transforms.contains("fl_x")) {
-            fl_x = finite_json_float(transforms, "fl_x");
-        } else if (transforms.contains("camera_angle_x")) {
-            const float angle = finite_json_float(transforms, "camera_angle_x");
-            if (angle <= 0.0f || angle >= std::numbers::pi_v<float>)
-                throw std::runtime_error("Transforms camera_angle_x must be in (0, pi)");
-            fl_x = fov_rad_to_focal_length(w, angle);
-        }
-
-        if (transforms.contains("fl_y")) {
-            fl_y = finite_json_float(transforms, "fl_y");
-        } else if (transforms.contains("camera_angle_y")) {
-            const float angle = finite_json_float(transforms, "camera_angle_y");
-            if (angle <= 0.0f || angle >= std::numbers::pi_v<float>)
-                throw std::runtime_error("Transforms camera_angle_y must be in (0, pi)");
-            fl_y = fov_rad_to_focal_length(h, angle);
-        } else {
-            const bool no_intrinsics = !transforms.contains("fl_x") && !transforms.contains("camera_angle_x") &&
-                                       !transforms.contains("fl_y") && !transforms.contains("camera_angle_y");
-            if (no_intrinsics) {
-                // Auto-detect equirectangular if not explicitly set
-                if (camera_model != lfs::core::CameraModelType::EQUIRECTANGULAR) {
-                    LOG_WARN("No camera intrinsics found, assuming equirectangular");
-                    camera_model = lfs::core::CameraModelType::EQUIRECTANGULAR;
-                }
-                fl_x = fl_y = EQUIRECTANGULAR_DUMMY_FOCAL;
-            } else {
-                if (w != h)
-                    throw std::runtime_error("Transforms JSON is missing vertical intrinsics for a non-square image");
-                fl_y = fl_x;
-            }
-        }
-
-        if (fl_x < 0.0f && fl_y > 0.0f) {
-            if (w != h)
-                throw std::runtime_error("Transforms JSON is missing horizontal intrinsics for a non-square image");
-            fl_x = fl_y;
-        }
-        const float max_focal = static_cast<float>(std::max(w, h)) * MAX_INTRINSIC_DIMENSION_MULTIPLIER;
-        if (!std::isfinite(fl_x) || !std::isfinite(fl_y) || fl_x <= 0.0f || fl_y <= 0.0f ||
-            fl_x > max_focal || fl_y > max_focal) {
-            throw std::runtime_error("Transforms focal lengths must be positive bounded finite values");
-        }
-
-        float cx = -1, cy = -1;
-        if (transforms.contains("cx")) {
-            cx = finite_json_float(transforms, "cx");
-        } else {
-            cx = 0.5f * w;
-        }
-
-        if (transforms.contains("cy")) {
-            cy = finite_json_float(transforms, "cy");
-        } else {
-            cy = 0.5f * h;
-        }
-        const float max_center = static_cast<float>(std::max(w, h)) * MAX_INTRINSIC_DIMENSION_MULTIPLIER;
-        if (!std::isfinite(cx) || !std::isfinite(cy) || std::abs(cx) > max_center || std::abs(cy) > max_center)
-            throw std::runtime_error("Transforms principal point must be a bounded finite value");
-
-        float k1 = 0;
-        float k2 = 0;
-        float k3 = 0;
-        float p1 = 0;
-        float p2 = 0;
-        if (transforms.contains("k1")) {
-            k1 = finite_json_float(transforms, "k1");
-        }
-        if (transforms.contains("k2")) {
-            k2 = finite_json_float(transforms, "k2");
-        }
-        if (transforms.contains("k3")) {
-            k3 = finite_json_float(transforms, "k3");
-        }
-        if (transforms.contains("p1")) {
-            p1 = finite_json_float(transforms, "p1");
-        }
-        if (transforms.contains("p2")) {
-            p2 = finite_json_float(transforms, "p2");
-        }
-        for (const float coefficient : {k1, k2, k3, p1, p2}) {
-            if (std::abs(coefficient) > MAX_DISTORTION_MAGNITUDE)
-                throw std::runtime_error("Transforms distortion coefficient exceeds the supported range");
-        }
-        bool is_distorted = (k1 != 0.0f) || (k2 != 0.0f) || (k3 != 0.0f) || (p1 != 0.0f) || (p2 != 0.0f);
-
-        if (is_distorted) {
-            LOG_DEBUG("Blender Loader: identified distortion in data set");
+        if (has_width) {
+            global_w = positive_image_dimension(transforms, "w");
+            global_h = positive_image_dimension(transforms, "h");
+            if (global_w <= 0 || global_h <= 0 ||
+                static_cast<uint64_t>(global_w) * static_cast<uint64_t>(global_h) > std::numeric_limits<int>::max())
+                throw std::runtime_error("Transforms image dimensions exceed the signed pixel-index budget");
         }
 
         // Validate remaining scalar metadata before allocating any camera tensors.
@@ -444,6 +511,7 @@ namespace lfs::io {
             LOG_DEBUG("Found aabb_scale: {}", aabb_scale);
         }
 
+        IntrinsicsWarningState intrinsics_warnings;
         std::vector<CameraData> camerasdata;
         {
             uint64_t counter = 0;
@@ -456,6 +524,15 @@ namespace lfs::io {
                 }
                 CameraData camdata;
                 const auto& frame = validated_frames[frameInd];
+
+                // Resolve intrinsics for this frame. Per-frame fields take priority
+                // over the global defaults so datasets with mixed sensors/resolutions
+                // load correctly; global-only datasets resolve identically as before.
+                const auto& frame_json = transforms["frames"][frameInd];
+                const auto [frame_w, frame_h] =
+                    resolve_frame_dimensions(frame_json, global_w, global_h, dir_path, frame.file_path);
+                const FrameIntrinsics intrinsics =
+                    resolve_frame_intrinsics(frame_json, transforms, frame_w, frame_h, intrinsics_warnings);
 
                 // Create camera-to-world transform matrix
                 lfs::core::Tensor c2w = lfs::core::Tensor::empty({4, 4}, Device::CPU, DataType::Float32);
@@ -482,14 +559,12 @@ namespace lfs::io {
                     throw std::runtime_error(std::format("Frame {} inverse transform is non-finite", frameInd));
                 Tensor w2c = mat4_to_tensor(w2c_glm);
 
-                // fix so that the z direction will be the same (currently it is faceing downward)
-                Tensor fixMat = createYRotationMatrix(static_cast<float>(M_PI));
-                w2c = w2c.mm(fixMat);
-
-                // In the post-efd822c4 coordinate refactor, transforms datasets convert their point cloud
-                // into the repo's "data/COLMAP" world basis by flipping Y/Z. To keep cameras and points
-                // consistent for training (especially GUT/3DGRUT which assumes OpenCV-style camera coords),
-                // apply the same world-basis flip to the camera extrinsics.
+                // transforms datasets convert their point cloud into the repo's
+                // "data/COLMAP" world basis via convert_transforms_point_cloud_to_colmap_world
+                // (diag(1,-1,-1) on Y/Z). Right-multiply the same worldAxesFlip into w2c so
+                // camera extrinsics share exactly that world basis and stay aligned with
+                // PLY-initialized point clouds. An identity JSON transform_matrix then yields
+                // identity extrinsics (R=I, T=0).
                 //
                 // This is a world-basis change, so it must be right-multiplied into the world->camera matrix.
                 Tensor worldAxesFlip = lfs::core::Tensor::eye(4, Device::CPU);
@@ -509,32 +584,44 @@ namespace lfs::io {
 
                 camdata._image_name = lfs::core::path_to_utf8(camdata._image_path.filename());
 
-                camdata._width = w;
-                camdata._height = h;
+                camdata._width = intrinsics.width;
+                camdata._height = intrinsics.height;
 
                 camdata._T = T.contiguous();
                 camdata._R = R.contiguous();
 
-                if (is_distorted) {
-                    camdata._radial_distortion = Tensor::from_vector({k1, k2, k3}, {3}, Device::CPU);
-                    camdata._tangential_distortion = Tensor::from_vector({p1, p2}, {2}, Device::CPU);
+                if (intrinsics.is_distorted) {
+                    camdata._radial_distortion =
+                        Tensor::from_vector({intrinsics.k1, intrinsics.k2, intrinsics.k3}, {3}, Device::CPU);
+                    camdata._tangential_distortion =
+                        Tensor::from_vector({intrinsics.p1, intrinsics.p2}, {2}, Device::CPU);
                 } else {
                     camdata._radial_distortion = Tensor::empty({0}, Device::CPU);
                     camdata._tangential_distortion = Tensor::empty({0}, Device::CPU);
                 }
 
-                camdata._focal_x = fl_x;
-                camdata._focal_y = fl_y;
+                camdata._focal_x = intrinsics.fl_x;
+                camdata._focal_y = intrinsics.fl_y;
 
-                camdata._center_x = cx;
-                camdata._center_y = cy;
+                camdata._center_x = intrinsics.cx;
+                camdata._center_y = intrinsics.cy;
 
-                camdata._camera_model_type = camera_model;
+                camdata._camera_model_type = intrinsics.camera_model;
                 camdata._camera_ID = static_cast<uint32_t>(counter++);
 
                 camerasdata.push_back(camdata);
                 LOG_TRACE("Processed frame {}: {}", frameInd, camdata._image_name);
             }
+        }
+
+        if (!intrinsics_warnings.unsupported_distortion_keys.empty()) {
+            std::string keys;
+            for (const auto& key : intrinsics_warnings.unsupported_distortion_keys) {
+                if (!keys.empty())
+                    keys += ", ";
+                keys += key;
+            }
+            LOG_WARN("Unsupported distortion coefficients ignored: {}", keys);
         }
 
         auto center = lfs::core::Tensor::zeros({3}, Device::CPU, DataType::Float32);

--- a/tests/test_python_io.cpp
+++ b/tests/test_python_io.cpp
@@ -5,6 +5,8 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -13,10 +15,12 @@
 #include <iterator>
 #include <limits>
 #include <nlohmann/json.hpp>
+#include <numbers>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
+#include "core/camera_types.h"
 #include "core/image_io.hpp"
 #include "core/point_cloud.hpp"
 #include "core/splat_data.hpp"
@@ -86,23 +90,95 @@ protected:
         }
     }
 
-    void write_png(const fs::path& path) const {
-        static const std::vector<unsigned char> png_1x1 = {
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
-            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
-            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
-            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
-            0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
-            0x54, 0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0xF0,
-            0x1F, 0x00, 0x05, 0x00, 0x01, 0xFF, 0x89, 0x99,
-            0x3D, 0x1D, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
-            0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82};
+    void write_png(const fs::path& path, int width = 1, int height = 1) const {
+        ASSERT_GT(width, 0);
+        ASSERT_GT(height, 0);
+
+        // Minimal solid-color RGBA PNG for the given dimensions (no external deps).
+        auto crc32 = [](const unsigned char* data, size_t len) -> uint32_t {
+            uint32_t crc = 0xFFFFFFFFu;
+            for (size_t i = 0; i < len; ++i) {
+                crc ^= data[i];
+                for (int b = 0; b < 8; ++b) {
+                    const uint32_t mask = -(crc & 1u);
+                    crc = (crc >> 1) ^ (0xEDB88320u & mask);
+                }
+            }
+            return ~crc;
+        };
+        auto append_be32 = [](std::vector<unsigned char>& out, uint32_t value) {
+            out.push_back(static_cast<unsigned char>((value >> 24) & 0xFF));
+            out.push_back(static_cast<unsigned char>((value >> 16) & 0xFF));
+            out.push_back(static_cast<unsigned char>((value >> 8) & 0xFF));
+            out.push_back(static_cast<unsigned char>(value & 0xFF));
+        };
+        auto append_chunk = [&](std::vector<unsigned char>& out, const char type[4],
+                                const std::vector<unsigned char>& data) {
+            append_be32(out, static_cast<uint32_t>(data.size()));
+            const size_t type_offset = out.size();
+            out.insert(out.end(), type, type + 4);
+            out.insert(out.end(), data.begin(), data.end());
+            append_be32(out, crc32(out.data() + type_offset, 4 + data.size()));
+        };
+
+        std::vector<unsigned char> raw;
+        raw.reserve(static_cast<size_t>(height) * (1u + static_cast<size_t>(width) * 4u));
+        for (int y = 0; y < height; ++y) {
+            raw.push_back(0); // filter: None
+            for (int x = 0; x < width; ++x) {
+                raw.push_back(0);
+                raw.push_back(0);
+                raw.push_back(0);
+                raw.push_back(255);
+            }
+        }
+
+        // Stored (uncompressed) deflate blocks — valid zlib stream for any size.
+        std::vector<unsigned char> zlib_data;
+        zlib_data.push_back(0x78);
+        zlib_data.push_back(0x01);
+        size_t offset = 0;
+        const size_t raw_size = raw.size();
+        while (offset < raw_size) {
+            const size_t chunk = std::min<size_t>(65535, raw_size - offset);
+            const bool final_block = (offset + chunk) >= raw_size;
+            zlib_data.push_back(final_block ? 0x01 : 0x00);
+            zlib_data.push_back(static_cast<unsigned char>(chunk & 0xFF));
+            zlib_data.push_back(static_cast<unsigned char>((chunk >> 8) & 0xFF));
+            const uint16_t nlen = static_cast<uint16_t>(~chunk);
+            zlib_data.push_back(static_cast<unsigned char>(nlen & 0xFF));
+            zlib_data.push_back(static_cast<unsigned char>((nlen >> 8) & 0xFF));
+            zlib_data.insert(zlib_data.end(), raw.begin() + static_cast<std::ptrdiff_t>(offset),
+                             raw.begin() + static_cast<std::ptrdiff_t>(offset + chunk));
+            offset += chunk;
+        }
+        // Adler-32 of the raw scanline data
+        uint32_t s1 = 1, s2 = 0;
+        for (unsigned char byte : raw) {
+            s1 = (s1 + byte) % 65521;
+            s2 = (s2 + s1) % 65521;
+        }
+        append_be32(zlib_data, (s2 << 16) | s1);
+
+        std::vector<unsigned char> png = {
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+        std::vector<unsigned char> ihdr;
+        append_be32(ihdr, static_cast<uint32_t>(width));
+        append_be32(ihdr, static_cast<uint32_t>(height));
+        ihdr.push_back(8); // bit depth
+        ihdr.push_back(6); // RGBA
+        ihdr.push_back(0);
+        ihdr.push_back(0);
+        ihdr.push_back(0);
+        append_chunk(png, "IHDR", ihdr);
+        append_chunk(png, "IDAT", zlib_data);
+        append_chunk(png, "IEND", {});
 
         fs::create_directories(path.parent_path());
         std::ofstream out(path, std::ios::binary);
         ASSERT_TRUE(out.is_open()) << "Failed to open " << path;
-        out.write(reinterpret_cast<const char*>(png_1x1.data()),
-                  static_cast<std::streamsize>(png_1x1.size()));
+        out.write(reinterpret_cast<const char*>(png.data()),
+                  static_cast<std::streamsize>(png.size()));
         out.close();
         ASSERT_TRUE(out.good()) << "Failed to write " << path;
     }
@@ -570,6 +646,323 @@ TEST_F(PythonIOTest, RejectsMalformedTransformsCameraContractsBeforeCameraConstr
     invalid = valid;
     invalid["frames"][0]["transform_matrix"][3] = nlohmann::json::array({0.0, 0.0, 1.0, 1.0});
     expect_rejected(std::move(invalid));
+}
+
+TEST_F(PythonIOTest, LoadTransformsPerFrameIntrinsics) {
+    const fs::path dataset_dir = temp_dir / "per_frame_intrinsics";
+    write_png(dataset_dir / "frame_a.png", 64, 48);
+    write_png(dataset_dir / "frame_b.png", 128, 96);
+
+    const nlohmann::json identity_matrix = {
+        {1.0, 0.0, 0.0, 0.0},
+        {0.0, 1.0, 0.0, 0.0},
+        {0.0, 0.0, 1.0, 0.0},
+        {0.0, 0.0, 0.0, 1.0},
+    };
+    nlohmann::json transforms = {
+        {"frames", nlohmann::json::array({
+                       {
+                           {"file_path", "frame_a.png"},
+                           {"w", 64},
+                           {"h", 48},
+                           {"fl_x", 50.0},
+                           {"fl_y", 45.0},
+                           {"cx", 32.0},
+                           {"cy", 24.0},
+                           {"camera_model", "OPENCV"},
+                           {"k1", 0.01},
+                           {"k2", -0.02},
+                           {"k3", 0.003},
+                           {"p1", 0.0001},
+                           {"p2", -0.0002},
+                           {"k4", 0.001},
+                           {"b1", 0.0003},
+                           {"b2", -0.0004},
+                           {"transform_matrix", identity_matrix},
+                       },
+                       {
+                           {"file_path", "frame_b.png"},
+                           {"w", 128},
+                           {"h", 96},
+                           {"fl_x", 90.0},
+                           {"fl_y", 88.0},
+                           {"cx", 64.0},
+                           {"cy", 48.0},
+                           {"camera_model", "OPENCV"},
+                           {"k1", 0.05},
+                           {"k2", -0.04},
+                           {"k3", 0.006},
+                           {"p1", 0.0005},
+                           {"p2", -0.0006},
+                           {"k4", 0.002},
+                           {"b1", 0.0007},
+                           {"b2", -0.0008},
+                           {"transform_matrix", identity_matrix},
+                       },
+                   })},
+    };
+    write_text_file(dataset_dir / "transforms.json", transforms.dump());
+
+    auto [cameras, center, splits] = read_transforms_cameras_and_images(dataset_dir / "transforms.json", {});
+    (void)center;
+    (void)splits;
+    ASSERT_EQ(cameras.size(), 2u);
+
+    EXPECT_EQ(cameras[0]._width, 64);
+    EXPECT_EQ(cameras[0]._height, 48);
+    EXPECT_FLOAT_EQ(cameras[0]._focal_x, 50.0f);
+    EXPECT_FLOAT_EQ(cameras[0]._focal_y, 45.0f);
+    EXPECT_FLOAT_EQ(cameras[0]._center_x, 32.0f);
+    EXPECT_FLOAT_EQ(cameras[0]._center_y, 24.0f);
+    EXPECT_EQ(cameras[0]._camera_model_type, CameraModelType::PINHOLE);
+    ASSERT_EQ(cameras[0]._radial_distortion.numel(), 3u);
+    ASSERT_EQ(cameras[0]._tangential_distortion.numel(), 2u);
+    {
+        const auto* radial = cameras[0]._radial_distortion.ptr<float>();
+        const auto* tangential = cameras[0]._tangential_distortion.ptr<float>();
+        EXPECT_FLOAT_EQ(radial[0], 0.01f);
+        EXPECT_FLOAT_EQ(radial[1], -0.02f);
+        EXPECT_FLOAT_EQ(radial[2], 0.003f);
+        EXPECT_FLOAT_EQ(tangential[0], 0.0001f);
+        EXPECT_FLOAT_EQ(tangential[1], -0.0002f);
+    }
+
+    EXPECT_EQ(cameras[1]._width, 128);
+    EXPECT_EQ(cameras[1]._height, 96);
+    EXPECT_FLOAT_EQ(cameras[1]._focal_x, 90.0f);
+    EXPECT_FLOAT_EQ(cameras[1]._focal_y, 88.0f);
+    EXPECT_FLOAT_EQ(cameras[1]._center_x, 64.0f);
+    EXPECT_FLOAT_EQ(cameras[1]._center_y, 48.0f);
+    EXPECT_EQ(cameras[1]._camera_model_type, CameraModelType::PINHOLE);
+    ASSERT_EQ(cameras[1]._radial_distortion.numel(), 3u);
+    ASSERT_EQ(cameras[1]._tangential_distortion.numel(), 2u);
+    {
+        const auto* radial = cameras[1]._radial_distortion.ptr<float>();
+        const auto* tangential = cameras[1]._tangential_distortion.ptr<float>();
+        EXPECT_FLOAT_EQ(radial[0], 0.05f);
+        EXPECT_FLOAT_EQ(radial[1], -0.04f);
+        EXPECT_FLOAT_EQ(radial[2], 0.006f);
+        EXPECT_FLOAT_EQ(tangential[0], 0.0005f);
+        EXPECT_FLOAT_EQ(tangential[1], -0.0006f);
+    }
+
+    // Distinct per-frame values prove resolution is not root-only.
+    EXPECT_NE(cameras[0]._focal_x, cameras[1]._focal_x);
+    EXPECT_NE(cameras[0]._width, cameras[1]._width);
+}
+
+TEST_F(PythonIOTest, LoadTransformsRootIntrinsicsFrameOverride) {
+    const fs::path dataset_dir = temp_dir / "root_override_intrinsics";
+    write_png(dataset_dir / "frame_0.png", 100, 80);
+    write_png(dataset_dir / "frame_1.png", 100, 80);
+
+    const nlohmann::json identity_matrix = {
+        {1.0, 0.0, 0.0, 0.0},
+        {0.0, 1.0, 0.0, 0.0},
+        {0.0, 0.0, 1.0, 0.0},
+        {0.0, 0.0, 0.0, 1.0},
+    };
+    nlohmann::json transforms = {
+        {"w", 100},
+        {"h", 80},
+        {"fl_x", 70.0},
+        {"fl_y", 65.0},
+        {"cx", 50.0},
+        {"cy", 40.0},
+        {"camera_model", "PINHOLE"},
+        {"frames", nlohmann::json::array({
+                       {
+                           {"file_path", "frame_0.png"},
+                           {"transform_matrix", identity_matrix},
+                       },
+                       {
+                           {"file_path", "frame_1.png"},
+                           {"fl_x", 110.0},
+                           {"fl_y", 105.0},
+                           {"cx", 49.0},
+                           {"cy", 39.0},
+                           {"transform_matrix", identity_matrix},
+                       },
+                   })},
+    };
+    write_text_file(dataset_dir / "transforms.json", transforms.dump());
+
+    auto [cameras, center, splits] = read_transforms_cameras_and_images(dataset_dir / "transforms.json", {});
+    (void)center;
+    (void)splits;
+    ASSERT_EQ(cameras.size(), 2u);
+
+    EXPECT_FLOAT_EQ(cameras[0]._focal_x, 70.0f);
+    EXPECT_FLOAT_EQ(cameras[0]._focal_y, 65.0f);
+    EXPECT_FLOAT_EQ(cameras[0]._center_x, 50.0f);
+    EXPECT_FLOAT_EQ(cameras[0]._center_y, 40.0f);
+
+    EXPECT_FLOAT_EQ(cameras[1]._focal_x, 110.0f);
+    EXPECT_FLOAT_EQ(cameras[1]._focal_y, 105.0f);
+    EXPECT_FLOAT_EQ(cameras[1]._center_x, 49.0f);
+    EXPECT_FLOAT_EQ(cameras[1]._center_y, 39.0f);
+}
+
+TEST_F(PythonIOTest, TransformsIdentityFrameYieldsIdentityExtrinsics) {
+    const fs::path dataset_dir = temp_dir / "identity_extrinsics";
+    write_png(dataset_dir / "frame.png", 32, 32);
+
+    const nlohmann::json identity_matrix = {
+        {1.0, 0.0, 0.0, 0.0},
+        {0.0, 1.0, 0.0, 0.0},
+        {0.0, 0.0, 1.0, 0.0},
+        {0.0, 0.0, 0.0, 1.0},
+    };
+    nlohmann::json transforms = {
+        {"w", 32},
+        {"h", 32},
+        {"fl_x", 20.0},
+        {"fl_y", 20.0},
+        {"frames", nlohmann::json::array({
+                       {
+                           {"file_path", "frame.png"},
+                           {"transform_matrix", identity_matrix},
+                       },
+                   })},
+    };
+    write_text_file(dataset_dir / "transforms.json", transforms.dump());
+
+    auto [cameras, center, splits] = read_transforms_cameras_and_images(dataset_dir / "transforms.json", {});
+    (void)center;
+    (void)splits;
+    ASSERT_EQ(cameras.size(), 1u);
+
+    ASSERT_EQ(cameras[0]._R.ndim(), 2u);
+    ASSERT_EQ(cameras[0]._R.size(0), 3u);
+    ASSERT_EQ(cameras[0]._R.size(1), 3u);
+    ASSERT_EQ(cameras[0]._T.numel(), 3u);
+
+    auto R = cameras[0]._R.cpu().contiguous();
+    auto T = cameras[0]._T.cpu().contiguous();
+    auto R_acc = R.accessor<float, 2>();
+    const auto* T_ptr = T.ptr<float>();
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            EXPECT_NEAR(R_acc(i, j), (i == j) ? 1.0f : 0.0f, 1e-5f)
+                << "R(" << i << "," << j << ")";
+        }
+        EXPECT_NEAR(T_ptr[i], 0.0f, 1e-5f) << "T[" << i << "]";
+    }
+}
+
+TEST_F(PythonIOTest, TransformsTranslationFrameMatchesFlippedWorld) {
+    const fs::path dataset_dir = temp_dir / "translation_extrinsics";
+    write_png(dataset_dir / "frame.png", 32, 32);
+
+    const nlohmann::json transform_matrix = {
+        {1.0, 0.0, 0.0, 1.0},
+        {0.0, 1.0, 0.0, 2.0},
+        {0.0, 0.0, 1.0, 3.0},
+        {0.0, 0.0, 0.0, 1.0},
+    };
+    nlohmann::json transforms = {
+        {"w", 32},
+        {"h", 32},
+        {"fl_x", 20.0},
+        {"fl_y", 20.0},
+        {"frames", nlohmann::json::array({
+                       {
+                           {"file_path", "frame.png"},
+                           {"transform_matrix", transform_matrix},
+                       },
+                   })},
+    };
+    write_text_file(dataset_dir / "transforms.json", transforms.dump());
+
+    auto [cameras, center, splits] = read_transforms_cameras_and_images(dataset_dir / "transforms.json", {});
+    (void)center;
+    (void)splits;
+    ASSERT_EQ(cameras.size(), 1u);
+
+    auto R = cameras[0]._R.cpu().contiguous();
+    auto T = cameras[0]._T.cpu().contiguous();
+    auto R_acc = R.accessor<float, 2>();
+    const auto* T_ptr = T.ptr<float>();
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            EXPECT_NEAR(R_acc(i, j), (i == j) ? 1.0f : 0.0f, 1e-5f)
+                << "R(" << i << "," << j << ")";
+        }
+    }
+    EXPECT_NEAR(T_ptr[0], -1.0f, 1e-5f);
+    EXPECT_NEAR(T_ptr[1], 2.0f, 1e-5f);
+    EXPECT_NEAR(T_ptr[2], 3.0f, 1e-5f);
+}
+
+TEST_F(PythonIOTest, LoadTransformsCrlfFile) {
+    const fs::path dataset_dir = temp_dir / "crlf_transforms";
+    write_png(dataset_dir / "frame.png", 16, 16);
+
+    std::string json = R"json({
+  "w": 16,
+  "h": 16,
+  "fl_x": 10.0,
+  "fl_y": 10.0,
+  "frames": [
+    {
+      "file_path": "frame.png",
+      "transform_matrix": [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0]
+      ]
+    }
+  ]
+})json";
+    for (size_t pos = 0; (pos = json.find('\n', pos)) != std::string::npos;) {
+        json.replace(pos, 1, "\r\n");
+        pos += 2;
+    }
+    write_text_file(dataset_dir / "transforms.json", json);
+
+    auto [cameras, center, splits] = read_transforms_cameras_and_images(dataset_dir / "transforms.json", {});
+    (void)center;
+    (void)splits;
+    ASSERT_EQ(cameras.size(), 1u);
+    EXPECT_EQ(cameras[0]._width, 16);
+    EXPECT_EQ(cameras[0]._height, 16);
+    EXPECT_FLOAT_EQ(cameras[0]._focal_x, 10.0f);
+}
+
+TEST_F(PythonIOTest, TransformsCameraAngleXPerFrame) {
+    const fs::path dataset_dir = temp_dir / "camera_angle_x_frame";
+    constexpr int resolution = 100;
+    write_png(dataset_dir / "frame.png", resolution, resolution);
+
+    const nlohmann::json identity_matrix = {
+        {1.0, 0.0, 0.0, 0.0},
+        {0.0, 1.0, 0.0, 0.0},
+        {0.0, 0.0, 1.0, 0.0},
+        {0.0, 0.0, 0.0, 1.0},
+    };
+    nlohmann::json transforms = {
+        {"w", resolution},
+        {"h", resolution},
+        {"frames", nlohmann::json::array({
+                       {
+                           {"file_path", "frame.png"},
+                           {"camera_angle_x", std::numbers::pi_v<double> / 2.0},
+                           {"transform_matrix", identity_matrix},
+                       },
+                   })},
+    };
+    write_text_file(dataset_dir / "transforms.json", transforms.dump());
+
+    auto [cameras, center, splits] = read_transforms_cameras_and_images(dataset_dir / "transforms.json", {});
+    (void)center;
+    (void)splits;
+    ASSERT_EQ(cameras.size(), 1u);
+
+    const float expected = 0.5f * static_cast<float>(resolution) /
+                           std::tan(static_cast<float>(std::numbers::pi_v<float> / 4.0f));
+    EXPECT_NEAR(cameras[0]._focal_x, expected, 1e-4f);
+    EXPECT_NEAR(cameras[0]._focal_y, expected, 1e-4f);
 }
 
 // Test loading COLMAP dataset


### PR DESCRIPTION
## Problem

The transforms.json loader only read camera intrinsics from the JSON root. nerfstudio/Metashape exports store `w/h`, focal lengths, principal point, distortion and `camera_model` **per frame**, often with no root-level values at all. Such datasets were misdetected as equirectangular ("No camera intrinsics found") and could not be trained.

Independently, camera extrinsics received a 180° Y rotation (`fixMat`) that the point cloud did not: the PLY is converted into the repo world basis with `diag(1,-1,-1)` while cameras got `fixMat * worldAxesFlip = diag(-1,-1,1)`. Net effect: cameras were rotated half a turn around world Y relative to any real initialization point cloud (`ply_file_path` / `pointcloud.ply`). Invisible on synthetic Blender scenes (random init cloud), wrong on every dataset that ships a sparse cloud.

## Changes

- **Per-frame intrinsics**: `w, h, fl_x, fl_y, camera_angle_x/y, cx, cy, k1–k3, p1, p2, camera_model` are resolved per frame, with root-level values as defaults. Root-only datasets resolve identically to before. When neither the frame nor the root define dimensions, the frame's own image header is read (mixed-resolution captures).
- **Camera/point-cloud alignment**: removed the `fixMat` rotation so extrinsics share exactly the `diag(1,-1,-1)` world basis applied to the point cloud. An identity `transform_matrix` now yields identity extrinsics (pinned by tests).
- **Camera model names**: `OPENCV`, `SIMPLE_PINHOLE`, `FULL_OPENCV` map to pinhole (OPENCV is pinhole + Brown-Conrady distortion); unknown models warn once per distinct name.
- **Unsupported distortion terms** (`k4, k5, k6, b1, b2`, emitted by Metashape/nerfstudio): warned once per load and ignored instead of silently dropped.
- **Windows CRLF**: the transforms file is read in binary mode so the size-integrity check no longer trips over `\r\n` translation.
- **Distortion bound** raised 1e4 → 1e8 for exporters emitting large coefficients.

## Validation

16-bit real capture (113 frames, per-frame `OPENCV` intrinsics only, `sparse_pc.ply`, 16-bit RGB PNGs):

| | master | this PR |
|---|---|---|
| Load | misdetected as equirectangular, training aborts | 113 pinhole cameras, per-frame intrinsics |
| Camera vs. cloud | rotated 180° around Y (mean look-at-centroid error 65°) | consistent (43°, matches raw JSON+PLY geometry exactly) |
| Training (`--undistort`, 7k iters, 15 held-out views) | impossible | **PSNR 21.77 / SSIM 0.735** |

Numeric cross-check: projecting the sparse cloud through the loaded cameras, the fixed basis is algebraically identical to the raw JSON+PLY convention (net transform = identity), while master injected a spurious R_y(π) between cameras and cloud.

Tests: 6 new gtests (per-frame resolution, root-with-frame-override, identity/translation extrinsics invariants, CRLF file, per-frame `camera_angle_x`); `write_png` fixture extended to arbitrary sizes. Full `lichtfeld_tests` suite green.

Based on the investigation by @harry7557558 (master...harry7557558:LichtFeld-Studio:master); deviations: the CRLF issue is fixed via binary-mode read instead of dropping the size check, and `fixMat` is removed outright with regression tests pinning the resulting convention.