### PR TITLE
Fix Save As over an existing project failing on Windows

### DIFF
--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -3604,40 +3604,52 @@ namespace lfs::io::project {
             return save_error;
         }
 
-        auto staged_reader =
-            ProjectReader::open(temporary);
-        if (!staged_reader) {
-            auto cause =
-                std::move(staged_reader).error();
-            auto restored =
-                rebind_preserving_dirty_lazy(
-                    original_path);
-            remove_temporary();
-            if (!restored) {
-                return std::move(cause)
-                    .with_suppressed(
-                        std::move(restored).error());
+        lfs::core::Uuid expected_commit_uuid;
+        {
+            auto staged_reader =
+                ProjectReader::open(temporary);
+            if (!staged_reader) {
+                auto cause =
+                    std::move(staged_reader).error();
+                auto restored =
+                    rebind_preserving_dirty_lazy(
+                        original_path);
+                remove_temporary();
+                if (!restored) {
+                    return std::move(cause)
+                        .with_suppressed(
+                            std::move(restored).error());
+                }
+                return cause;
             }
-            return cause;
-        }
-        if (auto verified =
-                staged_reader->verify_all();
-            !verified) {
-            auto cause =
-                std::move(verified).error();
-            auto restored =
-                rebind_preserving_dirty_lazy(
-                    original_path);
-            remove_temporary();
-            if (!restored) {
-                return std::move(cause)
-                    .with_suppressed(
-                        std::move(restored).error());
+            if (auto verified =
+                    staged_reader->verify_all();
+                !verified) {
+                auto cause =
+                    std::move(verified).error();
+                auto restored =
+                    rebind_preserving_dirty_lazy(
+                        original_path);
+                remove_temporary();
+                if (!restored) {
+                    return std::move(cause)
+                        .with_suppressed(
+                            std::move(restored).error());
+                }
+                return cause;
             }
-            return cause;
+            expected_commit_uuid =
+                staged_reader->commit().commit_uuid;
         }
-        const auto expected_commit_uuid =
-            staged_reader->commit().commit_uuid;
+
+        auto post_save_dirty = impl_->dirty;
+        auto post_save_keys = impl_->normalized_source_keys;
+        if (auto rebound =
+                rebind_preserving_dirty_lazy(original_path);
+            !rebound) {
+            remove_temporary();
+            return std::move(rebound).error();
+        }
 
         auto replacement =
             detail::atomic_replace(
@@ -3645,14 +3657,6 @@ namespace lfs::io::project {
         if (!replacement) {
             auto cause =
                 std::move(replacement).error();
-            auto restored =
-                rebind_preserving_dirty_lazy(
-                    original_path);
-            if (!restored) {
-                return std::move(cause)
-                    .with_suppressed(
-                        std::move(restored).error());
-            }
             return cause;
         }
         auto published =
@@ -3671,19 +3675,10 @@ namespace lfs::io::project {
             auto rollback =
                 detail::rollback_atomic_replace(
                     *replacement, *normalized);
-            auto restored =
-                rebind_preserving_dirty_lazy(
-                    original_path);
             if (!rollback) {
                 cause = std::move(cause)
                             .with_suppressed(
                                 std::move(rollback)
-                                    .error());
-            }
-            if (!restored) {
-                cause = std::move(cause)
-                            .with_suppressed(
-                                std::move(restored)
                                     .error());
             }
             return cause;
@@ -3695,19 +3690,10 @@ namespace lfs::io::project {
             auto rollback =
                 detail::rollback_atomic_replace(
                     *replacement, *normalized);
-            auto restored =
-                rebind_preserving_dirty_lazy(
-                    original_path);
             if (!rollback) {
                 cause = std::move(cause)
                             .with_suppressed(
                                 std::move(rollback)
-                                    .error());
-            }
-            if (!restored) {
-                cause = std::move(cause)
-                            .with_suppressed(
-                                std::move(restored)
                                     .error());
             }
             return cause;
@@ -3717,6 +3703,8 @@ namespace lfs::io::project {
             !refreshed) {
             return std::move(refreshed).error();
         }
+        impl_->dirty = std::move(post_save_dirty);
+        impl_->normalized_source_keys = std::move(post_save_keys);
         if (auto finished =
                 detail::finish_atomic_replace(
                     *replacement, *normalized);

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -3245,6 +3245,82 @@ namespace {
     }
 
     TEST(ProjectDocumentTest,
+         SaveAsToExistingForeignProjectSucceedsWithLazyCheckpoint) {
+        TemporaryDirectory temporary;
+        const fs::path source =
+            temporary.path / "saveas-handles-source.licht";
+        const fs::path destination =
+            temporary.path / "saveas-handles-dest.licht";
+        const Uuid checkpoint_uuid = fixed_uuid(9961);
+        write_phase_a_fixture(source);
+        {
+            auto seeded =
+                require_result_ptr(ProjectDocument::open(source));
+            install_bound_autosave_checkpoint(
+                *seeded, fixed_uuid(9960), checkpoint_uuid);
+            auto options = save_options(9962, 300);
+            options.commit.snapshot_uuid = checkpoint_uuid;
+            auto published = seeded->save(source, options);
+            ASSERT_TRUE(published)
+                << lfs::format_for_developer(
+                       published.error());
+        }
+
+        auto foreign = make_empty_document(fixed_uuid(9963), 100);
+        ASSERT_TRUE(foreign->save(
+            destination, save_options(9964, 400)));
+
+        auto document =
+            require_result_ptr(ProjectDocument::open(source));
+        const auto* checkpoint =
+            document->find_checkpoint(checkpoint_uuid);
+        ASSERT_NE(checkpoint, nullptr);
+        EXPECT_TRUE(checkpoint->is_clean_reference());
+        std::vector<std::byte> expected(
+            static_cast<std::size_t>(checkpoint->size()));
+        require_status(checkpoint->read_at(0, expected));
+        require_status(
+            document->edit_view().dom().set(
+                "save_as_handle_marker",
+                std::string{"dirty"}));
+        EXPECT_TRUE(document->dirty());
+
+        auto options = save_options(9965, 500);
+        options.commit.snapshot_uuid = checkpoint_uuid;
+        auto saved = document->save_as(destination, options);
+        ASSERT_TRUE(saved)
+            << lfs::format_for_developer(saved.error());
+        EXPECT_FALSE(document->dirty());
+        ASSERT_TRUE(document->source_path());
+        EXPECT_EQ(
+            *document->source_path(),
+            std::filesystem::absolute(destination)
+                .lexically_normal());
+
+        auto published =
+            require_result(ProjectReader::open(destination));
+        require_status(published.verify_all());
+        EXPECT_EQ(
+            published.superblock().project_uuid,
+            fixed_uuid(950));
+
+        const auto* rebound =
+            document->find_checkpoint(checkpoint_uuid);
+        ASSERT_NE(rebound, nullptr);
+        std::vector<std::byte> actual(
+            static_cast<std::size_t>(rebound->size()));
+        require_status(rebound->read_at(0, actual));
+        EXPECT_EQ(actual, expected);
+
+        auto append_options = save_options(9966, 600);
+        append_options.commit.snapshot_uuid = checkpoint_uuid;
+        auto appended =
+            document->save(destination, append_options);
+        ASSERT_TRUE(appended)
+            << lfs::format_for_developer(appended.error());
+    }
+
+    TEST(ProjectDocumentTest,
          AutosaveInheritsMasterCompatibilityFloorsAndRequiredCapabilities) {
         TemporaryDirectory temporary;
         const fs::path master = temporary.path / "compatibility-master.licht";


### PR DESCRIPTION
Fixes #1684.

Saving a project over an existing project file failed on Windows with "The compacted project could not replace the existing project" (error 32). The save kept its own working files open at the moment it swapped the new file into place, and Windows refuses the swap while they are open. The new file is now fully closed before the swap, matching how first-time saves already do it.

Verified by tracing the running app: before the fix, two handles were still open on the working file at swap time; after the fix, none. Covered by a new regression test that saves over an existing foreign project and checks the result end to end; all 44 project tests and 86 format tests pass.

Saving behavior is unchanged otherwise: saving over your own open project still appends in place, and a failed swap still leaves the existing project untouched.
