### PR TITLE
Fix export failure after switching from training to edit mode

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -21,6 +21,7 @@ add_subdirectory(logger)
 set(TENSOR_SOURCES
         tensor/cuda_event_pool.cpp
         tensor/cuda_stream_context.cpp
+        tensor/stream_lifetime.cpp
         tensor/gpu_slab_allocator.cpp
         tensor/size_bucketed_pool.cpp
         tensor/lazy_config.cpp

--- a/src/core/include/core/splat_data.hpp
+++ b/src/core/include/core/splat_data.hpp
@@ -303,6 +303,10 @@ namespace lfs::core {
         // to CPU first and unpacks there, avoiding a full canonical SH allocation on CUDA.
         Tensor shN_canonical_cpu() const;
 
+        // Synchronize every unique non-null CUDA home stream, then re-home all valid CUDA
+        // tensor members onto the default stream. Call before a trainer destroys its streams.
+        void detach_from_streams();
+
         // Replace _shN with the swizzled form of a canonical-layout source tensor.
         // `canonical` may be [N, K, 3] or [N, K*3]; K may be 0 for SH degree 0. The
         // swizzled buffer is allocated/resized to fit N with optional `capacity`.
@@ -462,7 +466,7 @@ namespace lfs::core {
         int _max_sh_degree = 0;
         float _scene_scale = 0.f;
 
-        // Parameters
+        // Parameters — any new Tensor member must be added to detach_from_streams().
         Tensor _means;
         Tensor _sh0;
         // When sh_value quant is ON: Float16 bit-pattern u16 codes,

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -12,7 +12,6 @@
 #include "nanoflann.hpp"
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <cuda_runtime.h>
 #include <expected>
@@ -800,7 +799,7 @@ namespace lfs::core {
     }
 
     void SplatData::detach_from_streams() {
-        const std::array tensors{
+        Tensor* const tensors[] = {
             &_means,
             &_sh0,
             &_shN,
@@ -811,33 +810,19 @@ namespace lfs::core {
             &_deleted,
             &_densification_info,
         };
-
-        std::array<cudaStream_t, tensors.size()> unique_streams{};
-        std::size_t unique_stream_count = 0;
-        for (const Tensor* tensor : tensors) {
+        for (Tensor* tensor : tensors) {
             if (!tensor->is_valid() || tensor->device() != Device::CUDA) {
                 continue;
             }
-            const cudaStream_t stream = tensor->stream();
-            if (stream != nullptr &&
-                std::find(unique_streams.begin(),
-                          unique_streams.begin() + unique_stream_count,
-                          stream) == unique_streams.begin() + unique_stream_count) {
-                unique_streams[unique_stream_count++] = stream;
+            if (const cudaStream_t stream = tensor->stream()) {
+                const cudaError_t sync_status = cudaStreamSynchronize(stream);
+                if (sync_status != cudaSuccess) {
+                    LOG_WARN("CUDA stream sync in detach_from_streams failed: {}",
+                             cudaGetErrorString(sync_status));
+                    (void)cudaGetLastError();
+                }
             }
-        }
-        for (std::size_t i = 0; i < unique_stream_count; ++i) {
-            const cudaError_t sync_status = cudaStreamSynchronize(unique_streams[i]);
-            if (sync_status != cudaSuccess) {
-                LOG_WARN("CUDA stream sync before detach_from_streams failed: {}",
-                         cudaGetErrorString(sync_status));
-            }
-        }
-
-        for (Tensor* tensor : tensors) {
-            if (tensor->is_valid() && tensor->device() == Device::CUDA) {
-                tensor->set_stream(nullptr);
-            }
+            tensor->set_stream(nullptr);
         }
     }
 

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -12,6 +12,7 @@
 #include "nanoflann.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cuda_runtime.h>
 #include <expected>
@@ -796,6 +797,48 @@ namespace lfs::core {
             shN = shN.to(_sh0.device());
         }
         return _sh0.cat(shN, 1);
+    }
+
+    void SplatData::detach_from_streams() {
+        const std::array tensors{
+            &_means,
+            &_sh0,
+            &_shN,
+            &_shN_value_bounds,
+            &_scaling,
+            &_rotation,
+            &_opacity,
+            &_deleted,
+            &_densification_info,
+        };
+
+        std::array<cudaStream_t, tensors.size()> unique_streams{};
+        std::size_t unique_stream_count = 0;
+        for (const Tensor* tensor : tensors) {
+            if (!tensor->is_valid() || tensor->device() != Device::CUDA) {
+                continue;
+            }
+            const cudaStream_t stream = tensor->stream();
+            if (stream != nullptr &&
+                std::find(unique_streams.begin(),
+                          unique_streams.begin() + unique_stream_count,
+                          stream) == unique_streams.begin() + unique_stream_count) {
+                unique_streams[unique_stream_count++] = stream;
+            }
+        }
+        for (std::size_t i = 0; i < unique_stream_count; ++i) {
+            const cudaError_t sync_status = cudaStreamSynchronize(unique_streams[i]);
+            if (sync_status != cudaSuccess) {
+                LOG_WARN("CUDA stream sync before detach_from_streams failed: {}",
+                         cudaGetErrorString(sync_status));
+            }
+        }
+
+        for (Tensor* tensor : tensors) {
+            if (tensor->is_valid() && tensor->device() == Device::CUDA) {
+                tensor->set_stream(nullptr);
+            }
+        }
     }
 
     Tensor SplatData::shN_canonical() const {

--- a/src/core/tensor/cuda_event_pool.cpp
+++ b/src/core/tensor/cuda_event_pool.cpp
@@ -6,6 +6,7 @@
 #include "core/logger.hpp"
 #include "internal/stream_lifetime.hpp"
 
+#include <atomic>
 #include <format>
 #include <string_view>
 
@@ -13,6 +14,14 @@ namespace lfs::core {
 
     namespace {
         std::atomic<bool> g_force_event_acquire_failure_for_testing{false};
+
+        void warn_bridge_skipped_once(cudaStream_t from, cudaStream_t to, const char* reason) {
+            static std::atomic<bool> warned{false};
+            if (!warned.exchange(true, std::memory_order_relaxed)) {
+                LOG_WARN("skipping stream bridge: {} (from_stream={}, to_stream={})",
+                         reason, static_cast<void*>(from), static_cast<void*>(to));
+            }
+        }
 
         void synchronize_stream_bridge_source(cudaStream_t from,
                                               cudaStream_t to,
@@ -117,12 +126,7 @@ namespace lfs::core {
             if (is_stream_retired(from)) {
                 // release_stream synchronized the stream before retiring it, so
                 // there is no pending work to order against.
-                static std::atomic<bool> warned{false};
-                if (!warned.exchange(true, std::memory_order_relaxed)) {
-                    LOG_WARN("source stream was retired before destruction; skipping bridge "
-                             "(from_stream={}, to_stream={})",
-                             static_cast<void*>(from), static_cast<void*>(to));
-                }
+                warn_bridge_skipped_once(from, to, "source stream retired before destruction");
                 return;
             }
             cudaStreamCaptureStatus capture = cudaStreamCaptureStatusNone;
@@ -131,12 +135,7 @@ namespace lfs::core {
                 (void)cudaGetLastError();
                 if (capture_status == cudaErrorInvalidResourceHandle ||
                     capture_status == cudaErrorContextIsDestroyed) {
-                    static std::atomic<bool> warned{false};
-                    if (!warned.exchange(true, std::memory_order_relaxed)) {
-                        LOG_WARN("source stream handle is invalid (already destroyed?); "
-                                 "skipping bridge (from_stream={}, to_stream={})",
-                                 static_cast<void*>(from), static_cast<void*>(to));
-                    }
+                    warn_bridge_skipped_once(from, to, "source stream handle invalid (already destroyed?)");
                     return;
                 }
                 synchronize_stream_bridge_source(from, to, "capture status query failed");

--- a/src/core/tensor/cuda_event_pool.cpp
+++ b/src/core/tensor/cuda_event_pool.cpp
@@ -3,6 +3,8 @@
 
 #include "internal/cuda_event_pool.hpp"
 #include "core/cuda_error.hpp"
+#include "core/logger.hpp"
+#include "internal/stream_lifetime.hpp"
 
 #include <format>
 #include <string_view>
@@ -22,6 +24,9 @@ namespace lfs::core {
                     std::format("from_stream={}, to_stream={}; reason={}",
                                 static_cast<void*>(from), static_cast<void*>(to), reason),
                     LFS_SOURCE_SITE_CURRENT(), CudaFailureDisposition::LogOnly);
+                // Drop the latched runtime error so later LFS_CUDA_LAUNCH_CHECK
+                // (cudaPeekAtLastError) does not misattribute this failure.
+                (void)cudaGetLastError();
             }
         }
     } // namespace
@@ -109,9 +114,31 @@ namespace lfs::core {
         // destroyed user stream handle can crash in the driver. Detect
         // capture status first; any query failure means the stream is unusable.
         if (from != nullptr) {
+            if (is_stream_retired(from)) {
+                // release_stream synchronized the stream before retiring it, so
+                // there is no pending work to order against.
+                static std::atomic<bool> warned{false};
+                if (!warned.exchange(true, std::memory_order_relaxed)) {
+                    LOG_WARN("source stream was retired before destruction; skipping bridge "
+                             "(from_stream={}, to_stream={})",
+                             static_cast<void*>(from), static_cast<void*>(to));
+                }
+                return;
+            }
             cudaStreamCaptureStatus capture = cudaStreamCaptureStatusNone;
-            if (cudaStreamIsCapturing(from, &capture) != cudaSuccess) {
+            const cudaError_t capture_status = cudaStreamIsCapturing(from, &capture);
+            if (capture_status != cudaSuccess) {
                 (void)cudaGetLastError();
+                if (capture_status == cudaErrorInvalidResourceHandle ||
+                    capture_status == cudaErrorContextIsDestroyed) {
+                    static std::atomic<bool> warned{false};
+                    if (!warned.exchange(true, std::memory_order_relaxed)) {
+                        LOG_WARN("source stream handle is invalid (already destroyed?); "
+                                 "skipping bridge (from_stream={}, to_stream={})",
+                                 static_cast<void*>(from), static_cast<void*>(to));
+                    }
+                    return;
+                }
                 synchronize_stream_bridge_source(from, to, "capture status query failed");
                 return;
             }
@@ -133,6 +160,7 @@ namespace lfs::core {
                     std::format("from_stream={}, to_stream={}; fallback=stream sync",
                                 static_cast<void*>(from), static_cast<void*>(to)),
                     LFS_SOURCE_SITE_CURRENT(), CudaFailureDisposition::LogOnly);
+                (void)cudaGetLastError();
             }
             if (record_status == cudaSuccess && wait_status != cudaSuccess) {
                 ensure_cuda_success(
@@ -140,6 +168,7 @@ namespace lfs::core {
                     std::format("from_stream={}, to_stream={}; fallback=stream sync",
                                 static_cast<void*>(from), static_cast<void*>(to)),
                     LFS_SOURCE_SITE_CURRENT(), CudaFailureDisposition::LogOnly);
+                (void)cudaGetLastError();
             }
             CudaEventPool::instance().release(edge);
             if (record_status == cudaSuccess && wait_status == cudaSuccess) {

--- a/src/core/tensor/cuda_stream_context.cpp
+++ b/src/core/tensor/cuda_stream_context.cpp
@@ -19,14 +19,14 @@ namespace lfs::core {
 
     void setCurrentCUDAStream(cudaStream_t stream) {
         if (stream) {
-            note_stream_reused(stream);
+            unretire_stream(stream);
         }
         tl_current_stream = stream;
     }
 
     void waitForCUDAStream(cudaStream_t execution_stream, cudaStream_t dependency_stream) {
-        note_stream_reused(execution_stream);
-        note_stream_reused(dependency_stream);
+        unretire_stream(execution_stream);
+        unretire_stream(dependency_stream);
         if (dependency_stream == nullptr || dependency_stream == execution_stream) {
             return;
         }

--- a/src/core/tensor/cuda_stream_context.cpp
+++ b/src/core/tensor/cuda_stream_context.cpp
@@ -4,6 +4,7 @@
 #include "internal/cuda_stream_context.hpp"
 #include "core/cuda_error.hpp"
 #include "internal/cuda_event_pool.hpp"
+#include "internal/stream_lifetime.hpp"
 #include "internal/tensor_impl.hpp"
 
 #include <format>
@@ -17,10 +18,15 @@ namespace lfs::core {
     }
 
     void setCurrentCUDAStream(cudaStream_t stream) {
+        if (stream) {
+            note_stream_reused(stream);
+        }
         tl_current_stream = stream;
     }
 
     void waitForCUDAStream(cudaStream_t execution_stream, cudaStream_t dependency_stream) {
+        note_stream_reused(execution_stream);
+        note_stream_reused(dependency_stream);
         if (dependency_stream == nullptr || dependency_stream == execution_stream) {
             return;
         }

--- a/src/core/tensor/internal/memory_pool.hpp
+++ b/src/core/tensor/internal/memory_pool.hpp
@@ -13,6 +13,7 @@
 #include "diagnostics/vram_profiler.hpp"
 #include "gpu_slab_allocator.hpp"
 #include "size_bucketed_pool.hpp"
+#include "stream_lifetime.hpp"
 #include <algorithm>
 #include <cuda_runtime.h>
 #include <iomanip>
@@ -112,12 +113,14 @@ namespace lfs::core {
         }
 
         void* allocate(size_t bytes, cudaStream_t stream = nullptr) {
+            note_stream_reused(stream);
             return allocate_cuda_storage(bytes, stream);
         }
 
         void* try_allocate(size_t bytes,
                            cudaStream_t stream = nullptr,
                            cudaError_t* failure_status = nullptr) {
+            note_stream_reused(stream);
             LFS_CUDA_BREADCRUMB_STREAM("tensor.pool.allocate", stream);
             if (failure_status) {
                 *failure_status = cudaSuccess;
@@ -229,6 +232,7 @@ namespace lfs::core {
         void* try_allocate_exact_async(size_t bytes,
                                        cudaStream_t stream = nullptr,
                                        cudaError_t* failure_status = nullptr) {
+            note_stream_reused(stream);
             LFS_CUDA_BREADCRUMB_STREAM("tensor.pool.allocate_exact_async", stream);
             if (failure_status) {
                 *failure_status = cudaSuccess;
@@ -283,6 +287,7 @@ namespace lfs::core {
         // Marks `ptr` as used by `stream` beyond its home stream. The free will
         // bridge that use back into the home stream before the block is recycled.
         void record_stream(void* ptr, cudaStream_t stream) {
+            note_stream_reused(stream);
             if (!ptr)
                 return;
             bool map_miss = false;
@@ -346,11 +351,13 @@ namespace lfs::core {
             GPUSlabAllocator::instance().merge_stream_into_virgin(stream);
             SizeBucketedPool::instance().retag_stream(stream, nullptr);
             PinnedMemoryAllocator::instance().release_stream(stream);
+            note_stream_retired(stream);
         }
 
         // Moves `ptr`'s home to `stream` (declarative re-homing for tensors whose
         // future writes happen there). The old home becomes a recorded use.
         void rehome_stream(void* ptr, cudaStream_t stream) {
+            note_stream_reused(stream);
             if (!ptr)
                 return;
             bool map_miss = false;

--- a/src/core/tensor/internal/memory_pool.hpp
+++ b/src/core/tensor/internal/memory_pool.hpp
@@ -113,14 +113,14 @@ namespace lfs::core {
         }
 
         void* allocate(size_t bytes, cudaStream_t stream = nullptr) {
-            note_stream_reused(stream);
+            unretire_stream(stream);
             return allocate_cuda_storage(bytes, stream);
         }
 
         void* try_allocate(size_t bytes,
                            cudaStream_t stream = nullptr,
                            cudaError_t* failure_status = nullptr) {
-            note_stream_reused(stream);
+            unretire_stream(stream);
             LFS_CUDA_BREADCRUMB_STREAM("tensor.pool.allocate", stream);
             if (failure_status) {
                 *failure_status = cudaSuccess;
@@ -232,7 +232,7 @@ namespace lfs::core {
         void* try_allocate_exact_async(size_t bytes,
                                        cudaStream_t stream = nullptr,
                                        cudaError_t* failure_status = nullptr) {
-            note_stream_reused(stream);
+            unretire_stream(stream);
             LFS_CUDA_BREADCRUMB_STREAM("tensor.pool.allocate_exact_async", stream);
             if (failure_status) {
                 *failure_status = cudaSuccess;
@@ -287,7 +287,7 @@ namespace lfs::core {
         // Marks `ptr` as used by `stream` beyond its home stream. The free will
         // bridge that use back into the home stream before the block is recycled.
         void record_stream(void* ptr, cudaStream_t stream) {
-            note_stream_reused(stream);
+            unretire_stream(stream);
             if (!ptr)
                 return;
             bool map_miss = false;
@@ -351,13 +351,16 @@ namespace lfs::core {
             GPUSlabAllocator::instance().merge_stream_into_virgin(stream);
             SizeBucketedPool::instance().retag_stream(stream, nullptr);
             PinnedMemoryAllocator::instance().release_stream(stream);
-            note_stream_retired(stream);
+            // The teardown calls above log-and-continue on CUDA errors; drop any
+            // latched error so LFS_CUDA_LAUNCH_CHECK does not blame a later launch.
+            (void)cudaGetLastError();
+            retire_stream(stream);
         }
 
         // Moves `ptr`'s home to `stream` (declarative re-homing for tensors whose
         // future writes happen there). The old home becomes a recorded use.
         void rehome_stream(void* ptr, cudaStream_t stream) {
-            note_stream_reused(stream);
+            unretire_stream(stream);
             if (!ptr)
                 return;
             bool map_miss = false;

--- a/src/core/tensor/internal/stream_lifetime.hpp
+++ b/src/core/tensor/internal/stream_lifetime.hpp
@@ -9,15 +9,14 @@
 
 namespace lfs::core {
 
-    // Records that `stream` is about to be destroyed. Handles later seen in
-    // bridgeStreams are skipped instead of being passed to the driver
-    // (a destroyed handle segfaults libcuda on Linux).
-    LFS_CORE_API void note_stream_retired(cudaStream_t stream) noexcept;
+    // Record `stream` as retired ahead of destruction. bridgeStreams skips
+    // retired handles instead of probing the driver (a destroyed handle
+    // segfaults libcuda on Linux).
+    LFS_CORE_API void retire_stream(cudaStream_t stream) noexcept;
 
-    // Removes `stream` from the retired set. Called when a handle value
-    // re-enters live circulation (the driver reuses heap pointers, so a new
-    // cudaStreamCreate can return a previously retired value).
-    LFS_CORE_API void note_stream_reused(cudaStream_t stream) noexcept;
+    // Remove `stream` from the retired set. Called wherever a caller-live
+    // handle enters the API, because the driver reuses pointer values.
+    LFS_CORE_API void unretire_stream(cudaStream_t stream) noexcept;
 
     LFS_CORE_API bool is_stream_retired(cudaStream_t stream) noexcept;
 

--- a/src/core/tensor/internal/stream_lifetime.hpp
+++ b/src/core/tensor/internal/stream_lifetime.hpp
@@ -1,0 +1,24 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include "core/export.hpp"
+
+#include <cuda_runtime.h>
+
+namespace lfs::core {
+
+    // Records that `stream` is about to be destroyed. Handles later seen in
+    // bridgeStreams are skipped instead of being passed to the driver
+    // (a destroyed handle segfaults libcuda on Linux).
+    LFS_CORE_API void note_stream_retired(cudaStream_t stream) noexcept;
+
+    // Removes `stream` from the retired set. Called when a handle value
+    // re-enters live circulation (the driver reuses heap pointers, so a new
+    // cudaStreamCreate can return a previously retired value).
+    LFS_CORE_API void note_stream_reused(cudaStream_t stream) noexcept;
+
+    LFS_CORE_API bool is_stream_retired(cudaStream_t stream) noexcept;
+
+} // namespace lfs::core

--- a/src/core/tensor/pinned_memory_allocator.cpp
+++ b/src/core/tensor/pinned_memory_allocator.cpp
@@ -438,7 +438,7 @@ namespace lfs::core {
     }
 
     void PinnedMemoryAllocator::deallocate(void* ptr, const cudaStream_t stream) {
-        note_stream_reused(stream);
+        unretire_stream(stream);
         if (!ptr) {
             return;
         }
@@ -524,7 +524,7 @@ namespace lfs::core {
     }
 
     void PinnedMemoryAllocator::record_stream(void* ptr, const cudaStream_t stream) {
-        note_stream_reused(stream);
+        unretire_stream(stream);
         if (!ptr) {
             return;
         }

--- a/src/core/tensor/pinned_memory_allocator.cpp
+++ b/src/core/tensor/pinned_memory_allocator.cpp
@@ -8,6 +8,7 @@
 #include "core/logger.hpp"
 #include "diagnostics/vram_profiler.hpp"
 #include "internal/cuda_event_pool.hpp"
+#include "internal/stream_lifetime.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -437,6 +438,7 @@ namespace lfs::core {
     }
 
     void PinnedMemoryAllocator::deallocate(void* ptr, const cudaStream_t stream) {
+        note_stream_reused(stream);
         if (!ptr) {
             return;
         }
@@ -522,6 +524,7 @@ namespace lfs::core {
     }
 
     void PinnedMemoryAllocator::record_stream(void* ptr, const cudaStream_t stream) {
+        note_stream_reused(stream);
         if (!ptr) {
             return;
         }

--- a/src/core/tensor/stream_lifetime.cpp
+++ b/src/core/tensor/stream_lifetime.cpp
@@ -6,14 +6,13 @@
 #include <algorithm>
 #include <atomic>
 #include <mutex>
-#include <shared_mutex>
 #include <vector>
 
 namespace lfs::core {
     namespace {
 
         struct RetiredStreamRegistry {
-            std::shared_mutex mutex;
+            std::mutex mutex;
             std::vector<cudaStream_t> streams;
             std::atomic<size_t> size{0};
         };
@@ -25,26 +24,22 @@ namespace lfs::core {
             return *instance;
         }
 
-        bool contains_locked(const std::vector<cudaStream_t>& streams, cudaStream_t stream) {
-            return std::find(streams.begin(), streams.end(), stream) != streams.end();
-        }
-
     } // namespace
 
-    void note_stream_retired(cudaStream_t stream) noexcept {
+    void retire_stream(cudaStream_t stream) noexcept {
         if (!stream) {
             return;
         }
         auto& reg = registry();
-        std::unique_lock lock(reg.mutex);
-        if (contains_locked(reg.streams, stream)) {
+        std::lock_guard lock(reg.mutex);
+        if (std::find(reg.streams.begin(), reg.streams.end(), stream) != reg.streams.end()) {
             return;
         }
         reg.streams.push_back(stream);
         reg.size.store(reg.streams.size(), std::memory_order_release);
     }
 
-    void note_stream_reused(cudaStream_t stream) noexcept {
+    void unretire_stream(cudaStream_t stream) noexcept {
         if (!stream) {
             return;
         }
@@ -52,13 +47,7 @@ namespace lfs::core {
         if (reg.size.load(std::memory_order_acquire) == 0) {
             return;
         }
-        {
-            std::shared_lock lock(reg.mutex);
-            if (!contains_locked(reg.streams, stream)) {
-                return;
-            }
-        }
-        std::unique_lock lock(reg.mutex);
+        std::lock_guard lock(reg.mutex);
         auto it = std::find(reg.streams.begin(), reg.streams.end(), stream);
         if (it == reg.streams.end()) {
             return;
@@ -75,8 +64,8 @@ namespace lfs::core {
         if (reg.size.load(std::memory_order_acquire) == 0) {
             return false;
         }
-        std::shared_lock lock(reg.mutex);
-        return contains_locked(reg.streams, stream);
+        std::lock_guard lock(reg.mutex);
+        return std::find(reg.streams.begin(), reg.streams.end(), stream) != reg.streams.end();
     }
 
 } // namespace lfs::core

--- a/src/core/tensor/stream_lifetime.cpp
+++ b/src/core/tensor/stream_lifetime.cpp
@@ -1,0 +1,82 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "internal/stream_lifetime.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <mutex>
+#include <shared_mutex>
+#include <vector>
+
+namespace lfs::core {
+    namespace {
+
+        struct RetiredStreamRegistry {
+            std::shared_mutex mutex;
+            std::vector<cudaStream_t> streams;
+            std::atomic<size_t> size{0};
+        };
+
+        RetiredStreamRegistry& registry() {
+            // Leak-on-exit: never destroyed, so CUDA teardown cannot race a
+            // static destructor (same rationale as CudaEventPool::instance).
+            static auto* instance = new RetiredStreamRegistry();
+            return *instance;
+        }
+
+        bool contains_locked(const std::vector<cudaStream_t>& streams, cudaStream_t stream) {
+            return std::find(streams.begin(), streams.end(), stream) != streams.end();
+        }
+
+    } // namespace
+
+    void note_stream_retired(cudaStream_t stream) noexcept {
+        if (!stream) {
+            return;
+        }
+        auto& reg = registry();
+        std::unique_lock lock(reg.mutex);
+        if (contains_locked(reg.streams, stream)) {
+            return;
+        }
+        reg.streams.push_back(stream);
+        reg.size.store(reg.streams.size(), std::memory_order_release);
+    }
+
+    void note_stream_reused(cudaStream_t stream) noexcept {
+        if (!stream) {
+            return;
+        }
+        auto& reg = registry();
+        if (reg.size.load(std::memory_order_acquire) == 0) {
+            return;
+        }
+        {
+            std::shared_lock lock(reg.mutex);
+            if (!contains_locked(reg.streams, stream)) {
+                return;
+            }
+        }
+        std::unique_lock lock(reg.mutex);
+        auto it = std::find(reg.streams.begin(), reg.streams.end(), stream);
+        if (it == reg.streams.end()) {
+            return;
+        }
+        reg.streams.erase(it);
+        reg.size.store(reg.streams.size(), std::memory_order_release);
+    }
+
+    bool is_stream_retired(cudaStream_t stream) noexcept {
+        if (!stream) {
+            return false;
+        }
+        auto& reg = registry();
+        if (reg.size.load(std::memory_order_acquire) == 0) {
+            return false;
+        }
+        std::shared_lock lock(reg.mutex);
+        return contains_locked(reg.streams, stream);
+    }
+
+} // namespace lfs::core

--- a/src/core/tensor/tensor.cpp
+++ b/src/core/tensor/tensor.cpp
@@ -13,6 +13,7 @@
 #include "internal/cuda_stream_context.hpp"
 #include "internal/lazy_executor.hpp"
 #include "internal/memory_pool.hpp"
+#include "internal/stream_lifetime.hpp"
 #include "internal/tensor_broadcast.hpp"
 #include "internal/tensor_dtype_dispatch.hpp"
 #include "internal/tensor_impl.hpp"
@@ -637,6 +638,9 @@ namespace lfs::core {
         LFS_ASSERT_MSG(data_ != nullptr || shape_.elements() == 0,
                        "Tensor constructor received null storage for a non-empty tensor");
 
+        if (home_stream != nullptr && device_ == Device::CUDA) {
+            note_stream_reused(home_stream);
+        }
         state_->stream = home_stream;
         init_storage_meta();
         compute_alignment();
@@ -857,6 +861,9 @@ namespace lfs::core {
     }
 
     void Tensor::set_stream(cudaStream_t stream) {
+        if (stream) {
+            note_stream_reused(stream);
+        }
         LFS_ASSERT_MSG(is_valid(),
                        "set_stream requires a valid tensor");
         ensure_state();
@@ -884,6 +891,9 @@ namespace lfs::core {
     }
 
     void Tensor::record_stream(cudaStream_t stream) const {
+        if (stream) {
+            note_stream_reused(stream);
+        }
         LFS_ASSERT_MSG(is_valid(),
                        "record_stream requires a valid tensor");
         if (!data_owner_) {

--- a/src/core/tensor/tensor.cpp
+++ b/src/core/tensor/tensor.cpp
@@ -639,7 +639,7 @@ namespace lfs::core {
                        "Tensor constructor received null storage for a non-empty tensor");
 
         if (home_stream != nullptr && device_ == Device::CUDA) {
-            note_stream_reused(home_stream);
+            unretire_stream(home_stream);
         }
         state_->stream = home_stream;
         init_storage_meta();
@@ -862,7 +862,7 @@ namespace lfs::core {
 
     void Tensor::set_stream(cudaStream_t stream) {
         if (stream) {
-            note_stream_reused(stream);
+            unretire_stream(stream);
         }
         LFS_ASSERT_MSG(is_valid(),
                        "set_stream requires a valid tensor");
@@ -892,7 +892,7 @@ namespace lfs::core {
 
     void Tensor::record_stream(cudaStream_t stream) const {
         if (stream) {
-            note_stream_reused(stream);
+            unretire_stream(stream);
         }
         LFS_ASSERT_MSG(is_valid(),
                        "record_stream requires a valid tensor");

--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -4185,6 +4185,7 @@ namespace lfs::python {
                               node_name,
                               lfs::core::path_to_utf8(path),
                               result.error().message);
+                    lfs::core::events::state::ExportFailed{.error = result.error().message}.emit();
                 } else {
                     LOG_INFO("Saved '{}' to {}", node_name, lfs::core::path_to_utf8(path));
                 }

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -41,7 +41,6 @@
 #include "window/vulkan_context.hpp"
 #include "window/window_manager.hpp"
 #include <algorithm>
-#include <array>
 #include <cctype>
 #include <cuda_runtime.h>
 #include <format>
@@ -188,47 +187,6 @@ namespace lfs::vis {
             return result;
         }
 
-        void detachSplatDataFromTrainerStreams(lfs::core::SplatData& model) {
-            const std::array tensors{
-                &model.means_raw(),
-                &model.sh0_raw(),
-                &model.shN_raw(),
-                &model.scaling_raw(),
-                &model.rotation_raw(),
-                &model.opacity_raw(),
-                &model.deleted(),
-                &model._densification_info,
-            };
-
-            std::array<cudaStream_t, tensors.size()> unique_streams{};
-            std::size_t unique_stream_count = 0;
-            for (const lfs::core::Tensor* tensor : tensors) {
-                if (!tensor->is_valid() || tensor->device() != lfs::core::Device::CUDA) {
-                    continue;
-                }
-                const cudaStream_t stream = tensor->stream();
-                if (stream != nullptr &&
-                    std::find(unique_streams.begin(),
-                              unique_streams.begin() + unique_stream_count,
-                              stream) == unique_streams.begin() + unique_stream_count) {
-                    unique_streams[unique_stream_count++] = stream;
-                }
-            }
-            for (std::size_t i = 0; i < unique_stream_count; ++i) {
-                const cudaError_t sync_status = cudaStreamSynchronize(unique_streams[i]);
-                if (sync_status != cudaSuccess) {
-                    LOG_WARN("CUDA stream sync before edit-mode trainer clear failed: {}",
-                             cudaGetErrorString(sync_status));
-                }
-            }
-
-            for (lfs::core::Tensor* tensor : tensors) {
-                if (tensor->is_valid() && tensor->device() == lfs::core::Device::CUDA) {
-                    tensor->set_stream(nullptr);
-                }
-            }
-        }
-
         [[nodiscard]] bool prepareSplatDataForEditMode(lfs::core::SplatData& model) {
             try {
                 if (model.has_deleted_mask()) {
@@ -241,7 +199,7 @@ namespace lfs::vis {
                     model.refresh_deleted_count();
                 }
                 model._densification_info = lfs::core::Tensor{};
-                detachSplatDataFromTrainerStreams(model);
+                model.detach_from_streams();
             } catch (const std::exception& e) {
                 LOG_ERROR("Failed to prepare splat data for edit mode: {}", e.what());
                 return false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ set(TEST_FILES
     test_steady_alloc_invariant.cpp
     test_allocator_hygiene.cpp
     test_pinned_stream_teardown.cpp
+    test_stale_stream_teardown.cpp
     test_fastgs_sort_buffers.cpp
     test_warp_cull_blend.cpp
     test_warp_cull_bwd.cpp

--- a/tests/test_stale_stream_teardown.cpp
+++ b/tests/test_stale_stream_teardown.cpp
@@ -145,12 +145,12 @@ TEST_F(StaleStreamTeardownTest, DetachFromStreamsCoversBoundsThenCanonicalSuccee
 
 TEST_F(StaleStreamTeardownTest, RetiredStreamRegistryReuseCycle) {
     const auto fake = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(0x1));
-    note_stream_retired(fake);
+    retire_stream(fake);
     EXPECT_TRUE(is_stream_retired(fake));
-    note_stream_reused(fake);
+    unretire_stream(fake);
     EXPECT_FALSE(is_stream_retired(fake));
 
-    note_stream_retired(nullptr);
+    retire_stream(nullptr);
     EXPECT_FALSE(is_stream_retired(nullptr));
     EXPECT_FALSE(is_stream_retired(fake));
 
@@ -170,31 +170,14 @@ TEST_F(StaleStreamTeardownTest, RetiredStreamRegistryReuseCycle) {
     ASSERT_EQ(cudaStreamDestroy(stream_a), cudaSuccess);
     EXPECT_TRUE(is_stream_retired(stream_a));
 
-    bool reused_handle = false;
-    for (int attempt = 0; attempt < 64; ++attempt) {
-        cudaStream_t stream_b = nullptr;
-        ASSERT_EQ(cudaStreamCreate(&stream_b), cudaSuccess);
-        if (stream_b == stream_a) {
-            reused_handle = true;
-            tensor.set_stream(stream_b);
-            EXPECT_FALSE(is_stream_retired(stream_b));
-            CudaMemoryPool::instance().release_stream(stream_b);
-            ASSERT_EQ(cudaStreamDestroy(stream_b), cudaSuccess);
-            break;
-        }
-        ASSERT_EQ(cudaStreamDestroy(stream_b), cudaSuccess);
-    }
-
-    if (!reused_handle) {
-        cudaStream_t stream_b = nullptr;
-        ASSERT_EQ(cudaStreamCreate(&stream_b), cudaSuccess);
-        note_stream_retired(stream_b);
-        EXPECT_TRUE(is_stream_retired(stream_b));
-        tensor.set_stream(stream_b);
-        EXPECT_FALSE(is_stream_retired(stream_b));
-        CudaMemoryPool::instance().release_stream(stream_b);
-        ASSERT_EQ(cudaStreamDestroy(stream_b), cudaSuccess);
-    }
+    cudaStream_t stream_b = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&stream_b), cudaSuccess);
+    retire_stream(stream_b);
+    EXPECT_TRUE(is_stream_retired(stream_b));
+    tensor.set_stream(stream_b);
+    EXPECT_FALSE(is_stream_retired(stream_b));
+    CudaMemoryPool::instance().release_stream(stream_b);
+    ASSERT_EQ(cudaStreamDestroy(stream_b), cudaSuccess);
 
     // Pool-level APIs must un-retire a live-by-contract handle. Tests talk to
     // the pool directly (no Tensor::set_stream / setCurrentCUDAStream), and the
@@ -204,12 +187,12 @@ TEST_F(StaleStreamTeardownTest, RetiredStreamRegistryReuseCycle) {
     void* live = CudaMemoryPool::instance().allocate(256, stream_s);
     ASSERT_NE(live, nullptr);
 
-    note_stream_retired(stream_s);
+    retire_stream(stream_s);
     EXPECT_TRUE(is_stream_retired(stream_s));
     CudaMemoryPool::instance().record_stream(live, stream_s);
     EXPECT_FALSE(is_stream_retired(stream_s));
 
-    note_stream_retired(stream_s);
+    retire_stream(stream_s);
     EXPECT_TRUE(is_stream_retired(stream_s));
     void* reused = CudaMemoryPool::instance().allocate(256, stream_s);
     ASSERT_NE(reused, nullptr);

--- a/tests/test_stale_stream_teardown.cpp
+++ b/tests/test_stale_stream_teardown.cpp
@@ -1,0 +1,222 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+// Trainer teardown can destroy CUDA streams while SplatData tensors still
+// stamp those handles. After that, .cpu() / shN_canonical() must not crash
+// or latch cudaErrorInvalidResourceHandle for later LFS_CUDA_LAUNCH_CHECK.
+
+#include "core/sh_value_quant.hpp"
+#include "core/splat_data.hpp"
+#include "core/tensor.hpp"
+#include "core/tensor/internal/cuda_stream_context.hpp"
+#include "core/tensor/internal/memory_pool.hpp"
+#include "core/tensor/internal/stream_lifetime.hpp"
+
+#include <cstdint>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+using namespace lfs::core;
+
+namespace {
+
+    class StaleStreamTeardownTest : public ::testing::Test {
+    protected:
+        void SetUp() override {
+            int device_count = 0;
+            if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+                GTEST_SKIP() << "No CUDA device";
+            }
+            ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+        }
+    };
+
+    void stamp_if_cuda(Tensor& tensor, cudaStream_t stream) {
+        if (tensor.is_valid() && tensor.device() == Device::CUDA) {
+            tensor.set_stream(stream);
+        }
+    }
+
+} // namespace
+
+TEST_F(StaleStreamTeardownTest, DeadHomeStreamCpuDoesNotPoisonThread) {
+    cudaStream_t user_stream = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&user_stream), cudaSuccess);
+
+    Tensor tensor;
+    {
+        CUDAStreamGuard guard(user_stream);
+        tensor = Tensor::full({8}, 3.25f, Device::CUDA);
+        tensor = tensor * 2.0f;
+    }
+    ASSERT_TRUE(tensor.is_valid());
+    ASSERT_EQ(tensor.stream(), user_stream);
+
+    CudaMemoryPool::instance().release_stream(user_stream);
+    ASSERT_EQ(cudaStreamDestroy(user_stream), cudaSuccess);
+
+    const Tensor host = tensor.cpu();
+    ASSERT_TRUE(host.is_valid());
+    ASSERT_EQ(host.numel(), 8);
+    const float* values = host.ptr<float>();
+    ASSERT_NE(values, nullptr);
+    for (int i = 0; i < 8; ++i) {
+        EXPECT_FLOAT_EQ(values[i], 6.5f);
+    }
+
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+
+    const Tensor fresh = Tensor::ones({32}, Device::CUDA);
+    EXPECT_EQ(fresh.count_nonzero(), 32u);
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+}
+
+TEST_F(StaleStreamTeardownTest, DetachFromStreamsCoversBoundsThenCanonicalSucceeds) {
+    cudaStream_t user_stream = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&user_stream), cudaSuccess);
+
+    constexpr size_t n = 4;
+    constexpr int sh_degree = 1;
+
+    SplatData model(sh_degree,
+                    Tensor::zeros({n, size_t{3}}, Device::CUDA),
+                    Tensor::zeros({n, size_t{1}, size_t{3}}, Device::CUDA),
+                    Tensor::zeros({n, size_t{3}, size_t{3}}, Device::CUDA),
+                    Tensor::zeros({n, size_t{3}}, Device::CUDA),
+                    Tensor::zeros({n, size_t{4}}, Device::CUDA),
+                    Tensor::zeros({n, size_t{1}}, Device::CUDA),
+                    1.0f);
+
+    const auto coeffs_rest = static_cast<std::uint32_t>(model.max_sh_coeffs_rest());
+    ASSERT_GT(coeffs_rest, 0u);
+    model.shN() = Tensor::zeros({sh_value_quant::sh_value_u16_count(n, coeffs_rest)},
+                                Device::CUDA, DataType::Float16);
+    model.shN_value_bounds() =
+        Tensor::zeros({sh_value_quant::n_bounds_for_prims(n), size_t{2}}, Device::CUDA);
+    model.deleted() = Tensor::zeros_bool({n}, Device::CUDA);
+    model._densification_info = Tensor::zeros({n}, Device::CUDA);
+
+    stamp_if_cuda(model.means_raw(), user_stream);
+    stamp_if_cuda(model.sh0_raw(), user_stream);
+    stamp_if_cuda(model.shN_raw(), user_stream);
+    stamp_if_cuda(model.shN_value_bounds(), user_stream);
+    stamp_if_cuda(model.scaling_raw(), user_stream);
+    stamp_if_cuda(model.rotation_raw(), user_stream);
+    stamp_if_cuda(model.opacity_raw(), user_stream);
+    stamp_if_cuda(model.deleted(), user_stream);
+    stamp_if_cuda(model._densification_info, user_stream);
+
+    ASSERT_EQ(model.shN_value_bounds().stream(), user_stream);
+
+    model.detach_from_streams();
+
+    const Tensor* members[] = {
+        &model.means_raw(),
+        &model.sh0_raw(),
+        &model.shN_raw(),
+        &model.shN_value_bounds(),
+        &model.scaling_raw(),
+        &model.rotation_raw(),
+        &model.opacity_raw(),
+        &model.deleted(),
+        &model._densification_info,
+    };
+    for (const Tensor* tensor : members) {
+        ASSERT_TRUE(tensor->is_valid());
+        ASSERT_EQ(tensor->device(), Device::CUDA);
+        EXPECT_EQ(tensor->stream(), nullptr);
+    }
+    EXPECT_EQ(model.shN_value_bounds().stream(), nullptr);
+
+    CudaMemoryPool::instance().release_stream(user_stream);
+    ASSERT_EQ(cudaStreamDestroy(user_stream), cudaSuccess);
+
+    EXPECT_NO_THROW({
+        const Tensor canonical = model.shN_canonical();
+        EXPECT_TRUE(canonical.is_valid());
+        EXPECT_EQ(canonical.numel(), n * static_cast<size_t>(coeffs_rest) * 3);
+    });
+    EXPECT_NO_THROW({
+        EXPECT_TRUE(model.shN_value_bounds().cpu().is_valid());
+        EXPECT_TRUE(model.shN_raw().cpu().is_valid());
+    });
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+}
+
+TEST_F(StaleStreamTeardownTest, RetiredStreamRegistryReuseCycle) {
+    const auto fake = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(0x1));
+    note_stream_retired(fake);
+    EXPECT_TRUE(is_stream_retired(fake));
+    note_stream_reused(fake);
+    EXPECT_FALSE(is_stream_retired(fake));
+
+    note_stream_retired(nullptr);
+    EXPECT_FALSE(is_stream_retired(nullptr));
+    EXPECT_FALSE(is_stream_retired(fake));
+
+    cudaStream_t stream_a = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&stream_a), cudaSuccess);
+
+    Tensor tensor;
+    {
+        CUDAStreamGuard guard(stream_a);
+        tensor = Tensor::full({4}, 1.0f, Device::CUDA);
+    }
+    ASSERT_TRUE(tensor.is_valid());
+    ASSERT_EQ(tensor.stream(), stream_a);
+
+    CudaMemoryPool::instance().release_stream(stream_a);
+    EXPECT_TRUE(is_stream_retired(stream_a));
+    ASSERT_EQ(cudaStreamDestroy(stream_a), cudaSuccess);
+    EXPECT_TRUE(is_stream_retired(stream_a));
+
+    bool reused_handle = false;
+    for (int attempt = 0; attempt < 64; ++attempt) {
+        cudaStream_t stream_b = nullptr;
+        ASSERT_EQ(cudaStreamCreate(&stream_b), cudaSuccess);
+        if (stream_b == stream_a) {
+            reused_handle = true;
+            tensor.set_stream(stream_b);
+            EXPECT_FALSE(is_stream_retired(stream_b));
+            CudaMemoryPool::instance().release_stream(stream_b);
+            ASSERT_EQ(cudaStreamDestroy(stream_b), cudaSuccess);
+            break;
+        }
+        ASSERT_EQ(cudaStreamDestroy(stream_b), cudaSuccess);
+    }
+
+    if (!reused_handle) {
+        cudaStream_t stream_b = nullptr;
+        ASSERT_EQ(cudaStreamCreate(&stream_b), cudaSuccess);
+        note_stream_retired(stream_b);
+        EXPECT_TRUE(is_stream_retired(stream_b));
+        tensor.set_stream(stream_b);
+        EXPECT_FALSE(is_stream_retired(stream_b));
+        CudaMemoryPool::instance().release_stream(stream_b);
+        ASSERT_EQ(cudaStreamDestroy(stream_b), cudaSuccess);
+    }
+
+    // Pool-level APIs must un-retire a live-by-contract handle. Tests talk to
+    // the pool directly (no Tensor::set_stream / setCurrentCUDAStream), and the
+    // driver can recycle a previously retired pointer value.
+    cudaStream_t stream_s = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&stream_s), cudaSuccess);
+    void* live = CudaMemoryPool::instance().allocate(256, stream_s);
+    ASSERT_NE(live, nullptr);
+
+    note_stream_retired(stream_s);
+    EXPECT_TRUE(is_stream_retired(stream_s));
+    CudaMemoryPool::instance().record_stream(live, stream_s);
+    EXPECT_FALSE(is_stream_retired(stream_s));
+
+    note_stream_retired(stream_s);
+    EXPECT_TRUE(is_stream_retired(stream_s));
+    void* reused = CudaMemoryPool::instance().allocate(256, stream_s);
+    ASSERT_NE(reused, nullptr);
+    EXPECT_FALSE(is_stream_retired(stream_s));
+    CudaMemoryPool::instance().deallocate(reused, stream_s);
+
+    CudaMemoryPool::instance().deallocate(live, stream_s);
+    CudaMemoryPool::instance().release_stream(stream_s);
+    ASSERT_EQ(cudaStreamDestroy(stream_s), cudaSuccess);
+}


### PR DESCRIPTION
Fixes the export errors reported on Discord (train → edit mode → export PLY fails with `cudaErrorInvalidResourceHandle`, HTML export crashes, Save to Disk fails silently).

Three problems, three fixes:

**1. One tensor kept a pointer to a deleted CUDA stream.**
When switching to edit mode, we re-home all model tensors away from the trainer's streams before those streams are destroyed. One tensor (`_shN_value_bounds`, used by quantized-SH models) was missing from that list, so exports touched a dead stream.
**Fix:** the re-homing now lives in `SplatData::detach_from_streams()` and covers every tensor member.

**2. Checking a dead stream handle can crash the app.**
`bridgeStreams` asked CUDA about the handle to see if it was still valid. On Windows CUDA answers with an error; on Linux it segfaults inside the driver.
**Fix:** a small registry remembers which streams were retired before destruction. Dead handles are skipped without ever asking the driver. Live handles are removed from the registry again wherever they re-enter use, so pointer reuse by the driver stays safe.

**3. One failed CUDA call broke everything after it.**
A failed stream sync left CUDA's "last error" set. Our kernel-launch checks only peek at that error, so the next healthy kernel launch was blamed for it — that's the `count_nonzero` error in the dialog and the cascade that crashed HTML export.
**Fix:** failure paths now clear the stale error.

Bonus: **Save to Disk** now shows the normal export error dialog instead of failing silently.

Tests: 3 new regression tests (dead-stream readback, detach coverage, registry retire/reuse). Full suite matches master (the 2 remaining failures exist on master too). Launch-overhead benchmark unchanged.