### PR TITLE
Fix mask loading regression (#1612) and CUDA stream race on GT images/masks (#1427)

### DIFF
--- a/src/core/tensor/tensor.cpp
+++ b/src/core/tensor/tensor.cpp
@@ -1760,9 +1760,12 @@ namespace lfs::core {
                     void* const destination = result.data_ptr();
                     const void* const source = data_ptr();
                     const size_t copy_bytes = bytes();
-                    LFS_CUDA_CHECK_MSG_ARGS(
-                        cudaMemcpy(destination, source, copy_bytes,
-                                   cudaMemcpyDeviceToDevice),
+                    const cudaStream_t execution_stream =
+                        prepare_inputs_for_stream({this}, result.stream());
+                    LFS_CUDA_CHECK_MSG_STREAM_ARGS(
+                        cudaMemcpyAsync(destination, source, copy_bytes,
+                                        cudaMemcpyDeviceToDevice, execution_stream),
+                        execution_stream,
                         reinterpret_cast<uintptr_t>(destination),
                         reinterpret_cast<uintptr_t>(source),
                         copy_bytes,

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -2280,18 +2280,9 @@ namespace lfs::io {
         SkipTally image_tally;
 
         RecursiveFileCache image_cache(images_path, options.cancel_requested);
-        std::optional<MaskDirCache> mask_cache;
-        std::optional<DepthDirCache> depth_cache;
-        std::optional<NormalDirCache> normal_cache;
-        if (options.load_masks) {
-            mask_cache.emplace(base_path, options.cancel_requested);
-        }
-        if (options.load_depths) {
-            depth_cache.emplace(base_path, options.cancel_requested);
-        }
-        if (options.load_normals) {
-            normal_cache.emplace(base_path, options.cancel_requested);
-        }
+        MaskDirCache mask_cache(base_path, options.cancel_requested);
+        DepthDirCache depth_cache(base_path, options.cancel_requested);
+        NormalDirCache normal_cache(base_path, options.cancel_requested);
         bool used_recursive_image_lookup = false;
         size_t depth_matched_count = 0;
         size_t normal_matched_count = 0;
@@ -2498,20 +2489,22 @@ namespace lfs::io {
             camera_positions.push_back(cam_pos[2]);
 
             std::filesystem::path mask_path;
-            if (options.load_masks && mask_cache) {
-                if (auto mask_lookup = mask_cache->lookup(img.name); mask_lookup.found()) {
-                    mask_path = std::move(mask_lookup.path);
-                } else if (mask_lookup.ambiguous()) {
+            if (auto mask_lookup = mask_cache.lookup(img.name); mask_lookup.found()) {
+                mask_path = std::move(mask_lookup.path);
+            } else if (mask_lookup.ambiguous()) {
+                if (options.load_masks) {
                     return make_ambiguous_mask_reference_error(base_path, img.name);
                 }
+                LOG_WARN("Mask for image '{}' is ambiguous; skipping sidecar because mask usage is disabled",
+                         img.name);
             }
 
             std::filesystem::path depth_path;
-            if (options.load_depths && depth_cache) {
-                if (auto depth_lookup = depth_cache->lookup(img.name); depth_lookup.found()) {
-                    depth_path = std::move(depth_lookup.path);
-                    ++depth_matched_count;
-                } else if (depth_lookup.ambiguous()) {
+            if (auto depth_lookup = depth_cache.lookup(img.name); depth_lookup.found()) {
+                depth_path = std::move(depth_lookup.path);
+                ++depth_matched_count;
+            } else if (depth_lookup.ambiguous()) {
+                if (options.load_depths) {
                     return make_error(
                         ErrorCode::INVALID_DATASET,
                         std::format("Depth map for image '{}' is ambiguous across the dataset depth folders. "
@@ -2519,14 +2512,16 @@ namespace lfs::io {
                                     img.name),
                         base_path);
                 }
+                LOG_WARN("Depth map for image '{}' is ambiguous; skipping sidecar because depth usage is disabled",
+                         img.name);
             }
 
             std::filesystem::path normal_path;
-            if (options.load_normals && normal_cache) {
-                if (auto normal_lookup = normal_cache->lookup(img.name); normal_lookup.found()) {
-                    normal_path = std::move(normal_lookup.path);
-                    ++normal_matched_count;
-                } else if (normal_lookup.ambiguous()) {
+            if (auto normal_lookup = normal_cache.lookup(img.name); normal_lookup.found()) {
+                normal_path = std::move(normal_lookup.path);
+                ++normal_matched_count;
+            } else if (normal_lookup.ambiguous()) {
+                if (options.load_normals) {
                     return make_error(
                         ErrorCode::INVALID_DATASET,
                         std::format("Normal map for image '{}' is ambiguous across the dataset normal folders. "
@@ -2534,6 +2529,8 @@ namespace lfs::io {
                                     img.name),
                         base_path);
                 }
+                LOG_WARN("Normal map for image '{}' is ambiguous; skipping sidecar because normal usage is disabled",
+                         img.name);
             }
 
             // Validate mask/depth dimensions match image dimensions
@@ -2544,7 +2541,7 @@ namespace lfs::io {
                 }
                 return *image_info;
             };
-            if (!mask_path.empty()) {
+            if (options.load_masks && !mask_path.empty()) {
                 auto [img_w, img_h, img_c] = get_image_info_cached();
                 auto [mask_w, mask_h, mask_c] = lfs::core::get_image_info(mask_path);
                 if (img_w != mask_w || img_h != mask_h) {
@@ -2555,7 +2552,7 @@ namespace lfs::io {
                                       mask_path);
                 }
             }
-            if (!depth_path.empty()) {
+            if (options.load_depths && !depth_path.empty()) {
                 auto [img_w, img_h, img_c] = get_image_info_cached();
                 auto [depth_w, depth_h, depth_c] = lfs::core::get_image_info(depth_path);
                 if (!sidecar_dimensions_match_contract(depth_w,
@@ -2571,7 +2568,7 @@ namespace lfs::io {
                                       depth_path);
                 }
             }
-            if (!normal_path.empty()) {
+            if (options.load_normals && !normal_path.empty()) {
                 auto [img_w, img_h, img_c] = get_image_info_cached();
                 auto [normal_w, normal_h, normal_c] = lfs::core::get_image_info(normal_path);
                 if (!sidecar_dimensions_match_contract(normal_w,
@@ -2623,7 +2620,7 @@ namespace lfs::io {
         Tensor scene_center = scene_center_tensor.mean({0}, false);
 
         LOG_INFO("Training with {} images", cameras.size());
-        if (depth_cache && depth_cache->has_depth_dirs()) {
+        if (depth_cache.has_depth_dirs()) {
             if (depth_matched_count == 0) {
                 LOG_WARN("Depth folder found but no depth map matched any of the {} images. "
                          "Depth files must share the image filename or its trailing frame number.",
@@ -2632,7 +2629,7 @@ namespace lfs::io {
                 LOG_INFO("Depth maps matched for {}/{} images", depth_matched_count, cameras.size());
             }
         }
-        if (normal_cache && normal_cache->has_normal_dirs()) {
+        if (normal_cache.has_normal_dirs()) {
             if (normal_matched_count == 0) {
                 LOG_WARN("Normal folder found but no normal map matched any of the {} images. "
                          "Normal files must share the image filename or its trailing frame number.",

--- a/src/io/include/io/filesystem_utils.hpp
+++ b/src/io/include/io/filesystem_utils.hpp
@@ -188,8 +188,13 @@ namespace lfs::io {
                 if (rel.empty())
                     continue;
 
+                raw_entries_.emplace(rel.generic_string(), entry.path());
+
                 const std::string rel_key = detail::normalize_lookup_key(rel);
-                exact_entries_.emplace(rel_key, entry.path());
+                if (auto [it_exact, inserted] = exact_entries_.emplace(rel_key, entry.path());
+                    !inserted && it_exact->second != entry.path()) {
+                    ambiguous_exact_.insert(rel_key);
+                }
 
                 const std::string basename_key =
                     detail::normalize_lookup_key(entry.path().filename());
@@ -244,8 +249,15 @@ namespace lfs::io {
             if (relative_or_name.empty())
                 return {};
 
+            if (auto it = raw_entries_.find(relative_or_name.generic_string());
+                it != raw_entries_.end()) {
+                return FileLookupResult{LookupStatus::Found, it->second};
+            }
+
             const std::string exact_key =
                 detail::normalize_lookup_key(relative_or_name);
+            if (ambiguous_exact_.contains(exact_key))
+                return FileLookupResult{LookupStatus::Ambiguous, {}};
             if (auto it = exact_entries_.find(exact_key);
                 it != exact_entries_.end()) {
                 return FileLookupResult{LookupStatus::Found, it->second};
@@ -272,8 +284,10 @@ namespace lfs::io {
         }
 
     private:
+        std::unordered_map<std::string, fs::path> raw_entries_;
         std::unordered_map<std::string, fs::path> exact_entries_;
         std::unordered_map<std::string, fs::path> basename_entries_;
+        std::unordered_set<std::string> ambiguous_exact_;
         std::unordered_set<std::string> ambiguous_basenames_;
         std::unordered_map<std::string, fs::path> digit_entries_;
         std::unordered_set<std::string> ambiguous_digits_;

--- a/src/io/loaders/blender_loader.cpp
+++ b/src/io/loaders/blender_loader.cpp
@@ -139,9 +139,9 @@ namespace lfs::io {
             std::vector<std::shared_ptr<lfs::core::Camera>> cameras;
             cameras.reserve(camera_infos.size());
 
-            // Get base path for optional sidecar lookup.  Do not scan unused
-            // sidecar folders: malformed auxiliary files must not block a load
-            // when their corresponding loss/feature is disabled.
+            // Sidecar paths are always associated so enabling masks/depth/normals
+            // after load works; malformed or ambiguous sidecar files only fail the
+            // load when the corresponding feature is enabled.
             std::filesystem::path base_path = transforms_file.parent_path();
             const auto has_sidecar_directory = [&base_path](const std::span<const char* const> folders) {
                 return std::ranges::any_of(folders, [&base_path](const char* folder) {
@@ -158,18 +158,9 @@ namespace lfs::io {
                 LOG_INFO("mask maps present but unused (mask usage disabled)");
             }
 
-            std::optional<MaskDirCache> mask_cache;
-            std::optional<DepthDirCache> depth_cache;
-            std::optional<NormalDirCache> normal_cache;
-            if (options.load_masks) {
-                mask_cache.emplace(base_path, options.cancel_requested);
-            }
-            if (options.load_depths) {
-                depth_cache.emplace(base_path, options.cancel_requested);
-            }
-            if (options.load_normals) {
-                normal_cache.emplace(base_path, options.cancel_requested);
-            }
+            MaskDirCache mask_cache(base_path, options.cancel_requested);
+            DepthDirCache depth_cache(base_path, options.cancel_requested);
+            NormalDirCache normal_cache(base_path, options.cancel_requested);
 
             for (size_t i = 0; i < camera_infos.size(); ++i) {
                 if ((i % 64) == 0) {
@@ -179,10 +170,10 @@ namespace lfs::io {
 
                 try {
                     std::filesystem::path mask_path;
-                    if (options.load_masks && mask_cache) {
-                        if (auto mask_lookup = mask_cache->lookup(info._image_name); mask_lookup.found()) {
-                            mask_path = std::move(mask_lookup.path);
-                        } else if (mask_lookup.ambiguous()) {
+                    if (auto mask_lookup = mask_cache.lookup(info._image_name); mask_lookup.found()) {
+                        mask_path = std::move(mask_lookup.path);
+                    } else if (mask_lookup.ambiguous()) {
+                        if (options.load_masks) {
                             return make_error(
                                 ErrorCode::INVALID_DATASET,
                                 std::format("Mask for image '{}' is ambiguous across the dataset mask folders. "
@@ -190,13 +181,15 @@ namespace lfs::io {
                                             info._image_name),
                                 base_path);
                         }
+                        LOG_WARN("Mask for image '{}' is ambiguous; skipping sidecar because mask usage is disabled",
+                                 info._image_name);
                     }
 
                     std::filesystem::path depth_path;
-                    if (options.load_depths && depth_cache) {
-                        if (auto depth_lookup = depth_cache->lookup(info._image_name); depth_lookup.found()) {
-                            depth_path = std::move(depth_lookup.path);
-                        } else if (depth_lookup.ambiguous()) {
+                    if (auto depth_lookup = depth_cache.lookup(info._image_name); depth_lookup.found()) {
+                        depth_path = std::move(depth_lookup.path);
+                    } else if (depth_lookup.ambiguous()) {
+                        if (options.load_depths) {
                             return make_error(
                                 ErrorCode::INVALID_DATASET,
                                 std::format("Depth map for image '{}' is ambiguous across the dataset depth folders. "
@@ -204,13 +197,15 @@ namespace lfs::io {
                                             info._image_name),
                                 base_path);
                         }
+                        LOG_WARN("Depth map for image '{}' is ambiguous; skipping sidecar because depth usage is disabled",
+                                 info._image_name);
                     }
 
                     std::filesystem::path normal_path;
-                    if (options.load_normals && normal_cache) {
-                        if (auto normal_lookup = normal_cache->lookup(info._image_name); normal_lookup.found()) {
-                            normal_path = std::move(normal_lookup.path);
-                        } else if (normal_lookup.ambiguous()) {
+                    if (auto normal_lookup = normal_cache.lookup(info._image_name); normal_lookup.found()) {
+                        normal_path = std::move(normal_lookup.path);
+                    } else if (normal_lookup.ambiguous()) {
+                        if (options.load_normals) {
                             return make_error(
                                 ErrorCode::INVALID_DATASET,
                                 std::format("Normal map for image '{}' is ambiguous across the dataset normal folders. "
@@ -218,6 +213,8 @@ namespace lfs::io {
                                             info._image_name),
                                 base_path);
                         }
+                        LOG_WARN("Normal map for image '{}' is ambiguous; skipping sidecar because normal usage is disabled",
+                                 info._image_name);
                     }
 
                     // Validate mask/depth dimensions match image dimensions
@@ -228,7 +225,7 @@ namespace lfs::io {
                         }
                         return *image_info;
                     };
-                    if (!mask_path.empty()) {
+                    if (options.load_masks && !mask_path.empty()) {
                         auto [img_w, img_h, img_c] = get_image_info_cached();
                         auto [mask_w, mask_h, mask_c] = lfs::core::get_image_info(mask_path);
                         if (img_w != mask_w || img_h != mask_h) {
@@ -239,7 +236,7 @@ namespace lfs::io {
                                               mask_path);
                         }
                     }
-                    if (!depth_path.empty()) {
+                    if (options.load_depths && !depth_path.empty()) {
                         auto [img_w, img_h, img_c] = get_image_info_cached();
                         auto [depth_w, depth_h, depth_c] = lfs::core::get_image_info(depth_path);
                         if (img_w != depth_w || img_h != depth_h) {
@@ -250,7 +247,7 @@ namespace lfs::io {
                                               depth_path);
                         }
                     }
-                    if (!normal_path.empty()) {
+                    if (options.load_normals && !normal_path.empty()) {
                         auto [img_w, img_h, img_c] = get_image_info_cached();
                         auto [normal_w, normal_h, normal_c] = lfs::core::get_image_info(normal_path);
                         if (img_w != normal_w || img_h != normal_h) {

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -6290,6 +6290,12 @@ namespace lfs::training {
                 if (pipelined_normal_.is_valid()) {
                     pipelined_normal_.set_stream(training_stream_);
                 }
+                if (gt_image.is_valid()) {
+                    gt_image.set_stream(training_stream_);
+                }
+                if (pipelined_mask_.is_valid()) {
+                    pipelined_mask_.set_stream(training_stream_);
+                }
 
                 if (!logged_epoch2_loader_cache && epoch2_loader_sample_count > 0 &&
                     static_cast<size_t>(iter) >= epoch2_loader_sample_count) {

--- a/tests/test_colmap_image_layout.cpp
+++ b/tests/test_colmap_image_layout.cpp
@@ -275,6 +275,51 @@ TEST_F(ColmapImageLayoutTest, ResolvesNestedImagesByBasename) {
     EXPECT_TRUE(fs::equivalent(cameras[0]->mask_path(), nested_mask));
 }
 
+TEST_F(ColmapImageLayoutTest, AssociatesMaskPathWhenMaskLoadingDisabled) {
+    const fs::path dataset_dir = temp_dir_ / "dataset";
+    const fs::path image_path = dataset_dir / "images" / "frame_0001.png";
+    const fs::path mask_path = dataset_dir / "masks" / "frame_0001.png";
+
+    write_minimal_colmap_text_dataset(dataset_dir, "frame_0001.png");
+    write_png(image_path);
+    write_png(mask_path);
+
+    auto result = lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images", {});
+    ASSERT_TRUE(result.has_value()) << result.error().format();
+
+    const auto& cameras = std::get<0>(result->value);
+
+    ASSERT_EQ(cameras.size(), 1u);
+    EXPECT_TRUE(cameras[0]->has_mask());
+    EXPECT_TRUE(fs::equivalent(cameras[0]->mask_path(), mask_path));
+}
+
+TEST_F(ColmapImageLayoutTest, LoadsDatasetWithPartialMaskCoverage) {
+    const fs::path dataset_dir = temp_dir_ / "dataset";
+    const fs::path image_1 = dataset_dir / "images" / "frame_0001.png";
+    const fs::path image_2 = dataset_dir / "images" / "frame_0002.png";
+    const fs::path mask_1 = dataset_dir / "masks" / "frame_0001.png";
+
+    write_minimal_colmap_text_dataset(
+        dataset_dir,
+        std::vector<std::string>{"frame_0001.png", "frame_0002.png"});
+    write_png(image_1);
+    write_png(image_2);
+    write_png(mask_1);
+
+    auto result =
+        lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images", {.load_masks = true});
+    ASSERT_TRUE(result.has_value()) << result.error().format();
+
+    const auto& cameras = std::get<0>(result->value);
+
+    ASSERT_EQ(cameras.size(), 2u);
+    EXPECT_TRUE(cameras[0]->has_mask());
+    EXPECT_TRUE(fs::equivalent(cameras[0]->mask_path(), mask_1));
+    EXPECT_FALSE(cameras[1]->has_mask());
+    EXPECT_TRUE(cameras[1]->mask_path().empty());
+}
+
 TEST_F(ColmapImageLayoutTest, AcceptsZeroBasedColmapIds) {
     const fs::path dataset_dir = temp_dir_ / "dataset";
 
@@ -364,11 +409,57 @@ TEST_F(ColmapImageLayoutTest, BrokenDepthIsIgnoredUnlessDepthLoadingIsEnabled) {
         lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images");
     ASSERT_TRUE(without_depth.has_value()) << without_depth.error().format();
     ASSERT_EQ(std::get<0>(without_depth->value).size(), 1u);
-    EXPECT_FALSE(std::get<0>(without_depth->value)[0]->has_depth());
+    EXPECT_TRUE(std::get<0>(without_depth->value)[0]->has_depth()); // associated, unvalidated
 
     const auto with_depth =
         lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images", {.load_depths = true});
     ASSERT_FALSE(with_depth.has_value());
+}
+
+TEST_F(ColmapImageLayoutTest, AmbiguousMaskOnlyFailsWhenMaskLoadingEnabled) {
+    const fs::path dataset_dir = temp_dir_ / "ambiguous_mask_dataset";
+    const fs::path image_path = dataset_dir / "images" / "frame_0001.png";
+    const fs::path mask_a = dataset_dir / "masks" / "Frame_0001.png";
+    const fs::path mask_b = dataset_dir / "masks" / "FRAME_0001.PNG";
+
+    write_minimal_colmap_text_dataset(dataset_dir, "frame_0001.png");
+    write_png(image_path);
+    write_png(mask_a);
+    write_png(mask_b);
+    if (fs::equivalent(mask_a, mask_b)) {
+        GTEST_SKIP() << "case-insensitive filesystem";
+    }
+
+    const auto without_masks =
+        lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images");
+    ASSERT_TRUE(without_masks.has_value()) << without_masks.error().format();
+    ASSERT_EQ(std::get<0>(without_masks->value).size(), 1u);
+    EXPECT_TRUE(std::get<0>(without_masks->value)[0]->mask_path().empty());
+
+    const auto with_masks =
+        lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images", {.load_masks = true});
+    ASSERT_FALSE(with_masks.has_value());
+}
+
+TEST_F(ColmapImageLayoutTest, CaseVariantMaskResolvedByExactPathMatch) {
+    const fs::path dataset_dir = temp_dir_ / "exact_mask_dataset";
+    const fs::path image_path = dataset_dir / "images" / "frame_0001.png";
+    const fs::path mask_a = dataset_dir / "masks" / "frame_0001.png";
+    const fs::path mask_b = dataset_dir / "masks" / "FRAME_0001.PNG";
+
+    write_minimal_colmap_text_dataset(dataset_dir, "frame_0001.png");
+    write_png(image_path);
+    write_png(mask_a);
+    write_png(mask_b);
+    if (fs::equivalent(mask_a, mask_b)) {
+        GTEST_SKIP() << "case-insensitive filesystem";
+    }
+
+    const auto with_masks =
+        lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images", {.load_masks = true});
+    ASSERT_TRUE(with_masks.has_value()) << with_masks.error().format();
+    ASSERT_EQ(std::get<0>(with_masks->value).size(), 1u);
+    EXPECT_TRUE(fs::equivalent(std::get<0>(with_masks->value)[0]->mask_path(), mask_a));
 }
 
 TEST_F(ColmapImageLayoutTest, AcceptsIntegerRatioDepthForScaledImages) {

--- a/tests/test_tensor_stream.cpp
+++ b/tests/test_tensor_stream.cpp
@@ -1,9 +1,14 @@
 /* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
+#include <iostream>
 #include <numeric>
+#include <thread>
 #include <vector>
 
 #include "core/tensor.hpp"
@@ -446,5 +451,119 @@ TEST_F(TensorStreamTest, DtypeConversionLaunchesOnCurrentResultStream) {
     EXPECT_EQ(cpu_ptr[kNumel - 1], static_cast<int>(kNumel - 1));
 
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    destroyStreamSafely(stream);
+}
+
+// Bool->UInt8 is a raw D2D copy. empty() reuse of a same-size cached block
+// calls bridgeStreams and would order the copy after the producer, masking a
+// missing convert-side wait. This test uses a unique size so the UInt8 dest
+// is a fresh cudaMallocAsync (no reuse-bridge), then races a default-stream
+// .to() against a fill still gated on a non-blocking producer stream.
+TEST_F(TensorStreamTest, BoolToUInt8OrderedAgainstGatedProducerStream) {
+    cudaStream_t stream = nullptr;
+    ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+
+    // Odd size unused elsewhere so the UInt8 dest misses the 8 MiB bucket cache.
+    constexpr size_t N = 7'340'033;
+
+    std::atomic<bool> gate_released{false};
+    const auto release_gate = [&gate_released]() {
+        gate_released.store(true, std::memory_order_release);
+    };
+    struct GateGuard {
+        std::atomic<bool>* released;
+        ~GateGuard() { released->store(true, std::memory_order_release); }
+    } gate_guard{&gate_released};
+
+    // Evict leftover same-bucket blocks so dest empty() cannot reuse-and-bridge.
+    CudaMemoryPool::instance().trim_cached_memory();
+
+    Tensor flags;
+    {
+        CUDAStreamGuard guard(stream);
+        flags = Tensor::empty({N}, Device::CUDA, DataType::Bool);
+        ASSERT_EQ(flags.stream(), stream);
+        ASSERT_EQ(flags.dtype(), DataType::Bool);
+
+        // Warm every in-place fill path this test will use; end at zeros.
+        // Stream-aware fill_ is required: the no-arg overload uses blocking
+        // H2D cudaMemcpy and would not enqueue on S.
+        flags.fill_(0.0f, stream);
+        flags.fill_(1.0f, stream);
+        flags.fill_(0.0f, stream);
+        ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+        ASSERT_EQ(cudaLaunchHostFunc(
+                      stream,
+                      [](void* userData) {
+                          auto* released = static_cast<std::atomic<bool>*>(userData);
+                          while (!released->load(std::memory_order_acquire)) {
+                          }
+                      },
+                      &gate_released),
+                  cudaSuccess);
+
+        flags.fill_(1.0f, stream);
+        // Force any deferred materialization without allocating or syncing.
+        (void)flags.data_ptr();
+    }
+
+    const uint64_t cross_before =
+        SizeBucketedPool::instance().stats().cross_stream_reuse.load();
+    const uint64_t misses_before =
+        SizeBucketedPool::instance().stats().cache_misses.load();
+
+    std::atomic<bool> to_finished{false};
+    std::thread watchdog([&] {
+        using namespace std::chrono_literals;
+        for (int i = 0; i < 500; ++i) {
+            if (to_finished.load(std::memory_order_acquire)) {
+                return;
+            }
+            std::this_thread::sleep_for(10ms);
+        }
+        // Unstick a wait on S so a failed ASSERT cannot hang the process.
+        gate_released.store(true, std::memory_order_release);
+    });
+
+    Tensor bytes = flags.to(DataType::UInt8);
+    to_finished.store(true, std::memory_order_release);
+    watchdog.join();
+
+    const cudaError_t query = cudaStreamQuery(stream);
+    const char* query_name = (query == cudaSuccess)         ? "Success"
+                             : (query == cudaErrorNotReady) ? "NotReady"
+                                                            : cudaGetErrorName(query);
+    (void)cudaGetLastError();
+
+    const uint64_t cross_after =
+        SizeBucketedPool::instance().stats().cross_stream_reuse.load();
+    const uint64_t misses_after =
+        SizeBucketedPool::instance().stats().cache_misses.load();
+
+    release_gate();
+    ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(bytes.stream()), cudaSuccess);
+
+    auto vals = bytes.to_vector_uint8();
+    ASSERT_EQ(vals.size(), N);
+    const size_t ones =
+        static_cast<size_t>(std::count(vals.begin(), vals.end(), uint8_t{1}));
+
+    std::cout << "BoolToUInt8OrderedAgainstGatedProducerStream: ones=" << ones
+              << " N=" << N << " query=" << query_name
+              << " cache_misses_delta=" << (misses_after - misses_before)
+              << " cross_stream_reuse_delta=" << (cross_after - cross_before)
+              << std::endl;
+
+    ASSERT_EQ(query, cudaErrorNotReady)
+        << "producer stream was already idle after .to(); test is not exercising "
+           "the gated window (watchdog may have released the gate)";
+    ASSERT_EQ(cross_after, cross_before)
+        << "UInt8 empty() reused a cross-stream pool block; bridgeStreams would "
+           "mask a missing convert-side wait";
+    ASSERT_EQ(ones, N)
+        << "Bool->UInt8 copy was not ordered after the gated producer fill";
+
     destroyStreamSafely(stream);
 }


### PR DESCRIPTION
Fixes #1612, fixes #1427.

**#1612 — masks not found at training start.** The loader only remembered mask file paths when mask mode was already enabled at load time. The GUI loads a dataset before you pick a mask mode, so no masks were ever attached and training refused to start with "no masks found". Now the loader always records where mask/depth/normal files are; they are only validated and used once the feature is actually turned on. Datasets where only some images have masks work fine. Broken or ambiguous sidecar files still don't block loading while unused.

**#1427 — random cudaErrorIllegalAddress crashes with masks.** The image loader writes GT images and masks on its own CUDA stream, but the training loop read them without waiting for that stream (depth/normal already waited). One mask conversion also used a plain cudaMemcpy that ignores streams. Now the GT image and mask are handed to the training stream exactly like depth/normal, and the copy is stream-ordered. A new test reproduces the race deterministically: it fails on the old code (reads all zeros) and passes with the fix.

Measured on a real masked dataset: no speed change (149.7 vs 149.4 it/s over 3000 iters), identical eval PSNR, full test suite green, 7 new regression tests.