### PR TITLE
Fix training failing to start with SH1 on some datasets

### DIFF
--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -362,7 +362,11 @@ namespace {
                                           allocator,
                                           name,
                                           DataType::Float32);
-            } catch (const std::exception&) {
+            } catch (const std::exception& error) {
+                LOG_DEBUG("allocate_swizzled_shN: allocator rejected float topology "
+                          "for '{}' ({}); using zeros_direct workspace",
+                          name,
+                          error.what());
             }
             if (t.is_valid() && t.dtype() == DataType::Float32 &&
                 t.capacity() >= capacity_floats) {

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -348,23 +348,26 @@ namespace {
             return tensor;
         }
         if (allocator) {
-            Tensor t = allocate_param_tensor(TensorShape({logical_floats}),
-                                             capacity_floats,
-                                             allocator,
-                                             name,
-                                             DataType::Float32);
             // Real SplatExportableStorage forces Float16 and clamps to pad-dropped
-            // q16 cells — too small / wrong dtype for float construction. Keep a
-            // float zeros_direct workspace; apply_shN_value_quant later encodes
-            // into the exportable q16 region via the same allocator.
-            if (t.dtype() != DataType::Float32 || t.capacity() < capacity_floats) {
-                Tensor workspace = Tensor::zeros_direct(TensorShape({logical_floats}),
-                                                        capacity_floats,
-                                                        Device::CUDA);
-                workspace.set_name(std::string{name});
-                return workspace;
+            // q16 cells — too small / wrong dtype for float construction — and
+            // rejects the swizzled float shape outright once live-N swizzled cells
+            // exceed the q16 region (SH1: 12 vs 9, SH3: 48 vs 45 cells/prim near
+            // max-cap). Either way fall through to a float zeros_direct workspace;
+            // apply_shN_value_quant later encodes into the exportable q16 region
+            // via the same allocator.
+            Tensor t;
+            try {
+                t = allocate_param_tensor(TensorShape({logical_floats}),
+                                          capacity_floats,
+                                          allocator,
+                                          name,
+                                          DataType::Float32);
+            } catch (const std::exception&) {
             }
-            return t;
+            if (t.is_valid() && t.dtype() == DataType::Float32 &&
+                t.capacity() >= capacity_floats) {
+                return t;
+            }
         }
         Tensor tensor = Tensor::zeros_direct(TensorShape({logical_floats}),
                                              capacity_floats,

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -418,8 +418,10 @@ namespace lfs::training {
                         }
                     } else {
                         // Try float topology install. Real SplatExportableStorage
-                        // forces Float16 and clamps capacity to q16 cells — detect
-                        // that and re-encode instead of bitcasting float into half.
+                        // forces Float16 and clamps capacity to q16 cells — and rejects
+                        // the swizzled float shape outright when live-N cells exceed the
+                        // pad-dropped region — detect that and re-encode instead of
+                        // bitcasting float into half.
                         lfs::core::Tensor src_float = model.shN_raw();
                         if (src_float.device() != lfs::core::Device::CUDA) {
                             src_float = src_float.cuda();
@@ -427,15 +429,27 @@ namespace lfs::training {
                         if (!src_float.is_contiguous()) {
                             src_float = src_float.contiguous();
                         }
-                        lfs::core::Tensor installed = copy_param(
-                            src_float, src_float.shape(), float_cap, "SplatData.shN");
+                        lfs::core::Tensor installed;
+                        try {
+                            installed = tensor_allocator(src_float.shape(),
+                                                         float_cap,
+                                                         lfs::core::DataType::Float32,
+                                                         "SplatData.shN");
+                        } catch (const std::exception&) {
+                            // Exportable q16 region rejects the swizzled float shape when
+                            // live-N cells exceed the pad-dropped capacity; same fallback
+                            // as the Float16/clamp detection below.
+                        }
                         const bool landed_in_q16_exportable =
+                            !installed.is_valid() ||
                             installed.dtype() == lfs::core::DataType::Float16 ||
                             installed.capacity() < float_cap;
                         if (landed_in_q16_exportable) {
                             shN = std::move(src_float);
                             need_q16_encode = true;
                         } else {
+                            installed.set_name("SplatData.shN");
+                            installed.copy_from(src_float);
                             shN = std::move(installed);
                         }
                     }

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -435,10 +435,13 @@ namespace lfs::training {
                                                          float_cap,
                                                          lfs::core::DataType::Float32,
                                                          "SplatData.shN");
-                        } catch (const std::exception&) {
+                        } catch (const std::exception& error) {
                             // Exportable q16 region rejects the swizzled float shape when
                             // live-N cells exceed the pad-dropped capacity; same fallback
                             // as the Float16/clamp detection below.
+                            LOG_DEBUG("Float shN install rejected by allocator ({}); "
+                                      "re-encoding to q16 instead",
+                                      error.what());
                         }
                         const bool landed_in_q16_exportable =
                             !installed.is_valid() ||

--- a/tests/test_exportable_storage.cpp
+++ b/tests/test_exportable_storage.cpp
@@ -5,6 +5,7 @@
 #include "core/cuda_error.hpp"
 #include "core/exportable_storage.hpp"
 #include "core/parameters.hpp"
+#include "core/point_cloud.hpp"
 #include "core/sh_value_quant.hpp"
 #include "core/splat_data.hpp"
 #include "core/splat_exportable_storage.hpp"
@@ -895,6 +896,94 @@ TEST(SplatExportableStorageTest, MigratePreservesCapacityEnsureUnderMaxCap) {
     EXPECT_GE(ensure_calls, 1);
     EXPECT_GE(model.means_raw().capacity(), kNeed);
     EXPECT_EQ(model.means_raw().external_storage_kind(), "splat.exportable");
+}
+
+// SH1/SH3 float-swizzled shN at live-N == capacity exceeds the pad-dropped
+// q16 region (12 vs 9 / 48 vs 45 cells per primitive); migrate used to abort
+// with "shape for 'SplatData.shN' needs ... bytes". It must fall back to the
+// float workspace and land q16-encoded.
+TEST(SplatExportableStorageTest, MigrateFloatSwizzledShNFallsBackToQ16AtFullCapacity) {
+    require_cuda();
+
+    constexpr std::size_t kCap = 1000;
+
+    for (int sh_degree : {1, 2, 3}) {
+        auto storage_result = SplatExportableStorage::create(kCap, sh_degree, 0, kCap);
+        if (!storage_result) {
+            FAIL() << storage_result.error();
+        }
+        auto storage = std::move(*storage_result);
+
+        const auto rest = sh_rest_coefficients_for_degree(sh_degree);
+        Tensor means = Tensor::zeros({kCap, 3}, Device::CUDA);
+        Tensor sh0 = Tensor::zeros({kCap, 1, 3}, Device::CUDA);
+        Tensor scaling = Tensor::zeros({kCap, 3}, Device::CUDA);
+        Tensor rotation = Tensor::zeros({kCap, 4}, Device::CUDA);
+        Tensor opacity = Tensor::zeros({kCap, 1}, Device::CUDA);
+        Tensor shN = Tensor::zeros_direct(
+            TensorShape({sh_swizzled_float_count(kCap, rest)}),
+            sh_swizzled_float_count(kCap, rest),
+            Device::CUDA);
+
+        SplatData model(sh_degree,
+                        std::move(means),
+                        std::move(sh0),
+                        std::move(shN),
+                        std::move(scaling),
+                        std::move(rotation),
+                        std::move(opacity),
+                        1.0f,
+                        SplatData::ShNLayout::Swizzled);
+
+        lfs::core::param::TrainingParameters params;
+        params.optimization.sh_degree = sh_degree;
+        params.optimization.max_cap = static_cast<int>(kCap);
+
+        auto result = lfs::training::migrateTrainingModelToAllocator(
+            params, model, storage.make_allocator());
+        ASSERT_TRUE(result.has_value()) << result.error() << " sh_degree=" << sh_degree;
+        EXPECT_TRUE(model.shN_value_quantized());
+        EXPECT_EQ(model.means_raw().external_storage_kind(), "splat.exportable");
+        EXPECT_EQ(static_cast<std::size_t>(model.shN_raw().capacity()),
+                  sh_value_quant::sh_value_u16_count(kCap, rest));
+    }
+}
+
+// The reported failure: dataset init with init_points > 0.75 x max_cap and
+// SH degree 1 threw from the exportable allocator inside
+// init_model_from_pointcloud. The float shN must come back as an
+// out-of-block workspace instead.
+TEST(SplatExportableStorageTest, InitModelFromPointcloudSucceedsAtFullExportableCapacitySh1) {
+    require_cuda();
+
+    constexpr std::size_t kCap = 1000;
+
+    auto storage_result = SplatExportableStorage::create(kCap, /*sh_degree=*/1, 0, kCap);
+    if (!storage_result) {
+        FAIL() << storage_result.error();
+    }
+    auto storage = std::move(*storage_result);
+
+    Tensor means = Tensor::rand({kCap, 3}, Device::CPU);
+    Tensor colors = Tensor::zeros({kCap, 3}, Device::CPU, DataType::UInt8);
+    PointCloud pcd(std::move(means), std::move(colors));
+
+    lfs::core::param::TrainingParameters params;
+    params.optimization.sh_degree = 1;
+    params.optimization.max_cap = static_cast<int>(kCap);
+    params.optimization.random = false;
+
+    auto model = init_model_from_pointcloud(params,
+                                            Tensor::zeros({3}, Device::CPU),
+                                            pcd,
+                                            static_cast<int>(kCap),
+                                            storage.make_allocator());
+    ASSERT_TRUE(model.has_value()) << model.error();
+    EXPECT_EQ(model->size(), kCap);
+    EXPECT_EQ(model->shN_raw().dtype(), DataType::Float32);
+    EXPECT_EQ(static_cast<std::size_t>(model->shN_raw().numel()),
+              sh_swizzled_float_count(kCap, sh_rest_coefficients_for_degree(1)));
+    EXPECT_EQ(model->means_raw().external_storage_kind(), "splat.exportable");
 }
 
 // A failed capacity ensure must abort before mutation and leave all parameter


### PR DESCRIPTION
Some datasets could not start training: picking SH degree 1 (and in rare cases 3) together with a target splat count close to the dataset's initial point count popped "Training Failed: ... SplatData.shN needs N bytes but region only holds M". Reported on Discord; reproduced with the dante dataset at a 400k target.

The GPU block that training and the viewer share reserves just enough room for the compressed color data. During setup, a temporary uncompressed request could exceed that room and was treated as a fatal error instead of using the intended fallback buffer. Setup now takes the fallback, exactly as designed.

- No extra GPU memory is used; the compact layout stays as is.
- Verified on dante: SH1 at a 400k target now trains and densifies to the cap (previously failed at start); SH3 near-cap case also covered.
- Two new regression tests pin both entry points; full affected test sweep is green (136/136).