### PR TITLE
Polish MCP server management after #1658

### DIFF
--- a/external/httplib/httplib.h
+++ b/external/httplib/httplib.h
@@ -8617,11 +8617,14 @@ namespace httplib {
         }
     }
 
+    // LFS patch: always exchange-then-close so stop() cannot double-close a
+    // stale fd after the accept-error path and cannot leak a bound-but-not-
+    // listening socket.
     inline void Server::stop() {
-        if (is_running_) {
-            assert(svr_sock_ != INVALID_SOCKET);
-            std::atomic<socket_t> sock(svr_sock_.exchange(INVALID_SOCKET));
-            detail::shutdown_socket(sock);
+        const socket_t sock = svr_sock_.exchange(INVALID_SOCKET);
+        if (sock != INVALID_SOCKET) {
+            std::atomic<socket_t> ssock(sock);
+            detail::shutdown_socket(ssock);
             detail::close_socket(sock);
         }
         is_decommissioned = false;
@@ -9234,8 +9237,11 @@ namespace httplib {
                     } else if (errno == EINTR || errno == EAGAIN) {
                         continue;
                     }
-                    if (svr_sock_ != INVALID_SOCKET) {
-                        detail::close_socket(svr_sock_);
+                    // LFS patch: exchange the listener fd before close so a
+                    // concurrent Server::stop() cannot double-close a reused fd.
+                    const socket_t sock = svr_sock_.exchange(INVALID_SOCKET);
+                    if (sock != INVALID_SOCKET) {
+                        detail::close_socket(sock);
                         ret = false;
                         output_error_log(Error::Connection, nullptr);
                     } else {

--- a/src/mcp/mcp_http_server.cpp
+++ b/src/mcp/mcp_http_server.cpp
@@ -476,15 +476,11 @@ namespace lfs::mcp {
             // Wait until the listener has entered its accept loop (or failed)
             // before stop(): cpp-httplib ignores stop() while startup is pending.
             http_server_->wait_until_ready();
-            // listen_internal() closes its socket on an accept failure without
-            // invalidating the stored descriptor. Do not close it a second time
-            // after the accept loop has already exited.
-            if (http_server_->is_running())
-                http_server_->stop();
-            listener_thread_.join();
-            // The listener exit path decommissions the server to wake readiness
-            // waiters. With no listener running, stop() only resets that flag so
+            // stop() invalidates-then-closes the listener socket exactly once.
+            // After join, a second stop() only resets the decommissioned flag so
             // the same endpoint can be bound again.
+            http_server_->stop();
+            listener_thread_.join();
             http_server_->stop();
         } else if (http_server_) {
             // stop() also clears cpp-httplib's decommissioned flag after a bind
@@ -713,6 +709,7 @@ namespace lfs::mcp {
             if (has_applied_config_ && applied_config_.enabled == effective_enabled &&
                 applied_config_.expose_network == config.expose_network &&
                 applied_config_.port == config.port && listener_healthy) {
+                auto endpoints = networkEndpoints(config.expose_network, config.port);
                 {
                     std::lock_guard status_lock(status_mutex_);
                     status_.enabled = effective_enabled;
@@ -720,6 +717,7 @@ namespace lfs::mcp {
                     status_.phase = effective_enabled ? McpHttpPhase::Running
                                                       : McpHttpPhase::Disabled;
                     status_.request_logging = effective_logging;
+                    status_.endpoints = std::move(endpoints);
                 }
                 applied_config_.request_logging = effective_logging;
                 request_logging_.store(effective_logging, std::memory_order_release);
@@ -731,9 +729,9 @@ namespace lfs::mcp {
 
     void McpHttpServer::stageConfig(const McpHttpConfig& config) {
         const bool safe_mode = core::environment::flag("LFS_SAFE_MODE", false);
-        // Staging runs on the UI thread. Keep it allocation-only and avoid the
-        // adapter walk used to discover network-facing endpoints; the worker
-        // publishes the complete list when it applies the configuration.
+        // Staging may run on any caller thread. Keep it allocation-only (no
+        // adapter walk / no I/O); the worker publishes the complete endpoint
+        // list when it applies the configuration.
         auto endpoints = loopbackEndpoints(config.port);
         std::lock_guard status_lock(status_mutex_);
         const bool was_running = status_.running;
@@ -782,7 +780,7 @@ namespace lfs::mcp {
 
     void McpHttpServer::reportConfigWorkerFailure() {
         std::lock_guard status_lock(status_mutex_);
-        status_.running = http_server_ && http_server_->is_running();
+        status_.running = false;
         status_.phase = McpHttpPhase::Failed;
         status_.error = "MCP HTTP configuration failed";
         status_.error_kind = McpHttpErrorKind::ListenerFailed;
@@ -828,9 +826,17 @@ namespace lfs::mcp {
                         } catch (const std::exception& e) {
                             LOG_ERROR("MCP configuration worker recovered from an exception: {}",
                                       e.what());
+                            try {
+                                active_server->stop();
+                            } catch (...) {
+                            }
                             active_server->reportConfigWorkerFailure();
                         } catch (...) {
                             LOG_ERROR("MCP configuration worker recovered from an unknown exception");
+                            try {
+                                active_server->stop();
+                            } catch (...) {
+                            }
                             active_server->reportConfigWorkerFailure();
                         }
                     }

--- a/src/mcp/mcp_http_server.cpp
+++ b/src/mcp/mcp_http_server.cpp
@@ -829,6 +829,7 @@ namespace lfs::mcp {
                             try {
                                 active_server->stop();
                             } catch (...) {
+                                // LFS-CENSUS-OK(empty-catch): best-effort listener stop during failure recovery; the outer handler already logged and reportConfigWorkerFailure records the state.
                             }
                             active_server->reportConfigWorkerFailure();
                         } catch (...) {
@@ -836,6 +837,7 @@ namespace lfs::mcp {
                             try {
                                 active_server->stop();
                             } catch (...) {
+                                // LFS-CENSUS-OK(empty-catch): best-effort listener stop during failure recovery; the outer handler already logged and reportConfigWorkerFailure records the state.
                             }
                             active_server->reportConfigWorkerFailure();
                         }

--- a/src/python/lfs_plugins/preferences_panel.py
+++ b/src/python/lfs_plugins/preferences_panel.py
@@ -102,7 +102,6 @@ class PreferencesPanel(Panel):
         model.bind_func("mcp_has_error", lambda: bool(self._mcp_error_text()))
         model.bind_func("mcp_log_file", self._mcp_log_file_text)
         model.bind_func("mcp_has_log_file", lambda: bool(self._mcp_log_file_text()))
-        model.bind_event("close", self._on_close)
         model.bind_event("accept_and_close", self._on_accept_and_close)
         model.bind_event("reset_current_section", self._on_reset_current_section)
         model.bind_event("reset_all_settings", self._on_reset_all_settings)
@@ -619,8 +618,9 @@ class PreferencesPanel(Panel):
         elif section == "interface":
             return lf.ui.reset_layout()
         elif section == "mcp":
-            lf.ui.set_mcp_preferences(True, False, 45677, False)
-            self._load_mcp_preferences()
+            if not self._mcp_safe_mode:
+                lf.ui.set_mcp_preferences(True, False, 45677, False)
+                self._load_mcp_preferences()
         self._refresh_selection()
         return None
 

--- a/src/visualizer/gui/rml_status_bar.cpp
+++ b/src/visualizer/gui/rml_status_bar.cpp
@@ -103,6 +103,7 @@ namespace lfs::vis::gui {
             try {
                 return std::vformat(pattern, std::make_format_args(value));
             } catch (...) {
+                // LFS-CENSUS-OK(empty-catch): render-loop translation fallback returns the untranslated pattern; logging here would spam every frame.
                 return pattern;
             }
         }

--- a/src/visualizer/gui/rml_status_bar.cpp
+++ b/src/visualizer/gui/rml_status_bar.cpp
@@ -102,7 +102,7 @@ namespace lfs::vis::gui {
                                          const std::string& value) noexcept {
             try {
                 return std::vformat(pattern, std::make_format_args(value));
-            } catch (const std::format_error&) {
+            } catch (...) {
                 return pattern;
             }
         }
@@ -759,7 +759,9 @@ namespace lfs::vis::gui {
             el->AddEventListener(Rml::EventId::Click, mcp_preferences_listener_);
 
         if (!mcp_power_listener_) {
-            mcp_power_listener_ = new CallbackListener([] {
+            mcp_power_listener_ = new CallbackListener([this] {
+                if (model_.safe_mode)
+                    return;
                 lfs::vis::toggleMcpRuntimeEnabled();
             });
         }
@@ -1560,7 +1562,7 @@ namespace lfs::vis::gui {
             return;
         }
 
-        trackRenderedContextFrame(x, y);
+        trackRenderedContextFrame(x, y, overlay_height);
 
         queueCachedVulkanContext(x, y - overlay_height, w_px, h_px + overlay_height,
                                  screen_w, screen_h,
@@ -1613,7 +1615,7 @@ namespace lfs::vis::gui {
             last_render_h_ = render_h;
         }
 
-        trackRenderedContextFrame(x, y);
+        trackRenderedContextFrame(x, y, overlay_height);
 
         queueCachedVulkanContext(x, y - overlay_height, w_px, h_px + overlay_height,
                                  screen_w, screen_h,

--- a/src/visualizer/gui/rml_status_bar.hpp
+++ b/src/visualizer/gui/rml_status_bar.hpp
@@ -99,8 +99,8 @@ namespace lfs::vis::gui {
                                       int render_w, int render_h,
                                       bool refresh_cache);
         LFS_VIS_API void trackContextFrame(float window_x, float window_y);
-        void trackRenderedContextFrame(float bar_x, float bar_y) {
-            trackContextFrame(bar_x, bar_y - overlayHeight());
+        void trackRenderedContextFrame(float bar_x, float bar_y, float overlay_height) {
+            trackContextFrame(bar_x, bar_y - overlay_height);
         }
         void pollGpuMemoryQuery(std::chrono::steady_clock::time_point now);
         void setModelString(const char* name, std::string& field, std::string value);

--- a/src/visualizer/gui/rmlui/resources/preferences.rcss
+++ b/src/visualizer/gui/rmlui/resources/preferences.rcss
@@ -113,6 +113,11 @@ body.floating-panel {
     padding-right: 8dp;
 }
 
+.preferences-port-confirm.disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
 .preferences-switch-row {
     align-items: center;
 }
@@ -128,6 +133,11 @@ body.floating-panel {
     padding: 0;
     border-width: 0;
     background-color: transparent;
+}
+
+.preferences-mcp-toggle.disabled {
+    opacity: 0.5;
+    cursor: default;
 }
 
 .preferences-mcp-switch-track {

--- a/src/visualizer/gui/rmlui/resources/preferences.rml
+++ b/src/visualizer/gui/rmlui/resources/preferences.rml
@@ -103,7 +103,7 @@
           <span class="preferences-description preferences-warning" data-if="mcp_safe_mode">@tr:preferences.mcp_safe_mode_notice</span>
           <div class="preferences-row preferences-switch-row">
             <span class="preferences-label">@tr:preferences.mcp_enabled</span>
-            <button class="preferences-mcp-toggle" data-class-is-on="mcp_enabled" data-event-click="toggle_mcp_enabled" data-attr-title="mcp_status" data-attrif-disabled="mcp_safe_mode">
+            <button class="preferences-mcp-toggle" data-class-is-on="mcp_enabled" data-event-click="toggle_mcp_enabled" data-attr-title="mcp_status" data-attrif-disabled="mcp_safe_mode" data-class-disabled="mcp_safe_mode">
               <span class="preferences-mcp-switch-track"><span class="preferences-mcp-switch-knob"></span></span>
             </button>
           </div>
@@ -117,7 +117,7 @@
             <div class="preferences-port-control">
               <input class="preferences-select preferences-port-input" type="text" data-value="mcp_port" maxlength="5"
                      data-event-change="mcp_port_change(ev.value)" data-attrif-disabled="mcp_safe_mode" />
-              <button class="btn btn--primary preferences-port-confirm" data-event-click="confirm_mcp_port" data-attrif-disabled="mcp_safe_mode">@tr:common.ok</button>
+              <button class="btn btn--primary preferences-port-confirm" data-event-click="confirm_mcp_port" data-attrif-disabled="mcp_safe_mode" data-class-disabled="mcp_safe_mode">@tr:common.ok</button>
             </div>
           </div>
           <div class="preferences-row preferences-checkbox-row">

--- a/src/visualizer/gui/rmlui/resources/statusbar.rcss
+++ b/src/visualizer/gui/rmlui/resources/statusbar.rcss
@@ -102,6 +102,11 @@ body {
     background-color: transparent;
 }
 
+#mcp-toggle.disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
 .mcp-switch-track {
     display: block;
     position: relative;

--- a/src/visualizer/gui/rmlui/resources/statusbar.rml
+++ b/src/visualizer/gui/rmlui/resources/statusbar.rml
@@ -69,7 +69,7 @@
             <div id="mcp-popup" class="hidden" data-class-hidden="!mcp_details_expanded">
                 <div id="mcp-popup-header">
                     <div id="mcp-popup-title" data-style-color="mcp_color">{{ mcp_summary }}</div>
-                    <button id="mcp-toggle" data-class-is-on="mcp_server_enabled" data-attr-title="mcp_toggle_label" data-attrif-disabled="safe_mode">
+                    <button id="mcp-toggle" data-class-is-on="mcp_server_enabled" data-attr-title="mcp_toggle_label" data-attrif-disabled="safe_mode" data-class-disabled="safe_mode">
                         <span class="mcp-switch-track"><span class="mcp-switch-knob"></span></span>
                     </button>
                 </div>

--- a/tests/python/test_preferences_panel.py
+++ b/tests/python/test_preferences_panel.py
@@ -310,6 +310,63 @@ def test_safe_mode_disables_live_mcp_mutations(preferences_panel_module):
     assert state.set_mcp_calls == []
 
 
+def test_safe_mode_reset_does_not_stage_mcp_changes(preferences_panel_module):
+    module, state = preferences_panel_module
+    state.mcp_preferences.update({"enabled": False, "safe_mode": True})
+    state.mcp_status.update({"enabled": False, "phase": "disabled", "safe_mode": True})
+    panel = module.PreferencesPanel()
+    panel._read_mcp_preferences()
+    panel._refresh_selection = lambda: None
+
+    snapshot = (
+        panel._mcp_enabled,
+        panel._mcp_expose_network,
+        panel._mcp_port,
+        panel._mcp_applied_port,
+        panel._mcp_request_logging,
+        panel._mcp_safe_mode,
+    )
+
+    panel._section = "mcp"
+    panel._reset_section()
+
+    assert state.set_mcp_calls == []
+    assert (
+        panel._mcp_enabled,
+        panel._mcp_expose_network,
+        panel._mcp_port,
+        panel._mcp_applied_port,
+        panel._mcp_request_logging,
+        panel._mcp_safe_mode,
+    ) == snapshot
+
+    def confirm_dialog(_title, _message, _buttons, callback):
+        callback("preferences.reset_all_settings")
+
+    module.lf.ui.confirm_dialog = confirm_dialog
+    module.lf.ui.message_dialog = lambda *_a, **_k: None
+    module.lf.ui.set_theme = lambda *_a, **_k: None
+    module.lf.ui.set_ui_scale = lambda *_a, **_k: None
+    module.lf.ui.set_remember_camera_navigation = lambda *_a, **_k: None
+    module.lf.ui.set_remember_camera_view_snap = lambda *_a, **_k: None
+    module.lf.ui.reset_layout = lambda: None
+    module.lf.ui.reset_window_state = lambda: None
+    module.lf.set_camera_navigation_mode = lambda *_a, **_k: None
+    module.lf.set_camera_view_snap_enabled = lambda *_a, **_k: None
+
+    panel._on_reset_all_settings(None, None, None)
+
+    assert state.set_mcp_calls == []
+    assert (
+        panel._mcp_enabled,
+        panel._mcp_expose_network,
+        panel._mcp_port,
+        panel._mcp_applied_port,
+        panel._mcp_request_logging,
+        panel._mcp_safe_mode,
+    ) == snapshot
+
+
 def test_safe_mode_disables_preferences_and_status_bar_mcp_controls():
     project_root = Path(__file__).parent.parent.parent
     resources = project_root / "src" / "visualizer" / "gui" / "rmlui" / "resources"
@@ -317,9 +374,11 @@ def test_safe_mode_disables_preferences_and_status_bar_mcp_controls():
     status_bar = (resources / "statusbar.rml").read_text(encoding="utf-8")
 
     assert preferences.count('data-attrif-disabled="mcp_safe_mode"') == 5
+    assert preferences.count('data-class-disabled="mcp_safe_mode"') == 2
     assert (
         '<button id="mcp-toggle" data-class-is-on="mcp_server_enabled" '
-        'data-attr-title="mcp_toggle_label" data-attrif-disabled="safe_mode">'
+        'data-attr-title="mcp_toggle_label" data-attrif-disabled="safe_mode" '
+        'data-class-disabled="safe_mode">'
         in status_bar
     )
 

--- a/tests/test_mcp_protocol.cpp
+++ b/tests/test_mcp_protocol.cpp
@@ -17,6 +17,7 @@
 
 #include <httplib/httplib.h>
 
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
@@ -877,6 +878,42 @@ namespace lfs::mcp {
         first.stop();
     }
 
+    TEST(McpHttpServerTest, FastPathApplyConfigPreservesStartedEndpoints) {
+        const int port = availableLoopbackPort();
+        ASSERT_GT(port, 0);
+        McpHttpServer server;
+        ASSERT_TRUE(server.start(McpHttpConfig{
+            .enabled = true,
+            .expose_network = false,
+            .port = port,
+            .request_logging = false,
+        }));
+        const auto started_endpoints = server.status().endpoints;
+        ASSERT_FALSE(started_endpoints.empty());
+
+        ASSERT_TRUE(server.applyConfig(McpHttpConfig{
+            .enabled = true,
+            .expose_network = false,
+            .port = port,
+            .request_logging = true,
+        }));
+        EXPECT_EQ(server.status().endpoints, started_endpoints);
+        EXPECT_FALSE(server.status().endpoints.empty());
+        EXPECT_TRUE(server.status().request_logging);
+        server.stop();
+    }
+
+    TEST(McpHttpServerTest, HttplibStopClosesBoundButNotListeningSocket) {
+        httplib::Server bound;
+        const int port = bound.bind_to_any_port("127.0.0.1");
+        ASSERT_GT(port, 0);
+        bound.stop();
+
+        httplib::Server rebound;
+        EXPECT_TRUE(rebound.bind_to_port("127.0.0.1", port));
+        rebound.stop();
+    }
+
     TEST(McpHttpServerTest, RapidQueuedDisableCannotLeaveAListenerRunning) {
         const int port = availableLoopbackPort();
         ASSERT_GT(port, 0);
@@ -886,6 +923,20 @@ namespace lfs::mcp {
 
         ASSERT_TRUE(applyActiveMcpHttpConfig({.enabled = true, .port = port}));
         ASSERT_TRUE(applyActiveMcpHttpConfig({.enabled = false, .port = port}));
+
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        bool reached_disabled = false;
+        while (std::chrono::steady_clock::now() < deadline) {
+            const auto polled = server.status();
+            if (polled.phase == McpHttpPhase::Disabled && !polled.running) {
+                reached_disabled = true;
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        ASSERT_TRUE(reached_disabled);
+
         setActiveMcpHttpServer(nullptr);
 
         const auto status = server.status();

--- a/tests/test_status_bar_fit.cpp
+++ b/tests/test_status_bar_fit.cpp
@@ -50,7 +50,8 @@ namespace lfs::vis::gui {
                                        const float bar_x,
                                        const float bar_y) {
             status_bar.rml_manager_ = &manager;
-            status_bar.trackRenderedContextFrame(bar_x, bar_y);
+            status_bar.trackRenderedContextFrame(bar_x, bar_y,
+                                                 status_bar.overlayHeight());
         }
     };
 


### PR DESCRIPTION
Follow-up fixes for the MCP server management shipped in #1658.

- The settings page no longer hides a server's network addresses after you toggle request logging.
- Safe mode is now fully locked down: the Reset buttons can no longer change MCP settings, and the MCP switches are greyed out and ignore clicks.
- Fixed two rare socket bugs that could make the server unable to restart on the same port, or close the wrong connection during shutdown.
- If applying a configuration fails, the server now shuts down cleanly and reports an honest error instead of a mixed state.
- Tightened tests: the rapid on/off test now proves the final "off" is really applied, plus new tests for the fixes above.

Verified with the full MCP test suites (138 tests), a 1000x repeat run of the lifecycle tests, and the Python panel tests.