### PR TITLE
Fix Windows test compilation and DLL linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,7 +619,9 @@ configure_file(
 )
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+    if(NOT MSVC)
+        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+    endif()
     set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -g -O0")
 endif()
 

--- a/src/visualizer/core/data_loading_service.hpp
+++ b/src/visualizer/core/data_loading_service.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include "core/events.hpp"
 #include "core/parameters.hpp"
 #include <expected>
@@ -17,7 +18,7 @@ namespace lfs::vis {
 
 namespace lfs::vis {
 
-    class DataLoadingService {
+    class LFS_VIS_API DataLoadingService {
     public:
         explicit DataLoadingService(SceneManager* scene_manager);
         ~DataLoadingService();

--- a/src/visualizer/core/main_loop.hpp
+++ b/src/visualizer/core/main_loop.hpp
@@ -4,12 +4,14 @@
 
 #pragma once
 
+#include "core/export.hpp"
+
 #include <exception>
 #include <functional>
 
 namespace lfs::vis {
 
-    class MainLoop {
+    class LFS_VIS_API MainLoop {
     public:
         using InitCallback = std::function<bool()>;
         using UpdateCallback = std::function<void()>;

--- a/src/visualizer/gui/editor/python_editor.hpp
+++ b/src/visualizer/gui/editor/python_editor.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "core/export.hpp"
+
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -80,7 +82,7 @@ namespace lfs::vis::editor {
             const PythonEditorWorkspaceSessionState&) = default;
     };
 
-    class PythonEditor {
+    class LFS_VIS_API PythonEditor {
     public:
         PythonEditor();
         ~PythonEditor();

--- a/src/visualizer/gui/sequencer_ui_manager.hpp
+++ b/src/visualizer/gui/sequencer_ui_manager.hpp
@@ -40,7 +40,7 @@ namespace lfs::vis {
 
     namespace gui {
 
-        class SequencerUIManager {
+        class LFS_VIS_API SequencerUIManager {
         public:
             SequencerUIManager(VisualizerImpl* viewer, panels::SequencerUIState& ui_state,
                                gui::RmlUIManager* rml_manager);
@@ -66,7 +66,7 @@ namespace lfs::vis {
             [[nodiscard]] float preferredFloatingHeight() const;
             // Serialized status of the active PLY sequence (empty when inactive).
             // Used by MCP tooling to verify playback/scrub behaviour.
-            [[nodiscard]] LFS_VIS_API std::string plyPlayerStatusJson() const;
+            [[nodiscard]] std::string plyPlayerStatusJson() const;
             [[nodiscard]] float timelineZoom() const;
             [[nodiscard]] float timelinePan() const;
             void setTimelineView(float zoom, float pan);

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "core/error.hpp"
+#include "core/export.hpp"
 #include "core/uuid.hpp"
 #include "io/project_document.hpp"
 #include "io/project_recovery.hpp"
@@ -100,7 +101,7 @@ namespace lfs::vis::project {
         const lfs::core::Uuid& project_uuid,
         const std::filesystem::path& path);
 
-    class ProjectLifecycle {
+    class LFS_VIS_API ProjectLifecycle {
     public:
         enum class CloseSaveStatus {
             NotDirty,

--- a/src/visualizer/window/vulkan_image_barrier_tracker.hpp
+++ b/src/visualizer/window/vulkan_image_barrier_tracker.hpp
@@ -4,13 +4,15 @@
 
 #pragma once
 
+#include "core/export.hpp"
+
 #include <cstdint>
 #include <unordered_map>
 #include <vulkan/vulkan.h>
 
 namespace lfs::vis {
 
-    class VulkanImageBarrierTracker {
+    class LFS_VIS_API VulkanImageBarrierTracker {
     public:
         struct AccessScope {
             VkPipelineStageFlags2 stage = VK_PIPELINE_STAGE_2_NONE;

--- a/src/visualizer/window/window_manager.hpp
+++ b/src/visualizer/window/window_manager.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include "input/frame_input_buffer.hpp"
 #include "input/input_router.hpp"
 #include "visualizer/visualizer.hpp"
@@ -22,7 +23,7 @@ namespace lfs::vis {
     class InputController;
     class VulkanContext;
 
-    class WindowManager {
+    class LFS_VIS_API WindowManager {
     public:
         enum class ResizeIntent {
             Interactive,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -517,7 +517,12 @@ add_executable(lichtfeld_tests ${TEST_SOURCES})
 
 # USD (pxr) headers from vcpkg pull in deprecated <ext/hash_set> and emit
 # #warning (-Wcpp). Third-party; suppress only for this translation unit.
-set_source_files_properties(test_usd_format.cpp PROPERTIES COMPILE_OPTIONS "-Wno-cpp")
+if(NOT MSVC)
+    set_source_files_properties(
+        test_usd_format.cpp
+        PROPERTIES COMPILE_OPTIONS "-Wno-cpp"
+    )
+endif()
 
 # Python integration tests import the in-tree extension at runtime.
 add_dependencies(lichtfeld_tests lfs_py)
@@ -640,9 +645,18 @@ target_link_libraries(lichtfeld_tests PRIVATE lfs_vulkan_rasterizer Vulkan::Vulk
 # Compiler options for CUDA debugging
 target_compile_options(lichtfeld_tests PRIVATE
     $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-lineinfo>
-    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
-    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
 )
+if(MSVC)
+    target_compile_options(lichtfeld_tests PRIVATE
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:/Od /Z7>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:/O2 /DNDEBUG>
+    )
+else()
+    target_compile_options(lichtfeld_tests PRIVATE
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
+    )
+endif()
 
 # Tensor-library hardening is intentionally isolated from the default test
 # tiers.  During the hardening phases these oracle tests are expected to expose
@@ -680,10 +694,17 @@ target_link_libraries(tensor_hardening_tests PRIVATE
     CUDA::curand
 )
 
-target_compile_options(tensor_hardening_tests PRIVATE
-    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
-    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
-)
+if(MSVC)
+    target_compile_options(tensor_hardening_tests PRIVATE
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:/Od /Z7>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:/O2 /DNDEBUG>
+    )
+else()
+    target_compile_options(tensor_hardening_tests PRIVATE
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
+    )
+endif()
 
 # =============================================================================
 # CTest registration

--- a/tests/licht_test_support.hpp
+++ b/tests/licht_test_support.hpp
@@ -35,8 +35,8 @@ namespace lfs::vis::project {
 }
 
 namespace lfs::core {
-    class MeshData;
-    class PointCloud;
+    struct MeshData;
+    struct PointCloud;
     class SplatData;
 } // namespace lfs::core
 


### PR DESCRIPTION
## What changed

- restrict the USD header `-Wno-cpp` suppression to non-MSVC toolchains
- route C++ Debug and Release options by compiler for `lichtfeld_tests` and `tensor_hardening_tests`
- keep the existing GCC/Clang and CUDA options unchanged
- avoid passing GNU C++ Debug flags to MSVC in single-config builds
- make the Licht test support forward declarations match the real `PointCloud` and `MeshData` struct definitions
- export the visualizer classes exercised by the Windows test executable from `lfs_visualizer.dll`

## Root causes

`test_usd_format.cpp` had an unconditional `-Wno-cpp` option. MSVC interpreted it as `/Wno-cpp` and aborted with `D8021`.

The test targets also passed GNU/Clang C++ optimization flags to MSVC, producing non-fatal `D9002` warnings.

After compilation, the Windows linker exposed two additional issues in the `.licht` tests:

- `licht_test_support.hpp` declared `PointCloud` and `MeshData` as classes while their definitions are structs; MSVC encoded different decorated names
- `lfs_visualizer` is shared on Windows, but several visualizer classes directly exercised by the tests were not exported from the DLL

Linux links `lfs_visualizer` statically and keeps the same non-MSVC compiler options, so its existing behavior is unchanged.

## Validation

- `git diff --check`
- static audit of project CMake files for unguarded C++ GNU/Clang flags
- user-confirmed MSVC 14.44 Release compilation and successful `lichtfeld_tests.exe` link
- focused runtime invocation reached 131 tests: 57 passed and 1 skipped
- the `MainLoopSignalTest` and `VulkanImageTracker` tests unlocked by the DLL exports passed

Remaining runtime failures are separate from compilation/linkage. Representative failures are an existing `ReplaceFileW` sharing violation (`Win32 error 32`) and `VisualizerImpl` access violations during test execution; CUDA unloading diagnostics occur only during teardown after those access violations.