### PR TITLE
Align Input Settings rebind rows

### DIFF
--- a/src/visualizer/gui/rmlui/resources/input_settings.rcss
+++ b/src/visualizer/gui/rmlui/resources/input_settings.rcss
@@ -55,6 +55,7 @@
 .is-binding-row {
     display: flex;
     align-items: center;
+    gap: 8dp;
     padding: 2dp 4dp;
     min-height: 22dp;
 }
@@ -64,6 +65,13 @@
     font-size: 12dp;
     flex-shrink: 0;
 }
+
+.is-binding-desc {
+    flex: 1;
+    min-width: 0;
+    font-size: 12dp;
+}
+
 .is-rebind-btn {
     flex-shrink: 0;
     min-width: 60dp;


### PR DESCRIPTION
Gives the Input Settings binding rows a clean three-column layout: the action name, the key combination and the Rebind button are now consistently spaced, and the button stays pinned to the right column across all rows instead of sitting flush against each description.