### PR TITLE
Save Sequencer camera path JSON in binary mode

### DIFF
--- a/src/sequencer/timeline.cpp
+++ b/src/sequencer/timeline.cpp
@@ -326,7 +326,8 @@ namespace lfs::sequencer {
                 lfs::io::AtomicOutputTempName::AppendSuffix,
                 lfs::io::AtomicOutputDurability::Durable);
             std::ofstream file;
-            if (!lfs::core::open_file_for_write(atomic_output.temp_path(), file)) {
+            // Binary mode keeps saved paths byte-identical on every platform (no CRLF rewriting on Windows).
+            if (!lfs::core::open_file_for_write(atomic_output.temp_path(), std::ios::binary, file)) {
                 LOG_ERROR("Failed to open timeline file: {}", path);
                 return false;
             }
@@ -439,8 +440,8 @@ namespace lfs::sequencer {
             const std::filesystem::path path_fs = lfs::core::utf8_to_path(path);
             std::ifstream file;
             // The size guard below compares bytes read with filesystem::file_size().
-            // Binary mode is required on Windows so CRLF translation does not make
-            // the logical character count smaller than the physical file size.
+            // Binary mode is required on Windows so CRLF translation does not shrink
+            // the bytes read below the physical file size.
             if (!lfs::core::open_file_for_read(path_fs, std::ios::binary, file)) {
                 LOG_ERROR("Failed to open timeline file: {}", path);
                 return false;

--- a/tests/test_sequencer_regressions.cpp
+++ b/tests/test_sequencer_regressions.cpp
@@ -98,6 +98,58 @@ namespace {
         EXPECT_FLOAT_EQ(loaded.getKeyframe(1)->focal_length_mm, 50.0f);
     }
 
+    TEST(SequencerTimelineRegressionTest, LoadAcceptsCrlfAndBomTimelineFile) {
+        Timeline source;
+        source.addKeyframe(makeKeyframe(0.0f, {1.0f, 2.0f, 3.0f}));
+        source.addKeyframe(makeKeyframe(2.0f, {4.0f, 5.0f, 6.0f}));
+
+        TempJsonPath file;
+        ASSERT_TRUE(source.saveToJson(file.path.string()));
+
+        std::ifstream input(file.path, std::ios::binary);
+        ASSERT_TRUE(input.is_open());
+        const std::string saved((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+        input.close();
+
+        std::string crlf_bom = "\xEF\xBB\xBF";
+        crlf_bom.reserve(saved.size() * 2 + 3);
+        for (const char ch : saved) {
+            if (ch == '\n')
+                crlf_bom += "\r\n";
+            else
+                crlf_bom += ch;
+        }
+
+        TempJsonPath crlf_file;
+        std::ofstream output(crlf_file.path, std::ios::binary);
+        ASSERT_TRUE(output.is_open());
+        output << crlf_bom;
+        output.close();
+
+        Timeline loaded;
+        ASSERT_TRUE(loaded.loadFromJson(crlf_file.path.string()));
+        ASSERT_EQ(loaded.realKeyframeCount(), 2u);
+        ASSERT_NE(loaded.getKeyframe(0), nullptr);
+        ASSERT_NE(loaded.getKeyframe(1), nullptr);
+        expectVec3Eq(loaded.getKeyframe(0)->position, {1.0f, 2.0f, 3.0f});
+        expectVec3Eq(loaded.getKeyframe(1)->position, {4.0f, 5.0f, 6.0f});
+    }
+
+    TEST(SequencerTimelineRegressionTest, SavedTimelineContainsNoCarriageReturns) {
+        Timeline timeline;
+        timeline.addKeyframe(makeKeyframe(0.0f));
+
+        TempJsonPath file;
+        ASSERT_TRUE(timeline.saveToJson(file.path.string()));
+
+        std::ifstream input(file.path, std::ios::binary);
+        ASSERT_TRUE(input.is_open());
+        const std::string saved((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+
+        EXPECT_EQ(saved.find('\r'), std::string::npos);
+        EXPECT_FALSE(saved.empty());
+    }
+
     TEST(SequencerTimelineRegressionTest, LoadReplacesStateAndClearsAbsentClip) {
         Timeline timeline;
         timeline.addKeyframe(makeKeyframe(9.0f, {9.0f, 0.0f, 0.0f}));


### PR DESCRIPTION
Follow-up to #1670.

### What was wrong

#1670 fixed **loading** camera path files on Windows. But **saving** still wrote the file in text mode. On Windows that silently rewrites every line ending, so a camera path saved on Windows looks different from the same path saved on Linux or macOS.

### What this does

- Save now writes the file byte-for-byte, the same on every platform (one line changed).
- Small wording fix in a code comment from #1670.
- Two new tests so this can never quietly break again:
  - a camera path file with Windows line endings and a Notepad-style BOM still loads,
  - a freshly saved file contains no Windows line endings.

### Risk

Very low. The file content is unchanged on Linux and macOS; on Windows the saved file simply stops getting rewritten. All 11 sequencer regression tests pass.