### PR TITLE
Fix Sequencer camera path JSON loading on Windows

### DIFF
--- a/src/sequencer/timeline.cpp
+++ b/src/sequencer/timeline.cpp
@@ -438,7 +438,10 @@ namespace lfs::sequencer {
         try {
             const std::filesystem::path path_fs = lfs::core::utf8_to_path(path);
             std::ifstream file;
-            if (!lfs::core::open_file_for_read(path_fs, file)) {
+            // The size guard below compares bytes read with filesystem::file_size().
+            // Binary mode is required on Windows so CRLF translation does not make
+            // the logical character count smaller than the physical file size.
+            if (!lfs::core::open_file_for_read(path_fs, std::ios::binary, file)) {
                 LOG_ERROR("Failed to open timeline file: {}", path);
                 return false;
             }

--- a/tests/test_sequencer_regressions.cpp
+++ b/tests/test_sequencer_regressions.cpp
@@ -79,6 +79,25 @@ namespace {
         }
     }
 
+    TEST(SequencerTimelineRegressionTest, SavedTimelineLoadsBackFromTheSameFile) {
+        Timeline source;
+        source.addKeyframe(makeKeyframe(0.0f, {1.0f, 2.0f, 3.0f}, 35.0f));
+        source.addKeyframe(makeKeyframe(2.0f, {4.0f, 5.0f, 6.0f}, 50.0f));
+
+        TempJsonPath file;
+        ASSERT_TRUE(source.saveToJson(file.path.string()));
+
+        Timeline loaded;
+        ASSERT_TRUE(loaded.loadFromJson(file.path.string()));
+        ASSERT_EQ(loaded.realKeyframeCount(), 2u);
+        ASSERT_NE(loaded.getKeyframe(0), nullptr);
+        ASSERT_NE(loaded.getKeyframe(1), nullptr);
+        expectVec3Eq(loaded.getKeyframe(0)->position, {1.0f, 2.0f, 3.0f});
+        expectVec3Eq(loaded.getKeyframe(1)->position, {4.0f, 5.0f, 6.0f});
+        EXPECT_FLOAT_EQ(loaded.getKeyframe(0)->focal_length_mm, 35.0f);
+        EXPECT_FLOAT_EQ(loaded.getKeyframe(1)->focal_length_mm, 50.0f);
+    }
+
     TEST(SequencerTimelineRegressionTest, LoadReplacesStateAndClearsAbsentClip) {
         Timeline timeline;
         timeline.addKeyframe(makeKeyframe(9.0f, {9.0f, 0.0f, 0.0f}));


### PR DESCRIPTION
Fixes #1627 

### Changes

- Open Sequencer timeline JSON files in binary mode.
- Keep the byte-count validation consistent with `std::filesystem::file_size()` on Windows.
- Add a regression test covering save-and-load of a Camera Path JSON file.