### PR TITLE
Fix multi-splat scenes not rendering after project reload

### DIFF
--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -4573,6 +4573,10 @@ namespace lfs::vis::project {
             std::memory_order_release);
         auto allocator =
             manager->makeExternalSplatAllocator();
+        if (allocator) {
+            manager->getScene().setCombinedModelAllocator(
+                allocator);
+        }
         std::lock_guard lock(thread_mutex_);
         try {
             hydration_threads_.emplace_back(

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -278,6 +278,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_StopSaveAndExitBindsUntitledDestinationBeforeStop_Test;
         friend class VisualizerImplResetTest_InfoDoesNotMutateDocumentUntilExplicitSync_Test;
         friend class VisualizerImplResetTest_BoundCheckpointIterationCacheSkipsHeaderWhenWarm_Test;
+        friend class VisualizerImplResetTest_ReopenedTwoSplatProjectBuildsExternalCombinedModel_Test;
 
         // Allow ToolContext to access GUI manager for logging
         friend class ToolContext;

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -4941,6 +4941,95 @@ namespace lfs::vis {
         }
     }
 
+    TEST_F(VisualizerImplResetTest,
+           ReopenedTwoSplatProjectBuildsExternalCombinedModel) {
+        // Reopening a two-visible-splat .licht left the combined
+        // model on plain CUDA tensors (no Vulkan-external allocator),
+        // so VkSplat refused to render until one node was hidden.
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto& temporary = temporary_.path;
+        const auto destination =
+            temporary / "two-splat-reopen.licht";
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()
+                            ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+
+            auto& scene = viewer.getScene();
+            const auto splat_a = scene.addSplat(
+                "Splat A",
+                lfs::test::licht::make_splat(2));
+            const auto splat_b = scene.addSplat(
+                "Splat B",
+                lfs::test::licht::make_splat(2));
+            ASSERT_NE(splat_a, lfs::core::NULL_NODE);
+            ASSERT_NE(splat_b, lfs::core::NULL_NODE);
+
+            auto saved = lifecycle->saveAs(
+                destination, false, true);
+            ASSERT_TRUE(saved)
+                << lfs::format_for_developer(
+                       saved.error());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            ASSERT_TRUE(
+                std::filesystem::is_regular_file(
+                    destination));
+        }
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()
+                            ->ensureLoaded());
+            ASSERT_TRUE(
+                viewer.getWindowManager()->init());
+            ASSERT_TRUE(viewer.projectOpen(
+                destination,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    const auto info =
+                        viewer.projectGetInfo();
+                    return info &&
+                           info->hydration_state ==
+                               "complete";
+                }));
+
+            auto& scene = viewer.getScene();
+            const auto* splat_a =
+                scene.getNode("Splat A");
+            const auto* splat_b =
+                scene.getNode("Splat B");
+            ASSERT_NE(splat_a, nullptr);
+            ASSERT_NE(splat_b, nullptr);
+            ASSERT_NE(splat_a->model, nullptr);
+            ASSERT_NE(splat_b->model, nullptr);
+
+            const auto* combined =
+                viewer.getScene().getCombinedModel();
+            ASSERT_NE(combined, nullptr);
+            EXPECT_TRUE(
+                combined->has_tensor_allocator());
+        }
+    }
+
 } // namespace lfs::vis
 
 namespace {


### PR DESCRIPTION
## Bug

Reported on Discord (Pierre): two splats in the scene, one with a crop box, both visible before saving the project. After closing LichtFeld Studio and loading the .licht back, they never render together: the viewport is empty (or shows one), and toggling the eye icons only ever gets one of them on screen.

Reproduced headlessly: save a two-splat project, restart, reopen. Both nodes report visible, the viewport stays empty, and the log shows:

```
VkSplat entered degraded mode; retaining the last good viewport image:
VkSplat refusing full input-copy fallback; model tensors must use
Vulkan-external storage (missing_means+missing_sh0+...)
```

## Root cause

With two or more visible splats, `Scene::rebuildModelCache` concatenates them into a combined render model allocated through the scene's combined-model allocator, falling back to plain `Tensor::empty` CUDA storage when that allocator is unset. The Vulkan renderer requires external-storage tensors and refuses the fallback, so the whole viewport goes dark. A single visible node takes the direct-bind fast path with the node's own tensors, which are external, so exactly one splat can ever render. That is the "either one or the other" eye-icon behavior.

Every live path that brings splats into a session (load, import, duplicate, paste, simplify) installs the allocator via `setCombinedModelAllocator`. Opening a .licht project does not: `ProjectLifecycle::launchHydration` creates the external allocator and uses it for the restored node tensors only. A session whose splats all came from a project open therefore has no combined-model allocator. Confirmed live: in a broken reloaded session, duplicating any node (which installs the allocator as a side effect) instantly made all splats render.

## Fix

Install the Vulkan-external allocator on the scene when hydration starts, at the single call site every project open goes through. Guarded for degraded/non-interop mode, same as the live paths. `Scene::clear()` does not reset the allocator, so once per open is enough.

## Test

`VisualizerImplResetTest.ReopenedTwoSplatProjectBuildsExternalCombinedModel`: saves a two-splat project, reopens it in a fresh viewer, pumps hydration to complete, and asserts the combined model is allocator-backed. Fails on master on exactly that assertion, passes with the fix; verified both directions by removing and restoring the fix. Full `VisualizerImplResetTest.*` suite: 62/62 pass.

Live E2E: reopened the repro project in a fresh session; both splats (plus crop box) render immediately, no degraded-mode entry, zero errors in the log.
