### PR TITLE
fix: accept partial optimization JSON; find uv on PATH

### DIFF
--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -99,7 +99,8 @@ namespace lfs::core {
 
                 for (const auto& meta : group.properties) {
                     const std::string key(optimization_json_key(meta));
-                    if (!meta.json_required && !json.contains(key))
+                    // Missing keys keep strategy defaults (partial config overlays).
+                    if (!json.contains(key))
                         continue;
 
                     const auto& value = json.at(key);

--- a/src/python/package_manager.cpp
+++ b/src/python/package_manager.cpp
@@ -12,10 +12,12 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
 #include <optional>
 #include <regex>
 #include <sstream>
 #include <vector>
+#include <string>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -268,10 +270,46 @@ namespace lfs::python {
             bundled = true;
         }
 
-        if (cached.empty())
-            LOG_WARN("Bundled uv not found");
-        else if (bundled)
+        if (cached.empty()) {
+            // Fall back to PATH when FetchUV did not bundle uv next to the binary.
+#ifdef _WIN32
+            wchar_t found[MAX_PATH];
+            if (SearchPathW(nullptr, L"uv.exe", nullptr, MAX_PATH, found, nullptr) > 0) {
+                cached = found;
+            }
+#else
+            if (const char* path_env = std::getenv("PATH")) {
+                std::string paths = path_env;
+                size_t start = 0;
+                while (start <= paths.size()) {
+                    const size_t end = paths.find(':', start);
+                    const auto dir = paths.substr(start, end == std::string::npos ? std::string::npos : end - start);
+                    if (!dir.empty()) {
+                        const auto candidate = std::filesystem::path(dir) / UV_BINARY;
+                        std::error_code ec;
+                        if (std::filesystem::exists(candidate, ec) && !ec) {
+                            cached = candidate;
+                            break;
+                        }
+                    }
+                    if (end == std::string::npos)
+                        break;
+                    start = end + 1;
+                }
+            }
+#endif
+        }
+
+        if (cached.empty()) {
+            LOG_WARN(
+                "uv not found beside the executable or on PATH. "
+                "Download uv from https://github.com/astral-sh/uv/releases and place it next to the binary, "
+                "or install uv so it is available on PATH.");
+        } else if (bundled) {
             LOG_INFO("Using bundled uv: {}", lfs::core::path_to_utf8(cached));
+        } else {
+            LOG_INFO("Using PATH uv (unpinned): {}", lfs::core::path_to_utf8(cached));
+        }
 
         return cached;
     }


### PR DESCRIPTION
## Summary
- Allow partial optimization JSON: missing keys keep strategy defaults instead of requiring every `json_required` field.
- Fall back to `uv` on `PATH` when no bundled binary is next to the executable, with a clearer error message (#1569).

## Test plan
- [ ] Load a JSON with only `optimization.grad_threshold` / `stop_refine` and confirm training starts with other defaults
- [ ] Build without bundled `uv`, install `uv` on PATH, confirm plugin install finds it
- [ ] Full configs and bundled `uv` still work

Fixes #1541
Fixes #1569
