### PR TITLE
Restore plugins and settings location on Windows builds

### DIFF
--- a/src/core/include/core/user_paths.hpp
+++ b/src/core/include/core/user_paths.hpp
@@ -39,7 +39,6 @@ namespace lfs::core {
      *
      * - Windows: `%USERPROFILE%/.lichtfeld/{config,data,cache,logs}`.
      * - Linux: `~/.lichtfeld/{config,data,cache,logs,plugins,venv}`.
-     * - Portable builds: `.lichtfeld` next to the executable.
      * - `LFS_HOME` and explicit roots use one unified root on every OS.
      */
     class LFS_CORE_API UserPaths {

--- a/src/core/user_paths.cpp
+++ b/src/core/user_paths.cpp
@@ -5,7 +5,6 @@
 #include "core/user_paths.hpp"
 
 #include "core/environment.hpp"
-#include "core/executable_path.hpp"
 #include "path_utils.hpp"
 
 #include <nlohmann/json.hpp>
@@ -324,20 +323,6 @@ namespace lfs::core {
 
         if (const auto root = environmentPath("LFS_HOME"))
             return fromUnifiedRoot(*root);
-
-#ifdef LFS_BUILD_PORTABLE
-        if (!options.portable) {
-            try {
-                return fromUnifiedRoot(getExecutableDir() / ".lichtfeld");
-            } catch (const std::exception& error) {
-                // LFS-CENSUS-OK(empty-catch): convert executable path failures into a typed result.
-                return userPathError(
-                    lfs::ErrorCode::Unavailable,
-                    "Portable user storage could not be resolved.",
-                    std::format("Unable to resolve portable executable directory: {}", error.what()));
-            }
-        }
-#endif
 
         if (options.portable) {
             if (!options.executable_dir || options.executable_dir->empty())

--- a/tests/test_user_paths.cpp
+++ b/tests/test_user_paths.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include "core/executable_path.hpp"
 #include "core/legacy_settings_migration.hpp"
 #include "core/user_paths.hpp"
 
@@ -459,7 +458,6 @@ namespace {
         EXPECT_NE((*first)->parent_path(), (*second)->parent_path());
     }
 
-#if !defined(LFS_BUILD_PORTABLE)
 #ifdef _WIN32
     TEST_F(UserPathsContractTest, WindowsDefaultUsesProfileDotLichtfeld) {
         const ScopedEnvironmentVariable lfs_home("LFS_HOME", std::nullopt);
@@ -497,17 +495,6 @@ namespace {
         ASSERT_TRUE(resolved.has_value()) << resolved.error();
         EXPECT_EQ(resolved->configDir(), root_ / "home" / ".lichtfeld" / "config");
         EXPECT_EQ(resolved->logDir(), root_ / "home" / ".lichtfeld" / "logs");
-    }
-#endif
-#endif
-
-#if defined(LFS_BUILD_PORTABLE)
-    TEST_F(UserPathsContractTest, PortableBuildDefaultsNextToExecutable) {
-        const ScopedEnvironmentVariable lfs_home("LFS_HOME", std::nullopt);
-        const auto resolved = lfs::core::UserPaths::resolve();
-        ASSERT_TRUE(resolved.has_value()) << resolved.error();
-        EXPECT_EQ(resolved->configDir(),
-                  lfs::core::getExecutableDir() / ".lichtfeld" / "config");
     }
 #endif
 


### PR DESCRIPTION
Since #1629, Windows builds stored plugins and settings in a new `.lichtfeld` folder next to the exe instead of the user's home folder. Result: installed plugins showed as "Install" and installing created a stray folder beside the exe.

Nothing was lost — the app just looked in the wrong place. This removes the wrong path rule so every build uses `~/.lichtfeld` again, exactly as in 0.5.3. Plugins reappear with no user action.

29 deleted lines, no additions. All UserPaths tests pass (24/24).