### PR TITLE
Fix node delete failing for viewer-loaded PLYs (#1616)

### DIFF
--- a/src/core/include/core/splat_data.hpp
+++ b/src/core/include/core/splat_data.hpp
@@ -224,6 +224,10 @@ namespace lfs::core {
                   float scene_scale,
                   ShNLayout shN_layout = ShNLayout::Canonical);
 
+        // Deep-copies scalars and tensors, including q16 bounds. Skips allocator,
+        // capacity hook, LOD tree, frozen ranges, and layout generation.
+        [[nodiscard]] SplatData clone() const;
+
         // ========== Computed getters ==========
         Tensor get_means() const;
         Tensor get_opacity() const;  // Returns sigmoid(opacity_raw)

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -688,12 +688,12 @@ namespace lfs::core {
         copy._means = cloned(_means, "splat.positions");
         copy._sh0 = cloned(_sh0, "splat.sh0");
         copy._shN = cloned(_shN, "splat.shN");
-        copy._shN_value_bounds = cloned(_shN_value_bounds);
+        copy._shN_value_bounds = cloned(_shN_value_bounds, "splat.shN_value_bounds");
         copy._scaling = cloned(_scaling, "splat.scaling");
         copy._rotation = cloned(_rotation, "splat.rotation");
         copy._opacity = cloned(_opacity, "splat.opacity");
-        copy._densification_info = cloned(_densification_info);
-        copy._deleted = cloned(_deleted);
+        copy._densification_info = cloned(_densification_info, "splat.densification_info");
+        copy._deleted = cloned(_deleted, "splat.deleted_mask");
         copy._deleted_count.store(_deleted_count.load(std::memory_order_relaxed),
                                   std::memory_order_relaxed);
         // q16 degree validation requires shN row capacity >= its reserved row count.

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -670,6 +670,40 @@ namespace lfs::core {
 
     SplatData::~SplatData() = default;
 
+    SplatData SplatData::clone() const {
+        // Tensor::clone() copies neither the name nor the row capacity.
+        const auto cloned = [](const Tensor& src, const char* name = nullptr) {
+            if (!src.is_valid())
+                return Tensor{};
+            Tensor t = src.clone();
+            if (name)
+                t.set_name(name);
+            return t;
+        };
+
+        SplatData copy;
+        copy._max_sh_degree = _max_sh_degree;
+        copy._active_sh_degree = _active_sh_degree;
+        copy._scene_scale = _scene_scale;
+        copy._means = cloned(_means, "splat.positions");
+        copy._sh0 = cloned(_sh0, "splat.sh0");
+        copy._shN = cloned(_shN, "splat.shN");
+        copy._shN_value_bounds = cloned(_shN_value_bounds);
+        copy._scaling = cloned(_scaling, "splat.scaling");
+        copy._rotation = cloned(_rotation, "splat.rotation");
+        copy._opacity = cloned(_opacity, "splat.opacity");
+        copy._densification_info = cloned(_densification_info);
+        copy._deleted = cloned(_deleted);
+        copy._deleted_count.store(_deleted_count.load(std::memory_order_relaxed),
+                                  std::memory_order_relaxed);
+        // q16 degree validation requires shN row capacity >= its reserved row count.
+        if (copy._shN.is_valid() && copy._shN.shape().rank() > 0 &&
+            copy._shN.capacity() < copy._shN.shape()[0]) {
+            copy._shN.reserve(copy._shN.shape()[0]);
+        }
+        return copy;
+    }
+
     // ========== MOVE SEMANTICS ==========
 
     SplatData::SplatData(SplatData&& other) noexcept

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -447,10 +447,11 @@ namespace lfs::training {
                                               std::move(opacity),
                                               scene_scale,
                                               lfs::core::SplatData::ShNLayout::Swizzled);
-                migrated.set_active_sh_degree(active_sh);
                 if (shN_bounds.is_valid()) {
+                    // Codes and bounds are one declared representation; install before degree validation.
                     migrated.shN_value_bounds() = std::move(shN_bounds);
                 }
+                migrated.set_active_sh_degree(active_sh);
                 if (deleted.is_valid()) {
                     migrated.deleted() = std::move(deleted);
                 }

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -121,28 +121,6 @@ namespace lfs::vis::gui {
             window_manager->wakeEventLoop();
     }
 
-    [[nodiscard]] std::unique_ptr<lfs::core::SplatData> cloneSplatData(const lfs::core::SplatData& src) {
-        auto cloned = std::make_unique<lfs::core::SplatData>(
-            src.get_max_sh_degree(),
-            src.means_raw().clone(),
-            src.sh0_raw().clone(),
-            src.shN_raw().is_valid() ? src.shN_raw().clone() : lfs::core::Tensor{},
-            src.scaling_raw().clone(),
-            src.rotation_raw().clone(),
-            src.opacity_raw().clone(),
-            src.get_scene_scale(),
-            lfs::core::SplatData::ShNLayout::Swizzled);
-        cloned->set_active_sh_degree(src.get_active_sh_degree());
-        cloned->set_max_sh_degree(src.get_max_sh_degree());
-        if (src.has_deleted_mask()) {
-            cloned->deleted() = src.deleted().clone();
-        }
-        if (src._densification_info.is_valid()) {
-            cloned->_densification_info = src._densification_info.clone();
-        }
-        return cloned;
-    }
-
     void truncateSHDegree(lfs::core::SplatData& splat, const int target_degree) {
         splat.set_sh_degree(target_degree);
     }
@@ -2465,7 +2443,7 @@ namespace lfs::vis::gui {
                     int64_t{1},
                     std::max<int64_t>(int64_t{1}, input_count));
                 return SimplifyCapture{
-                    .model = cloneSplatData(*node->model),
+                    .model = std::make_unique<lfs::core::SplatData>(node->model->clone()),
                     .source_name = source_name,
                     .output_name = std::format("{}_{}", source_name, target_count),
                 };

--- a/src/visualizer/gui/video_export_utils.cpp
+++ b/src/visualizer/gui/video_export_utils.cpp
@@ -17,28 +17,6 @@ namespace lfs::vis::gui {
 
     namespace {
 
-        std::unique_ptr<lfs::core::SplatData> cloneSplatData(const lfs::core::SplatData& src) {
-            auto cloned = std::make_unique<lfs::core::SplatData>(
-                src.get_max_sh_degree(),
-                src.means_raw().clone(),
-                src.sh0_raw().clone(),
-                src.shN_raw().is_valid() ? src.shN_raw().clone() : lfs::core::Tensor{},
-                src.scaling_raw().clone(),
-                src.rotation_raw().clone(),
-                src.opacity_raw().clone(),
-                src.get_scene_scale(),
-                lfs::core::SplatData::ShNLayout::Swizzled);
-            cloned->set_active_sh_degree(src.get_active_sh_degree());
-            cloned->set_max_sh_degree(src.get_max_sh_degree());
-            if (src.has_deleted_mask()) {
-                cloned->deleted() = src.deleted().clone();
-            }
-            if (src._densification_info.is_valid()) {
-                cloned->_densification_info = src._densification_info.clone();
-            }
-            return cloned;
-        }
-
         std::shared_ptr<lfs::core::PointCloud> clonePointCloud(const lfs::core::PointCloud& src) {
             auto cloned = std::make_shared<lfs::core::PointCloud>();
             cloned->means = src.means.is_valid() ? src.means.clone() : src.means;
@@ -98,7 +76,7 @@ namespace lfs::vis::gui {
 
         if (const auto* const model = scene_manager.getModelForRendering();
             model && model->size() > 0) {
-            snapshot.combined_model = std::shared_ptr<lfs::core::SplatData>(cloneSplatData(*model).release());
+            snapshot.combined_model = std::make_shared<lfs::core::SplatData>(model->clone());
             if (auto allocator = lfs::vis::makeViewerSplatTensorAllocator()) {
                 if (auto migrated = lfs::io::migrateSplatTensorsToAllocator(*snapshot.combined_model, allocator);
                     !migrated) {

--- a/src/visualizer/operation/undo_entry.cpp
+++ b/src/visualizer/operation/undo_entry.cpp
@@ -689,25 +689,7 @@ namespace lfs::vis::op {
         }
 
         std::unique_ptr<lfs::core::SplatData> cloneSplatData(const lfs::core::SplatData& src) {
-            auto cloned = std::make_unique<lfs::core::SplatData>(
-                src.get_max_sh_degree(),
-                src.means_raw().clone(),
-                src.sh0_raw().clone(),
-                src.shN_raw().is_valid() ? src.shN_raw().clone() : lfs::core::Tensor{},
-                src.scaling_raw().clone(),
-                src.rotation_raw().clone(),
-                src.opacity_raw().clone(),
-                src.get_scene_scale(),
-                lfs::core::SplatData::ShNLayout::Swizzled);
-            cloned->set_active_sh_degree(src.get_active_sh_degree());
-            cloned->set_max_sh_degree(src.get_max_sh_degree());
-            if (src.has_deleted_mask()) {
-                cloned->deleted() = src.deleted().clone();
-            }
-            if (src._densification_info.is_valid()) {
-                cloned->_densification_info = src._densification_info.clone();
-            }
-            return cloned;
+            return std::make_unique<lfs::core::SplatData>(src.clone());
         }
 
         std::unique_ptr<lfs::core::SplatData> cloneRendererReadySplatData(

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -171,6 +171,15 @@ namespace lfs::vis {
             return name;
         }
 
+        // Codes and bounds are one declared representation; install before degree validation.
+        void installShNValueBounds(lfs::core::SplatData& dst, lfs::core::Tensor bounds) {
+            dst.shN_value_bounds() = std::move(bounds);
+            auto& shN = dst.shN_raw();
+            if (shN.is_valid() && shN.shape().rank() > 0 && shN.capacity() < shN.shape()[0]) {
+                shN.reserve(shN.shape()[0]);
+            }
+        }
+
         [[nodiscard]] std::unique_ptr<lfs::core::SplatData> cloneSplatDataToCpu(
             const lfs::core::SplatData& src) {
             auto result = std::make_unique<lfs::core::SplatData>(
@@ -183,6 +192,8 @@ namespace lfs::vis {
                 src.opacity_raw().cpu(),
                 src.get_scene_scale(),
                 lfs::core::SplatData::ShNLayout::Swizzled);
+            if (src.shN_value_quantized())
+                installShNValueBounds(*result, src.shN_value_bounds().cpu());
             result->set_active_sh_degree(src.get_active_sh_degree());
             return result;
         }
@@ -4654,6 +4665,8 @@ namespace lfs::vis {
             src.scaling_raw().cuda(), src.rotation_raw().cuda(), src.opacity_raw().cuda(),
             src.get_scene_scale(),
             lfs::core::SplatData::ShNLayout::Swizzled);
+        if (src.shN_value_quantized())
+            installShNValueBounds(*data, src.shN_value_bounds().cuda());
         data->set_active_sh_degree(src.get_active_sh_degree());
 
         const std::string name = makeUniqueCounterNodeName(scene_, "Selection", clipboard_counter_);
@@ -4801,6 +4814,8 @@ namespace lfs::vis {
                     entry.data->scaling_raw().cuda(), entry.data->rotation_raw().cuda(), entry.data->opacity_raw().cuda(),
                     entry.data->get_scene_scale(),
                     lfs::core::SplatData::ShNLayout::Swizzled);
+                if (entry.data->shN_value_quantized())
+                    installShNValueBounds(*paste_data, entry.data->shN_value_bounds().cuda());
                 paste_data->set_active_sh_degree(entry.data->get_active_sh_degree());
 
                 if (auto allocator = makeExternalSplatAllocator()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,6 +141,7 @@ set(TEST_FILES
     test_joint_adam_codec.cpp
     test_sh_value_codec.cpp
     test_sh_value_storage.cpp
+    test_splat_data_clone.cpp
     test_tensor_reduction.cpp
     test_tensor_reduction_alignment.cpp
     test_tensor_views.cpp

--- a/tests/test_splat_data_clone.cpp
+++ b/tests/test_splat_data_clone.cpp
@@ -10,6 +10,7 @@
 
 #include <cstring>
 #include <gtest/gtest.h>
+#include <optional>
 #include <random>
 #include <vector>
 
@@ -52,7 +53,7 @@ namespace {
         if (!a.is_valid() || !b.is_valid()) {
             return a.is_valid() == b.is_valid();
         }
-        if (a.dtype() != b.dtype() || a.numel() != b.numel()) {
+        if (a.dtype() != b.dtype() || a.shape() != b.shape()) {
             return false;
         }
         auto ac = a.cpu().contiguous();

--- a/tests/test_splat_data_clone.cpp
+++ b/tests/test_splat_data_clone.cpp
@@ -1,0 +1,156 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/parameters.hpp"
+#include "core/splat_data.hpp"
+#include "core/splat_exportable_storage.hpp"
+#include "lfs/training/sh_value_codec.hpp"
+#include "lfs/training/sh_value_storage.hpp"
+#include "training/training_setup.hpp"
+
+#include <cstring>
+#include <gtest/gtest.h>
+#include <random>
+#include <vector>
+
+using namespace lfs::core;
+using namespace lfs::training;
+
+namespace {
+
+    constexpr size_t kN = 600; // ≥ 2 q16 blocks
+    constexpr int kShDegree = 3;
+
+    SplatData make_random_sh3(const size_t n, const uint32_t seed = 42) {
+        auto means = Tensor::zeros({n, size_t{3}}, Device::CUDA, DataType::Float32);
+        auto sh0 = Tensor::zeros({n, size_t{1}, size_t{3}}, Device::CUDA, DataType::Float32);
+        auto shN_can = Tensor::zeros({n, size_t{15}, size_t{3}}, Device::CUDA, DataType::Float32);
+        auto scaling = Tensor::zeros({n, size_t{3}}, Device::CUDA, DataType::Float32);
+        auto rotation = Tensor::zeros({n, size_t{4}}, Device::CUDA, DataType::Float32);
+        auto opacity = Tensor::zeros({n, size_t{1}}, Device::CUDA, DataType::Float32);
+
+        {
+            std::mt19937 rng(seed);
+            std::normal_distribution<float> nd(0.0f, 0.15f);
+            auto cpu = shN_can.cpu();
+            auto* p = cpu.ptr<float>();
+            for (size_t i = 0; i < n * 15 * 3; ++i)
+                p[i] = nd(rng);
+            shN_can = cpu.to(Device::CUDA);
+
+            auto rcpu = rotation.cpu();
+            auto* r = rcpu.ptr<float>();
+            for (size_t i = 0; i < n; ++i)
+                r[i * 4] = 1.0f;
+            rotation = rcpu.to(Device::CUDA);
+        }
+
+        return SplatData(kShDegree, means, sh0, shN_can, scaling, rotation, opacity, 1.0f);
+    }
+
+    [[nodiscard]] bool tensors_equal(const Tensor& a, const Tensor& b) {
+        if (!a.is_valid() || !b.is_valid()) {
+            return a.is_valid() == b.is_valid();
+        }
+        if (a.dtype() != b.dtype() || a.numel() != b.numel()) {
+            return false;
+        }
+        auto ac = a.cpu().contiguous();
+        auto bc = b.cpu().contiguous();
+        return std::memcmp(ac.data_ptr(), bc.data_ptr(), ac.bytes()) == 0;
+    }
+
+} // namespace
+
+TEST(SplatDataCloneTest, Q16CloneCarriesBounds) {
+    sh_value::set_sh_value_quant_enabled_for_testing(true);
+    auto model = make_random_sh3(kN);
+    ASSERT_TRUE(sh_value::apply_shN_value_quant(model));
+    ASSERT_TRUE(model.shN_value_quantized());
+
+    const auto canonical_before = model.shN_canonical();
+    const void* const src_means_ptr = model.means_raw().data_ptr();
+    const float src_mean0 = model.means_raw().cpu().ptr<float>()[0];
+
+    auto copy = model.clone();
+
+    EXPECT_TRUE(copy.shN_value_quantized());
+    ASSERT_TRUE(copy.shN_value_bounds().is_valid());
+    EXPECT_EQ(copy.shN_value_bounds().numel(), model.shN_value_bounds().numel());
+
+    EXPECT_NO_THROW(copy.set_active_sh_degree(1));
+    EXPECT_NO_THROW(copy.set_active_sh_degree(3));
+    EXPECT_NO_THROW(copy.set_max_sh_degree(3));
+
+    EXPECT_TRUE(tensors_equal(copy.shN_canonical(), canonical_before));
+
+    EXPECT_NE(copy.means_raw().data_ptr(), src_means_ptr);
+    copy.means_raw().fill_(123.0f);
+    EXPECT_FLOAT_EQ(model.means_raw().cpu().ptr<float>()[0], src_mean0);
+
+    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+}
+
+TEST(SplatDataCloneTest, Fp32CloneUnchangedBehavior) {
+    sh_value::set_sh_value_quant_enabled_for_testing(false);
+    auto model = make_random_sh3(kN);
+    ASSERT_FALSE(model.shN_value_quantized());
+
+    const auto canonical_before = model.shN_canonical();
+    auto copy = model.clone();
+
+    EXPECT_FALSE(model.shN_value_quantized());
+    EXPECT_FALSE(copy.shN_value_quantized());
+    EXPECT_NO_THROW(copy.set_active_sh_degree(1));
+    EXPECT_NO_THROW(copy.set_active_sh_degree(3));
+    EXPECT_TRUE(tensors_equal(copy.shN_canonical(), canonical_before));
+
+    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+}
+
+TEST(SplatDataCloneTest, CloneCarriesDeletedMask) {
+    auto model = make_random_sh3(64);
+    std::vector<bool> deleted(64, false);
+    deleted[1] = true;
+    deleted[17] = true;
+    deleted[63] = true;
+    model.deleted() = Tensor::from_vector(deleted, {deleted.size()}, Device::CPU).to(Device::CUDA);
+    model.refresh_deleted_count();
+    ASSERT_TRUE(model.has_deleted_mask());
+    ASSERT_EQ(model.deleted_count(), 3u);
+
+    auto copy = model.clone();
+
+    ASSERT_TRUE(copy.has_deleted_mask());
+    EXPECT_EQ(copy.deleted_count(), model.deleted_count());
+    EXPECT_EQ(copy.deleted().cpu().to_vector_bool(), model.deleted().cpu().to_vector_bool());
+
+    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+}
+
+TEST(SplatDataCloneTest, Q16CloneMigratesToExportableAllocator) {
+    sh_value::set_sh_value_quant_enabled_for_testing(true);
+    auto model = make_random_sh3(kN);
+    ASSERT_TRUE(sh_value::apply_shN_value_quant(model));
+    ASSERT_TRUE(model.shN_value_quantized());
+
+    auto copy = model.clone();
+    ASSERT_TRUE(copy.shN_value_quantized());
+    const auto canonical_before = copy.shN_canonical();
+
+    constexpr size_t kCap = 1024;
+    auto storage_result = SplatExportableStorage::create(kCap, kShDegree, /*device=*/0, kCap * 4);
+    if (!storage_result) {
+        GTEST_SKIP() << "exportable create failed: " << storage_result.error();
+    }
+    auto storage = std::make_shared<SplatExportableStorage>(std::move(*storage_result));
+
+    param::TrainingParameters params;
+    params.optimization.max_cap = static_cast<int>(kCap);
+    const auto result = migrateTrainingModelToAllocator(params, copy, storage->make_allocator());
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_TRUE(copy.shN_value_quantized());
+    EXPECT_TRUE(tensors_equal(copy.shN_canonical(), canonical_before));
+
+    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+}


### PR DESCRIPTION
Closes #1616

## What was broken
Deleting a loaded PLY node did nothing (trash icon, context menu, Del key). Deleting a copy worked. Repeated attempts could crash the app.

## Why
Loaded PLYs store their color data compressed (q16 codes + a small bounds tensor — two halves of one representation). Every delete first snapshots the node for undo, and that snapshot copied the codes but dropped the bounds. The copy was rejected as corrupted, which silently aborted the delete. The same copy-without-bounds pattern existed in export, clipboard, paste, and undo-restore.

## Fix
- `SplatData::clone()`: one correct deep copy that keeps both halves. All copy sites now use it.
- Clipboard/paste and undo-restore now attach the bounds before validation runs.
- Net −7 lines of production code.

## Proof
- New regression tests cover clone and the undo-restore round-trip (4 tests). Existing export / undo / storage suites all green (164 tests).
- Live app: delete → undo → redo → duplicate → delete both, on a 3.3M-splat PLY — all work, no crash.

Known follow-up (pre-existing, unchanged): rotating a compressed model via the Python transform capability still converts it to fp32.