### PR TITLE
Stream compressed project payloads instead of materializing them

### DIFF
--- a/src/io/include/io/project_chapters.hpp
+++ b/src/io/include/io/project_chapters.hpp
@@ -37,6 +37,26 @@ namespace lfs::io::project {
 
     [[nodiscard]] LFS_IO_API Hash128 xxh3_128(std::span<const std::byte> bytes);
 
+    // Incremental XXH3-128 over sequential spans. digest() matches xxh3_128 of
+    // the concatenation of every update() argument, in order.
+    class LFS_IO_API Hash128Stream {
+    public:
+        Hash128Stream();
+        Hash128Stream(Hash128Stream&&) noexcept;
+        Hash128Stream& operator=(Hash128Stream&&) noexcept;
+        Hash128Stream(const Hash128Stream&) = delete;
+        Hash128Stream& operator=(const Hash128Stream&) = delete;
+        ~Hash128Stream();
+
+        [[nodiscard]] bool valid() const noexcept;
+        [[nodiscard]] bool update(std::span<const std::byte> bytes) noexcept;
+        [[nodiscard]] Hash128 digest() const noexcept;
+
+    private:
+        struct Impl;
+        std::unique_ptr<Impl> impl_;
+    };
+
     struct SemanticVersion {
         std::uint16_t major = 1;
         std::uint16_t minor = 0;

--- a/src/io/include/io/project_document.hpp
+++ b/src/io/include/io/project_document.hpp
@@ -59,6 +59,9 @@ namespace lfs::io::project {
         [[nodiscard]] std::uint64_t size() const noexcept;
         [[nodiscard]] const lfs::core::Uuid& snapshot_uuid() const noexcept;
         [[nodiscard]] bool is_clean_reference() const noexcept;
+        // Test-only: forget the CleanProof while keeping the file-backed
+        // source so save() cannot reuse the row and must copy stored bytes.
+        void drop_clean_proof_for_testing() noexcept;
 
         [[nodiscard]] lfs::Result<void>
         read_at(std::uint64_t offset, std::span<std::byte> destination) const;
@@ -229,6 +232,10 @@ namespace lfs::io::project {
 
         [[nodiscard]] const LazyChunkValue*
         find_checkpoint(const lfs::core::Uuid& instance_uuid) const noexcept;
+        // Test-only: drop the file-backed CKPT CleanProof. find_checkpoint()
+        // is const and LazyChunkValue::Impl is translation-unit local.
+        void drop_checkpoint_clean_proof_for_testing(
+            const lfs::core::Uuid& instance_uuid);
         [[nodiscard]] lfs::Result<void>
         set_checkpoint(const lfs::core::Uuid& instance_uuid,
                        LazyChunkValue payload);

--- a/src/io/include/io/splat_chapter.hpp
+++ b/src/io/include/io/splat_chapter.hpp
@@ -8,9 +8,14 @@
 #include "core/error.hpp"
 #include "core/export.hpp"
 #include "core/splat_data.hpp"
+#include "io/project_chapters.hpp"
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <iosfwd>
+#include <memory>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -23,6 +28,11 @@ namespace lfs::io::project {
         Generated,
         BakedRad, // reserved: SOG embed / bake-to-embedded (owner decision 2026-07-30)
         LiveRad,
+    };
+
+    struct LFS_IO_API HydratedSplatStream {
+        std::unique_ptr<lfs::core::SplatData> splat;
+        Hash128 content_xxh3_128;
     };
 
     class LFS_IO_API SplatChapterPayload {
@@ -44,6 +54,15 @@ namespace lfs::io::project {
         [[nodiscard]] lfs::Result<std::unique_ptr<lfs::core::SplatData>>
         hydrate(lfs::core::SplatTensorAllocator tensor_allocator = {}) const;
 
+        // Parse and hydrate an LFSP v2 raw splat from a seekable logical-payload
+        // stream without materializing the full payload. The returned hash is
+        // XXH3-128 of the entire logical payload in order.
+        [[nodiscard]] static lfs::Result<HydratedSplatStream>
+        hydrate_lfsp_stream(
+            std::istream& stream, std::uint64_t size,
+            lfs::core::SplatTensorAllocator allocator = {},
+            std::function<void(std::size_t, std::size_t)> progress = {});
+
         [[nodiscard]] static bool must_reference_external(
             SplatSourceKind source_kind) noexcept;
 
@@ -51,5 +70,11 @@ namespace lfs::io::project {
         std::vector<std::byte> bytes_;
         std::uint32_t lfsp_version_ = 0;
     };
+
+    namespace detail {
+        // Test-only override of the stream-hydrate window. nullopt restores 16 MiB.
+        LFS_IO_API void set_splat_stream_window_bytes_for_testing(
+            std::optional<std::size_t> window_bytes);
+    } // namespace detail
 
 } // namespace lfs::io::project

--- a/src/io/project/project_chapters.cpp
+++ b/src/io/project/project_chapters.cpp
@@ -782,6 +782,44 @@ namespace lfs::io::project {
         return hash128_from_xxh(XXH3_128bits(bytes.data(), bytes.size()));
     }
 
+    struct Hash128Stream::Impl {
+        using StatePtr = std::unique_ptr<XXH3_state_t, decltype(&XXH3_freeState)>;
+        StatePtr state{nullptr, &XXH3_freeState};
+    };
+
+    Hash128Stream::Hash128Stream() : impl_(std::make_unique<Impl>()) {
+        impl_->state.reset(XXH3_createState());
+        if (!impl_->state || XXH3_128bits_reset(impl_->state.get()) == XXH_ERROR) {
+            impl_->state.reset();
+        }
+    }
+
+    Hash128Stream::Hash128Stream(Hash128Stream&&) noexcept = default;
+    Hash128Stream& Hash128Stream::operator=(Hash128Stream&&) noexcept = default;
+    Hash128Stream::~Hash128Stream() = default;
+
+    bool Hash128Stream::valid() const noexcept {
+        return impl_ && impl_->state;
+    }
+
+    bool Hash128Stream::update(const std::span<const std::byte> bytes) noexcept {
+        if (!valid()) {
+            return false;
+        }
+        if (bytes.empty()) {
+            return true;
+        }
+        return XXH3_128bits_update(impl_->state.get(), bytes.data(),
+                                   bytes.size()) != XXH_ERROR;
+    }
+
+    Hash128 Hash128Stream::digest() const noexcept {
+        if (!valid()) {
+            return {};
+        }
+        return hash128_from_xxh(XXH3_128bits_digest(impl_->state.get()));
+    }
+
     lfs::Result<ReferenceFingerprint> fingerprint_path(
         const std::filesystem::path& path, const bool include_full_hash) {
         std::error_code error;
@@ -2624,8 +2662,7 @@ namespace lfs::io::project {
                 value.georef_pose->rotation[2] * value.georef_pose->rotation[2] +
                 value.georef_pose->rotation[3] * value.georef_pose->rotation[3]);
             if (!std::isfinite(norm) || norm < 1e-12 ||
-                std::ranges::any_of(value.georef_pose->translation,
-                                    [](const double item) { return !std::isfinite(item); })) {
+                std::ranges::any_of(value.georef_pose->translation, [](const double item) { return !std::isfinite(item); })) {
                 return fail<void>(
                     lfs::ErrorCode::InvalidArgument,
                     "The node georeference pose is invalid.",

--- a/src/io/project/project_container.cpp
+++ b/src/io/project/project_container.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cassert>
 #include <cerrno>
 #include <chrono>
@@ -3958,10 +3959,55 @@ namespace lfs::io::project {
             bool failed_ = false;
         };
 
+        // Inverse of the f32 byte-plane shuffle for a logical byte range.
+        // `plane_cursors[p]` points at the first in-range byte of plane p
+        // (planes that the range does not touch may be null). Full words are
+        // gathered without per-byte `% 4` / `/ 4`; unaligned head/tail bytes
+        // use a short scalar path.
+        void gather_unshuffle_words(char* dest, const std::uint64_t logical_pos,
+                                    const std::size_t count,
+                                    std::array<const char*, 4>& plane_cursors) {
+            if (dest == nullptr || count == 0) {
+                return;
+            }
+            std::size_t offset = 0;
+            auto plane = static_cast<std::size_t>(logical_pos & 3u);
+            while (offset < count && plane != 0) {
+                dest[offset++] = *plane_cursors[plane]++;
+                plane = (plane + 1) & 3u;
+            }
+            const std::size_t remaining = count - offset;
+            const std::size_t words = remaining / 4;
+            if (words != 0) {
+                const char* p0 = plane_cursors[0];
+                const char* p1 = plane_cursors[1];
+                const char* p2 = plane_cursors[2];
+                const char* p3 = plane_cursors[3];
+                char* out = dest + offset;
+                for (std::size_t word = 0; word < words; ++word) {
+                    out[4 * word + 0] = p0[word];
+                    out[4 * word + 1] = p1[word];
+                    out[4 * word + 2] = p2[word];
+                    out[4 * word + 3] = p3[word];
+                }
+                plane_cursors[0] = p0 + words;
+                plane_cursors[1] = p1 + words;
+                plane_cursors[2] = p2 + words;
+                plane_cursors[3] = p3 + words;
+                offset += words * 4;
+            }
+            plane = 0;
+            while (offset < count) {
+                dest[offset++] = *plane_cursors[plane]++;
+                ++plane;
+            }
+        }
+
         // Logical (decoded / unshuffled) view of a framed payload. Resident
         // decoded records are capped: ZstdFramed keeps current + one
         // read-ahead; ByteShuffleZstdFramed keeps at most one record per
-        // byte plane plus a bounded gather window.
+        // byte plane plus a bounded gather window. Bulk `xsgetn` decodes at
+        // most kMaxResidentDecodeRecords (~512MiB decoded) beyond dest.
         class FramedLogicalStreambuf final : public std::streambuf {
         public:
             FramedLogicalStreambuf(std::shared_ptr<ReaderState> state,
@@ -4007,6 +4053,48 @@ namespace lfs::io::project {
                 }
                 failed_ = true;
                 return traits_type::eof();
+            }
+
+            std::streamsize xsgetn(char* s, std::streamsize count) override {
+                if (failed_ || s == nullptr || count <= 0) {
+                    return 0;
+                }
+                std::streamsize delivered = 0;
+                if (gptr() < egptr()) {
+                    const auto available =
+                        static_cast<std::streamsize>(egptr() - gptr());
+                    const auto take = std::min(available, count);
+                    std::memcpy(s, gptr(), static_cast<std::size_t>(take));
+                    gbump(static_cast<int>(take));
+                    delivered += take;
+                    if (delivered >= count) {
+                        return delivered;
+                    }
+                }
+                sync_position();
+                setg(nullptr, nullptr, nullptr);
+                if (position_ >= size_) {
+                    return delivered;
+                }
+                const auto want = static_cast<std::uint64_t>(count - delivered);
+                const auto take = std::min(want, size_ - position_);
+                if (take == 0) {
+                    return delivered;
+                }
+                if (!ensure_table()) {
+                    failed_ = true;
+                    return delivered;
+                }
+                const std::uint64_t before = position_;
+                const bool ok =
+                    byteshuffle_ ? bulk_copy_shuffle(s + delivered, take)
+                                 : bulk_copy_zstd(s + delivered, take);
+                delivered += static_cast<std::streamsize>(position_ - before);
+                if (!ok) {
+                    failed_ = true;
+                }
+                prune_cache_after_bulk();
+                return delivered;
             }
 
             pos_type seekoff(const off_type offset, const std::ios_base::seekdir direction,
@@ -4060,6 +4148,9 @@ namespace lfs::io::project {
         private:
             static constexpr std::size_t kNpos = static_cast<std::size_t>(-1);
             static constexpr std::size_t kShuffleWindowBytes = 8ull * 1024 * 1024;
+            // Bulk decode cap: 8 records × 64MiB target ≈ 512MiB decoded
+            // resident at once beyond the caller's destination buffer.
+            static constexpr std::size_t kMaxResidentDecodeRecords = 8;
 
             struct FramedRecord {
                 std::uint64_t so = 0;
@@ -4267,12 +4358,12 @@ namespace lfs::io::project {
                 return nullptr;
             }
 
-            bool decode_record(const std::size_t index, std::vector<char>& decoded) {
+            bool read_record_stored(const std::size_t index,
+                                    std::vector<std::byte>& stored) {
                 if (index >= records_.size()) {
                     return false;
                 }
                 const FramedRecord& record = records_[index];
-                std::vector<std::byte> stored;
                 try {
                     stored.resize(static_cast<std::size_t>(record.sb));
                 } catch (const std::bad_alloc&) {
@@ -4280,31 +4371,471 @@ namespace lfs::io::project {
                 } catch (const std::length_error&) {
                     return false;
                 }
-                {
-                    std::scoped_lock lock(io_mutex_);
-                    if (!ensure_blocks_locked(record.so, record.sb)) {
-                        return false;
-                    }
-                    if (!read_stored_locked(
-                            record.so, std::span<std::byte>(stored.data(), stored.size()))) {
-                        return false;
-                    }
+                std::scoped_lock lock(io_mutex_);
+                if (!ensure_blocks_locked(record.so, record.sb)) {
+                    return false;
+                }
+                return read_stored_locked(
+                    record.so, std::span<std::byte>(stored.data(), stored.size()));
+            }
+
+            bool decompress_record(const FramedRecord& record,
+                                   const std::vector<std::byte>& stored, void* dest,
+                                   const std::size_t dest_bytes) const {
+                if (dest == nullptr || dest_bytes != record.ub) {
+                    return false;
                 }
                 const auto frame_size =
                     ZSTD_getFrameContentSize(stored.data(), stored.size());
                 if (frame_size != record.ub) {
                     return false;
                 }
+                const auto result = ZSTD_decompress(dest, dest_bytes, stored.data(),
+                                                    stored.size());
+                return !ZSTD_isError(result) && result == record.ub;
+            }
+
+            bool decode_record(const std::size_t index, std::vector<char>& decoded) {
+                if (index >= records_.size()) {
+                    return false;
+                }
+                std::vector<std::byte> stored;
+                if (!read_record_stored(index, stored)) {
+                    return false;
+                }
                 try {
-                    decoded.resize(static_cast<std::size_t>(record.ub));
+                    decoded.resize(static_cast<std::size_t>(records_[index].ub));
                 } catch (const std::bad_alloc&) {
                     return false;
                 } catch (const std::length_error&) {
                     return false;
                 }
-                const auto result = ZSTD_decompress(
-                    decoded.data(), decoded.size(), stored.data(), stored.size());
-                return !ZSTD_isError(result) && result == record.ub;
+                return decompress_record(records_[index], stored, decoded.data(),
+                                         decoded.size());
+            }
+
+            bool decode_record_direct(const std::size_t index, void* dest,
+                                      const std::size_t dest_bytes) {
+                if (index >= records_.size()) {
+                    return false;
+                }
+                std::vector<std::byte> stored;
+                if (!read_record_stored(index, stored)) {
+                    return false;
+                }
+                return decompress_record(records_[index], stored, dest, dest_bytes);
+            }
+
+            struct DecodeItem {
+                std::size_t index = kNpos;
+                char* direct = nullptr;
+            };
+
+            bool decode_items(const std::vector<DecodeItem>& items,
+                              std::vector<std::uint8_t>& ok) {
+                if (items.empty()) {
+                    return true;
+                }
+                ok.assign(items.size(), std::uint8_t{1});
+                std::atomic<std::size_t> next{0};
+                std::mutex cache_mutex;
+                const auto run_one = [&](const std::size_t slot) {
+                    const DecodeItem& item = items[slot];
+                    if (item.index >= records_.size()) {
+                        ok[slot] = 0;
+                        return;
+                    }
+                    if (item.direct != nullptr) {
+                        if (!decode_record_direct(
+                                item.index, item.direct,
+                                static_cast<std::size_t>(records_[item.index].ub))) {
+                            ok[slot] = 0;
+                        }
+                        return;
+                    }
+                    CachedRecord decoded;
+                    decoded.index = item.index;
+                    if (!decode_record(item.index, decoded.bytes)) {
+                        ok[slot] = 0;
+                        return;
+                    }
+                    std::scoped_lock lock(cache_mutex);
+                    if (find_cached(item.index) == nullptr) {
+                        cache_.push_back(std::move(decoded));
+                    }
+                };
+                if (items.size() == 1) {
+                    try {
+                        run_one(0);
+                    } catch (...) {
+                        ok[0] = 0;
+                    }
+                    return ok[0] != 0;
+                }
+                const auto workers_count = std::min<std::size_t>(
+                    items.size(),
+                    std::max(1u, std::thread::hardware_concurrency()));
+                std::vector<std::jthread> workers;
+                try {
+                    workers.reserve(workers_count);
+                    for (std::size_t worker = 0; worker < workers_count; ++worker) {
+                        workers.emplace_back([&] {
+                            while (true) {
+                                const auto slot = next.fetch_add(1);
+                                if (slot >= items.size()) {
+                                    return;
+                                }
+                                try {
+                                    run_one(slot);
+                                } catch (...) {
+                                    ok[slot] = 0;
+                                }
+                            }
+                        });
+                    }
+                } catch (...) {
+                    ok.assign(items.size(), std::uint8_t{0});
+                }
+                workers.clear();
+                return std::find(ok.begin(), ok.end(), std::uint8_t{0}) == ok.end();
+            }
+
+            static std::uint64_t first_plane_word(const std::uint64_t plane,
+                                                  const std::uint64_t lo,
+                                                  const std::uint64_t hi,
+                                                  const std::uint64_t n_words) noexcept {
+                if (lo >= hi || plane >= 4 || n_words == 0) {
+                    return kNpos;
+                }
+                const std::uint64_t first =
+                    lo / 4 + (plane < (lo % 4) ? 1 : 0);
+                const std::uint64_t last_byte = hi - 1;
+                const std::uint64_t last_word = last_byte / 4;
+                const std::uint64_t plane_last =
+                    plane <= (last_byte % 4)
+                        ? last_word
+                        : (last_word == 0 ? static_cast<std::uint64_t>(kNpos)
+                                          : last_word - 1);
+                if (plane_last == kNpos || first > plane_last || first >= n_words) {
+                    return kNpos;
+                }
+                return first;
+            }
+
+            static std::uint64_t last_plane_word(const std::uint64_t plane,
+                                                 const std::uint64_t lo,
+                                                 const std::uint64_t hi,
+                                                 const std::uint64_t n_words) noexcept {
+                if (first_plane_word(plane, lo, hi, n_words) == kNpos) {
+                    return kNpos;
+                }
+                const std::uint64_t last_byte = hi - 1;
+                const std::uint64_t last_word = last_byte / 4;
+                const std::uint64_t plane_last =
+                    plane <= (last_byte % 4) ? last_word : last_word - 1;
+                return std::min(plane_last, n_words - 1);
+            }
+
+            [[nodiscard]] bool
+            shuffle_record_covers(const std::size_t index, const std::uint64_t lo,
+                                  const std::uint64_t hi) const {
+                if (index >= records_.size() || lo >= hi || size_ % 4 != 0) {
+                    return false;
+                }
+                const std::uint64_t n_words = size_ / 4;
+                const FramedRecord& record = records_[index];
+                for (std::uint64_t plane = 0; plane < 4; ++plane) {
+                    const std::uint64_t word =
+                        first_plane_word(plane, lo, hi, n_words);
+                    const std::uint64_t last =
+                        last_plane_word(plane, lo, hi, n_words);
+                    if (word == kNpos || last == kNpos) {
+                        continue;
+                    }
+                    const std::uint64_t dec_lo = plane * n_words + word;
+                    const std::uint64_t dec_hi = plane * n_words + last + 1;
+                    if (record.uo < dec_hi && record.uo + record.ub > dec_lo) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            void retain_cache(const std::vector<std::size_t>& keep) {
+                cache_.erase(std::remove_if(cache_.begin(), cache_.end(),
+                                            [&](const CachedRecord& cached) {
+                                                return std::find(keep.begin(),
+                                                                 keep.end(),
+                                                                 cached.index) ==
+                                                       keep.end();
+                                            }),
+                             cache_.end());
+            }
+
+            void prune_cache_after_bulk() {
+                if (position_ >= size_ || !table_ready_) {
+                    cache_.clear();
+                    return;
+                }
+                std::vector<std::size_t> keep;
+                if (byteshuffle_) {
+                    if (size_ % 4 != 0) {
+                        cache_.clear();
+                        return;
+                    }
+                    const std::uint64_t n_words = size_ / 4;
+                    for (std::uint64_t plane = 0; plane < 4; ++plane) {
+                        const std::uint64_t word =
+                            first_plane_word(plane, position_, size_, n_words);
+                        if (word == kNpos) {
+                            continue;
+                        }
+                        const auto index =
+                            record_index_containing(plane * n_words + word);
+                        if (index != kNpos &&
+                            std::find(keep.begin(), keep.end(), index) ==
+                                keep.end()) {
+                            keep.push_back(index);
+                        }
+                    }
+                } else {
+                    const auto index = record_index_containing(position_);
+                    if (index != kNpos) {
+                        keep.push_back(index);
+                        if (index + 1 < records_.size()) {
+                            keep.push_back(index + 1);
+                        }
+                    }
+                }
+                retain_cache(keep);
+            }
+
+            bool bulk_copy_zstd(char* dest, const std::uint64_t count) {
+                const std::uint64_t start = position_;
+                const std::uint64_t end = start + count;
+                if (count == 0) {
+                    return true;
+                }
+                const auto first = record_index_containing(start);
+                const auto last = record_index_containing(end - 1);
+                if (first == kNpos || last == kNpos || last < first) {
+                    return false;
+                }
+                for (std::size_t batch_begin = first; batch_begin <= last;
+                     batch_begin += kMaxResidentDecodeRecords) {
+                    const std::size_t batch_end = std::min(
+                        batch_begin + kMaxResidentDecodeRecords, last + 1);
+                    std::vector<DecodeItem> items;
+                    items.reserve(batch_end - batch_begin);
+                    for (std::size_t index = batch_begin; index < batch_end;
+                         ++index) {
+                        const FramedRecord& record = records_[index];
+                        const bool full = record.uo >= start &&
+                                          record.uo + record.ub <= end;
+                        DecodeItem item;
+                        item.index = index;
+                        if (full) {
+                            item.direct =
+                                dest + static_cast<std::size_t>(record.uo - start);
+                        }
+                        items.push_back(item);
+                    }
+                    std::vector<std::uint8_t> ok;
+                    decode_items(items, ok);
+                    for (std::size_t slot = 0; slot < items.size(); ++slot) {
+                        const std::size_t index = items[slot].index;
+                        const FramedRecord& record = records_[index];
+                        if (slot >= ok.size() || ok[slot] == 0) {
+                            position_ = std::max(start, record.uo);
+                            return false;
+                        }
+                        if (items[slot].direct != nullptr) {
+                            continue;
+                        }
+                        const CachedRecord* cached = find_cached(index);
+                        if (cached == nullptr) {
+                            position_ = std::max(start, record.uo);
+                            return false;
+                        }
+                        const std::uint64_t lo = std::max(record.uo, start);
+                        const std::uint64_t hi =
+                            std::min(record.uo + record.ub, end);
+                        if (lo < hi) {
+                            std::memcpy(
+                                dest + static_cast<std::size_t>(lo - start),
+                                cached->bytes.data() +
+                                    static_cast<std::size_t>(lo - record.uo),
+                                static_cast<std::size_t>(hi - lo));
+                        }
+                    }
+                }
+                position_ = end;
+                return true;
+            }
+
+            bool bulk_copy_shuffle(char* dest, const std::uint64_t count) {
+                if (size_ % 4 != 0) {
+                    return false;
+                }
+                const std::uint64_t n_words = size_ / 4;
+                const std::uint64_t start = position_;
+                const std::uint64_t end = start + count;
+                if (count == 0) {
+                    return true;
+                }
+                // 0 = unknown, 1 = ready, 2 = failed
+                std::vector<std::uint8_t> status(records_.size(), std::uint8_t{0});
+                for (const auto& cached : cache_) {
+                    if (cached.index < status.size()) {
+                        status[cached.index] = 1;
+                    }
+                }
+                const auto add_unique = [](std::vector<std::size_t>& batch,
+                                           const std::size_t index) {
+                    if (index == kNpos) {
+                        return;
+                    }
+                    if (std::find(batch.begin(), batch.end(), index) !=
+                        batch.end()) {
+                        return;
+                    }
+                    if (batch.size() >= kMaxResidentDecodeRecords) {
+                        return;
+                    }
+                    batch.push_back(index);
+                };
+
+                std::uint64_t logical = start;
+                while (logical < end) {
+                    std::vector<std::size_t> batch;
+                    for (std::uint64_t plane = 0; plane < 4; ++plane) {
+                        const std::uint64_t word =
+                            first_plane_word(plane, logical, end, n_words);
+                        if (word == kNpos) {
+                            continue;
+                        }
+                        add_unique(batch,
+                                   record_index_containing(plane * n_words + word));
+                    }
+                    for (std::uint64_t plane = 0; plane < 4; ++plane) {
+                        const std::uint64_t word =
+                            first_plane_word(plane, logical, end, n_words);
+                        if (word == kNpos) {
+                            continue;
+                        }
+                        const auto index =
+                            record_index_containing(plane * n_words + word);
+                        if (index == kNpos || index + 1 >= records_.size()) {
+                            continue;
+                        }
+                        if (shuffle_record_covers(index + 1, logical, end)) {
+                            add_unique(batch, index + 1);
+                        }
+                    }
+
+                    std::vector<DecodeItem> items;
+                    for (const auto index : batch) {
+                        if (index >= status.size()) {
+                            continue;
+                        }
+                        if (status[index] == 1 || find_cached(index) != nullptr) {
+                            status[index] = 1;
+                            continue;
+                        }
+                        if (status[index] == 2) {
+                            continue;
+                        }
+                        items.push_back(DecodeItem{index, nullptr});
+                    }
+                    std::vector<std::uint8_t> ok;
+                    decode_items(items, ok);
+                    for (std::size_t slot = 0; slot < items.size(); ++slot) {
+                        const auto index = items[slot].index;
+                        if (index >= status.size()) {
+                            continue;
+                        }
+                        status[index] =
+                            (slot < ok.size() && ok[slot] != 0) ? 1 : 2;
+                    }
+                    for (const auto& cached : cache_) {
+                        if (cached.index < status.size() &&
+                            status[cached.index] != 2) {
+                            status[cached.index] = 1;
+                        }
+                    }
+
+                    std::uint64_t stripe_end = end;
+                    for (std::uint64_t plane = 0; plane < 4; ++plane) {
+                        const std::uint64_t word =
+                            first_plane_word(plane, logical, end, n_words);
+                        if (word == kNpos) {
+                            continue;
+                        }
+                        const auto index =
+                            record_index_containing(plane * n_words + word);
+                        const std::uint64_t first_logical = word * 4 + plane;
+                        if (index == kNpos || index >= status.size() ||
+                            status[index] != 1) {
+                            stripe_end = std::min(stripe_end, first_logical);
+                            continue;
+                        }
+                        const FramedRecord& record = records_[index];
+                        const std::uint64_t plane_base = plane * n_words;
+                        const std::uint64_t overlap_hi = std::min(
+                            record.uo + record.ub, plane_base + n_words);
+                        if (overlap_hi <= plane_base + word) {
+                            stripe_end = std::min(stripe_end, first_logical);
+                            continue;
+                        }
+                        const std::uint64_t last_word = overlap_hi - plane_base - 1;
+                        const std::uint64_t record_end = last_word * 4 + plane + 1;
+                        stripe_end = std::min(stripe_end, record_end);
+                    }
+
+                    if (stripe_end <= logical) {
+                        position_ = logical;
+                        return false;
+                    }
+
+                    std::array<const char*, 4> cursors{};
+                    for (std::uint64_t plane = 0; plane < 4; ++plane) {
+                        const std::uint64_t word =
+                            first_plane_word(plane, logical, stripe_end, n_words);
+                        if (word == kNpos) {
+                            continue;
+                        }
+                        const auto index =
+                            record_index_containing(plane * n_words + word);
+                        const CachedRecord* cached =
+                            index == kNpos ? nullptr : find_cached(index);
+                        if (cached == nullptr) {
+                            position_ = logical;
+                            return false;
+                        }
+                        const std::uint64_t decoded = plane * n_words + word;
+                        const std::uint64_t local = decoded - records_[index].uo;
+                        if (local >= cached->bytes.size()) {
+                            position_ = logical;
+                            return false;
+                        }
+                        cursors[static_cast<std::size_t>(plane)] =
+                            cached->bytes.data() + static_cast<std::size_t>(local);
+                    }
+                    gather_unshuffle_words(
+                        dest + static_cast<std::size_t>(logical - start), logical,
+                        static_cast<std::size_t>(stripe_end - logical), cursors);
+                    logical = stripe_end;
+
+                    cache_.erase(
+                        std::remove_if(cache_.begin(), cache_.end(),
+                                       [&](const CachedRecord& cached) {
+                                           return !shuffle_record_covers(
+                                               cached.index, logical, end);
+                                       }),
+                        cache_.end());
+                }
+                position_ = end;
+                return true;
             }
 
             bool ensure_decoded(const std::vector<std::size_t>& needed) {
@@ -4488,20 +5019,25 @@ namespace lfs::io::project {
                 }
 
                 const auto count = static_cast<std::size_t>(window_end - position_);
-                for (std::size_t index = 0; index < count; ++index) {
-                    const std::uint64_t logical = position_ + index;
-                    const std::uint64_t plane = logical % 4;
-                    const std::uint64_t word = logical / 4;
-                    const auto* cached = plane_cache[static_cast<std::size_t>(plane)];
-                    const auto record_index =
+                std::array<const char*, 4> cursors{};
+                for (std::uint64_t plane = 0; plane < 4; ++plane) {
+                    const auto index =
                         plane_record[static_cast<std::size_t>(plane)];
+                    if (index == kNpos) {
+                        continue;
+                    }
+                    const auto* cached = plane_cache[static_cast<std::size_t>(plane)];
+                    const std::uint64_t word =
+                        plane >= start_plane ? start_word : start_word + 1;
                     const std::uint64_t decoded = plane * n_words + word;
-                    const std::uint64_t local = decoded - records_[record_index].uo;
+                    const std::uint64_t local = decoded - records_[index].uo;
                     if (cached == nullptr || local >= cached->bytes.size()) {
                         return false;
                     }
-                    window_[index] = cached->bytes[static_cast<std::size_t>(local)];
+                    cursors[static_cast<std::size_t>(plane)] =
+                        cached->bytes.data() + static_cast<std::size_t>(local);
                 }
+                gather_unshuffle_words(window_.data(), position_, count, cursors);
                 buffer_start_ = position_;
                 setg(window_.data(), window_.data(), window_.data() + count);
                 return true;

--- a/src/io/project/project_container.cpp
+++ b/src/io/project/project_container.cpp
@@ -2857,6 +2857,46 @@ namespace lfs::io::project {
             return {};
         }
 
+        // Stored-only integrity: one bounded pass over the payload range.
+        // Matches verify_chunk's payload CRC mismatch identity (field string
+        // and expected/actual hex). Does not decode framed records.
+        // payload_bytes_read is incremented before each block read, same as
+        // verify_chunk's stored CRC loop (the subsequent framed materialize
+        // in verify_chunk does not increment this counter).
+        lfs::Result<void> verify_stored_payload_crc32c(const ReaderState& state,
+                                                       const ChunkInfo& row) {
+            std::uint32_t running_crc = 0;
+            std::uint64_t relative = 0;
+            while (relative < row.stored_bytes) {
+                const std::uint64_t count =
+                    std::min<std::uint64_t>(BLOCK_CRC_BYTES,
+                                            row.stored_bytes - relative);
+                if (state.options.payload_bytes_read) {
+                    state.options.payload_bytes_read->fetch_add(
+                        count, std::memory_order_relaxed);
+                }
+                auto bytes = read_vector(*state.file,
+                                         row.payload_offset + relative, count,
+                                         state.physical_size,
+                                         state.selected.commit.info.committed_file_end,
+                                         "payload.verify",
+                                         BLOCK_CRC_BYTES);
+                if (!bytes) {
+                    return status_failure(std::move(bytes).error());
+                }
+                running_crc = crc32c(running_crc, bytes->data(), bytes->size());
+                relative += count;
+            }
+            if (running_crc != row.payload_crc32c) {
+                return status_failure(format_error(
+                    state.path, row.payload_offset,
+                    std::format("payload[{}].crc32c", row.key_string()),
+                    std::format("0x{:08x}", row.payload_crc32c),
+                    std::format("0x{:08x}", running_crc)));
+            }
+            return {};
+        }
+
         lfs::Result<void>
         require_supported_payload_access(const ProjectReader& reader) {
             if (reader.open_state() == OpenState::Open) {
@@ -5117,7 +5157,18 @@ namespace lfs::io::project {
                 std::to_string(row.uncompressed_bytes));
         }
         if (!row.block_crc_table.has_value()) {
-            if (auto verified = verify_chunk(row); !verified) {
+            // Framed: CRC the stored range in BLOCK_CRC_BYTES windows. Do not
+            // decode — ensure_table validates the record table on first use,
+            // and decompress_record checks ZSTD_getFrameContentSize == ub and
+            // decode size == ub when that record is read.
+            // Stored: verify_chunk does not decode and stays as-is.
+            if (framed) {
+                if (auto verified =
+                        verify_stored_payload_crc32c(*impl_->state, row);
+                    !verified) {
+                    return std::move(verified).error();
+                }
+            } else if (auto verified = verify_chunk(row); !verified) {
                 return std::move(verified).error();
             }
         }

--- a/src/io/project/project_container.cpp
+++ b/src/io/project/project_container.cpp
@@ -84,14 +84,6 @@ namespace lfs::io::project {
 
         std::optional<std::uint64_t> payload_materialized_bytes_override;
 
-        std::uint64_t max_materialized_bytes_for(const ChunkInfo& row) noexcept {
-            if (is_payload_class_chunk(row)) {
-                return payload_materialized_bytes_override.value_or(
-                    MAX_PAYLOAD_MATERIALIZED_BYTES);
-            }
-            return MAX_MATERIALIZED_CHUNK_BYTES;
-        }
-
         lfs::Result<void> status_failure(lfs::Error error) {
             return lfs::Result<void>::failure(std::move(error));
         }
@@ -3042,6 +3034,14 @@ namespace lfs::io::project {
         payload_materialized_bytes_override = maximum_decoded_size;
     }
 
+    std::uint64_t detail::max_materialized_bytes_for(const ChunkInfo& row) noexcept {
+        if (is_payload_class_chunk(row)) {
+            return payload_materialized_bytes_override.value_or(
+                MAX_PAYLOAD_MATERIALIZED_BYTES);
+        }
+        return MAX_MATERIALIZED_CHUNK_BYTES;
+    }
+
     lfs::Result<void>
     ProjectReader::read_stored_at(const ChunkInfo& chunk,
                                   const std::uint64_t relative_offset,
@@ -3162,7 +3162,7 @@ namespace lfs::io::project {
                     std::to_string(row.stored_bytes)));
             }
             const std::uint64_t materialize_max =
-                max_materialized_bytes_for(row);
+                detail::max_materialized_bytes_for(row);
             auto stored = read_vector(*impl_->state->file, row.payload_offset,
                                       row.stored_bytes,
                                       impl_->state->physical_size,
@@ -3218,7 +3218,7 @@ namespace lfs::io::project {
             std::chrono::steady_clock::now();
         const ChunkInfo& row = **resolved;
         const std::uint64_t materialize_max =
-            max_materialized_bytes_for(**resolved);
+            detail::max_materialized_bytes_for(**resolved);
         if ((*resolved)->stored_bytes > materialize_max ||
             (*resolved)->uncompressed_bytes > materialize_max) {
             return detail::project_error(

--- a/src/io/project/project_container.cpp
+++ b/src/io/project/project_container.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <format>
 #include <istream>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <mutex>
@@ -80,9 +81,14 @@ namespace lfs::io::project {
                    row.key.fourcc == FOURCC_PPIS;
         }
 
+        std::optional<std::uint64_t> payload_materialized_bytes_override;
+
         std::uint64_t max_materialized_bytes_for(const ChunkInfo& row) noexcept {
-            return is_payload_class_chunk(row) ? MAX_PAYLOAD_MATERIALIZED_BYTES
-                                               : MAX_MATERIALIZED_CHUNK_BYTES;
+            if (is_payload_class_chunk(row)) {
+                return payload_materialized_bytes_override.value_or(
+                    MAX_PAYLOAD_MATERIALIZED_BYTES);
+            }
+            return MAX_MATERIALIZED_CHUNK_BYTES;
         }
 
         lfs::Result<void> status_failure(lfs::Error error) {
@@ -3030,6 +3036,11 @@ namespace lfs::io::project {
                                       maximum_decoded_size);
     }
 
+    void detail::set_max_payload_materialized_bytes_for_testing(
+        const std::optional<std::uint64_t> maximum_decoded_size) {
+        payload_materialized_bytes_override = maximum_decoded_size;
+    }
+
     lfs::Result<void>
     ProjectReader::read_stored_at(const ChunkInfo& chunk,
                                   const std::uint64_t relative_offset,
@@ -3947,21 +3958,580 @@ namespace lfs::io::project {
             bool failed_ = false;
         };
 
+        // Logical (decoded / unshuffled) view of a framed payload. Resident
+        // decoded records are capped: ZstdFramed keeps current + one
+        // read-ahead; ByteShuffleZstdFramed keeps at most one record per
+        // byte plane plus a bounded gather window.
+        class FramedLogicalStreambuf final : public std::streambuf {
+        public:
+            FramedLogicalStreambuf(std::shared_ptr<ReaderState> state,
+                                   ChunkInfo row, const bool byteshuffle)
+                : state_(std::move(state)),
+                  row_(std::move(row)),
+                  byteshuffle_(byteshuffle),
+                  size_(row_.uncompressed_bytes),
+                  window_(byteshuffle_ ? kShuffleWindowBytes : 0) {
+                if (row_.block_crc_table.has_value() && row_.stored_bytes != 0) {
+                    const auto blocks =
+                        (row_.stored_bytes + row_.block_crc_table->block_size - 1) /
+                        row_.block_crc_table->block_size;
+                    block_validated_.assign(static_cast<std::size_t>(blocks),
+                                            std::uint8_t{0});
+                }
+                setg(nullptr, nullptr, nullptr);
+            }
+
+        protected:
+            int_type underflow() override {
+                if (failed_) {
+                    return traits_type::eof();
+                }
+                if (gptr() < egptr()) {
+                    return traits_type::to_int_type(*gptr());
+                }
+                sync_position();
+                if (position_ >= size_) {
+                    return traits_type::eof();
+                }
+                // Drop the get area before cache mutation so evicted records
+                // cannot leave dangling eback/gptr pointers.
+                setg(nullptr, nullptr, nullptr);
+                const bool ready =
+                    byteshuffle_ ? prepare_shuffle_window() : prepare_zstd_window();
+                if (!ready) {
+                    failed_ = true;
+                    return traits_type::eof();
+                }
+                if (gptr() < egptr()) {
+                    return traits_type::to_int_type(*gptr());
+                }
+                failed_ = true;
+                return traits_type::eof();
+            }
+
+            pos_type seekoff(const off_type offset, const std::ios_base::seekdir direction,
+                             const std::ios_base::openmode mode) override {
+                if ((mode & std::ios_base::in) == 0) {
+                    return pos_type(off_type(-1));
+                }
+                sync_position();
+                std::int64_t base = 0;
+                if (direction == std::ios_base::beg) {
+                    base = 0;
+                } else if (direction == std::ios_base::cur) {
+                    if (position_ > static_cast<std::uint64_t>(
+                                        std::numeric_limits<std::int64_t>::max())) {
+                        return pos_type(off_type(-1));
+                    }
+                    base = static_cast<std::int64_t>(position_);
+                } else if (direction == std::ios_base::end) {
+                    if (size_ > static_cast<std::uint64_t>(
+                                    std::numeric_limits<std::int64_t>::max())) {
+                        return pos_type(off_type(-1));
+                    }
+                    base = static_cast<std::int64_t>(size_);
+                } else {
+                    return pos_type(off_type(-1));
+                }
+                if (offset > 0 &&
+                    base > std::numeric_limits<std::int64_t>::max() - offset) {
+                    return pos_type(off_type(-1));
+                }
+                if (offset < 0 &&
+                    base < std::numeric_limits<std::int64_t>::min() - offset) {
+                    return pos_type(off_type(-1));
+                }
+                const std::int64_t target = base + offset;
+                if (target < 0 || static_cast<std::uint64_t>(target) > size_) {
+                    return pos_type(off_type(-1));
+                }
+                position_ = static_cast<std::uint64_t>(target);
+                buffer_start_ = position_;
+                setg(nullptr, nullptr, nullptr);
+                return pos_type(static_cast<off_type>(position_));
+            }
+
+            pos_type seekpos(const pos_type position,
+                             const std::ios_base::openmode mode) override {
+                return seekoff(static_cast<off_type>(position), std::ios_base::beg,
+                               mode);
+            }
+
+        private:
+            static constexpr std::size_t kNpos = static_cast<std::size_t>(-1);
+            static constexpr std::size_t kShuffleWindowBytes = 8ull * 1024 * 1024;
+
+            struct FramedRecord {
+                std::uint64_t so = 0;
+                std::uint64_t sb = 0;
+                std::uint64_t uo = 0;
+                std::uint64_t ub = 0;
+            };
+
+            struct CachedRecord {
+                std::size_t index = kNpos;
+                std::vector<char> bytes;
+            };
+
+            void sync_position() noexcept {
+                if (eback() != nullptr && gptr() != nullptr) {
+                    position_ =
+                        buffer_start_ + static_cast<std::uint64_t>(gptr() - eback());
+                }
+            }
+
+            void account_payload_bytes(const std::uint64_t count) const {
+                if (state_ && state_->options.payload_bytes_read) {
+                    state_->options.payload_bytes_read->fetch_add(
+                        count, std::memory_order_relaxed);
+                }
+            }
+
+            bool read_stored_locked(const std::uint64_t relative,
+                                    const std::span<std::byte> destination) {
+                if (!state_ || destination.empty()) {
+                    return destination.empty();
+                }
+                if (auto read = state_->file->read_exact(
+                        row_.payload_offset + relative, destination);
+                    !read) {
+                    return false;
+                }
+                account_payload_bytes(destination.size());
+                return true;
+            }
+
+            bool ensure_blocks_locked(const std::uint64_t relative,
+                                      const std::uint64_t length) {
+                if (!row_.block_crc_table.has_value() || length == 0) {
+                    return true;
+                }
+                const BlockCrcTable& table = *row_.block_crc_table;
+                if (table.block_size == 0 || relative >= row_.stored_bytes ||
+                    length > row_.stored_bytes - relative) {
+                    return false;
+                }
+                const std::uint64_t first = relative / table.block_size;
+                const std::uint64_t last = (relative + length - 1) / table.block_size;
+                for (std::uint64_t block_index = first; block_index <= last;
+                     ++block_index) {
+                    const auto index = static_cast<std::size_t>(block_index);
+                    if (index < block_validated_.size() &&
+                        block_validated_[index] != 0) {
+                        continue;
+                    }
+                    if (index >= table.entries.size()) {
+                        return false;
+                    }
+                    const std::uint64_t block_offset = block_index * table.block_size;
+                    const std::uint64_t block_bytes = std::min<std::uint64_t>(
+                        table.block_size, row_.stored_bytes - block_offset);
+                    if (auto verified =
+                            verify_block_range(*state_, row_, block_offset, block_bytes);
+                        !verified) {
+                        return false;
+                    }
+                    if (index < block_validated_.size()) {
+                        block_validated_[index] = 1;
+                    }
+                }
+                return true;
+            }
+
+            bool ensure_table() {
+                if (table_ready_) {
+                    return true;
+                }
+                if (size_ == 0) {
+                    table_ready_ = true;
+                    return true;
+                }
+                std::scoped_lock lock(io_mutex_);
+                if (table_ready_) {
+                    return true;
+                }
+                if (row_.stored_bytes < detail::FRAMED_HEADER_BYTES) {
+                    return false;
+                }
+                if (!ensure_blocks_locked(0, detail::FRAMED_HEADER_BYTES)) {
+                    return false;
+                }
+                std::array<std::byte, detail::FRAMED_HEADER_BYTES> header{};
+                if (!read_stored_locked(0, byte_span(header))) {
+                    return false;
+                }
+                if (!std::equal(detail::FRAMED_MAGIC.begin(), detail::FRAMED_MAGIC.end(),
+                                header.begin())) {
+                    return false;
+                }
+                const auto count = read_u32(byte_span(header), 12);
+                if (count > (std::numeric_limits<std::size_t>::max() -
+                             detail::FRAMED_HEADER_BYTES) /
+                                detail::FRAMED_RECORD_BYTES) {
+                    return false;
+                }
+                const auto table = detail::FRAMED_HEADER_BYTES +
+                                   static_cast<std::size_t>(count) *
+                                       detail::FRAMED_RECORD_BYTES;
+                if (read_u16(byte_span(header), 8) != detail::FRAMED_VERSION ||
+                    read_u16(byte_span(header), 10) != 0 || count == 0 ||
+                    table > row_.stored_bytes) {
+                    return false;
+                }
+                if (count > size_ || row_.stored_bytes - table < count) {
+                    return false;
+                }
+                std::vector<std::byte> table_bytes;
+                try {
+                    table_bytes.resize(table);
+                } catch (const std::bad_alloc&) {
+                    return false;
+                } catch (const std::length_error&) {
+                    return false;
+                }
+                std::memcpy(table_bytes.data(), header.data(), header.size());
+                if (table > header.size()) {
+                    if (!ensure_blocks_locked(0, table)) {
+                        return false;
+                    }
+                    if (!read_stored_locked(
+                            header.size(),
+                            std::span<std::byte>(table_bytes.data() + header.size(),
+                                                 table - header.size()))) {
+                        return false;
+                    }
+                }
+                std::vector<FramedRecord> records;
+                try {
+                    records.reserve(count);
+                } catch (const std::bad_alloc&) {
+                    return false;
+                } catch (const std::length_error&) {
+                    return false;
+                }
+                std::uint64_t so = table;
+                std::uint64_t uo = 0;
+                for (std::uint32_t index = 0; index < count; ++index) {
+                    const auto at = detail::FRAMED_HEADER_BYTES +
+                                    static_cast<std::size_t>(index) *
+                                        detail::FRAMED_RECORD_BYTES;
+                    const auto sb64 = read_u64(table_bytes, at);
+                    const auto ub64 = read_u64(table_bytes, at + 8);
+                    if (sb64 == 0 || ub64 == 0 || sb64 > row_.stored_bytes - so ||
+                        ub64 > size_ - uo ||
+                        sb64 > std::numeric_limits<std::size_t>::max() ||
+                        ub64 > std::numeric_limits<std::size_t>::max()) {
+                        return false;
+                    }
+                    records.push_back({so, sb64, uo, ub64});
+                    so += sb64;
+                    uo += ub64;
+                }
+                if (so != row_.stored_bytes || uo != size_) {
+                    return false;
+                }
+                records_ = std::move(records);
+                table_ready_ = true;
+                return true;
+            }
+
+            [[nodiscard]] std::size_t
+            record_index_containing(const std::uint64_t decoded_pos) const {
+                if (records_.empty() || decoded_pos >= size_) {
+                    return kNpos;
+                }
+                const auto iterator = std::upper_bound(
+                    records_.begin(), records_.end(), decoded_pos,
+                    [](const std::uint64_t pos, const FramedRecord& record) {
+                        return pos < record.uo;
+                    });
+                if (iterator == records_.begin()) {
+                    return kNpos;
+                }
+                const auto index = static_cast<std::size_t>(
+                    std::distance(records_.begin(), iterator) - 1);
+                const auto& record = records_[index];
+                if (decoded_pos < record.uo ||
+                    decoded_pos >= record.uo + record.ub) {
+                    return kNpos;
+                }
+                return index;
+            }
+
+            [[nodiscard]] CachedRecord* find_cached(const std::size_t index) {
+                for (auto& cached : cache_) {
+                    if (cached.index == index) {
+                        return &cached;
+                    }
+                }
+                return nullptr;
+            }
+
+            bool decode_record(const std::size_t index, std::vector<char>& decoded) {
+                if (index >= records_.size()) {
+                    return false;
+                }
+                const FramedRecord& record = records_[index];
+                std::vector<std::byte> stored;
+                try {
+                    stored.resize(static_cast<std::size_t>(record.sb));
+                } catch (const std::bad_alloc&) {
+                    return false;
+                } catch (const std::length_error&) {
+                    return false;
+                }
+                {
+                    std::scoped_lock lock(io_mutex_);
+                    if (!ensure_blocks_locked(record.so, record.sb)) {
+                        return false;
+                    }
+                    if (!read_stored_locked(
+                            record.so, std::span<std::byte>(stored.data(), stored.size()))) {
+                        return false;
+                    }
+                }
+                const auto frame_size =
+                    ZSTD_getFrameContentSize(stored.data(), stored.size());
+                if (frame_size != record.ub) {
+                    return false;
+                }
+                try {
+                    decoded.resize(static_cast<std::size_t>(record.ub));
+                } catch (const std::bad_alloc&) {
+                    return false;
+                } catch (const std::length_error&) {
+                    return false;
+                }
+                const auto result = ZSTD_decompress(
+                    decoded.data(), decoded.size(), stored.data(), stored.size());
+                return !ZSTD_isError(result) && result == record.ub;
+            }
+
+            bool ensure_decoded(const std::vector<std::size_t>& needed) {
+                std::vector<std::size_t> missing;
+                missing.reserve(needed.size());
+                for (const auto index : needed) {
+                    if (index >= records_.size()) {
+                        return false;
+                    }
+                    if (find_cached(index) == nullptr) {
+                        missing.push_back(index);
+                    }
+                }
+                if (!missing.empty()) {
+                    std::atomic<std::size_t> next{0};
+                    std::atomic<bool> ok{true};
+                    std::mutex cache_mutex;
+                    const auto decode_one = [&](const std::size_t index) {
+                        CachedRecord decoded;
+                        decoded.index = index;
+                        if (!decode_record(index, decoded.bytes)) {
+                            ok.store(false, std::memory_order_relaxed);
+                            return;
+                        }
+                        std::scoped_lock lock(cache_mutex);
+                        cache_.push_back(std::move(decoded));
+                    };
+                    if (missing.size() == 1) {
+                        decode_one(missing.front());
+                    } else {
+                        const auto workers_count = std::min<std::size_t>(
+                            missing.size(),
+                            std::max(1u, std::thread::hardware_concurrency()));
+                        std::vector<std::jthread> workers;
+                        try {
+                            workers.reserve(workers_count);
+                            for (std::size_t worker = 0; worker < workers_count;
+                                 ++worker) {
+                                workers.emplace_back([&] {
+                                    try {
+                                        while (ok.load(std::memory_order_relaxed)) {
+                                            const auto which = next.fetch_add(1);
+                                            if (which >= missing.size()) {
+                                                return;
+                                            }
+                                            decode_one(missing[which]);
+                                        }
+                                    } catch (...) {
+                                        ok.store(false, std::memory_order_relaxed);
+                                    }
+                                });
+                            }
+                        } catch (...) {
+                            ok.store(false, std::memory_order_relaxed);
+                        }
+                        workers.clear();
+                    }
+                    if (!ok.load(std::memory_order_relaxed)) {
+                        return false;
+                    }
+                }
+                cache_.erase(std::remove_if(cache_.begin(), cache_.end(),
+                                            [&](const CachedRecord& cached) {
+                                                return std::find(needed.begin(),
+                                                                 needed.end(),
+                                                                 cached.index) ==
+                                                       needed.end();
+                                            }),
+                             cache_.end());
+                return true;
+            }
+
+            bool prepare_zstd_window() {
+                if (!ensure_table()) {
+                    return false;
+                }
+                const auto index = record_index_containing(position_);
+                if (index == kNpos) {
+                    return false;
+                }
+                std::vector<std::size_t> needed;
+                needed.push_back(index);
+                if (index + 1 < records_.size()) {
+                    needed.push_back(index + 1);
+                }
+                if (!ensure_decoded(needed)) {
+                    return false;
+                }
+                auto* cached = find_cached(index);
+                if (cached == nullptr ||
+                    cached->bytes.size() != records_[index].ub) {
+                    return false;
+                }
+                const auto offset =
+                    static_cast<std::ptrdiff_t>(position_ - records_[index].uo);
+                if (offset < 0 ||
+                    static_cast<std::size_t>(offset) >= cached->bytes.size()) {
+                    return false;
+                }
+                buffer_start_ = records_[index].uo;
+                setg(cached->bytes.data(), cached->bytes.data() + offset,
+                     cached->bytes.data() + cached->bytes.size());
+                return true;
+            }
+
+            bool prepare_shuffle_window() {
+                if (!ensure_table()) {
+                    return false;
+                }
+                if (size_ % 4 != 0) {
+                    return false;
+                }
+                const std::uint64_t n_words = size_ / 4;
+                const std::uint64_t start_word = position_ / 4;
+                const std::uint64_t start_plane = position_ % 4;
+                std::array<std::size_t, 4> plane_record{};
+                plane_record.fill(kNpos);
+                std::vector<std::size_t> needed;
+                needed.reserve(4);
+                const auto add_needed = [&](const std::size_t index) {
+                    if (index == kNpos) {
+                        return false;
+                    }
+                    if (std::find(needed.begin(), needed.end(), index) ==
+                        needed.end()) {
+                        needed.push_back(index);
+                    }
+                    return true;
+                };
+                for (std::uint64_t plane = 0; plane < 4; ++plane) {
+                    const std::uint64_t word =
+                        plane >= start_plane ? start_word : start_word + 1;
+                    if (word >= n_words) {
+                        continue;
+                    }
+                    const std::uint64_t decoded = plane * n_words + word;
+                    const auto index = record_index_containing(decoded);
+                    plane_record[static_cast<std::size_t>(plane)] = index;
+                    if (!add_needed(index)) {
+                        return false;
+                    }
+                }
+                if (needed.empty() || !ensure_decoded(needed)) {
+                    return false;
+                }
+
+                std::uint64_t window_end = std::min(size_, position_ + window_.size());
+                for (std::uint64_t plane = 0; plane < 4; ++plane) {
+                    const auto index =
+                        plane_record[static_cast<std::size_t>(plane)];
+                    if (index == kNpos) {
+                        continue;
+                    }
+                    const auto& record = records_[index];
+                    const std::uint64_t plane_base = plane * n_words;
+                    const std::uint64_t overlap_lo = std::max(record.uo, plane_base);
+                    const std::uint64_t overlap_hi =
+                        std::min(record.uo + record.ub, plane_base + n_words);
+                    if (overlap_hi <= overlap_lo) {
+                        return false;
+                    }
+                    const std::uint64_t last_word = overlap_hi - plane_base - 1;
+                    const std::uint64_t plane_end = last_word * 4 + plane + 1;
+                    window_end = std::min(window_end, plane_end);
+                }
+                if (window_end <= position_) {
+                    return false;
+                }
+
+                std::array<const CachedRecord*, 4> plane_cache{};
+                for (std::uint64_t plane = 0; plane < 4; ++plane) {
+                    const auto index =
+                        plane_record[static_cast<std::size_t>(plane)];
+                    if (index == kNpos) {
+                        continue;
+                    }
+                    plane_cache[static_cast<std::size_t>(plane)] = find_cached(index);
+                    if (plane_cache[static_cast<std::size_t>(plane)] == nullptr) {
+                        return false;
+                    }
+                }
+
+                const auto count = static_cast<std::size_t>(window_end - position_);
+                for (std::size_t index = 0; index < count; ++index) {
+                    const std::uint64_t logical = position_ + index;
+                    const std::uint64_t plane = logical % 4;
+                    const std::uint64_t word = logical / 4;
+                    const auto* cached = plane_cache[static_cast<std::size_t>(plane)];
+                    const auto record_index =
+                        plane_record[static_cast<std::size_t>(plane)];
+                    const std::uint64_t decoded = plane * n_words + word;
+                    const std::uint64_t local = decoded - records_[record_index].uo;
+                    if (cached == nullptr || local >= cached->bytes.size()) {
+                        return false;
+                    }
+                    window_[index] = cached->bytes[static_cast<std::size_t>(local)];
+                }
+                buffer_start_ = position_;
+                setg(window_.data(), window_.data(), window_.data() + count);
+                return true;
+            }
+
+            std::shared_ptr<ReaderState> state_;
+            ChunkInfo row_;
+            bool byteshuffle_ = false;
+            bool failed_ = false;
+            bool table_ready_ = false;
+            std::uint64_t size_ = 0;
+            std::uint64_t position_ = 0;
+            std::uint64_t buffer_start_ = 0;
+            std::vector<FramedRecord> records_;
+            std::vector<std::uint8_t> block_validated_;
+            std::vector<CachedRecord> cache_;
+            std::vector<char> window_;
+            std::mutex io_mutex_;
+        };
+
     } // namespace
 
     struct BoundedInputStream::Impl {
-        Impl(
-            std::shared_ptr<detail::NativeFile> file,
-            const std::uint64_t start,
-            const std::uint64_t size,
-            std::optional<BlockCrcTable> block_crc_table)
-            : buffer(
-                  std::move(file), start, size,
-                  std::move(block_crc_table)),
-              input(&buffer),
+        Impl(std::unique_ptr<std::streambuf> owned_buffer,
+             const std::uint64_t size)
+            : buffer(std::move(owned_buffer)),
+              input(buffer.get()),
               size_bytes(size) {}
 
-        PositionalStreambuf buffer;
+        std::unique_ptr<std::streambuf> buffer;
         std::istream input;
         std::uint64_t size_bytes = 0;
     };
@@ -3991,24 +4561,42 @@ namespace lfs::io::project {
         if (!resolved) {
             return std::move(resolved).error();
         }
-        if ((*resolved)->compression != Compression::Stored) {
+        const ChunkInfo& row = **resolved;
+        const bool framed = row.compression == Compression::ZstdFramed ||
+                            row.compression == Compression::ByteShuffleZstdFramed;
+        if (row.compression != Compression::Stored && !framed) {
             return detail::project_error(
                 lfs::ErrorCode::FailedPrecondition,
                 "A random-access stream requires a stored project chunk.",
                 std::format("{} is compressed (not STORED)",
-                            (*resolved)->key_string()),
-                path(), (*resolved)->payload_offset,
+                            row.key_string()),
+                path(), row.payload_offset,
                 "bounded_stream.compression");
         }
-        if (!(*resolved)->block_crc_table.has_value()) {
-            if (auto verified = verify_chunk(**resolved); !verified) {
+        if (row.compression == Compression::ByteShuffleZstdFramed &&
+            row.uncompressed_bytes % 4 != 0) {
+            return format_error(
+                path(), row.payload_offset, "payload.byteshuffle",
+                "decoded size multiple of 4",
+                std::to_string(row.uncompressed_bytes));
+        }
+        if (!row.block_crc_table.has_value()) {
+            if (auto verified = verify_chunk(row); !verified) {
                 return std::move(verified).error();
             }
         }
+        if (framed) {
+            return BoundedInputStream(std::make_unique<BoundedInputStream::Impl>(
+                std::make_unique<FramedLogicalStreambuf>(
+                    impl_->state, row,
+                    row.compression == Compression::ByteShuffleZstdFramed),
+                row.uncompressed_bytes));
+        }
         return BoundedInputStream(std::make_unique<BoundedInputStream::Impl>(
-            impl_->state->file, (*resolved)->payload_offset,
-            (*resolved)->stored_bytes,
-            (*resolved)->block_crc_table));
+            std::make_unique<PositionalStreambuf>(
+                impl_->state->file, row.payload_offset, row.stored_bytes,
+                row.block_crc_table),
+            row.stored_bytes));
     }
 
     struct MappedRegion::Impl {

--- a/src/io/project/project_container_internal.hpp
+++ b/src/io/project/project_container_internal.hpp
@@ -24,6 +24,10 @@
 #include <windows.h>
 #endif
 
+namespace lfs::io::project {
+    struct ChunkInfo;
+}
+
 namespace lfs::io::project::detail {
 
     [[nodiscard]] lfs::Result<std::vector<std::byte>>
@@ -36,6 +40,10 @@ namespace lfs::io::project::detail {
     // chunks (TENSOR_PAYLOAD / CKPT / PPIS). nullopt restores the production cap.
     void set_max_payload_materialized_bytes_for_testing(
         std::optional<std::uint64_t> maximum_decoded_size);
+
+    // Same cap read_chunk uses for a materialized decode of `row`.
+    [[nodiscard]] std::uint64_t
+    max_materialized_bytes_for(const ChunkInfo& row) noexcept;
 
     [[nodiscard]] lfs::Error project_error(
         lfs::ErrorCode code, std::string user_message, std::string detail,

--- a/src/io/project/project_container_internal.hpp
+++ b/src/io/project/project_container_internal.hpp
@@ -32,6 +32,11 @@ namespace lfs::io::project::detail {
         std::span<const std::byte> stored, std::uint64_t expected_size,
         std::uint64_t maximum_decoded_size);
 
+    // Test-only override of MAX_PAYLOAD_MATERIALIZED_BYTES for payload-class
+    // chunks (TENSOR_PAYLOAD / CKPT / PPIS). nullopt restores the production cap.
+    void set_max_payload_materialized_bytes_for_testing(
+        std::optional<std::uint64_t> maximum_decoded_size);
+
     [[nodiscard]] lfs::Error project_error(
         lfs::ErrorCode code, std::string user_message, std::string detail,
         const std::filesystem::path& path = {}, std::optional<std::uint64_t> offset = std::nullopt,

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -514,9 +514,9 @@ namespace lfs::io::project {
         std::optional<CleanProof> proof;
         std::shared_ptr<const std::vector<std::byte>> owned;
         // Cache of container-decompressed logical bytes for Zstd /
-        // ByteShuffleZstd sources. Stored sources keep streaming via
-        // read_stored_at (no second copy). Full-buffer inflate is intentional:
-        // consumers need the whole tensor/LFKP payload.
+        // ByteShuffleZstd sources. visit_stream prefers a bounded decode
+        // stream and does not populate this. read_at still materializes
+        // compressed sources once.
         mutable std::shared_ptr<const std::vector<std::byte>> inflated;
         lfs::core::Uuid snapshot_uuid;
 
@@ -690,7 +690,15 @@ namespace lfs::io::project {
                 "Neither clean file range nor owned storage is available",
                 "lazy_chunk.source");
         }
-        if (impl_->source->compression == Compression::Stored) {
+        if (impl_->inflated) {
+            ReadOnlyMemoryBuffer buffer(std::span<const std::byte>(
+                impl_->inflated->data(), impl_->inflated->size()));
+            std::istream stream(&buffer);
+            return visitor(stream, impl_->inflated->size());
+        }
+        if (impl_->source->compression == Compression::Stored ||
+            impl_->source->compression == Compression::ZstdFramed ||
+            impl_->source->compression == Compression::ByteShuffleZstdFramed) {
             auto bounded =
                 impl_->reader->open_bounded_stream(*impl_->source);
             if (!bounded) {

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -1676,10 +1676,18 @@ namespace lfs::io::project {
                                 impl->project_uuid.to_string()),
                     "chunk.instance_uuid");
             }
-            if (options.defer_geometry_payloads &&
-                (row.key.fourcc == FOURCC_SPLT ||
-                 row.key.fourcc == FOURCC_PCLD ||
-                 row.key.fourcc == FOURCC_MESH)) {
+            const bool geometry_payload =
+                row.key.fourcc == FOURCC_SPLT ||
+                row.key.fourcc == FOURCC_PCLD ||
+                row.key.fourcc == FOURCC_MESH;
+            const auto materialized_max =
+                detail::max_materialized_bytes_for(row);
+            const bool oversized_splat =
+                row.key.fourcc == FOURCC_SPLT &&
+                (row.stored_bytes > materialized_max ||
+                 row.uncompressed_bytes > materialized_max);
+            if ((options.defer_geometry_payloads && geometry_payload) ||
+                oversized_splat) {
                 impl->deferred_geometry_keys.insert(row.key);
                 continue;
             }
@@ -3874,39 +3882,48 @@ namespace lfs::io::project {
                 if (key.fourcc != FOURCC_SPLT) {
                     continue;
                 }
+                if (!impl_->source_reader) {
+                    return fail<ProjectHydrationPlan>(
+                        lfs::ErrorCode::FailedPrecondition,
+                        "The unloaded project payload has no source file.",
+                        std::format("{} instance {} lost its clean source handle",
+                                    key.fourcc.to_string(),
+                                    key.instance_uuid.to_string()),
+                        "hydrate.deferred_source");
+                }
+                const auto found = impl_->source_rows.find(key);
+                if (found == impl_->source_rows.end()) {
+                    return fail<ProjectHydrationPlan>(
+                        lfs::ErrorCode::DataLoss,
+                        "The unloaded project payload is missing.",
+                        std::format("{} instance {} has no live source row",
+                                    key.fourcc.to_string(),
+                                    key.instance_uuid.to_string()),
+                        "hydrate.deferred_source");
+                }
                 const auto read_started =
                     std::chrono::steady_clock::now();
-                auto bytes = read_deferred(key);
+                auto bounded = impl_->source_reader->open_bounded_stream(
+                    found->second.info);
                 splat_read_ms += milliseconds(
                     read_started, std::chrono::steady_clock::now());
-                if (!bytes) {
-                    return std::move(bytes).error();
-                }
-                const auto hash_started =
-                    std::chrono::steady_clock::now();
-                hashes.insert_or_assign(key, xxh3_128(*bytes));
-                splat_hash_ms += milliseconds(
-                    hash_started, std::chrono::steady_clock::now());
-                const auto copy_started =
-                    std::chrono::steady_clock::now();
-                auto payload = SplatChapterPayload::from_lfsp(std::move(*bytes));
-                splat_copy_ms += milliseconds(
-                    copy_started, std::chrono::steady_clock::now());
-                if (!payload) {
-                    return std::move(payload).error();
+                if (!bounded) {
+                    return std::move(bounded).error();
                 }
                 const auto materialize_started =
                     std::chrono::steady_clock::now();
-                auto materialized =
-                    payload->hydrate(splat_allocator);
+                auto hydrated = SplatChapterPayload::hydrate_lfsp_stream(
+                    bounded->stream(), bounded->size(), splat_allocator,
+                    payload_progress);
                 splat_materialize_ms += milliseconds(
                     materialize_started,
                     std::chrono::steady_clock::now());
-                if (!materialized) {
-                    return std::move(materialized).error();
+                if (!hydrated) {
+                    return std::move(hydrated).error();
                 }
+                hashes.insert_or_assign(key, hydrated->content_xxh3_128);
                 staged_splats.emplace(
-                    key.instance_uuid, std::move(*materialized));
+                    key.instance_uuid, std::move(hydrated->splat));
             }
 
             std::optional<lfs::core::Uuid>

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -620,6 +620,10 @@ namespace lfs::io::project {
                !impl_->owned;
     }
 
+    void LazyChunkValue::drop_clean_proof_for_testing() noexcept {
+        impl_->proof.reset();
+    }
+
     lfs::Result<void>
     LazyChunkValue::read_at(
         const std::uint64_t offset,
@@ -2212,6 +2216,15 @@ namespace lfs::io::project {
                    : &found->second;
     }
 
+    void ProjectDocument::drop_checkpoint_clean_proof_for_testing(
+        const lfs::core::Uuid& instance_uuid) {
+        const auto found = impl_->checkpoints.find(instance_uuid);
+        if (found == impl_->checkpoints.end()) {
+            return;
+        }
+        found->second.drop_clean_proof_for_testing();
+    }
+
     lfs::Result<void>
     ProjectDocument::set_checkpoint(
         const lfs::core::Uuid& instance_uuid,
@@ -3293,30 +3306,50 @@ namespace lfs::io::project {
                     .fourcc = fourcc,
                     .instance_uuid = uuid,
                 };
-                // Container zstd goes through write_chunk (begin_chunk is
-                // Stored-streaming only). Owned staged bytes avoid an extra
-                // materialization; clean-file sources materialize once.
-                const auto options =
-                    lazy_binary_options(fourcc, payload.size());
+                // Owned staged bytes go through write_chunk (container zstd;
+                // begin_chunk is Stored-streaming only). File-backed sources
+                // without a clean proof are copied stored-byte-verbatim so a
+                // compressed CKPT/PPIS is never inflated on the save path.
+                // The copy keeps the source compression, uncompressed_bytes,
+                // and chunk_version; those are correct for an unchanged
+                // payload. Counted as rewritten_chunks because stored bytes
+                // are physically rewritten.
                 if (payload.impl_->owned) {
+                    const auto options =
+                        lazy_binary_options(fourcc, payload.size());
                     if (auto written = writer->write_chunk(
                             key, *payload.impl_->owned, options);
                         !written) {
                         return written;
                     }
+                } else if (payload.impl_->reader && payload.impl_->source) {
+                    const ChunkInfo& source = *payload.impl_->source;
+                    if (source.key != key) {
+                        return fail<void>(
+                            lfs::ErrorCode::Internal,
+                            "The lazy chapter source key does not match the "
+                            "chapter being saved.",
+                            std::format(
+                                "expected {} instance {}, source is {} "
+                                "instance {}",
+                                key.fourcc.to_string(),
+                                key.instance_uuid.to_string(),
+                                source.key.fourcc.to_string(),
+                                source.key.instance_uuid.to_string()),
+                            "lazy_chunk.source_key");
+                    }
+                    if (auto copied = writer->copy_chunk_verbatim(
+                            *payload.impl_->reader, source);
+                        !copied) {
+                        return copied;
+                    }
                 } else {
-                    std::vector<std::byte> materialized(
-                        static_cast<std::size_t>(payload.size()));
-                    if (auto read = payload.read_at(
-                            0, std::span<std::byte>(materialized));
-                        !read) {
-                        return read;
-                    }
-                    if (auto written = writer->write_chunk(
-                            key, materialized, options);
-                        !written) {
-                        return written;
-                    }
+                    return fail<void>(
+                        lfs::ErrorCode::FailedPrecondition,
+                        "The lazy chapter has no byte source.",
+                        "Neither clean file range nor owned storage is "
+                        "available",
+                        "lazy_chunk.source");
                 }
                 ++report.rewritten_chunks;
             }

--- a/src/io/project/splat_chapter.cpp
+++ b/src/io/project/splat_chapter.cpp
@@ -19,9 +19,13 @@
 #include <cuda_runtime_api.h>
 #include <exception>
 #include <format>
+#include <functional>
+#include <istream>
 #include <limits>
+#include <optional>
 #include <ranges>
 #include <streambuf>
+#include <string_view>
 #include <utility>
 
 namespace lfs::io::project {
@@ -72,12 +76,36 @@ namespace lfs::io::project {
             std::uint64_t length = 0;
         };
 
+        struct RawSplatHeader {
+            int active = 0;
+            int maximum = 0;
+            float scene_scale = 0.0f;
+            std::uint32_t count = 0;
+            std::uint64_t manifest_bytes = 0;
+        };
+
+        struct RawSplatManifest {
+            int active = 0;
+            int maximum = 0;
+            float scene_scale = 0.0f;
+            std::uint64_t manifest_bytes = 0;
+            std::vector<RawTensor> descriptors;
+            std::vector<lfs::core::SplatData::FrozenRange> ranges;
+        };
+
         lfs::Error splat_error(const lfs::ErrorCode code, std::string message,
                                std::string detail);
 
-        lfs::Result<std::unique_ptr<lfs::core::SplatData>> hydrate_raw(
-            const std::span<const std::byte> bytes,
-            lfs::core::SplatTensorAllocator allocator) {
+        constexpr std::size_t RAW_STREAM_WINDOW_BYTES = 16ull * 1024ull * 1024ull;
+        constexpr std::uint64_t RAW_STREAM_MAX_MANIFEST_BYTES = 32ull * 1024ull * 1024ull;
+        std::optional<std::size_t> splat_stream_window_override;
+
+        std::size_t splat_stream_window_bytes() noexcept {
+            return splat_stream_window_override.value_or(RAW_STREAM_WINDOW_BYTES);
+        }
+
+        lfs::Result<RawSplatHeader>
+        parse_raw_splat_header(const std::span<const std::byte> bytes) {
             if (bytes.size() < RAW_HEADER_BYTES ||
                 !std::equal(RAW_MAGIC.begin(), RAW_MAGIC.end(), bytes.begin()) ||
                 get_u16(bytes, 8) != 2 || get_u16(bytes, 10) != 0) {
@@ -85,57 +113,89 @@ namespace lfs::io::project {
                                    "The raw splat payload header is invalid.",
                                    "expected LFSPLT2 version 2");
             }
-            const int active = static_cast<int>(get_u32(bytes, 12));
-            const int maximum = static_cast<int>(get_u32(bytes, 16));
-            float scene_scale = 0.0f;
+            RawSplatHeader header;
+            header.active = static_cast<int>(get_u32(bytes, 12));
+            header.maximum = static_cast<int>(get_u32(bytes, 16));
             const auto scene_bits = get_u32(bytes, 20);
-            std::memcpy(&scene_scale, &scene_bits, sizeof(scene_scale));
-            const auto count = get_u32(bytes, 24);
-            const auto manifest_bytes = get_u64(bytes, 32);
-            if (count == 0 || count > 8 || manifest_bytes > bytes.size() ||
-                manifest_bytes < RAW_HEADER_BYTES + static_cast<std::uint64_t>(count) * RAW_DESCRIPTOR_BYTES + 8) {
-                return splat_error(lfs::ErrorCode::DataLoss,
-                                   "The raw splat payload manifest is invalid.",
-                                   "tensor count or manifest length is out of range");
+            std::memcpy(&header.scene_scale, &scene_bits, sizeof(header.scene_scale));
+            header.count = get_u32(bytes, 24);
+            header.manifest_bytes = get_u64(bytes, 32);
+            return header;
+        }
+
+        lfs::Result<void> validate_raw_splat_manifest_bounds(
+            const RawSplatHeader& header, const std::uint64_t payload_size,
+            const std::size_t prefix_size) {
+            if (header.count == 0 || header.count > 8 ||
+                header.manifest_bytes > payload_size ||
+                header.manifest_bytes < RAW_HEADER_BYTES +
+                                            static_cast<std::uint64_t>(header.count) *
+                                                RAW_DESCRIPTOR_BYTES +
+                                            8 ||
+                prefix_size < header.manifest_bytes) {
+                return lfs::Result<void>::failure(splat_error(
+                    lfs::ErrorCode::DataLoss,
+                    "The raw splat payload manifest is invalid.",
+                    "tensor count or manifest length is out of range"));
             }
-            std::vector<RawTensor> descriptors;
-            descriptors.reserve(count);
+            return {};
+        }
+
+        lfs::Result<RawSplatManifest> parse_raw_splat_manifest(
+            const std::span<const std::byte> prefix, const std::uint64_t payload_size) {
+            auto header = parse_raw_splat_header(prefix);
+            if (!header) {
+                return std::move(header).error();
+            }
+            if (auto bounds = validate_raw_splat_manifest_bounds(
+                    *header, payload_size, prefix.size());
+                !bounds) {
+                return std::move(bounds).error();
+            }
+            RawSplatManifest parsed;
+            parsed.active = header->active;
+            parsed.maximum = header->maximum;
+            parsed.scene_scale = header->scene_scale;
+            parsed.manifest_bytes = header->manifest_bytes;
+            const auto count = header->count;
+            parsed.descriptors.reserve(count);
             std::uint32_t seen = 0;
             for (std::uint32_t i = 0; i < count; ++i) {
                 const auto at = RAW_HEADER_BYTES + static_cast<std::size_t>(i) * RAW_DESCRIPTOR_BYTES;
-                const auto id = get_u32(bytes, at);
-                const auto rank = std::to_integer<std::uint8_t>(bytes[at + 5]);
+                const auto id = get_u32(prefix, at);
+                const auto rank = std::to_integer<std::uint8_t>(prefix[at + 5]);
                 if (id >= 8 || (seen & (1u << id)) != 0 || rank > 4)
                     return splat_error(lfs::ErrorCode::DataLoss, "The raw splat tensor manifest is invalid.", "duplicate id or rank");
                 seen |= 1u << id;
-                const auto dtype = static_cast<lfs::core::DataType>(std::to_integer<std::uint8_t>(bytes[at + 4]));
+                const auto dtype = static_cast<lfs::core::DataType>(std::to_integer<std::uint8_t>(prefix[at + 4]));
                 if (lfs::core::dtype_size(dtype) == 0)
                     return splat_error(lfs::ErrorCode::DataLoss, "The raw splat tensor manifest is invalid.", "unsupported dtype");
                 std::vector<std::size_t> shape(rank);
                 for (std::size_t d = 0; d < shape.size(); ++d) {
-                    const auto dimension = get_u64(bytes, at + 8 + d * 8);
+                    const auto dimension = get_u64(prefix, at + 8 + d * 8);
                     if (dimension > std::numeric_limits<std::size_t>::max())
                         return splat_error(lfs::ErrorCode::DataLoss, "The raw splat tensor manifest is invalid.", "dimension overflow");
                     shape[d] = static_cast<std::size_t>(dimension);
                 }
-                descriptors.push_back({id, dtype, std::move(shape), get_u64(bytes, at + 40), get_u64(bytes, at + 48)});
+                parsed.descriptors.push_back(
+                    {id, dtype, std::move(shape), get_u64(prefix, at + 40),
+                     get_u64(prefix, at + 48)});
             }
-            const auto frozen_count = get_u64(bytes, RAW_HEADER_BYTES + static_cast<std::size_t>(count) * RAW_DESCRIPTOR_BYTES);
-            const auto ranges_end = manifest_bytes;
+            const auto frozen_count = get_u64(
+                prefix, RAW_HEADER_BYTES + static_cast<std::size_t>(count) * RAW_DESCRIPTOR_BYTES);
+            const auto ranges_end = parsed.manifest_bytes;
             if (frozen_count > 1'000'000 ||
                 frozen_count > (ranges_end - (RAW_HEADER_BYTES + static_cast<std::size_t>(count) * RAW_DESCRIPTOR_BYTES + 8)) / 16)
                 return splat_error(lfs::ErrorCode::DataLoss, "The raw splat payload manifest is invalid.", "frozen-range table overflow");
-            std::vector<lfs::core::SplatData::FrozenRange> ranges;
-            ranges.reserve(static_cast<std::size_t>(frozen_count));
+            parsed.ranges.reserve(static_cast<std::size_t>(frozen_count));
             auto range_at = RAW_HEADER_BYTES + static_cast<std::size_t>(count) * RAW_DESCRIPTOR_BYTES + 8;
             for (std::uint64_t i = 0; i < frozen_count; ++i, range_at += 16)
-                ranges.push_back({static_cast<std::size_t>(get_u64(bytes, range_at)), static_cast<std::size_t>(get_u64(bytes, range_at + 8))});
-            const auto data_start = static_cast<std::size_t>(manifest_bytes);
-            std::vector<lfs::core::Tensor> tensors(8);
-            auto owner = std::shared_ptr<void>(
-                const_cast<std::byte*>(bytes.data()), [](void*) {});
+                parsed.ranges.push_back({static_cast<std::size_t>(get_u64(prefix, range_at)),
+                                         static_cast<std::size_t>(get_u64(prefix, range_at + 8))});
+            const auto data_start = parsed.manifest_bytes;
+            std::uint32_t present = 0;
             std::uint64_t end = data_start;
-            for (const auto& descriptor : descriptors) {
+            for (const auto& descriptor : parsed.descriptors) {
                 std::uint64_t elements = 1;
                 for (const auto dimension : descriptor.shape) {
                     if (dimension != 0 && elements > std::numeric_limits<std::uint64_t>::max() / dimension)
@@ -144,10 +204,43 @@ namespace lfs::io::project {
                 }
                 if (elements > std::numeric_limits<std::uint64_t>::max() / lfs::core::dtype_size(descriptor.dtype) ||
                     descriptor.length != elements * lfs::core::dtype_size(descriptor.dtype) ||
-                    descriptor.offset < data_start || descriptor.offset > bytes.size() ||
-                    descriptor.length > bytes.size() - descriptor.offset || descriptor.offset != end)
+                    descriptor.offset < data_start || descriptor.offset > payload_size ||
+                    descriptor.length > payload_size - descriptor.offset || descriptor.offset != end)
                     return splat_error(lfs::ErrorCode::DataLoss, "The raw splat tensor manifest is invalid.", "tensor range is overlapping or out of bounds");
                 end = descriptor.offset + descriptor.length;
+                present |= 1u << descriptor.id;
+            }
+            if (end != payload_size)
+                return splat_error(lfs::ErrorCode::DataLoss, "The raw splat tensor manifest is invalid.", "tensor data does not cover the payload exactly");
+            if ((present & 0x3fu) != 0x3fu)
+                return splat_error(lfs::ErrorCode::DataLoss, "The raw splat tensor manifest is invalid.", "required tensor is missing");
+            return parsed;
+        }
+
+        lfs::Result<std::unique_ptr<lfs::core::SplatData>>
+        splat_from_cpu_tensors(RawSplatManifest& parsed,
+                               std::vector<lfs::core::Tensor> tensors,
+                               lfs::core::SplatTensorAllocator allocator) {
+            return lfs::core::SplatData::from_raw_tensors(
+                parsed.active, parsed.maximum, parsed.scene_scale,
+                std::move(tensors[0]), std::move(tensors[1]),
+                std::move(tensors[2]), std::move(tensors[3]),
+                std::move(tensors[4]), std::move(tensors[5]),
+                std::move(tensors[6]), std::move(tensors[7]),
+                std::move(parsed.ranges), std::move(allocator));
+        }
+
+        lfs::Result<std::unique_ptr<lfs::core::SplatData>> hydrate_raw(
+            const std::span<const std::byte> bytes,
+            lfs::core::SplatTensorAllocator allocator) {
+            auto parsed = parse_raw_splat_manifest(bytes, bytes.size());
+            if (!parsed) {
+                return std::move(parsed).error();
+            }
+            std::vector<lfs::core::Tensor> tensors(8);
+            auto owner = std::shared_ptr<void>(
+                const_cast<std::byte*>(bytes.data()), [](void*) {});
+            for (const auto& descriptor : parsed->descriptors) {
                 auto tensor = lfs::core::Tensor::from_external_owner(
                     const_cast<std::byte*>(bytes.data() + descriptor.offset),
                     lfs::core::TensorShape(descriptor.shape), lfs::core::Device::CPU,
@@ -156,16 +249,34 @@ namespace lfs::io::project {
                     return splat_error(lfs::ErrorCode::DataLoss, "The raw splat tensor manifest is invalid.", "tensor byte length mismatch");
                 tensors[descriptor.id] = std::move(tensor);
             }
-            if (end != bytes.size())
-                return splat_error(lfs::ErrorCode::DataLoss, "The raw splat tensor manifest is invalid.", "tensor data does not cover the payload exactly");
-            if (!tensors[0].is_valid() || !tensors[1].is_valid() || !tensors[2].is_valid() ||
-                !tensors[3].is_valid() || !tensors[4].is_valid() || !tensors[5].is_valid())
-                return splat_error(lfs::ErrorCode::DataLoss, "The raw splat tensor manifest is invalid.", "required tensor is missing");
-            return lfs::core::SplatData::from_raw_tensors(
-                active, maximum, scene_scale, std::move(tensors[0]), std::move(tensors[1]),
-                std::move(tensors[2]), std::move(tensors[3]), std::move(tensors[4]),
-                std::move(tensors[5]), std::move(tensors[6]), std::move(tensors[7]),
-                std::move(ranges), std::move(allocator));
+            return splat_from_cpu_tensors(*parsed, std::move(tensors),
+                                          std::move(allocator));
+        }
+
+        lfs::Result<void> read_exact_stream(std::istream& stream,
+                                            const std::span<std::byte> destination,
+                                            const std::string_view what) {
+            if (destination.empty()) {
+                return {};
+            }
+            if (destination.size() >
+                static_cast<std::size_t>(
+                    std::numeric_limits<std::streamsize>::max())) {
+                return lfs::Result<void>::failure(splat_error(
+                    lfs::ErrorCode::ResourceExhausted,
+                    "The raw splat payload could not be read.",
+                    std::format("{} exceeds this build's streamsize range", what)));
+            }
+            stream.read(reinterpret_cast<char*>(destination.data()),
+                        static_cast<std::streamsize>(destination.size()));
+            if (stream.gcount() != static_cast<std::streamsize>(destination.size())) {
+                return lfs::Result<void>::failure(splat_error(
+                    lfs::ErrorCode::DataLoss,
+                    "The raw splat payload is truncated.",
+                    std::format("short read of {}: expected {}, got {}", what,
+                                destination.size(), stream.gcount())));
+            }
+            return {};
         }
 
         class SpanStreambuf final : public std::streambuf {
@@ -596,9 +707,156 @@ namespace lfs::io::project {
         }
     }
 
+    lfs::Result<HydratedSplatStream> SplatChapterPayload::hydrate_lfsp_stream(
+        std::istream& stream, const std::uint64_t size,
+        lfs::core::SplatTensorAllocator allocator,
+        std::function<void(std::size_t, std::size_t)> progress) {
+        try {
+            if (size > std::numeric_limits<std::size_t>::max()) {
+                return splat_error(
+                    lfs::ErrorCode::ResourceExhausted,
+                    "The raw splat payload is too large for this build.",
+                    std::format("logical size {} exceeds size_t", size));
+            }
+            Hash128Stream hasher;
+            if (!hasher.valid()) {
+                return splat_error(
+                    lfs::ErrorCode::ResourceExhausted,
+                    "The splat content hash could not be initialized.",
+                    "XXH3 state allocation/reset failed");
+            }
+            const auto report = [&](const std::uint64_t consumed) {
+                if (!progress) {
+                    return;
+                }
+                progress(static_cast<std::size_t>(consumed),
+                         static_cast<std::size_t>(size));
+            };
+            if (size < RAW_HEADER_BYTES) {
+                return splat_error(lfs::ErrorCode::DataLoss,
+                                   "The raw splat payload header is invalid.",
+                                   "expected LFSPLT2 version 2");
+            }
+            std::array<std::byte, RAW_HEADER_BYTES> header{};
+            if (auto read = read_exact_stream(stream, header, "LFSPLT2 header");
+                !read) {
+                return std::move(read).error();
+            }
+            auto parsed_header = parse_raw_splat_header(header);
+            if (!parsed_header) {
+                return std::move(parsed_header).error();
+            }
+            // prefix_size is the full declared manifest so a header-only buffer
+            // does not trip the "prefix shorter than manifest" bound.
+            if (auto bounds = validate_raw_splat_manifest_bounds(
+                    *parsed_header, size,
+                    static_cast<std::size_t>(parsed_header->manifest_bytes));
+                !bounds) {
+                return std::move(bounds).error();
+            }
+            const auto manifest_bytes = parsed_header->manifest_bytes;
+            if (manifest_bytes > RAW_STREAM_MAX_MANIFEST_BYTES) {
+                return splat_error(
+                    lfs::ErrorCode::DataLoss,
+                    "The raw splat payload manifest is invalid.",
+                    "tensor count or manifest length is out of range");
+            }
+            std::vector<std::byte> manifest(static_cast<std::size_t>(manifest_bytes));
+            std::copy(header.begin(), header.end(), manifest.begin());
+            if (manifest_bytes > RAW_HEADER_BYTES) {
+                if (auto read = read_exact_stream(
+                        stream,
+                        std::span<std::byte>(manifest.data() + RAW_HEADER_BYTES,
+                                             static_cast<std::size_t>(
+                                                 manifest_bytes - RAW_HEADER_BYTES)),
+                        "LFSPLT2 manifest");
+                    !read) {
+                    return std::move(read).error();
+                }
+            }
+            auto parsed = parse_raw_splat_manifest(manifest, size);
+            if (!parsed) {
+                return std::move(parsed).error();
+            }
+            if (!hasher.update(manifest)) {
+                return splat_error(
+                    lfs::ErrorCode::Internal,
+                    "The splat content hash could not be computed.",
+                    "XXH3 streaming update failed");
+            }
+            std::uint64_t consumed = manifest_bytes;
+            report(consumed);
+
+            std::vector<lfs::core::Tensor> tensors(8);
+            const auto window =
+                std::max<std::size_t>(splat_stream_window_bytes(), 1);
+            for (const auto& descriptor : parsed->descriptors) {
+                auto tensor = lfs::core::Tensor::empty_unpinned(
+                    lfs::core::TensorShape(descriptor.shape), descriptor.dtype);
+                if (tensor.bytes() != descriptor.length) {
+                    return splat_error(
+                        lfs::ErrorCode::DataLoss,
+                        "The raw splat tensor manifest is invalid.",
+                        "tensor byte length mismatch");
+                }
+                if (descriptor.length != 0) {
+                    auto* destination = static_cast<std::byte*>(tensor.data_ptr());
+                    std::uint64_t remaining = descriptor.length;
+                    while (remaining > 0) {
+                        const auto chunk = static_cast<std::size_t>(
+                            std::min<std::uint64_t>(window, remaining));
+                        if (auto read = read_exact_stream(
+                                stream, std::span<std::byte>(destination, chunk),
+                                "LFSPLT2 tensor");
+                            !read) {
+                            return std::move(read).error();
+                        }
+                        if (!hasher.update(std::span<const std::byte>(
+                                destination, chunk))) {
+                            return splat_error(
+                                lfs::ErrorCode::Internal,
+                                "The splat content hash could not be computed.",
+                                "XXH3 streaming update failed");
+                        }
+                        destination += chunk;
+                        remaining -= chunk;
+                        consumed += chunk;
+                        report(consumed);
+                    }
+                }
+                tensors[descriptor.id] = std::move(tensor);
+            }
+            report(consumed);
+            auto splat = splat_from_cpu_tensors(*parsed, std::move(tensors),
+                                                std::move(allocator));
+            if (!splat) {
+                return std::move(splat).error();
+            }
+            return HydratedSplatStream{
+                .splat = std::move(*splat),
+                .content_xxh3_128 = hasher.digest(),
+            };
+        } catch (const std::bad_alloc& error) {
+            return splat_error(
+                lfs::ErrorCode::ResourceExhausted,
+                "The raw splat payload could not be hydrated.",
+                std::format("SPLT stream allocation failed: {}", error.what()));
+        } catch (const std::exception& error) {
+            return splat_error(
+                lfs::ErrorCode::DataLoss,
+                "The raw splat payload could not be hydrated.",
+                std::format("SPLT stream hydrate failed: {}", error.what()));
+        }
+    }
+
     bool SplatChapterPayload::must_reference_external(
         const SplatSourceKind source_kind) noexcept {
         return source_kind == SplatSourceKind::LiveRad;
+    }
+
+    void detail::set_splat_stream_window_bytes_for_testing(
+        const std::optional<std::size_t> window_bytes) {
+        splat_stream_window_override = window_bytes;
     }
 
 } // namespace lfs::io::project

--- a/tests/test_project_container.cpp
+++ b/tests/test_project_container.cpp
@@ -33,6 +33,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #ifndef _WIN32
@@ -648,6 +649,9 @@ namespace {
         return first;
     }
 
+    [[nodiscard]] std::optional<std::string>
+    error_field_string(const lfs::Error& error, std::string_view key);
+
     struct PayloadCapGuard {
         explicit PayloadCapGuard(const std::optional<std::uint64_t> value) {
             detail::set_max_payload_materialized_bytes_for_testing(value);
@@ -838,6 +842,109 @@ namespace {
         ASSERT_EQ(bounded->stream().gcount(),
                   static_cast<std::streamsize>(got.size()));
         EXPECT_EQ(got, payload);
+    }
+
+    TEST(ProjectContainerReader,
+         BoundedStreamReadsNoTableFramedPayloadBeyondMaterializeCap) {
+        const auto check = [](const Compression compression,
+                              const std::string_view name) {
+            TemporaryDirectory temporary;
+            const fs::path path =
+                temporary.path / (std::string(name) + "-no-table-cap.licht");
+            const auto payload = patterned_payload(64 * 1024);
+            write_framed_fixture(path, FOURCC_CKPT, 1200, payload, compression,
+                                 true, false, 1200);
+            ProjectReader reader = require_result(ProjectReader::open(path));
+            const ChunkInfo& chunk = reader.chunks().front();
+            EXPECT_EQ(chunk.compression, compression) << name;
+            ASSERT_FALSE(chunk.block_crc_table.has_value()) << name;
+            ASSERT_LT(chunk.stored_bytes, BLOCK_CRC_REQUIRED_AT) << name;
+            ASSERT_GT(chunk.uncompressed_bytes, 64u) << name;
+            const PayloadCapGuard cap(chunk.uncompressed_bytes - 1);
+            auto materialized = reader.read_chunk(chunk);
+            ASSERT_FALSE(materialized) << name;
+            EXPECT_EQ(materialized.error().code(),
+                      lfs::ErrorCode::ResourceExhausted)
+                << name;
+            auto bounded = reader.open_bounded_stream(chunk);
+            ASSERT_TRUE(bounded) << lfs::format_for_developer(bounded.error());
+            expect_bounded_stream_matches(*bounded, payload);
+        };
+        check(Compression::ZstdFramed, "zstd-framed");
+        check(Compression::ByteShuffleZstdFramed, "byteshuffle-framed");
+    }
+
+    TEST(ProjectContainerReader, BoundedStreamRejectsNoTableFramedPayloadCrcMismatch) {
+        const auto check = [](const Compression compression,
+                              const std::string_view name) {
+            TemporaryDirectory temporary;
+            const fs::path path =
+                temporary.path / (std::string(name) + "-no-table-crc.licht");
+            const auto payload = patterned_payload(64 * 1024);
+            write_framed_fixture(path, FOURCC_CKPT, 1201, payload, compression,
+                                 true, false, 1201);
+            ProjectReader reader = require_result(ProjectReader::open(path));
+            const ChunkInfo& chunk = reader.chunks().front();
+            ASSERT_FALSE(chunk.block_crc_table.has_value()) << name;
+            ASSERT_GT(chunk.stored_bytes, 0u) << name;
+            const std::uint64_t corrupt_offset =
+                chunk.payload_offset + chunk.stored_bytes / 2;
+            const auto original = read_file_range(path, corrupt_offset, 1);
+            ASSERT_EQ(original.size(), 1u) << name;
+            write_file_range(path, corrupt_offset,
+                             std::array{original.front() ^ std::byte{0xff}});
+            auto bounded = reader.open_bounded_stream(chunk);
+            ASSERT_FALSE(bounded) << name;
+            const auto formatted = lfs::format_for_developer(bounded.error());
+            const auto field =
+                std::format("payload[{}].crc32c", chunk.key_string());
+            EXPECT_EQ(error_field_string(bounded.error(), "field"), field)
+                << formatted;
+            EXPECT_EQ(bounded.error().code(), lfs::ErrorCode::DataLoss) << name;
+            EXPECT_NE(formatted.find(std::format("expected 0x{:08x}",
+                                                 chunk.payload_crc32c)),
+                      std::string::npos)
+                << formatted;
+            EXPECT_NE(formatted.find("got 0x"), std::string::npos) << formatted;
+        };
+        check(Compression::ZstdFramed, "zstd-framed");
+        check(Compression::ByteShuffleZstdFramed, "byteshuffle-framed");
+    }
+
+    TEST(ProjectContainerReader,
+         BoundedStreamOpenAccountsStoredPrePassOnlyWithoutBlockTable) {
+        const auto measure_open = [](const bool with_table,
+                                     const std::string_view name) {
+            TemporaryDirectory temporary;
+            const fs::path path =
+                temporary.path / (std::string(name) + "-open-account.licht");
+            const auto payload = patterned_payload(64 * 1024);
+            write_framed_fixture(path, FOURCC_CKPT, 1202, payload,
+                                 Compression::ZstdFramed, true, with_table,
+                                 1202);
+            auto payload_reads = std::make_shared<std::atomic_uint64_t>(0);
+            ReaderOptions options;
+            options.payload_bytes_read = payload_reads;
+            ProjectReader reader =
+                require_result(ProjectReader::open(path, options));
+            const ChunkInfo& chunk = reader.chunks().front();
+            EXPECT_EQ(chunk.block_crc_table.has_value(), with_table) << name;
+            EXPECT_GT(chunk.stored_bytes, 0u) << name;
+            EXPECT_EQ(payload_reads->load(), 0u) << name;
+            auto bounded = reader.open_bounded_stream(chunk);
+            EXPECT_TRUE(bounded) << lfs::format_for_developer(bounded.error());
+            return std::pair{payload_reads->load(), chunk.stored_bytes};
+        };
+
+        const auto [with_table_reads, with_table_stored] =
+            measure_open(true, "with-table");
+        EXPECT_LT(with_table_reads, with_table_stored);
+        EXPECT_EQ(with_table_reads, 0u);
+
+        const auto [no_table_reads, no_table_stored] =
+            measure_open(false, "no-table");
+        EXPECT_EQ(no_table_reads, no_table_stored);
+        EXPECT_GT(no_table_stored, 0u);
     }
 
     TEST(ProjectContainerReader, BoundedStreamRejectsCorruptFramedStoredBytes) {

--- a/tests/test_project_container.cpp
+++ b/tests/test_project_container.cpp
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <functional>
 #include <gtest/gtest.h>
+#include <iostream>
 #include <iterator>
 #include <limits>
 #include <optional>
@@ -557,6 +558,96 @@ namespace {
         return payload;
     }
 
+    std::vector<std::byte> compressible_payload(const std::size_t bytes) {
+        std::vector<std::byte> payload(bytes);
+        std::array<std::byte, 256> tile{};
+        for (std::size_t index = 0; index < tile.size(); ++index) {
+            tile[index] =
+                static_cast<std::byte>(static_cast<unsigned>(index * 13u + 7u));
+        }
+        for (std::size_t offset = 0; offset < bytes;) {
+            const auto n = std::min(tile.size(), bytes - offset);
+            std::memcpy(payload.data() + offset, tile.data(), n);
+            offset += n;
+        }
+        constexpr std::size_t kStamp = 1024 * 1024;
+        for (std::size_t block = 0; block * kStamp < bytes; ++block) {
+            payload[block * kStamp] =
+                static_cast<std::byte>(static_cast<unsigned>(block & 0xffu));
+        }
+        return payload;
+    }
+
+    std::uint64_t read_le_u64(const std::vector<std::byte>& bytes,
+                              const std::size_t at) {
+        std::uint64_t value = 0;
+        for (std::size_t index = 0; index < 8; ++index) {
+            value |= static_cast<std::uint64_t>(
+                         std::to_integer<std::uint8_t>(bytes[at + index]))
+                     << (8 * index);
+        }
+        return value;
+    }
+
+    struct FramedTableRecord {
+        std::uint64_t stored_offset = 0;
+        std::uint64_t stored_bytes = 0;
+        std::uint64_t decoded_offset = 0;
+        std::uint64_t decoded_bytes = 0;
+    };
+
+    std::vector<FramedTableRecord> read_framed_table(const fs::path& path,
+                                                     const ChunkInfo& chunk) {
+        const auto header = read_file_range(path, chunk.payload_offset, 16);
+        const auto count = static_cast<std::uint32_t>(header[12]) |
+                           (static_cast<std::uint32_t>(header[13]) << 8) |
+                           (static_cast<std::uint32_t>(header[14]) << 16) |
+                           (static_cast<std::uint32_t>(header[15]) << 24);
+        const auto table = 16u + static_cast<std::size_t>(count) * 16u;
+        const auto bytes = read_file_range(path, chunk.payload_offset, table);
+        std::vector<FramedTableRecord> records;
+        records.reserve(count);
+        std::uint64_t stored_offset = table;
+        std::uint64_t decoded_offset = 0;
+        for (std::uint32_t index = 0; index < count; ++index) {
+            const auto at = 16u + static_cast<std::size_t>(index) * 16u;
+            const auto stored_bytes = read_le_u64(bytes, at);
+            const auto decoded_bytes = read_le_u64(bytes, at + 8);
+            records.push_back({stored_offset, stored_bytes, decoded_offset,
+                               decoded_bytes});
+            stored_offset += stored_bytes;
+            decoded_offset += decoded_bytes;
+        }
+        return records;
+    }
+
+    std::uint64_t first_logical_byte_of_record(const FramedTableRecord& record,
+                                               const std::uint64_t uncompressed,
+                                               const bool byteshuffle) {
+        if (!byteshuffle) {
+            return record.decoded_offset;
+        }
+        if (uncompressed < 4 || uncompressed % 4 != 0) {
+            return record.decoded_offset;
+        }
+        const std::uint64_t n_words = uncompressed / 4;
+        std::uint64_t first = uncompressed;
+        for (std::uint64_t plane = 0; plane < 4; ++plane) {
+            const std::uint64_t plane_lo = plane * n_words;
+            const std::uint64_t plane_hi = plane_lo + n_words;
+            const std::uint64_t overlap_lo =
+                std::max(record.decoded_offset, plane_lo);
+            const std::uint64_t overlap_hi = std::min(
+                record.decoded_offset + record.decoded_bytes, plane_hi);
+            if (overlap_hi <= overlap_lo) {
+                continue;
+            }
+            const std::uint64_t word = overlap_lo - plane_lo;
+            first = std::min(first, word * 4 + plane);
+        }
+        return first;
+    }
+
     struct PayloadCapGuard {
         explicit PayloadCapGuard(const std::optional<std::uint64_t> value) {
             detail::set_max_payload_materialized_bytes_for_testing(value);
@@ -793,6 +884,275 @@ namespace {
                                path, chunk.payload_offset + 20,
                                std::array{std::byte{0xff}});
                        });
+    }
+
+    TEST(ProjectContainerReader, BoundedStreamBulkReadEquivalence) {
+        constexpr std::size_t kBytes =
+            2ull * 64ull * 1024ull * 1024ull + 32ull * 1024ull * 1024ull;
+        const auto payload = patterned_payload(kBytes);
+        const auto check = [&](const Compression compression,
+                               const std::string_view name) {
+            TemporaryDirectory temporary;
+            const fs::path path =
+                temporary.path / (std::string(name) + "-bulk.licht");
+            write_framed_fixture(path, FOURCC_CKPT, 1100, payload, compression,
+                                 true, true, 1100);
+            ProjectReader reader = require_result(ProjectReader::open(path));
+            const ChunkInfo& chunk = reader.chunks().front();
+            EXPECT_EQ(chunk.compression, compression) << name;
+            const auto records = read_framed_table(path, chunk);
+            ASSERT_GE(records.size(), 3u) << name;
+            const auto materialized = require_result(reader.read_chunk(chunk));
+            ASSERT_EQ(materialized, payload) << name;
+
+            auto bounded = reader.open_bounded_stream(chunk);
+            ASSERT_TRUE(bounded) << lfs::format_for_developer(bounded.error());
+            auto& stream = bounded->stream();
+
+            std::vector<std::byte> whole(payload.size());
+            stream.read(reinterpret_cast<char*>(whole.data()),
+                        static_cast<std::streamsize>(whole.size()));
+            ASSERT_EQ(stream.gcount(),
+                      static_cast<std::streamsize>(whole.size()))
+                << name;
+            EXPECT_EQ(whole, materialized) << name;
+            EXPECT_EQ(static_cast<std::uint64_t>(stream.tellg()), payload.size())
+                << name;
+
+            struct Slice {
+                std::uint64_t offset;
+                std::uint64_t length;
+            };
+            const std::array<Slice, 6> slices{{
+                {1, 17},
+                {3, 64ull * 1024ull * 1024ull + 9},
+                {7, 2ull * 64ull * 1024ull * 1024ull + 13},
+                {64ull * 1024ull * 1024ull - 1, 32},
+                {64ull * 1024ull * 1024ull + 3, 64ull * 1024ull * 1024ull + 5},
+                {2ull * 64ull * 1024ull * 1024ull + 1, 1000},
+            }};
+            for (const auto& slice : slices) {
+                ASSERT_LE(slice.offset + slice.length, payload.size()) << name;
+                stream.clear();
+                stream.seekg(static_cast<std::streamoff>(slice.offset));
+                ASSERT_TRUE(stream) << name;
+                std::vector<std::byte> got(static_cast<std::size_t>(slice.length));
+                stream.read(reinterpret_cast<char*>(got.data()),
+                            static_cast<std::streamsize>(got.size()));
+                ASSERT_EQ(stream.gcount(),
+                          static_cast<std::streamsize>(got.size()))
+                    << name << " @" << slice.offset;
+                EXPECT_TRUE(std::equal(
+                    got.begin(), got.end(),
+                    materialized.begin() +
+                        static_cast<std::ptrdiff_t>(slice.offset)))
+                    << name << " @" << slice.offset;
+            }
+
+            stream.clear();
+            stream.seekg(5);
+            ASSERT_TRUE(stream) << name;
+            constexpr std::size_t kLarge1 = 64ull * 1024ull * 1024ull + 100;
+            constexpr std::size_t kLarge2 = 64ull * 1024ull * 1024ull + 77;
+            std::vector<std::byte> first(kLarge1);
+            stream.read(reinterpret_cast<char*>(first.data()),
+                        static_cast<std::streamsize>(first.size()));
+            ASSERT_EQ(stream.gcount(), static_cast<std::streamsize>(kLarge1))
+                << name;
+            EXPECT_TRUE(std::equal(first.begin(), first.end(),
+                                   materialized.begin() + 5))
+                << name;
+            const int mid = stream.get();
+            ASSERT_NE(mid, std::char_traits<char>::eof()) << name;
+            EXPECT_EQ(static_cast<unsigned char>(mid),
+                      std::to_integer<unsigned char>(materialized[5 + kLarge1]))
+                << name;
+            std::vector<std::byte> second(kLarge2);
+            stream.read(reinterpret_cast<char*>(second.data()),
+                        static_cast<std::streamsize>(second.size()));
+            ASSERT_EQ(stream.gcount(), static_cast<std::streamsize>(kLarge2))
+                << name;
+            EXPECT_TRUE(std::equal(
+                second.begin(), second.end(),
+                materialized.begin() +
+                    static_cast<std::ptrdiff_t>(5 + kLarge1 + 1)))
+                << name;
+
+            stream.clear();
+            stream.seekg(0);
+            ASSERT_TRUE(stream) << name;
+            std::vector<std::byte> extra(payload.size() + 32);
+            stream.read(reinterpret_cast<char*>(extra.data()),
+                        static_cast<std::streamsize>(extra.size()));
+            ASSERT_EQ(stream.gcount(),
+                      static_cast<std::streamsize>(payload.size()))
+                << name;
+            EXPECT_TRUE(std::equal(extra.begin(),
+                                   extra.begin() +
+                                       static_cast<std::ptrdiff_t>(payload.size()),
+                                   materialized.begin()))
+                << name;
+            EXPECT_TRUE(stream.eof()) << name;
+            EXPECT_FALSE(stream.bad()) << name;
+            stream.clear();
+            EXPECT_EQ(static_cast<std::uint64_t>(stream.tellg()), payload.size())
+                << name;
+            stream.seekg(0);
+            ASSERT_TRUE(stream) << name;
+            std::byte first_byte{};
+            stream.read(reinterpret_cast<char*>(&first_byte), 1);
+            ASSERT_EQ(stream.gcount(), 1) << name;
+            EXPECT_EQ(first_byte, materialized.front()) << name;
+        };
+        check(Compression::ZstdFramed, "zstd-framed");
+        check(Compression::ByteShuffleZstdFramed, "byteshuffle-framed");
+    }
+
+    std::vector<std::byte> incompressible_payload(const std::size_t bytes) {
+        std::vector<std::byte> payload(bytes);
+        std::uint64_t state = 0x9e3779b97f4a7c15ull;
+        auto* words = reinterpret_cast<std::uint64_t*>(payload.data());
+        const std::size_t n_words = bytes / sizeof(std::uint64_t);
+        for (std::size_t index = 0; index < n_words; ++index) {
+            state = state * 6364136223846793005ull + 1;
+            words[index] = state;
+        }
+        for (std::size_t index = n_words * sizeof(std::uint64_t); index < bytes;
+             ++index) {
+            state = state * 6364136223846793005ull + 1;
+            payload[index] = static_cast<std::byte>(state >> 56);
+        }
+        return payload;
+    }
+
+    TEST(ProjectContainerReader, BoundedStreamBulkReadStopsAtCorruptRecord) {
+        constexpr std::size_t kBytes =
+            2ull * 64ull * 1024ull * 1024ull + 32ull * 1024ull * 1024ull;
+        const auto payload = incompressible_payload(kBytes);
+        const auto check = [&](const Compression compression,
+                               const std::string_view name) {
+            TemporaryDirectory temporary;
+            const fs::path path =
+                temporary.path / (std::string(name) + "-bulk-corrupt.licht");
+            write_framed_fixture(path, FOURCC_CKPT, 1110, payload, compression,
+                                 true, true, 1110);
+            ProjectReader reader = require_result(ProjectReader::open(path));
+            const ChunkInfo& chunk = reader.chunks().front();
+            const auto records = read_framed_table(path, chunk);
+            ASSERT_GE(records.size(), 3u) << name;
+            const auto& victim = records[2];
+            ASSERT_GT(victim.stored_bytes, 8u) << name;
+            const std::uint64_t corrupt_rel =
+                victim.stored_offset + victim.stored_bytes - 1;
+            write_file_range(path, chunk.payload_offset + corrupt_rel,
+                             std::array{std::byte{0x7f}});
+            const std::uint64_t block = corrupt_rel / BLOCK_CRC_BYTES;
+            const std::uint64_t block_lo = block * BLOCK_CRC_BYTES;
+            const std::uint64_t block_hi = block_lo + BLOCK_CRC_BYTES;
+            std::size_t first_bad = records.size();
+            for (std::size_t index = 0; index < records.size(); ++index) {
+                const auto& record = records[index];
+                if (record.stored_offset < block_hi &&
+                    record.stored_offset + record.stored_bytes > block_lo) {
+                    first_bad = index;
+                    break;
+                }
+            }
+            ASSERT_LT(first_bad, records.size()) << name;
+            const bool byteshuffle =
+                compression == Compression::ByteShuffleZstdFramed;
+            const auto prefix = first_logical_byte_of_record(
+                records[first_bad], chunk.uncompressed_bytes, byteshuffle);
+            ASSERT_GT(prefix, 0u) << name;
+            ASSERT_LT(prefix, payload.size()) << name;
+
+            auto bounded = reader.open_bounded_stream(chunk);
+            ASSERT_TRUE(bounded) << lfs::format_for_developer(bounded.error());
+            auto& stream = bounded->stream();
+            std::vector<std::byte> got(payload.size(), std::byte{0x3c});
+            stream.read(reinterpret_cast<char*>(got.data()),
+                        static_cast<std::streamsize>(got.size()));
+            EXPECT_EQ(stream.gcount(), static_cast<std::streamsize>(prefix))
+                << name;
+            EXPECT_TRUE(stream.fail()) << name;
+            EXPECT_TRUE(std::equal(got.begin(),
+                                   got.begin() + static_cast<std::ptrdiff_t>(prefix),
+                                   payload.begin()))
+                << name;
+
+            stream.clear();
+            stream.seekg(0);
+            std::byte probe{};
+            stream.read(reinterpret_cast<char*>(&probe), 1);
+            EXPECT_EQ(stream.gcount(), 0) << name;
+            EXPECT_TRUE(stream.fail()) << name;
+        };
+        check(Compression::ZstdFramed, "zstd-framed");
+        check(Compression::ByteShuffleZstdFramed, "byteshuffle-framed");
+    }
+
+    TEST(ProjectContainerReader, DISABLED_FramedStreamThroughputBenchmark) {
+        constexpr std::size_t kBytes = 24ull * 64ull * 1024ull * 1024ull;
+        std::vector<std::byte> payload;
+        try {
+            payload = compressible_payload(kBytes);
+        } catch (const std::bad_alloc&) {
+            GTEST_SKIP() << "not enough memory for 1.5GiB framed stream benchmark";
+        }
+
+        const auto run = [&](const Compression compression,
+                             const std::string_view name) {
+            TemporaryDirectory temporary;
+            const fs::path path =
+                temporary.path / (std::string(name) + "-bench.licht");
+            write_framed_fixture(path, FOURCC_CKPT, 1120, payload, compression,
+                                 true, true, 1120);
+            ProjectReader reader = require_result(ProjectReader::open(path));
+            const ChunkInfo& chunk = reader.chunks().front();
+            EXPECT_EQ(chunk.compression, compression) << name;
+            const auto records = read_framed_table(path, chunk);
+            ASSERT_GE(records.size(), 3u) << name;
+
+            const auto started_chunk = std::chrono::steady_clock::now();
+            const auto materialized = require_result(reader.read_chunk(chunk));
+            const auto chunk_ms = std::chrono::duration<double, std::milli>(
+                                      std::chrono::steady_clock::now() -
+                                      started_chunk)
+                                      .count();
+            ASSERT_EQ(materialized, payload) << name;
+
+            auto bounded = reader.open_bounded_stream(chunk);
+            ASSERT_TRUE(bounded) << lfs::format_for_developer(bounded.error());
+            std::vector<std::byte> streamed;
+            try {
+                streamed.resize(payload.size());
+            } catch (const std::bad_alloc&) {
+                GTEST_SKIP() << "not enough memory for streamed 1.5GiB buffer";
+            }
+            const auto started_stream = std::chrono::steady_clock::now();
+            bounded->stream().read(reinterpret_cast<char*>(streamed.data()),
+                                   static_cast<std::streamsize>(streamed.size()));
+            const auto stream_ms = std::chrono::duration<double, std::milli>(
+                                       std::chrono::steady_clock::now() -
+                                       started_stream)
+                                       .count();
+            ASSERT_EQ(bounded->stream().gcount(),
+                      static_cast<std::streamsize>(streamed.size()))
+                << name;
+            ASSERT_EQ(streamed, payload) << name;
+
+            const double megabytes = static_cast<double>(kBytes) / (1024.0 * 1024.0);
+            const auto mbps = [&](const double milliseconds) {
+                return milliseconds <= 0.0 ? 0.0
+                                           : megabytes / (milliseconds / 1000.0);
+            };
+            std::cout << "FramedStreamThroughputBenchmark " << name
+                      << " read_chunk=" << mbps(chunk_ms) << " MB/s ("
+                      << chunk_ms << " ms) stream=" << mbps(stream_ms)
+                      << " MB/s (" << stream_ms << " ms)\n";
+        };
+        run(Compression::ByteShuffleZstdFramed, "byteshuffle-framed");
+        run(Compression::ZstdFramed, "zstd-framed");
     }
 
     TEST(ProjectContainerWriter, CleanProofRejectsForcedFalseCleanAndReaderStaysPinned) {

--- a/tests/test_project_container.cpp
+++ b/tests/test_project_container.cpp
@@ -540,6 +540,261 @@ namespace {
         EXPECT_EQ(bounded->stream().gcount(), 0);
     }
 
+    std::vector<std::byte> patterned_payload(const std::size_t bytes) {
+        std::vector<std::byte> payload(bytes);
+        for (std::size_t index = 0; index + 4 <= bytes; index += 4) {
+            const auto word =
+                static_cast<std::uint32_t>(index / 4) * 2654435761u;
+            payload[index + 0] = static_cast<std::byte>(word);
+            payload[index + 1] = static_cast<std::byte>(word >> 8);
+            payload[index + 2] = static_cast<std::byte>(word >> 16);
+            payload[index + 3] = static_cast<std::byte>(word >> 24);
+        }
+        for (std::size_t index = (bytes / 4) * 4; index < bytes; ++index) {
+            payload[index] =
+                static_cast<std::byte>(0xA5u ^ static_cast<unsigned>(index));
+        }
+        return payload;
+    }
+
+    struct PayloadCapGuard {
+        explicit PayloadCapGuard(const std::optional<std::uint64_t> value) {
+            detail::set_max_payload_materialized_bytes_for_testing(value);
+        }
+        PayloadCapGuard(const PayloadCapGuard&) = delete;
+        PayloadCapGuard& operator=(const PayloadCapGuard&) = delete;
+        ~PayloadCapGuard() {
+            detail::set_max_payload_materialized_bytes_for_testing(std::nullopt);
+        }
+    };
+
+    void expect_bounded_stream_matches(BoundedInputStream& bounded,
+                                       const std::vector<std::byte>& expected) {
+        auto& stream = bounded.stream();
+        ASSERT_EQ(bounded.size(), expected.size());
+        EXPECT_EQ(static_cast<std::uint64_t>(stream.tellg()), 0u);
+
+        std::vector<std::byte> got(expected.size());
+        stream.read(reinterpret_cast<char*>(got.data()),
+                    static_cast<std::streamsize>(got.size()));
+        ASSERT_EQ(stream.gcount(), static_cast<std::streamsize>(got.size()));
+        EXPECT_EQ(got, expected);
+
+        stream.clear();
+        stream.seekg(0);
+        ASSERT_TRUE(stream);
+        EXPECT_EQ(static_cast<std::uint64_t>(stream.tellg()), 0u);
+        std::vector<std::byte> again(expected.size());
+        stream.read(reinterpret_cast<char*>(again.data()),
+                    static_cast<std::streamsize>(again.size()));
+        ASSERT_EQ(stream.gcount(), static_cast<std::streamsize>(again.size()));
+        EXPECT_EQ(again, expected);
+
+        const auto tail = std::min<std::size_t>(64, expected.size());
+        ASSERT_GT(tail, 0u);
+        const auto tail_offset = expected.size() - tail;
+        stream.clear();
+        stream.seekg(static_cast<std::streamoff>(tail_offset), std::ios::beg);
+        ASSERT_TRUE(stream);
+        EXPECT_EQ(static_cast<std::uint64_t>(stream.tellg()), tail_offset);
+        std::vector<std::byte> tail_bytes(tail);
+        stream.read(reinterpret_cast<char*>(tail_bytes.data()),
+                    static_cast<std::streamsize>(tail_bytes.size()));
+        ASSERT_EQ(stream.gcount(), static_cast<std::streamsize>(tail));
+        EXPECT_TRUE(std::equal(tail_bytes.begin(), tail_bytes.end(),
+                               expected.end() - static_cast<std::ptrdiff_t>(tail)));
+
+        if (tail_offset >= 8) {
+            stream.clear();
+            stream.seekg(static_cast<std::streamoff>(tail_offset), std::ios::beg);
+            ASSERT_TRUE(stream);
+            stream.seekg(-8, std::ios::cur);
+            ASSERT_TRUE(stream);
+            EXPECT_EQ(static_cast<std::uint64_t>(stream.tellg()), tail_offset - 8);
+            std::array<std::byte, 8> relative{};
+            stream.read(reinterpret_cast<char*>(relative.data()),
+                        static_cast<std::streamsize>(relative.size()));
+            ASSERT_EQ(stream.gcount(), static_cast<std::streamsize>(relative.size()));
+            EXPECT_TRUE(std::equal(relative.begin(), relative.end(),
+                                   expected.begin() +
+                                       static_cast<std::ptrdiff_t>(tail_offset - 8)));
+        }
+
+        stream.clear();
+        stream.seekg(-static_cast<std::streamoff>(tail), std::ios::end);
+        ASSERT_TRUE(stream);
+        EXPECT_EQ(static_cast<std::uint64_t>(stream.tellg()), tail_offset);
+        std::vector<std::byte> from_end(tail);
+        stream.read(reinterpret_cast<char*>(from_end.data()),
+                    static_cast<std::streamsize>(from_end.size()));
+        ASSERT_EQ(stream.gcount(), static_cast<std::streamsize>(tail));
+        EXPECT_EQ(from_end, tail_bytes);
+
+        stream.clear();
+        stream.seekg(static_cast<std::streamoff>(expected.size() + 1),
+                     std::ios::beg);
+        EXPECT_TRUE(stream.fail());
+    }
+
+    void write_framed_fixture(const fs::path& path, const Fourcc fourcc,
+                              const std::uint64_t key_tag,
+                              const std::vector<std::byte>& payload,
+                              const Compression compression,
+                              const bool tensor_payload, const bool block_crcs,
+                              const std::uint64_t file_tag) {
+        ProjectWriter writer = require_result(
+            ProjectWriter::create(path, fixture_create_options(file_tag)));
+        require_status(writer.plan_commit(
+            fixture_commit_options(file_tag + 1, file_tag + 2, 1)));
+        require_status(writer.preflight(payload.size()));
+        require_status(writer.write_chunk(
+            ChunkKey{.fourcc = fourcc, .instance_uuid = fixed_uuid(key_tag)},
+            payload,
+            ChunkWriteOptions{
+                .chunk_version = 1,
+                .compression = compression,
+                .tensor_payload = tensor_payload,
+                .block_crcs = block_crcs,
+            }));
+        require_status(writer.commit());
+    }
+
+    TEST(ProjectContainerReader, BoundedStreamMatchesReadChunkForFramedPayloads) {
+        constexpr std::size_t kBytes =
+            2ull * 64ull * 1024ull * 1024ull + 32ull * 1024ull * 1024ull;
+        const auto payload = patterned_payload(kBytes);
+        const auto check = [&](const Compression compression,
+                               const std::string_view name) {
+            TemporaryDirectory temporary;
+            const fs::path path =
+                temporary.path / (std::string(name) + "-multi.licht");
+            write_framed_fixture(path, FOURCC_CKPT, 840, payload, compression,
+                                 true, true, 840);
+            ProjectReader reader = require_result(ProjectReader::open(path));
+            const ChunkInfo& chunk = reader.chunks().front();
+            EXPECT_EQ(chunk.compression, compression) << name;
+            EXPECT_GE(chunk.uncompressed_bytes,
+                      2ull * 64ull * 1024ull * 1024ull + 1ull)
+                << name;
+            const auto header = read_file_range(path, chunk.payload_offset, 16);
+            const auto record_count =
+                static_cast<std::uint32_t>(header[12]) |
+                (static_cast<std::uint32_t>(header[13]) << 8) |
+                (static_cast<std::uint32_t>(header[14]) << 16) |
+                (static_cast<std::uint32_t>(header[15]) << 24);
+            ASSERT_GE(record_count, 3u) << name;
+            const auto materialized = require_result(reader.read_chunk(chunk));
+            ASSERT_EQ(materialized, payload) << name;
+            auto bounded = reader.open_bounded_stream(chunk);
+            ASSERT_TRUE(bounded) << lfs::format_for_developer(bounded.error());
+            expect_bounded_stream_matches(*bounded, materialized);
+        };
+        check(Compression::ZstdFramed, "zstd-framed");
+        check(Compression::ByteShuffleZstdFramed, "byteshuffle-framed");
+    }
+
+    TEST(ProjectContainerReader, BoundedStreamMatchesReadChunkForSmallFramedPayloads) {
+        const auto check = [](const std::string_view name,
+                              const std::vector<std::byte>& payload,
+                              const Compression requested) {
+            TemporaryDirectory temporary;
+            const fs::path path =
+                temporary.path / (std::string(name) + "-small.licht");
+            write_framed_fixture(path, FOURCC_SPLT, 850, payload, requested, true,
+                                 false, 850);
+            ProjectReader reader = require_result(ProjectReader::open(path));
+            const ChunkInfo& chunk = reader.chunks().front();
+            if (requested == Compression::ByteShuffleZstdFramed &&
+                payload.size() % 4 != 0) {
+                EXPECT_EQ(chunk.compression, Compression::ZstdFramed) << name;
+            } else {
+                EXPECT_EQ(chunk.compression, requested) << name;
+            }
+            const auto materialized = require_result(reader.read_chunk(chunk));
+            ASSERT_EQ(materialized, payload) << name;
+            auto bounded = reader.open_bounded_stream(chunk);
+            ASSERT_TRUE(bounded) << lfs::format_for_developer(bounded.error());
+            expect_bounded_stream_matches(*bounded, materialized);
+        };
+        check("zstd-single", patterned_payload(4096), Compression::ZstdFramed);
+        check("byteshuffle-single", patterned_payload(4096),
+              Compression::ByteShuffleZstdFramed);
+        check("zstd-fallback-non-multiple-of-4", patterned_payload(4097),
+              Compression::ByteShuffleZstdFramed);
+    }
+
+    TEST(ProjectContainerReader, BoundedStreamReadsPayloadClassBeyondMaterializeCap) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "cap-stream.licht";
+        const auto payload = patterned_payload(8192);
+        write_framed_fixture(path, FOURCC_CKPT, 860, payload,
+                             Compression::ZstdFramed, true, true, 860);
+        ProjectReader reader = require_result(ProjectReader::open(path));
+        const ChunkInfo& chunk = reader.chunks().front();
+        ASSERT_GT(chunk.uncompressed_bytes, 64u);
+        const PayloadCapGuard cap(chunk.uncompressed_bytes - 1);
+        auto materialized = reader.read_chunk(chunk);
+        ASSERT_FALSE(materialized);
+        EXPECT_EQ(materialized.error().code(), lfs::ErrorCode::ResourceExhausted);
+        const auto detail = lfs::format_for_developer(materialized.error());
+        EXPECT_NE(detail.find("materialized-read maximum"), std::string::npos)
+            << detail;
+        auto bounded = reader.open_bounded_stream(chunk);
+        ASSERT_TRUE(bounded) << lfs::format_for_developer(bounded.error());
+        std::vector<std::byte> got(static_cast<std::size_t>(bounded->size()));
+        bounded->stream().read(reinterpret_cast<char*>(got.data()),
+                               static_cast<std::streamsize>(got.size()));
+        ASSERT_EQ(bounded->stream().gcount(),
+                  static_cast<std::streamsize>(got.size()));
+        EXPECT_EQ(got, payload);
+    }
+
+    TEST(ProjectContainerReader, BoundedStreamRejectsCorruptFramedStoredBytes) {
+        const auto write_and_open =
+            [](const std::string_view name,
+               const std::function<void(const ChunkInfo&, const fs::path&)>&
+                   corrupt) {
+                TemporaryDirectory temporary;
+                const fs::path path =
+                    temporary.path / (std::string(name) + "-corrupt.licht");
+                const auto payload = patterned_payload(256 * 1024);
+                write_framed_fixture(path, FOURCC_CKPT, 870, payload,
+                                     Compression::ZstdFramed, true, true, 870);
+                ProjectReader reader = require_result(ProjectReader::open(path));
+                const ChunkInfo& chunk = reader.chunks().front();
+                ASSERT_TRUE(chunk.block_crc_table.has_value());
+                corrupt(chunk, path);
+                auto bounded = reader.open_bounded_stream(chunk);
+                ASSERT_TRUE(bounded) << lfs::format_for_developer(bounded.error());
+                std::vector<char> sink(64);
+                bounded->stream().read(sink.data(),
+                                       static_cast<std::streamsize>(sink.size()));
+                EXPECT_TRUE(bounded->stream().fail()) << name;
+                EXPECT_EQ(bounded->stream().gcount(), 0) << name;
+            };
+        write_and_open("framed-record-bytes",
+                       [](const ChunkInfo& chunk, const fs::path& path) {
+                           const auto header =
+                               read_file_range(path, chunk.payload_offset, 16);
+                           const auto record_count =
+                               static_cast<std::uint32_t>(header[12]) |
+                               (static_cast<std::uint32_t>(header[13]) << 8) |
+                               (static_cast<std::uint32_t>(header[14]) << 16) |
+                               (static_cast<std::uint32_t>(header[15]) << 24);
+                           const auto table =
+                               16u + static_cast<std::uint64_t>(record_count) * 16u;
+                           write_file_range(
+                               path, chunk.payload_offset + table + 8,
+                               std::array{std::byte{0x7f}});
+                       });
+        write_and_open("framed-record-table",
+                       [](const ChunkInfo& chunk, const fs::path& path) {
+                           write_file_range(
+                               path, chunk.payload_offset + 20,
+                               std::array{std::byte{0xff}});
+                       });
+    }
+
     TEST(ProjectContainerWriter, CleanProofRejectsForcedFalseCleanAndReaderStaysPinned) {
         TemporaryDirectory temporary;
         const fs::path path = temporary.path / "clean-proof.licht";

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -3581,6 +3581,184 @@ namespace {
     }
 
     TEST(ProjectDocumentTest,
+         SaveCopiesFileBackedCkptVerbatimWhenCleanProofIsLost) {
+        TemporaryDirectory temporary;
+        const fs::path path =
+            temporary.path / "ckpt-verbatim-no-proof.licht";
+        const Uuid project_uuid = fixed_uuid(9950);
+        const Uuid training_uuid = fixed_uuid(9951);
+        const Uuid checkpoint_uuid = fixed_uuid(9952);
+        auto document = make_empty_document(project_uuid, 100);
+        require_status(document->edit_scene_graph().upsert_node(
+            SceneNodeRecord{
+                .uuid = training_uuid,
+                .type = "splat",
+                .name = "Training",
+                .child_order = 0,
+                .payload =
+                    PayloadBinding{
+                        .fourcc = "CKPT",
+                        .instance_uuid = checkpoint_uuid,
+                        .source_kind = "training",
+                    },
+            }));
+        require_status(
+            document->edit_scene_graph().set_training_model_uuid(
+                training_uuid));
+        require_status(document->set_checkpoint(
+            checkpoint_uuid,
+            make_autosave_checkpoint_payload(checkpoint_uuid)));
+        auto seed_options = save_options(9953, 1600);
+        seed_options.commit.snapshot_uuid = checkpoint_uuid;
+        auto seeded = document->save(path, seed_options);
+        ASSERT_TRUE(seeded)
+            << lfs::format_for_developer(seeded.error());
+
+        std::vector<std::byte> logical_payload;
+        {
+            ProjectReader seed = require_result(ProjectReader::open(path));
+            const ChunkInfo* ckpt =
+                seed.find(FOURCC_CKPT, checkpoint_uuid);
+            ASSERT_NE(ckpt, nullptr);
+            logical_payload = require_result(seed.read_chunk(*ckpt));
+            ProjectWriter writer = require_result(
+                ProjectWriter::append(
+                    path,
+                    AppendOptions{
+                        .index_compression =
+                            IndexCompression::
+                                StoredForDeterministicTests,
+                        .disk_reserve_bytes = 0,
+                    }));
+            require_status(writer.plan_commit(
+                CommitOptions{
+                    .kind = CommitKind::Explicit,
+                    .commit_uuid = fixed_uuid(9954),
+                    .snapshot_uuid = checkpoint_uuid,
+                    .wallclock_unix_ns = 1700,
+                }));
+            require_status(writer.preflight(logical_payload.size()));
+            for (const auto& chunk : seed.chunks()) {
+                if (!chunk.is_live()) {
+                    continue;
+                }
+                if (chunk.key.fourcc == FOURCC_CKPT) {
+                    require_status(writer.write_chunk(
+                        chunk.key, logical_payload,
+                        ChunkWriteOptions{
+                            .chunk_version = 1,
+                            .compression = chunk.compression,
+                            .tensor_payload = true,
+                            .block_crcs = true,
+                        }));
+                    continue;
+                }
+                auto proof =
+                    require_result(seed.make_clean_proof(chunk, 1));
+                require_status(writer.reuse_if_clean(proof, 1));
+            }
+            require_status(writer.commit());
+        }
+
+        ProjectReader probe = require_result(ProjectReader::open(path));
+        const ChunkInfo* source_row =
+            probe.find(FOURCC_CKPT, checkpoint_uuid);
+        ASSERT_NE(source_row, nullptr);
+        ASSERT_GT(source_row->uncompressed_bytes, 1u);
+        ASSERT_TRUE(source_row->block_crc_table.has_value());
+        EXPECT_TRUE(source_row->compression == Compression::ZstdFramed ||
+                    source_row->compression ==
+                        Compression::ByteShuffleZstdFramed);
+        const auto source_compression = source_row->compression;
+        const auto source_uncompressed = source_row->uncompressed_bytes;
+        const auto source_version = source_row->chunk_version;
+        const auto source_block_crc_count =
+            source_row->block_crc_table->entries.size();
+        const auto source_payload_offset = source_row->payload_offset;
+        const auto source_generation = probe.commit().generation;
+
+        auto opened = require_result_ptr(ProjectDocument::open(path));
+        const auto* checkpoint = opened->find_checkpoint(checkpoint_uuid);
+        ASSERT_NE(checkpoint, nullptr);
+        EXPECT_TRUE(checkpoint->is_clean_reference());
+        opened->drop_checkpoint_clean_proof_for_testing(checkpoint_uuid);
+        EXPECT_FALSE(checkpoint->is_clean_reference());
+
+        struct PayloadCapGuard {
+            explicit PayloadCapGuard(const std::uint64_t value) {
+                detail::set_max_payload_materialized_bytes_for_testing(value);
+            }
+            PayloadCapGuard(const PayloadCapGuard&) = delete;
+            PayloadCapGuard& operator=(const PayloadCapGuard&) = delete;
+            ~PayloadCapGuard() {
+                detail::set_max_payload_materialized_bytes_for_testing(
+                    std::nullopt);
+            }
+        };
+        const PayloadCapGuard cap(source_uncompressed - 1);
+        auto materialized = probe.read_chunk(*source_row);
+        ASSERT_FALSE(materialized);
+        EXPECT_EQ(materialized.error().code(),
+                  lfs::ErrorCode::ResourceExhausted);
+
+        auto rewrite_options = save_options(9955, 1800);
+        rewrite_options.commit.snapshot_uuid = checkpoint_uuid;
+        auto rewritten = opened->save(path, rewrite_options);
+        ASSERT_TRUE(rewritten)
+            << lfs::format_for_developer(rewritten.error());
+        EXPECT_GE(rewritten->rewritten_chunks, 1u);
+        EXPECT_GT(rewritten->generation, source_generation);
+
+        auto reopened = require_result_ptr(ProjectDocument::open(path));
+        const auto* restored = reopened->find_checkpoint(checkpoint_uuid);
+        ASSERT_NE(restored, nullptr);
+
+        std::vector<std::byte> restored_logical;
+        std::optional<lfs::core::CheckpointHeader> header;
+        bool restored_read_ok = false;
+        auto visited = restored->visit_stream(
+            [&](std::istream& stream, const std::uint64_t bytes)
+                -> lfs::Result<void> {
+                auto loaded_header =
+                    lfs::core::load_checkpoint_header(stream, bytes);
+                if (loaded_header) {
+                    header = *loaded_header;
+                }
+                stream.clear();
+                stream.seekg(0);
+                restored_logical.resize(static_cast<std::size_t>(bytes));
+                if (bytes != 0) {
+                    stream.read(
+                        reinterpret_cast<char*>(restored_logical.data()),
+                        static_cast<std::streamsize>(bytes));
+                }
+                restored_read_ok =
+                    static_cast<bool>(stream) &&
+                    static_cast<std::uint64_t>(stream.gcount()) == bytes;
+                return {};
+            });
+        ASSERT_TRUE(visited)
+            << lfs::format_for_developer(visited.error());
+        ASSERT_TRUE(header.has_value());
+        EXPECT_EQ(header->iteration, 11);
+        EXPECT_EQ(header->num_gaussians, 2u);
+        ASSERT_TRUE(restored_read_ok);
+        EXPECT_EQ(restored_logical, logical_payload);
+
+        ProjectReader after = require_result(ProjectReader::open(path));
+        const ChunkInfo* copied =
+            after.find(FOURCC_CKPT, checkpoint_uuid);
+        ASSERT_NE(copied, nullptr);
+        EXPECT_EQ(copied->uncompressed_bytes, source_uncompressed);
+        EXPECT_EQ(copied->compression, source_compression);
+        EXPECT_EQ(copied->chunk_version, source_version);
+        ASSERT_TRUE(copied->block_crc_table.has_value());
+        EXPECT_EQ(copied->block_crc_table->entries.size(),
+                  source_block_crc_count);
+        EXPECT_NE(copied->payload_offset, source_payload_offset);
+    }
+
+    TEST(ProjectDocumentTest,
          HeadlessOpenWithoutRecoverKeepsSidecarUntilExplicitHeadAdvances) {
         TemporaryDirectory temporary;
         const fs::path master =

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -5,6 +5,7 @@
 
 #include "app/headless_recovery_document.hpp"
 #include "io/loaders/loader_utils.hpp"
+#include "io/project/project_container_internal.hpp"
 #include "io/project_document.hpp"
 #include "io/project_recovery.hpp"
 #include "licht_test_support.hpp"
@@ -3433,6 +3434,150 @@ namespace {
                    training.error());
         ASSERT_TRUE(training->has_value());
         EXPECT_EQ(**training, fixed_uuid(9930));
+    }
+
+    TEST(ProjectDocumentTest,
+         OpenStreamsCkptWhenDecodedSizeExceedsMaterializeCap) {
+        TemporaryDirectory temporary;
+        const fs::path path =
+            temporary.path / "ckpt-stream-cap.licht";
+        const Uuid project_uuid = fixed_uuid(9940);
+        const Uuid training_uuid = fixed_uuid(9941);
+        const Uuid checkpoint_uuid = fixed_uuid(9942);
+        auto document = make_empty_document(project_uuid, 100);
+        require_status(document->edit_scene_graph().upsert_node(
+            SceneNodeRecord{
+                .uuid = training_uuid,
+                .type = "splat",
+                .name = "Training",
+                .child_order = 0,
+                .payload =
+                    PayloadBinding{
+                        .fourcc = "CKPT",
+                        .instance_uuid = checkpoint_uuid,
+                        .source_kind = "training",
+                    },
+            }));
+        require_status(
+            document->edit_scene_graph().set_training_model_uuid(
+                training_uuid));
+        require_status(document->set_checkpoint(
+            checkpoint_uuid,
+            make_autosave_checkpoint_payload(checkpoint_uuid)));
+        auto options = save_options(9943, 1600);
+        options.commit.snapshot_uuid = checkpoint_uuid;
+        auto saved = document->save(path, options);
+        ASSERT_TRUE(saved)
+            << lfs::format_for_developer(saved.error());
+
+        {
+            ProjectReader seed = require_result(ProjectReader::open(path));
+            const ChunkInfo* ckpt =
+                seed.find(FOURCC_CKPT, checkpoint_uuid);
+            ASSERT_NE(ckpt, nullptr);
+            auto ckpt_bytes = require_result(seed.read_chunk(*ckpt));
+            ProjectWriter writer = require_result(
+                ProjectWriter::append(
+                    path,
+                    AppendOptions{
+                        .index_compression =
+                            IndexCompression::
+                                StoredForDeterministicTests,
+                        .disk_reserve_bytes = 0,
+                    }));
+            require_status(writer.plan_commit(
+                CommitOptions{
+                    .kind = CommitKind::Explicit,
+                    .commit_uuid = fixed_uuid(9944),
+                    .snapshot_uuid = checkpoint_uuid,
+                    .wallclock_unix_ns = 1700,
+                }));
+            require_status(writer.preflight(ckpt_bytes.size()));
+            for (const auto& chunk : seed.chunks()) {
+                if (!chunk.is_live()) {
+                    continue;
+                }
+                if (chunk.key.fourcc == FOURCC_CKPT) {
+                    require_status(writer.write_chunk(
+                        chunk.key, ckpt_bytes,
+                        ChunkWriteOptions{
+                            .chunk_version = 1,
+                            .compression = chunk.compression,
+                            .tensor_payload = true,
+                            .block_crcs = true,
+                        }));
+                    continue;
+                }
+                auto proof =
+                    require_result(seed.make_clean_proof(chunk, 1));
+                require_status(writer.reuse_if_clean(proof, 1));
+            }
+            require_status(writer.commit());
+        }
+
+        ProjectReader probe = require_result(ProjectReader::open(path));
+        const ChunkInfo* row =
+            probe.find(FOURCC_CKPT, checkpoint_uuid);
+        ASSERT_NE(row, nullptr);
+        ASSERT_GT(row->uncompressed_bytes, 1u);
+        ASSERT_TRUE(row->block_crc_table.has_value());
+        EXPECT_TRUE(row->compression == Compression::ZstdFramed ||
+                    row->compression == Compression::ByteShuffleZstdFramed);
+
+        struct PayloadCapGuard {
+            explicit PayloadCapGuard(const std::uint64_t value) {
+                detail::set_max_payload_materialized_bytes_for_testing(value);
+            }
+            PayloadCapGuard(const PayloadCapGuard&) = delete;
+            PayloadCapGuard& operator=(const PayloadCapGuard&) = delete;
+            ~PayloadCapGuard() {
+                detail::set_max_payload_materialized_bytes_for_testing(
+                    std::nullopt);
+            }
+        };
+        const PayloadCapGuard cap(row->uncompressed_bytes - 1);
+        auto materialized = probe.read_chunk(*row);
+        ASSERT_FALSE(materialized);
+        EXPECT_EQ(materialized.error().code(),
+                  lfs::ErrorCode::ResourceExhausted);
+
+        auto opened = require_result_ptr(ProjectDocument::open(path));
+        const auto* checkpoint = opened->find_checkpoint(checkpoint_uuid);
+        ASSERT_NE(checkpoint, nullptr);
+        std::optional<lfs::core::CheckpointHeader> header;
+        std::optional<lfs::core::SplatData> splat;
+        auto visited = checkpoint->visit_stream(
+            [&](std::istream& stream, const std::uint64_t bytes)
+                -> lfs::Result<void> {
+                auto loaded_header =
+                    lfs::core::load_checkpoint_header(stream, bytes);
+                if (!loaded_header) {
+                    return {};
+                }
+                header = *loaded_header;
+                stream.clear();
+                stream.seekg(0);
+                if (!stream) {
+                    return {};
+                }
+                auto loaded_splat =
+                    lfs::core::load_checkpoint_splat_data(stream, bytes);
+                if (loaded_splat) {
+                    splat = std::move(*loaded_splat);
+                }
+                return {};
+            });
+        ASSERT_TRUE(visited)
+            << lfs::format_for_developer(visited.error());
+        ASSERT_TRUE(header.has_value());
+        EXPECT_EQ(header->iteration, 11);
+        EXPECT_EQ(header->num_gaussians, 2u);
+        ASSERT_TRUE(splat.has_value());
+        EXPECT_EQ(splat->size(), 2);
+        EXPECT_EQ(splat->get_max_sh_degree(), 0);
+        const auto expected = make_splat(2);
+        EXPECT_EQ(tensor_bytes(splat->means_raw()),
+                  tensor_bytes(expected->means_raw()));
     }
 
     TEST(ProjectDocumentTest,

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -411,6 +411,135 @@ namespace {
             << lfs::format_for_developer(saved.error());
     }
 
+    void write_one_splat_document(
+        const fs::path& path, const lfs::core::SplatData& model,
+        const Uuid& project_uuid, const Uuid& splat_uuid,
+        const std::uint64_t save_tag) {
+        auto document = make_empty_document(project_uuid, 100);
+        require_status(document->edit_scene_graph().upsert_node(
+            SceneNodeRecord{
+                .uuid = splat_uuid,
+                .type = "splat",
+                .name = "Splat",
+                .child_order = 0,
+                .payload =
+                    PayloadBinding{
+                        .fourcc = "SPLT",
+                        .instance_uuid = splat_uuid,
+                        .source_kind = "ply",
+                    },
+            }));
+        auto splat = require_result(SplatChapterPayload::capture(
+            model, SplatSourceKind::ImportedPly, false));
+        require_status(document->set_splat(splat_uuid, std::move(splat)));
+        require_status(document->edit_project().upsert_embed_decision(
+            EmbedDecision{
+                .uuid = splat_uuid,
+                .node_uuid = splat_uuid,
+                .payload_fourcc = "SPLT",
+                .decision = "embedded",
+                .reason = "stream-hydrate fixture",
+            }));
+        require_status(document->edit_project().upsert_embedded_payload_provenance(
+            provenance(splat_uuid, "SPLT", "assets/SPLT.bin", 41)));
+        (void)require_result(document->save(path, save_options(save_tag, 200)));
+    }
+
+    void rewrite_splat_chunk(const fs::path& path, const Uuid& splat_uuid,
+                             const Compression compression,
+                             const std::uint64_t commit_tag,
+                             const bool block_crcs = false) {
+        ProjectReader seed = require_result(ProjectReader::open(path));
+        const ChunkInfo* row = seed.find(FOURCC_SPLT, splat_uuid);
+        ASSERT_NE(row, nullptr);
+        auto bytes = require_result(seed.read_chunk(*row));
+        ProjectWriter writer = require_result(ProjectWriter::append(
+            path,
+            AppendOptions{
+                .index_compression =
+                    IndexCompression::StoredForDeterministicTests,
+                .disk_reserve_bytes = 0,
+            }));
+        require_status(writer.plan_commit(CommitOptions{
+            .kind = CommitKind::Explicit,
+            .commit_uuid = fixed_uuid(commit_tag),
+            .snapshot_uuid = seed.commit().snapshot_uuid,
+            .wallclock_unix_ns = 300,
+        }));
+        require_status(writer.preflight(bytes.size()));
+        for (const auto& chunk : seed.chunks()) {
+            if (!chunk.is_live()) {
+                continue;
+            }
+            if (chunk.key.fourcc == FOURCC_SPLT &&
+                chunk.key.instance_uuid == splat_uuid) {
+                require_status(writer.write_chunk(
+                    chunk.key, bytes,
+                    ChunkWriteOptions{
+                        .chunk_version = chunk.chunk_version,
+                        .compression = compression,
+                        .tensor_payload = true,
+                        .block_crcs = block_crcs ||
+                                      chunk.block_crc_table.has_value(),
+                    }));
+                continue;
+            }
+            auto proof = require_result(seed.make_clean_proof(chunk, 1));
+            require_status(writer.reuse_if_clean(proof, 1));
+        }
+        require_status(writer.commit());
+    }
+
+    void expect_splats_bit_equal(const lfs::core::SplatData& lhs,
+                                 const lfs::core::SplatData& rhs) {
+        EXPECT_EQ(lhs.get_active_sh_degree(), rhs.get_active_sh_degree());
+        EXPECT_EQ(lhs.get_max_sh_degree(), rhs.get_max_sh_degree());
+        EXPECT_EQ(lhs.get_scene_scale(), rhs.get_scene_scale());
+        EXPECT_EQ(lhs.size(), rhs.size());
+        EXPECT_EQ(tensor_bytes(lhs.means()), tensor_bytes(rhs.means()));
+        EXPECT_EQ(tensor_bytes(lhs.scaling_raw()),
+                  tensor_bytes(rhs.scaling_raw()));
+        EXPECT_EQ(tensor_bytes(lhs.rotation_raw()),
+                  tensor_bytes(rhs.rotation_raw()));
+        EXPECT_EQ(tensor_bytes(lhs.opacity_raw()),
+                  tensor_bytes(rhs.opacity_raw()));
+        EXPECT_EQ(tensor_bytes(lhs.sh0()), tensor_bytes(rhs.sh0()));
+        EXPECT_EQ(tensor_bytes(lhs.shN()), tensor_bytes(rhs.shN()));
+        EXPECT_EQ(lhs.has_deleted_mask(), rhs.has_deleted_mask());
+        if (lhs.has_deleted_mask() && rhs.has_deleted_mask()) {
+            EXPECT_EQ(tensor_bytes(lhs.deleted()), tensor_bytes(rhs.deleted()));
+        }
+        ASSERT_EQ(lhs.frozen_ranges().size(), rhs.frozen_ranges().size());
+        for (std::size_t i = 0; i < lhs.frozen_ranges().size(); ++i) {
+            EXPECT_EQ(lhs.frozen_ranges()[i].start, rhs.frozen_ranges()[i].start);
+            EXPECT_EQ(lhs.frozen_ranges()[i].count, rhs.frozen_ranges()[i].count);
+        }
+    }
+
+    Hash128 splat_provenance_hash(const ProjectDocument& document,
+                                  const Uuid& splat_uuid) {
+        const auto records =
+            require_result(document.project().embedded_payload_provenance());
+        for (const auto& record : records) {
+            if (record.node_uuid == splat_uuid && record.fourcc == "SPLT") {
+                return record.content_xxh3_128;
+            }
+        }
+        ADD_FAILURE() << "missing SPLT provenance for " << splat_uuid.to_string();
+        return {};
+    }
+
+    struct PayloadCapGuard {
+        explicit PayloadCapGuard(const std::uint64_t value) {
+            detail::set_max_payload_materialized_bytes_for_testing(value);
+        }
+        PayloadCapGuard(const PayloadCapGuard&) = delete;
+        PayloadCapGuard& operator=(const PayloadCapGuard&) = delete;
+        ~PayloadCapGuard() {
+            detail::set_max_payload_materialized_bytes_for_testing(std::nullopt);
+        }
+    };
+
     TEST(SplatChapterTest,
          ImportedBytesRoundTripAndTrainingOrLiveRadEmbeddingIsRefused) {
         auto model = make_splat(3);
@@ -3578,6 +3707,196 @@ namespace {
         const auto expected = make_splat(2);
         EXPECT_EQ(tensor_bytes(splat->means_raw()),
                   tensor_bytes(expected->means_raw()));
+    }
+
+    TEST(ProjectDocumentTest,
+         StreamHydrateDeferredSpltMatchesMaterializedAndContentHash) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "splat-stream.licht";
+        const Uuid project_uuid = fixed_uuid(12100);
+        const Uuid splat_uuid = fixed_uuid(12101);
+        auto model = make_splat(8);
+        model->set_frozen_ranges({{1, 2}, {5, 1}});
+        write_one_splat_document(path, *model, project_uuid, splat_uuid, 12110);
+
+        ProjectReader probe = require_result(ProjectReader::open(path));
+        const ChunkInfo* row = probe.find(FOURCC_SPLT, splat_uuid);
+        ASSERT_NE(row, nullptr);
+        EXPECT_EQ(row->compression, Compression::ZstdFramed);
+        auto raw_bytes = require_result(probe.read_chunk(*row));
+        const auto raw_hash = xxh3_128(raw_bytes);
+
+        auto materialized = require_result_ptr(ProjectDocument::open(path));
+        ASSERT_NE(materialized->find_splat(splat_uuid), nullptr);
+        Scene materialized_scene;
+        auto materialized_report = materialized->hydrate(materialized_scene);
+        ASSERT_TRUE(materialized_report)
+            << lfs::format_for_developer(materialized_report.error());
+        const auto* materialized_node =
+            materialized_scene.getNodeByUuid(splat_uuid);
+        ASSERT_NE(materialized_node, nullptr);
+        ASSERT_NE(materialized_node->model, nullptr);
+
+        auto deferred = require_result_ptr(ProjectDocument::open(
+            path, ProjectDocumentOpenOptions{.defer_geometry_payloads = true}));
+        EXPECT_EQ(deferred->find_splat(splat_uuid), nullptr);
+        ASSERT_EQ(deferred->payload_states().size(), 1u);
+        EXPECT_FALSE(deferred->payload_states().front().loaded);
+        EXPECT_EQ(splat_provenance_hash(*deferred, splat_uuid), raw_hash);
+        Scene deferred_scene;
+        auto deferred_report = deferred->hydrate(deferred_scene);
+        ASSERT_TRUE(deferred_report)
+            << lfs::format_for_developer(deferred_report.error());
+        const auto* deferred_node = deferred_scene.getNodeByUuid(splat_uuid);
+        ASSERT_NE(deferred_node, nullptr);
+        ASSERT_NE(deferred_node->model, nullptr);
+        expect_splats_bit_equal(*materialized_node->model, *deferred_node->model);
+
+        rewrite_splat_chunk(path, splat_uuid,
+                            Compression::ByteShuffleZstdFramed, 12120);
+        ProjectReader shuffled = require_result(ProjectReader::open(path));
+        const ChunkInfo* shuffled_row = shuffled.find(FOURCC_SPLT, splat_uuid);
+        ASSERT_NE(shuffled_row, nullptr);
+        ASSERT_EQ(raw_bytes.size() % 4, 0u);
+        EXPECT_EQ(shuffled_row->compression, Compression::ByteShuffleZstdFramed);
+        auto shuffled_bytes = require_result(shuffled.read_chunk(*shuffled_row));
+        EXPECT_EQ(shuffled_bytes, raw_bytes);
+
+        auto shuffled_deferred = require_result_ptr(ProjectDocument::open(
+            path, ProjectDocumentOpenOptions{.defer_geometry_payloads = true}));
+        Scene shuffled_scene;
+        auto shuffled_report = shuffled_deferred->hydrate(shuffled_scene);
+        ASSERT_TRUE(shuffled_report)
+            << lfs::format_for_developer(shuffled_report.error());
+        const auto* shuffled_node = shuffled_scene.getNodeByUuid(splat_uuid);
+        ASSERT_NE(shuffled_node, nullptr);
+        ASSERT_NE(shuffled_node->model, nullptr);
+        expect_splats_bit_equal(*materialized_node->model, *shuffled_node->model);
+        EXPECT_EQ(splat_provenance_hash(*shuffled_deferred, splat_uuid),
+                  xxh3_128(shuffled_bytes));
+    }
+
+    TEST(ProjectDocumentTest, StreamHydrateForwardsMonotonicPayloadProgress) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "splat-progress.licht";
+        const Uuid project_uuid = fixed_uuid(12180);
+        const Uuid splat_uuid = fixed_uuid(12181);
+        auto model = make_splat(16);
+        write_one_splat_document(path, *model, project_uuid, splat_uuid, 12190);
+
+        struct WindowGuard {
+            explicit WindowGuard(const std::size_t bytes) {
+                detail::set_splat_stream_window_bytes_for_testing(bytes);
+            }
+            WindowGuard(const WindowGuard&) = delete;
+            WindowGuard& operator=(const WindowGuard&) = delete;
+            ~WindowGuard() {
+                detail::set_splat_stream_window_bytes_for_testing(std::nullopt);
+            }
+        };
+        const WindowGuard window(64);
+        auto deferred = require_result_ptr(ProjectDocument::open(
+            path, ProjectDocumentOpenOptions{.defer_geometry_payloads = true}));
+        std::vector<std::pair<std::size_t, std::size_t>> reports;
+        Scene live;
+        auto staged = deferred->stage_hydration(
+            live, {}, {},
+            [&](const std::size_t consumed, const std::size_t total) {
+                reports.emplace_back(consumed, total);
+            });
+        ASSERT_TRUE(staged) << lfs::format_for_developer(staged.error());
+        ASSERT_GE(reports.size(), 2u);
+        EXPECT_EQ(reports.back().first, reports.back().second);
+        for (std::size_t i = 0; i < reports.size(); ++i) {
+            EXPECT_EQ(reports[i].second, reports.back().second);
+            if (i > 0) {
+                EXPECT_LE(reports[i - 1].first, reports[i].first);
+            }
+        }
+        EXPECT_GT(reports.back().first, 0u);
+    }
+
+    TEST(ProjectDocumentTest,
+         OversizedSpltAutoDefersOnOpenAndStreamHydrates) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "splat-auto-defer.licht";
+        const Uuid project_uuid = fixed_uuid(12130);
+        const Uuid splat_uuid = fixed_uuid(12131);
+        auto model = make_splat(6);
+        model->set_frozen_ranges({{0, 2}});
+        auto reference_payload = require_result(SplatChapterPayload::capture(
+            *model, SplatSourceKind::ImportedPly, false));
+        auto reference = require_result(reference_payload.hydrate());
+        write_one_splat_document(path, *model, project_uuid, splat_uuid, 12140);
+        rewrite_splat_chunk(path, splat_uuid, Compression::ByteShuffleZstdFramed,
+                            12141, true);
+
+        ProjectReader probe = require_result(ProjectReader::open(path));
+        const ChunkInfo* row = probe.find(FOURCC_SPLT, splat_uuid);
+        ASSERT_NE(row, nullptr);
+        ASSERT_GT(row->uncompressed_bytes, 1u);
+        const auto raw_bytes = require_result(probe.read_chunk(*row));
+
+        const PayloadCapGuard cap(row->uncompressed_bytes - 1);
+        auto exhausted = probe.read_chunk(*row);
+        ASSERT_FALSE(exhausted);
+        EXPECT_EQ(exhausted.error().code(), lfs::ErrorCode::ResourceExhausted);
+
+        auto opened = require_result_ptr(ProjectDocument::open(path));
+        EXPECT_EQ(opened->find_splat(splat_uuid), nullptr);
+        ASSERT_EQ(opened->payload_states().size(), 1u);
+        EXPECT_EQ(opened->payload_states().front().fourcc, FOURCC_SPLT);
+        EXPECT_EQ(opened->payload_states().front().instance_uuid, splat_uuid);
+        EXPECT_FALSE(opened->payload_states().front().loaded);
+        EXPECT_EQ(splat_provenance_hash(*opened, splat_uuid), xxh3_128(raw_bytes));
+
+        Scene live;
+        auto report = opened->hydrate(live);
+        ASSERT_TRUE(report) << lfs::format_for_developer(report.error());
+        const auto* node = live.getNodeByUuid(splat_uuid);
+        ASSERT_NE(node, nullptr);
+        ASSERT_NE(node->model, nullptr);
+        expect_splats_bit_equal(*reference, *node->model);
+    }
+
+    TEST(ProjectDocumentTest,
+         ByteShuffleZstdFallsBackWhenSpltSizeIsNotMultipleOfFour) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "splat-zstd-fallback.licht";
+        const Uuid project_uuid = fixed_uuid(12150);
+        const Uuid splat_uuid = fixed_uuid(12151);
+        auto model = make_splat(3);
+        model->deleted() = Tensor::zeros({std::size_t{3}}, Device::CPU,
+                                         DataType::Bool);
+        auto reference_payload = require_result(SplatChapterPayload::capture(
+            *model, SplatSourceKind::ImportedPly, false));
+        auto reference = require_result(reference_payload.hydrate());
+        write_one_splat_document(path, *model, project_uuid, splat_uuid, 12160);
+
+        ProjectReader before = require_result(ProjectReader::open(path));
+        const ChunkInfo* source = before.find(FOURCC_SPLT, splat_uuid);
+        ASSERT_NE(source, nullptr);
+        auto raw_bytes = require_result(before.read_chunk(*source));
+        ASSERT_NE(raw_bytes.size() % 4, 0u);
+
+        rewrite_splat_chunk(path, splat_uuid,
+                            Compression::ByteShuffleZstdFramed, 12170);
+        ProjectReader after = require_result(ProjectReader::open(path));
+        const ChunkInfo* row = after.find(FOURCC_SPLT, splat_uuid);
+        ASSERT_NE(row, nullptr);
+        EXPECT_EQ(row->compression, Compression::ZstdFramed);
+
+        auto deferred = require_result_ptr(ProjectDocument::open(
+            path, ProjectDocumentOpenOptions{.defer_geometry_payloads = true}));
+        Scene live;
+        auto report = deferred->hydrate(live);
+        ASSERT_TRUE(report) << lfs::format_for_developer(report.error());
+        const auto* node = live.getNodeByUuid(splat_uuid);
+        ASSERT_NE(node, nullptr);
+        ASSERT_NE(node->model, nullptr);
+        expect_splats_bit_equal(*reference, *node->model);
+        EXPECT_EQ(splat_provenance_hash(*deferred, splat_uuid),
+                  xxh3_128(raw_bytes));
     }
 
     TEST(ProjectDocumentTest,

--- a/tests/test_splat_raw_payload.cpp
+++ b/tests/test_splat_raw_payload.cpp
@@ -6,14 +6,21 @@
 #include <cstring>
 #include <filesystem>
 #include <optional>
+#include <span>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include "io/formats/ply.hpp"
+#include "io/project_chapters.hpp"
 #include "io/splat_chapter.hpp"
 #include "lfs/training/sh_value_codec.hpp"
 #include "lfs/training/sh_value_storage.hpp"
+#include "licht_test_support.hpp"
 
 namespace {
 
@@ -58,6 +65,9 @@ namespace {
         static void SetUpTestSuite() {
             const auto path = std::filesystem::path(PROJECT_ROOT_PATH) /
                               "tests/data/bike.ply";
+            if (!std::filesystem::exists(path)) {
+                return;
+            }
             auto loaded = lfs::io::load_ply(path);
             ASSERT_TRUE(loaded.has_value()) << lfs::format_for_developer(loaded.error());
             auto captured = SplatChapterPayload::capture(
@@ -67,11 +77,33 @@ namespace {
             payload.assign(captured->bytes().begin(), captured->bytes().end());
         }
 
+        void SetUp() override {
+            if (payload.empty()) {
+                GTEST_SKIP() << "tests/data/bike.ply is not available";
+            }
+        }
+
         static void expect_invalid(std::vector<std::byte> bytes) {
-            auto parsed = SplatChapterPayload::from_lfsp(std::move(bytes));
+            auto parsed = SplatChapterPayload::from_lfsp(bytes);
             ASSERT_TRUE(parsed.has_value()) << lfs::format_for_developer(parsed.error());
             auto hydrated = parsed->hydrate();
             EXPECT_FALSE(hydrated.has_value());
+
+            std::string storage(reinterpret_cast<const char*>(bytes.data()),
+                                bytes.size());
+            std::istringstream stream(storage, std::ios::binary);
+            auto streamed = SplatChapterPayload::hydrate_lfsp_stream(
+                stream, bytes.size());
+            EXPECT_FALSE(streamed.has_value());
+            if (hydrated.has_value() == false && streamed.has_value() == false) {
+                EXPECT_EQ(hydrated.error().code(), streamed.error().code());
+            }
+        }
+
+        static std::istringstream stream_of(const std::span<const std::byte> bytes) {
+            std::string storage(reinterpret_cast<const char*>(bytes.data()),
+                                bytes.size());
+            return std::istringstream(std::move(storage), std::ios::binary);
         }
     };
 
@@ -181,6 +213,251 @@ namespace {
         EXPECT_TRUE(std::ranges::any_of(deleted, [](const bool value) {
             return value;
         }));
+    }
+
+    TEST_F(SplatRawPayloadTest, StreamHydrateMatchesRawBytesAndContentHash) {
+        auto stream = stream_of(payload);
+        auto streamed = SplatChapterPayload::hydrate_lfsp_stream(
+            stream, payload.size());
+        ASSERT_TRUE(streamed.has_value())
+            << lfs::format_for_developer(streamed.error());
+        EXPECT_EQ(streamed->content_xxh3_128,
+                  lfs::io::project::xxh3_128(payload));
+
+        auto parsed = SplatChapterPayload::from_lfsp(payload);
+        ASSERT_TRUE(parsed.has_value()) << lfs::format_for_developer(parsed.error());
+        auto hydrated = parsed->hydrate();
+        ASSERT_TRUE(hydrated.has_value())
+            << lfs::format_for_developer(hydrated.error());
+
+        const auto equal = [](const lfs::core::Tensor& lhs,
+                              const lfs::core::Tensor& rhs) {
+            const auto left = lhs.contiguous().cpu();
+            const auto right = rhs.contiguous().cpu();
+            return left.shape() == right.shape() && left.dtype() == right.dtype() &&
+                   left.bytes() == right.bytes() &&
+                   std::memcmp(left.data_ptr(), right.data_ptr(), left.bytes()) == 0;
+        };
+        EXPECT_EQ((*hydrated)->get_active_sh_degree(),
+                  streamed->splat->get_active_sh_degree());
+        EXPECT_EQ((*hydrated)->get_max_sh_degree(),
+                  streamed->splat->get_max_sh_degree());
+        EXPECT_EQ((*hydrated)->get_scene_scale(),
+                  streamed->splat->get_scene_scale());
+        EXPECT_EQ((*hydrated)->frozen_ranges().size(),
+                  streamed->splat->frozen_ranges().size());
+        EXPECT_TRUE(equal((*hydrated)->means(), streamed->splat->means()));
+        EXPECT_TRUE(equal((*hydrated)->scaling_raw(),
+                          streamed->splat->scaling_raw()));
+        EXPECT_TRUE(equal((*hydrated)->rotation_raw(),
+                          streamed->splat->rotation_raw()));
+        EXPECT_TRUE(equal((*hydrated)->opacity_raw(),
+                          streamed->splat->opacity_raw()));
+        EXPECT_TRUE(equal((*hydrated)->sh0(), streamed->splat->sh0()));
+        EXPECT_TRUE(equal((*hydrated)->shN(), streamed->splat->shN()));
+    }
+
+    TEST_F(SplatRawPayloadTest, StreamHydrateProgressIsMonotonicAcrossWindows) {
+        struct WindowGuard {
+            explicit WindowGuard(const std::size_t bytes) {
+                lfs::io::project::detail::set_splat_stream_window_bytes_for_testing(
+                    bytes);
+            }
+            WindowGuard(const WindowGuard&) = delete;
+            WindowGuard& operator=(const WindowGuard&) = delete;
+            ~WindowGuard() {
+                lfs::io::project::detail::set_splat_stream_window_bytes_for_testing(
+                    std::nullopt);
+            }
+        };
+        const WindowGuard window(128);
+        std::vector<std::pair<std::size_t, std::size_t>> reports;
+        auto stream = stream_of(payload);
+        auto streamed = SplatChapterPayload::hydrate_lfsp_stream(
+            stream, payload.size(), {},
+            [&](const std::size_t consumed, const std::size_t total) {
+                reports.emplace_back(consumed, total);
+            });
+        ASSERT_TRUE(streamed.has_value())
+            << lfs::format_for_developer(streamed.error());
+        ASSERT_GE(reports.size(), 2u);
+        EXPECT_EQ(reports.back().first, reports.back().second);
+        EXPECT_EQ(reports.back().first, payload.size());
+        for (std::size_t i = 0; i < reports.size(); ++i) {
+            EXPECT_EQ(reports[i].second, payload.size());
+            if (i > 0) {
+                EXPECT_LE(reports[i - 1].first, reports[i].first);
+            }
+        }
+    }
+
+    TEST_F(SplatRawPayloadTest, StreamHydrateRejectsSameCorruptionsAsHydrateRaw) {
+        auto bad_magic = payload;
+        bad_magic[0] = std::byte{
+            static_cast<unsigned char>(~std::to_integer<unsigned char>(bad_magic[0]))};
+        {
+            std::string storage(reinterpret_cast<const char*>(bad_magic.data()),
+                                bad_magic.size());
+            std::istringstream stream(storage, std::ios::binary);
+            auto streamed = SplatChapterPayload::hydrate_lfsp_stream(
+                stream, bad_magic.size());
+            EXPECT_FALSE(streamed.has_value());
+            if (!streamed) {
+                EXPECT_EQ(streamed.error().code(), lfs::ErrorCode::DataLoss);
+            }
+        }
+
+        auto overlap = payload;
+        const auto first_offset = get_u64(overlap, 40 + 40);
+        put_u64(overlap, 40 + 64 + 40, first_offset);
+        expect_invalid(std::move(overlap));
+
+        auto truncated = payload;
+        ASSERT_GT(truncated.size(), 8u);
+        truncated.resize(truncated.size() - 8);
+        expect_invalid(std::move(truncated));
+    }
+
+    std::vector<std::byte> captured_raw_payload() {
+        auto model = lfs::test::licht::make_splat(24);
+        model->set_frozen_ranges({{2, 4}, {10, 3}});
+        auto captured = SplatChapterPayload::capture(
+            *model, lfs::io::project::SplatSourceKind::ImportedPly, false);
+        if (!captured) {
+            throw std::runtime_error(lfs::format_for_developer(captured.error()));
+        }
+        return {captured->bytes().begin(), captured->bytes().end()};
+    }
+
+    std::istringstream bytes_to_stream(const std::vector<std::byte>& bytes) {
+        std::string storage(reinterpret_cast<const char*>(bytes.data()),
+                            bytes.size());
+        return std::istringstream(std::move(storage), std::ios::binary);
+    }
+
+    TEST(SplatStreamHydrateTest, MatchesMaterializedTensorsAndXxh3) {
+        const auto bytes = captured_raw_payload();
+        auto parsed = SplatChapterPayload::from_lfsp(bytes);
+        ASSERT_TRUE(parsed.has_value()) << lfs::format_for_developer(parsed.error());
+        auto hydrated = parsed->hydrate();
+        ASSERT_TRUE(hydrated.has_value())
+            << lfs::format_for_developer(hydrated.error());
+
+        auto stream = bytes_to_stream(bytes);
+        auto streamed = SplatChapterPayload::hydrate_lfsp_stream(
+            stream, bytes.size());
+        ASSERT_TRUE(streamed.has_value())
+            << lfs::format_for_developer(streamed.error());
+        EXPECT_EQ(streamed->content_xxh3_128,
+                  lfs::io::project::xxh3_128(bytes));
+
+        const auto equal = [](const lfs::core::Tensor& lhs,
+                              const lfs::core::Tensor& rhs) {
+            const auto left = lhs.contiguous().cpu();
+            const auto right = rhs.contiguous().cpu();
+            return left.shape() == right.shape() && left.dtype() == right.dtype() &&
+                   left.bytes() == right.bytes() &&
+                   std::memcmp(left.data_ptr(), right.data_ptr(), left.bytes()) == 0;
+        };
+        EXPECT_EQ((*hydrated)->get_active_sh_degree(),
+                  streamed->splat->get_active_sh_degree());
+        EXPECT_EQ((*hydrated)->get_max_sh_degree(),
+                  streamed->splat->get_max_sh_degree());
+        EXPECT_EQ((*hydrated)->get_scene_scale(),
+                  streamed->splat->get_scene_scale());
+        ASSERT_EQ((*hydrated)->frozen_ranges().size(),
+                  streamed->splat->frozen_ranges().size());
+        for (std::size_t i = 0; i < (*hydrated)->frozen_ranges().size(); ++i) {
+            EXPECT_EQ((*hydrated)->frozen_ranges()[i].start,
+                      streamed->splat->frozen_ranges()[i].start);
+            EXPECT_EQ((*hydrated)->frozen_ranges()[i].count,
+                      streamed->splat->frozen_ranges()[i].count);
+        }
+        EXPECT_TRUE(equal((*hydrated)->means(), streamed->splat->means()));
+        EXPECT_TRUE(equal((*hydrated)->scaling_raw(),
+                          streamed->splat->scaling_raw()));
+        EXPECT_TRUE(equal((*hydrated)->rotation_raw(),
+                          streamed->splat->rotation_raw()));
+        EXPECT_TRUE(equal((*hydrated)->opacity_raw(),
+                          streamed->splat->opacity_raw()));
+        EXPECT_TRUE(equal((*hydrated)->sh0(), streamed->splat->sh0()));
+        EXPECT_TRUE(equal((*hydrated)->shN(), streamed->splat->shN()));
+    }
+
+    TEST(SplatStreamHydrateTest, ProgressIsMonotonicAcrossWindows) {
+        struct WindowGuard {
+            explicit WindowGuard(const std::size_t bytes) {
+                lfs::io::project::detail::set_splat_stream_window_bytes_for_testing(
+                    bytes);
+            }
+            WindowGuard(const WindowGuard&) = delete;
+            WindowGuard& operator=(const WindowGuard&) = delete;
+            ~WindowGuard() {
+                lfs::io::project::detail::set_splat_stream_window_bytes_for_testing(
+                    std::nullopt);
+            }
+        };
+        const auto bytes = captured_raw_payload();
+        const WindowGuard window(64);
+        std::vector<std::pair<std::size_t, std::size_t>> reports;
+        auto stream = bytes_to_stream(bytes);
+        auto streamed = SplatChapterPayload::hydrate_lfsp_stream(
+            stream, bytes.size(), {},
+            [&](const std::size_t consumed, const std::size_t total) {
+                reports.emplace_back(consumed, total);
+            });
+        ASSERT_TRUE(streamed.has_value())
+            << lfs::format_for_developer(streamed.error());
+        ASSERT_GE(reports.size(), 2u);
+        EXPECT_EQ(reports.back().first, reports.back().second);
+        EXPECT_EQ(reports.back().first, bytes.size());
+        for (std::size_t i = 0; i < reports.size(); ++i) {
+            EXPECT_EQ(reports[i].second, bytes.size());
+            if (i > 0) {
+                EXPECT_LE(reports[i - 1].first, reports[i].first);
+            }
+        }
+    }
+
+    TEST(SplatStreamHydrateTest, RejectsSameCorruptionsAsHydrateRaw) {
+        const auto bytes = captured_raw_payload();
+        const auto expect_both_reject = [](std::vector<std::byte> corrupted) {
+            auto parsed = SplatChapterPayload::from_lfsp(corrupted);
+            ASSERT_TRUE(parsed.has_value())
+                << lfs::format_for_developer(parsed.error());
+            auto hydrated = parsed->hydrate();
+            EXPECT_FALSE(hydrated.has_value());
+            auto stream = bytes_to_stream(corrupted);
+            auto streamed = SplatChapterPayload::hydrate_lfsp_stream(
+                stream, corrupted.size());
+            EXPECT_FALSE(streamed.has_value());
+            if (!hydrated && !streamed) {
+                EXPECT_EQ(hydrated.error().code(), streamed.error().code());
+            }
+        };
+
+        auto bad_magic = bytes;
+        bad_magic[0] = std::byte{static_cast<unsigned char>(
+            ~std::to_integer<unsigned char>(bad_magic[0]))};
+        {
+            auto stream = bytes_to_stream(bad_magic);
+            auto streamed = SplatChapterPayload::hydrate_lfsp_stream(
+                stream, bad_magic.size());
+            EXPECT_FALSE(streamed.has_value());
+            if (!streamed) {
+                EXPECT_EQ(streamed.error().code(), lfs::ErrorCode::DataLoss);
+            }
+        }
+
+        auto overlap = bytes;
+        const auto first_offset = get_u64(overlap, 40 + 40);
+        put_u64(overlap, 40 + 64 + 40, first_offset);
+        expect_both_reject(std::move(overlap));
+
+        auto truncated = bytes;
+        ASSERT_GT(truncated.size(), 8u);
+        truncated.resize(truncated.size() - 8);
+        expect_both_reject(std::move(truncated));
     }
 
 } // namespace


### PR DESCRIPTION
## Problem

A `.licht` project from a headless 50M-splat training run (~15.2GB on disk, CKPT decoding to ~19.9GB) cannot be opened or resumed through the GUI or `--headless --resume` (reported on Discord):

```
stored bytes 15200910807, decoded bytes 19920525852, materialized-read maximum 17179869184;
use the bounded stream or mapped-range API
```

Every checkpoint consumer funnels through `LazyChunkValue::visit_stream`, which materialized compressed chunks via `read_chunk` (capped at 16GiB decoded) — and the APIs the error message recommends rejected compressed chunks outright, so a compressed payload past the cap was unreadable by any path. Both front-ends fail at the same place (CKPT header inspection inside `ProjectDocument::open`), which is why GUI and CLI report identical numbers.

## What changed

Five commits, reviewed in sequence:

1. **Stream compressed project payloads instead of materializing them** — `open_bounded_stream` now serves `ZstdFramed` and `ByteShuffleZstdFramed` chunks as a seekable *logical* (decoded, unshuffled) stream built on the framed 64MiB record table: on-demand record decode, lazy per-block CRC validation before any stored range is consumed, 4-plane record caches for the byte-plane unshuffle. `visit_stream` routes compressed clean-file sources through it, so open/hydrate/resume never materialize checkpoints at all. `read_chunk`, its cap, and its error text are unchanged; a test-only cap override reproduces the reported failure at miniature scale.
2. **Parallel bulk reads** — an `xsgetn` override decodes covering records in parallel batches; fully-covered zstd records decompress directly into the caller's buffer, byte-plane payloads gather word-wise. At most 8 decoded records resident beyond the destination. A disabled-by-default benchmark documents throughput: the stream now exceeds `read_chunk` (≈2.0 vs 0.9 GB/s byteshuffle, ≈13.3 vs 2.3 GB/s zstd on the test rig).
3. **Save-path hardening** — the `write_lazy` fallback for a file-backed CKPT/PPIS without a clean proof no longer materializes + re-encodes; it streams stored bytes via `copy_chunk_verbatim`. No public flow currently loses a proof (verified), so this hardens the safety net; `save_as` already streamed via compaction.
4. **SPLT streaming hydrate** — deferred SPLT chapters hydrate straight from the bounded stream: manifest validation shared with the in-memory path, tensor sections streamed in bounded windows directly into owning CPU tensors, content hash computed incrementally (bit-identical to `xxh3_128` of the payload). Opening a project auto-defers any SPLT row whose materialization would exceed the cap even when geometry deferral is off; under-cap files behave exactly as before.
5. **No-block-CRC-table streaming** — opening a stream on a framed chunk without a block CRC table now runs a single bounded CRC pass over the stored bytes (same error identity as `verify_chunk`) instead of a full materializing decode. Chunks with a table are unchanged.

Worst-case resident memory for streaming a well-formed multi-GB chunk is a few hundred MB, independent of payload size.

## Tests

- Equivalence of stream vs `read_chunk` for multi-record payloads (both compressions), including deep seeks (the `params_json_offset` pattern), rewinds, end-relative seeks, odd-offset bulk reads crossing record boundaries, and short reads at EOF.
- Regression tests encoding the reported failure at small scale: chunk beyond a test-lowered cap — `read_chunk` fails `ResourceExhausted`, the stream succeeds byte-identically; document-level CKPT open/hydrate under the lowered cap; oversized-SPLT auto-defer; lost-proof save; no-table framed streaming.
- Corruption tests: flipped stored bytes and record-table fields fail via CRC before any corrupt logical bytes are served, in both the with-table (lazy) and no-table (open-time) modes.
- Malformed-LFSP parity: the stream hydrate rejects everything the in-memory parser rejects.

## Verification beyond unit tests

End-to-end on a real training project (garden dataset, embedded CKPT): GUI open hydrates and renders, `--headless --resume` restores trainer state and continues training, and a full save/reopen round-trips — all through the new streaming paths, which are exercised unconditionally for compressed payloads regardless of size.

Known non-goals: PCLD/MESH chapters keep the materialized path (bounded by realistic sizes); `map_stored_range` on a no-table chunk still uses `verify_chunk` (stored-only, never decodes).
