### PR TITLE
Disable Compact Project until a project file is bound

### DIFF
--- a/src/python/lfs_plugins/file_menu.py
+++ b/src/python/lfs_plugins/file_menu.py
@@ -332,6 +332,13 @@ def _on_show_resume_checkpoint_popup(path: str):
     open_resume_checkpoint_panel(path)
 
 
+def _can_compact_project() -> bool:
+    try:
+        return bool(lf.project_has_path())
+    except Exception:
+        return False
+
+
 @register_menu
 class FileMenu:
     """File menu for the menu bar."""
@@ -382,7 +389,10 @@ class FileMenu:
                 shortcut="Ctrl+S",
             ),
             menu_operator(SaveProjectAsOperator),
-            menu_operator(CompactProjectOperator),
+            menu_operator(
+                CompactProjectOperator,
+                enabled=_can_compact_project(),
+            ),
             menu_toggle(
                 lf.ui.tr("menu.file.auto_save_on_close"),
                 lambda: lf.project_set_auto_save_on_close(

--- a/src/python/lfs_plugins/layouts/menus.py
+++ b/src/python/lfs_plugins/layouts/menus.py
@@ -58,6 +58,8 @@ def menu_operator(
     operator_cls_or_id: Any,
     label: str = "",
     shortcut: str = "",
+    *,
+    enabled: bool = True,
 ) -> dict[str, Any]:
     """Create an operator-backed menu entry.
 
@@ -78,6 +80,8 @@ def menu_operator(
     }
     if shortcut:
         entry["shortcut"] = shortcut
+    if not enabled:
+        entry["enabled"] = False
     return entry
 
 

--- a/tests/python/test_file_menu_recent.py
+++ b/tests/python/test_file_menu_recent.py
@@ -54,6 +54,7 @@ def _load_file_menu(monkeypatch, recent_paths=()):
     lf_stub.project_clear_recent_files = lambda: None
     lf_stub.project_auto_save_on_close_enabled = lambda: False
     lf_stub.project_is_dirty = lambda: False
+    lf_stub.project_has_path = lambda: False
     lf_stub.project_open = project_open
     lf_stub.project_remove_recent_file = project_remove_recent_file
     lf_stub.project_open_calls = opened
@@ -219,4 +220,30 @@ def test_open_recent_existing_other_error_shows_message(monkeypatch, tmp_path):
     _title, message, style = file_menu.lf.message_dialogs[0]
     assert style == "error"
     assert "boom" in message
+
+
+def _compact_project_item(file_menu):
+    for item in file_menu.FileMenu().menu_items():
+        if str(item.get("operator_id", "")).endswith("CompactProjectOperator"):
+            return item
+    raise AssertionError("CompactProjectOperator menu entry missing")
+
+
+def test_compact_project_enabled_only_with_durable_path(monkeypatch):
+    file_menu = _load_file_menu(monkeypatch)
+
+    file_menu.lf.project_has_path = lambda: False
+    disabled = _compact_project_item(file_menu)
+    assert disabled["enabled"] is False
+
+    file_menu.lf.project_has_path = lambda: True
+    enabled = _compact_project_item(file_menu)
+    assert "enabled" not in enabled or enabled["enabled"] is True
+
+    def raise_missing():
+        raise RuntimeError("project_has_path unavailable")
+
+    file_menu.lf.project_has_path = raise_missing
+    guarded = _compact_project_item(file_menu)
+    assert guarded["enabled"] is False
 


### PR DESCRIPTION
Fixes #1657.

Compact Project was always clickable and simply errored when no project was loaded. The menu entry is now greyed out until the project has been saved or opened, and updates every time the menu opens — disabled on a fresh start and after New Project, enabled once a project file is bound.

Verified in the running app across all three scenarios from the issue: fresh start (disabled), after saving a project (enabled), after New Project (disabled again).
