### PR TITLE
Keep the window inside the GNOME work area on Wayland

### DIFF
--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -1560,6 +1560,16 @@ namespace lfs::vis {
             return;
         }
 
+#if !defined(_WIN32)
+        // The WM may maximize a window that already spans the work area (e.g.
+        // auto-maximize at map). Undoing that shrinks the window to a WM-invented
+        // restore size; accept the native maximize state instead.
+        if (is_borderless_maximized_) {
+            updateWindowSize(reason, ResizeIntent::Exact);
+            return;
+        }
+#endif
+
         bool restored_sdl_maximize = false;
         if (isSdlMaximized()) {
             if (!SDL_RestoreWindow(window_)) {
@@ -1615,10 +1625,12 @@ namespace lfs::vis {
         }
 
         SDL_Rect target_bounds = usable_bounds;
-        // Keep work-area dimensions so taskbars stay visible. Ask for the
-        // display top; some WMs may still clamp managed windows to work-area y.
+#if defined(_WIN32)
+        // Windows-only: keep work-area dimensions so the taskbar stays visible.
+        // Ask for the display top; the WM may still clamp managed windows to work-area y.
         target_bounds.y = display_bounds.y;
         target_bounds.h = std::min(usable_bounds.h, display_bounds.h);
+#endif
 
         const bool size_set = SDL_SetWindowSize(window_, target_bounds.w, target_bounds.h);
         const bool position_set = SDL_SetWindowPosition(window_, target_bounds.x, target_bounds.y);

--- a/src/visualizer/window/window_state_utils.hpp
+++ b/src/visualizer/window/window_state_utils.hpp
@@ -62,6 +62,18 @@ namespace lfs::vis {
         return window;
     }
 
+    [[nodiscard]] inline WindowRectangle clampWindowIntoDisplay(
+        WindowRectangle window, const WindowRectangle& display,
+        const int minimum_width = 640, const int minimum_height = 360) {
+        if (display.width <= 0 || display.height <= 0)
+            return window;
+        window.width = std::clamp(window.width, std::min(minimum_width, display.width), display.width);
+        window.height = std::clamp(window.height, std::min(minimum_height, display.height), display.height);
+        window.x = std::clamp(window.x, display.x, display.x + display.width - window.width);
+        window.y = std::clamp(window.y, display.y, display.y + display.height - window.height);
+        return window;
+    }
+
     [[nodiscard]] inline std::optional<WindowRectangle> displayWithLargestIntersection(
         const WindowRectangle& window, const std::vector<WindowRectangle>& displays) {
         std::optional<WindowRectangle> best;
@@ -96,6 +108,30 @@ namespace lfs::vis {
         if (!windowRectangleVisible(window, displays, minimum_visible_width,
                                     minimum_visible_height)) {
             return centerWindowOnDisplay(window, fallback_display, minimum_width, minimum_height);
+        }
+
+        int intersecting_displays = 0;
+        std::optional<WindowRectangle> unique_display;
+        for (const auto& display : displays) {
+            if (display.width <= 0 || display.height <= 0)
+                continue;
+            const std::int64_t left = std::max<std::int64_t>(window.x, display.x);
+            const std::int64_t top = std::max<std::int64_t>(window.y, display.y);
+            const std::int64_t right = std::min<std::int64_t>(
+                static_cast<std::int64_t>(window.x) + window.width,
+                static_cast<std::int64_t>(display.x) + display.width);
+            const std::int64_t bottom = std::min<std::int64_t>(
+                static_cast<std::int64_t>(window.y) + window.height,
+                static_cast<std::int64_t>(display.y) + display.height);
+            const std::int64_t area = std::max<std::int64_t>(0, right - left) *
+                                      std::max<std::int64_t>(0, bottom - top);
+            if (area <= 0)
+                continue;
+            ++intersecting_displays;
+            unique_display = display;
+        }
+        if (intersecting_displays == 1 && unique_display) {
+            return clampWindowIntoDisplay(window, *unique_display, minimum_width, minimum_height);
         }
 
         if (intersected_display &&

--- a/tests/test_window_state.cpp
+++ b/tests/test_window_state.cpp
@@ -73,6 +73,33 @@ namespace {
         EXPECT_EQ(lfs::vis::recoverWindowRectangle(saved, displays, displays.front()), saved);
     }
 
+    TEST(WindowStateContract, SavedGeometryUnderTopPanelIsPushedIntoWorkArea) {
+        const std::vector<WindowRectangle> displays{{67, 32, 1853, 1168}};
+        const auto recovered = lfs::vis::recoverWindowRectangle(
+            {0, 0, 1280, 720}, displays, displays.front());
+        EXPECT_EQ(recovered, (WindowRectangle{67, 32, 1280, 720}));
+    }
+
+    TEST(WindowStateContract, FullDisplaySaveIsClampedToWorkArea) {
+        const std::vector<WindowRectangle> displays{{67, 32, 1853, 1168}};
+        const auto recovered = lfs::vis::recoverWindowRectangle(
+            {0, 0, 1920, 1200}, displays, displays.front());
+        EXPECT_EQ(recovered, (WindowRectangle{67, 32, 1853, 1168}));
+    }
+
+    TEST(WindowStateContract, WindowAboveWorkAreaTopIsPulledDown) {
+        const std::vector<WindowRectangle> displays{{0, 32, 1920, 1168}};
+        const auto recovered = lfs::vis::recoverWindowRectangle(
+            {600, -40, 1280, 720}, displays, displays.front());
+        EXPECT_EQ(recovered, (WindowRectangle{600, 32, 1280, 720}));
+    }
+
+    TEST(WindowStateContract, StraddlingTwoDisplaysIsPreserved) {
+        const std::vector<WindowRectangle> displays{{0, 32, 1920, 1168}, {1920, 32, 1920, 1168}};
+        const WindowRectangle saved{1400, 100, 1200, 700};
+        EXPECT_EQ(lfs::vis::recoverWindowRectangle(saved, displays, displays.front()), saved);
+    }
+
     TEST(WindowStateContract, SafeModeDisablesAutomaticPersistence) {
         const char* previous_raw = std::getenv("LFS_SAFE_MODE");
         const std::optional<std::string> previous = previous_raw


### PR DESCRIPTION
On GNOME Wayland (e.g. Ubuntu 24+), the app window could cover the top bar or come up with a broken, in-between size after launch or maximize. On X11 desktops the window manager silently corrected this, so it went unnoticed.

**What this fixes**
- Maximizing now fills exactly the usable screen area on Linux — the top bar and dock stay visible and clickable.
- A bad remembered window position (e.g. written by a headless or Wayland-backend run) is corrected on the next launch instead of placing the window under the panel.
- When the desktop maximizes the window on its own, the app now accepts that instead of undoing it, which previously left a shrunken window.

Windows behavior is unchanged. No new dependencies. Covered by 4 new unit tests; verified live on GNOME Wayland (launch, maximize/restore, fresh start, saved-state recovery).