### PR TITLE
Make stopping and saving training instant on large datasets

### DIFF
--- a/src/io/include/io/json_chapter_dom.hpp
+++ b/src/io/include/io/json_chapter_dom.hpp
@@ -135,6 +135,14 @@ namespace lfs::io {
             return read_scalar<T>(find_node_from(root_, path));
         }
 
+        template <json_chapter_detail::ReadableScalar T>
+        [[nodiscard]] static std::optional<T> read(const Json& node,
+                                                   std::string_view path) {
+            return read_scalar<T>(find_node_from(node, path));
+        }
+        [[nodiscard]] static std::optional<Json> read_json(const Json& node,
+                                                           std::string_view path);
+
         template <typename T>
             requires json_chapter_detail::WritableScalar<T>
         [[nodiscard]] lfs::Result<void> set(const std::string_view path, T&& value) {
@@ -154,6 +162,23 @@ namespace lfs::io {
         [[nodiscard]] lfs::Result<bool> array_remove(std::string_view path, std::string_view uuid);
         [[nodiscard]] lfs::Result<std::vector<std::string>>
         array_uuids(std::string_view path) const;
+
+        // One-pass enumeration of a UUID-addressed object array: each element's
+        // canonical uuid together with a copy of its JSON, in array order. Same
+        // validation and error taxonomy as array_uuids; a missing path yields an
+        // empty vector.
+        [[nodiscard]] lfs::Result<std::vector<std::pair<std::string, Json>>>
+        array_items(std::string_view path) const;
+
+        // Copy of one element's JSON, or nullopt when the array or element is absent
+        // (same resolution semantics as const array_find).
+        [[nodiscard]] std::optional<Json> array_get(std::string_view path,
+                                                    std::string_view uuid) const;
+
+        // Replace-or-insert one element. value must be an object whose "uuid" member
+        // equals uuid (canonical form); a replaced element keeps its array position.
+        [[nodiscard]] lfs::Result<void> array_put(std::string_view path,
+                                                  std::string_view uuid, Json value);
 
     private:
         explicit JsonChapterDom(Json root)

--- a/src/io/json_chapter_dom.cpp
+++ b/src/io/json_chapter_dom.cpp
@@ -181,15 +181,24 @@ namespace lfs::io {
             }
 
             Json* destination = &root;
-            for (std::size_t i = 0; i + 1 < split->values.size(); ++i) {
+            std::size_t i = 0;
+            for (; i + 1 < split->values.size(); ++i) {
                 auto found = destination->find(std::string(split->values[i]));
                 if (found == destination->end()) {
-                    (*destination)[std::string(split->values[i])] = Json::object();
-                    found = destination->find(std::string(split->values[i]));
+                    break;
                 }
                 destination = &*found;
             }
-            (*destination)[std::string(split->values.back())] = std::move(value);
+            if (i + 1 >= split->values.size()) {
+                (*destination)[std::string(split->values.back())] = std::move(value);
+                return {};
+            }
+
+            Json chain = std::move(value);
+            for (std::size_t j = split->values.size(); j-- > i + 1;) {
+                chain = Json{{std::string(split->values[j]), std::move(chain)}};
+            }
+            (*destination)[std::string(split->values[i])] = std::move(chain);
             return {};
         }
 
@@ -422,31 +431,25 @@ namespace lfs::io {
 
     lfs::Result<void> JsonChapterDom::set_value(const std::string_view path, Json value) {
         return guarded_dom_operation<void>(path, [&]() -> lfs::Result<void> {
-            Json candidate = root_;
-            auto result = set_value_at(candidate, path, std::move(value));
-            if (!result) {
-                return result;
-            }
-            root_ = std::move(candidate);
-            return {};
+            return set_value_at(root_, path, std::move(value));
         });
     }
 
     lfs::Result<bool> JsonChapterDom::remove(const std::string_view path) {
         return guarded_dom_operation<bool>(path, [&]() -> lfs::Result<bool> {
-            Json candidate = root_;
-            auto removed = remove_value_at(candidate, path);
-            if (!removed || !*removed) {
-                return removed;
-            }
-            root_ = std::move(candidate);
-            return true;
+            return remove_value_at(root_, path);
         });
     }
 
     std::optional<JsonChapterDom::Json> JsonChapterDom::get_json(
         const std::string_view path) const {
         const Json* value = find_node_from(root_, path);
+        return value == nullptr ? std::nullopt : std::optional<Json>(*value);
+    }
+
+    std::optional<JsonChapterDom::Json> JsonChapterDom::read_json(
+        const Json& node, const std::string_view path) {
+        const Json* value = find_node_from(node, path);
         return value == nullptr ? std::nullopt : std::optional<Json>(*value);
     }
 
@@ -497,25 +500,16 @@ namespace lfs::io {
                 if (find_array_element_node(root_, path, uuid) != nullptr) {
                     return Element(*this, std::string(path), std::string(uuid));
                 }
+                (*existing_array)->push_back(Json{{"uuid", std::string(uuid)}});
+                return Element(*this, std::string(path), std::string(uuid));
             }
 
-            Json candidate = root_;
-            auto candidate_array = resolve_node(candidate, path, "upsert into");
-            if (!candidate_array) {
-                return std::move(candidate_array).error();
+            Json created_array = Json::array();
+            created_array.push_back(Json{{"uuid", std::string(uuid)}});
+            auto created = set_value_at(root_, path, std::move(created_array));
+            if (!created) {
+                return std::move(created).error();
             }
-            if (*candidate_array == nullptr) {
-                auto created = set_value_at(candidate, path, Json::array());
-                if (!created) {
-                    return std::move(created).error();
-                }
-                candidate_array = resolve_node(candidate, path, "upsert into");
-                if (!candidate_array) {
-                    return std::move(candidate_array).error();
-                }
-            }
-            (*candidate_array)->push_back(Json{{"uuid", std::string(uuid)}});
-            root_ = std::move(candidate);
             return Element(*this, std::string(path), std::string(uuid));
         });
     }
@@ -546,26 +540,19 @@ namespace lfs::io {
                                 path, (*current_array)->type_name()),
                     path, uuid);
             }
-            if (find_array_element_node(root_, path, uuid) == nullptr) {
+            auto& array = **current_array;
+            const auto found = std::find_if(array.begin(), array.end(), [uuid](const Json& element) {
+                if (!element.is_object()) {
+                    return false;
+                }
+                const auto member = element.find("uuid");
+                return member != element.end() && member->is_string() &&
+                       member->get_ref<const std::string&>() == uuid;
+            });
+            if (found == array.end()) {
                 return false;
             }
-
-            Json candidate = root_;
-            auto candidate_array = resolve_node(candidate, path, "remove from");
-            if (!candidate_array) {
-                return std::move(candidate_array).error();
-            }
-            const auto found = std::find_if((*candidate_array)->begin(), (*candidate_array)->end(),
-                                            [uuid](const Json& element) {
-                                                if (!element.is_object()) {
-                                                    return false;
-                                                }
-                                                const auto member = element.find("uuid");
-                                                return member != element.end() && member->is_string() &&
-                                                       member->get_ref<const std::string&>() == uuid;
-                                            });
-            (*candidate_array)->erase(found);
-            root_ = std::move(candidate);
+            array.erase(found);
             return true;
         });
     }
@@ -592,6 +579,8 @@ namespace lfs::io {
 
                 std::vector<std::string> uuids;
                 uuids.reserve((*resolved)->size());
+                std::unordered_set<std::string_view> seen;
+                seen.reserve((*resolved)->size());
                 for (std::size_t i = 0; i < (*resolved)->size(); ++i) {
                     const Json& element = (**resolved)[i];
                     if (!element.is_object()) {
@@ -612,7 +601,7 @@ namespace lfs::io {
                             path);
                     }
                     const std::string& uuid = member->get_ref<const std::string&>();
-                    if (std::ranges::find(uuids, uuid) != uuids.end()) {
+                    if (!seen.insert(uuid).second) {
                         return make_dom_error(
                             lfs::ErrorCode::DataLoss,
                             "The JSON chapter contains a duplicate UUID.",
@@ -625,23 +614,144 @@ namespace lfs::io {
             });
     }
 
+    lfs::Result<std::vector<std::pair<std::string, JsonChapterDom::Json>>>
+    JsonChapterDom::array_items(const std::string_view path) const {
+        return guarded_dom_operation<std::vector<std::pair<std::string, Json>>>(
+            path, [&]() -> lfs::Result<std::vector<std::pair<std::string, Json>>> {
+                auto resolved = resolve_node(root_, path, "enumerate");
+                if (!resolved) {
+                    return std::move(resolved).error();
+                }
+                if (*resolved == nullptr) {
+                    return std::vector<std::pair<std::string, Json>>{};
+                }
+                if (!(*resolved)->is_array()) {
+                    return make_dom_error(
+                        lfs::ErrorCode::FailedPrecondition,
+                        "The JSON chapter has an incompatible structure.",
+                        std::format("Cannot enumerate '{}': value is {}, expected an array",
+                                    path, (*resolved)->type_name()),
+                        path);
+                }
+
+                std::vector<std::pair<std::string, Json>> items;
+                items.reserve((*resolved)->size());
+                std::unordered_set<std::string_view> seen;
+                seen.reserve((*resolved)->size());
+                for (std::size_t i = 0; i < (*resolved)->size(); ++i) {
+                    const Json& element = (**resolved)[i];
+                    if (!element.is_object()) {
+                        return make_dom_error(
+                            lfs::ErrorCode::DataLoss,
+                            "The JSON chapter contains an invalid UUID array.",
+                            std::format("Element {} of '{}' is {}, expected an object",
+                                        i, path, element.type_name()),
+                            path);
+                    }
+                    const auto member = element.find("uuid");
+                    if (member == element.end() || !member->is_string() ||
+                        !is_canonical_uuid(member->get_ref<const std::string&>())) {
+                        return make_dom_error(
+                            lfs::ErrorCode::DataLoss,
+                            "The JSON chapter contains an invalid UUID array.",
+                            std::format("Element {} of '{}' has no canonical UUID", i, path),
+                            path);
+                    }
+                    const std::string& uuid = member->get_ref<const std::string&>();
+                    if (!seen.insert(uuid).second) {
+                        return make_dom_error(
+                            lfs::ErrorCode::DataLoss,
+                            "The JSON chapter contains a duplicate UUID.",
+                            std::format("UUID '{}' occurs more than once in '{}'", uuid, path),
+                            path, uuid);
+                    }
+                    items.emplace_back(uuid, element);
+                }
+                return items;
+            });
+    }
+
+    std::optional<JsonChapterDom::Json> JsonChapterDom::array_get(
+        const std::string_view path, const std::string_view uuid) const {
+        if (!is_canonical_uuid(uuid)) {
+            return std::nullopt;
+        }
+        const Json* element = find_array_element_node(root_, path, uuid);
+        return element == nullptr ? std::nullopt : std::optional<Json>(*element);
+    }
+
+    lfs::Result<void> JsonChapterDom::array_put(const std::string_view path,
+                                                const std::string_view uuid, Json value) {
+        if (!is_canonical_uuid(uuid)) {
+            return lfs::Result<void>::failure(make_dom_error(
+                lfs::ErrorCode::InvalidArgument, "The JSON chapter UUID is invalid.",
+                std::format("UUID '{}' is not canonical lowercase xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+                            uuid),
+                path, uuid));
+        }
+        if (!value.is_object()) {
+            return lfs::Result<void>::failure(make_dom_error(
+                lfs::ErrorCode::InvalidArgument, "The JSON chapter array element is invalid.",
+                std::format("Cannot put UUID '{}' at '{}': value is {}, expected an object", uuid,
+                            path, value.type_name()),
+                path, uuid));
+        }
+        const auto member = value.find("uuid");
+        if (member == value.end() || !member->is_string() ||
+            member->get_ref<const std::string&>() != uuid) {
+            return lfs::Result<void>::failure(make_dom_error(
+                lfs::ErrorCode::InvalidArgument, "The JSON chapter array element is invalid.",
+                std::format("Cannot put UUID '{}' at '{}': element \"uuid\" must equal the canonical uuid argument",
+                            uuid, path),
+                path, uuid));
+        }
+
+        return guarded_dom_operation<void>(path, [&]() -> lfs::Result<void> {
+            auto existing_array = resolve_node(root_, path, "put into");
+            if (!existing_array) {
+                return lfs::Result<void>::failure(std::move(existing_array).error());
+            }
+            if (*existing_array != nullptr) {
+                if (!(*existing_array)->is_array()) {
+                    return lfs::Result<void>::failure(make_dom_error(
+                        lfs::ErrorCode::FailedPrecondition,
+                        "The JSON chapter has an incompatible structure.",
+                        std::format("Cannot put UUID '{}' at '{}': value is {}, expected an array",
+                                    uuid, path, (*existing_array)->type_name()),
+                        path, uuid));
+                }
+                Json* element = find_array_element_node(root_, path, uuid);
+                if (element != nullptr) {
+                    *element = std::move(value);
+                    return {};
+                }
+                (*existing_array)->push_back(std::move(value));
+                return {};
+            }
+
+            Json created_array = Json::array();
+            created_array.push_back(std::move(value));
+            return set_value_at(root_, path, std::move(created_array));
+        });
+    }
+
     lfs::Result<void> JsonChapterDom::set_element_value(
         const std::string_view array_path, const std::string_view uuid, const std::string_view path,
         Json value) {
         return guarded_dom_operation<void>(path, [&]() -> lfs::Result<void> {
-            Json candidate = root_;
-            Json* element = find_array_element_node(candidate, array_path, uuid);
+            Json* element = find_array_element_node(root_, array_path, uuid);
             if (element == nullptr) {
                 return lfs::Result<void>::failure(make_dom_error(
                     lfs::ErrorCode::NotFound, "The JSON chapter element no longer exists.",
                     std::format("UUID '{}' was not found in JSON array '{}'", uuid, array_path),
                     array_path, uuid));
             }
-            auto result = set_value_at(*element, path, std::move(value));
+            Json candidate = *element;
+            auto result = set_value_at(candidate, path, std::move(value));
             if (!result) {
                 return result;
             }
-            root_ = std::move(candidate);
+            *element = std::move(candidate);
             return {};
         });
     }
@@ -649,19 +759,19 @@ namespace lfs::io {
     lfs::Result<bool> JsonChapterDom::remove_element_value(
         const std::string_view array_path, const std::string_view uuid, const std::string_view path) {
         return guarded_dom_operation<bool>(path, [&]() -> lfs::Result<bool> {
-            Json candidate = root_;
-            Json* element = find_array_element_node(candidate, array_path, uuid);
+            Json* element = find_array_element_node(root_, array_path, uuid);
             if (element == nullptr) {
                 return make_dom_error(
                     lfs::ErrorCode::NotFound, "The JSON chapter element no longer exists.",
                     std::format("UUID '{}' was not found in JSON array '{}'", uuid, array_path),
                     array_path, uuid);
             }
-            auto removed = remove_value_at(*element, path);
+            Json candidate = *element;
+            auto removed = remove_value_at(candidate, path);
             if (!removed || !*removed) {
                 return removed;
             }
-            root_ = std::move(candidate);
+            *element = std::move(candidate);
             return true;
         });
     }

--- a/src/io/project/project_chapters.cpp
+++ b/src/io/project/project_chapters.cpp
@@ -1346,21 +1346,20 @@ namespace lfs::io::project {
     }
 
     lfs::Result<std::vector<EmbedDecision>> ProjectChapter::embed_decisions() const {
-        auto uuids = dom_.array_uuids("embed_decisions");
-        if (!uuids) {
-            return std::move(uuids).error();
+        auto items = dom_.array_items("embed_decisions");
+        if (!items) {
+            return std::move(items).error();
         }
         std::vector<EmbedDecision> result;
-        result.reserve(uuids->size());
-        for (const std::string& id : *uuids) {
-            auto element = dom_.array_find("embed_decisions", id);
+        result.reserve(items->size());
+        for (const auto& [id, element] : *items) {
             auto uuid = lfs::core::Uuid::from_string(id);
-            auto node_text = element->get<std::string>("node_uuid");
+            auto node_text = JsonChapterDom::read<std::string>(element, "node_uuid");
             auto node = node_text ? lfs::core::Uuid::from_string(*node_text) : std::nullopt;
-            auto fourcc = element->get<std::string>("payload_fourcc");
-            auto decision = element->get<std::string>("decision");
-            auto reason = element->get<std::string>("reason");
-            auto ref_text = element->get<std::string>("reference_uuid");
+            auto fourcc = JsonChapterDom::read<std::string>(element, "payload_fourcc");
+            auto decision = JsonChapterDom::read<std::string>(element, "decision");
+            auto reason = JsonChapterDom::read<std::string>(element, "reason");
+            auto ref_text = JsonChapterDom::read<std::string>(element, "reference_uuid");
             std::optional<lfs::core::Uuid> reference;
             if (ref_text) {
                 reference = lfs::core::Uuid::from_string(*ref_text);
@@ -1423,17 +1422,16 @@ namespace lfs::io::project {
     }
 
     lfs::Result<std::vector<ProvenanceRecord>> ProjectChapter::provenance() const {
-        auto uuids = dom_.array_uuids("provenance");
-        if (!uuids) {
-            return std::move(uuids).error();
+        auto items = dom_.array_items("provenance");
+        if (!items) {
+            return std::move(items).error();
         }
         std::vector<ProvenanceRecord> result;
-        result.reserve(uuids->size());
-        for (const std::string& id : *uuids) {
-            auto element = dom_.array_find("provenance", id);
+        result.reserve(items->size());
+        for (const auto& [id, element] : *items) {
             auto uuid = lfs::core::Uuid::from_string(id);
-            auto kind = element->get<std::string>("kind");
-            auto value = element->get<std::string>("value");
+            auto kind = JsonChapterDom::read<std::string>(element, "kind");
+            auto value = JsonChapterDom::read<std::string>(element, "value");
             if (!uuid || !kind || kind->empty() || !value) {
                 return fail<std::vector<ProvenanceRecord>>(
                     lfs::ErrorCode::DataLoss,
@@ -1465,16 +1463,15 @@ namespace lfs::io::project {
 
     lfs::Result<std::vector<EmbeddedPayloadProvenance>>
     ProjectChapter::embedded_payload_provenance() const {
-        auto uuids = dom_.array_uuids("embedded_payloads");
-        if (!uuids) {
-            return std::move(uuids).error();
+        auto items = dom_.array_items("embedded_payloads");
+        if (!items) {
+            return std::move(items).error();
         }
         std::vector<EmbeddedPayloadProvenance> result;
-        result.reserve(uuids->size());
-        for (const std::string& id : *uuids) {
-            auto element = dom_.array_find("embedded_payloads", id);
+        result.reserve(items->size());
+        for (const auto& [id, element] : *items) {
             auto uuid = lfs::core::Uuid::from_string(id);
-            const auto node_value = element->get_json("node_uuid");
+            const auto node_value = JsonChapterDom::read_json(element, "node_uuid");
             auto node = node_value ? parse_uuid(*node_value, "PROJ",
                                                 "embedded_payloads.node_uuid")
                                    : fail<lfs::core::Uuid>(
@@ -1482,11 +1479,11 @@ namespace lfs::io::project {
                                          "Embedded payload provenance is incomplete.",
                                          "node_uuid is missing", "PROJ",
                                          "embedded_payloads.node_uuid");
-            auto fourcc = element->get<std::string>("fourcc");
-            const auto locator_value = element->get_json("import_locator");
+            auto fourcc = JsonChapterDom::read<std::string>(element, "fourcc");
+            const auto locator_value = JsonChapterDom::read_json(element, "import_locator");
             const auto fingerprint_value =
-                element->get_json("import_fingerprint");
-            auto hash_text = element->get<std::string>("content_xxh3_128");
+                JsonChapterDom::read_json(element, "import_fingerprint");
+            auto hash_text = JsonChapterDom::read<std::string>(element, "content_xxh3_128");
             if (!uuid || !node || !fourcc || fourcc->size() != 4 ||
                 !locator_value || !fingerprint_value || !hash_text) {
                 return fail<std::vector<EmbeddedPayloadProvenance>>(
@@ -1586,21 +1583,20 @@ namespace lfs::io::project {
     }
 
     lfs::Result<std::vector<ReferenceRecord>> ReferencesChapter::records() const {
-        auto uuids = dom_.array_uuids("references");
-        if (!uuids) {
-            return std::move(uuids).error();
+        auto items = dom_.array_items("references");
+        if (!items) {
+            return std::move(items).error();
         }
         std::vector<ReferenceRecord> result;
-        result.reserve(uuids->size());
+        result.reserve(items->size());
         std::unordered_set<std::string> keys;
-        for (const std::string& id : *uuids) {
-            auto element = dom_.array_find("references", id);
+        for (const auto& [id, element] : *items) {
             auto uuid = lfs::core::Uuid::from_string(id);
-            auto key = element->get<std::string>("key");
-            auto kind = element->get<std::string>("kind");
-            auto unresolved = element->get<bool>("unresolved");
-            const auto locator_value = element->get_json("locator");
-            const auto fingerprint_value = element->get_json("fingerprint");
+            auto key = JsonChapterDom::read<std::string>(element, "key");
+            auto kind = JsonChapterDom::read<std::string>(element, "kind");
+            auto unresolved = JsonChapterDom::read<bool>(element, "unresolved");
+            const auto locator_value = JsonChapterDom::read_json(element, "locator");
+            const auto fingerprint_value = JsonChapterDom::read_json(element, "fingerprint");
             if (!uuid || !key || key->empty() || !kind || kind->empty() ||
                 !unresolved || !locator_value || !fingerprint_value ||
                 !keys.insert(*key).second) {
@@ -2354,11 +2350,10 @@ namespace lfs::io::project {
         }
 
         lfs::Result<SceneNodeRecord> parse_scene_node(
-            const JsonChapterDom::ConstElement& element,
-            const lfs::core::Uuid& uuid) {
-            auto type = element.get<std::string>("type");
-            auto name = element.get<std::string>("name");
-            auto parent_value = element.get_json("parent_uuid");
+            const Json& element, const lfs::core::Uuid& uuid) {
+            auto type = JsonChapterDom::read<std::string>(element, "type");
+            auto name = JsonChapterDom::read<std::string>(element, "name");
+            auto parent_value = JsonChapterDom::read_json(element, "parent_uuid");
             std::optional<lfs::core::Uuid> parent;
             if (parent_value && !parent_value->is_null()) {
                 auto parsed = parse_uuid(*parent_value, "SCNG", "nodes.parent_uuid");
@@ -2367,12 +2362,12 @@ namespace lfs::io::project {
                 }
                 parent = *parsed;
             }
-            auto order = element.get<std::uint32_t>("child_order");
-            const auto transform_value = element.get_json("local_transform");
-            auto visible = element.get<bool>("visible");
-            auto locked = element.get<bool>("locked");
-            auto training = element.get<bool>("training_enabled");
-            auto diverged = element.get<bool>("payload_diverged");
+            auto order = JsonChapterDom::read<std::uint32_t>(element, "child_order");
+            const auto transform_value = JsonChapterDom::read_json(element, "local_transform");
+            auto visible = JsonChapterDom::read<bool>(element, "visible");
+            auto locked = JsonChapterDom::read<bool>(element, "locked");
+            auto training = JsonChapterDom::read<bool>(element, "training_enabled");
+            auto diverged = JsonChapterDom::read<bool>(element, "payload_diverged");
             if (!type || type->empty() || !name || name->empty() || !order ||
                 !transform_value || !visible || !locked || !training || !diverged) {
                 return fail<SceneNodeRecord>(
@@ -2404,7 +2399,7 @@ namespace lfs::io::project {
                 .camera = std::nullopt,
             };
 
-            if (const auto pose = element.get_json("georef_pose"); pose) {
+            if (const auto pose = JsonChapterDom::read_json(element, "georef_pose"); pose) {
                 if (auto valid = require_object(*pose, "SCNG", "nodes.georef_pose");
                     !valid) {
                     return std::move(valid).error();
@@ -2440,28 +2435,28 @@ namespace lfs::io::project {
                 }
                 result.georef_pose = GeorefPose{*r, *t};
             }
-            if (const auto payload = element.get_json("payload"); payload) {
+            if (const auto payload = JsonChapterDom::read_json(element, "payload"); payload) {
                 auto parsed = parse_payload_binding(*payload, "nodes.payload");
                 if (!parsed) {
                     return std::move(parsed).error();
                 }
                 result.payload = std::move(*parsed);
             }
-            if (const auto cropbox = element.get_json("cropbox"); cropbox) {
+            if (const auto cropbox = JsonChapterDom::read_json(element, "cropbox"); cropbox) {
                 auto parsed = parse_cropbox(*cropbox, "nodes.cropbox");
                 if (!parsed) {
                     return std::move(parsed).error();
                 }
                 result.cropbox = std::move(*parsed);
             }
-            if (const auto ellipsoid = element.get_json("ellipsoid"); ellipsoid) {
+            if (const auto ellipsoid = JsonChapterDom::read_json(element, "ellipsoid"); ellipsoid) {
                 auto parsed = parse_ellipsoid(*ellipsoid, "nodes.ellipsoid");
                 if (!parsed) {
                     return std::move(parsed).error();
                 }
                 result.ellipsoid = std::move(*parsed);
             }
-            if (const auto camera = element.get_json("camera"); camera) {
+            if (const auto camera = JsonChapterDom::read_json(element, "camera"); camera) {
                 auto parsed = parse_camera(*camera, "nodes.camera");
                 if (!parsed) {
                     return std::move(parsed).error();
@@ -2469,15 +2464,6 @@ namespace lfs::io::project {
                 result.camera = std::move(*parsed);
             }
             return result;
-        }
-
-        lfs::Result<void> remove_optional(
-            JsonChapterDom::Element& element, const std::string_view path) {
-            auto removed = element.remove(path);
-            if (!removed) {
-                return lfs::Result<void>::failure(std::move(removed).error());
-            }
-            return {};
         }
 
     } // namespace
@@ -2540,22 +2526,21 @@ namespace lfs::io::project {
     }
 
     lfs::Result<std::vector<SceneNodeRecord>> SceneGraphChapter::nodes() const {
-        auto uuids = dom_.array_uuids("nodes");
-        if (!uuids) {
-            return std::move(uuids).error();
+        auto items = dom_.array_items("nodes");
+        if (!items) {
+            return std::move(items).error();
         }
         std::vector<SceneNodeRecord> result;
-        result.reserve(uuids->size());
-        for (const std::string& id : *uuids) {
+        result.reserve(items->size());
+        for (const auto& [id, element] : *items) {
             const auto uuid = lfs::core::Uuid::from_string(id);
-            const auto element = dom_.array_find("nodes", id);
-            if (!uuid || !element) {
+            if (!uuid) {
                 return fail<std::vector<SceneNodeRecord>>(
                     lfs::ErrorCode::DataLoss, "A scene node UUID is invalid.",
                     std::format("SCNG node UUID '{}' cannot be decoded", id), "SCNG",
                     "nodes.uuid");
             }
-            auto parsed = parse_scene_node(*element, *uuid);
+            auto parsed = parse_scene_node(element, *uuid);
             if (!parsed) {
                 return std::move(parsed).error();
             }
@@ -2571,7 +2556,7 @@ namespace lfs::io::project {
                 lfs::ErrorCode::InvalidArgument, "The scene node UUID cannot be null.",
                 "SCNG lookup UUID must be non-null", "SCNG", "nodes.uuid");
         }
-        const auto element = dom_.array_find("nodes", uuid.to_string());
+        const auto element = dom_.array_get("nodes", uuid.to_string());
         if (!element) {
             return std::optional<SceneNodeRecord>{};
         }
@@ -2606,54 +2591,6 @@ namespace lfs::io::project {
                 "Payload fourcc, UUID, source kind, and reference must be valid", "SCNG",
                 "nodes.payload");
         }
-        auto element = dom_.array_upsert("nodes", value.uuid.to_string());
-        if (!element) {
-            return lfs::Result<void>::failure(std::move(element).error());
-        }
-        if (auto result = element->set("type", value.type); !result) {
-            return result;
-        }
-        if (auto result = element->set("name", value.name); !result) {
-            return result;
-        }
-        if (auto result = value.parent_uuid
-                              ? element->set("parent_uuid",
-                                             value.parent_uuid->to_string())
-                              : element->set_json("parent_uuid", nullptr);
-            !result) {
-            return result;
-        }
-        if (auto result = element->set("child_order", value.child_order); !result) {
-            return result;
-        }
-        if (auto result =
-                element->set_json("local_transform", json_array(value.local_transform));
-            !result) {
-            return result;
-        }
-        if (auto result = element->set("visible", value.visible); !result) {
-            return result;
-        }
-        if (auto result = element->set("locked", value.locked); !result) {
-            return result;
-        }
-        if (auto result =
-                element->set("training_enabled", value.training_enabled);
-            !result) {
-            return result;
-        }
-        if (auto result =
-                element->set("payload_diverged", value.payload_diverged);
-            !result) {
-            return result;
-        }
-
-        const auto set_or_remove =
-            [&](const std::string_view path, const std::optional<Json>& json)
-            -> lfs::Result<void> {
-            return json ? element->set_json(path, *json)
-                        : remove_optional(*element, path);
-        };
         std::optional<Json> pose;
         if (value.georef_pose) {
             const double norm = std::sqrt(
@@ -2674,39 +2611,48 @@ namespace lfs::io::project {
                 {"translation", json_array(value.georef_pose->translation)},
             };
         }
-        if (auto result = set_or_remove("georef_pose", pose); !result) {
-            return result;
+
+        const std::string uuid = value.uuid.to_string();
+        Json element = dom_.array_get("nodes", uuid).value_or(Json{{"uuid", uuid}});
+        element["type"] = value.type;
+        element["name"] = value.name;
+        if (value.parent_uuid) {
+            element["parent_uuid"] = value.parent_uuid->to_string();
+        } else {
+            element["parent_uuid"] = nullptr;
         }
-        if (auto result =
-                set_or_remove("payload",
-                              value.payload
-                                  ? std::optional<Json>(
-                                        payload_binding_json(*value.payload))
-                                  : std::nullopt);
-            !result) {
-            return result;
+        element["child_order"] = value.child_order;
+        element["local_transform"] = json_array(value.local_transform);
+        element["visible"] = value.visible;
+        element["locked"] = value.locked;
+        element["training_enabled"] = value.training_enabled;
+        element["payload_diverged"] = value.payload_diverged;
+        if (pose) {
+            element["georef_pose"] = std::move(*pose);
+        } else {
+            element.erase("georef_pose");
         }
-        if (auto result =
-                set_or_remove("cropbox",
-                              value.cropbox
-                                  ? std::optional<Json>(cropbox_json(*value.cropbox))
-                                  : std::nullopt);
-            !result) {
-            return result;
+        if (value.payload) {
+            element["payload"] = payload_binding_json(*value.payload);
+        } else {
+            element.erase("payload");
         }
-        if (auto result =
-                set_or_remove("ellipsoid",
-                              value.ellipsoid
-                                  ? std::optional<Json>(
-                                        ellipsoid_json(*value.ellipsoid))
-                                  : std::nullopt);
-            !result) {
-            return result;
+        if (value.cropbox) {
+            element["cropbox"] = cropbox_json(*value.cropbox);
+        } else {
+            element.erase("cropbox");
         }
-        return set_or_remove(
-            "camera", value.camera
-                          ? std::optional<Json>(camera_json(*value.camera))
-                          : std::nullopt);
+        if (value.ellipsoid) {
+            element["ellipsoid"] = ellipsoid_json(*value.ellipsoid);
+        } else {
+            element.erase("ellipsoid");
+        }
+        if (value.camera) {
+            element["camera"] = camera_json(*value.camera);
+        } else {
+            element.erase("camera");
+        }
+        return dom_.array_put("nodes", uuid, std::move(element));
     }
 
     lfs::Result<bool> SceneGraphChapter::remove_node(

--- a/tests/test_json_chapter_dom.cpp
+++ b/tests/test_json_chapter_dom.cpp
@@ -144,4 +144,146 @@ namespace {
         EXPECT_NE(first_dump.find("\n  \"z\""), std::string::npos);
     }
 
+    TEST(JsonChapterDomTest, ArrayItemsReturnsOrderedPairsAndTypedErrors) {
+        const std::string input = std::string(R"json({"items":[{"uuid":")json") +
+                                  std::string(UUID_A) +
+                                  R"json(","name":"first"},{"uuid":")json" +
+                                  std::string(UUID_B) +
+                                  R"json(","name":"second"}]})json";
+        auto dom = JsonChapterDom::parse(input);
+        ASSERT_TRUE(dom) << lfs::format_for_developer(dom.error());
+
+        auto items = dom->array_items("items");
+        ASSERT_TRUE(items) << lfs::format_for_developer(items.error());
+        ASSERT_EQ(items->size(), 2);
+        EXPECT_EQ((*items)[0].first, std::string(UUID_A));
+        EXPECT_EQ((*items)[0].second["name"], "first");
+        EXPECT_EQ((*items)[1].first, std::string(UUID_B));
+        EXPECT_EQ((*items)[1].second["name"], "second");
+
+        auto missing = dom->array_items("absent");
+        ASSERT_TRUE(missing) << lfs::format_for_developer(missing.error());
+        EXPECT_TRUE(missing->empty());
+
+        auto duplicate = JsonChapterDom::parse(
+            std::string(R"json({"items":[{"uuid":")json") + std::string(UUID_A) +
+            R"json("},{"uuid":")json" + std::string(UUID_A) + R"json("}]})json");
+        ASSERT_TRUE(duplicate) << lfs::format_for_developer(duplicate.error());
+        auto duplicate_items = duplicate->array_items("items");
+        ASSERT_FALSE(duplicate_items);
+        EXPECT_EQ(duplicate_items.error().code(), lfs::ErrorCode::DataLoss);
+        EXPECT_NE(duplicate_items.error().detail().find("occurs more than once"),
+                  std::string_view::npos);
+
+        auto non_object = JsonChapterDom::parse(R"json({"items":[1]})json");
+        ASSERT_TRUE(non_object) << lfs::format_for_developer(non_object.error());
+        auto non_object_items = non_object->array_items("items");
+        ASSERT_FALSE(non_object_items);
+        EXPECT_EQ(non_object_items.error().code(), lfs::ErrorCode::DataLoss);
+        EXPECT_NE(non_object_items.error().detail().find("expected an object"),
+                  std::string_view::npos);
+    }
+
+    TEST(JsonChapterDomTest, ArrayGetCopiesPresentElementAndNulloptsAbsence) {
+        const std::string input = std::string(R"json({"items":[{"uuid":")json") +
+                                  std::string(UUID_A) +
+                                  R"json(","name":"first","extra":[1,2]}]})json";
+        auto dom = JsonChapterDom::parse(input);
+        ASSERT_TRUE(dom) << lfs::format_for_developer(dom.error());
+
+        auto present = dom->array_get("items", UUID_A);
+        ASSERT_TRUE(present);
+        EXPECT_EQ((*present)["name"], "first");
+        EXPECT_EQ((*present)["extra"], Json({1, 2}));
+
+        EXPECT_FALSE(dom->array_get("items", UUID_B));
+        EXPECT_FALSE(dom->array_get("missing", UUID_A));
+        EXPECT_FALSE(dom->array_get("items", "not-a-canonical-uuid"));
+    }
+
+    TEST(JsonChapterDomTest, ArrayPutInsertsAtEndReplacesInPlaceAndRejectsTypedErrors) {
+        const std::string input = std::string(R"json({"items":[{"uuid":")json") +
+                                  std::string(UUID_A) +
+                                  R"json(","name":"first"},{"uuid":")json" +
+                                  std::string(UUID_B) +
+                                  R"json(","name":"second"}]})json";
+        auto dom = JsonChapterDom::parse(input);
+        ASSERT_TRUE(dom) << lfs::format_for_developer(dom.error());
+
+        auto inserted = dom->array_put(
+            "items", UUID_C, Json{{"uuid", std::string(UUID_C)}, {"name", "third"}});
+        ASSERT_TRUE(inserted) << lfs::format_for_developer(inserted.error());
+
+        auto replaced = dom->array_put(
+            "items", UUID_B,
+            Json{{"uuid", std::string(UUID_B)}, {"name", "second-edited"}, {"keep", 7}});
+        ASSERT_TRUE(replaced) << lfs::format_for_developer(replaced.error());
+
+        const Json dumped = Json::parse(dom->dump());
+        ASSERT_EQ(dumped["items"].size(), 3);
+        EXPECT_EQ(dumped["items"][0]["uuid"], std::string(UUID_A));
+        EXPECT_EQ(dumped["items"][1]["uuid"], std::string(UUID_B));
+        EXPECT_EQ(dumped["items"][1]["name"], "second-edited");
+        EXPECT_EQ(dumped["items"][1]["keep"], 7);
+        EXPECT_EQ(dumped["items"][2]["uuid"], std::string(UUID_C));
+        EXPECT_EQ(dumped["items"][2]["name"], "third");
+        EXPECT_LT(dom->dump().find(std::string(UUID_A)),
+                  dom->dump().find(std::string(UUID_B)));
+        EXPECT_LT(dom->dump().find(std::string(UUID_B)),
+                  dom->dump().find(std::string(UUID_C)));
+
+        auto mismatch = dom->array_put(
+            "items", UUID_A, Json{{"uuid", std::string(UUID_B)}, {"name", "wrong"}});
+        ASSERT_FALSE(mismatch);
+        EXPECT_EQ(mismatch.error().code(), lfs::ErrorCode::InvalidArgument);
+
+        auto non_object = dom->array_put("items", UUID_A, Json("not-an-object"));
+        ASSERT_FALSE(non_object);
+        EXPECT_EQ(non_object.error().code(), lfs::ErrorCode::InvalidArgument);
+
+        auto non_canonical =
+            dom->array_put("items", "Not-Canonical", Json{{"uuid", "Not-Canonical"}});
+        ASSERT_FALSE(non_canonical);
+        EXPECT_EQ(non_canonical.error().code(), lfs::ErrorCode::InvalidArgument);
+        EXPECT_EQ(Json::parse(dom->dump())["items"].size(), 3);
+    }
+
+    TEST(JsonChapterDomTest, StaticReadHelpersResolveDetachedElementScalarsAndSubtrees) {
+        const Json element{
+            {"uuid", std::string(UUID_A)},
+            {"name", "detached"},
+            {"count", 4},
+            {"flag", true},
+            {"nested", Json{{"value", 9}, {"label", "inner"}}},
+        };
+
+        EXPECT_EQ(JsonChapterDom::read<std::string>(element, "name"), "detached");
+        EXPECT_EQ(JsonChapterDom::read<int>(element, "count"), 4);
+        EXPECT_EQ(JsonChapterDom::read<bool>(element, "flag"), true);
+        EXPECT_EQ(JsonChapterDom::read<int>(element, "nested.value"), 9);
+        EXPECT_EQ(JsonChapterDom::read<std::string>(element, "missing"), std::nullopt);
+        EXPECT_EQ(JsonChapterDom::read_json(element, "nested"),
+                  Json({{"value", 9}, {"label", "inner"}}));
+        EXPECT_EQ(JsonChapterDom::read_json(element, "missing"), std::nullopt);
+    }
+
+    TEST(JsonChapterDomTest, FailedElementSetAcrossNonObjectIsTypedAndTransactional) {
+        const std::string input = std::string(R"json({"items":[{"uuid":")json") +
+                                  std::string(UUID_A) +
+                                  R"json(","view":{"split":3},"keep":true}]})json";
+        auto dom = JsonChapterDom::parse(input);
+        ASSERT_TRUE(dom) << lfs::format_for_developer(dom.error());
+        const std::string before = dom->dump();
+
+        auto element = dom->array_find("items", UUID_A);
+        ASSERT_TRUE(element);
+        auto result = element->set("view.split.mode", "side_by_side");
+        ASSERT_FALSE(result);
+        EXPECT_EQ(result.error().code(), lfs::ErrorCode::FailedPrecondition);
+        EXPECT_EQ(result.error().domain(), lfs::ErrorDomain::IO);
+        EXPECT_NE(result.error().detail().find("view.split"), std::string_view::npos);
+        EXPECT_EQ(dom->dump(), before);
+        EXPECT_EQ(Json::parse(dom->dump())["items"][0]["keep"], true);
+    }
+
 } // namespace

--- a/tests/test_project_chapters.cpp
+++ b/tests/test_project_chapters.cpp
@@ -489,4 +489,133 @@ namespace {
         }
     }
 
+    TEST(ProjectChapterTest, SceneGraphBatchedUpsertRetainsUnknownNodeMembers) {
+        const auto node_id = uuid_literal("43000000-0000-4000-8000-000000000001");
+        const std::string source = std::format(
+            R"({{
+  "schema_version": 1,
+  "training_model_uuid": null,
+  "nodes": [{{
+    "uuid": "{}",
+    "type": "group",
+    "name": "Root",
+    "parent_uuid": null,
+    "child_order": 0,
+    "local_transform": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
+    "visible": true,
+    "locked": false,
+    "training_enabled": true,
+    "payload_diverged": false,
+    "vendor_extra": {{"keep": 42, "nested": [1, {{"x": true}}]}}
+  }}]
+}})",
+            node_id.to_string());
+        auto chapter = SceneGraphChapter::parse(source);
+        ASSERT_TRUE(chapter) << lfs::format_for_developer(chapter.error());
+        auto found = chapter->find(node_id);
+        ASSERT_TRUE(found) << lfs::format_for_developer(found.error());
+        ASSERT_TRUE(*found);
+        auto node = **found;
+        node.name = "Renamed";
+        node.visible = false;
+        ASSERT_TRUE(chapter->upsert_node(node));
+
+        const auto dumped = lfs::io::JsonChapterDom::Json::parse(chapter->dom().dump());
+        ASSERT_EQ(dumped["nodes"].size(), 1);
+        EXPECT_EQ(dumped["nodes"][0]["name"], "Renamed");
+        EXPECT_EQ(dumped["nodes"][0]["visible"], false);
+        const auto extra = dumped["nodes"][0]["vendor_extra"];
+        ASSERT_TRUE(extra.is_object());
+        EXPECT_EQ(extra["keep"], 42);
+        ASSERT_TRUE(extra["nested"].is_array());
+        ASSERT_EQ(extra["nested"].size(), 2);
+        EXPECT_EQ(extra["nested"][0], 1);
+        EXPECT_EQ(extra["nested"][1]["x"], true);
+    }
+
+    TEST(SceneGraphChapterScaleTest, UpsertParseAndEnumerateThousandsOfCameraNodes) {
+        using clock = std::chrono::steady_clock;
+        const auto started = clock::now();
+
+        const auto root_id = uuid_literal("52000000-0000-4000-8000-000000000001");
+        const auto group_id = uuid_literal("52000000-0000-4000-8000-000000000002");
+
+        SceneGraphChapter chapter;
+        ASSERT_TRUE(chapter.upsert_node(SceneNodeRecord{
+            .uuid = root_id,
+            .type = "dataset",
+            .name = "Dataset",
+            .parent_uuid = std::nullopt,
+            .child_order = 0,
+        }));
+        ASSERT_TRUE(chapter.upsert_node(SceneNodeRecord{
+            .uuid = group_id,
+            .type = "camera_group",
+            .name = "Cameras",
+            .parent_uuid = root_id,
+            .child_order = 0,
+        }));
+
+        constexpr int camera_count = 1998;
+        for (int i = 0; i < camera_count; ++i) {
+            const auto camera_id = uuid_literal(std::format(
+                "52000000-0000-4000-8000-{:012x}", static_cast<unsigned>(i + 3)));
+            CameraRecord camera;
+            camera.uid = i;
+            camera.camera_id = 1;
+            camera.rotation = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+            camera.translation = {0.0f, 0.0f, static_cast<float>(i)};
+            camera.focal_x = 800.0f;
+            camera.focal_y = 800.0f;
+            camera.center_x = 640.0f;
+            camera.center_y = 360.0f;
+            camera.camera_width = 1280;
+            camera.camera_height = 720;
+            camera.image_width = 1280;
+            camera.image_height = 720;
+            camera.image_name = std::format("cam_{:04}.png", i);
+            camera.image_path = camera.image_name;
+            camera.split = "train";
+            ASSERT_TRUE(chapter.upsert_node(SceneNodeRecord{
+                .uuid = camera_id,
+                .type = "camera",
+                .name = camera.image_name,
+                .parent_uuid = group_id,
+                .child_order = static_cast<std::uint32_t>(i),
+                .camera = std::move(camera),
+            })) << "failed to upsert camera "
+                << i;
+        }
+
+        auto hierarchy = chapter.validate_hierarchy();
+        ASSERT_TRUE(hierarchy) << lfs::format_for_developer(hierarchy.error());
+        const auto bytes = chapter.to_bytes();
+        auto reparsed = SceneGraphChapter::from_bytes(bytes);
+        ASSERT_TRUE(reparsed) << lfs::format_for_developer(reparsed.error());
+        auto nodes = reparsed->nodes();
+        ASSERT_TRUE(nodes) << lfs::format_for_developer(nodes.error());
+        ASSERT_EQ(nodes->size(), 2000u);
+        EXPECT_EQ((*nodes)[0].uuid, root_id);
+        EXPECT_EQ((*nodes)[0].type, "dataset");
+        EXPECT_EQ((*nodes)[0].name, "Dataset");
+        EXPECT_EQ((*nodes)[1].uuid, group_id);
+        EXPECT_EQ((*nodes)[1].type, "camera_group");
+        EXPECT_EQ((*nodes)[1].parent_uuid, root_id);
+        EXPECT_EQ((*nodes)[2].type, "camera");
+        ASSERT_TRUE((*nodes)[2].camera);
+        EXPECT_EQ((*nodes)[2].camera->uid, 0);
+        EXPECT_EQ((*nodes)[2].camera->image_name, "cam_0000.png");
+        const auto& last = nodes->back();
+        EXPECT_EQ(last.type, "camera");
+        ASSERT_TRUE(last.camera);
+        EXPECT_EQ(last.camera->uid, 1997);
+        EXPECT_EQ(last.camera->image_name, "cam_1997.png");
+        EXPECT_EQ(last.parent_uuid, group_id);
+        EXPECT_EQ(last.child_order, 1997u);
+
+        const auto elapsed = clock::now() - started;
+        EXPECT_LT(elapsed, std::chrono::seconds(30))
+            << "scale pass took " << std::chrono::duration<double>(elapsed).count() << "s";
+    }
+
 } // namespace


### PR DESCRIPTION
## What

Stopping training on a dataset with 1600+ cameras took over 13 minutes (Discord report). The same stop now takes under half a second.

## Why it was slow

Every save rewrote its internal bookkeeping in a way that got drastically more expensive as the camera count grew: 4x the cameras meant 16x the save time. Small scenes never noticed; a 1600-camera scene paid minutes, twice per stop.

## Fix

The bookkeeping now only touches what actually changed. The saved file format is unchanged — old projects open fine, and projects saved by this branch open in older builds.

## Measured

| Scenario (1600 cameras) | Before | After |
|---|---|---|
| Stop with save in flight | 69.3s | 0.38s |
| Final save | 34.4s | 0.18s |

Covered by new regression tests, including a 2000-node scale guard; all existing project and format tests pass.