### PR TITLE
Add close buttons to Asset Manager and Python Console

### DIFF
--- a/src/visualizer/gui/panels/python_console_panel.cpp
+++ b/src/visualizer/gui/panels/python_console_panel.cpp
@@ -772,6 +772,12 @@ namespace {
             close_popover();
         } else if (action == "packages-refresh") {
             request_packages_refresh(pane);
+        } else if (action == "close-panel") {
+            auto close_event = lfs::core::events::cmd::ShowWindow{
+                .window_name = "python_console",
+                .show = false,
+            };
+            close_event.emit();
         }
 
         mark_dirty(pane);

--- a/src/visualizer/gui/rmlui/resources/asset_manager.rcss
+++ b/src/visualizer/gui/rmlui/resources/asset_manager.rcss
@@ -46,6 +46,39 @@
     min-width: 64dp;
 }
 
+.asset-panel-close {
+    flex-shrink: 0;
+    width: 28dp;
+    min-width: 28dp;
+    max-width: 28dp;
+    height: 28dp;
+    min-height: 28dp;
+    padding: 0;
+    margin-left: auto;
+    border-width: 1dp;
+    border-color: #514a42;
+    border-radius: 4dp;
+    background-color: #302d29;
+    color: #d8d0c3;
+    font-size: 18dp;
+    line-height: 26dp;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    cursor: pointer;
+}
+
+.asset-panel-close:hover {
+    background-color: #454038;
+    border-color: #7fb9a5;
+    color: #f0ebe2;
+}
+
+.asset-panel-close:active {
+    background-color: #36564b;
+    border-color: #7fb9a5;
+}
+
 /* ── Shell wrapper ─────────────────────────────────────── */
 
 #asset-shell {

--- a/src/visualizer/gui/rmlui/resources/asset_manager.rml
+++ b/src/visualizer/gui/rmlui/resources/asset_manager.rml
@@ -32,6 +32,7 @@
               <div class="asset-import-menu-item" data-event-click="on_import_from_url">{{import_from_url_label}}</div>
             </div>
           </div>
+          <button class="asset-panel-close" type="button" data-event-click="close_panel" data-tooltip="common.close">&#215;</button>
         </div>
 
         <div class="toolbar-row toolbar-row-secondary">

--- a/src/visualizer/gui/rmlui/resources/asset_manager.theme.rcss
+++ b/src/visualizer/gui/rmlui/resources/asset_manager.theme.rcss
@@ -15,6 +15,21 @@
     border-bottom-color: @{border};
 }
 
+.asset-panel-close {
+    background-color: @{surface_bright};
+    border-color: @{border};
+    color: @{text};
+}
+
+.asset-panel-close:hover {
+    background-color: @{lighten(surface_bright,0.06)};
+}
+
+.asset-panel-close:active {
+    background-color: @{alpha(primary,0.32)};
+    border-color: @{primary};
+}
+
 .asset-search-box {
     background-color: @{surface_bright};
     border-color: @{border};

--- a/src/visualizer/gui/rmlui/resources/python_console_panel.rcss
+++ b/src/visualizer/gui/rmlui/resources/python_console_panel.rcss
@@ -50,10 +50,20 @@ body {
 .toolbar-row {
     display: flex;
     align-items: center;
-    width: 100%;
+    flex: 1;
     height: 24dp;
     min-width: 0;
-    padding-left: 2dp;
+    padding: 0 4dp 0 2dp;
+    gap: 4dp;
+    overflow: hidden;
+}
+
+.toolbar-actions {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+    height: 24dp;
     gap: 4dp;
     overflow: hidden;
 }
@@ -94,6 +104,21 @@ button {
 
 #python-console-toolbar button:hover {
     background-color: rgb(38, 42, 54);
+}
+
+#close-panel-button {
+    flex: 0 0 28dp;
+    flex-shrink: 0;
+    width: 28dp;
+    min-width: 28dp;
+    max-width: 28dp;
+    height: 24dp;
+    padding: 0;
+    margin-left: 0;
+    margin-right: 0;
+    font-size: 18dp;
+    line-height: 22dp;
+    text-align: center;
 }
 
 #python-console-toolbar button:active,

--- a/src/visualizer/gui/rmlui/resources/python_console_panel.rml
+++ b/src/visualizer/gui/rmlui/resources/python_console_panel.rml
@@ -7,25 +7,28 @@
             <div id="content">
                 <div id="python-console-toolbar">
                     <div class="toolbar-row">
-                        <button id="new-button" class="toolbar-button btn-new" type="button" data-action="new"></button>
-                        <button id="load-button" class="toolbar-button btn-load" type="button" data-action="load"></button>
-                        <button id="reload-button" class="toolbar-button btn-reload" type="button" data-action="reload"></button>
-                        <button id="save-button" class="toolbar-button btn-save" type="button" data-action="save"></button>
-                        <button id="save-as-button" class="toolbar-button btn-save-as" type="button" data-action="save-as"></button>
-                        <button id="format-button" class="toolbar-button btn-format" type="button" data-action="format"></button>
-                        <button id="vim-button" class="toolbar-button btn-vim" type="button" data-action="toggle-vim"></button>
-                        <button id="run-button" class="toolbar-button btn-run run-button" type="button" data-action="run"></button>
-                        <button id="stop-button" class="toolbar-button btn-stop stop-button" type="button" data-action="stop"></button>
-                        <button id="reset-button" class="toolbar-button btn-reset" type="button" data-action="reset"></button>
-                        <button id="clear-button" class="toolbar-button btn-clear" type="button" data-action="clear"></button>
-                        <span class="toolbar-separator">|</span>
-                        <span id="run-status"></span>
-                        <span id="syntax-status"></span>
-                        <button id="outline-button" type="button" data-action="toggle-outline"></button>
-                        <button id="breadcrumb-button" type="button" data-action="toggle-breadcrumbs"></button>
-                        <button id="fold-button" type="button" data-action="toggle-folds"></button>
-                        <span id="script-label"></span>
-                        <button id="font-status" type="button" data-action="font-reset">100%</button>
+                        <div class="toolbar-actions">
+                            <button id="new-button" class="toolbar-button btn-new" type="button" data-action="new"></button>
+                            <button id="load-button" class="toolbar-button btn-load" type="button" data-action="load"></button>
+                            <button id="reload-button" class="toolbar-button btn-reload" type="button" data-action="reload"></button>
+                            <button id="save-button" class="toolbar-button btn-save" type="button" data-action="save"></button>
+                            <button id="save-as-button" class="toolbar-button btn-save-as" type="button" data-action="save-as"></button>
+                            <button id="format-button" class="toolbar-button btn-format" type="button" data-action="format"></button>
+                            <button id="vim-button" class="toolbar-button btn-vim" type="button" data-action="toggle-vim"></button>
+                            <button id="run-button" class="toolbar-button btn-run run-button" type="button" data-action="run"></button>
+                            <button id="stop-button" class="toolbar-button btn-stop stop-button" type="button" data-action="stop"></button>
+                            <button id="reset-button" class="toolbar-button btn-reset" type="button" data-action="reset"></button>
+                            <button id="clear-button" class="toolbar-button btn-clear" type="button" data-action="clear"></button>
+                            <span class="toolbar-separator">|</span>
+                            <span id="run-status"></span>
+                            <span id="syntax-status"></span>
+                            <button id="outline-button" type="button" data-action="toggle-outline"></button>
+                            <button id="breadcrumb-button" type="button" data-action="toggle-breadcrumbs"></button>
+                            <button id="fold-button" type="button" data-action="toggle-folds"></button>
+                            <span id="script-label"></span>
+                            <button id="font-status" type="button" data-action="font-reset">100%</button>
+                        </div>
+                        <button id="close-panel-button" type="button" data-action="close-panel" data-tooltip="common.close">&#215;</button>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary

This is a small quality-of-life update adding quick close buttons to the Asset Manager and Python Console.

- adds a compact close button to the Asset Manager toolbar
- adds the corresponding close action to the Python Console
- keeps the close controls available when the panels become narrower
- uses the existing panel theme colors and button states

These are intentionally small, localized additions that make both panels quicker to dismiss without changing their broader behavior or docking logic.
