### PR TITLE
Ask to locate a missing dataset when opening a project

### DIFF
--- a/src/core/camera.cpp
+++ b/src/core/camera.cpp
@@ -454,6 +454,43 @@ namespace lfs::core {
         return num_bytes;
     }
 
+    static bool path_is_under_root(const std::filesystem::path& stored,
+                                   const std::filesystem::path& old_root,
+                                   std::filesystem::path& relative_out) {
+        const auto relative =
+            stored.lexically_normal().lexically_relative(old_root.lexically_normal());
+        if (relative.empty()) {
+            return false;
+        }
+        const auto first = relative.begin();
+        if (first != relative.end() && *first == "..") {
+            return false;
+        }
+        relative_out = relative;
+        return true;
+    }
+
+    static void rebase_path_if_under(std::filesystem::path& stored,
+                                     const std::filesystem::path& old_root,
+                                     const std::filesystem::path& new_root) {
+        if (stored.empty()) {
+            return;
+        }
+        std::filesystem::path relative;
+        if (!path_is_under_root(stored, old_root, relative)) {
+            return;
+        }
+        stored = new_root / relative;
+    }
+
+    void Camera::rebase_asset_paths(const std::filesystem::path& old_root,
+                                    const std::filesystem::path& new_root) {
+        rebase_path_if_under(_image_path, old_root, new_root);
+        rebase_path_if_under(_mask_path, old_root, new_root);
+        rebase_path_if_under(_depth_path, old_root, new_root);
+        rebase_path_if_under(_normal_path, old_root, new_root);
+    }
+
     void Camera::set_mask_tensor(Tensor mask) {
         _in_memory_mask_raw = std::move(mask);
         // Force reprocessing on the next load_and_get_mask call.

--- a/src/core/include/core/camera.hpp
+++ b/src/core/include/core/camera.hpp
@@ -156,6 +156,14 @@ namespace lfs::core {
         const std::filesystem::path& mask_path() const noexcept { return _mask_path; }
         const std::filesystem::path& depth_path() const noexcept { return _depth_path; }
         const std::filesystem::path& normal_path() const noexcept { return _normal_path; }
+
+        // Rewrites image/mask/depth/normal paths that live under old_root to the same
+        // relative location under new_root. Paths outside old_root are left unchanged.
+        // Sidecar caches and in-memory masks (set_mask_tensor) are not cleared: a
+        // dataset relocation keeps the same files, and injected masks do not originate
+        // from _mask_path.
+        void rebase_asset_paths(const std::filesystem::path& old_root,
+                                const std::filesystem::path& new_root);
         bool has_in_memory_mask() const noexcept { return _in_memory_mask_raw.is_valid(); }
         bool has_mask() const noexcept {
             return has_in_memory_mask() ||

--- a/src/core/include/core/scene.hpp
+++ b/src/core/include/core/scene.hpp
@@ -504,6 +504,11 @@ namespace lfs::core {
         [[nodiscard]] std::shared_ptr<const lfs::core::Camera> getCameraByUid(int uid) const;
         [[nodiscard]] std::vector<std::shared_ptr<lfs::core::Camera>> getAllCameras() const;
         [[nodiscard]] std::vector<std::shared_ptr<lfs::core::Camera>> getActiveCameras() const;
+        // Rebases every camera node's asset paths from old_root to new_root and
+        // refreshes the SceneNode mirror strings. Returns the number of cameras
+        // touched.
+        size_t rebaseCameraAssetPaths(const std::filesystem::path& old_root,
+                                      const std::filesystem::path& new_root);
         [[nodiscard]] size_t getActiveCameraCount() const;
         [[nodiscard]] CameraTrainingCounts getCameraTrainingCounts(NodeId camera_group_id) const;
         void setCameraTrainingEnabled(const std::string& name, bool enabled);

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -4691,6 +4691,22 @@ namespace lfs::core {
         return result;
     }
 
+    size_t Scene::rebaseCameraAssetPaths(const std::filesystem::path& old_root,
+                                         const std::filesystem::path& new_root) {
+        size_t touched = 0;
+        for (const auto& node : nodes_) {
+            if (node->type != NodeType::CAMERA || !node->camera) {
+                continue;
+            }
+            node->camera->rebase_asset_paths(old_root, new_root);
+            node->image_path = lfs::core::path_to_utf8(node->camera->image_path());
+            node->mask_path = lfs::core::path_to_utf8(node->camera->mask_path());
+            node->depth_path = lfs::core::path_to_utf8(node->camera->depth_path());
+            ++touched;
+        }
+        return touched;
+    }
+
     size_t Scene::getActiveCameraCount() const {
         size_t count = 0;
         for (const auto& node : nodes_) {

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1652,6 +1652,20 @@
     "tooltip_max_resolution": "Maximale Auflösung für das Abtastraster. Höhere Werte ermöglichen feinere Abtastung bei Qualität 1.0.",
     "effective_resolution": "Effektive Auflösung"
   },
+  "dataset_relocate": {
+    "title": "Datensatz nicht gefunden",
+    "message": "Der Trainingsdatensatz des Projekts wurde nicht gefunden.",
+    "expected_label": "Erwarteter Speicherort:",
+    "locate": "Datensatz suchen",
+    "invalid_title": "Ausgewählter Ordner stimmt nicht überein",
+    "invalid_message": "Der ausgewählte Ordner enthält nicht den erwarteten Datensatz.",
+    "missing_label": "Fehlt:",
+    "missing_images": "Bilderordner mit Trainingsbildern",
+    "missing_cameras": "Kamerametadaten (COLMAP Sparse Reconstruction oder transforms.json)",
+    "missing_point_cloud": "Punktwolke (points3D)",
+    "choose_again": "Erneut wählen",
+    "unavailable": "Der Datensatzspeicherort kann nicht aktualisiert werden."
+  },
   "disk_space_dialog": {
     "error_label": "Fehler",
     "checkpoint_save_failed": "Checkpoint-Speicherung fehlgeschlagen (Iteration {})",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1652,6 +1652,20 @@
     "tooltip_max_resolution": "Maximum resolution for the sampling grid. Higher values allow finer sampling at quality 1.0.",
     "effective_resolution": "Effective Resolution"
   },
+  "dataset_relocate": {
+    "title": "Dataset Not Found",
+    "message": "The project's training dataset was not found.",
+    "expected_label": "Expected location:",
+    "locate": "Locate Dataset",
+    "invalid_title": "Selected Folder Does Not Match",
+    "invalid_message": "The selected folder does not contain the expected dataset.",
+    "missing_label": "Missing:",
+    "missing_images": "images folder with training images",
+    "missing_cameras": "camera metadata (COLMAP sparse reconstruction or transforms.json)",
+    "missing_point_cloud": "point cloud (points3D)",
+    "choose_again": "Choose Again",
+    "unavailable": "The dataset location cannot be updated."
+  },
   "disk_space_dialog": {
     "error_label": "Error",
     "checkpoint_save_failed": "Checkpoint Save Failed (Iteration {})",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -1652,6 +1652,20 @@
     "tooltip_max_resolution": "Resolución máxima para la cuadrícula de muestreo. Los valores más altos permiten un muestreo más fino a calidad 1.0.",
     "effective_resolution": "Resolución efectiva"
   },
+  "dataset_relocate": {
+    "title": "Dataset no encontrado",
+    "message": "No se encontró el dataset de entrenamiento del proyecto.",
+    "expected_label": "Ubicación esperada:",
+    "locate": "Localizar dataset",
+    "invalid_title": "La carpeta seleccionada no coincide",
+    "invalid_message": "La carpeta seleccionada no contiene el dataset esperado.",
+    "missing_label": "Falta:",
+    "missing_images": "carpeta de imágenes con imágenes de entrenamiento",
+    "missing_cameras": "metadatos de cámara (reconstrucción dispersa COLMAP o transforms.json)",
+    "missing_point_cloud": "nube de puntos (points3D)",
+    "choose_again": "Elegir de nuevo",
+    "unavailable": "No se puede actualizar la ubicación del dataset."
+  },
   "disk_space_dialog": {
     "error_label": "Error",
     "checkpoint_save_failed": "Error al guardar el punto de control (iteración {})",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1652,6 +1652,20 @@
     "tooltip_max_resolution": "Résolution maximale pour la grille d'échantillonnage. Des valeurs plus élevées permettent un échantillonnage plus fin à qualité 1.0.",
     "effective_resolution": "Résolution effective"
   },
+  "dataset_relocate": {
+    "title": "Dataset introuvable",
+    "message": "Le dataset d'entraînement du projet est introuvable.",
+    "expected_label": "Emplacement attendu :",
+    "locate": "Localiser le dataset",
+    "invalid_title": "Le dossier sélectionné ne correspond pas",
+    "invalid_message": "Le dossier sélectionné ne contient pas le dataset attendu.",
+    "missing_label": "Manquant :",
+    "missing_images": "dossier d'images avec les images d'entraînement",
+    "missing_cameras": "métadonnées de caméra (reconstruction éparse COLMAP ou transforms.json)",
+    "missing_point_cloud": "nuage de points (points3D)",
+    "choose_again": "Choisir à nouveau",
+    "unavailable": "L'emplacement du dataset ne peut pas être mis à jour."
+  },
   "disk_space_dialog": {
     "error_label": "Erreur",
     "checkpoint_save_failed": "Échec de la sauvegarde du checkpoint (itération {})",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1652,6 +1652,20 @@
     "tooltip_max_resolution": "Risoluzione massima per la griglia di campionamento. Valori più alti permettono un campionamento più fine a qualità 1.0.",
     "effective_resolution": "Risoluzione effettiva"
   },
+  "dataset_relocate": {
+    "title": "Dataset non trovato",
+    "message": "Il dataset di addestramento del progetto non è stato trovato.",
+    "expected_label": "Percorso previsto:",
+    "locate": "Individua dataset",
+    "invalid_title": "La cartella selezionata non corrisponde",
+    "invalid_message": "La cartella selezionata non contiene il dataset previsto.",
+    "missing_label": "Mancante:",
+    "missing_images": "cartella immagini con le immagini di addestramento",
+    "missing_cameras": "metadati della camera (ricostruzione sparsa COLMAP o transforms.json)",
+    "missing_point_cloud": "nuvola di punti (points3D)",
+    "choose_again": "Scegli di nuovo",
+    "unavailable": "Impossibile aggiornare il percorso del dataset."
+  },
   "disk_space_dialog": {
     "error_label": "Errore",
     "checkpoint_save_failed": "Salvataggio checkpoint fallito (iterazione {})",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1652,6 +1652,20 @@
     "tooltip_max_resolution": "サンプリンググリッドの最大解像度。値が高いほどクオリティ1.0でより細かいサンプリングが可能になります。",
     "effective_resolution": "実効解像度"
   },
+  "dataset_relocate": {
+    "title": "データセットが見つかりません",
+    "message": "プロジェクトの学習用データセットが見つかりませんでした。",
+    "expected_label": "想定される場所：",
+    "locate": "データセットを指定",
+    "invalid_title": "選択したフォルダーが一致しません",
+    "invalid_message": "選択したフォルダーには想定されたデータセットが含まれていません。",
+    "missing_label": "不足：",
+    "missing_images": "学習画像を含む images フォルダー",
+    "missing_cameras": "カメラメタデータ（COLMAP の sparse 再構成または transforms.json）",
+    "missing_point_cloud": "点群（points3D）",
+    "choose_again": "再選択",
+    "unavailable": "データセットの場所を更新できません。"
+  },
   "disk_space_dialog": {
     "error_label": "エラー",
     "checkpoint_save_failed": "チェックポイント保存失敗（反復 {}）",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1652,6 +1652,20 @@
     "tooltip_max_resolution": "샘플링 그리드의 최대 해상도. 높은 값은 품질 1.0에서 더 세밀한 샘플링을 가능하게 합니다.",
     "effective_resolution": "유효 해상도"
   },
+  "dataset_relocate": {
+    "title": "데이터셋을 찾을 수 없음",
+    "message": "프로젝트의 학습 데이터셋을 찾을 수 없습니다.",
+    "expected_label": "예상 위치:",
+    "locate": "데이터셋 찾기",
+    "invalid_title": "선택한 폴더가 일치하지 않음",
+    "invalid_message": "선택한 폴더에 예상된 데이터셋이 없습니다.",
+    "missing_label": "누락:",
+    "missing_images": "학습 이미지가 있는 images 폴더",
+    "missing_cameras": "카메라 메타데이터(COLMAP 희소 재구성 또는 transforms.json)",
+    "missing_point_cloud": "포인트 클라우드(points3D)",
+    "choose_again": "다시 선택",
+    "unavailable": "데이터셋 위치를 업데이트할 수 없습니다."
+  },
   "disk_space_dialog": {
     "error_label": "오류",
     "checkpoint_save_failed": "체크포인트 저장 실패 (반복 {})",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1652,6 +1652,20 @@
     "tooltip_max_resolution": "Maximale resolutie voor het bemonsteringsraster. Hogere waarden maken fijnere bemonstering mogelijk bij kwaliteit 1.0.",
     "effective_resolution": "Effectieve resolutie"
   },
+  "dataset_relocate": {
+    "title": "Dataset niet gevonden",
+    "message": "De trainingsdataset van het project is niet gevonden.",
+    "expected_label": "Verwachte locatie:",
+    "locate": "Dataset zoeken",
+    "invalid_title": "Geselecteerde map komt niet overeen",
+    "invalid_message": "De geselecteerde map bevat niet de verwachte dataset.",
+    "missing_label": "Ontbreekt:",
+    "missing_images": "map met trainingsafbeeldingen",
+    "missing_cameras": "camerametagegevens (COLMAP sparse reconstructie of transforms.json)",
+    "missing_point_cloud": "puntenwolk (points3D)",
+    "choose_again": "Opnieuw kiezen",
+    "unavailable": "De datasetlocatie kan niet worden bijgewerkt."
+  },
   "disk_space_dialog": {
     "error_label": "Fout",
     "checkpoint_save_failed": "Checkpoint opslaan mislukt (iteratie {})",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1652,6 +1652,20 @@
     "tooltip_max_resolution": "Maksymalna rozdzielczość siatki próbkowania. Wyższe wartości umożliwiają dokładniejsze próbkowanie przy jakości 1,0.",
     "effective_resolution": "Efektywna rozdzielczość"
   },
+  "dataset_relocate": {
+    "title": "Nie znaleziono zbioru danych",
+    "message": "Nie znaleziono zbioru danych treningowych projektu.",
+    "expected_label": "Oczekiwana lokalizacja:",
+    "locate": "Wskaż zbiór danych",
+    "invalid_title": "Wybrany folder nie pasuje",
+    "invalid_message": "Wybrany folder nie zawiera oczekiwanego zbioru danych.",
+    "missing_label": "Brakuje:",
+    "missing_images": "folder images z obrazami treningowymi",
+    "missing_cameras": "metadane kamery (rzadka rekonstrukcja COLMAP lub transforms.json)",
+    "missing_point_cloud": "chmura punktów (points3D)",
+    "choose_again": "Wybierz ponownie",
+    "unavailable": "Nie można zaktualizować lokalizacji zbioru danych."
+  },
   "disk_space_dialog": {
     "error_label": "Błąd",
     "checkpoint_save_failed": "Błąd zapisu punktu kontrolnego (iteracja {})",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -1652,6 +1652,20 @@
     "tooltip_max_resolution": "采样网格的最大分辨率。数值越高，质量1.0时的采样越精细。",
     "effective_resolution": "有效分辨率"
   },
+  "dataset_relocate": {
+    "title": "未找到数据集",
+    "message": "未找到该项目的训练数据集。",
+    "expected_label": "预期位置：",
+    "locate": "定位数据集",
+    "invalid_title": "所选文件夹不匹配",
+    "invalid_message": "所选文件夹不包含预期的数据集。",
+    "missing_label": "缺少：",
+    "missing_images": "包含训练图像的 images 文件夹",
+    "missing_cameras": "相机元数据（COLMAP 稀疏重建或 transforms.json）",
+    "missing_point_cloud": "点云（points3D）",
+    "choose_again": "重新选择",
+    "unavailable": "无法更新数据集位置。"
+  },
   "disk_space_dialog": {
     "error_label": "错误",
     "checkpoint_save_failed": "检查点保存失败（迭代 {}）",

--- a/src/visualizer/gui/string_keys.hpp
+++ b/src/visualizer/gui/string_keys.hpp
@@ -786,6 +786,21 @@ namespace lichtfeld::Strings {
         inline constexpr const char* EDIT_DELTA = "sequencer.edit_delta";
     } // namespace Sequencer
 
+    namespace DatasetRelocate {
+        inline constexpr const char* TITLE = "dataset_relocate.title";
+        inline constexpr const char* MESSAGE = "dataset_relocate.message";
+        inline constexpr const char* EXPECTED_LABEL = "dataset_relocate.expected_label";
+        inline constexpr const char* LOCATE = "dataset_relocate.locate";
+        inline constexpr const char* INVALID_TITLE = "dataset_relocate.invalid_title";
+        inline constexpr const char* INVALID_MESSAGE = "dataset_relocate.invalid_message";
+        inline constexpr const char* MISSING_LABEL = "dataset_relocate.missing_label";
+        inline constexpr const char* MISSING_IMAGES = "dataset_relocate.missing_images";
+        inline constexpr const char* MISSING_CAMERAS = "dataset_relocate.missing_cameras";
+        inline constexpr const char* MISSING_POINT_CLOUD = "dataset_relocate.missing_point_cloud";
+        inline constexpr const char* CHOOSE_AGAIN = "dataset_relocate.choose_again";
+        inline constexpr const char* UNAVAILABLE = "dataset_relocate.unavailable";
+    } // namespace DatasetRelocate
+
     namespace DiskSpaceDialog {
         inline constexpr const char* ERROR_LABEL = "disk_space_dialog.error_label";
         inline constexpr const char* CHECKPOINT_SAVE_FAILED = "disk_space_dialog.checkpoint_save_failed";

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -20,6 +20,10 @@
 #include "gui/error_event_bridge.hpp"
 #include "gui/error_surface_types.hpp"
 #include "gui/gui_manager.hpp"
+#include "gui/string_keys.hpp"
+#include "gui/utils/native_file_dialog.hpp"
+#include "io/filesystem_utils.hpp"
+#include "io/loader.hpp"
 #include "io/project_path.hpp"
 #include "io/project_recovery.hpp"
 #include "io/scene_chapter_adapter.hpp"
@@ -250,202 +254,144 @@ namespace lfs::vis::project {
             return result;
         }
 
-        // After display hydration, stream CKPT into a
-        // Trainer and install it as Paused. Soft-fails:
-        // keeps the display model, never dirties the
-        // document.
-        void tryInstallTrainerFromHydratedProject(
+        [[nodiscard]] std::optional<std::string>
+        describeDatasetFolderProblem(
+            const std::filesystem::path& root) {
+            if (lfs::io::Loader::getDatasetType(root) !=
+                lfs::io::DatasetType::Unknown) {
+                return std::nullopt;
+            }
+
+            const auto info =
+                lfs::io::detect_dataset_info(root);
+            std::vector<std::string> missing;
+            const bool has_images =
+                lfs::io::safe_is_directory(
+                    info.images_path) &&
+                info.image_count > 0;
+            if (!has_images) {
+                missing.push_back(LOC(
+                    lichtfeld::Strings::DatasetRelocate::
+                        MISSING_IMAGES));
+            }
+
+            const bool has_transforms =
+                lfs::io::safe_exists(
+                    root / "transforms.json") ||
+                lfs::io::safe_exists(
+                    root / "transforms_train.json");
+            bool has_colmap_cameras = false;
+            std::filesystem::path sparse_dir;
+            for (const auto& search :
+                 lfs::io::get_colmap_search_paths(root)) {
+                const bool has_camera_marker =
+                    !lfs::io::find_file_ci(
+                         search, "cameras.bin")
+                         .empty() ||
+                    !lfs::io::find_file_ci(
+                         search, "cameras.txt")
+                         .empty() ||
+                    !lfs::io::find_file_ci(
+                         search, "images.bin")
+                         .empty() ||
+                    !lfs::io::find_file_ci(
+                         search, "images.txt")
+                         .empty();
+                if (has_camera_marker) {
+                    has_colmap_cameras = true;
+                    if (sparse_dir.empty()) {
+                        sparse_dir = search;
+                    }
+                }
+                if (search != root &&
+                    lfs::io::safe_is_directory(search) &&
+                    sparse_dir.empty()) {
+                    sparse_dir = search;
+                }
+            }
+            if (!has_colmap_cameras && !has_transforms) {
+                missing.push_back(LOC(
+                    lichtfeld::Strings::DatasetRelocate::
+                        MISSING_CAMERAS));
+            }
+            if (!sparse_dir.empty()) {
+                const bool has_points =
+                    !lfs::io::find_file_ci(
+                         sparse_dir, "points3D.bin")
+                         .empty() ||
+                    !lfs::io::find_file_ci(
+                         sparse_dir, "points3D.txt")
+                         .empty();
+                if (!has_points) {
+                    missing.push_back(LOC(
+                        lichtfeld::Strings::
+                            DatasetRelocate::
+                                MISSING_POINT_CLOUD));
+                }
+            }
+
+            if (missing.empty()) {
+                return LOC(
+                    lichtfeld::Strings::DatasetRelocate::
+                        INVALID_MESSAGE);
+            }
+            std::string detail = missing.front();
+            for (std::size_t i = 1; i < missing.size();
+                 ++i) {
+                detail += ", ";
+                detail += missing[i];
+            }
+            return detail;
+        }
+
+        void installCheckpointTrainerWithDatasetRoot(
             VisualizerImpl& viewer,
             SceneManager& scene_manager,
             ProjectDocument& document,
-            const lfs::io::project::
-                ProjectDocumentHydrationReport&
-                    report) {
-            if (!report.trainer_state_pending ||
-                !report.checkpoint_uuid ||
-                !report.checkpoint_header) {
-                const auto persisted_dataset =
-                    inspectPersistedDatasetScene(
-                        document);
-                if (!persisted_dataset.has_dataset_node) {
-                    if (persisted_dataset
-                            .has_training_model) {
-                        notifyTrainerRestoreFailure(
-                            viewer,
-                            "Project has a training model but no checkpoint to resume");
-                    }
-                    return;
-                }
-
-                const auto dataset =
-                    document.project().dataset_reference();
-                if (!dataset || !*dataset) {
-                    notifyTrainerRestoreFailure(
-                        viewer,
-                        "Project dataset reference is missing");
-                    return;
-                }
-
-                auto* const parameter_manager =
-                    viewer.getParameterManager();
-                auto* const trainer_manager =
-                    viewer.getTrainerManager();
-                if (!parameter_manager ||
-                    !trainer_manager) {
-                    notifyTrainerRestoreFailure(
-                        viewer,
-                        "Project has no trainer manager or parameter manager");
-                    return;
-                }
-
-                auto dataset_root =
-                    resolveDatasetRootForTrainer(
-                        document,
-                        std::filesystem::path{});
-                if (!dataset_root ||
-                    dataset_root->empty() ||
-                    !std::filesystem::exists(*dataset_root)) {
-                    notifyTrainerRestoreFailure(
-                        viewer,
-                        dataset_root &&
-                                !dataset_root->empty()
-                            ? std::format(
-                                  "Dataset path does not exist: {}",
-                                  lfs::core::path_to_utf8(
-                                      *dataset_root))
-                            : "Project dataset reference could not be resolved");
-                    return;
-                }
-
-                auto* const data_loader =
-                    viewer.getDataLoader();
-                if (!data_loader) {
-                    notifyTrainerRestoreFailure(
-                        viewer,
-                        "Project dataset loader is unavailable");
-                    return;
-                }
-                auto params =
-                    parameter_manager->createForDataset(
-                        *dataset_root,
-                        report.pending_parameters.dataset
-                            .output_path);
-                data_loader->setParameters(params);
-                scene_manager.setDatasetPath(*dataset_root);
-                lfs::core::events::cmd::LoadFile{
-                    .path = *dataset_root,
-                    .is_dataset = true,
-                    .output_path = params.dataset
-                                       .output_path,
-                }
-                    .emit();
+            const lfs::core::Uuid& checkpoint_uuid,
+            lfs::core::param::TrainingParameters
+                ckpt_params,
+            const int expected_iteration,
+            const std::filesystem::path& dataset_root) {
+            const auto old_root =
+                ckpt_params.dataset.data_path;
+            if (!old_root.empty() &&
+                old_root.lexically_normal() !=
+                    dataset_root.lexically_normal()) {
+                const auto rebased =
+                    scene_manager.getScene()
+                        .rebaseCameraAssetPaths(
+                            old_root, dataset_root);
                 LOG_INFO(
-                    "Queued project dataset reload for trainer restoration; the hydrated scene will be rebuilt from the dataset (dataset={})",
-                    lfs::core::path_to_utf8(*dataset_root));
-                return;
+                    "Rebased {} camera asset path(s) from {} to {}",
+                    rebased,
+                    lfs::core::path_to_utf8(old_root),
+                    lfs::core::path_to_utf8(
+                        dataset_root));
             }
-            if (report.checkpoint_header->iteration <
-                0) {
-                notifyTrainerRestoreFailure(
-                    viewer,
-                    "Project CKPT iteration is negative");
-                return;
-            }
-            const auto* checkpoint =
-                document.find_checkpoint(
-                    *report.checkpoint_uuid);
-            if (!checkpoint) {
-                notifyTrainerRestoreFailure(
-                    viewer,
-                    "Project CKPT handle disappeared");
-                return;
-            }
-
-            std::optional<
-                lfs::core::
-                    CheckpointParametersLoadResult>
-                parsed_params;
-            auto params_visit =
-                checkpoint->visit_stream(
-                    [&](std::istream& source,
-                        const std::uint64_t bytes)
-                        -> lfs::Result<void> {
-                        parsed_params =
-                            lfs::core::
-                                load_checkpoint_params(
-                                    source, bytes);
-                        return {};
-                    });
-            if (!params_visit) {
-                notifyTrainerRestoreFailure(
-                    viewer,
-                    developerError(
-                        params_visit.error()));
-                return;
-            }
-            if (!parsed_params || !*parsed_params) {
-                notifyTrainerRestoreFailure(
-                    viewer,
-                    parsed_params
-                        ? parsed_params->error()
-                        : "CKPT parameter visitor did not run");
-                return;
-            }
-            auto ckpt_params =
-                std::move(**parsed_params);
-            ckpt_params.resume_checkpoint.reset();
-            if (const auto source =
-                    document.source_path()) {
-                ckpt_params.resume_project = *source;
-            }
-
-            const auto dataset_root =
-                resolveDatasetRootForTrainer(
-                    document,
-                    ckpt_params.dataset.data_path);
-            if (!dataset_root ||
-                dataset_root->empty() ||
-                !std::filesystem::exists(
-                    *dataset_root)) {
-                notifyTrainerRestoreFailure(
-                    viewer,
-                    dataset_root &&
-                            !dataset_root->empty()
-                        ? std::format(
-                              "Dataset path does not exist: {}",
-                              lfs::core::path_to_utf8(
-                                  *dataset_root))
-                        : "Project has no resolvable dataset root");
-                return;
-            }
-            ckpt_params.dataset.data_path =
-                *dataset_root;
+            ckpt_params.dataset.data_path = dataset_root;
 
             // Reset path authority without re-applying
             // PRMS onto the live trainer (ownership
             // matrix rule 3).
-            scene_manager.setDatasetPath(
-                *dataset_root);
+            scene_manager.setDatasetPath(dataset_root);
             if (auto* data_loader =
                     viewer.getDataLoader()) {
                 auto loader_params =
                     data_loader->getParameters();
                 loader_params.dataset.data_path =
-                    *dataset_root;
+                    dataset_root;
                 if (!ckpt_params.dataset.output_path
                          .empty()) {
-                    loader_params.dataset
-                        .output_path =
-                        ckpt_params.dataset
-                            .output_path;
+                    loader_params.dataset.output_path =
+                        ckpt_params.dataset.output_path;
                 }
-                data_loader->setParameters(
-                    loader_params);
+                data_loader->setParameters(loader_params);
             }
             if (auto* param_mgr =
                     viewer.getParameterManager()) {
-                param_mgr->getDatasetConfig()
-                    .data_path = *dataset_root;
+                param_mgr->getDatasetConfig().data_path =
+                    dataset_root;
             }
 
             auto* trainer_manager =
@@ -457,8 +403,7 @@ namespace lfs::vis::project {
                 return;
             }
             if (trainer_manager->hasTrainer()) {
-                if (!trainer_manager
-                         ->clearTrainer()) {
+                if (!trainer_manager->clearTrainer()) {
                     notifyTrainerRestoreFailure(
                         viewer,
                         "Previous training worker is still stopping");
@@ -470,18 +415,16 @@ namespace lfs::vis::project {
                 document.source_path()
                     ? lfs::core::path_to_utf8(
                           *document.source_path())
-                    : std::string{
-                          "project CKPT"};
+                    : std::string{"project CKPT"};
             auto installed =
                 lfs::training::
                     installTrainerFromProjectCheckpoint(
                         scene_manager.getScene(),
                         document,
-                        *report.checkpoint_uuid,
+                        checkpoint_uuid,
                         ckpt_params,
                         source_name,
-                        report.checkpoint_header
-                            ->iteration,
+                        expected_iteration,
                         std::nullopt,
                         makeViewerSplatTensorAllocator());
             if (!installed) {
@@ -491,10 +434,9 @@ namespace lfs::vis::project {
             }
             trainer_manager->setScene(
                 &scene_manager.getScene());
-            trainer_manager
-                ->setTrainerFromCheckpoint(
-                    std::move(installed->trainer),
-                    installed->iteration);
+            trainer_manager->setTrainerFromCheckpoint(
+                std::move(installed->trainer),
+                installed->iteration);
             if (!trainer_manager->hasTrainer()) {
                 notifyTrainerRestoreFailure(
                     viewer,
@@ -504,9 +446,164 @@ namespace lfs::vis::project {
             LOG_INFO(
                 "Project trainer restored at iteration {} (dataset={})",
                 installed->iteration,
-                lfs::core::path_to_utf8(
-                    *dataset_root));
+                lfs::core::path_to_utf8(dataset_root));
         }
+
+    } // namespace
+
+    // After display hydration, stream CKPT into a
+    // Trainer and install it as Paused. Soft-fails:
+    // keeps the display model, never dirties the
+    // document.
+    void ProjectLifecycle::tryInstallTrainerFromHydratedProject(
+        SceneManager& scene_manager,
+        lfs::io::project::ProjectDocument& document,
+        const lfs::io::project::
+            ProjectDocumentHydrationReport&
+                report) {
+        if (!report.trainer_state_pending ||
+            !report.checkpoint_uuid ||
+            !report.checkpoint_header) {
+            const auto persisted_dataset =
+                inspectPersistedDatasetScene(document);
+            if (!persisted_dataset.has_dataset_node) {
+                if (persisted_dataset.has_training_model) {
+                    notifyTrainerRestoreFailure(
+                        viewer_,
+                        "Project has a training model but no checkpoint to resume");
+                }
+                return;
+            }
+
+            const auto dataset =
+                document.project().dataset_reference();
+            if (!dataset || !*dataset) {
+                notifyTrainerRestoreFailure(
+                    viewer_,
+                    "Project dataset reference is missing");
+                return;
+            }
+
+            auto* const parameter_manager =
+                viewer_.getParameterManager();
+            auto* const trainer_manager =
+                viewer_.getTrainerManager();
+            if (!parameter_manager || !trainer_manager) {
+                notifyTrainerRestoreFailure(
+                    viewer_,
+                    "Project has no trainer manager or parameter manager");
+                return;
+            }
+
+            auto dataset_root =
+                resolveDatasetRootForTrainer(
+                    document, std::filesystem::path{});
+            if (!dataset_root || dataset_root->empty() ||
+                !std::filesystem::exists(*dataset_root)) {
+                if (dataset_root && !dataset_root->empty()) {
+                    armMissingDatasetReload(
+                        *dataset_root,
+                        report.pending_parameters.dataset
+                            .output_path);
+                } else {
+                    notifyTrainerRestoreFailure(
+                        viewer_,
+                        "Project dataset reference could not be resolved");
+                }
+                return;
+            }
+
+            auto* const data_loader = viewer_.getDataLoader();
+            if (!data_loader) {
+                notifyTrainerRestoreFailure(
+                    viewer_,
+                    "Project dataset loader is unavailable");
+                return;
+            }
+            auto params = parameter_manager->createForDataset(
+                *dataset_root,
+                report.pending_parameters.dataset.output_path);
+            data_loader->setParameters(params);
+            scene_manager.setDatasetPath(*dataset_root);
+            lfs::core::events::cmd::LoadFile{
+                .path = *dataset_root,
+                .is_dataset = true,
+                .output_path = params.dataset.output_path,
+            }
+                .emit();
+            LOG_INFO(
+                "Queued project dataset reload for trainer restoration; the hydrated scene will be rebuilt from the dataset (dataset={})",
+                lfs::core::path_to_utf8(*dataset_root));
+            return;
+        }
+        if (report.checkpoint_header->iteration < 0) {
+            notifyTrainerRestoreFailure(
+                viewer_, "Project CKPT iteration is negative");
+            return;
+        }
+        const auto* checkpoint =
+            document.find_checkpoint(*report.checkpoint_uuid);
+        if (!checkpoint) {
+            notifyTrainerRestoreFailure(
+                viewer_, "Project CKPT handle disappeared");
+            return;
+        }
+
+        std::optional<lfs::core::CheckpointParametersLoadResult>
+            parsed_params;
+        auto params_visit = checkpoint->visit_stream(
+            [&](std::istream& source, const std::uint64_t bytes)
+                -> lfs::Result<void> {
+                parsed_params = lfs::core::load_checkpoint_params(
+                    source, bytes);
+                return {};
+            });
+        if (!params_visit) {
+            notifyTrainerRestoreFailure(
+                viewer_, developerError(params_visit.error()));
+            return;
+        }
+        if (!parsed_params || !*parsed_params) {
+            notifyTrainerRestoreFailure(
+                viewer_,
+                parsed_params ? parsed_params->error()
+                              : "CKPT parameter visitor did not run");
+            return;
+        }
+        auto ckpt_params = std::move(**parsed_params);
+        ckpt_params.resume_checkpoint.reset();
+        if (const auto source = document.source_path()) {
+            ckpt_params.resume_project = *source;
+        }
+
+        const auto dataset_root = resolveDatasetRootForTrainer(
+            document, ckpt_params.dataset.data_path);
+        if (!dataset_root || dataset_root->empty() ||
+            !std::filesystem::exists(*dataset_root)) {
+            if (dataset_root && !dataset_root->empty()) {
+                armMissingCheckpointDataset(
+                    *dataset_root,
+                    *report.checkpoint_uuid,
+                    ckpt_params,
+                    report.checkpoint_header->iteration);
+            } else {
+                notifyTrainerRestoreFailure(
+                    viewer_,
+                    "Project has no resolvable dataset root");
+            }
+            return;
+        }
+        installCheckpointTrainerWithDatasetRoot(
+            viewer_,
+            scene_manager,
+            document,
+            *report.checkpoint_uuid,
+            std::move(ckpt_params),
+            report.checkpoint_header->iteration,
+            *dataset_root);
+    }
+
+    namespace {
 
         void bindRolePathReference(
             lfs::io::project::ReferencesChapter&
@@ -1310,6 +1407,7 @@ namespace lfs::vis::project {
         }
         recovery_prompt_pending_ = false;
         epoch_.fetch_add(1, std::memory_order_acq_rel);
+        pending_dataset_relocation_.reset();
         project_write_thread_.request_stop();
         if (project_write_thread_.joinable()) {
             project_write_thread_.join();
@@ -1430,6 +1528,349 @@ namespace lfs::vis::project {
                 "project.dirty");
         }
         return {};
+    }
+
+    std::optional<std::filesystem::path>
+    ProjectLifecycle::pendingDatasetRelocationPath()
+        const {
+        if (!isDatasetRelocationCurrent(
+                epoch_.load(std::memory_order_acquire))) {
+            return std::nullopt;
+        }
+        return pending_dataset_relocation_->missing_path;
+    }
+
+    bool ProjectLifecycle::relocateProjectDataset(
+        const std::filesystem::path& new_root,
+        std::string* error_message) {
+        const auto set_error = [&](std::string message) {
+            if (error_message) {
+                *error_message = std::move(message);
+            }
+        };
+        const auto epoch =
+            epoch_.load(std::memory_order_acquire);
+        if (!pending_dataset_relocation_) {
+            set_error(LOC(
+                lichtfeld::Strings::DatasetRelocate::
+                    UNAVAILABLE));
+            return false;
+        }
+        if (pending_dataset_relocation_->open_epoch !=
+            epoch) {
+            pending_dataset_relocation_.reset();
+            set_error(LOC(
+                lichtfeld::Strings::DatasetRelocate::
+                    UNAVAILABLE));
+            return false;
+        }
+        if (auto problem =
+                describeDatasetFolderProblem(new_root)) {
+            set_error(std::move(*problem));
+            return false;
+        }
+        auto retry =
+            std::move(pending_dataset_relocation_->retry);
+        pending_dataset_relocation_.reset();
+        retry(new_root);
+        return true;
+    }
+
+    bool ProjectLifecycle::isDatasetRelocationCurrent(
+        const std::uint64_t epoch) const {
+        return pending_dataset_relocation_ &&
+               pending_dataset_relocation_->open_epoch ==
+                   epoch &&
+               epoch_.load(std::memory_order_acquire) ==
+                   epoch;
+    }
+
+    void ProjectLifecycle::beginPendingDatasetRelocation(
+        std::filesystem::path missing_path,
+        std::function<void(const std::filesystem::path&)>
+            retry) {
+        const auto epoch =
+            epoch_.load(std::memory_order_acquire);
+        pending_dataset_relocation_ =
+            PendingDatasetRelocation{
+                .missing_path = std::move(missing_path),
+                .open_epoch = epoch,
+                .retry = std::move(retry),
+            };
+        if (viewer_.getGuiManager()) {
+            enqueueMissingDatasetDialog(epoch);
+            return;
+        }
+        notifyTrainerRestoreFailure(
+            viewer_,
+            std::format(
+                "Dataset path does not exist: {}",
+                lfs::core::path_to_utf8(
+                    pending_dataset_relocation_
+                        ->missing_path)));
+    }
+
+    void ProjectLifecycle::armMissingDatasetReload(
+        std::filesystem::path missing_path,
+        std::filesystem::path output_path) {
+        const auto epoch =
+            epoch_.load(std::memory_order_acquire);
+        beginPendingDatasetRelocation(
+            std::move(missing_path),
+            [this, epoch,
+             output_path = std::move(output_path)](
+                const std::filesystem::path& new_root) {
+                if (!viewer_.postWork({
+                        .run =
+                            [this, epoch, output_path,
+                             new_root] {
+                                if (epoch_.load(
+                                        std::memory_order_acquire) !=
+                                    epoch) {
+                                    return;
+                                }
+                                auto* parameter_manager =
+                                    viewer_
+                                        .getParameterManager();
+                                auto* data_loader =
+                                    viewer_.getDataLoader();
+                                auto* scene_manager =
+                                    viewer_
+                                        .getSceneManager();
+                                if (!parameter_manager ||
+                                    !data_loader ||
+                                    !scene_manager) {
+                                    notifyTrainerRestoreFailure(
+                                        viewer_,
+                                        "Project dataset loader is unavailable");
+                                    return;
+                                }
+                                auto params =
+                                    parameter_manager
+                                        ->createForDataset(
+                                            new_root,
+                                            output_path);
+                                data_loader->setParameters(
+                                    params);
+                                scene_manager->setDatasetPath(
+                                    new_root);
+                                lfs::core::events::cmd::
+                                    LoadFile{
+                                        .path = new_root,
+                                        .is_dataset = true,
+                                        .output_path =
+                                            params.dataset
+                                                .output_path,
+                                    }
+                                        .emit();
+                                LOG_INFO(
+                                    "Queued project dataset reload for trainer restoration; the hydrated scene will be rebuilt from the dataset (dataset={})",
+                                    lfs::core::path_to_utf8(
+                                        new_root));
+                            },
+                        .cancel = {},
+                    })) {
+                    notifyTrainerRestoreFailure(
+                        viewer_,
+                        "Project dataset loader is unavailable");
+                }
+            });
+    }
+
+    void ProjectLifecycle::armMissingCheckpointDataset(
+        std::filesystem::path missing_path,
+        lfs::core::Uuid checkpoint_uuid,
+        const lfs::core::param::TrainingParameters&
+            ckpt_params,
+        const int expected_iteration) {
+        const auto epoch =
+            epoch_.load(std::memory_order_acquire);
+        beginPendingDatasetRelocation(
+            std::move(missing_path),
+            [this, epoch, checkpoint_uuid, ckpt_params,
+             expected_iteration](
+                const std::filesystem::path& new_root) {
+                if (!viewer_.postWork({
+                        .run =
+                            [this, epoch, checkpoint_uuid,
+                             ckpt_params,
+                             expected_iteration,
+                             new_root] {
+                                if (epoch_.load(
+                                        std::memory_order_acquire) !=
+                                    epoch) {
+                                    return;
+                                }
+                                if (!document_ ||
+                                    !document_
+                                         ->find_checkpoint(
+                                             checkpoint_uuid)) {
+                                    notifyTrainerRestoreFailure(
+                                        viewer_,
+                                        "Project CKPT handle disappeared");
+                                    return;
+                                }
+                                auto* scene_manager =
+                                    viewer_
+                                        .getSceneManager();
+                                if (!scene_manager) {
+                                    notifyTrainerRestoreFailure(
+                                        viewer_,
+                                        "No trainer manager available");
+                                    return;
+                                }
+                                installCheckpointTrainerWithDatasetRoot(
+                                    viewer_,
+                                    *scene_manager,
+                                    *document_,
+                                    checkpoint_uuid,
+                                    ckpt_params,
+                                    expected_iteration,
+                                    new_root);
+                            },
+                        .cancel = {},
+                    })) {
+                    notifyTrainerRestoreFailure(
+                        viewer_,
+                        "No trainer manager available");
+                }
+            });
+    }
+
+    void ProjectLifecycle::cancelPendingDatasetRelocation(
+        const std::uint64_t epoch) {
+        if (!isDatasetRelocationCurrent(epoch)) {
+            return;
+        }
+        const auto missing_path =
+            pending_dataset_relocation_->missing_path;
+        pending_dataset_relocation_.reset();
+        notifyTrainerRestoreFailure(
+            viewer_,
+            std::format(
+                "Dataset path does not exist: {}",
+                lfs::core::path_to_utf8(missing_path)));
+    }
+
+    void ProjectLifecycle::enqueueMissingDatasetDialog(
+        const std::uint64_t epoch) {
+        auto* gui = viewer_.getGuiManager();
+        if (!gui || !isDatasetRelocationCurrent(epoch)) {
+            return;
+        }
+        namespace Keys = lichtfeld::Strings::DatasetRelocate;
+        const auto missing_utf8 = lfs::core::path_to_utf8(
+            pending_dataset_relocation_->missing_path);
+        lfs::core::ModalRequest request;
+        request.title = LOC(Keys::TITLE);
+        request.body_rml = std::format(
+            "<div>{}</div>"
+            "<div class=\"content-row\"><span class=\"dim-text\">{} </span>{}</div>",
+            lfs::vis::gui::escapeRmlText(LOC(Keys::MESSAGE)),
+            lfs::vis::gui::escapeRmlText(
+                LOC(Keys::EXPECTED_LABEL)),
+            lfs::vis::gui::escapeRmlText(missing_utf8));
+        request.style = lfs::core::ModalStyle::Warning;
+        request.width_dp = 520;
+        request.buttons = {
+            {LOC(lichtfeld::Strings::Common::CANCEL),
+             "secondary"},
+            {LOC(Keys::LOCATE), "primary"},
+        };
+        request.on_result =
+            [this, epoch](const lfs::core::ModalResult&
+                              result) {
+                if (!isDatasetRelocationCurrent(epoch)) {
+                    return;
+                }
+                if (result.button_label ==
+                    LOC(lichtfeld::Strings::DatasetRelocate::
+                            LOCATE)) {
+                    handleLocateDatasetPicker(epoch);
+                    return;
+                }
+                cancelPendingDatasetRelocation(epoch);
+            };
+        request.on_cancel = [this, epoch] {
+            cancelPendingDatasetRelocation(epoch);
+        };
+        gui->enqueueModal(std::move(request));
+    }
+
+    void ProjectLifecycle::enqueueInvalidDatasetDialog(
+        const std::uint64_t epoch,
+        const std::filesystem::path& chosen_path,
+        const std::string& detail) {
+        auto* gui = viewer_.getGuiManager();
+        if (!gui || !isDatasetRelocationCurrent(epoch)) {
+            return;
+        }
+        namespace Keys = lichtfeld::Strings::DatasetRelocate;
+        lfs::core::ModalRequest request;
+        request.title = LOC(Keys::INVALID_TITLE);
+        request.body_rml = std::format(
+            "<div>{}</div>"
+            "<div class=\"content-row\"><span class=\"dim-text\">{} </span>{}</div>"
+            "<div class=\"content-row\"><span class=\"dim-text\">{}</span></div>",
+            lfs::vis::gui::escapeRmlText(
+                LOC(Keys::INVALID_MESSAGE)),
+            lfs::vis::gui::escapeRmlText(
+                LOC(Keys::MISSING_LABEL)),
+            lfs::vis::gui::escapeRmlText(detail),
+            lfs::vis::gui::escapeRmlText(
+                lfs::core::path_to_utf8(chosen_path)));
+        request.style = lfs::core::ModalStyle::Error;
+        request.width_dp = 520;
+        request.buttons = {
+            {LOC(lichtfeld::Strings::Common::CANCEL),
+             "secondary"},
+            {LOC(Keys::CHOOSE_AGAIN), "primary"},
+        };
+        request.on_result =
+            [this, epoch](const lfs::core::ModalResult&
+                              result) {
+                if (!isDatasetRelocationCurrent(epoch)) {
+                    return;
+                }
+                if (result.button_label ==
+                    LOC(lichtfeld::Strings::DatasetRelocate::
+                            CHOOSE_AGAIN)) {
+                    handleLocateDatasetPicker(epoch);
+                    return;
+                }
+                cancelPendingDatasetRelocation(epoch);
+            };
+        request.on_cancel = [this, epoch] {
+            cancelPendingDatasetRelocation(epoch);
+        };
+        gui->enqueueModal(std::move(request));
+    }
+
+    void ProjectLifecycle::handleLocateDatasetPicker(
+        const std::uint64_t epoch) {
+        if (!isDatasetRelocationCurrent(epoch)) {
+            return;
+        }
+        const auto default_path =
+            pending_dataset_relocation_->missing_path
+                .parent_path();
+        const auto chosen =
+            lfs::vis::gui::OpenDatasetFolderDialog(
+                default_path);
+        if (chosen.empty()) {
+            enqueueMissingDatasetDialog(epoch);
+            return;
+        }
+        std::string error_message;
+        if (relocateProjectDataset(
+                chosen, &error_message)) {
+            return;
+        }
+        if (!isDatasetRelocationCurrent(epoch)) {
+            return;
+        }
+        enqueueInvalidDatasetDialog(
+            epoch, chosen, error_message);
     }
 
     lfs::Result<void>
@@ -4695,6 +5136,7 @@ namespace lfs::vis::project {
             epoch_.fetch_add(
                 1, std::memory_order_acq_rel) +
             1;
+        pending_dataset_relocation_.reset();
         hydration_.store(
             Hydration::ShellReady,
             std::memory_order_release);
@@ -5056,8 +5498,8 @@ namespace lfs::vis::project {
                                             epoch &&
                                         document_ == document) {
                                         tryInstallTrainerFromHydratedProject(
-                                            viewer_, *manager,
-                                            *document, report);
+                                            *manager, *document,
+                                            report);
                                     }
                                     const auto trainer_restored_at =
                                         std::chrono::steady_clock::
@@ -5315,6 +5757,7 @@ namespace lfs::vis::project {
         recovery_prompt_pending_ = false;
         epoch_.fetch_add(
             1, std::memory_order_acq_rel);
+        pending_dataset_relocation_.reset();
         hydration_.store(
             Hydration::Empty,
             std::memory_order_release);

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -241,6 +241,11 @@ namespace lfs::vis::project {
                 training) {
                 result.has_training_model =
                     training->has_value();
+            } else {
+                LOG_WARN(
+                    "Persisted SCNG training_model_uuid is unreadable: {}",
+                    developerError(
+                        training.error()));
             }
             if (const auto nodes =
                     document.scene_graph().nodes();
@@ -250,6 +255,10 @@ namespace lfs::vis::project {
                         *nodes, [](const auto& node) {
                             return node.type == "dataset";
                         });
+            } else {
+                LOG_WARN(
+                    "Persisted SCNG nodes are unreadable: {}",
+                    developerError(nodes.error()));
             }
             return result;
         }
@@ -1597,6 +1606,11 @@ namespace lfs::vis::project {
                 .open_epoch = epoch,
                 .retry = std::move(retry),
             };
+        LOG_WARN(
+            "Project dataset root is missing; offering a relocation prompt (missing={})",
+            lfs::core::path_to_utf8(
+                pending_dataset_relocation_
+                    ->missing_path));
         if (viewer_.getGuiManager()) {
             enqueueMissingDatasetDialog(epoch);
             return;

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -15,7 +15,9 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -193,6 +195,12 @@ namespace lfs::vis::project {
         [[nodiscard]] lfs::Result<void>
         prepareForEditModeTransition();
 
+        [[nodiscard]] std::optional<std::filesystem::path>
+        pendingDatasetRelocationPath() const;
+        bool relocateProjectDataset(
+            const std::filesystem::path& new_root,
+            std::string* error_message = nullptr);
+
     private:
         friend class lfs::vis::VisualizerImplResetTest_AutosaveStartsAfterFirstSaveAsWithoutReopen_Test;
         friend class lfs::vis::VisualizerImplResetTest_AutosaveSkipsWhileManualProjectWriteJobIsRunning_Test;
@@ -367,6 +375,44 @@ namespace lfs::vis::project {
         [[nodiscard]] static std::string
         hydrationName(Hydration state);
 
+        struct PendingDatasetRelocation {
+            std::filesystem::path missing_path;
+            std::uint64_t open_epoch = 0;
+            std::function<void(const std::filesystem::path&)>
+                retry;
+        };
+
+        void tryInstallTrainerFromHydratedProject(
+            SceneManager& scene_manager,
+            lfs::io::project::ProjectDocument& document,
+            const lfs::io::project::ProjectDocumentHydrationReport&
+                report);
+        void beginPendingDatasetRelocation(
+            std::filesystem::path missing_path,
+            std::function<void(const std::filesystem::path&)>
+                retry);
+        void armMissingDatasetReload(
+            std::filesystem::path missing_path,
+            std::filesystem::path output_path);
+        void armMissingCheckpointDataset(
+            std::filesystem::path missing_path,
+            lfs::core::Uuid checkpoint_uuid,
+            const lfs::core::param::TrainingParameters&
+                ckpt_params,
+            int expected_iteration);
+        void cancelPendingDatasetRelocation(
+            std::uint64_t epoch);
+        void enqueueMissingDatasetDialog(
+            std::uint64_t epoch);
+        void enqueueInvalidDatasetDialog(
+            std::uint64_t epoch,
+            const std::filesystem::path& chosen_path,
+            const std::string& detail);
+        void handleLocateDatasetPicker(
+            std::uint64_t epoch);
+        [[nodiscard]] bool isDatasetRelocationCurrent(
+            std::uint64_t epoch) const;
+
         VisualizerImpl& viewer_;
         std::shared_ptr<lfs::io::project::ProjectDocument> document_;
         ProjectLifecycleSettings settings_;
@@ -458,6 +504,8 @@ namespace lfs::vis::project {
         mutable std::mutex close_save_mutex_;
         std::string close_save_error_;
         std::string hydration_error_;
+        std::optional<PendingDatasetRelocation>
+            pending_dataset_relocation_;
     };
 
 } // namespace lfs::vis::project

--- a/src/visualizer/training/training_manager.cpp
+++ b/src/visualizer/training/training_manager.cpp
@@ -1567,12 +1567,17 @@ namespace lfs::vis {
     }
 
     FinishReason TrainerManager::resolvedRestoredFinishReason() const {
-        // UserStopped is a saved pause: resume unless the run already hit total.
+        // UserStopped and Error are saved pauses: resume unless the run
+        // already hit total. An error terminal save is a valid safe-point
+        // snapshot; the persisted Error value is provenance, not a restore
+        // directive. Only Completed still restores as Finished.
         if (restored_finish_reason_ &&
             *restored_finish_reason_ !=
                 lfs::io::project::TrainingFinishReason::None &&
             *restored_finish_reason_ !=
-                lfs::io::project::TrainingFinishReason::UserStopped) {
+                lfs::io::project::TrainingFinishReason::UserStopped &&
+            *restored_finish_reason_ !=
+                lfs::io::project::TrainingFinishReason::Error) {
             return fromIoFinishReason(*restored_finish_reason_);
         }
         int iteration = getCurrentIteration();
@@ -1603,6 +1608,22 @@ namespace lfs::vis {
         }
         const FinishReason finish_reason =
             resolvedRestoredFinishReason();
+        if (finish_reason == FinishReason::None &&
+            restored_finish_reason_ &&
+            *restored_finish_reason_ ==
+                lfs::io::project::TrainingFinishReason::
+                    Error) {
+            int iteration = getCurrentIteration();
+            if (checkpoint_baseline_iteration_ &&
+                *checkpoint_baseline_iteration_ >
+                    iteration) {
+                iteration =
+                    *checkpoint_baseline_iteration_;
+            }
+            LOG_INFO(
+                "Previous training run ended in an error; restoring as paused at iteration {}",
+                iteration);
+        }
         if (finish_reason != FinishReason::None &&
             getState() != TrainingState::Finished) {
             if (!state_machine_.transitionToFinished(finish_reason)) {

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -285,6 +285,12 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_BoundCheckpointIterationCacheSkipsHeaderWhenWarm_Test;
         friend class VisualizerImplResetTest_SelectedGaussiansAndSelectionToolSurviveSaveAndReopen_Test;
         friend class VisualizerImplResetTest_DatasetProjectWithoutCheckpointReloadsTrainer_Test;
+        friend class VisualizerImplResetTest_MissingDatasetProjectArmsRelocationInsteadOfImport_Test;
+        friend class VisualizerImplResetTest_RelocateProjectDatasetRestoresTrainerFromNewRoot_Test;
+        friend class VisualizerImplResetTest_RelocateRejectsFolderWithoutDatasetElements_Test;
+        friend class VisualizerImplResetTest_OpeningAnotherProjectClearsPendingRelocation_Test;
+        friend class VisualizerImplResetTest_MissingCheckpointDatasetProjectArmsRelocationInsteadOfInstall_Test;
+        friend class VisualizerImplResetTest_RelocateCheckpointProjectDatasetRestoresTrainerFromNewRoot_Test;
         friend class VisualizerImplResetTest_DatasetProjectWithoutReferenceIsNotRecoveredFromContainingDirectory_Test;
         friend class VisualizerImplResetTest_NonDatasetProjectInsideDatasetRootIsNotReimported_Test;
         friend class VisualizerImplResetTest_OpeningAnotherProjectCancelsPendingDatasetRestoreImport_Test;

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -296,6 +296,8 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_OpeningAnotherProjectCancelsPendingDatasetRestoreImport_Test;
         friend class VisualizerImplResetTest_NonDatasetSaveDoesNotBindStaleDatasetPath_Test;
         friend class VisualizerImplResetTest_TrainingCheckpointReopenRestoresPausedResumableState_Test;
+        friend class VisualizerImplResetTest_ErrorFinishedCheckpointProjectReopensPausedAndResumable_Test;
+        friend class VisualizerImplResetTest_CompletedCheckpointProjectStillReopensFinished_Test;
         friend class VisualizerImplResetTest_EditModeSaveDropsFormerTrainingCheckpoint_Test;
         friend class VisualizerImplResetTest_ReopenedTwoSplatProjectBuildsExternalCombinedModel_Test;
         friend class VisualizerImplResetTest_ForceExitDiscardDeletesAutosaveSidecarOnTeardown_Test;

--- a/tests/test_p5_session_chapters.cpp
+++ b/tests/test_p5_session_chapters.cpp
@@ -1590,8 +1590,11 @@ namespace {
     }
 
     TEST_F(P5MetricsRestoreTest,
-           ErrorRestoreDisablesResumeBothOrders) {
+           ErrorRestoreStaysPausedAndResumableBothOrders) {
         MetricsChapter metrics;
+        metrics.loss_history = {
+            {.iteration = 8, .value = 0.31f},
+        };
         metrics.accumulated_training_seconds =
             3.0;
         metrics.finish_reason =
@@ -1613,31 +1616,57 @@ namespace {
             return scene;
         };
 
+        const auto expect_resumable =
+            [](lfs::vis::TrainerManager& manager) {
+                EXPECT_EQ(
+                    manager.getState(),
+                    lfs::vis::TrainingState::Paused);
+                EXPECT_EQ(
+                    manager.getStateMachine()
+                        .getFinishReason(),
+                    lfs::vis::FinishReason::None);
+                EXPECT_TRUE(manager.canResume());
+                EXPECT_TRUE(manager.canPerform(
+                    lfs::vis::TrainingAction::Resume));
+                EXPECT_FALSE(manager.canStart());
+                EXPECT_FALSE(manager.isFinished());
+                EXPECT_NEAR(
+                    manager.getElapsedSeconds(),
+                    3.0f, 0.001f);
+                const auto snapshot =
+                    lfs::training::CommandCenter::
+                        instance()
+                            .snapshot();
+                EXPECT_EQ(snapshot.iteration, 8);
+                EXPECT_TRUE(snapshot.is_paused);
+                EXPECT_FALSE(snapshot.is_running);
+            };
+
         {
+            bool completed_emitted = false;
             auto scene = make_scene();
             lfs::vis::TrainerManager manager;
+            lfs::core::events::state::TrainingCompleted::
+                when([&](const auto&) {
+                    completed_emitted = true;
+                });
             manager.restoreProjectMetrics(metrics);
             manager.setTrainerFromCheckpoint(
                 std::make_unique<
                     lfs::training::Trainer>(
                     *scene),
                 8);
-            EXPECT_EQ(
-                manager.getState(),
-                lfs::vis::TrainingState::Finished);
-            EXPECT_EQ(
-                manager.getStateMachine()
-                    .getFinishReason(),
-                lfs::vis::FinishReason::Error);
-            EXPECT_FALSE(manager.canResume());
-            EXPECT_FALSE(manager.canStart());
-            EXPECT_NEAR(
-                manager.getElapsedSeconds(),
-                3.0f, 0.001f);
+            expect_resumable(manager);
+            EXPECT_FALSE(completed_emitted);
         }
         {
+            bool completed_emitted = false;
             auto scene = make_scene();
             lfs::vis::TrainerManager manager;
+            lfs::core::events::state::TrainingCompleted::
+                when([&](const auto&) {
+                    completed_emitted = true;
+                });
             manager.setTrainerFromCheckpoint(
                 std::make_unique<
                     lfs::training::Trainer>(
@@ -1647,15 +1676,8 @@ namespace {
                 manager.getState(),
                 lfs::vis::TrainingState::Paused);
             manager.restoreProjectMetrics(metrics);
-            EXPECT_EQ(
-                manager.getState(),
-                lfs::vis::TrainingState::Finished);
-            EXPECT_EQ(
-                manager.getStateMachine()
-                    .getFinishReason(),
-                lfs::vis::FinishReason::Error);
-            EXPECT_FALSE(manager.canResume());
-            EXPECT_FALSE(manager.canStart());
+            expect_resumable(manager);
+            EXPECT_FALSE(completed_emitted);
         }
     }
 

--- a/tests/test_scene_graph_identity.cpp
+++ b/tests/test_scene_graph_identity.cpp
@@ -1,9 +1,12 @@
 /* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "core/camera.hpp"
 #include "core/event_bridge/event_bridge.hpp"
 #include "core/event_bus.hpp"
 #include "core/events.hpp"
+#include "core/path_utils.hpp"
+#include "core/scene.hpp"
 #include "core/services.hpp"
 #include "core/splat_data.hpp"
 #include "core/tensor.hpp"
@@ -13,6 +16,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cuda_runtime.h>
 #include <filesystem>
 #include <gtest/gtest.h>
 #include <memory>
@@ -488,4 +492,78 @@ TEST_F(SceneGraphIdentityTest, PlyPathRestoredToFreshIdByTopologyUndo) {
     const auto restored_path = scene_manager_->getPlyPath(restored->id);
     ASSERT_TRUE(restored_path.has_value());
     EXPECT_EQ(*restored_path, source_path);
+}
+
+TEST(SceneCameraAssetPathTest, RebaseRewritesUnderOldRootAndRefreshesNodeMirrors) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count <= 0) {
+        GTEST_SKIP() << "CUDA device unavailable";
+    }
+
+    const auto old_root = std::filesystem::temp_directory_path() / "lfs-rebase-old";
+    const auto new_root = std::filesystem::temp_directory_path() / "lfs-rebase-new";
+    const auto outside = std::filesystem::temp_directory_path() / "lfs-rebase-elsewhere" / "photo.jpg";
+
+    auto make_camera = [](const std::string& name,
+                          const std::filesystem::path& image,
+                          const std::filesystem::path& mask,
+                          const std::filesystem::path& depth,
+                          const std::filesystem::path& normal,
+                          const int uid) {
+        return std::make_shared<lfs::core::Camera>(
+            Tensor::eye(3, Device::CPU),
+            Tensor::zeros({3}, Device::CPU),
+            100.0f, 100.0f, 32.0f, 32.0f,
+            Tensor(), Tensor(), lfs::core::CameraModelType::PINHOLE,
+            name, image, mask, 64, 64, uid, 0, depth, normal);
+    };
+
+    lfs::core::Scene scene;
+    const auto group = scene.addCameraGroup("Training", scene.addGroup("Cameras"), 2);
+    scene.addCamera(
+        "inside.png", group,
+        make_camera("inside.png",
+                    old_root / "images" / "inside.png",
+                    old_root / "masks" / "inside.png",
+                    old_root / "depth" / "inside.exr",
+                    old_root / "normals" / "inside.png",
+                    1));
+    scene.addCamera(
+        "outside.png", group,
+        make_camera("outside.png", outside, {}, {}, {}, 2));
+
+    EXPECT_EQ(scene.rebaseCameraAssetPaths(old_root / "", new_root), 2u);
+
+    const auto cameras = scene.getAllCameras();
+    ASSERT_EQ(cameras.size(), 2u);
+
+    std::shared_ptr<lfs::core::Camera> inside;
+    std::shared_ptr<lfs::core::Camera> outside_cam;
+    for (const auto& cam : cameras) {
+        if (cam->image_name() == "inside.png") {
+            inside = cam;
+        } else if (cam->image_name() == "outside.png") {
+            outside_cam = cam;
+        }
+    }
+    ASSERT_NE(inside, nullptr);
+    ASSERT_NE(outside_cam, nullptr);
+
+    EXPECT_EQ(inside->image_path(), new_root / "images" / "inside.png");
+    EXPECT_EQ(inside->mask_path(), new_root / "masks" / "inside.png");
+    EXPECT_EQ(inside->depth_path(), new_root / "depth" / "inside.exr");
+    EXPECT_EQ(inside->normal_path(), new_root / "normals" / "inside.png");
+    EXPECT_EQ(outside_cam->image_path(), outside);
+    EXPECT_TRUE(outside_cam->mask_path().empty());
+
+    const auto* inside_node = scene.getNode("inside.png");
+    ASSERT_NE(inside_node, nullptr);
+    EXPECT_EQ(inside_node->image_path, lfs::core::path_to_utf8(new_root / "images" / "inside.png"));
+    EXPECT_EQ(inside_node->mask_path, lfs::core::path_to_utf8(new_root / "masks" / "inside.png"));
+    EXPECT_EQ(inside_node->depth_path, lfs::core::path_to_utf8(new_root / "depth" / "inside.exr"));
+
+    const auto* outside_node = scene.getNode("outside.png");
+    ASSERT_NE(outside_node, nullptr);
+    EXPECT_EQ(outside_node->image_path, lfs::core::path_to_utf8(outside));
+    EXPECT_TRUE(outside_node->mask_path.empty());
 }

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -522,7 +522,11 @@ namespace {
         const std::filesystem::path& path,
         const lfs::core::Uuid& training_uuid,
         const lfs::core::Uuid& checkpoint_uuid,
-        const std::filesystem::path& dataset_path) {
+        const std::filesystem::path& dataset_path,
+        lfs::io::project::TrainingFinishReason
+            finish_reason =
+                lfs::io::project::
+                    TrainingFinishReason::None) {
         auto document = lfs::test::licht::make_empty_document(
             lfs::core::generate_uuid_v4(), 1);
         lfs::core::Scene source;
@@ -565,6 +569,12 @@ namespace {
                 checkpoint_uuid,
                 make_training_autosave_checkpoint_payload(
                     checkpoint_uuid, dataset_path)));
+        if (finish_reason !=
+            lfs::io::project::TrainingFinishReason::
+                None) {
+            document->edit_metrics().finish_reason =
+                finish_reason;
+        }
         auto options =
             lfs::test::licht::
                 deterministic_document_save_options(
@@ -6705,6 +6715,107 @@ namespace lfs::vis {
         EXPECT_EQ(manager->checkpointBaselineIteration(),
                   std::optional<int>{11});
         EXPECT_EQ(manager->getCurrentIteration(), 11);
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           ErrorFinishedCheckpointProjectReopensPausedAndResumable) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto project_path =
+            temporary_.path / "error-finish-reopen.licht";
+        const auto dataset_path =
+            temporary_.path / "error-finish-dataset";
+        write_minimal_transforms_dataset(dataset_path);
+        write_resumable_project_with_checkpoint(
+            project_path,
+            lfs::core::generate_uuid_v4(),
+            lfs::core::generate_uuid_v4(),
+            dataset_path,
+            lfs::io::project::TrainingFinishReason::
+                Error);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       viewer.getTrainerManager()
+                           ->hasTrainer();
+            }));
+
+        auto* const manager =
+            viewer.getTrainerManager();
+        ASSERT_NE(manager, nullptr);
+        EXPECT_TRUE(manager->isPaused());
+        EXPECT_TRUE(manager->canResume());
+        EXPECT_EQ(manager->checkpointBaselineIteration(),
+                  std::optional<int>{11});
+        EXPECT_EQ(manager->getCurrentIteration(), 11);
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           CompletedCheckpointProjectStillReopensFinished) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto project_path =
+            temporary_.path /
+            "completed-finish-reopen.licht";
+        const auto dataset_path =
+            temporary_.path / "completed-finish-dataset";
+        write_minimal_transforms_dataset(dataset_path);
+        write_resumable_project_with_checkpoint(
+            project_path,
+            lfs::core::generate_uuid_v4(),
+            lfs::core::generate_uuid_v4(),
+            dataset_path,
+            lfs::io::project::TrainingFinishReason::
+                Completed);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       viewer.getTrainerManager()
+                           ->hasTrainer();
+            }));
+
+        auto* const manager =
+            viewer.getTrainerManager();
+        ASSERT_NE(manager, nullptr);
+        EXPECT_FALSE(manager->isPaused());
+        EXPECT_FALSE(manager->canResume());
+        EXPECT_TRUE(manager->isFinished());
     }
 
     TEST_F(VisualizerImplResetTest,

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -313,7 +313,8 @@ namespace {
     }
 
     std::shared_ptr<lfs::core::Camera>
-    make_project_request_test_camera() {
+    make_project_request_test_camera(
+        const std::filesystem::path& image_path = {}) {
         const auto empty_distortion =
             lfs::core::Tensor::zeros(
                 {0}, lfs::core::Device::CPU,
@@ -326,7 +327,7 @@ namespace {
             100.0F, 100.0F, 32.0F, 32.0F,
             empty_distortion, empty_distortion,
             lfs::core::CameraModelType::PINHOLE,
-            "camera.png", std::filesystem::path{},
+            "camera.png", image_path,
             std::filesystem::path{}, 64, 64, 0);
     }
 
@@ -530,7 +531,8 @@ namespace {
             "Training cameras", root, 1);
         source.addCamera(
             "frame_0001.png", cameras,
-            make_project_request_test_camera());
+            make_project_request_test_camera(
+                dataset_path / "frame_0001.png"));
         const auto training = source.restoreNodeWithUuid(
             lfs::core::Scene::RestoreNodeDesc{
                 .uuid = training_uuid,
@@ -5984,6 +5986,444 @@ namespace lfs::vis {
         EXPECT_EQ(
             viewer.getTrainer()->getParams().optimization.iterations,
             1234);
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           MissingDatasetProjectArmsRelocationInsteadOfImport) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto project_path =
+            temporary_.path /
+            "dataset-missing-relocation.licht";
+        const auto dataset_path =
+            temporary_.path /
+            "dataset-missing-relocation-source";
+        const auto moved_path =
+            temporary_.path /
+            "dataset-missing-relocation-moved";
+        write_minimal_transforms_dataset(dataset_path);
+        write_dataset_project_without_checkpoint(
+            project_path, dataset_path);
+        std::filesystem::rename(dataset_path, moved_path);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
+            }));
+
+        EXPECT_FALSE(viewer.jobs().anyRunning(
+            JobType::Import));
+        EXPECT_FALSE(
+            viewer.getTrainerManager()->hasTrainer());
+        const auto pending =
+            viewer.project_lifecycle_
+                ->pendingDatasetRelocationPath();
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(
+            pending->lexically_normal(),
+            dataset_path.lexically_normal());
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           RelocateProjectDatasetRestoresTrainerFromNewRoot) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto project_path =
+            temporary_.path /
+            "dataset-relocate-restore.licht";
+        const auto dataset_path =
+            temporary_.path /
+            "dataset-relocate-restore-source";
+        const auto moved_path =
+            temporary_.path /
+            "dataset-relocate-restore-moved";
+        write_minimal_transforms_dataset(dataset_path);
+        write_dataset_project_without_checkpoint(
+            project_path, dataset_path);
+        std::filesystem::rename(dataset_path, moved_path);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
+            }));
+
+        ASSERT_TRUE(
+            viewer.project_lifecycle_
+                ->pendingDatasetRelocationPath()
+                .has_value());
+        ASSERT_TRUE(
+            viewer.project_lifecycle_
+                ->relocateProjectDataset(moved_path))
+            << "relocateProjectDataset rejected a valid dataset";
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                viewer.getGuiManager()
+                    ->asyncTasks()
+                    .pollImportCompletion();
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       viewer.getTrainerManager()
+                           ->hasTrainer() &&
+                       !viewer.jobs().anyRunning(
+                           JobType::Import);
+            }));
+
+        EXPECT_FALSE(
+            viewer.project_lifecycle_
+                ->pendingDatasetRelocationPath()
+                .has_value());
+        EXPECT_TRUE(
+            viewer.getSceneManager()->hasDataset());
+        EXPECT_EQ(
+            viewer.getSceneManager()->getDatasetPath(),
+            moved_path);
+        ASSERT_NE(viewer.getTrainer(), nullptr);
+        EXPECT_EQ(
+            viewer.getTrainer()->getParams().optimization.iterations,
+            1234);
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           RelocateRejectsFolderWithoutDatasetElements) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto project_path =
+            temporary_.path /
+            "dataset-relocate-reject.licht";
+        const auto dataset_path =
+            temporary_.path /
+            "dataset-relocate-reject-source";
+        const auto moved_path =
+            temporary_.path /
+            "dataset-relocate-reject-moved";
+        const auto empty_path =
+            temporary_.path /
+            "dataset-relocate-reject-empty";
+        write_minimal_transforms_dataset(dataset_path);
+        write_dataset_project_without_checkpoint(
+            project_path, dataset_path);
+        std::filesystem::rename(dataset_path, moved_path);
+        std::filesystem::create_directories(empty_path);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
+            }));
+
+        ASSERT_TRUE(
+            viewer.project_lifecycle_
+                ->pendingDatasetRelocationPath()
+                .has_value());
+        std::string error_message;
+        EXPECT_FALSE(
+            viewer.project_lifecycle_
+                ->relocateProjectDataset(
+                    empty_path, &error_message));
+        EXPECT_FALSE(error_message.empty());
+        const auto pending =
+            viewer.project_lifecycle_
+                ->pendingDatasetRelocationPath();
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(
+            pending->lexically_normal(),
+            dataset_path.lexically_normal());
+        EXPECT_FALSE(
+            viewer.getTrainerManager()->hasTrainer());
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           OpeningAnotherProjectClearsPendingRelocation) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto project_path =
+            temporary_.path /
+            "dataset-relocate-switch-a.licht";
+        const auto other_path =
+            temporary_.path /
+            "dataset-relocate-switch-b.licht";
+        const auto dataset_path =
+            temporary_.path /
+            "dataset-relocate-switch-source";
+        const auto moved_path =
+            temporary_.path /
+            "dataset-relocate-switch-moved";
+        write_minimal_transforms_dataset(dataset_path);
+        write_dataset_project_without_checkpoint(
+            project_path, dataset_path);
+        write_empty_project(other_path);
+        std::filesystem::rename(dataset_path, moved_path);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened_a = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened_a)
+            << lfs::format_for_developer(
+                   opened_a.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
+            }));
+
+        ASSERT_TRUE(
+            viewer.project_lifecycle_
+                ->pendingDatasetRelocationPath()
+                .has_value());
+
+        auto opened_b = viewer.projectOpen(
+            other_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened_b)
+            << lfs::format_for_developer(
+                   opened_b.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
+            }));
+
+        EXPECT_FALSE(
+            viewer.project_lifecycle_
+                ->pendingDatasetRelocationPath()
+                .has_value());
+        EXPECT_FALSE(
+            viewer.project_lifecycle_
+                ->relocateProjectDataset(moved_path));
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           MissingCheckpointDatasetProjectArmsRelocationInsteadOfInstall) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto project_path =
+            temporary_.path /
+            "ckpt-missing-relocation.licht";
+        const auto dataset_path =
+            temporary_.path /
+            "ckpt-missing-relocation-source";
+        const auto moved_path =
+            temporary_.path /
+            "ckpt-missing-relocation-moved";
+        write_minimal_transforms_dataset(dataset_path);
+        write_resumable_project_with_checkpoint(
+            project_path,
+            lfs::core::generate_uuid_v4(),
+            lfs::core::generate_uuid_v4(),
+            dataset_path);
+        std::filesystem::rename(dataset_path, moved_path);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
+            }));
+
+        EXPECT_FALSE(
+            viewer.getTrainerManager()->hasTrainer());
+        const auto pending =
+            viewer.project_lifecycle_
+                ->pendingDatasetRelocationPath();
+        ASSERT_TRUE(pending.has_value());
+        EXPECT_EQ(
+            pending->lexically_normal(),
+            dataset_path.lexically_normal());
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           RelocateCheckpointProjectDatasetRestoresTrainerFromNewRoot) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto project_path =
+            temporary_.path /
+            "ckpt-relocate-restore.licht";
+        const auto dataset_path =
+            temporary_.path /
+            "ckpt-relocate-restore-source";
+        const auto moved_path =
+            temporary_.path /
+            "ckpt-relocate-restore-moved";
+        write_minimal_transforms_dataset(dataset_path);
+        write_resumable_project_with_checkpoint(
+            project_path,
+            lfs::core::generate_uuid_v4(),
+            lfs::core::generate_uuid_v4(),
+            dataset_path);
+        std::filesystem::rename(dataset_path, moved_path);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
+            }));
+
+        ASSERT_TRUE(
+            viewer.project_lifecycle_
+                ->pendingDatasetRelocationPath()
+                .has_value());
+        ASSERT_TRUE(
+            viewer.project_lifecycle_
+                ->relocateProjectDataset(moved_path))
+            << "relocateProjectDataset rejected a valid dataset";
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       viewer.getTrainerManager()
+                           ->hasTrainer();
+            }));
+
+        EXPECT_FALSE(
+            viewer.project_lifecycle_
+                ->pendingDatasetRelocationPath()
+                .has_value());
+        EXPECT_EQ(
+            viewer.getSceneManager()->getDatasetPath(),
+            moved_path);
+        auto* const manager = viewer.getTrainerManager();
+        ASSERT_NE(manager, nullptr);
+        EXPECT_TRUE(manager->isPaused());
+        EXPECT_TRUE(manager->canResume());
+        EXPECT_EQ(manager->checkpointBaselineIteration(),
+                  std::optional<int>{11});
+        EXPECT_EQ(manager->getCurrentIteration(), 11);
+
+        const auto cameras =
+            viewer.getSceneManager()
+                ->getScene()
+                .getActiveCameras();
+        ASSERT_FALSE(cameras.empty());
+        const auto moved_prefix =
+            moved_path.lexically_normal().string();
+        for (const auto& cam : cameras) {
+            ASSERT_NE(cam, nullptr);
+            const auto image =
+                cam->image_path()
+                    .lexically_normal()
+                    .string();
+            EXPECT_TRUE(image.starts_with(moved_prefix))
+                << image << " does not start with "
+                << moved_prefix;
+            EXPECT_TRUE(std::filesystem::exists(
+                cam->image_path()))
+                << cam->image_path();
+        }
     }
 
     TEST_F(VisualizerImplResetTest,


### PR DESCRIPTION
Fixes #1656

When a project's training data folder was moved or renamed, opening the project only showed a small error toast and training was lost.

Now:
- Opening the project shows a clear dialog: **Locate Dataset** or **Cancel**.
- The user picks the new folder. If it's the wrong folder, the app says exactly what's missing (images, camera data, point cloud) and lets them try again.
- After picking the right folder, training resumes where it left off. The new location is saved with the project.

Also fixed along the way: a training run that crashed (for example because its images went missing) saved a recovery file that could never be resumed. It now reopens paused and can simply continue.

Verified end to end in the running app: open with missing folder, cancel, relocate, wrong-folder message, resume training. All tests pass.