### PR TITLE
Make checkpoint steps editable again (#1648)

### DIFF
--- a/src/python/lfs_plugins/training_panel.py
+++ b/src/python/lfs_plugins/training_panel.py
@@ -471,6 +471,9 @@ class TrainingPanel(Panel):
         def _iteration():
             return RuntimeState.iteration.value
 
+        def _save_steps_editable():
+            return _state() in ("ready", "running", "paused")
+
         model.bind_func("show_no_trainer", lambda: not RuntimeState.has_trainer.value)
         model.bind_func(
             "show_no_params",
@@ -595,17 +598,12 @@ class TrainingPanel(Panel):
             "show_dataset_no_data", lambda: d() is None or not d().has_params()
         )
 
-        model.bind_func(
-            "save_edit_mode", lambda: _state() == "ready" and _iteration() == 0
-        )
-        model.bind_func(
-            "save_readonly_mode", lambda: _state() != "ready" or _iteration() != 0
-        )
+        model.bind_func("save_edit_mode", lambda: _save_steps_editable())
+        model.bind_func("save_readonly_mode", lambda: not _save_steps_editable())
         model.bind_func(
             "no_save_steps",
             lambda: (
-                _state() == "ready"
-                and _iteration() == 0
+                _save_steps_editable()
                 and p() is not None
                 and p().has_params()
                 and not list(p().save_steps)
@@ -614,7 +612,7 @@ class TrainingPanel(Panel):
         model.bind_func(
             "no_save_steps_ro",
             lambda: (
-                (_state() != "ready" or _iteration() != 0)
+                not _save_steps_editable()
                 and p() is not None
                 and p().has_params()
                 and not list(p().save_steps)
@@ -1344,11 +1342,6 @@ class TrainingPanel(Panel):
     def _update_save_steps(self, doc):
         params = lf.optimization_params()
         if not params or not params.has_params():
-            return False
-
-        state = RuntimeState.trainer_state.value
-        can_edit = state == "ready" and RuntimeState.iteration.value == 0
-        if not can_edit:
             return False
 
         return self._refresh_save_steps_model(params)

--- a/src/visualizer/gui/rml_status_bar.cpp
+++ b/src/visualizer/gui/rml_status_bar.cpp
@@ -872,7 +872,7 @@ namespace lfs::vis::gui {
 
     void RmlStatusBar::commitSaveStepEdit() {
         auto* tm = lfs::vis::services().trainerOrNull();
-        if (!tm || !tm->canEditSaveSteps() || save_step_interaction_.preview_step == 0)
+        if (!tm || save_step_interaction_.preview_step == 0)
             return;
 
         auto steps = tm->getSaveSteps();
@@ -888,7 +888,7 @@ namespace lfs::vis::gui {
 
     void RmlStatusBar::removeSaveStep(const size_t step) {
         auto* tm = lfs::vis::services().trainerOrNull();
-        if (!tm || !tm->canEditSaveSteps() || step == 0)
+        if (!tm || step == 0)
             return;
 
         auto steps = tm->getSaveSteps();
@@ -913,7 +913,7 @@ namespace lfs::vis::gui {
                                                  const float local_x,
                                                  const float local_y) {
         auto* tm = lfs::vis::services().trainerOrNull();
-        if (!tm || !tm->canEditSaveSteps() || tm->getTotalIterations() <= 0) {
+        if (!tm || tm->getTotalIterations() <= 0) {
             resetSaveStepInteraction();
             return;
         }

--- a/src/visualizer/gui/rmlui/resources/training.rml
+++ b/src/visualizer/gui/rmlui/resources/training.rml
@@ -569,7 +569,7 @@
         <span class="text-accent">{{pv_header_save_steps}}</span>
       </div>
       <div class="section-content collapsed" id="sec-save-steps">
-        <div data-if="save_edit_mode" data-class-disabled-overlay="step_scaling_params_locked">
+        <div data-if="save_edit_mode">
           <div class="setting-row" data-tooltip="training.tooltip.save_step_input">
             <input type="text" id="num-new_step" class="number-input" data-value="new_step_str" />
             <button class="num-step-btn" data-event-mousedown="num_step('new_step', -1)">-</button>

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -482,6 +482,17 @@ namespace lfs::vis::project {
                     "Checkpoint trainer install was rejected");
                 return;
             }
+            if (auto* trainer =
+                    trainer_manager->getTrainer()) {
+                // The user opened this project; trainer
+                // runs continue publishing generations
+                // into it.
+                trainer->set_trainer_project_save_policy({
+                    .on_completion = true,
+                    .on_stop_or_error = false,
+                    .at_step_boundaries = true,
+                });
+            }
             LOG_INFO(
                 "Project trainer restored at iteration {} (dataset={})",
                 installed->iteration,

--- a/src/visualizer/training/training_manager.cpp
+++ b/src/visualizer/training/training_manager.cpp
@@ -1287,19 +1287,7 @@ namespace lfs::vis {
         return pending_opt_params_.save_steps;
     }
 
-    bool TrainerManager::canEditSaveSteps() const {
-        if (!trainer_) {
-            return true;
-        }
-        const auto params = trainer_->getParams();
-        return !params.resume_checkpoint.has_value() &&
-               !params.resume_project.has_value();
-    }
-
-    bool TrainerManager::setSaveSteps(std::vector<size_t> save_steps) {
-        if (!canEditSaveSteps())
-            return false;
-
+    void TrainerManager::setSaveSteps(std::vector<size_t> save_steps) {
         save_steps = normalize_save_steps(std::move(save_steps));
         apply_save_steps(pending_opt_params_, save_steps);
 
@@ -1320,8 +1308,6 @@ namespace lfs::vis {
             apply_save_steps(params.optimization, save_steps);
             trainer_->setParams(params);
         }
-
-        return true;
     }
 
     const char* TrainerManager::getStrategyType() const {
@@ -1887,9 +1873,12 @@ namespace lfs::vis {
 
         if (trainer_->isInitialized() && trainer_->getParams().resume_checkpoint.has_value()) {
             if (auto* const param_mgr = services().paramsOrNull()) {
-                param_mgr->importTrainingParams(trainer_->getParams());
+                auto params = trainer_->getParams();
+                params.optimization.save_steps = param_mgr->copyActiveParams().save_steps;
+                trainer_->setParams(params);
+                param_mgr->importTrainingParams(params);
             }
-            LOG_DEBUG("Ignoring parameter updates for checkpoint-backed trainer");
+            LOG_DEBUG("Ignoring parameter updates for checkpoint-backed trainer (save steps kept)");
             return;
         }
 

--- a/src/visualizer/training/training_manager.hpp
+++ b/src/visualizer/training/training_manager.hpp
@@ -123,8 +123,7 @@ namespace lfs::vis {
         int getNumSplats() const;
         int getMaxGaussians() const;
         std::vector<size_t> getSaveSteps() const;
-        bool setSaveSteps(std::vector<size_t> save_steps);
-        bool canEditSaveSteps() const;
+        void setSaveSteps(std::vector<size_t> save_steps);
         const char* getStrategyType() const;
         bool isGutEnabled() const;
 

--- a/tests/python/test_training_panel_regressions.py
+++ b/tests/python/test_training_panel_regressions.py
@@ -202,6 +202,12 @@ class _ModelStub:
     def bind(self, name, getter, setter):
         self.bindings[name] = (getter, setter)
 
+    def bind_func(self, name, getter):
+        self.bindings[name] = (getter, None)
+
+    def bind_string_list(self, name):
+        self.bindings[name] = (None, None)
+
 
 def test_strategy_switch_resyncs_generated_rows_and_requests_panel_update(
     training_panel_module, monkeypatch
@@ -938,3 +944,38 @@ def test_training_panel_no_longer_uses_removed_image_dialog_alias():
     training_panel = project_root / "src" / "python" / "lfs_plugins" / "training_panel.py"
 
     assert "open_image_file_dialog" not in training_panel.read_text()
+
+
+def test_save_steps_editable_in_active_trainer_states(training_panel_module):
+    """Issue #1648: save steps stay editable after checkpoint resume and while running."""
+    panel = training_panel_module.TrainingPanel()
+    model = _ModelStub()
+    params = _ParamsStub()
+    dataset = _DatasetStub()
+    runtime = training_panel_module.RuntimeState
+
+    panel._bind_visibility(model, lambda: params, lambda: dataset)
+    save_edit_mode = model.bindings["save_edit_mode"][0]
+    save_readonly_mode = model.bindings["save_readonly_mode"][0]
+
+    try:
+        runtime.trainer_state.value = "ready"
+        runtime.iteration.value = 0
+        assert save_edit_mode() is True
+        assert save_readonly_mode() is False
+
+        runtime.iteration.value = 15000
+        assert save_edit_mode() is True
+
+        runtime.trainer_state.value = "paused"
+        assert save_edit_mode() is True
+
+        runtime.trainer_state.value = "running"
+        assert save_edit_mode() is True
+
+        runtime.trainer_state.value = "finished"
+        assert save_edit_mode() is False
+        assert save_readonly_mode() is True
+    finally:
+        runtime.iteration._fallback = 0
+        runtime.training_state._fallback = "idle"

--- a/tests/test_p5_session_chapters.cpp
+++ b/tests/test_p5_session_chapters.cpp
@@ -1755,7 +1755,7 @@ namespace {
     }
 
     TEST_F(P5MetricsRestoreTest,
-           ProjectCheckpointLocksSaveSteps) {
+           ProjectCheckpointAcceptsSaveStepEdits) {
         lfs::core::Scene scene;
         const auto cameras = scene.addGroup("Cameras");
         const auto training_cameras =
@@ -1774,7 +1774,8 @@ namespace {
         lfs::vis::TrainerManager manager;
         manager.setTrainerFromCheckpoint(
             std::move(trainer), 3);
-        EXPECT_FALSE(manager.canEditSaveSteps());
+        manager.setSaveSteps({5});
+        EXPECT_EQ(manager.getSaveSteps(), (std::vector<size_t>{5}));
     }
 
     TEST_F(P5MetricsRestoreTest,


### PR DESCRIPTION
Fixes the editing half of #1648.

The checkpoint steps panel was effectively locked: it only allowed edits before training ever started, it sat under the auto-scale padlock that is on by default, and the progress-bar markers refused any reopened project. On top of that, a reopened project silently never saved at its checkpoint steps, so editing them would have changed nothing.

Now:
- The save-steps panel is editable before, during, and after pausing a run — including reopened projects. The padlock only locks the auto-scaled parameters.
- The progress-bar markers work again everywhere: click to add a checkpoint, drag to move it, right-click to remove it, also mid-training.

When the project saves now:
- At every checkpoint step, during fresh runs and resumed runs alike.
- When training completes.
- Never on stop or on error (#1644) — those still require a manual save.
- Starting fresh over an existing checkpoint still asks first.

Verified with unit tests (Python + C++) and live runs: added a step to a reopened project paused at 2534 and got a save at exactly that step plus the final save; the old build saved nothing on the same flow.