### PR TITLE
Exclude soft-deleted Gaussians from node-level clipboard copies

### DIFF
--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -4531,7 +4531,18 @@ namespace lfs::vis {
                 cloned->texture_images = sm.texture_images;
                 entry.mesh = std::move(cloned);
             } else if (node->model && node->model->size() > 0) {
-                entry.data = cloneSplatDataToCpu(*node->model);
+                const auto& model = *node->model;
+                lfs::core::Tensor keep;
+                if (model.has_deleted_mask() &&
+                    model.deleted().numel() == static_cast<size_t>(model.size()) &&
+                    model.deleted().count_nonzero() > 0) {
+                    keep = model.deleted().logical_not();
+                    if (keep.count_nonzero() == 0)
+                        continue;
+                }
+                entry.data = keep.is_valid()
+                                 ? cloneSplatDataToCpu(lfs::core::extract_by_mask(model, keep))
+                                 : cloneSplatDataToCpu(model);
             } else {
                 continue;
             }

--- a/tests/test_undo_history.cpp
+++ b/tests/test_undo_history.cpp
@@ -1595,6 +1595,67 @@ TEST_F(UndoHistoryTest, GaussianSelectionIgnoresSoftDeletedRowsForAllSelectionSo
     EXPECT_EQ(mean_x_values(*pasted_node->model), (std::vector<float>{0.0f, 2.0f}));
 }
 
+TEST_F(UndoHistoryTest, NodeCopyPasteExcludesSoftDeletedRows) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    scene_manager->getScene().addSplat("model", make_linear_test_splat(4));
+    auto* node = scene_manager->getScene().getNode("model");
+    ASSERT_NE(node, nullptr);
+    ASSERT_NE(node->model, nullptr);
+    node->model->soft_delete(make_uint8_mask({0, 1, 0, 1}).to(DataType::Bool));
+
+    scene_manager->selectNode("model");
+    EXPECT_TRUE(scene_manager->copySelectedNodes());
+
+    const auto pasted = scene_manager->pasteNodes();
+    ASSERT_EQ(pasted.size(), 1u);
+    const auto* pasted_node = scene_manager->getScene().getNode(pasted.front());
+    ASSERT_NE(pasted_node, nullptr);
+    ASSERT_NE(pasted_node->model, nullptr);
+    EXPECT_EQ(pasted_node->model->size(), 2);
+    EXPECT_FALSE(pasted_node->model->has_deleted_mask());
+    EXPECT_EQ(mean_x_values(*pasted_node->model), (std::vector<float>{0.0f, 2.0f}));
+}
+
+TEST_F(UndoHistoryTest, NodeCopyPasteWithoutDeletionsKeepsAllRows) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    scene_manager->getScene().addSplat("model", make_linear_test_splat(3));
+    scene_manager->selectNode("model");
+    EXPECT_TRUE(scene_manager->copySelectedNodes());
+
+    const auto pasted = scene_manager->pasteNodes();
+    ASSERT_EQ(pasted.size(), 1u);
+    const auto* pasted_node = scene_manager->getScene().getNode(pasted.front());
+    ASSERT_NE(pasted_node, nullptr);
+    ASSERT_NE(pasted_node->model, nullptr);
+    EXPECT_EQ(pasted_node->model->size(), 3);
+    EXPECT_FALSE(pasted_node->model->has_deleted_mask());
+}
+
+TEST_F(UndoHistoryTest, NodeCopyWithAllRowsDeletedProducesNoClipboard) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    scene_manager->getScene().addSplat("model", make_linear_test_splat(2));
+    auto* node = scene_manager->getScene().getNode("model");
+    ASSERT_NE(node, nullptr);
+    ASSERT_NE(node->model, nullptr);
+    node->model->soft_delete(make_uint8_mask({1, 1}).to(DataType::Bool));
+
+    scene_manager->selectNode("model");
+    EXPECT_FALSE(scene_manager->copySelectedNodes());
+    EXPECT_FALSE(scene_manager->hasClipboard());
+}
+
 TEST_F(UndoHistoryTest, SelectingOnlySoftDeletedRowsClearsSelectionAndClipboard) {
     auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
     auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();


### PR DESCRIPTION
Fixes #1661.

Applying a crop soft-deletes Gaussians (the model keeps all physical rows plus a deleted mask). Node-level clipboard copy (`SceneManager::copySelectedNodes`) cloned the whole model without consulting that mask, and `pasteNodes()` rebuilds the splat data without a mask — so Ctrl-C/Ctrl-V on a cropped 500K→100K node pasted all 500K Gaussians, resurrecting the deleted ones. Duplicate was unaffected, matching the report.

## Fix

In `copySelectedNodes`, when the model carries a deleted mask with deletions, the clipboard entry is built from `extract_by_mask(model, deleted().logical_not())`, mirroring the existing gaussian-level copy path. A fully-deleted node is skipped before extraction (calling `size()` on the empty `SplatData` an all-false mask produces would throw).

## Tests

- `NodeCopyPasteExcludesSoftDeletedRows` — pasted node contains only live rows, no mask
- `NodeCopyPasteWithoutDeletionsKeepsAllRows` — unchanged behavior without deletions
- `NodeCopyWithAllRowsDeletedProducesNoClipboard` — all-deleted node yields no clipboard
- Full `UndoHistoryTest` suite passes (90/90)

Verified end-to-end in the app with a 137,502-splat PLY: crop to 839 visible, Ctrl-C/Ctrl-V previously pasted 137,502; now pastes 839. Duplicate of the cropped node and copy/paste of uncropped nodes behave as before.