### PR TITLE
Split build test fix from PR 1615

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,7 +614,9 @@ configure_file(
 )
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+    if(NOT MSVC)
+        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+    endif()
     set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -g -O0")
 endif()
 

--- a/src/visualizer/window/vulkan_image_barrier_tracker.hpp
+++ b/src/visualizer/window/vulkan_image_barrier_tracker.hpp
@@ -4,13 +4,15 @@
 
 #pragma once
 
+#include "core/export.hpp"
+
 #include <cstdint>
 #include <unordered_map>
 #include <vulkan/vulkan.h>
 
 namespace lfs::vis {
 
-    class VulkanImageBarrierTracker {
+    class LFS_VIS_API VulkanImageBarrierTracker {
     public:
         struct AccessScope {
             VkPipelineStageFlags2 stage = VK_PIPELINE_STAGE_2_NONE;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -503,9 +503,18 @@ target_link_libraries(lichtfeld_tests PRIVATE lfs_vulkan_rasterizer Vulkan::Vulk
 # Compiler options for CUDA debugging
 target_compile_options(lichtfeld_tests PRIVATE
     $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-lineinfo>
-    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
-    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
 )
+if(MSVC)
+    target_compile_options(lichtfeld_tests PRIVATE
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:/Od /Z7>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:/O2 /DNDEBUG>
+    )
+else()
+    target_compile_options(lichtfeld_tests PRIVATE
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
+    )
+endif()
 
 # Tensor-library hardening is intentionally isolated from the default test
 # tiers.  During the hardening phases these oracle tests are expected to expose
@@ -543,10 +552,17 @@ target_link_libraries(tensor_hardening_tests PRIVATE
     CUDA::curand
 )
 
-target_compile_options(tensor_hardening_tests PRIVATE
-    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
-    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
-)
+if(MSVC)
+    target_compile_options(tensor_hardening_tests PRIVATE
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:/Od /Z7>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:/O2 /DNDEBUG>
+    )
+else()
+    target_compile_options(tensor_hardening_tests PRIVATE
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
+    )
+endif()
 
 # =============================================================================
 # CTest registration

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -379,7 +379,8 @@ add_executable(lichtfeld_tests ${TEST_SOURCES})
 
 # USD (pxr) headers from vcpkg pull in deprecated <ext/hash_set> and emit
 # #warning (-Wcpp). Third-party; suppress only for this translation unit.
-set_source_files_properties(test_usd_format.cpp PROPERTIES COMPILE_OPTIONS "-Wno-cpp")
+set_source_files_properties(test_usd_format.cpp PROPERTIES
+    COMPILE_OPTIONS "$<$<CXX_COMPILER_FRONTEND_VARIANT:GNU>:-Wno-cpp>")
 
 # Python integration tests import the in-tree extension at runtime.
 add_dependencies(lichtfeld_tests lfs_py)


### PR DESCRIPTION
## Summary

This branch contains the two non-PLY changes that were removed from PR #1615
after maintainer review. They are kept together here so they can be reviewed as
a separate, focused build/test compatibility fix.

## Changes

- `CMakeLists.txt`
  - Avoids appending GNU-style C++ debug flags (`-g -O0`) when configuring
    with MSVC. CUDA debug flags remain unchanged.
- `tests/CMakeLists.txt`
  - Narrows the `test_usd_format.cpp` `-Wno-cpp` suppression to GNU-frontend
    compilers so MSVC does not receive an invalid warning flag.
  - Routes test C++ debug/release options by compiler:
    - MSVC gets `/Od /Z7` for Debug and `/O2 /DNDEBUG` for Release.
    - Non-MSVC builds keep `-O0 -g -fno-omit-frame-pointer` for Debug and
      `-O3 -DNDEBUG` for Release.
  - Applies that routing to both `lichtfeld_tests` and
    `tensor_hardening_tests`.
- `src/visualizer/window/vulkan_image_barrier_tracker.hpp`
  - Includes the export macro header.
  - Exports `VulkanImageBarrierTracker` with `LFS_VIS_API` for shared-library
    visibility.

## Why this was split

PR #1615 is intended to be a small PLY opacity import fix. MrNeRF requested
moving these unrelated build/visibility changes to their own PR.

## Verification

No tests were run as part of the split. This branch only preserves the already
identified build/test compatibility changes for separate review.
