### PR TITLE
Fix remaining q16 SH bugs and Python bridge correctness

### DIFF
--- a/src/app/mcp_gui_tools.cpp
+++ b/src/app/mcp_gui_tools.cpp
@@ -4908,52 +4908,6 @@ namespace lfs::app {
                     auto* const node = scene.getMutableNode(*node_name);
                     if (!node || !node->model)
                         return json{{"error", "Gaussian node not found: " + *node_name}};
-                    // Compact SH cannot be scattered via ptr<float>(). Decode,
-                    // scatter selected rows into the canonical [N,K,3] tensor,
-                    // then reinstall (W1 leaves the model fp32 and clears bounds).
-                    if (field_name == "shN" && node->model->shN_raw().is_valid() &&
-                        node->model->shN_raw().numel() > 0 &&
-                        node->model->max_sh_coeffs_rest() > 0 &&
-                        node->model->shN_raw().dtype() != core::DataType::Float32) {
-                        const size_t rest = node->model->max_sh_coeffs_rest();
-                        const size_t row_width = rest * size_t{3};
-                        if (row_width == 0 ||
-                            indices.size() > std::numeric_limits<size_t>::max() / row_width ||
-                            values.size() != row_width * indices.size()) {
-                            return json{{"error",
-                                         "Field slice expects " +
-                                             std::to_string(row_width * indices.size()) +
-                                             " values but received " + std::to_string(values.size())}};
-                        }
-                        for (const int index : indices) {
-                            if (index < 0 || static_cast<size_t>(index) >= node->model->size())
-                                return json{{"error", "Gaussian index out of range: " + std::to_string(index)}};
-                        }
-                        core::Tensor canon = node->model->shN_canonical();
-                        const auto index_tensor = core::Tensor::from_vector(
-                            indices, {indices.size()}, canon.device());
-                        const auto src_tensor = core::Tensor::from_vector(
-                            values,
-                            core::TensorShape({indices.size(), rest, size_t{3}}),
-                            canon.device());
-                        auto indices_for_copy = index_tensor;
-                        if (indices_for_copy.dtype() != core::DataType::Int32 &&
-                            indices_for_copy.dtype() != core::DataType::Int64) {
-                            indices_for_copy = indices_for_copy.to(core::DataType::Int32);
-                        }
-                        canon.index_copy_(0, indices_for_copy, src_tensor);
-                        node->model->shN_set_from_canonical(canon, node->model->means().capacity());
-                        scene.markPayloadDiverged(node->id);
-                        scene.notifyMutation(core::Scene::MutationType::MODEL_CHANGED);
-                        if (rendering_manager)
-                            rendering_manager->markDirty(vis::DirtyFlag::SPLATS | vis::DirtyFlag::OVERLAY);
-                        return json{
-                            {"success", true},
-                            {"node", *node_name},
-                            {"field", field_name},
-                            {"updated_count", static_cast<int64_t>(indices.size())},
-                        };
-                    }
                     if (auto result = vis::cap::writeGaussianField(
                             *scene_manager,
                             rendering_manager,

--- a/src/app/mcp_gui_tools.cpp
+++ b/src/app/mcp_gui_tools.cpp
@@ -4829,15 +4829,29 @@ namespace lfs::app {
                             }
                             const auto rest_coefficients =
                                 static_cast<uint32_t>(node->model->max_sh_coeffs_rest());
-                            auto selected_sh = core::Tensor::empty(
-                                {resolved_indices.size(), static_cast<size_t>(rest_coefficients), size_t{3}},
-                                node->model->shN_raw().device());
-                            core::shN_swizzled_gather_to_linear(
-                                node->model->shN_raw().ptr<float>(),
-                                index_tensor.ptr<int>(),
-                                selected_sh.ptr<float>(),
-                                resolved_indices.size(),
-                                rest_coefficients);
+                            core::Tensor selected_sh;
+                            // q16 / IEEE-f16: dequant to [N,K,3] then index_select (no ptr<float> on codes).
+                            if (node->model->shN_raw().dtype() != core::DataType::Float32) {
+                                core::Tensor canon = node->model->shN_canonical();
+                                auto indices_for_select = index_tensor;
+                                if (indices_for_select.device() != canon.device())
+                                    indices_for_select = indices_for_select.to(canon.device());
+                                if (indices_for_select.dtype() != core::DataType::Int32 &&
+                                    indices_for_select.dtype() != core::DataType::Int64) {
+                                    indices_for_select = indices_for_select.to(core::DataType::Int32);
+                                }
+                                selected_sh = canon.index_select(0, indices_for_select).contiguous();
+                            } else {
+                                selected_sh = core::Tensor::empty(
+                                    {resolved_indices.size(), static_cast<size_t>(rest_coefficients), size_t{3}},
+                                    node->model->shN_raw().device());
+                                core::shN_swizzled_gather_to_linear(
+                                    node->model->shN_raw().ptr<float>(),
+                                    index_tensor.ptr<int>(),
+                                    selected_sh.ptr<float>(),
+                                    resolved_indices.size(),
+                                    rest_coefficients);
+                            }
                             field_payloads[field_name] = tensor_payload_json(selected_sh);
                             continue;
                         }
@@ -4894,6 +4908,52 @@ namespace lfs::app {
                     auto* const node = scene.getMutableNode(*node_name);
                     if (!node || !node->model)
                         return json{{"error", "Gaussian node not found: " + *node_name}};
+                    // Compact SH cannot be scattered via ptr<float>(). Decode,
+                    // scatter selected rows into the canonical [N,K,3] tensor,
+                    // then reinstall (W1 leaves the model fp32 and clears bounds).
+                    if (field_name == "shN" && node->model->shN_raw().is_valid() &&
+                        node->model->shN_raw().numel() > 0 &&
+                        node->model->max_sh_coeffs_rest() > 0 &&
+                        node->model->shN_raw().dtype() != core::DataType::Float32) {
+                        const size_t rest = node->model->max_sh_coeffs_rest();
+                        const size_t row_width = rest * size_t{3};
+                        if (row_width == 0 ||
+                            indices.size() > std::numeric_limits<size_t>::max() / row_width ||
+                            values.size() != row_width * indices.size()) {
+                            return json{{"error",
+                                         "Field slice expects " +
+                                             std::to_string(row_width * indices.size()) +
+                                             " values but received " + std::to_string(values.size())}};
+                        }
+                        for (const int index : indices) {
+                            if (index < 0 || static_cast<size_t>(index) >= node->model->size())
+                                return json{{"error", "Gaussian index out of range: " + std::to_string(index)}};
+                        }
+                        core::Tensor canon = node->model->shN_canonical();
+                        const auto index_tensor = core::Tensor::from_vector(
+                            indices, {indices.size()}, canon.device());
+                        const auto src_tensor = core::Tensor::from_vector(
+                            values,
+                            core::TensorShape({indices.size(), rest, size_t{3}}),
+                            canon.device());
+                        auto indices_for_copy = index_tensor;
+                        if (indices_for_copy.dtype() != core::DataType::Int32 &&
+                            indices_for_copy.dtype() != core::DataType::Int64) {
+                            indices_for_copy = indices_for_copy.to(core::DataType::Int32);
+                        }
+                        canon.index_copy_(0, indices_for_copy, src_tensor);
+                        node->model->shN_set_from_canonical(canon, node->model->means().capacity());
+                        scene.markPayloadDiverged(node->id);
+                        scene.notifyMutation(core::Scene::MutationType::MODEL_CHANGED);
+                        if (rendering_manager)
+                            rendering_manager->markDirty(vis::DirtyFlag::SPLATS | vis::DirtyFlag::OVERLAY);
+                        return json{
+                            {"success", true},
+                            {"node", *node_name},
+                            {"field", field_name},
+                            {"updated_count", static_cast<int64_t>(indices.size())},
+                        };
+                    }
                     if (auto result = vis::cap::writeGaussianField(
                             *scene_manager,
                             rendering_manager,

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -1232,9 +1232,9 @@ namespace lfs::core {
             grow_direct(_sh0, capacity);
         if (_shN.is_valid()) {
             const auto layout_rest = static_cast<uint32_t>(max_sh_coeffs_rest());
-            // q16 (Float16 bit-pattern): capacity is pad-dropped uint16 cells.
-            // fp32: capacity is float4-swizzled float count.
-            if (_shN.dtype() == DataType::Float16) {
+            // q16: capacity is pad-dropped uint16 cells.
+            // fp32 and ieee-f16: capacity is float4-swizzled element count.
+            if (shN_value_quantized()) {
                 const size_t need = sh_value_quant::sh_value_u16_count(capacity, layout_rest);
                 if (need > 0)
                     grow_direct(_shN, need);

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -988,6 +988,21 @@ namespace lfs::core {
         const size_t needed_floats = sh_swizzled_float_count(n, layout_rest);
         const size_t needed_capacity = sh_swizzled_float_count(cap, layout_rest);
 
+        // SH degree 2: q16 cell count (rest*3=24/prim) equals ieee-f16 float4-swizzle
+        // count (slots*4=24/prim). Size/capacity reuse cannot distinguish the two,
+        // so a declared q16 pair must be dropped before any numel check — otherwise
+        // IEEE halfs land in the codes buffer while bounds stay attached.
+        const auto replace_shN_fp32 = [&]() {
+            const bool drop_bounds = _shN.is_valid() && _shN.dtype() == DataType::Float16;
+            _shN = allocate_swizzled_shN(n, cap, layout_rest);
+            if (drop_bounds) {
+                _shN_value_bounds = Tensor{};
+            }
+        };
+        if (shN_value_quantized()) {
+            replace_shN_fp32();
+        }
+
         // Adjust _shN's logical size to match the new N without losing reserved capacity
         // when possible. Reallocating drops the pre-alloc buffer and can break async
         // pointer aliasing for downstream kernels; we only do it when capacity is short.
@@ -998,11 +1013,11 @@ namespace lfs::core {
                 // N shrank (e.g. random_choose, crop, prune-then-compact). The Tensor lib
                 // doesn't have a "shrink logical size" op other than reassigning shape.
                 // Allocate a smaller buffer in this case — it's a one-shot edit operation.
-                _shN = allocate_swizzled_shN(n, cap, layout_rest);
+                replace_shN_fp32();
             }
             // else: numel() == needed_floats, nothing to do.
         } else {
-            _shN = allocate_swizzled_shN(n, cap, layout_rest);
+            replace_shN_fp32();
         }
 
         const auto src_rest = std::min(canonical_rest_coefficients(canonical), layout_rest);
@@ -1186,6 +1201,16 @@ namespace lfs::core {
                 return;
             if (t.external_storage_kind().empty()) {
                 t.reserve(cap_rows);
+                return;
+            }
+            // Renderer-backed tensors grow with live N via capacity_ensure / migrate.
+            // Rebuilding them onto private zeros_direct detaches the zero-copy block.
+            // cuda.direct still rebuilds here (checkpoint resume).
+            const auto kind = t.external_storage_kind();
+            if (kind == "vulkan_external_buffer" || kind == "splat.exportable") {
+                LOG_DEBUG("reserve_capacity: skip grow of renderer-backed storage "
+                          "(kind={}); growth is owned by capacity_ensure/migrate",
+                          kind);
                 return;
             }
             auto grown = Tensor::zeros_direct(t.shape(), cap_rows, t.device(), t.dtype());

--- a/src/core/splat_simplify.cpp
+++ b/src/core/splat_simplify.cpp
@@ -112,26 +112,38 @@ namespace lfs::core {
                         keep_indices = keep_indices.squeeze(1);
                     const size_t keep_count = static_cast<size_t>(keep_indices.numel());
                     const size_t layout_rest = input.max_sh_coeffs_rest();
-                    shN = Tensor::empty({keep_count, layout_rest, 3}, input.shN_raw().device());
-                    if (keep_indices.dtype() == DataType::Int64) {
-                        shN_swizzled_gather_to_linear_i64(
-                            input.shN_raw().ptr<float>(),
-                            keep_indices.ptr<int64_t>(),
-                            shN.ptr<float>(),
-                            keep_count,
-                            static_cast<uint32_t>(layout_rest),
-                            static_cast<uint32_t>(layout_rest));
+                    // q16 / IEEE-f16: dequant to [N,K,3] then index_select (no ptr<float> on codes).
+                    if (input.shN_raw().dtype() != DataType::Float32) {
+                        Tensor canon = input.shN_canonical();
+                        if (keep_indices.device() != canon.device())
+                            keep_indices = keep_indices.to(canon.device());
+                        if (keep_indices.dtype() != DataType::Int32 &&
+                            keep_indices.dtype() != DataType::Int64) {
+                            keep_indices = keep_indices.to(DataType::Int32);
+                        }
+                        shN = canon.index_select(0, keep_indices).contiguous();
                     } else {
-                        auto keep_i32 = keep_indices.dtype() == DataType::Int32
-                                            ? keep_indices
-                                            : keep_indices.to(DataType::Int32);
-                        shN_swizzled_gather_to_linear(
-                            input.shN_raw().ptr<float>(),
-                            keep_i32.ptr<int>(),
-                            shN.ptr<float>(),
-                            keep_count,
-                            static_cast<uint32_t>(layout_rest),
-                            static_cast<uint32_t>(layout_rest));
+                        shN = Tensor::empty({keep_count, layout_rest, 3}, input.shN_raw().device());
+                        if (keep_indices.dtype() == DataType::Int64) {
+                            shN_swizzled_gather_to_linear_i64(
+                                input.shN_raw().ptr<float>(),
+                                keep_indices.ptr<int64_t>(),
+                                shN.ptr<float>(),
+                                keep_count,
+                                static_cast<uint32_t>(layout_rest),
+                                static_cast<uint32_t>(layout_rest));
+                        } else {
+                            auto keep_i32 = keep_indices.dtype() == DataType::Int32
+                                                ? keep_indices
+                                                : keep_indices.to(DataType::Int32);
+                            shN_swizzled_gather_to_linear(
+                                input.shN_raw().ptr<float>(),
+                                keep_i32.ptr<int>(),
+                                shN.ptr<float>(),
+                                keep_count,
+                                static_cast<uint32_t>(layout_rest),
+                                static_cast<uint32_t>(layout_rest));
+                        }
                     }
                     shN = shN.to(device).contiguous();
                 } else {

--- a/src/python/lfs/py_scene.cpp
+++ b/src/python/lfs/py_scene.cpp
@@ -373,6 +373,20 @@ namespace lfs::python {
                                const int sh_degree,
                                const float scene_scale,
                                const int32_t parent) {
+        const auto require_float32 = [](const char* field, const PyTensor& tensor) {
+            const auto dtype = tensor.tensor().dtype();
+            if (dtype != core::DataType::Float32) {
+                throw std::runtime_error(std::string("add_splat: ") + field +
+                                         " must be float32, got " + core::dtype_name(dtype));
+            }
+        };
+        require_float32("means", means);
+        require_float32("sh0", sh0);
+        require_float32("shN", shN);
+        require_float32("scaling", scaling);
+        require_float32("rotation", rotation);
+        require_float32("opacity", opacity);
+
         std::optional<vis::op::SceneGraphStateSnapshot> history_before;
         if (auto* const scene_manager = get_scene_manager()) {
             history_before = vis::op::SceneGraphPatchEntry::captureState(*scene_manager, {name});

--- a/src/python/lfs/py_splat_data.cpp
+++ b/src/python/lfs/py_splat_data.cpp
@@ -4,10 +4,34 @@
 
 #include "py_splat_data.hpp"
 #include <nanobind/stl/optional.h>
+#include <stdexcept>
+#include <string_view>
 
 namespace {
     constexpr float SH_C0 = 0.28209479177387814f;
     constexpr float SH_DC_OFFSET = 0.5f;
+
+    [[nodiscard]] bool is_renderer_backed_kind(const std::string_view kind) {
+        return kind == "vulkan_external_buffer" || kind == "splat.exportable";
+    }
+
+    [[nodiscard]] bool splat_is_renderer_backed(const lfs::core::SplatData& data) {
+        const lfs::core::Tensor* const tensors[] = {
+            &data.means_raw(),
+            &data.sh0_raw(),
+            &data.shN_raw(),
+            &data.scaling_raw(),
+            &data.rotation_raw(),
+            &data.opacity_raw(),
+            &data.shN_value_bounds(),
+        };
+        for (const auto* tensor : tensors) {
+            if (tensor->is_valid() && is_renderer_backed_kind(tensor->external_storage_kind())) {
+                return true;
+            }
+        }
+        return false;
+    }
 } // namespace
 
 namespace lfs::python {
@@ -96,6 +120,15 @@ namespace lfs::python {
         data_->undelete(mask.tensor());
     }
 
+    void PySplatData::reserve_capacity(const size_t capacity) {
+        if (splat_is_renderer_backed(*data_)) {
+            throw std::runtime_error(
+                "Capacity of renderer-backed models is managed by the application "
+                "and cannot be reserved from Python");
+        }
+        data_->reserve_capacity(capacity);
+    }
+
     void register_splat_data(nb::module_& m) {
         nb::class_<PySplatData>(m, "SplatData")
             // Raw tensor access (views)
@@ -168,7 +201,8 @@ namespace lfs::python {
 
             // Capacity
             .def("reserve_capacity", &PySplatData::reserve_capacity, nb::arg("capacity"),
-                 "Reserve capacity for Gaussians (for densification)");
+                 "Reserve capacity for Gaussians (for densification). "
+                 "Raises if the model is renderer-backed.");
     }
 
 } // namespace lfs::python

--- a/src/python/lfs/py_splat_data.hpp
+++ b/src/python/lfs/py_splat_data.hpp
@@ -64,7 +64,7 @@ namespace lfs::python {
         void set_max_sh_degree(int degree) { data_->set_max_sh_degree(degree); }
 
         // Capacity management
-        void reserve_capacity(size_t capacity) { data_->reserve_capacity(capacity); }
+        void reserve_capacity(size_t capacity);
 
         // Access underlying data (for internal use)
         core::SplatData* data() { return data_; }

--- a/src/python/lfs/py_tensor.cpp
+++ b/src/python/lfs/py_tensor.cpp
@@ -1397,6 +1397,9 @@ namespace lfs::python {
             int64_t expected = 1;
             for (int32_t i = dl.ndim - 1; i >= 0; --i) {
                 const int64_t extent = dl.shape[i];
+                if (extent == 0) {
+                    return true;
+                }
                 if (extent != 1 && dl.strides[i] != expected) {
                     return false;
                 }

--- a/src/python/lfs/py_tensor.cpp
+++ b/src/python/lfs/py_tensor.cpp
@@ -108,6 +108,27 @@ namespace lfs::python {
             }
         }
 
+        // nanobind ndarray::stride(i) is in ELEMENTS (not bytes), matching DLPack.
+        bool ndarray_is_c_contiguous(const nb::ndarray<>& arr) {
+            const size_t ndim = arr.ndim();
+            if (ndim == 0 || !arr.stride_ptr()) {
+                return true;
+            }
+            int64_t expected = 1;
+            for (size_t i = ndim; i-- > 0;) {
+                const int64_t extent = static_cast<int64_t>(arr.shape(i));
+                if (extent == 0) {
+                    return true;
+                }
+                // Extent-1 dims may carry arbitrary strides.
+                if (extent != 1 && arr.stride(i) != expected) {
+                    return false;
+                }
+                expected *= extent;
+            }
+            return true;
+        }
+
         template <typename Getter>
         nb::object build_nested_list(const std::vector<size_t>& dims, size_t dim, size_t& offset, const Getter& getter) {
             if (dims.empty()) {
@@ -502,7 +523,16 @@ namespace lfs::python {
         return tensor_.count_nonzero();
     }
 
-    PyTensor PyTensor::from_numpy(nb::ndarray<> arr, bool /*copy*/) {
+    PyTensor PyTensor::from_numpy(nb::ndarray<> arr, bool copy) {
+        if (!copy) {
+            throw std::runtime_error(
+                "from_numpy: zero-copy import is not supported; omit copy or pass copy=True");
+        }
+        if (!ndarray_is_c_contiguous(arr)) {
+            throw std::runtime_error(
+                "from_numpy: array must be C-contiguous; call np.ascontiguousarray() first");
+        }
+
         // Get shape
         std::vector<size_t> shape_vec;
         for (size_t i = 0; i < arr.ndim(); ++i) {
@@ -1340,6 +1370,40 @@ namespace lfs::python {
             const uintptr_t v = reinterpret_cast<uintptr_t>(s);
             return v == 0 ? kDLPackLegacyDefault : static_cast<int64_t>(v);
         }
+
+        // Query __dlpack_device__ so CPU producers (e.g. NumPy) are not
+        // given a CUDA stream. Matches from_dl_device for CUDA types.
+        bool dlpack_producer_is_cuda_ordered(const nb::object& obj) {
+            if (!nb::hasattr(obj, "__dlpack_device__")) {
+                return false;
+            }
+            try {
+                const nb::object dev = obj.attr("__dlpack_device__")();
+                const int32_t device_type = nb::cast<int32_t>(dev[0]);
+                return device_type == kDLCUDA || device_type == kDLCUDAManaged;
+            } catch (const nb::python_error&) {
+                return false;
+            } catch (const nb::cast_error&) {
+                return false;
+            }
+        }
+
+        // nullptr strides = compact row-major (DLPack). Extent-1 dims may carry
+        // arbitrary strides; every other dim must match the compact C layout.
+        bool dlpack_is_compact_row_major(const DLTensor& dl) {
+            if (dl.strides == nullptr) {
+                return true;
+            }
+            int64_t expected = 1;
+            for (int32_t i = dl.ndim - 1; i >= 0; --i) {
+                const int64_t extent = dl.shape[i];
+                if (extent != 1 && dl.strides[i] != expected) {
+                    return false;
+                }
+                expected *= extent;
+            }
+            return true;
+        }
     } // namespace
 
     nb::capsule PyTensor::dlpack(nb::object stream) const {
@@ -1384,17 +1448,21 @@ namespace lfs::python {
 
         if (nb::hasattr(obj, "__dlpack__")) {
             nb::object dlpack_fn = obj.attr("__dlpack__");
-            const int64_t consumer = cuda_stream_to_dlpack(lfs::core::getCurrentCUDAStream());
-            try {
-                capsule = nb::cast<nb::capsule>(dlpack_fn(nb::arg("stream") = consumer));
-                stream_handshake = true;
-            } catch (const nb::python_error& e) {
-                // Only the capability-signaling TypeError ("__dlpack__ takes no
-                // stream argument") warrants the legacy zero-arg retry; any other
-                // producer error propagates so a real bug is not masked by a silent
-                // second producer execution (Phase 9 Section 1.5 / doc :202).
-                if (!e.matches(PyExc_TypeError))
-                    throw;
+            if (dlpack_producer_is_cuda_ordered(obj)) {
+                const int64_t consumer = cuda_stream_to_dlpack(lfs::core::getCurrentCUDAStream());
+                try {
+                    capsule = nb::cast<nb::capsule>(dlpack_fn(nb::arg("stream") = consumer));
+                    stream_handshake = true;
+                } catch (const nb::python_error& e) {
+                    // Only the capability-signaling TypeError ("__dlpack__ takes no
+                    // stream argument") warrants the legacy zero-arg retry; any other
+                    // producer error propagates so a real bug is not masked by a silent
+                    // second producer execution (Phase 9 Section 1.5 / doc :202).
+                    if (!e.matches(PyExc_TypeError))
+                        throw;
+                    capsule = nb::cast<nb::capsule>(dlpack_fn());
+                }
+            } else {
                 capsule = nb::cast<nb::capsule>(dlpack_fn());
             }
         } else if (nb::isinstance<nb::capsule>(obj)) {
@@ -1416,14 +1484,19 @@ namespace lfs::python {
             throw std::runtime_error("from_dlpack: null DLManagedTensor");
         }
 
+        const DLTensor& dl = managed->dl_tensor;
+        if (!dlpack_is_compact_row_major(dl)) {
+            throw std::runtime_error(
+                "from_dlpack: non-contiguous producer tensors are not supported; "
+                "call .contiguous() on the source first");
+        }
+
         // "Consume" the capsule per DLPack spec:
         // 1. Rename to "used_dltensor" so producer knows we took ownership
         // 2. Disable the capsule's destructor - we'll call the deleter ourselves
         PyObject* py_capsule = capsule.ptr();
         PyCapsule_SetName(py_capsule, "used_dltensor");
         PyCapsule_SetDestructor(py_capsule, nullptr);
-
-        const DLTensor& dl = managed->dl_tensor;
 
         std::vector<size_t> shape_vec;
         shape_vec.reserve(dl.ndim);

--- a/src/python/stubs/lichtfeld/scene.pyi
+++ b/src/python/stubs/lichtfeld/scene.pyi
@@ -108,7 +108,9 @@ class SplatData:
         """Set maximum SH degree"""
 
     def reserve_capacity(self, capacity: int) -> None:
-        """Reserve capacity for Gaussians (for densification)"""
+        """
+        Reserve capacity for Gaussians (for densification). Raises if the model is renderer-backed.
+        """
 
 class NodeType(enum.Enum):
     SPLAT = 0

--- a/src/visualizer/CMakeLists.txt
+++ b/src/visualizer/CMakeLists.txt
@@ -125,6 +125,7 @@ add_library(lfs_visualizer ${LFS_VIS_LIB_TYPE}
         # Scene management
         scene/scene_manager.cpp
         scene/selection_state.cpp
+        scene/viewer_splat_quantize.cpp
 
         # Input handling
         input/input_controller.cpp

--- a/src/visualizer/gui/sequencer_ui_manager.cpp
+++ b/src/visualizer/gui/sequencer_ui_manager.cpp
@@ -18,11 +18,11 @@
 #include "gui/utils/native_file_dialog.hpp"
 #include "io/loader.hpp"
 #include "io/video/video_export_options.hpp"
-#include "lfs/training/sh_value_storage.hpp"
 #include "rendering/coordinate_conventions.hpp"
 #include "rendering/rendering.hpp"
 #include "rendering/rendering_manager.hpp"
 #include "scene/scene_manager.hpp"
+#include "scene/viewer_splat_quantize.hpp"
 #include "sequencer/interpolation.hpp"
 #include "sequencer/keyframe.hpp"
 #include "sequencer/timeline_view_math.hpp"
@@ -242,56 +242,6 @@ namespace lfs::vis::gui {
                 return false;
             }
             return true;
-        }
-
-        [[nodiscard]] bool isPlyPath(const std::filesystem::path& path) {
-            auto extension = path.extension().string();
-            std::transform(extension.begin(), extension.end(), extension.begin(),
-                           [](const unsigned char c) { return static_cast<char>(std::tolower(c)); });
-            return extension == ".ply";
-        }
-
-        // Same renderer-ready guard as SceneManager's single-PLY load. Sequence
-        // playback binds one visible vulkan-external node through vksplat, so q16
-        // is safe here; skip (keep fp32) when interop storage is unavailable.
-        void quantizeViewerLoadedPlyShN(const std::filesystem::path& path,
-                                        lfs::core::SplatData& model) {
-            if (!isPlyPath(path)) {
-                return;
-            }
-            if (model.shN_value_quantized() ||
-                !model.shN_raw().is_valid() || model.shN_raw().numel() == 0) {
-                return;
-            }
-            if (!model.has_tensor_allocator() || !lfs::io::splatTensorsRendererReady(model)) {
-                LOG_WARN("Viewer PLY SH q16 skipped for '{}': Vulkan-external storage is unavailable or degraded",
-                         lfs::core::path_to_utf8(path));
-                return;
-            }
-
-            const std::size_t shN_before_bytes = model.shN_raw().bytes();
-            bool converted = false;
-            try {
-                converted = lfs::training::sh_value::apply_shN_value_quant(model);
-            } catch (const std::exception& e) {
-                LOG_WARN("Viewer PLY SH q16 failed for '{}'; retaining fp32 SH: {}",
-                         lfs::core::path_to_utf8(path), e.what());
-                return;
-            }
-            if (!converted) {
-                return;
-            }
-            if (!model.shN_value_quantized() || !lfs::io::splatTensorsRendererReady(model)) {
-                throw std::runtime_error(
-                    "Viewer PLY SH q16 produced a non-bindable codes/bounds pair");
-            }
-
-            const std::size_t shN_after_bytes =
-                model.shN_raw().bytes() + model.shN_value_bounds().bytes();
-            LOG_INFO(
-                "Viewer PLY SH q16: path='{}' gaussians={} before_bytes={} after_bytes={} saved_mib={:.3f}",
-                lfs::core::path_to_utf8(path), model.size(), shN_before_bytes, shN_after_bytes,
-                static_cast<double>(shN_before_bytes - shN_after_bytes) / (1024.0 * 1024.0));
         }
 
     } // namespace

--- a/src/visualizer/gui/sequencer_ui_manager.cpp
+++ b/src/visualizer/gui/sequencer_ui_manager.cpp
@@ -18,6 +18,7 @@
 #include "gui/utils/native_file_dialog.hpp"
 #include "io/loader.hpp"
 #include "io/video/video_export_options.hpp"
+#include "lfs/training/sh_value_storage.hpp"
 #include "rendering/coordinate_conventions.hpp"
 #include "rendering/rendering.hpp"
 #include "rendering/rendering_manager.hpp"
@@ -241,6 +242,56 @@ namespace lfs::vis::gui {
                 return false;
             }
             return true;
+        }
+
+        [[nodiscard]] bool isPlyPath(const std::filesystem::path& path) {
+            auto extension = path.extension().string();
+            std::transform(extension.begin(), extension.end(), extension.begin(),
+                           [](const unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            return extension == ".ply";
+        }
+
+        // Same renderer-ready guard as SceneManager's single-PLY load. Sequence
+        // playback binds one visible vulkan-external node through vksplat, so q16
+        // is safe here; skip (keep fp32) when interop storage is unavailable.
+        void quantizeViewerLoadedPlyShN(const std::filesystem::path& path,
+                                        lfs::core::SplatData& model) {
+            if (!isPlyPath(path)) {
+                return;
+            }
+            if (model.shN_value_quantized() ||
+                !model.shN_raw().is_valid() || model.shN_raw().numel() == 0) {
+                return;
+            }
+            if (!model.has_tensor_allocator() || !lfs::io::splatTensorsRendererReady(model)) {
+                LOG_WARN("Viewer PLY SH q16 skipped for '{}': Vulkan-external storage is unavailable or degraded",
+                         lfs::core::path_to_utf8(path));
+                return;
+            }
+
+            const std::size_t shN_before_bytes = model.shN_raw().bytes();
+            bool converted = false;
+            try {
+                converted = lfs::training::sh_value::apply_shN_value_quant(model);
+            } catch (const std::exception& e) {
+                LOG_WARN("Viewer PLY SH q16 failed for '{}'; retaining fp32 SH: {}",
+                         lfs::core::path_to_utf8(path), e.what());
+                return;
+            }
+            if (!converted) {
+                return;
+            }
+            if (!model.shN_value_quantized() || !lfs::io::splatTensorsRendererReady(model)) {
+                throw std::runtime_error(
+                    "Viewer PLY SH q16 produced a non-bindable codes/bounds pair");
+            }
+
+            const std::size_t shN_after_bytes =
+                model.shN_raw().bytes() + model.shN_value_bounds().bytes();
+            LOG_INFO(
+                "Viewer PLY SH q16: path='{}' gaussians={} before_bytes={} after_bytes={} saved_mib={:.3f}",
+                lfs::core::path_to_utf8(path), model.size(), shN_before_bytes, shN_after_bytes,
+                static_cast<double>(shN_before_bytes - shN_after_bytes) / (1024.0 * 1024.0));
         }
 
     } // namespace
@@ -820,10 +871,16 @@ namespace lfs::vis::gui {
                                   write_error);
                     }
                 }
+                // Cache deserialize always materializes fp32 swizzled shN; quantize
+                // after both hit and miss so resident frames (up to 64) stay q16.
+                quantizeViewerLoadedPlyShN(path, *completed.model);
             } catch (const lfs::io::LoadCancelledError& e) {
                 completed.cancelled = true;
                 completed.error = e.what();
             } catch (const std::exception& e) {
+                // Quantize can throw after the model is assigned. Drain installs
+                // any non-null model, so drop it rather than bind a broken q16 pair.
+                completed.model.reset();
                 completed.error = e.what();
             }
 

--- a/src/visualizer/gui_capabilities.cpp
+++ b/src/visualizer/gui_capabilities.cpp
@@ -18,6 +18,7 @@
 #include "visualizer/scene_coordinate_utils.hpp"
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/euler_angles.hpp>
@@ -1053,6 +1054,45 @@ namespace lfs::vis::cap {
         } else {
             shape_dims[0] = indices.size();
         }
+
+        if (is_shN && field->dtype() != core::DataType::Float32) {
+            core::Tensor canon = node->model->shN_canonical();
+            const auto index_tensor = core::Tensor::from_vector(indices, {indices.size()}, canon.device());
+            const auto src_tensor = core::Tensor::from_vector(
+                values, core::TensorShape(shape_dims), canon.device());
+            core::Tensor before_rows = canon.index_select(0, index_tensor).contiguous();
+            canon.index_copy_(0, index_tensor, src_tensor);
+            node->model->shN_set_from_canonical(canon, node->model->means().capacity());
+            scene.markPayloadDiverged(node->id);
+
+            const auto before_host = before_rows.cpu().contiguous();
+            const auto after_host = src_tensor.cpu().contiguous();
+            const bool rows_differ =
+                before_host.bytes() != after_host.bytes() ||
+                (before_host.bytes() > 0 &&
+                 std::memcmp(before_host.data_ptr(), after_host.data_ptr(), before_host.bytes()) != 0);
+            if (rows_differ) {
+                vis::op::undoHistory().push(std::make_unique<vis::op::ShNCanonicalRowsUndoEntry>(
+                    "gaussians.write",
+                    vis::op::UndoMetadata{
+                        .id = "tensor.shN",
+                        .label = gaussian_field_label(canonical_field_name),
+                        .source = "mcp",
+                        .scope = "tensor",
+                    },
+                    node_name,
+                    index_tensor.clone(),
+                    std::move(before_rows),
+                    src_tensor.clone(),
+                    &scene_manager));
+            }
+
+            scene.notifyMutation(core::Scene::MutationType::MODEL_CHANGED);
+            if (rendering_manager)
+                rendering_manager->markDirty(vis::DirtyFlag::SPLATS | vis::DirtyFlag::OVERLAY);
+            return {};
+        }
+
         const auto before = field->clone();
 
         const auto index_tensor = core::Tensor::from_vector(indices, {indices.size()}, field->device());

--- a/src/visualizer/operation/undo_entry.cpp
+++ b/src/visualizer/operation/undo_entry.cpp
@@ -6,6 +6,7 @@
 #include "core/events.hpp"
 #include "core/logger.hpp"
 #include "core/scene.hpp"
+#include "core/splat_data.hpp"
 #include "python/python_runtime.hpp"
 #include "rendering/rendering_manager.hpp"
 #include "rendering/vulkan_external_tensor.hpp"
@@ -2246,6 +2247,131 @@ namespace lfs::vis::op {
     }
 
     DirtyMask TensorUndoEntry::dirtyFlags() const {
+        return DirtyFlag::SPLATS;
+    }
+
+    ShNCanonicalRowsUndoEntry::ShNCanonicalRowsUndoEntry(std::string name,
+                                                         UndoMetadata metadata,
+                                                         std::string node_name,
+                                                         lfs::core::Tensor indices,
+                                                         lfs::core::Tensor before_rows,
+                                                         lfs::core::Tensor after_rows,
+                                                         SceneManager* scene)
+        : name_(std::move(name)),
+          metadata_(std::move(metadata)),
+          node_name_(std::move(node_name)),
+          scene_(scene),
+          indices_(std::move(indices)),
+          before_rows_(std::move(before_rows)),
+          after_rows_(std::move(after_rows)) {
+        if (scene_) {
+            expected_topology_ =
+                captureTopologyProof(
+                    scene_->getScene());
+        }
+        if (!metadata_.label.size()) {
+            metadata_.label = name_;
+        }
+        if (before_rows_.is_valid()) {
+            preferred_device_ = before_rows_.device();
+        } else if (after_rows_.is_valid()) {
+            preferred_device_ = after_rows_.device();
+        } else if (indices_.is_valid()) {
+            preferred_device_ = indices_.device();
+        }
+    }
+
+    size_t ShNCanonicalRowsUndoEntry::estimatedBytes() const {
+        return tensorBytes(indices_) + tensorBytes(before_rows_) + tensorBytes(after_rows_);
+    }
+
+    UndoMemoryBreakdown ShNCanonicalRowsUndoEntry::memoryBreakdown() const {
+        UndoMemoryBreakdown total;
+        total += tensorMemory(indices_);
+        total += tensorMemory(before_rows_);
+        total += tensorMemory(after_rows_);
+        return total;
+    }
+
+    void ShNCanonicalRowsUndoEntry::offloadToCPU() {
+        offloadTensor(indices_);
+        offloadTensor(before_rows_);
+        offloadTensor(after_rows_);
+    }
+
+    void ShNCanonicalRowsUndoEntry::restoreToPreferredDevice() {
+        restoreTensorToDevice(indices_, preferred_device_);
+        restoreTensorToDevice(before_rows_, preferred_device_);
+        restoreTensorToDevice(after_rows_, preferred_device_);
+    }
+
+    void ShNCanonicalRowsUndoEntry::apply(const lfs::core::Tensor& rows) {
+        if (scene_ && expected_topology_) {
+            requireTopologyProof(
+                scene_->getScene(),
+                *expected_topology_, name_);
+        }
+        if (!scene_) {
+            throw std::runtime_error("Missing tensor target for undo entry '" + node_name_ + ".shN'");
+        }
+        auto* node = scene_->getScene().getMutableNode(node_name_);
+        if (!node || !node->model) {
+            throw std::runtime_error("Missing tensor target for undo entry '" + node_name_ + ".shN'");
+        }
+        auto& model = *node->model;
+        if (!model.shN_raw().is_valid() || model.shN_raw().numel() == 0) {
+            throw std::runtime_error("Incompatible tensor target for undo entry '" + node_name_ + ".shN'");
+        }
+        if (!rows.is_valid() || rows.ndim() < 2) {
+            throw std::runtime_error("Incompatible tensor target for undo entry '" + node_name_ + ".shN'");
+        }
+        const size_t K = rows.size(1);
+        if (model.max_sh_coeffs_rest() != K) {
+            throw std::runtime_error("Incompatible tensor target for undo entry '" + node_name_ + ".shN'");
+        }
+        if (!indices_.is_valid()) {
+            throw std::runtime_error("Incompatible tensor target for undo entry '" + node_name_ + ".shN'");
+        }
+        const auto idx_cpu = indices_.cpu().contiguous();
+        const int* const idx_ptr = idx_cpu.ptr<int>();
+        const size_t n_idx = idx_cpu.numel();
+        const size_t model_size = model.size();
+        for (size_t i = 0; i < n_idx; ++i) {
+            if (static_cast<size_t>(idx_ptr[i]) >= model_size) {
+                throw std::runtime_error("Incompatible tensor target for undo entry '" + node_name_ + ".shN'");
+            }
+        }
+
+        lfs::core::Tensor canon = model.shN_canonical();
+        lfs::core::Tensor idx = indices_;
+        if (idx.device() != canon.device()) {
+            idx = idx.to(canon.device());
+        }
+        if (idx.dtype() != lfs::core::DataType::Int32) {
+            idx = idx.to(lfs::core::DataType::Int32);
+        }
+        lfs::core::Tensor src = rows;
+        if (src.device() != canon.device()) {
+            src = src.to(canon.device());
+        }
+        canon.index_copy_(0, idx, src);
+        model.shN_set_from_canonical(canon, model.means().capacity());
+        if (scene_) {
+            expected_topology_ =
+                captureTopologyProof(
+                    scene_->getScene());
+        }
+    }
+
+    void ShNCanonicalRowsUndoEntry::undo() {
+        apply(before_rows_);
+    }
+
+    void ShNCanonicalRowsUndoEntry::redo() {
+        apply(after_rows_);
+    }
+
+    DirtyMask ShNCanonicalRowsUndoEntry::dirtyFlags() const {
         return DirtyFlag::SPLATS;
     }
 

--- a/src/visualizer/operation/undo_entry.cpp
+++ b/src/visualizer/operation/undo_entry.cpp
@@ -2306,13 +2306,13 @@ namespace lfs::vis::op {
     }
 
     void ShNCanonicalRowsUndoEntry::apply(const lfs::core::Tensor& rows) {
-        if (scene_ && expected_topology_) {
+        if (!scene_) {
+            throw std::runtime_error("Missing tensor target for undo entry '" + node_name_ + ".shN'");
+        }
+        if (expected_topology_) {
             requireTopologyProof(
                 scene_->getScene(),
                 *expected_topology_, name_);
-        }
-        if (!scene_) {
-            throw std::runtime_error("Missing tensor target for undo entry '" + node_name_ + ".shN'");
         }
         auto* node = scene_->getScene().getMutableNode(node_name_);
         if (!node || !node->model) {
@@ -2356,11 +2356,9 @@ namespace lfs::vis::op {
         }
         canon.index_copy_(0, idx, src);
         model.shN_set_from_canonical(canon, model.means().capacity());
-        if (scene_) {
-            expected_topology_ =
-                captureTopologyProof(
-                    scene_->getScene());
-        }
+        expected_topology_ =
+            captureTopologyProof(
+                scene_->getScene());
     }
 
     void ShNCanonicalRowsUndoEntry::undo() {

--- a/src/visualizer/operation/undo_entry.hpp
+++ b/src/visualizer/operation/undo_entry.hpp
@@ -282,6 +282,40 @@ namespace lfs::vis::op {
             expected_topology_;
     };
 
+    class LFS_VIS_API ShNCanonicalRowsUndoEntry : public UndoEntry {
+    public:
+        ShNCanonicalRowsUndoEntry(std::string name,
+                                  UndoMetadata metadata,
+                                  std::string node_name,
+                                  lfs::core::Tensor indices,
+                                  lfs::core::Tensor before_rows,
+                                  lfs::core::Tensor after_rows,
+                                  SceneManager* scene);
+
+        void undo() override;
+        void redo() override;
+        [[nodiscard]] std::string name() const override { return name_; }
+        [[nodiscard]] UndoMetadata metadata() const override { return metadata_; }
+        [[nodiscard]] size_t estimatedBytes() const override;
+        [[nodiscard]] UndoMemoryBreakdown memoryBreakdown() const override;
+        void offloadToCPU() override;
+        void restoreToPreferredDevice() override;
+        [[nodiscard]] DirtyMask dirtyFlags() const override;
+
+    private:
+        void apply(const lfs::core::Tensor& rows);
+
+        std::string name_;
+        UndoMetadata metadata_;
+        std::string node_name_;
+        SceneManager* scene_ = nullptr;
+        lfs::core::Tensor indices_;
+        lfs::core::Tensor before_rows_;
+        lfs::core::Tensor after_rows_;
+        lfs::core::Device preferred_device_ = lfs::core::Device::CUDA;
+        std::optional<SceneTopologyProof> expected_topology_;
+    };
+
     class LFS_VIS_API CropBoxUndoEntry : public UndoEntry {
     public:
         CropBoxUndoEntry(SceneManager& scene,

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -18,13 +18,13 @@
 #include "io/cache_image_loader.hpp"
 #include "io/formats/colmap.hpp"
 #include "io/loader.hpp"
-#include "lfs/training/sh_value_storage.hpp"
 #include "operation/undo_entry.hpp"
 #include "operation/undo_history.hpp"
 #include "python/python_runtime.hpp"
 #include "rendering/coordinate_conventions.hpp"
 #include "rendering/rendering_manager.hpp"
 #include "rendering/vulkan_external_tensor.hpp"
+#include "scene/viewer_splat_quantize.hpp"
 #include "tools/unified_tool_registry.hpp"
 #include "training/checkpoint.hpp"
 #include "training/components/ppisp.hpp"
@@ -57,66 +57,13 @@ namespace lfs::vis {
     namespace {
         constexpr float DEFAULT_VOXEL_SIZE = 0.01f;
 
-        [[nodiscard]] bool isPlyPath(const std::filesystem::path& path) {
-            std::string extension = path.extension().string();
-            std::ranges::transform(extension, extension.begin(), [](const unsigned char c) {
-                return static_cast<char>(std::tolower(c));
-            });
-            return extension == ".ply";
-        }
-
         void quantizeViewerLoadedPlyShN(const std::filesystem::path& path,
                                         lfs::io::LoadResult& load_result) {
-            if (!isPlyPath(path)) {
-                return;
-            }
-
             auto* loaded = std::get_if<std::shared_ptr<lfs::core::SplatData>>(&load_result.data);
             if (!loaded || !*loaded) {
                 return;
             }
-
-            auto& model = **loaded;
-            if (model.shN_value_quantized() ||
-                !model.shN_raw().is_valid() || model.shN_raw().numel() == 0) {
-                return;
-            }
-
-            // Static viewer PLYs are only rewritten when every live parameter already has
-            // the exact storage kind vksplat can bind. In degraded/non-interop mode, retain
-            // the loader's fp32 representation instead of creating an unbindable q16 pair.
-            if (!model.has_tensor_allocator() || !lfs::io::splatTensorsRendererReady(model)) {
-                LOG_WARN("Viewer PLY SH q16 skipped for '{}': Vulkan-external storage is unavailable or degraded",
-                         lfs::core::path_to_utf8(path));
-                return;
-            }
-
-            const std::size_t shN_before_bytes = model.shN_raw().bytes();
-            bool converted = false;
-            try {
-                converted = lfs::training::sh_value::apply_shN_value_quant(model);
-            } catch (const std::exception& e) {
-                // Allocation/codec failure leaves the source tensor live; preserve the
-                // established fp32 load path rather than turning an optimization into a
-                // viewer load failure.
-                LOG_WARN("Viewer PLY SH q16 failed for '{}'; retaining fp32 SH: {}",
-                         lfs::core::path_to_utf8(path), e.what());
-                return;
-            }
-            if (!converted) {
-                return;
-            }
-            if (!model.shN_value_quantized() || !lfs::io::splatTensorsRendererReady(model)) {
-                throw std::runtime_error(
-                    "Viewer PLY SH q16 produced a non-bindable codes/bounds pair");
-            }
-
-            const std::size_t shN_after_bytes =
-                model.shN_raw().bytes() + model.shN_value_bounds().bytes();
-            LOG_INFO(
-                "Viewer PLY SH q16: path='{}' gaussians={} before_bytes={} after_bytes={} saved_mib={:.3f}",
-                lfs::core::path_to_utf8(path), model.size(), shN_before_bytes, shN_after_bytes,
-                static_cast<double>(shN_before_bytes - shN_after_bytes) / (1024.0 * 1024.0));
+            lfs::vis::quantizeViewerLoadedPlyShN(path, **loaded);
         }
 
         void clearMeshCpuCache();

--- a/src/visualizer/scene/viewer_splat_quantize.cpp
+++ b/src/visualizer/scene/viewer_splat_quantize.cpp
@@ -63,7 +63,8 @@ namespace lfs::vis {
         LOG_INFO(
             "Viewer PLY SH q16: path='{}' gaussians={} before_bytes={} after_bytes={} saved_mib={:.3f}",
             lfs::core::path_to_utf8(path), model.size(), shN_before_bytes, shN_after_bytes,
-            static_cast<double>(shN_before_bytes - shN_after_bytes) / (1024.0 * 1024.0));
+            (static_cast<double>(shN_before_bytes) - static_cast<double>(shN_after_bytes)) /
+                (1024.0 * 1024.0));
     }
 
 } // namespace lfs::vis

--- a/src/visualizer/scene/viewer_splat_quantize.cpp
+++ b/src/visualizer/scene/viewer_splat_quantize.cpp
@@ -1,0 +1,69 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "scene/viewer_splat_quantize.hpp"
+
+#include "core/logger.hpp"
+#include "core/path_utils.hpp"
+#include "core/splat_data.hpp"
+#include "io/loader.hpp"
+#include "lfs/training/sh_value_storage.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <stdexcept>
+
+namespace lfs::vis {
+    namespace {
+
+        [[nodiscard]] bool isPlyPath(const std::filesystem::path& path) {
+            auto extension = path.extension().string();
+            std::transform(extension.begin(), extension.end(), extension.begin(),
+                           [](const unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            return extension == ".ply";
+        }
+
+    } // namespace
+
+    void quantizeViewerLoadedPlyShN(const std::filesystem::path& path,
+                                    lfs::core::SplatData& model) {
+        if (!isPlyPath(path)) {
+            return;
+        }
+        if (model.shN_value_quantized() ||
+            !model.shN_raw().is_valid() || model.shN_raw().numel() == 0) {
+            return;
+        }
+        if (!model.has_tensor_allocator() || !lfs::io::splatTensorsRendererReady(model)) {
+            LOG_WARN("Viewer PLY SH q16 skipped for '{}': Vulkan-external storage is unavailable or degraded",
+                     lfs::core::path_to_utf8(path));
+            return;
+        }
+
+        const std::size_t shN_before_bytes = model.shN_raw().bytes();
+        bool converted = false;
+        try {
+            converted = lfs::training::sh_value::apply_shN_value_quant(model);
+        } catch (const std::exception& e) {
+            LOG_WARN("Viewer PLY SH q16 failed for '{}'; retaining fp32 SH: {}",
+                     lfs::core::path_to_utf8(path), e.what());
+            return;
+        }
+        if (!converted) {
+            return;
+        }
+        if (!model.shN_value_quantized() || !lfs::io::splatTensorsRendererReady(model)) {
+            throw std::runtime_error(
+                "Viewer PLY SH q16 produced a non-bindable codes/bounds pair");
+        }
+
+        const std::size_t shN_after_bytes =
+            model.shN_raw().bytes() + model.shN_value_bounds().bytes();
+        LOG_INFO(
+            "Viewer PLY SH q16: path='{}' gaussians={} before_bytes={} after_bytes={} saved_mib={:.3f}",
+            lfs::core::path_to_utf8(path), model.size(), shN_before_bytes, shN_after_bytes,
+            static_cast<double>(shN_before_bytes - shN_after_bytes) / (1024.0 * 1024.0));
+    }
+
+} // namespace lfs::vis

--- a/src/visualizer/scene/viewer_splat_quantize.hpp
+++ b/src/visualizer/scene/viewer_splat_quantize.hpp
@@ -1,0 +1,17 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include <filesystem>
+
+namespace lfs::core {
+    class SplatData;
+}
+
+namespace lfs::vis {
+
+    void quantizeViewerLoadedPlyShN(const std::filesystem::path& path, lfs::core::SplatData& model);
+
+} // namespace lfs::vis

--- a/tests/python/test_scene.py
+++ b/tests/python/test_scene.py
@@ -78,6 +78,18 @@ class TestSplatDataAfterLoad:
         # DC is (N, 1, 3) typically
         assert features_dc.shape[2] == 3
 
+    @pytest.mark.slow
+    def test_reserve_capacity_grows_plain_splat(self, loaded_splat):
+        """Plain (non-interop) SplatData can reserve extra capacity."""
+        n = loaded_splat.num_points
+        loaded_splat.reserve_capacity(n + 1024)
+        assert loaded_splat.num_points == n
+        assert loaded_splat.means_raw.shape[0] == n
+
+        # Renderer-backed (vulkan_external_buffer / splat.exportable) models
+        # must raise from Python. That assertion needs the GUI app and is
+        # skipped here.
+
 
 class TestTensorOperations:
     """Tests for tensor operations within scene context."""

--- a/tests/python/test_tensor_bridges.py
+++ b/tests/python/test_tensor_bridges.py
@@ -59,6 +59,18 @@ class TestFromDlpack:
         with pytest.raises(RuntimeError, match="contiguous"):
             lf.Tensor.from_dlpack(producer)
 
+    def test_empty_sliced_view_roundtrip(self, lf, numpy):
+        base = numpy.arange(12, dtype=numpy.float32).reshape(3, 4)
+        view = base[:, ::2][:, :0]
+        if not hasattr(view, "__dlpack__"):
+            pytest.skip("numpy cannot export an empty sliced DLPack producer")
+        try:
+            view.__dlpack__()
+        except Exception:
+            pytest.skip("numpy cannot export an empty sliced DLPack producer")
+        tensor = lf.Tensor.from_dlpack(view)
+        numpy.testing.assert_array_equal(tensor.numpy(), numpy.ascontiguousarray(view))
+
 
 class TestAddSplatDtype:
     def test_float16_shn_raises(self, lf):

--- a/tests/python/test_tensor_bridges.py
+++ b/tests/python/test_tensor_bridges.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Bridge correctness for Tensor.from_numpy, from_dlpack, and Scene.add_splat."""
+
+import pytest
+
+
+def _noncontiguous_dlpack_producer(numpy):
+    """Return an object whose __dlpack__ exports a non-contiguous layout.
+
+    Prefers a transposed NumPy array when that producer can actually emit a
+    capsule. Falls back to torch, then skips.
+    """
+    base = numpy.arange(12, dtype=numpy.float32).reshape(3, 4)
+    view = base.T
+    if hasattr(view, "__dlpack__"):
+        try:
+            view.__dlpack__()
+            return view
+        except Exception:
+            pass
+
+    torch = pytest.importorskip(
+        "torch",
+        reason="numpy cannot export a non-contiguous DLPack producer and torch is unavailable",
+    )
+    return torch.from_numpy(view)
+
+
+class TestFromNumpy:
+    def test_contiguous_roundtrip(self, lf, numpy):
+        arr = numpy.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=numpy.float32)
+        tensor = lf.Tensor.from_numpy(arr)
+        numpy.testing.assert_array_equal(tensor.numpy(), arr)
+
+    def test_strided_slice_raises(self, lf, numpy):
+        arr = numpy.arange(12, dtype=numpy.float32).reshape(3, 4)
+        view = arr[:, ::2]
+        with pytest.raises(RuntimeError, match="contiguous"):
+            lf.Tensor.from_numpy(view)
+
+    def test_copy_false_raises(self, lf, numpy):
+        arr = numpy.array([1.0, 2.0, 3.0], dtype=numpy.float32)
+        with pytest.raises(RuntimeError, match="copy"):
+            lf.Tensor.from_numpy(arr, copy=False)
+
+
+class TestFromDlpack:
+    def test_contiguous_roundtrip(self, lf, numpy):
+        arr = numpy.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=numpy.float32)
+        if hasattr(arr, "__dlpack__"):
+            tensor = lf.Tensor.from_dlpack(arr)
+        else:
+            tensor = lf.Tensor.from_dlpack(lf.Tensor.from_numpy(arr))
+        numpy.testing.assert_array_equal(tensor.numpy(), arr)
+
+    def test_noncontiguous_raises(self, lf, numpy):
+        producer = _noncontiguous_dlpack_producer(numpy)
+        with pytest.raises(RuntimeError, match="contiguous"):
+            lf.Tensor.from_dlpack(producer)
+
+
+class TestAddSplatDtype:
+    def test_float16_shn_raises(self, lf):
+        scene = lf.get_scene()
+        if scene is None or not scene.is_valid():
+            pytest.skip("Scene not available")
+
+        n = 1
+        means = lf.Tensor.zeros([n, 3], device="cpu", dtype="float32")
+        sh0 = lf.Tensor.zeros([n, 1, 3], device="cpu", dtype="float32")
+        shN = lf.Tensor.zeros([n, 3, 3], device="cpu", dtype="float16")
+        scaling = lf.Tensor.zeros([n, 3], device="cpu", dtype="float32")
+        rotation = lf.Tensor.zeros([n, 4], device="cpu", dtype="float32")
+        opacity = lf.Tensor.zeros([n, 1], device="cpu", dtype="float32")
+        with pytest.raises(RuntimeError, match="shN"):
+            scene.add_splat(
+                "bad_shn",
+                means,
+                sh0,
+                shN,
+                scaling,
+                rotation,
+                opacity,
+                sh_degree=1,
+            )

--- a/tests/python/test_typed_errors.py
+++ b/tests/python/test_typed_errors.py
@@ -203,7 +203,8 @@ class TestDlpackNarrowing:
                 raise RuntimeError("legacy-zero-arg-reached")
 
             def __dlpack_device__(self):
-                return (1, 0)
+                # kDLCUDA: stream handshake then TypeError retry.
+                return (2, 0)
 
         producer = TypeErrorProducer()
         with pytest.raises(RuntimeError, match="legacy-zero-arg-reached"):
@@ -222,9 +223,29 @@ class TestDlpackNarrowing:
                 raise ValueError("producer-bug")
 
             def __dlpack_device__(self):
+                # kDLCPU: single zero-arg call, no stream handshake.
                 return (1, 0)
 
         producer = ValueErrorProducer()
         with pytest.raises(ValueError, match="producer-bug"):
             lf.Tensor.from_dlpack(producer)
         assert len(producer.calls) == 1
+        assert producer.calls[0] is None
+
+    def test_cpu_producer_gets_no_stream(self, lf):
+        class CpuProducer:
+            def __init__(self):
+                self.calls = []
+
+            def __dlpack__(self, stream=None):
+                self.calls.append(stream)
+                raise RuntimeError("cpu-zero-arg-only")
+
+            def __dlpack_device__(self):
+                return (1, 0)
+
+        producer = CpuProducer()
+        with pytest.raises(RuntimeError, match="cpu-zero-arg-only"):
+            lf.Tensor.from_dlpack(producer)
+        assert len(producer.calls) == 1
+        assert producer.calls[0] is None

--- a/tests/test_splat_data_clone.cpp
+++ b/tests/test_splat_data_clone.cpp
@@ -201,12 +201,7 @@ TEST(SplatDataCloneTest, WritebackClearsQ16Pair) {
     sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
 }
 
-TEST(SplatDataCloneTest, ReserveCapacitySkipsRendererStorage) {
-    // Tensor::set_external_storage_kind is not a public hook; do not invent one.
-    // Real vulkan_external_buffer / splat.exportable growth is owned by
-    // capacity_ensure/migrate (grow_direct skips those kinds). Assert the
-    // intended cuda.direct rebuild instead: capacity grows, values survive.
-
+TEST(SplatDataCloneTest, ReserveCapacityRebuildsCudaDirect) {
     const size_t n = 64;
     auto means = Tensor::zeros_direct({n, size_t{3}}, n, Device::CUDA, DataType::Float32);
     auto sh0 = Tensor::zeros_direct({n, size_t{1}, size_t{3}}, n, Device::CUDA, DataType::Float32);
@@ -234,4 +229,52 @@ TEST(SplatDataCloneTest, ReserveCapacitySkipsRendererStorage) {
     EXPECT_EQ(model.means().external_storage_kind(), "cuda.direct");
     EXPECT_TRUE(tensors_equal(model.means(), means_before));
     EXPECT_TRUE(tensors_equal(model.shN_canonical(), shN_before));
+}
+
+TEST(SplatDataCloneTest, ReserveCapacitySkipsRendererStorage) {
+    sh_value::set_sh_value_quant_enabled_for_testing(true);
+    auto model = make_random_sh3(kN);
+    ASSERT_TRUE(sh_value::apply_shN_value_quant(model));
+    ASSERT_TRUE(model.shN_value_quantized());
+
+    constexpr size_t kCap = 1024;
+    auto storage_result = SplatExportableStorage::create(kCap, kShDegree, /*device=*/0, kCap * 4);
+    if (!storage_result) {
+        GTEST_SKIP() << "exportable create failed: " << storage_result.error();
+    }
+    auto storage = std::make_shared<SplatExportableStorage>(std::move(*storage_result));
+
+    param::TrainingParameters params;
+    params.optimization.max_cap = static_cast<int>(kCap);
+    const auto result = migrateTrainingModelToAllocator(params, model, storage->make_allocator());
+    ASSERT_TRUE(result.has_value()) << result.error();
+
+    const auto means_kind = model.means().external_storage_kind();
+    const auto shN_kind = model.shN_raw().external_storage_kind();
+    ASSERT_TRUE(means_kind == "splat.exportable" || means_kind == "vulkan_external_buffer")
+        << "means kind=" << means_kind;
+    ASSERT_TRUE(shN_kind == "splat.exportable" || shN_kind == "vulkan_external_buffer")
+        << "shN kind=" << shN_kind;
+
+    const void* const means_ptr = model.means().data_ptr();
+    const void* const shN_ptr = model.shN_raw().data_ptr();
+    const size_t means_cap = model.means().capacity();
+    const size_t shN_cap = model.shN_raw().capacity();
+    const auto means_before = model.means().clone();
+    const auto shN_before = model.shN_canonical();
+
+    const size_t new_cap = std::max(means_cap, shN_cap) + 256;
+    model.reserve_capacity(new_cap);
+
+    EXPECT_EQ(model.means().data_ptr(), means_ptr);
+    EXPECT_EQ(model.shN_raw().data_ptr(), shN_ptr);
+    EXPECT_EQ(model.means().capacity(), means_cap);
+    EXPECT_EQ(model.shN_raw().capacity(), shN_cap);
+    EXPECT_EQ(model.means().external_storage_kind(), means_kind);
+    EXPECT_EQ(model.shN_raw().external_storage_kind(), shN_kind);
+    EXPECT_TRUE(model.shN_value_quantized());
+    EXPECT_TRUE(tensors_equal(model.means(), means_before));
+    EXPECT_TRUE(tensors_equal(model.shN_canonical(), shN_before));
+
+    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
 }

--- a/tests/test_splat_data_clone.cpp
+++ b/tests/test_splat_data_clone.cpp
@@ -8,6 +8,7 @@
 #include "lfs/training/sh_value_storage.hpp"
 #include "training/training_setup.hpp"
 
+#include <algorithm>
 #include <cstring>
 #include <gtest/gtest.h>
 #include <optional>
@@ -22,10 +23,21 @@ namespace {
     constexpr size_t kN = 600; // ≥ 2 q16 blocks
     constexpr int kShDegree = 3;
 
-    SplatData make_random_sh3(const size_t n, const uint32_t seed = 42) {
+    [[nodiscard]] size_t rest_coeffs_for_degree(const int sh_degree) {
+        if (sh_degree <= 0)
+            return 0;
+        if (sh_degree == 1)
+            return 3;
+        if (sh_degree == 2)
+            return 8;
+        return 15;
+    }
+
+    SplatData make_random_model(const size_t n, const int sh_degree, const uint32_t seed = 42) {
+        const size_t rest = rest_coeffs_for_degree(sh_degree);
         auto means = Tensor::zeros({n, size_t{3}}, Device::CUDA, DataType::Float32);
         auto sh0 = Tensor::zeros({n, size_t{1}, size_t{3}}, Device::CUDA, DataType::Float32);
-        auto shN_can = Tensor::zeros({n, size_t{15}, size_t{3}}, Device::CUDA, DataType::Float32);
+        auto shN_can = Tensor::zeros({n, rest, size_t{3}}, Device::CUDA, DataType::Float32);
         auto scaling = Tensor::zeros({n, size_t{3}}, Device::CUDA, DataType::Float32);
         auto rotation = Tensor::zeros({n, size_t{4}}, Device::CUDA, DataType::Float32);
         auto opacity = Tensor::zeros({n, size_t{1}}, Device::CUDA, DataType::Float32);
@@ -33,11 +45,13 @@ namespace {
         {
             std::mt19937 rng(seed);
             std::normal_distribution<float> nd(0.0f, 0.15f);
-            auto cpu = shN_can.cpu();
-            auto* p = cpu.ptr<float>();
-            for (size_t i = 0; i < n * 15 * 3; ++i)
-                p[i] = nd(rng);
-            shN_can = cpu.to(Device::CUDA);
+            if (rest > 0) {
+                auto cpu = shN_can.cpu();
+                auto* p = cpu.ptr<float>();
+                for (size_t i = 0; i < n * rest * 3; ++i)
+                    p[i] = nd(rng);
+                shN_can = cpu.to(Device::CUDA);
+            }
 
             auto rcpu = rotation.cpu();
             auto* r = rcpu.ptr<float>();
@@ -46,7 +60,11 @@ namespace {
             rotation = rcpu.to(Device::CUDA);
         }
 
-        return SplatData(kShDegree, means, sh0, shN_can, scaling, rotation, opacity, 1.0f);
+        return SplatData(sh_degree, means, sh0, shN_can, scaling, rotation, opacity, 1.0f);
+    }
+
+    SplatData make_random_sh3(const size_t n, const uint32_t seed = 42) {
+        return make_random_model(n, kShDegree, seed);
     }
 
     [[nodiscard]] bool tensors_equal(const Tensor& a, const Tensor& b) {
@@ -154,4 +172,66 @@ TEST(SplatDataCloneTest, Q16CloneMigratesToExportableAllocator) {
     EXPECT_TRUE(tensors_equal(copy.shN_canonical(), canonical_before));
 
     sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+}
+
+TEST(SplatDataCloneTest, WritebackClearsQ16Pair) {
+    sh_value::set_sh_value_quant_enabled_for_testing(true);
+
+    // Degree 2: q16 cell count equals ieee-f16 swizzle count. Degree 3 does not.
+    for (const int sh_degree : {2, 3}) {
+        auto model = make_random_model(kN, sh_degree);
+        ASSERT_TRUE(sh_value::apply_shN_value_quant(model)) << "degree=" << sh_degree;
+        ASSERT_TRUE(model.shN_value_quantized()) << "degree=" << sh_degree;
+
+        const auto captured = model.shN_canonical();
+        const size_t cap = model.means().is_valid()
+                               ? std::max(model.means().capacity(), static_cast<size_t>(model.size()))
+                               : static_cast<size_t>(model.size());
+        model.shN_set_from_canonical(captured, cap);
+
+        EXPECT_FALSE(model.shN_value_quantized()) << "degree=" << sh_degree;
+        EXPECT_TRUE(!model.shN_value_bounds().is_valid() ||
+                    model.shN_value_bounds().numel() == 0)
+            << "degree=" << sh_degree;
+        ASSERT_TRUE(model.shN().is_valid()) << "degree=" << sh_degree;
+        EXPECT_EQ(model.shN().dtype(), DataType::Float32) << "degree=" << sh_degree;
+        EXPECT_TRUE(tensors_equal(model.shN_canonical(), captured)) << "degree=" << sh_degree;
+    }
+
+    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+}
+
+TEST(SplatDataCloneTest, ReserveCapacitySkipsRendererStorage) {
+    // Tensor::set_external_storage_kind is not a public hook; do not invent one.
+    // Real vulkan_external_buffer / splat.exportable growth is owned by
+    // capacity_ensure/migrate (grow_direct skips those kinds). Assert the
+    // intended cuda.direct rebuild instead: capacity grows, values survive.
+
+    const size_t n = 64;
+    auto means = Tensor::zeros_direct({n, size_t{3}}, n, Device::CUDA, DataType::Float32);
+    auto sh0 = Tensor::zeros_direct({n, size_t{1}, size_t{3}}, n, Device::CUDA, DataType::Float32);
+    auto shN_can = Tensor::zeros_direct({n, size_t{15}, size_t{3}}, n, Device::CUDA, DataType::Float32);
+    auto scaling = Tensor::zeros_direct({n, size_t{3}}, n, Device::CUDA, DataType::Float32);
+    auto rotation = Tensor::zeros_direct({n, size_t{4}}, n, Device::CUDA, DataType::Float32);
+    auto opacity = Tensor::zeros_direct({n, size_t{1}}, n, Device::CUDA, DataType::Float32);
+    means.fill_(1.25f);
+    shN_can.fill_(0.05f);
+
+    auto model = SplatData(kShDegree, std::move(means), std::move(sh0), std::move(shN_can),
+                           std::move(scaling), std::move(rotation), std::move(opacity), 1.0f);
+    ASSERT_EQ(model.means().external_storage_kind(), "cuda.direct");
+    ASSERT_EQ(model.shN().external_storage_kind(), "cuda.direct");
+
+    const auto means_before = model.means().clone();
+    const auto shN_before = model.shN_canonical();
+    const size_t old_means_cap = model.means().capacity();
+    const size_t old_shN_cap = model.shN().capacity();
+    const size_t new_cap = old_means_cap + 256;
+    model.reserve_capacity(new_cap);
+
+    EXPECT_GE(model.means().capacity(), new_cap);
+    EXPECT_GT(model.shN().capacity(), old_shN_cap);
+    EXPECT_EQ(model.means().external_storage_kind(), "cuda.direct");
+    EXPECT_TRUE(tensors_equal(model.means(), means_before));
+    EXPECT_TRUE(tensors_equal(model.shN_canonical(), shN_before));
 }

--- a/tests/test_splat_data_clone.cpp
+++ b/tests/test_splat_data_clone.cpp
@@ -79,10 +79,18 @@ namespace {
         return std::memcmp(ac.data_ptr(), bc.data_ptr(), ac.bytes()) == 0;
     }
 
+    struct ShValueQuantGuard {
+        explicit ShValueQuantGuard(const bool enabled) {
+            sh_value::set_sh_value_quant_enabled_for_testing(enabled);
+        }
+        ~ShValueQuantGuard() {
+            sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+        }
+    };
 } // namespace
 
 TEST(SplatDataCloneTest, Q16CloneCarriesBounds) {
-    sh_value::set_sh_value_quant_enabled_for_testing(true);
+    const ShValueQuantGuard quant_guard{true};
     auto model = make_random_sh3(kN);
     ASSERT_TRUE(sh_value::apply_shN_value_quant(model));
     ASSERT_TRUE(model.shN_value_quantized());
@@ -106,12 +114,10 @@ TEST(SplatDataCloneTest, Q16CloneCarriesBounds) {
     EXPECT_NE(copy.means_raw().data_ptr(), src_means_ptr);
     copy.means_raw().fill_(123.0f);
     EXPECT_FLOAT_EQ(model.means_raw().cpu().ptr<float>()[0], src_mean0);
-
-    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
 }
 
 TEST(SplatDataCloneTest, Fp32CloneUnchangedBehavior) {
-    sh_value::set_sh_value_quant_enabled_for_testing(false);
+    const ShValueQuantGuard quant_guard{false};
     auto model = make_random_sh3(kN);
     ASSERT_FALSE(model.shN_value_quantized());
 
@@ -123,8 +129,6 @@ TEST(SplatDataCloneTest, Fp32CloneUnchangedBehavior) {
     EXPECT_NO_THROW(copy.set_active_sh_degree(1));
     EXPECT_NO_THROW(copy.set_active_sh_degree(3));
     EXPECT_TRUE(tensors_equal(copy.shN_canonical(), canonical_before));
-
-    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
 }
 
 TEST(SplatDataCloneTest, CloneCarriesDeletedMask) {
@@ -143,12 +147,10 @@ TEST(SplatDataCloneTest, CloneCarriesDeletedMask) {
     ASSERT_TRUE(copy.has_deleted_mask());
     EXPECT_EQ(copy.deleted_count(), model.deleted_count());
     EXPECT_EQ(copy.deleted().cpu().to_vector_bool(), model.deleted().cpu().to_vector_bool());
-
-    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
 }
 
 TEST(SplatDataCloneTest, Q16CloneMigratesToExportableAllocator) {
-    sh_value::set_sh_value_quant_enabled_for_testing(true);
+    const ShValueQuantGuard quant_guard{true};
     auto model = make_random_sh3(kN);
     ASSERT_TRUE(sh_value::apply_shN_value_quant(model));
     ASSERT_TRUE(model.shN_value_quantized());
@@ -170,12 +172,10 @@ TEST(SplatDataCloneTest, Q16CloneMigratesToExportableAllocator) {
     ASSERT_TRUE(result.has_value()) << result.error();
     EXPECT_TRUE(copy.shN_value_quantized());
     EXPECT_TRUE(tensors_equal(copy.shN_canonical(), canonical_before));
-
-    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
 }
 
 TEST(SplatDataCloneTest, WritebackClearsQ16Pair) {
-    sh_value::set_sh_value_quant_enabled_for_testing(true);
+    const ShValueQuantGuard quant_guard{true};
 
     // Degree 2: q16 cell count equals ieee-f16 swizzle count. Degree 3 does not.
     for (const int sh_degree : {2, 3}) {
@@ -197,8 +197,6 @@ TEST(SplatDataCloneTest, WritebackClearsQ16Pair) {
         EXPECT_EQ(model.shN().dtype(), DataType::Float32) << "degree=" << sh_degree;
         EXPECT_TRUE(tensors_equal(model.shN_canonical(), captured)) << "degree=" << sh_degree;
     }
-
-    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
 }
 
 TEST(SplatDataCloneTest, ReserveCapacityRebuildsCudaDirect) {
@@ -232,7 +230,7 @@ TEST(SplatDataCloneTest, ReserveCapacityRebuildsCudaDirect) {
 }
 
 TEST(SplatDataCloneTest, ReserveCapacitySkipsRendererStorage) {
-    sh_value::set_sh_value_quant_enabled_for_testing(true);
+    const ShValueQuantGuard quant_guard{true};
     auto model = make_random_sh3(kN);
     ASSERT_TRUE(sh_value::apply_shN_value_quant(model));
     ASSERT_TRUE(model.shN_value_quantized());
@@ -275,6 +273,4 @@ TEST(SplatDataCloneTest, ReserveCapacitySkipsRendererStorage) {
     EXPECT_TRUE(model.shN_value_quantized());
     EXPECT_TRUE(tensors_equal(model.means(), means_before));
     EXPECT_TRUE(tensors_equal(model.shN_canonical(), shN_before));
-
-    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
 }

--- a/tests/test_splat_simplify.cpp
+++ b/tests/test_splat_simplify.cpp
@@ -6,6 +6,8 @@
 #include "core/splat_simplify_history.hpp"
 #include "core/tensor.hpp"
 #include "io/formats/ply.hpp"
+#include "lfs/training/sh_value_codec.hpp"
+#include "lfs/training/sh_value_storage.hpp"
 
 #include <gtest/gtest.h>
 
@@ -1123,4 +1125,107 @@ TEST(SplatSimplify, RealPlySimplifyDoesNotUndershootRequestedTarget) {
     ASSERT_NE(*result, nullptr);
     EXPECT_EQ(source.size(), source_size_before);
     EXPECT_EQ((*result)->size(), target_count);
+}
+
+TEST(SplatSimplify, Q16DeletedMaskPreservesCanonicalSH) {
+    using lfs::training::sh_value::apply_shN_value_quant;
+    using lfs::training::sh_value::set_sh_value_quant_enabled_for_testing;
+
+    set_sh_value_quant_enabled_for_testing(true);
+
+    constexpr size_t kN = 64;
+    constexpr int kShDegree = 3;
+    constexpr size_t kRest = 15;
+
+    auto means = Tensor::zeros({kN, size_t{3}}, Device::CUDA, DataType::Float32);
+    auto sh0 = Tensor::zeros({kN, size_t{1}, size_t{3}}, Device::CUDA, DataType::Float32);
+    auto shN_can = Tensor::zeros({kN, kRest, size_t{3}}, Device::CUDA, DataType::Float32);
+    auto scaling = Tensor::zeros({kN, size_t{3}}, Device::CUDA, DataType::Float32);
+    auto rotation = Tensor::zeros({kN, size_t{4}}, Device::CUDA, DataType::Float32);
+    auto opacity = Tensor::zeros({kN, size_t{1}}, Device::CUDA, DataType::Float32);
+
+    {
+        auto means_cpu = means.cpu();
+        auto* m = means_cpu.ptr<float>();
+        for (size_t i = 0; i < kN; ++i) {
+            m[i * 3 + 0] = static_cast<float>(i) * 0.25f;
+        }
+        means = means_cpu.to(Device::CUDA);
+
+        auto shN_cpu = shN_can.cpu();
+        auto* p = shN_cpu.ptr<float>();
+        for (size_t i = 0; i < kN; ++i) {
+            for (size_t c = 0; c < kRest * 3; ++c)
+                p[i * kRest * 3 + c] = static_cast<float>(i) * 0.01f + static_cast<float>(c) * 0.001f;
+        }
+        shN_can = shN_cpu.to(Device::CUDA);
+
+        auto rot_cpu = rotation.cpu();
+        auto* r = rot_cpu.ptr<float>();
+        for (size_t i = 0; i < kN; ++i)
+            r[i * 4] = 1.0f;
+        rotation = rot_cpu.to(Device::CUDA);
+
+        opacity.fill_(2.0f);
+        scaling.fill_(std::log(0.1f));
+    }
+
+    auto source = std::make_unique<SplatData>(
+        kShDegree, means, sh0, shN_can, scaling, rotation, opacity, 1.0f);
+    source->set_active_sh_degree(kShDegree);
+    source->set_max_sh_degree(kShDegree);
+
+    const auto ref = source->shN_canonical().cpu().contiguous();
+    ASSERT_TRUE(apply_shN_value_quant(*source));
+    ASSERT_TRUE(source->shN_value_quantized());
+    ASSERT_EQ(source->shN_raw().dtype(), DataType::Float16);
+
+    std::vector<bool> deleted(kN, false);
+    deleted[1] = true;
+    deleted[17] = true;
+    deleted[63] = true;
+    source->deleted() = Tensor::from_vector(deleted, {deleted.size()}, Device::CPU).to(Device::CUDA);
+    source->refresh_deleted_count();
+    ASSERT_TRUE(source->has_deleted_mask());
+    ASSERT_EQ(source->deleted_count(), 3u);
+
+    SplatSimplifyOptions options;
+    options.ratio = 1.0;
+    options.opacity_prune_threshold = 0.0f;
+
+    auto result = lfs::core::simplify_splats(*source, options, {});
+    ASSERT_TRUE(result) << result.error();
+    ASSERT_NE(*result, nullptr);
+    ASSERT_EQ((*result)->size(), kN - 3);
+
+    const auto got = (*result)->shN_canonical().cpu().contiguous();
+    ASSERT_EQ(got.dtype(), DataType::Float32);
+    ASSERT_EQ(got.ndim(), 3u);
+    ASSERT_EQ(got.size(0), kN - 3);
+    ASSERT_EQ(got.size(1), kRest);
+    ASSERT_EQ(got.size(2), 3u);
+
+    const auto* refp = ref.ptr<float>();
+    const auto* gotp = got.ptr<float>();
+    constexpr size_t kRow = kRest * 3;
+    size_t out = 0;
+    float max_abs = 0.0f;
+    float max_mag = 0.0f;
+    for (size_t i = 0; i < kN; ++i) {
+        if (deleted[i])
+            continue;
+        for (size_t c = 0; c < kRow; ++c) {
+            const float expected = refp[i * kRow + c];
+            const float actual = gotp[out * kRow + c];
+            max_mag = std::max(max_mag, std::abs(expected));
+            max_abs = std::max(max_abs, std::abs(actual - expected));
+            EXPECT_NEAR(actual, expected, 0.05f) << "splat " << i << " coeff " << c;
+        }
+        ++out;
+    }
+    EXPECT_EQ(out, kN - 3);
+    EXPECT_LT(max_abs, 0.05f);
+    EXPECT_GT(max_mag, 0.01f);
+
+    set_sh_value_quant_enabled_for_testing(std::nullopt);
 }

--- a/tests/test_splat_simplify.cpp
+++ b/tests/test_splat_simplify.cpp
@@ -316,6 +316,15 @@ namespace {
             EXPECT_NEAR(actual[i], expected[i], tol);
     }
 
+    struct ShValueQuantGuard {
+        explicit ShValueQuantGuard(const bool enabled) {
+            lfs::training::sh_value::set_sh_value_quant_enabled_for_testing(enabled);
+        }
+        ~ShValueQuantGuard() {
+            lfs::training::sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+        }
+    };
+
 } // namespace
 
 TEST(SplatSimplify, TwoPointMergeMatchesReferenceMomentMatching) {
@@ -1129,9 +1138,8 @@ TEST(SplatSimplify, RealPlySimplifyDoesNotUndershootRequestedTarget) {
 
 TEST(SplatSimplify, Q16DeletedMaskPreservesCanonicalSH) {
     using lfs::training::sh_value::apply_shN_value_quant;
-    using lfs::training::sh_value::set_sh_value_quant_enabled_for_testing;
 
-    set_sh_value_quant_enabled_for_testing(true);
+    const ShValueQuantGuard quant_guard{true};
 
     constexpr size_t kN = 64;
     constexpr int kShDegree = 3;
@@ -1226,6 +1234,4 @@ TEST(SplatSimplify, Q16DeletedMaskPreservesCanonicalSH) {
     EXPECT_EQ(out, kN - 3);
     EXPECT_LT(max_abs, 0.05f);
     EXPECT_GT(max_mag, 0.01f);
-
-    set_sh_value_quant_enabled_for_testing(std::nullopt);
 }


### PR DESCRIPTION
Follow-up to #1618. A systematic audit of the compressed-SH storage from the speed/VRAM release found the remaining bugs of that family, plus independent Python bridge defects. All are fixed here with regression tests.

## The core bug: silent wrong colors at SH degree 2
At degree 2 the compressed layout and the plain-float layout have the exact same element count (24 per splat, both 16-bit), so size checks cannot tell them apart. The shared SH write-back routine reused the buffer and filled it with plain floats while the model still declared itself compressed — the renderer then decoded wrong bytes. **No error, just wrong colors**, from Mirror, transform bake, or scripted color edits. The routine now drops the compressed pair before any size check and installs plain floats. (Degrees 1/3 were losing the memory saving silently; also fixed.)

## Operations that failed on loaded PLYs
- **Simplify after a crop/delete** aborted with an internal type error.
- **Scripted color reads/writes** (`gaussians.read`/`write` of `shN`) threw on any loaded model.
Both now decode through the canonical form. Verified live: read, write, and zero round-trip on a 3.3M-splat model.

## Memory
- **PLY sequences** never compressed their color data — up to 64 full-size buffers resident. Frames now compress like single PLYs.
- **`reserve_capacity`** rebuilt renderer-owned buffers onto private memory, silently detaching the zero-copy path — and made the IGS+ preset duplicate the whole model (~584 MB) at training start. Renderer-backed tensors are now skipped; the Python API refuses with a clear error.

## Python bridges (independent finds)
- `Tensor.from_numpy` copied raw bytes from sliced/transposed arrays (silent garbage) and ignored its `copy` argument. Both rejected with clear errors now.
- `Tensor.from_dlpack` ignored producer strides, and passed a CUDA stream to CPU producers — `from_dlpack(numpy_array)` never worked. Fixed per DLPack spec (`__dlpack_device__` consulted first).
- `Scene.add_splat` with a float16 field now says which field must be float32 instead of an internal assert.

## Verification
- New tests: SH2 write-back round-trip, quantized simplify with deleted mask, capacity growth, all bridge contracts (26 Python tests green, 59 C++ q16-suite tests green).
- 280 tests across undo/scene-graph/stream/mask/provenance suites unchanged and green.
- Live GUI: delete/undo (#1616 regression), MCP shN read + write round-trip on a 3.3M-splat model.
- Sequence quantization: verify by loading a sequence and checking the per-frame `Viewer PLY SH q16` log line.

Not touched, deliberately: the memory-arena grow/teardown finding from the audit needs a runtime repro before any edit; the transform-bake q16 round-trip (now a loud error instead of silent corruption) remains a known follow-up.