### PR TITLE
 Add ALT-G Grid Visibility Shortcut

### DIFF
--- a/src/python/lfs/py_keymap.cpp
+++ b/src/python/lfs/py_keymap.cpp
@@ -181,7 +181,8 @@ namespace lfs::python {
             .value("TOGGLE_CAMERA_FRUSTUMS", Action::TOGGLE_CAMERA_FRUSTUMS)
             .value("OPEN_PREFERENCES", Action::OPEN_PREFERENCES)
             .value("TOGGLE_MCP_SERVER", Action::TOGGLE_MCP_SERVER)
-            .value("TOGGLE_MCP_BINDING", Action::TOGGLE_MCP_BINDING);
+            .value("TOGGLE_MCP_BINDING", Action::TOGGLE_MCP_BINDING)
+            .value("TOGGLE_GRID", Action::TOGGLE_GRID);
 
         // Expose ToolMode enum
         nb::enum_<ToolMode>(keymap, "ToolMode")

--- a/src/python/lfs_plugins/input_settings_panel.py
+++ b/src/python/lfs_plugins/input_settings_panel.py
@@ -105,6 +105,7 @@ class InputSettingsPanel(Panel):
             lf.keymap.Action.TOGGLE_INDEPENDENT_SPLIT_VIEW,
             lf.keymap.Action.TOGGLE_GT_COMPARISON,
             lf.keymap.Action.TOGGLE_CAMERA_FRUSTUMS,
+            lf.keymap.Action.TOGGLE_GRID,
             lf.keymap.Action.CYCLE_PLY,
             lf.keymap.Action.CYCLE_SELECTION_VIS,
         ],

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -287,6 +287,9 @@ def project_recent_files() -> list[str]:
 def project_clear_recent_files() -> None:
     """Clear the most-recently-used .licht project list"""
 
+def project_remove_recent_file(path: str) -> None:
+    """Remove one path from the most-recently-used .licht project list"""
+
 def project_autosave_recovery_disposition(path: str) -> str:
     """
     Return autosave recovery disposition for a .licht master path ("none", "offer", "stale_deleted", "invalid", "ambiguous", "busy", "unavailable")

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -287,9 +287,6 @@ def project_recent_files() -> list[str]:
 def project_clear_recent_files() -> None:
     """Clear the most-recently-used .licht project list"""
 
-def project_remove_recent_file(path: str) -> None:
-    """Remove one path from the most-recently-used .licht project list"""
-
 def project_autosave_recovery_disposition(path: str) -> str:
     """
     Return autosave recovery disposition for a .licht master path ("none", "offer", "stale_deleted", "invalid", "ambiguous", "busy", "unavailable")

--- a/src/python/stubs/lichtfeld/keymap.pyi
+++ b/src/python/stubs/lichtfeld/keymap.pyi
@@ -163,6 +163,8 @@ class Action(enum.Enum):
 
     TOGGLE_MCP_BINDING = 80
 
+    TOGGLE_GRID = 81
+
 class ToolMode(enum.Enum):
     GLOBAL = 0
 

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1369,6 +1369,7 @@
     "action.toggle_independent_split_view": "Unabhängige geteilte Ansicht umschalten",
     "action.toggle_gt_comparison": "GT-Vergleich umschalten",
     "action.toggle_camera_frustums": "Kamera-Frustums umschalten",
+    "action.toggle_grid": "Gitter umschalten",
     "action.toggle_depth_mode": "Tiefenbox umschalten",
     "action.cycle_ply": "PLY durchschalten",
     "action.delete_selected": "Ausgewählte Gaussians löschen",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1369,6 +1369,7 @@
     "action.toggle_independent_split_view": "Toggle Independent Split View",
     "action.toggle_gt_comparison": "Toggle GT Comparison",
     "action.toggle_camera_frustums": "Toggle Camera Frustums",
+    "action.toggle_grid": "Toggle Grid",
     "action.toggle_depth_mode": "Toggle Depth Box",
     "action.cycle_ply": "Cycle PLY",
     "action.delete_selected": "Delete Selected Gaussians",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -1369,6 +1369,7 @@
     "action.toggle_independent_split_view": "Alternar vista dividida independiente",
     "action.toggle_gt_comparison": "Alternar comparación GT",
     "action.toggle_camera_frustums": "Alternar frustos de cámara",
+    "action.toggle_grid": "Alternar cuadrícula",
     "action.toggle_depth_mode": "Alternar caja de profundidad",
     "action.cycle_ply": "Recorrer PLY",
     "action.delete_selected": "Eliminar gaussianas seleccionadas",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1369,6 +1369,7 @@
     "action.toggle_independent_split_view": "Basculer la vue divisée indépendante",
     "action.toggle_gt_comparison": "Basculer la comparaison GT",
     "action.toggle_camera_frustums": "Afficher/masquer les frustums de caméra",
+    "action.toggle_grid": "Afficher/masquer la grille",
     "action.toggle_depth_mode": "Basculer la boîte de profondeur",
     "action.cycle_ply": "Parcourir les PLY",
     "action.delete_selected": "Supprimer les gaussiennes sélectionnées",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1369,6 +1369,7 @@
     "action.toggle_independent_split_view": "Attiva vista divisa indipendente",
     "action.toggle_gt_comparison": "Attiva confronto GT",
     "action.toggle_camera_frustums": "Attiva/disattiva frustum fotocamera",
+    "action.toggle_grid": "Attiva/disattiva griglia",
     "action.toggle_depth_mode": "Attiva box di profondità",
     "action.cycle_ply": "Scorri PLY",
     "action.delete_selected": "Elimina gaussiane selezionate",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1369,6 +1369,7 @@
     "action.toggle_independent_split_view": "独立分割ビュー切替",
     "action.toggle_gt_comparison": "GT比較切替",
     "action.toggle_camera_frustums": "カメラ視錐台を切り替え",
+    "action.toggle_grid": "グリッドを切り替え",
     "action.toggle_depth_mode": "深度ボックス切替",
     "action.cycle_ply": "PLY切替",
     "action.delete_selected": "選択したガウシアンを削除",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1369,6 +1369,7 @@
     "action.toggle_independent_split_view": "독립 분할 보기 전환",
     "action.toggle_gt_comparison": "GT 비교 전환",
     "action.toggle_camera_frustums": "카메라 절두체 전환",
+    "action.toggle_grid": "그리드 전환",
     "action.toggle_depth_mode": "깊이 상자 전환",
     "action.cycle_ply": "PLY 순환",
     "action.delete_selected": "선택한 가우시안 삭제",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1369,6 +1369,7 @@
     "action.toggle_independent_split_view": "Onafhankelijke gesplitste weergave omschakelen",
     "action.toggle_gt_comparison": "GT-vergelijking omschakelen",
     "action.toggle_camera_frustums": "Camerafrustums in-/uitschakelen",
+    "action.toggle_grid": "Raster in-/uitschakelen",
     "action.toggle_depth_mode": "Diepteboog omschakelen",
     "action.cycle_ply": "PLY doorlopen",
     "action.delete_selected": "Geselecteerde gaussians verwijderen",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1369,6 +1369,7 @@
     "action.toggle_independent_split_view": "Przełącz niezależny widok podzielony",
     "action.toggle_gt_comparison": "Przełącz porównanie GT",
     "action.toggle_camera_frustums": "Przełącz ostrosłupy kamery",
+    "action.toggle_grid": "Przełącz siatkę",
     "action.toggle_depth_mode": "Przełącz pudełko głębi",
     "action.cycle_ply": "Przełączaj PLY",
     "action.delete_selected": "Usuń wybrane gaussiany",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -1369,6 +1369,7 @@
     "action.toggle_independent_split_view": "切换独立分屏视图",
     "action.toggle_gt_comparison": "切换 GT 对比",
     "action.toggle_camera_frustums": "切换相机视锥体",
+    "action.toggle_grid": "切换网格",
     "action.toggle_depth_mode": "切换深度框",
     "action.cycle_ply": "循环 PLY",
     "action.delete_selected": "删除选中的高斯",

--- a/src/visualizer/input/input_bindings.cpp
+++ b/src/visualizer/input/input_bindings.cpp
@@ -23,8 +23,8 @@ namespace lfs::vis::input {
 
         std::atomic<bool> g_persistence_enabled{true};
 
-        constexpr int PROFILE_VERSION = 22; // Version 22 adds MCP runtime shortcuts.
-        constexpr Action LAST_ACTION = Action::TOGGLE_MCP_BINDING;
+        constexpr int PROFILE_VERSION = 23; // Version 23 adds the grid visibility shortcut.
+        constexpr Action LAST_ACTION = Action::TOGGLE_GRID;
         constexpr int REMOVED_TOOL_MODE_2 = 2;
         constexpr int REMOVED_ACTION_39 = 39;
         constexpr int REMOVED_ACTION_66 = 66;
@@ -516,7 +516,8 @@ namespace lfs::vis::input {
                 (version < 20 && def.action == Action::TOGGLE_PERFORMANCE_HUD) ||
                 (version < 21 && def.action == Action::OPEN_PREFERENCES) ||
                 (version < 22 && def.action == Action::TOGGLE_MCP_SERVER) ||
-                (version < 22 && def.action == Action::TOGGLE_MCP_BINDING);
+                (version < 22 && def.action == Action::TOGGLE_MCP_BINDING) ||
+                (version < 23 && def.action == Action::TOGGLE_GRID);
             if (!should_add) {
                 continue;
             }
@@ -998,6 +999,7 @@ namespace lfs::vis::input {
             {KeyTrigger{KEY_V, MODIFIER_SHIFT}, Action::TOGGLE_INDEPENDENT_SPLIT_VIEW, "Independent split"},
             {KeyTrigger{KEY_G, MODIFIER_NONE}, Action::TOGGLE_GT_COMPARISON, "GT comparison"},
             {KeyTrigger{KEY_C, MODIFIER_ALT}, Action::TOGGLE_CAMERA_FRUSTUMS, "Camera frustums"},
+            {KeyTrigger{KEY_G, MODIFIER_ALT}, Action::TOGGLE_GRID, "Grid"},
             {KeyTrigger{KEY_T, MODIFIER_NONE}, Action::CYCLE_PLY, "Cycle PLY"},
             // Editing (Delete is mode-specific, added below)
             {KeyTrigger{KEY_Z, MODIFIER_CTRL}, Action::UNDO, "Undo"},
@@ -1192,6 +1194,7 @@ namespace lfs::vis::input {
         case Action::OPEN_PREFERENCES: return "Open Preferences";
         case Action::TOGGLE_MCP_SERVER: return "Toggle MCP Server";
         case Action::TOGGLE_MCP_BINDING: return "Toggle MCP Local/Network Binding";
+        case Action::TOGGLE_GRID: return "Toggle Grid";
         default: return "Unknown";
         }
     }
@@ -1277,6 +1280,7 @@ namespace lfs::vis::input {
         case Action::OPEN_PREFERENCES: return "open_preferences";
         case Action::TOGGLE_MCP_SERVER: return "toggle_mcp_server";
         case Action::TOGGLE_MCP_BINDING: return "toggle_mcp_binding";
+        case Action::TOGGLE_GRID: return "toggle_grid";
         default: return {};
         }
     }
@@ -1895,6 +1899,7 @@ namespace lfs::vis::input {
         case Action::TOGGLE_INDEPENDENT_SPLIT_VIEW:
         case Action::TOGGLE_GT_COMPARISON:
         case Action::TOGGLE_CAMERA_FRUSTUMS:
+        case Action::TOGGLE_GRID:
         case Action::CYCLE_PLY:
         case Action::CYCLE_SELECTION_VIS:
             return d_view_global_key;
@@ -2023,6 +2028,7 @@ namespace lfs::vis::input {
         case Action::TOGGLE_INDEPENDENT_SPLIT_VIEW:
         case Action::TOGGLE_GT_COMPARISON:
         case Action::TOGGLE_CAMERA_FRUSTUMS:
+        case Action::TOGGLE_GRID:
         case Action::CYCLE_SELECTION_VIS:
             return ShortcutScope::GlobalWhenNotTextEditing;
 

--- a/src/visualizer/input/input_bindings.hpp
+++ b/src/visualizer/input/input_bindings.hpp
@@ -135,6 +135,7 @@ namespace lfs::vis::input {
         OPEN_PREFERENCES,
         TOGGLE_MCP_SERVER,
         TOGGLE_MCP_BINDING,
+        TOGGLE_GRID,
 
     };
 

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -1727,6 +1727,14 @@ namespace lfs::vis {
                 }
                 return;
 
+            case input::Action::TOGGLE_GRID:
+                if (auto* rendering_manager = services().renderingOrNull()) {
+                    auto settings = rendering_manager->getSettings();
+                    settings.show_grid = !settings.show_grid;
+                    rendering_manager->updateSettings(settings);
+                }
+                return;
+
             case input::Action::CAMERA_NEXT_VIEW:
             case input::Action::CAMERA_PREV_VIEW: {
                 const auto* trainer = services().trainerOrNull();

--- a/tests/python/test_input_settings_panel.py
+++ b/tests/python/test_input_settings_panel.py
@@ -101,6 +101,7 @@ ACTION_NAMES = (
     "OPEN_PREFERENCES",
     "TOGGLE_MCP_SERVER",
     "TOGGLE_MCP_BINDING",
+    "TOGGLE_GRID",
 )
 
 
@@ -530,6 +531,7 @@ def test_input_settings_global_mode_exposes_system_sections(input_settings_modul
     assert str(module.lf.keymap.Action.OPEN_PREFERENCES.value) in action_ids
     assert str(module.lf.keymap.Action.HISTOGRAM_ZOOM_MARKED.value) in action_ids
     assert str(module.lf.keymap.Action.TOGGLE_CAMERA_FRUSTUMS.value) in action_ids
+    assert str(module.lf.keymap.Action.TOGGLE_GRID.value) in action_ids
     assert str(module.lf.keymap.Action.SEQUENCER_PLAY_PAUSE.value) in action_ids
     assert str(module.lf.keymap.Action.TOGGLE_MCP_SERVER.value) in action_ids
     assert str(module.lf.keymap.Action.TOGGLE_MCP_BINDING.value) in action_ids

--- a/tests/test_input_controller_focus.cpp
+++ b/tests/test_input_controller_focus.cpp
@@ -1148,6 +1148,7 @@ namespace lfs::vis {
 
         EXPECT_EQ(static_cast<int>(input::Action::TOGGLE_MCP_SERVER), 79);
         EXPECT_EQ(static_cast<int>(input::Action::TOGGLE_MCP_BINDING), 80);
+        EXPECT_EQ(static_cast<int>(input::Action::TOGGLE_GRID), 81);
         EXPECT_EQ(bindings.getActionForKey(input::ToolMode::GLOBAL,
                                            input::KEY_M,
                                            input::MODIFIER_CTRL | input::MODIFIER_SHIFT),
@@ -1279,6 +1280,31 @@ namespace lfs::vis {
         EXPECT_FALSE(rendering_manager.getSettings().show_camera_frustums);
     }
 
+    TEST_F(InputControllerFocusTest, GridDefaultToAltGAndToggleRenderSetting) {
+        RenderingManager rendering_manager;
+        services().set(&rendering_manager);
+
+        Viewport viewport(200, 200);
+        InputController controller(nullptr, viewport);
+        input::InputRouter router;
+        router.setInputController(&controller);
+        controller.setInputRouter(&router);
+        router.focusViewportKeyboard();
+
+        EXPECT_EQ(controller.getBindings().getActionForKey(input::ToolMode::GLOBAL,
+                                                           input::KEY_G,
+                                                           input::MODIFIER_ALT),
+                  input::Action::TOGGLE_GRID);
+        EXPECT_EQ(input::shortcutScopeForAction(input::Action::TOGGLE_GRID),
+                  input::ShortcutScope::GlobalWhenNotTextEditing);
+
+        EXPECT_TRUE(rendering_manager.getSettings().show_grid);
+        controller.handleKey(input::KEY_G, input::ACTION_PRESS, input::KEYMOD_ALT);
+        EXPECT_FALSE(rendering_manager.getSettings().show_grid);
+        controller.handleKey(input::KEY_G, input::ACTION_PRESS, input::KEYMOD_ALT);
+        EXPECT_TRUE(rendering_manager.getSettings().show_grid);
+    }
+
     TEST_F(InputControllerFocusTest, VersionFifteenProfileMigratesCameraFrustumShortcutWhenFree) {
         const auto profile_path = std::filesystem::temp_directory_path() / "lfs_input_bindings_legacy_v15.json";
         std::filesystem::remove(profile_path);
@@ -1331,6 +1357,64 @@ namespace lfs::vis {
                                          input::MODIFIER_ALT),
                   input::Action::CYCLE_PLY);
         EXPECT_FALSE(loaded.getTriggerForAction(input::Action::TOGGLE_CAMERA_FRUSTUMS,
+                                                input::ToolMode::GLOBAL)
+                         .has_value());
+
+        std::filesystem::remove(profile_path);
+    }
+
+    TEST_F(InputControllerFocusTest, VersionTwentyTwoProfileMigratesGridShortcutWhenFree) {
+        const auto profile_path = std::filesystem::temp_directory_path() / "lfs_input_bindings_legacy_v22.json";
+        std::filesystem::remove(profile_path);
+        {
+            std::ofstream file(profile_path);
+            ASSERT_TRUE(file.is_open());
+            file << R"({
+  "name": "LegacyV22",
+  "version": 22,
+  "bindings": []
+})";
+        }
+
+        input::InputBindings loaded;
+        ASSERT_TRUE(loaded.loadProfileFromFile(profile_path));
+        EXPECT_EQ(loaded.getActionForKey(input::ToolMode::GLOBAL,
+                                         input::KEY_G,
+                                         input::MODIFIER_ALT),
+                  input::Action::TOGGLE_GRID);
+
+        std::filesystem::remove(profile_path);
+    }
+
+    TEST_F(InputControllerFocusTest, VersionTwentyTwoProfilePreservesOccupiedAltG) {
+        const auto profile_path = std::filesystem::temp_directory_path() / "lfs_input_bindings_legacy_v22_alt_g.json";
+        std::filesystem::remove(profile_path);
+        {
+            std::ofstream file(profile_path);
+            ASSERT_TRUE(file.is_open());
+            file << R"({
+  "name": "LegacyV22AltG",
+  "version": 22,
+  "bindings": [
+    {
+      "mode": 0,
+      "action": 25,
+      "description": "Cycle PLY",
+      "trigger_type": "key",
+      "key": 71,
+      "modifiers": 4
+    }
+  ]
+})";
+        }
+
+        input::InputBindings loaded;
+        ASSERT_TRUE(loaded.loadProfileFromFile(profile_path));
+        EXPECT_EQ(loaded.getActionForKey(input::ToolMode::GLOBAL,
+                                         input::KEY_G,
+                                         input::MODIFIER_ALT),
+                  input::Action::CYCLE_PLY);
+        EXPECT_FALSE(loaded.getTriggerForAction(input::Action::TOGGLE_GRID,
                                                 input::ToolMode::GLOBAL)
                          .has_value());
 


### PR DESCRIPTION
## Overview

This is a quality of life feature. When using LFS, frequently hide all UI elements like cameras and grid.  Camera's already have ATL-C for toggling their visibility, but for the grid, I have to manually go into the render panel and find the checkbox for hiding the grid.  This patch adds a "toggle grid" shortcut to make hiding/showing the grid easier.

## Summary

This patch adds a rebindable `TOGGLE_GRID` keymap action with the default shortcut `ALT-G`. The action toggles the existing `RenderingSettings::show_grid` flag through `RenderingManager::updateSettings()`, so the rendering state generation is advanced and the Rendering panel checkbox stays in sync.

## Replication Steps

1. Start LichtFeld Studio with the default keymap.
2. Press `ALT-C` and observe camera frustum visibility toggling.
3. Press `ALT-G`.
4. Before this patch, no grid visibility action was registered for `ALT-G`, so the grid did not toggle and the Input Settings panel had no grid action to rebind.

## What This Patch Fixes

- Adds `input::Action::TOGGLE_GRID` after the previous final action to preserve existing persisted action IDs.
- Bumps the keymap profile version to 23.
- Adds default `ALT-G` binding in the global view shortcuts.
- Migrates v22 profiles to `ALT-G` only when `TOGGLE_GRID` is unbound and `ALT-G` is free.
- Handles `TOGGLE_GRID` by reading the deployed `RenderingManager` settings, flipping `show_grid`, and calling `updateSettings()`.
- Exposes `lf.keymap.Action.TOGGLE_GRID` in the Python binding and stub.
- Adds the action to the Input Settings panel's global view section.
- Adds localized `action.toggle_grid` UI strings to the existing locale JSON files.

