### PR TITLE
add fast compile to test build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,9 @@ if(BUILD_UNICODE_TEST_ONLY)
         CXX_STANDARD 23
         CXX_STANDARD_REQUIRED ON
     )
+    if(COMMAND lfs_enable_fast_cxx_compile)
+        lfs_enable_fast_cxx_compile(unicode_path_test)
+    endif()
 
     # Enable Windows long path support (paths > MAX_PATH/260 chars)
     if(WIN32 AND MSVC)
@@ -186,6 +189,9 @@ set_target_properties(lichtfeld_format_tests PROPERTIES
     CXX_STANDARD 23
     CXX_STANDARD_REQUIRED ON
 )
+if(COMMAND lfs_enable_fast_cxx_compile)
+    lfs_enable_fast_cxx_compile(lichtfeld_format_tests)
+endif()
 add_test(NAME lichtfeld_format_tests
     COMMAND $<TARGET_FILE:lichtfeld_format_tests> --gtest_color=no
 )
@@ -658,6 +664,9 @@ else()
         $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
     )
 endif()
+if(COMMAND lfs_enable_fast_cxx_compile)
+    lfs_enable_fast_cxx_compile(lichtfeld_tests)
+endif()
 
 # Tensor-library hardening is intentionally isolated from the default test
 # tiers.  During the hardening phases these oracle tests are expected to expose
@@ -705,6 +714,9 @@ else()
         $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:-O0 -g -fno-omit-frame-pointer>
         $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:-O3 -DNDEBUG>
     )
+endif()
+if(COMMAND lfs_enable_fast_cxx_compile)
+    lfs_enable_fast_cxx_compile(tensor_hardening_tests)
 endif()
 
 # =============================================================================


### PR DESCRIPTION
The main app already has -DLFS_FAST_COMPILE=ON option for some time and it provides great improvement to the build speed.  This change adds the same compile time option to the test build

These are the results with ON and OFF:
<img width="772" height="269" alt="image" src="https://github.com/user-attachments/assets/243eb75b-f48e-463c-ad04-a86c6c4d87a0" />

