### PR TITLE
Cancel in-flight dataset import when opening a project

### DIFF
--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -4544,6 +4544,12 @@ namespace lfs::vis::project {
         const auto shell_staged_at =
             std::chrono::steady_clock::now();
 
+        // A stale import completion must not outlive
+        // a project switch.
+        if (auto* const gui = viewer_.getGuiManager()) {
+            gui->asyncTasks().cancelImport();
+        }
+
         stopHydrationThreads();
         if (auto* trainer_manager = viewer_.getTrainerManager();
             trainer_manager && trainer_manager->hasTrainer() &&
@@ -4556,6 +4562,7 @@ namespace lfs::vis::project {
         }
         viewer_.deactivateProjectTools();
         viewer_.resetProjectState();
+        manager->setDatasetPath({});
         manager->getScene().commitRestoreStage(
             std::move(*shell));
         manager->changeContentType(

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -285,6 +285,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_DatasetProjectWithoutCheckpointReloadsTrainer_Test;
         friend class VisualizerImplResetTest_DatasetProjectWithoutReferenceIsNotRecoveredFromContainingDirectory_Test;
         friend class VisualizerImplResetTest_NonDatasetProjectInsideDatasetRootIsNotReimported_Test;
+        friend class VisualizerImplResetTest_OpeningAnotherProjectCancelsPendingDatasetRestoreImport_Test;
         friend class VisualizerImplResetTest_NonDatasetSaveDoesNotBindStaleDatasetPath_Test;
         friend class VisualizerImplResetTest_TrainingCheckpointReopenRestoresPausedResumableState_Test;
         friend class VisualizerImplResetTest_EditModeSaveDropsFormerTrainingCheckpoint_Test;

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -5627,6 +5627,84 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
+           OpeningAnotherProjectCancelsPendingDatasetRestoreImport) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto dataset_path =
+            temporary_.path /
+            "dataset-pending-restore-import";
+        write_minimal_transforms_dataset(dataset_path);
+        const auto project_a =
+            temporary_.path /
+            "dataset-pending-restore-a.licht";
+        write_dataset_project_without_checkpoint(
+            project_a, dataset_path);
+        const auto project_b =
+            temporary_.path /
+            "ply-only-pending-restore-b.licht";
+        write_non_dataset_project_with_stale_dataset_params(
+            project_b, dataset_path);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened_a = viewer.projectOpen(
+            project_a,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened_a)
+            << lfs::format_for_developer(
+                   opened_a.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       viewer.jobs().anyRunning(
+                           JobType::Import);
+            }));
+
+        auto opened_b = viewer.projectOpen(
+            project_b,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened_b)
+            << lfs::format_for_developer(
+                   opened_b.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                viewer.getGuiManager()
+                    ->asyncTasks()
+                    .pollImportCompletion();
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       !viewer.jobs().anyRunning(
+                           JobType::Import);
+            }));
+
+        EXPECT_NE(
+            viewer.getScene().getNode(
+                "PLY-only marker"),
+            nullptr);
+        EXPECT_FALSE(
+            viewer.getSceneManager()->hasDataset());
+        EXPECT_TRUE(
+            viewer.getSceneManager()
+                ->getDatasetPath()
+                .empty());
+        EXPECT_FALSE(
+            viewer.getTrainerManager()->hasTrainer());
+    }
+
+    TEST_F(VisualizerImplResetTest,
            NonDatasetSaveDoesNotBindStaleDatasetPath) {
         const auto source_path =
             temporary_.path / "non-dataset-source.licht";


### PR DESCRIPTION
## Summary

Since #1635, opening a dataset project saved before training kicks off a background dataset reload. If you opened another project while that reload was still running, the reload finished anyway: it cleared the new project's scene and put the old dataset in its place. Saving at that point would write the wrong dataset into the new project.

## What changed

- Opening a project now cancels any import that is still running (same as File > New Project already did).
- The stale dataset path from the previous session is cleared on project switch, so a later save can't bind the old dataset into the new project.

## Testing

- New regression test: open a no-checkpoint dataset project, then open a PLY project while the reload is still running. The PLY project must stay intact.
- Without the fix the test fails: the PLY scene is wiped and the old dataset and trainer show up in the wrong project.
- Full VisualizerImplResetTest fixture passes (73 tests), plus the project-related test sweep (107 tests).
- Also reproduced and verified in the running app: the log shows the reload being cancelled when the second project opens, and the second project's scene stays untouched.