### PR TITLE
Suppress the stale Training Stopped popup when loading a new dataset

### DIFF
--- a/src/python/lfs/notification_bridge.cpp
+++ b/src/python/lfs/notification_bridge.cpp
@@ -70,7 +70,7 @@ namespace lfs::python {
             if (!e.success)
                 return; // failures surface via the native ErrorBus bridge
             if (e.suppress_notification)
-                return; // stop was part of New Project / app close / reset — no modal (issue #1604)
+                return; // stop was part of New Project / app close / reset / trainer teardown on scene/dataset replacement — no modal (issue #1604, #1645)
 
             namespace Str = lichtfeld::Strings::Training::Button;
 

--- a/src/visualizer/training/training_manager.cpp
+++ b/src/visualizer/training/training_manager.cpp
@@ -608,6 +608,7 @@ namespace lfs::vis {
             if (state == TrainingState::Paused && trainer_) {
                 trainer_->request_resume();
             }
+            suppressCompletionNotification();
             stopTraining();
         }
 

--- a/tests/test_scene_validity.cpp
+++ b/tests/test_scene_validity.cpp
@@ -75,6 +75,9 @@ namespace lfs::python {
         private:
             std::filesystem::path path_;
         };
+
+        bool transition_trainer_manager_for_test(lfs::vis::TrainerManager& trainer_manager,
+                                                 lfs::vis::TrainingState state);
     } // namespace
 
     TEST(TrainingStateMachineTest, PublishesFinishReasonBeforeFinishedCallback) {
@@ -349,6 +352,36 @@ namespace lfs::python {
         EXPECT_EQ(manager.splatExportableStorage(), nullptr);
         EXPECT_EQ(after.allocated_bytes, before.allocated_bytes);
         EXPECT_EQ(after.cached_bytes, 0u);
+    }
+
+    TEST(TrainerConstructionTest, ClearTrainerSuppressesStoppedNotificationForPausedTrainer) {
+        core::Scene scene;
+        const core::NodeId cameras = scene.addGroup("Cameras");
+        scene.addCamera("camera.png", cameras, make_test_camera());
+        lfs::vis::TrainerManager manager;
+        manager.setScene(&scene);
+        manager.setTrainer(std::make_unique<training::Trainer>(scene));
+
+        ASSERT_TRUE(transition_trainer_manager_for_test(manager, lfs::vis::TrainingState::Running));
+        ASSERT_TRUE(transition_trainer_manager_for_test(manager, lfs::vis::TrainingState::Paused));
+
+        int completions = 0;
+        bool user_stopped = false;
+        bool suppress_notification = false;
+        const auto id = lfs::core::events::state::TrainingCompleted::when([&](const auto& e) {
+            ++completions;
+            user_stopped = e.user_stopped;
+            suppress_notification = e.suppress_notification;
+        });
+
+        ASSERT_TRUE(manager.clearTrainer());
+        EXPECT_EQ(completions, 1);
+        EXPECT_TRUE(user_stopped);
+        EXPECT_TRUE(suppress_notification);
+        EXPECT_EQ(manager.getState(), lfs::vis::TrainingState::Idle);
+
+        lfs::event::EventBridge::instance().unsubscribe(
+            typeid(lfs::core::events::state::TrainingCompleted), id);
     }
 
     namespace {


### PR DESCRIPTION
Fixes #1645.

Opening a project that was saved while training was paused, then loading a new dataset, popped a "Training Stopped at iteration N" message showing the previous project's numbers — nothing had been stopped, and nothing was saved. The popup came from the internal cleanup that shuts the old training session down before the new dataset loads.

That cleanup is now marked as housekeeping, the same way New Project, app close, and reset already are, so no popup appears. A genuine user stop still shows it.

Verified in the app: the reported steps no longer show the popup, a real stop still does. Unit test included.
