### PR TITLE
Do not offer autosave recovery after an intentional discard

### DIFF
--- a/src/core/include/core/events.hpp
+++ b/src/core/include/core/events.hpp
@@ -81,7 +81,7 @@ namespace lfs::core {
             EVENT(SaveAsAndExit, );
             EVENT(StopSaveAndExit, );
             EVENT(CancelExit, );
-            EVENT(ForceExit, );
+            EVENT(ForceExit, bool discard_autosave = false;);
             EVENT(SwitchToEditMode, );
             EVENT(ResetCamera, );
             EVENT(ShowWindow, std::string window_name; bool show;);

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -261,7 +261,7 @@ namespace {
         if (auto posted = lfs::vis::post_guarded_and_wait<void>(
                 viewer, context,
                 [emit = std::forward<EmitFn>(emit_fn)]() mutable
-                -> lfs::Result<void> {
+                    -> lfs::Result<void> {
                     emit();
                     return {};
                 },
@@ -1320,7 +1320,8 @@ NB_MODULE(lichtfeld, m) {
             nb::gil_scoped_release release;
             emit_project_cmd_marshaled(
                 "python.force_exit", [] {
-                    lfs::core::events::cmd::ForceExit{}
+                    lfs::core::events::cmd::ForceExit{
+                        .discard_autosave = true}
                         .emit();
                 });
         },

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -1315,8 +1315,25 @@ namespace lfs::vis::project {
             project_write_thread_.join();
         }
         stopHydrationThreads();
+        std::optional<std::filesystem::path> discard_master;
+        if (close_discard_requested_) {
+            if (recovered_master_path_) {
+                discard_master = *recovered_master_path_;
+            } else if (document_ && document_->source_path()) {
+                discard_master = *document_->source_path();
+            }
+        }
         document_.reset();
         cleanupRecoverySession();
+        // The user explicitly discarded unsaved changes at exit; delete
+        // the autosave overlay only after the write thread has joined and
+        // the document/recovery locks are released. Emergency ForceExit
+        // paths (X11 error, interrupt) never set
+        // close_discard_requested_, so crash recovery survives.
+        if (discard_master) {
+            removeDiscardedAutosaveArtifacts(
+                *discard_master);
+        }
     }
 
     void ProjectLifecycle::stopHydrationThreads() {
@@ -4251,6 +4268,32 @@ namespace lfs::vis::project {
                 }
                 return ProjectOpenOutcome::Opened;
             }
+            // The offered sidecar is the unsaved state
+            // the user just authorized discarding for
+            // this project. Prompting Recover? right
+            // after Discard? is the #1641 confusion.
+            // Do not set declined_recovery_ here:
+            // openMaster's discard cleanup deletes the
+            // sidecar instead.
+            const auto current_master =
+                recovered_master_path_
+                    ? recovered_master_path_
+                    : (document_
+                           ? document_->source_path()
+                           : std::nullopt);
+            if (disposition ==
+                    ProjectSwitchDisposition::
+                        DiscardChanges &&
+                current_master &&
+                current_master->lexically_normal() ==
+                    normalized->lexically_normal()) {
+                auto opened = openMaster(
+                    *normalized, disposition);
+                if (!opened) {
+                    return std::move(opened).error();
+                }
+                return ProjectOpenOutcome::Opened;
+            }
             auto* gui =
                 viewer_.getGuiManager();
             if (!gui) {
@@ -4452,6 +4495,17 @@ namespace lfs::vis::project {
             !preflight) {
             return preflight;
         }
+        std::optional<std::filesystem::path> discard_master;
+        if (disposition ==
+            ProjectSwitchDisposition::DiscardChanges) {
+            if (recovered_master_path_) {
+                discard_master = *recovered_master_path_;
+            } else if (document_ &&
+                       document_->source_path()) {
+                discard_master =
+                    *document_->source_path();
+            }
+        }
         const auto started =
             std::chrono::steady_clock::now();
         auto normalized =
@@ -4582,6 +4636,22 @@ namespace lfs::vis::project {
         document_ = candidate;
         bindTrainerSnapshotTarget();
         cleanupRecoverySession();
+        // Removal runs only after the replacement
+        // document is installed and
+        // cleanupRecoverySession() has released the
+        // old recovery session's writer lock. Every
+        // failure path of openMaster returns before
+        // this point, so a failed switch never
+        // deletes the old project's recovery
+        // artifacts
+        // (FailedNewProjectKeepsRecoveredSessionTemp
+        // relies on that). Capture happens before
+        // cleanupRecoverySession() because it resets
+        // recovered_master_path_.
+        if (discard_master) {
+            removeDiscardedAutosaveArtifacts(
+                *discard_master);
+        }
         adopted_training_snapshot_count_ = 0;
         application_close_pending_ = false;
         suppress_training_adoption_ = false;
@@ -5162,6 +5232,17 @@ namespace lfs::vis::project {
             !preflight) {
             return preflight;
         }
+        std::optional<std::filesystem::path> discard_master;
+        if (disposition ==
+            ProjectSwitchDisposition::DiscardChanges) {
+            if (recovered_master_path_) {
+                discard_master = *recovered_master_path_;
+            } else if (document_ &&
+                       document_->source_path()) {
+                discard_master =
+                    *document_->source_path();
+            }
+        }
         auto created =
             ProjectDocument::create(
                 lfs::core::generate_uuid_v4());
@@ -5184,6 +5265,10 @@ namespace lfs::vis::project {
             std::make_shared<ProjectDocument>(
                 std::move(*created));
         cleanupRecoverySession();
+        if (discard_master) {
+            removeDiscardedAutosaveArtifacts(
+                *discard_master);
+        }
         adopted_training_snapshot_count_ = 0;
         application_close_pending_ = false;
         suppress_training_adoption_ = false;
@@ -5488,6 +5573,24 @@ namespace lfs::vis::project {
 
     void ProjectLifecycle::markApplicationClosePending() {
         application_close_pending_ = true;
+    }
+
+    void ProjectLifecycle::markCloseDiscardRequested() {
+        close_discard_requested_ = true;
+    }
+
+    void ProjectLifecycle::removeDiscardedAutosaveArtifacts(
+        const std::filesystem::path& master) {
+        if (auto removed =
+                lfs::io::project::
+                    remove_autosave_artifacts(
+                        master);
+            !removed) {
+            LOG_WARN(
+                "Discarded autosave cleanup failed for {}: {}",
+                master.string(),
+                developerError(removed.error()));
+        }
     }
 
     bool ProjectLifecycle::isApplicationClosePending()

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -65,6 +65,12 @@ namespace lfs::vis {
     class VisualizerImplResetTest_OpenAndNewProjectClearSuppressAdoption_Test;
     class VisualizerImplResetTest_InfoDoesNotMutateDocumentUntilExplicitSync_Test;
     class VisualizerImplResetTest_BoundCheckpointIterationCacheSkipsHeaderWhenWarm_Test;
+    class VisualizerImplResetTest_ForceExitDiscardDeletesAutosaveSidecarOnTeardown_Test;
+    class VisualizerImplResetTest_EmergencyForceExitKeepsAutosaveSidecarOnTeardown_Test;
+    class VisualizerImplResetTest_DiscardSwitchDeletesOldProjectAutosaveSidecar_Test;
+    class VisualizerImplResetTest_DiscardSamePathReopenSkipsRecoveryPromptAndDeletesSidecar_Test;
+    class VisualizerImplResetTest_DirtyRequireCleanSwitchKeepsAutosaveSidecar_Test;
+    class VisualizerImplResetTest_NewProjectDiscardDeletesAutosaveSidecar_Test;
 } // namespace lfs::vis
 
 namespace lfs::vis::project {
@@ -171,6 +177,7 @@ namespace lfs::vis::project {
         [[nodiscard]] std::string
         closeSaveError() const;
         void markApplicationClosePending();
+        void markCloseDiscardRequested();
         [[nodiscard]] bool
         isApplicationClosePending() const;
         void setSuppressTrainingAdoption(bool suppress);
@@ -222,6 +229,12 @@ namespace lfs::vis::project {
         friend class lfs::vis::VisualizerImplResetTest_OpenAndNewProjectClearSuppressAdoption_Test;
         friend class lfs::vis::VisualizerImplResetTest_InfoDoesNotMutateDocumentUntilExplicitSync_Test;
         friend class lfs::vis::VisualizerImplResetTest_BoundCheckpointIterationCacheSkipsHeaderWhenWarm_Test;
+        friend class lfs::vis::VisualizerImplResetTest_ForceExitDiscardDeletesAutosaveSidecarOnTeardown_Test;
+        friend class lfs::vis::VisualizerImplResetTest_EmergencyForceExitKeepsAutosaveSidecarOnTeardown_Test;
+        friend class lfs::vis::VisualizerImplResetTest_DiscardSwitchDeletesOldProjectAutosaveSidecar_Test;
+        friend class lfs::vis::VisualizerImplResetTest_DiscardSamePathReopenSkipsRecoveryPromptAndDeletesSidecar_Test;
+        friend class lfs::vis::VisualizerImplResetTest_DirtyRequireCleanSwitchKeepsAutosaveSidecar_Test;
+        friend class lfs::vis::VisualizerImplResetTest_NewProjectDiscardDeletesAutosaveSidecar_Test;
         enum class Hydration {
             Empty,
             ShellReady,
@@ -323,6 +336,8 @@ namespace lfs::vis::project {
         isTrainingWriteWindowOpen() const;
         void cancelBackgroundAutosaveIfRunning();
         void cleanupRecoverySession();
+        void removeDiscardedAutosaveArtifacts(
+            const std::filesystem::path& master);
         [[nodiscard]] lfs::Result<void>
         adoptCompletedTrainingSnapshot(
             bool allow_during_application_close = false);
@@ -379,6 +394,7 @@ namespace lfs::vis::project {
             last_autosaved_scene_serial_ = 0;
         std::uint64_t autosave_sequence_ = 0;
         bool application_close_pending_ = false;
+        bool close_discard_requested_ = false;
         bool suppress_training_adoption_ = false;
         std::uint64_t
             project_write_autosave_sequence_ = 0;

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -1492,7 +1492,7 @@ namespace lfs::vis {
             abandonSaveAndExitAttempt();
         });
 
-        cmd::ForceExit::when([this](const auto&) {
+        cmd::ForceExit::when([this](const auto& event) {
             if (gui_manager_) {
                 gui_manager_->setForceExit(true);
                 gui_manager_->dismissExitConfirmation();
@@ -1502,6 +1502,10 @@ namespace lfs::vis {
                     ->markApplicationClosePending();
                 project_lifecycle_
                     ->setSuppressTrainingAdoption(true);
+                if (event.discard_autosave) {
+                    project_lifecycle_
+                        ->markCloseDiscardRequested();
+                }
             }
             if (trainer_manager_ &&
                 (trainer_manager_->isTrainingActive() ||

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -290,6 +290,12 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_TrainingCheckpointReopenRestoresPausedResumableState_Test;
         friend class VisualizerImplResetTest_EditModeSaveDropsFormerTrainingCheckpoint_Test;
         friend class VisualizerImplResetTest_ReopenedTwoSplatProjectBuildsExternalCombinedModel_Test;
+        friend class VisualizerImplResetTest_ForceExitDiscardDeletesAutosaveSidecarOnTeardown_Test;
+        friend class VisualizerImplResetTest_EmergencyForceExitKeepsAutosaveSidecarOnTeardown_Test;
+        friend class VisualizerImplResetTest_DiscardSwitchDeletesOldProjectAutosaveSidecar_Test;
+        friend class VisualizerImplResetTest_DiscardSamePathReopenSkipsRecoveryPromptAndDeletesSidecar_Test;
+        friend class VisualizerImplResetTest_DirtyRequireCleanSwitchKeepsAutosaveSidecar_Test;
+        friend class VisualizerImplResetTest_NewProjectDiscardDeletesAutosaveSidecar_Test;
 
         // Allow ToolContext to access GUI manager for logging
         friend class ToolContext;

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -1388,6 +1388,341 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
+           ForceExitDiscardDeletesAutosaveSidecarOnTeardown) {
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "discard-exit.licht";
+        const auto sidecar =
+            lfs::io::project::
+                autosave_sidecar_path(project_path);
+        write_empty_project(project_path);
+
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    const auto info = viewer.projectGetInfo();
+                    EXPECT_TRUE(info);
+                    return info && info->hydration_state == "complete";
+                }));
+            auto hydrated =
+                viewer.projectGetInfo();
+            ASSERT_TRUE(hydrated);
+            ASSERT_EQ(hydrated->hydration_state,
+                      "complete");
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Dirty for autosave"),
+                lfs::core::NULL_NODE);
+            ASSERT_TRUE(viewer.project_lifecycle_
+                            ->startAutosave());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            ASSERT_TRUE(
+                std::filesystem::is_regular_file(
+                    sidecar));
+            lfs::core::events::cmd::ForceExit{
+                .discard_autosave = true}
+                .emit();
+        }
+        EXPECT_FALSE(std::filesystem::exists(sidecar));
+        EXPECT_TRUE(
+            std::filesystem::is_regular_file(
+                project_path));
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           EmergencyForceExitKeepsAutosaveSidecarOnTeardown) {
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "emergency-exit.licht";
+        const auto sidecar =
+            lfs::io::project::
+                autosave_sidecar_path(project_path);
+        write_empty_project(project_path);
+
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    const auto info = viewer.projectGetInfo();
+                    EXPECT_TRUE(info);
+                    return info && info->hydration_state == "complete";
+                }));
+            auto hydrated =
+                viewer.projectGetInfo();
+            ASSERT_TRUE(hydrated);
+            ASSERT_EQ(hydrated->hydration_state,
+                      "complete");
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Dirty for autosave"),
+                lfs::core::NULL_NODE);
+            ASSERT_TRUE(viewer.project_lifecycle_
+                            ->startAutosave());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            ASSERT_TRUE(
+                std::filesystem::is_regular_file(
+                    sidecar));
+            lfs::core::events::cmd::ForceExit{}.emit();
+        }
+        EXPECT_TRUE(
+            std::filesystem::is_regular_file(
+                sidecar));
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           DiscardSwitchDeletesOldProjectAutosaveSidecar) {
+        const auto& temporary = temporary_.path;
+        const auto old_path =
+            temporary / "old.licht";
+        const auto next_path =
+            temporary / "next.licht";
+        const auto sidecar =
+            lfs::io::project::
+                autosave_sidecar_path(old_path);
+        write_empty_project(old_path);
+        write_empty_project(next_path);
+
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.projectOpen(
+                old_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    const auto info = viewer.projectGetInfo();
+                    EXPECT_TRUE(info);
+                    return info && info->hydration_state == "complete";
+                }));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Dirty for autosave"),
+                lfs::core::NULL_NODE);
+            ASSERT_TRUE(viewer.project_lifecycle_
+                            ->startAutosave());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            ASSERT_TRUE(
+                std::filesystem::is_regular_file(
+                    sidecar));
+            const auto opened =
+                viewer.projectOpen(
+                    next_path,
+                    ProjectSwitchDisposition::
+                        DiscardChanges);
+            ASSERT_TRUE(opened)
+                << lfs::format_for_developer(
+                       opened.error());
+            EXPECT_EQ(*opened,
+                      ProjectOpenOutcome::Opened);
+            EXPECT_FALSE(
+                std::filesystem::exists(sidecar));
+            EXPECT_TRUE(
+                std::filesystem::is_regular_file(
+                    old_path));
+            ASSERT_TRUE(viewer.project_lifecycle_
+                            ->document_->source_path());
+            EXPECT_EQ(viewer.project_lifecycle_
+                          ->document_->source_path()
+                          ->lexically_normal(),
+                      next_path.lexically_normal());
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           DiscardSamePathReopenSkipsRecoveryPromptAndDeletesSidecar) {
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "same-path.licht";
+        const auto sidecar =
+            lfs::io::project::
+                autosave_sidecar_path(project_path);
+        write_empty_project(project_path);
+
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    const auto info = viewer.projectGetInfo();
+                    EXPECT_TRUE(info);
+                    return info && info->hydration_state == "complete";
+                }));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Dirty for autosave"),
+                lfs::core::NULL_NODE);
+            ASSERT_TRUE(viewer.project_lifecycle_
+                            ->startAutosave());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            ASSERT_TRUE(
+                std::filesystem::is_regular_file(
+                    sidecar));
+            const auto reopened =
+                viewer.projectOpen(
+                    project_path,
+                    ProjectSwitchDisposition::
+                        DiscardChanges);
+            ASSERT_TRUE(reopened)
+                << lfs::format_for_developer(
+                       reopened.error());
+            EXPECT_EQ(*reopened,
+                      ProjectOpenOutcome::Opened);
+            EXPECT_FALSE(viewer.project_lifecycle_
+                             ->recovery_prompt_pending_);
+            EXPECT_FALSE(
+                std::filesystem::exists(sidecar));
+            auto info = viewer.projectGetInfo();
+            ASSERT_TRUE(info);
+            EXPECT_FALSE(info->dirty);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           DirtyRequireCleanSwitchKeepsAutosaveSidecar) {
+        const auto& temporary = temporary_.path;
+        const auto old_path =
+            temporary / "old.licht";
+        const auto next_path =
+            temporary / "next.licht";
+        const auto sidecar =
+            lfs::io::project::
+                autosave_sidecar_path(old_path);
+        write_empty_project(old_path);
+        write_empty_project(next_path);
+
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.projectOpen(
+                old_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    const auto info = viewer.projectGetInfo();
+                    EXPECT_TRUE(info);
+                    return info && info->hydration_state == "complete";
+                }));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Dirty for autosave"),
+                lfs::core::NULL_NODE);
+            ASSERT_TRUE(viewer.project_lifecycle_
+                            ->startAutosave());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            ASSERT_TRUE(
+                std::filesystem::is_regular_file(
+                    sidecar));
+            const auto blocked =
+                viewer.projectOpen(
+                    next_path,
+                    ProjectSwitchDisposition::
+                        RequireClean);
+            ASSERT_FALSE(blocked);
+            EXPECT_TRUE(
+                std::filesystem::is_regular_file(
+                    sidecar));
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           NewProjectDiscardDeletesAutosaveSidecar) {
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "new-project.licht";
+        const auto sidecar =
+            lfs::io::project::
+                autosave_sidecar_path(project_path);
+        write_empty_project(project_path);
+
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    const auto info = viewer.projectGetInfo();
+                    EXPECT_TRUE(info);
+                    return info && info->hydration_state == "complete";
+                }));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Dirty for autosave"),
+                lfs::core::NULL_NODE);
+            ASSERT_TRUE(viewer.project_lifecycle_
+                            ->startAutosave());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_, viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            ASSERT_TRUE(
+                std::filesystem::is_regular_file(
+                    sidecar));
+            ASSERT_TRUE(
+                viewer.project_lifecycle_->newProject(
+                    ProjectSwitchDisposition::
+                        DiscardChanges));
+            EXPECT_FALSE(
+                std::filesystem::exists(sidecar));
+            EXPECT_TRUE(
+                std::filesystem::is_regular_file(
+                    project_path));
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
            ProjectWriteSettlementCompletesBeforeNextDocumentWrite) {
         const auto& temporary = temporary_.path;
         const auto first_path =


### PR DESCRIPTION
Fixes #1641.

When you close the app and choose **Discard**, the autosave file is now deleted. Opening the project afterwards loads it exactly as saved — no more confusing "Recover project?" dialog for changes you already threw away.

The same now applies when you switch projects (open another project, reopen the same one, or start a new one) and confirm the discard there.

What stays the same:
- A crash (or a forced emergency exit) keeps the autosave, so crash recovery still works.
- Declining a recovery offer still keeps the autosave file.
- If a project switch fails midway, nothing is deleted.

Tested with 6 new regression tests (full `VisualizerImplResetTest` fixture green, 79/79) and verified manually: reproduced the exact repro steps from the issue before the fix, then confirmed the project reopens cleanly after it.