### PR TITLE
Clear the viewport when every splat node is hidden

### DIFF
--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -1789,20 +1789,17 @@ namespace lfs::vis {
                 (void)frame_lifecycle_service_.handleModelChange(model_ptr, viewport_artifact_service_);
             }
         }
-        if (!has_render_content && !has_cached_viewport_output) {
+        // Scene state is authoritative here (contended frames returned above): nothing
+        // visible must clear the viewport even when a cached frame exists — a consolidated
+        // multi-splat scene keeps the same combined-model pointer when every node is
+        // hidden, so model-change tracking never clears the stale image.
+        if (!has_render_content) {
             clearVulkanViewportImageState();
             last_logged_vksplat_render_error_.clear();
             viewport_artifact_service_.clearViewportOutput();
             clearVulkanMeshFrame();
             render_lock.reset();
             return {};
-        }
-        if (!has_render_content && has_cached_viewport_output) {
-            if (frame_dirty != 0) {
-                dirty_mask_.fetch_or(frame_dirty, std::memory_order_relaxed);
-            }
-            render_lock.reset();
-            return cached_frame_result();
         }
 
         const DirtyMask split_deferred_dirty = frame_dirty & ~DirtyFlag::SPLIT_POSITION;


### PR DESCRIPTION
## Problem

With multiple PLYs loaded together (compare workflow), toggling node visibility misbehaved: hiding all nodes left the last rendered splat frozen in the viewport, so the scene looked stuck on "one or the other" and never went empty.

## Root cause

PR #1588 split the empty-content branch in `renderVulkanFrame` and made `!has_render_content && has_cached_viewport_output` return the cached previous frame. That branch only triggers when the model pointer stays the same while visible content drops to zero — exactly the consolidated multi-splat case: `Scene::getCombinedModel()` keeps returning the same consolidated model and only `visible_splat_count` drops, so model-change tracking never clears the cached image. Non-consolidated scenes null the model pointer on hide-all, which clears the cache — that's why the bug only shows with batch-loaded PLYs.

## Fix

Restore the pre-#1588 unconditional viewport clear for the non-contended empty-content case. The training step-boundary branches that legitimately retain the cached frame during densify contention are untouched.

## Verification

- E2E via MCP against the real GUI command path (`cmd::SetNodeVisibilityById`, same as the scene-panel eye icon) on a consolidated two-PLY scene, with pixel-diff comparison of `render_capture` output per visibility state:
  - Pre-fix: "only A visible" and "both hidden" were pixel-identical (stale frame).
  - Post-fix: both visible renders both models; each single-visible state renders that model; all hidden renders an empty viewport; the lit states are byte-identical to their pre-fix renders (no rendering regression); recovery from all-hidden re-renders correctly.
- Suites: ViewportFrameLifecycleServiceTest, SplitViewServiceTest, SceneValidityTest, VisualizerImplResetTest — 144/144 green.
