### PR TITLE
Add built-in phase timing to the performance bench

### DIFF
--- a/src/training/include/lfs/training/perf_bench.hpp
+++ b/src/training/include/lfs/training/perf_bench.hpp
@@ -11,13 +11,21 @@
  * Collects per-iteration wall time, real device allocs (alloc_counter), peak
  * CUDA VRAM, last loss, and the training-state ledger. Writes a JSON report
  * at finalize().
+ *
+ * When enabled, also samples paired host-clock + cudaEvent stamps at the
+ * train-step phase boundaries (every 25th steady-state iteration, plus the
+ * following iteration so inter_step can be measured). Events are recorded
+ * without synchronizing; elapsed times are read only at finalize().
  */
 
 #include "diagnostics/vram_profiler.hpp"
 
+#include <cuda_runtime_api.h>
+
 #include <cstdint>
 #include <filesystem>
 #include <string>
+#include <vector>
 
 namespace lfs::training {
 
@@ -39,6 +47,16 @@ namespace lfs::training {
 
     class PerfBenchCollector {
     public:
+        enum class PhaseBoundary : int {
+            StepBegin = 0,
+            FwdBegin,
+            LossBegin,
+            BwdBegin,
+            OptBegin,
+            StepEnd,
+            Count
+        };
+
         static PerfBenchCollector& instance();
 
         /// Configure from CLI (`--perf-bench` / `--perf-bench-warmup=N`). Call before training.
@@ -48,6 +66,17 @@ namespace lfs::training {
 
         /// Warmup length for steady-state metrics (default 200).
         [[nodiscard]] static int warmup_iters();
+
+        /// Training stream used for phase cudaEventRecord (lfs.train).
+        void set_timing_stream(cudaStream_t stream);
+
+        /// One integer compare when disabled or this iter is not sampled.
+        static void phase_mark(PhaseBoundary b, int iter) {
+            if (iter != phase_active_iter_) {
+                return;
+            }
+            instance().record_phase_mark(b);
+        }
 
         void on_training_start(int total_iters);
         void on_step_begin(int iter);
@@ -87,9 +116,38 @@ namespace lfs::training {
         [[nodiscard]] diagnostics::PeakExCacheLedger peak_ex_cache_ledger() const;
 
     private:
+        static constexpr int kPhaseSampleStride = 25;
+        static constexpr int kPhaseSampleCap = 400;
+        static constexpr int kPhaseBoundaryCount = static_cast<int>(PhaseBoundary::Count);
+
+        struct PhaseSample {
+            int iter = 0;
+            std::uint32_t seen_mask = 0;
+            std::int64_t host_ns[kPhaseBoundaryCount]{};
+        };
+
         PerfBenchCollector() = default;
+        ~PerfBenchCollector();
+        PerfBenchCollector(const PerfBenchCollector&) = delete;
+        PerfBenchCollector& operator=(const PerfBenchCollector&) = delete;
+        PerfBenchCollector(PerfBenchCollector&&) = delete;
+        PerfBenchCollector& operator=(PerfBenchCollector&&) = delete;
 
         void capture_peak_snapshot(int iter, std::size_t used, std::size_t total);
+        void record_phase_mark(PhaseBoundary b);
+        [[nodiscard]] bool ensure_phase_event_pool();
+        void destroy_phase_event_pool();
+        void reset_phase_session();
+
+        static inline int phase_active_iter_ = 0;
+
+        cudaStream_t timing_stream_ = nullptr;
+        bool phase_pool_ready_ = false;
+        int phase_sample_count_ = 0;
+        int phase_current_index_ = -1;
+        int phase_last_primary_iter_ = 0;
+        std::vector<PhaseSample> phase_samples_;
+        std::vector<cudaEvent_t> phase_events_;
 
         bool started_ = false;
         int total_iters_ = 0;

--- a/src/training/perf_bench.cpp
+++ b/src/training/perf_bench.cpp
@@ -12,6 +12,7 @@
 #include <cuda_runtime.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <fstream>
@@ -93,6 +94,44 @@ namespace lfs::training {
             std::size_t grow_required_bytes = 0;
         };
 
+        struct PhaseStats {
+            double wall_ms = 0.0;
+            double gpu_span_ms = 0.0;
+            double bubble_ms = 0.0;
+            double wall_p90_ms = 0.0;
+        };
+
+        [[nodiscard]] double mean_or_zero(const std::vector<double>& values) {
+            if (values.empty()) {
+                return 0.0;
+            }
+            double sum = 0.0;
+            for (const double v : values) {
+                sum += v;
+            }
+            return sum / static_cast<double>(values.size());
+        }
+
+        [[nodiscard]] double p90_or_zero(std::vector<double> values) {
+            if (values.empty()) {
+                return 0.0;
+            }
+            std::sort(values.begin(), values.end());
+            const std::size_t idx = static_cast<std::size_t>(
+                0.9 * static_cast<double>(values.size() - 1));
+            return values[idx];
+        }
+
+        [[nodiscard]] PhaseStats summarize_phase(const std::vector<double>& wall,
+                                                 const std::vector<double>& gpu) {
+            PhaseStats stats;
+            stats.wall_ms = mean_or_zero(wall);
+            stats.gpu_span_ms = mean_or_zero(gpu);
+            stats.bubble_ms = std::max(0.0, stats.wall_ms - stats.gpu_span_ms);
+            stats.wall_p90_ms = p90_or_zero(wall);
+            return stats;
+        }
+
         [[nodiscard]] MrnfTransientPeaks mrnf_transient_peaks(
             const diagnostics::VramProfilerSnapshot& snapshot) {
             MrnfTransientPeaks peaks;
@@ -151,8 +190,80 @@ namespace lfs::training {
         return collector;
     }
 
+    PerfBenchCollector::~PerfBenchCollector() {
+        destroy_phase_event_pool();
+    }
+
+    void PerfBenchCollector::set_timing_stream(const cudaStream_t stream) {
+        timing_stream_ = stream;
+    }
+
+    void PerfBenchCollector::destroy_phase_event_pool() {
+        for (auto& ev : phase_events_) {
+            if (ev) {
+                (void)cudaEventDestroy(ev);
+                ev = nullptr;
+            }
+        }
+        phase_events_.clear();
+        phase_pool_ready_ = false;
+    }
+
+    bool PerfBenchCollector::ensure_phase_event_pool() {
+        if (phase_pool_ready_) {
+            return true;
+        }
+        const std::size_t n =
+            static_cast<std::size_t>(kPhaseSampleCap) *
+            static_cast<std::size_t>(kPhaseBoundaryCount);
+        phase_events_.assign(n, nullptr);
+        phase_samples_.assign(static_cast<std::size_t>(kPhaseSampleCap), PhaseSample{});
+        for (std::size_t i = 0; i < n; ++i) {
+            if (cudaEventCreateWithFlags(&phase_events_[i], cudaEventDefault) != cudaSuccess) {
+                (void)cudaGetLastError();
+                destroy_phase_event_pool();
+                LOG_WARN("PerfBench: failed to allocate phase event pool; phase timings disabled");
+                return false;
+            }
+        }
+        phase_pool_ready_ = true;
+        return true;
+    }
+
+    void PerfBenchCollector::reset_phase_session() {
+        phase_active_iter_ = 0;
+        phase_sample_count_ = 0;
+        phase_current_index_ = -1;
+        phase_last_primary_iter_ = 0;
+    }
+
+    void PerfBenchCollector::record_phase_mark(const PhaseBoundary b) {
+        if (phase_current_index_ < 0 || !phase_pool_ready_ ||
+            phase_current_index_ >= phase_sample_count_) {
+            return;
+        }
+        const int bi = static_cast<int>(b);
+        if (bi < 0 || bi >= kPhaseBoundaryCount) {
+            return;
+        }
+        auto& sample = phase_samples_[static_cast<std::size_t>(phase_current_index_)];
+        sample.host_ns[bi] = now_ns();
+        const std::size_t ev_idx =
+            static_cast<std::size_t>(phase_current_index_) *
+                static_cast<std::size_t>(kPhaseBoundaryCount) +
+            static_cast<std::size_t>(bi);
+        if (cudaEventRecord(phase_events_[ev_idx], timing_stream_) != cudaSuccess) {
+            (void)cudaGetLastError();
+            return;
+        }
+        sample.seen_mask |= (1u << bi);
+    }
+
     void PerfBenchCollector::configure(const bool enable, const int warmup) {
         g_perf_bench_enabled.store(enable, std::memory_order_relaxed);
+        if (!enable) {
+            phase_active_iter_ = 0;
+        }
         if (warmup > 0) {
             g_perf_bench_warmup.store(warmup, std::memory_order_relaxed);
         }
@@ -244,17 +355,50 @@ namespace lfs::training {
         train_end_ns_ = train_start_ns_;
         lfs::core::alloc_counter::reset_site_counts();
 
+        reset_phase_session();
+        // Allocate the event pool before any sampled step so creation cost is
+        // not charged to the first phase sample.
+        (void)ensure_phase_event_pool();
+
         // Ensure the VRAM profiler is on so the ledger is published each step.
         lfs::diagnostics::VramProfiler::instance().setEnabled(true);
-        LOG_INFO("PerfBench: enabled (warmup={} iters, total={})", warmup_, total_iters_);
+        LOG_INFO("PerfBench: enabled (warmup={} iters, total={}, phase stride={} cap={})",
+                 warmup_, total_iters_, kPhaseSampleStride, kPhaseSampleCap);
     }
 
-    void PerfBenchCollector::on_step_begin(const int /*iter*/) {
+    void PerfBenchCollector::on_step_begin(const int iter) {
         if (!started_) {
             return;
         }
         step_alloc_snap_ = lfs::core::alloc_counter::snapshot();
         step_start_ns_ = now_ns();
+
+        phase_active_iter_ = 0;
+        phase_current_index_ = -1;
+        if (iter <= warmup_ || !phase_pool_ready_ ||
+            phase_sample_count_ >= kPhaseSampleCap) {
+            return;
+        }
+        const int offset = iter - warmup_;
+        if (offset <= 0) {
+            return;
+        }
+        const int rem = offset % kPhaseSampleStride;
+        const bool primary = rem == 0;
+        const bool pair = rem == 1 && phase_last_primary_iter_ == iter - 1;
+        if (!primary && !pair) {
+            return;
+        }
+
+        auto& sample = phase_samples_[static_cast<std::size_t>(phase_sample_count_)];
+        sample = PhaseSample{};
+        sample.iter = iter;
+        phase_current_index_ = phase_sample_count_;
+        ++phase_sample_count_;
+        if (primary) {
+            phase_last_primary_iter_ = iter;
+        }
+        phase_active_iter_ = iter;
     }
 
     void PerfBenchCollector::capture_peak_snapshot(const int iter,
@@ -626,6 +770,101 @@ namespace lfs::training {
         const double signed_residual_mib =
             static_cast<double>(peak_ledger.signed_residual_bytes) / (1024.0 * 1024.0);
 
+        constexpr int kDerivedPhaseCount = 6;
+        constexpr const char* kDerivedPhaseNames[kDerivedPhaseCount] = {
+            "pre_fwd", "forward", "loss", "backward", "optimizer", "inter_step"};
+        const std::uint32_t kAllBoundaries =
+            (1u << static_cast<unsigned>(kPhaseBoundaryCount)) - 1u;
+        std::array<std::vector<double>, kDerivedPhaseCount> phase_wall{};
+        std::array<std::vector<double>, kDerivedPhaseCount> phase_gpu{};
+        int phase_valid = 0;
+
+        if (phase_pool_ready_ && phase_sample_count_ > 0) {
+            // Bench-end only: the training loop has finished; make events readable.
+            if (timing_stream_ != nullptr) {
+                if (cudaStreamSynchronize(timing_stream_) != cudaSuccess) {
+                    (void)cudaGetLastError();
+                }
+            }
+
+            const auto event_at = [this](const int sample, const int boundary) -> cudaEvent_t {
+                return phase_events_[static_cast<std::size_t>(sample) *
+                                         static_cast<std::size_t>(kPhaseBoundaryCount) +
+                                     static_cast<std::size_t>(boundary)];
+            };
+
+            std::vector<char> sample_ok(static_cast<std::size_t>(phase_sample_count_), 0);
+            for (int i = 0; i < phase_sample_count_; ++i) {
+                const auto& sample = phase_samples_[static_cast<std::size_t>(i)];
+                if (sample.seen_mask != kAllBoundaries) {
+                    continue;
+                }
+                bool ok = true;
+                double wall[5];
+                double gpu[5];
+                for (int p = 0; p < 5; ++p) {
+                    const int a = p;
+                    const int b = p + 1;
+                    wall[p] = static_cast<double>(sample.host_ns[b] - sample.host_ns[a]) / 1.0e6;
+                    if (wall[p] < 0.0) {
+                        ok = false;
+                        break;
+                    }
+                    float elapsed_ms = 0.0f;
+                    if (cudaEventElapsedTime(&elapsed_ms, event_at(i, a), event_at(i, b)) !=
+                        cudaSuccess) {
+                        (void)cudaGetLastError();
+                        ok = false;
+                        break;
+                    }
+                    gpu[p] = static_cast<double>(elapsed_ms);
+                }
+                if (!ok) {
+                    continue;
+                }
+                sample_ok[static_cast<std::size_t>(i)] = 1;
+                ++phase_valid;
+                for (int p = 0; p < 5; ++p) {
+                    phase_wall[static_cast<std::size_t>(p)].push_back(wall[p]);
+                    phase_gpu[static_cast<std::size_t>(p)].push_back(gpu[p]);
+                }
+            }
+
+            for (int i = 0; i + 1 < phase_sample_count_; ++i) {
+                if (!sample_ok[static_cast<std::size_t>(i)] ||
+                    !sample_ok[static_cast<std::size_t>(i + 1)]) {
+                    continue;
+                }
+                const auto& a = phase_samples_[static_cast<std::size_t>(i)];
+                const auto& b = phase_samples_[static_cast<std::size_t>(i + 1)];
+                if (b.iter != a.iter + 1) {
+                    continue;
+                }
+                const int end_b = static_cast<int>(PhaseBoundary::StepEnd);
+                const int begin_b = static_cast<int>(PhaseBoundary::StepBegin);
+                const double wall =
+                    static_cast<double>(b.host_ns[begin_b] - a.host_ns[end_b]) / 1.0e6;
+                float elapsed_ms = 0.0f;
+                if (cudaEventElapsedTime(&elapsed_ms, event_at(i, end_b),
+                                         event_at(i + 1, begin_b)) != cudaSuccess) {
+                    (void)cudaGetLastError();
+                    continue;
+                }
+                phase_wall[5].push_back(wall);
+                phase_gpu[5].push_back(static_cast<double>(elapsed_ms));
+            }
+        }
+
+        std::array<PhaseStats, kDerivedPhaseCount> phase_stats{};
+        for (int p = 0; p < kDerivedPhaseCount; ++p) {
+            phase_stats[static_cast<std::size_t>(p)] =
+                summarize_phase(phase_wall[static_cast<std::size_t>(p)],
+                                phase_gpu[static_cast<std::size_t>(p)]);
+        }
+
+        phase_active_iter_ = 0;
+        phase_current_index_ = -1;
+
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);
 
@@ -865,7 +1104,19 @@ namespace lfs::training {
             out << (i + 1 < peak_ledger.peak_rows.size() ? ",\n" : "\n");
         }
         out << "    ]\n";
-        out << "  }\n";
+        out << "  },\n";
+        out << "  \"phases\": {\n";
+        for (int p = 0; p < kDerivedPhaseCount; ++p) {
+            const auto& s = phase_stats[static_cast<std::size_t>(p)];
+            out << "    \"" << kDerivedPhaseNames[p] << "\": {"
+                << "\"wall_ms\": " << s.wall_ms
+                << ", \"gpu_span_ms\": " << s.gpu_span_ms
+                << ", \"bubble_ms\": " << s.bubble_ms
+                << ", \"wall_p90_ms\": " << s.wall_p90_ms << "}";
+            out << (p + 1 < kDerivedPhaseCount ? ",\n" : "\n");
+        }
+        out << "  },\n";
+        out << "  \"phase_samples\": " << phase_valid << "\n";
         out << "}\n";
         out.close();
 
@@ -887,6 +1138,20 @@ namespace lfs::training {
                  static_cast<double>(peak_ledger.fastgs_sort_allocated_bytes) /
                      (1024.0 * 1024.0),
                  ledger_.bytes_per_splat);
+
+        std::ostringstream phase_line;
+        phase_line << std::fixed << std::setprecision(2);
+        phase_line << "PerfBench phases (n=" << phase_valid << "):";
+        for (int p = 0; p < kDerivedPhaseCount; ++p) {
+            const auto& s = phase_stats[static_cast<std::size_t>(p)];
+            phase_line << ' ' << kDerivedPhaseNames[p] << " wall=" << s.wall_ms
+                       << " gpu=" << s.gpu_span_ms << " bubble=" << s.bubble_ms
+                       << " p90=" << s.wall_p90_ms;
+            if (p + 1 < kDerivedPhaseCount) {
+                phase_line << " |";
+            }
+        }
+        LOG_INFO("{}", phase_line.str());
     }
 
 } // namespace lfs::training

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -2029,6 +2029,7 @@ namespace lfs::training {
             nvtxNameCudaStreamA(callback_stream_, "lfs.train.callback");
             nvtxNameCudaStreamA(metrics_stream_, "lfs.metrics");
             createSyncPrimitives();
+            PerfBenchCollector::instance().set_timing_stream(training_stream_);
         } catch (...) {
             // A C++ destructor is not invoked when its constructor throws.
             // Roll back every member handle published by this transaction.
@@ -5482,6 +5483,7 @@ namespace lfs::training {
                 if (PerfBenchCollector::enabled()) {
                     PerfBenchCollector::instance().on_step_begin(iter);
                 }
+                PerfBenchCollector::phase_mark(PerfBenchCollector::PhaseBoundary::StepBegin, iter);
                 if (live_vram_profiler_enabled()) {
                     auto& profiler = lfs::diagnostics::VramProfiler::instance();
                     profiler.beginIteration(iter);
@@ -5902,6 +5904,7 @@ namespace lfs::training {
 
                     // Render the tile
                     nvtxRangePush("rasterize_forward");
+                    PerfBenchCollector::phase_mark(PerfBenchCollector::PhaseBoundary::FwdBegin, iter);
 
                     // Storage for render output (used by both paths)
                     RenderOutput output;
@@ -6117,6 +6120,7 @@ namespace lfs::training {
 
                         // Photometric loss
                         nvtxRangePush("compute_photometric_loss");
+                        PerfBenchCollector::phase_mark(PerfBenchCollector::PhaseBoundary::LossBegin, iter);
                         lfs::core::Tensor tile_loss;
                         lfs::core::Tensor tile_grad;
 
@@ -6253,6 +6257,7 @@ namespace lfs::training {
                         }
 
                         nvtxRangePush("compute_photometric_loss");
+                        PerfBenchCollector::phase_mark(PerfBenchCollector::PhaseBoundary::LossBegin, iter);
                         lfs::core::Tensor tile_loss;
                         lfs::core::Tensor tile_grad;
                         lfs::core::Tensor tile_grad_raw;
@@ -6956,6 +6961,7 @@ namespace lfs::training {
 
                         current_phase = StepPhase::Backward;
                         nvtxRangePush("rasterize_backward");
+                        PerfBenchCollector::phase_mark(PerfBenchCollector::PhaseBoundary::BwdBegin, iter);
                         {
                             LFS_VRAM_SCOPE("train.rasterize_backward");
                             LOG_VRAM_DIFF("train.rasterize_backward");
@@ -7013,6 +7019,7 @@ namespace lfs::training {
                     current_phase = StepPhase::OptimizerCommit;
                     // Controller phase: only update controller weights
                     nvtxRangePush("controller_optimizer_step");
+                    PerfBenchCollector::phase_mark(PerfBenchCollector::PhaseBoundary::OptBegin, iter);
                     LFS_VRAM_SCOPE("train.optimizer.ppisp_controller_step");
                     LOG_VRAM_DIFF("train.optimizer.ppisp_controller_step");
                     ppisp_controller_pool_->optimizer_step(ppisp_cam_idx);
@@ -7022,6 +7029,9 @@ namespace lfs::training {
                     persistent_commit = true;
                     nvtxRangePop();
                 } else {
+                    // Default path has no controller_optimizer_step NVTX; mark the
+                    // same OptBegin boundary at the start of the optimizer region.
+                    PerfBenchCollector::phase_mark(PerfBenchCollector::PhaseBoundary::OptBegin, iter);
                     // Normal phase: regularization losses + optimizer steps for all components
 
                     if (params_.optimization.scale_reg > 0.0f) {
@@ -7480,6 +7490,7 @@ namespace lfs::training {
                                                   &strategy_->get_optimizer());
                     lfs::diagnostics::VramProfiler::instance().sampleCudaMemory();
                 }
+                PerfBenchCollector::phase_mark(PerfBenchCollector::PhaseBoundary::StepEnd, iter);
                 if (PerfBenchCollector::enabled() && strategy_) {
                     auto& bench = PerfBenchCollector::instance();
                     const auto ledger = compute_training_state_ledger(


### PR DESCRIPTION
Until now, finding out where a training iteration spends its time required external profiling tools that slow the app down so much they distort the answer.

The performance bench can now measure this itself: it periodically samples an iteration and records how long each phase takes on the CPU and on the GPU, with no measurable overhead and no effect on training output. The results land in the bench's JSON report and the log.

First insight from the new data: the remaining idle time at small scene sizes comes from the pipeline running only one step ahead — the groundwork for the next optimization.