### PR TITLE
Fix CUDA event-pool cleanup during runtime shutdown

### DIFF
--- a/src/core/tensor/cuda_event_pool.cpp
+++ b/src/core/tensor/cuda_event_pool.cpp
@@ -98,7 +98,11 @@ namespace lfs::core {
         std::lock_guard<std::mutex> lock(mutex_);
         for (cudaEvent_t event : pool_) {
             const cudaError_t destroy_status = cudaEventDestroy(event);
-            if (destroy_status != cudaSuccess) {
+            // The runtime may already be unloading during process teardown.
+            // At that point the event is unusable and cleanup is effectively
+            // complete; keep reporting every other destruction failure.
+            if (destroy_status != cudaSuccess &&
+                destroy_status != cudaErrorCudartUnloading) {
                 ensure_cuda_success(
                     destroy_status, "cudaEventDestroy(tensor event pool shutdown)", {},
                     LFS_SOURCE_SITE_CURRENT(), CudaFailureDisposition::LogOnlyNoLatch);


### PR DESCRIPTION
Treat cudaErrorCudartUnloading as an expected terminal condition when destroying pooled tensor events during process shutdown. At that point the CUDA runtime is already unavailable and the event cannot be reused, so reporting the condition as a cleanup failure only adds noise and can destabilize teardown-focused tests.

Continue routing every other cudaEventDestroy failure through the existing diagnostic path, preserving error visibility for genuine resource-lifecycle defects.