### PR TITLE
Keep .licht project saves working past 2 GiB checkpoints on Windows

### DIFF
--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -258,6 +258,7 @@ add_library(lfs_io STATIC
         project/crc32c.hpp
         project/crc32c.cpp
         project/project_container_internal.hpp
+        project/span_streambuf.hpp
         project/project_file.cpp
         project/project_container.cpp
         project/project_writer.cpp

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -9,6 +9,7 @@
 #include "io/loader.hpp"
 #include "project_container_internal.hpp"
 #include "project_framing.hpp"
+#include "span_streambuf.hpp"
 
 #include <zstd.h>
 
@@ -23,7 +24,6 @@
 #include <ostream>
 #include <ranges>
 #include <set>
-#include <streambuf>
 #include <string>
 #include <system_error>
 #include <unordered_map>
@@ -464,50 +464,6 @@ namespace lfs::io::project {
 
     } // namespace
 
-    namespace {
-
-        class ReadOnlyMemoryBuffer final : public std::streambuf {
-        public:
-            explicit ReadOnlyMemoryBuffer(
-                const std::span<const std::byte> bytes) {
-                auto* begin = const_cast<char*>(
-                    reinterpret_cast<const char*>(bytes.data()));
-                setg(begin, begin, begin + bytes.size());
-            }
-
-        protected:
-            pos_type seekoff(const off_type offset,
-                             const std::ios_base::seekdir direction,
-                             const std::ios_base::openmode mode) override {
-                if ((mode & std::ios_base::in) == 0) {
-                    return pos_type(off_type(-1));
-                }
-                char* base = eback();
-                char* target = nullptr;
-                if (direction == std::ios_base::beg) {
-                    target = base + offset;
-                } else if (direction == std::ios_base::cur) {
-                    target = gptr() + offset;
-                } else if (direction == std::ios_base::end) {
-                    target = egptr() + offset;
-                }
-                if (!target || target < base || target > egptr()) {
-                    return pos_type(off_type(-1));
-                }
-                setg(base, target, egptr());
-                return pos_type(target - base);
-            }
-
-            pos_type seekpos(const pos_type position,
-                             const std::ios_base::openmode mode) override {
-                return seekoff(
-                    static_cast<off_type>(position),
-                    std::ios_base::beg, mode);
-            }
-        };
-
-    } // namespace
-
     struct LazyChunkValue::Impl {
         std::shared_ptr<ProjectReader> reader;
         std::optional<ChunkInfo> source;
@@ -682,7 +638,7 @@ namespace lfs::io::project {
                 "lazy_chunk.visitor");
         }
         if (impl_->owned) {
-            ReadOnlyMemoryBuffer buffer(std::span<const std::byte>(
+            SpanStreambuf buffer(std::span<const std::byte>(
                 impl_->owned->data(), impl_->owned->size()));
             std::istream stream(&buffer);
             return visitor(stream, impl_->owned->size());
@@ -695,7 +651,7 @@ namespace lfs::io::project {
                 "lazy_chunk.source");
         }
         if (impl_->inflated) {
-            ReadOnlyMemoryBuffer buffer(std::span<const std::byte>(
+            SpanStreambuf buffer(std::span<const std::byte>(
                 impl_->inflated->data(), impl_->inflated->size()));
             std::istream stream(&buffer);
             return visitor(stream, impl_->inflated->size());
@@ -715,7 +671,7 @@ namespace lfs::io::project {
         if (!logical) {
             return lfs::Result<void>::failure(std::move(logical).error());
         }
-        ReadOnlyMemoryBuffer buffer(*logical);
+        SpanStreambuf buffer(*logical);
         std::istream stream(&buffer);
         return visitor(stream, logical->size());
     }

--- a/src/io/project/span_streambuf.hpp
+++ b/src/io/project/span_streambuf.hpp
@@ -1,0 +1,175 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <span>
+#include <streambuf>
+
+namespace lfs::io::project {
+
+    // Get-area windows stay at most INT_MAX bytes because MSVC stores the
+    // get-area length as int.
+    class SpanStreambuf final : public std::streambuf {
+    public:
+        explicit SpanStreambuf(
+            std::span<const std::byte> bytes,
+            std::size_t window_bytes = static_cast<std::size_t>(
+                std::numeric_limits<int>::max()))
+            : bytes_(bytes),
+              window_bytes_(std::clamp(
+                  window_bytes, std::size_t{1},
+                  static_cast<std::size_t>(
+                      std::numeric_limits<int>::max()))) {
+            assert(window_bytes >= 1 &&
+                   window_bytes <=
+                       static_cast<std::size_t>(
+                           std::numeric_limits<int>::max()));
+            set_window(0);
+        }
+
+    protected:
+        int_type underflow() override {
+            if (gptr() < egptr()) {
+                return traits_type::to_int_type(*gptr());
+            }
+            const auto pos = logical_position();
+            if (pos >= size()) {
+                return traits_type::eof();
+            }
+            set_window(pos);
+            if (gptr() < egptr()) {
+                return traits_type::to_int_type(*gptr());
+            }
+            return traits_type::eof();
+        }
+
+        std::streamsize xsgetn(char* s,
+                               std::streamsize count) override {
+            if (s == nullptr || count <= 0) {
+                return 0;
+            }
+            const auto pos = logical_position();
+            const auto total = size();
+            if (pos >= total) {
+                return 0;
+            }
+            const auto want = static_cast<std::uint64_t>(count);
+            const auto take = std::min(want, total - pos);
+            std::memcpy(s, bytes_.data() + pos,
+                        static_cast<std::size_t>(take));
+            set_window(pos + take);
+            return static_cast<std::streamsize>(take);
+        }
+
+        pos_type seekoff(const off_type offset,
+                         const std::ios_base::seekdir direction,
+                         const std::ios_base::openmode mode) override {
+            if ((mode & std::ios_base::in) == 0) {
+                return pos_type(off_type(-1));
+            }
+            const auto total = size();
+            std::uint64_t base = 0;
+            if (direction == std::ios_base::beg) {
+                base = 0;
+            } else if (direction == std::ios_base::cur) {
+                base = logical_position();
+            } else if (direction == std::ios_base::end) {
+                base = total;
+            } else {
+                return pos_type(off_type(-1));
+            }
+
+            std::uint64_t target = 0;
+            if (offset >= 0) {
+                const auto add = static_cast<std::uint64_t>(offset);
+                if (add > total - base) {
+                    return pos_type(off_type(-1));
+                }
+                target = base + add;
+            } else {
+                std::uint64_t mag = 0;
+                if (offset ==
+                    std::numeric_limits<off_type>::min()) {
+                    mag = static_cast<std::uint64_t>(
+                              std::numeric_limits<off_type>::max()) +
+                          1;
+                } else {
+                    mag = static_cast<std::uint64_t>(-offset);
+                }
+                if (mag > base) {
+                    return pos_type(off_type(-1));
+                }
+                target = base - mag;
+            }
+
+            const auto window_len =
+                (eback() != nullptr && egptr() != nullptr)
+                    ? static_cast<std::uint64_t>(egptr() - eback())
+                    : 0;
+            if (eback() != nullptr && target >= window_start_ &&
+                target <= window_start_ + window_len) {
+                setg(eback(),
+                     eback() + static_cast<std::ptrdiff_t>(
+                                   target - window_start_),
+                     egptr());
+            } else {
+                set_window(target);
+            }
+            return pos_type(static_cast<off_type>(target));
+        }
+
+        pos_type seekpos(const pos_type position,
+                         const std::ios_base::openmode mode) override {
+            return seekoff(static_cast<off_type>(position),
+                           std::ios_base::beg, mode);
+        }
+
+    private:
+        [[nodiscard]] std::uint64_t size() const noexcept {
+            return static_cast<std::uint64_t>(bytes_.size());
+        }
+
+        [[nodiscard]] char* data() const noexcept {
+            return const_cast<char*>(
+                reinterpret_cast<const char*>(bytes_.data()));
+        }
+
+        [[nodiscard]] std::uint64_t
+        logical_position() const noexcept {
+            if (eback() == nullptr || gptr() == nullptr) {
+                return window_start_;
+            }
+            return window_start_ +
+                   static_cast<std::uint64_t>(gptr() - eback());
+        }
+
+        void set_window(const std::uint64_t pos) {
+            const auto total = size();
+            window_start_ = pos > total ? total : pos;
+            char* const first = data() + window_start_;
+            if (window_start_ >= total) {
+                setg(first, first, first);
+                return;
+            }
+            const auto remaining = total - window_start_;
+            const auto count = std::min(
+                remaining,
+                static_cast<std::uint64_t>(window_bytes_));
+            setg(first, first,
+                 first + static_cast<std::ptrdiff_t>(count));
+        }
+
+        std::span<const std::byte> bytes_{};
+        std::uint64_t window_start_ = 0;
+        std::size_t window_bytes_ = 1;
+    };
+
+} // namespace lfs::io::project

--- a/src/io/project/splat_chapter.cpp
+++ b/src/io/project/splat_chapter.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "io/splat_chapter.hpp"
+#include "span_streambuf.hpp"
 
 #include "core/cuda/sh_layout.cuh"
 #include "core/cuda_error_typed.hpp"
@@ -24,7 +25,6 @@
 #include <limits>
 #include <optional>
 #include <ranges>
-#include <streambuf>
 #include <string_view>
 #include <utility>
 
@@ -278,47 +278,6 @@ namespace lfs::io::project {
             }
             return {};
         }
-
-        class SpanStreambuf final : public std::streambuf {
-        public:
-            explicit SpanStreambuf(const std::span<const char> bytes) {
-                auto* begin = const_cast<char*>(bytes.data());
-                setg(begin, begin, begin + bytes.size());
-            }
-
-        protected:
-            pos_type seekoff(const off_type offset, const std::ios_base::seekdir direction,
-                             const std::ios_base::openmode which = std::ios_base::in) override {
-                if ((which & std::ios_base::in) == 0)
-                    return pos_type(off_type(-1));
-                const auto current = static_cast<off_type>(gptr() - eback());
-                const auto end = static_cast<off_type>(egptr() - eback());
-                off_type target = 0;
-                if (direction == std::ios_base::beg) {
-                    if (offset < 0 || offset > end)
-                        return pos_type(off_type(-1));
-                    target = offset;
-                } else if (direction == std::ios_base::cur) {
-                    if ((offset > 0 && offset > end - current) ||
-                        (offset < 0 && offset < -current))
-                        return pos_type(off_type(-1));
-                    target = current + offset;
-                } else if (direction == std::ios_base::end) {
-                    if ((offset > 0 && offset > end) ||
-                        (offset < 0 && offset < -end))
-                        return pos_type(off_type(-1));
-                    target = end + offset;
-                } else
-                    return pos_type(off_type(-1));
-                setg(eback(), eback() + target, egptr());
-                return pos_type(target);
-            }
-
-            pos_type seekpos(const pos_type position,
-                             const std::ios_base::openmode which = std::ios_base::in) override {
-                return seekoff(off_type(position), std::ios_base::beg, which);
-            }
-        };
 
         lfs::Error splat_error(const lfs::ErrorCode code, std::string message,
                                std::string detail) {
@@ -687,9 +646,8 @@ namespace lfs::io::project {
         }
         try {
             auto result = std::make_unique<lfs::core::SplatData>();
-            const auto chars = std::span<const char>(
-                reinterpret_cast<const char*>(bytes_.data()), bytes_.size());
-            SpanStreambuf buffer(chars);
+            SpanStreambuf buffer(std::span<const std::byte>(
+                bytes_.data(), bytes_.size()));
             std::istream stream(&buffer);
             result->deserialize(stream, std::move(tensor_allocator));
             if (!stream || stream.peek() != std::char_traits<char>::eof()) {

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -6,6 +6,7 @@
 #include "app/headless_recovery_document.hpp"
 #include "io/loaders/loader_utils.hpp"
 #include "io/project/project_container_internal.hpp"
+#include "io/project/span_streambuf.hpp"
 #include "io/project_document.hpp"
 #include "io/project_recovery.hpp"
 #include "licht_test_support.hpp"
@@ -31,6 +32,7 @@
 #include <fstream>
 #include <glm/gtc/type_ptr.hpp>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <ranges>
@@ -579,6 +581,224 @@ namespace {
         EXPECT_FALSE(live_rad);
         EXPECT_EQ(live_rad.error().code(),
                   lfs::ErrorCode::FailedPrecondition);
+    }
+
+    TEST(SpanStreambufTest, WindowedReadsAndSeeks) {
+        constexpr std::size_t n = 1000;
+        std::vector<std::byte> pattern(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            pattern[i] = static_cast<std::byte>((i * 131u) & 0xffu);
+        }
+        SpanStreambuf buffer(
+            std::span<const std::byte>(pattern.data(),
+                                       pattern.size()),
+            7);
+        std::istream stream(&buffer);
+
+        for (std::size_t i = 0; i < n; ++i) {
+            const int ch = stream.get();
+            ASSERT_NE(ch, std::char_traits<char>::eof()) << i;
+            EXPECT_EQ(static_cast<unsigned char>(ch),
+                      static_cast<unsigned char>(pattern[i]))
+                << i;
+        }
+        EXPECT_EQ(stream.get(), std::char_traits<char>::eof());
+
+        stream.clear();
+        stream.seekg(0);
+        ASSERT_TRUE(stream);
+        std::array<char, 64> chunk{};
+        stream.read(chunk.data(), 64);
+        ASSERT_EQ(stream.gcount(), 64);
+        ASSERT_TRUE(stream);
+        for (std::size_t i = 0; i < chunk.size(); ++i) {
+            EXPECT_EQ(static_cast<unsigned char>(chunk[i]),
+                      static_cast<unsigned char>(pattern[i]))
+                << i;
+        }
+
+        stream.clear();
+        stream.seekg(333, std::ios::beg);
+        EXPECT_EQ(stream.tellg(), std::streampos(333));
+        ASSERT_TRUE(stream);
+        {
+            const int ch = stream.get();
+            ASSERT_NE(ch, std::char_traits<char>::eof());
+            EXPECT_EQ(static_cast<unsigned char>(ch),
+                      static_cast<unsigned char>(pattern[333]));
+        }
+
+        stream.seekg(17, std::ios::cur);
+        EXPECT_EQ(stream.tellg(), std::streampos(351));
+        ASSERT_TRUE(stream);
+        {
+            const int ch = stream.get();
+            ASSERT_NE(ch, std::char_traits<char>::eof());
+            EXPECT_EQ(static_cast<unsigned char>(ch),
+                      static_cast<unsigned char>(pattern[351]));
+        }
+
+        stream.seekg(-12, std::ios::cur);
+        EXPECT_EQ(stream.tellg(), std::streampos(340));
+        ASSERT_TRUE(stream);
+        {
+            const int ch = stream.get();
+            ASSERT_NE(ch, std::char_traits<char>::eof());
+            EXPECT_EQ(static_cast<unsigned char>(ch),
+                      static_cast<unsigned char>(pattern[340]));
+        }
+
+        stream.seekg(-80, std::ios::end);
+        EXPECT_EQ(stream.tellg(), std::streampos(920));
+        ASSERT_TRUE(stream);
+        {
+            const int ch = stream.get();
+            ASSERT_NE(ch, std::char_traits<char>::eof());
+            EXPECT_EQ(static_cast<unsigned char>(ch),
+                      static_cast<unsigned char>(pattern[920]));
+        }
+
+        stream.clear();
+        stream.seekg(static_cast<std::streamoff>(n),
+                     std::ios::beg);
+        ASSERT_TRUE(stream);
+        EXPECT_EQ(stream.tellg(), std::streampos(n));
+        EXPECT_EQ(stream.get(), std::char_traits<char>::eof());
+        EXPECT_TRUE(stream.eof());
+
+        stream.clear();
+        stream.seekg(static_cast<std::streamoff>(n + 1),
+                     std::ios::beg);
+        EXPECT_TRUE(stream.fail());
+
+        stream.clear();
+        stream.seekg(0);
+        ASSERT_TRUE(stream);
+        stream.seekg(-1, std::ios::beg);
+        EXPECT_TRUE(stream.fail());
+
+        stream.clear();
+        stream.seekg(static_cast<std::streamoff>(n - 10));
+        ASSERT_TRUE(stream);
+        std::array<char, 32> tail{};
+        stream.read(tail.data(), 32);
+        EXPECT_EQ(stream.gcount(), 10);
+        EXPECT_TRUE(stream.eof());
+        for (std::size_t i = 0; i < 10; ++i) {
+            EXPECT_EQ(static_cast<unsigned char>(tail[i]),
+                      static_cast<unsigned char>(
+                          pattern[n - 10 + i]))
+                << i;
+        }
+    }
+
+    TEST(ProjectDocumentTest, VisitStreamOwnedSeekableRoundTrip) {
+        constexpr std::size_t n = 512;
+        std::vector<std::byte> pattern(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            pattern[i] = static_cast<std::byte>((i * 131u) & 0xffu);
+        }
+        const auto expected = pattern;
+        auto chunk = require_result(LazyChunkValue::from_owned(
+            std::move(pattern), fixed_uuid(1679)));
+        auto visited = chunk.visit_stream(
+            [&](std::istream& stream,
+                const std::uint64_t bytes) -> lfs::Result<void> {
+                EXPECT_EQ(bytes, n);
+                std::array<char, 32> head{};
+                stream.read(
+                    head.data(),
+                    static_cast<std::streamsize>(head.size()));
+                EXPECT_TRUE(stream.good());
+                EXPECT_EQ(stream.gcount(), 32);
+                for (std::size_t i = 0; i < head.size(); ++i) {
+                    EXPECT_EQ(
+                        static_cast<unsigned char>(head[i]),
+                        static_cast<unsigned char>(expected[i]))
+                        << i;
+                }
+                const auto tail_offset =
+                    static_cast<std::streamoff>(bytes - 16);
+                stream.seekg(tail_offset);
+                EXPECT_TRUE(stream.good());
+                EXPECT_EQ(stream.tellg(),
+                          std::streampos(tail_offset));
+                std::array<char, 16> tail{};
+                stream.read(
+                    tail.data(),
+                    static_cast<std::streamsize>(tail.size()));
+                EXPECT_TRUE(stream.good());
+                EXPECT_EQ(stream.gcount(), 16);
+                for (std::size_t i = 0; i < tail.size(); ++i) {
+                    EXPECT_EQ(
+                        static_cast<unsigned char>(tail[i]),
+                        static_cast<unsigned char>(
+                            expected[expected.size() - 16 + i]))
+                        << i;
+                }
+                return {};
+            });
+        ASSERT_TRUE(visited)
+            << lfs::format_for_developer(visited.error());
+    }
+
+    TEST(SpanStreambufTest, SpanStreambufServesBuffersOver2GiB) {
+        const auto int_max = static_cast<std::size_t>(
+            std::numeric_limits<int>::max());
+        const std::size_t size = int_max + 4096;
+        std::vector<std::byte> bytes(size, std::byte{0});
+        for (std::size_t i = 0; i < 40; ++i) {
+            bytes[i] = static_cast<std::byte>(0xA0 + i);
+        }
+        for (std::size_t i = 0; i < 16; ++i) {
+            bytes[int_max - 8 + i] =
+                static_cast<std::byte>(0xB0 + i);
+        }
+        for (std::size_t i = 0; i < 16; ++i) {
+            bytes[size - 16 + i] =
+                static_cast<std::byte>(0xC0 + i);
+        }
+
+        SpanStreambuf buffer(
+            std::span<const std::byte>(bytes.data(),
+                                       bytes.size()));
+        std::istream stream(&buffer);
+
+        std::array<char, 40> head{};
+        stream.read(head.data(), 40);
+        ASSERT_TRUE(stream.good());
+        ASSERT_EQ(stream.gcount(), 40);
+        for (std::size_t i = 0; i < head.size(); ++i) {
+            EXPECT_EQ(static_cast<unsigned char>(head[i]),
+                      static_cast<unsigned char>(bytes[i]))
+                << i;
+        }
+
+        stream.seekg(static_cast<std::streamoff>(int_max - 8));
+        ASSERT_TRUE(stream.good());
+        std::array<char, 16> mid{};
+        stream.read(mid.data(), 16);
+        ASSERT_TRUE(stream.good());
+        ASSERT_EQ(stream.gcount(), 16);
+        for (std::size_t i = 0; i < mid.size(); ++i) {
+            EXPECT_EQ(
+                static_cast<unsigned char>(mid[i]),
+                static_cast<unsigned char>(bytes[int_max - 8 + i]))
+                << i;
+        }
+
+        stream.seekg(-16, std::ios::end);
+        ASSERT_TRUE(stream.good());
+        std::array<char, 16> tail{};
+        stream.read(tail.data(), 16);
+        ASSERT_TRUE(stream.good());
+        ASSERT_EQ(stream.gcount(), 16);
+        for (std::size_t i = 0; i < tail.size(); ++i) {
+            EXPECT_EQ(
+                static_cast<unsigned char>(tail[i]),
+                static_cast<unsigned char>(bytes[size - 16 + i]))
+                << i;
+        }
     }
 
     TEST(LoaderGeoreferenceTest,


### PR DESCRIPTION
Fixes #1679.

On Windows, saving a `.licht` project silently started failing once the model grew past ~8M Gaussians. At that point the checkpoint inside the project crosses 2 GB, and the memory reader that validates it before writing tops out at 2 GB on Microsoft's compiler. Every read comes back empty, the app wrongly reports the checkpoint as truncated, and a finished multi-hour run can be lost on exit. Linux and macOS were never affected.

The fix replaces that reader (and a second one with the same flaw in splat loading) with one shared reader that serves the data in safe-sized windows, so size no longer matters.

**When saves happen now** — timing is unchanged, they just work at any size:
- starting training saves the project first,
- during training the project is saved in the background at the configured checkpoint steps,
- a final save runs when training completes,
- stopping early or an error does not write (per #1696).

Previously each of these silently failed past 2 GB on Windows; now they all succeed regardless of model size.

New unit tests cover the windowed reader, including a real over-2-GB buffer crossing the exact boundary Windows trips on.
