### PR TITLE
Fix training autosave failing while the training model is selected

### DIFF
--- a/src/io/include/io/selection_chapter.hpp
+++ b/src/io/include/io/selection_chapter.hpp
@@ -103,7 +103,8 @@ namespace lfs::io::project {
     [[nodiscard]] LFS_IO_API lfs::Result<CapturedSelectionState>
     capture_selection_state(
         const lfs::core::Scene& scene,
-        std::span<const lfs::core::Uuid> selected_node_uuids);
+        std::span<const lfs::core::Uuid> selected_node_uuids,
+        std::span<const lfs::core::Uuid> omit_node_uuids = {});
 
     [[nodiscard]] LFS_IO_API lfs::Result<SelectionChapter>
     materialize_selection_chapter(CapturedSelectionState state);
@@ -117,7 +118,8 @@ namespace lfs::io::project {
     [[nodiscard]] LFS_IO_API lfs::Result<SelectionChapter>
     capture_selection_chapter(
         const lfs::core::Scene& scene,
-        std::span<const lfs::core::Uuid> selected_node_uuids);
+        std::span<const lfs::core::Uuid> selected_node_uuids,
+        std::span<const lfs::core::Uuid> omit_node_uuids = {});
 
     // Phase-A API. Every slice is validated against topology and copied into
     // its final contiguous CPU tensor. topology is not mutated.

--- a/src/io/include/io/selection_chapter.hpp
+++ b/src/io/include/io/selection_chapter.hpp
@@ -100,6 +100,8 @@ namespace lfs::io::project {
         std::vector<lfs::core::Uuid> selected_node_uuids;
     };
 
+    // The omit list prunes each listed node and its whole subtree,
+    // matching capture_scene_graph.
     [[nodiscard]] LFS_IO_API lfs::Result<CapturedSelectionState>
     capture_selection_state(
         const lfs::core::Scene& scene,
@@ -115,6 +117,8 @@ namespace lfs::io::project {
     [[nodiscard]] LFS_IO_API lfs::Result<SelectionChapter>
     decode_selection_chapter(std::span<const std::byte> payload);
 
+    // The omit list prunes each listed node and its whole subtree,
+    // matching capture_scene_graph.
     [[nodiscard]] LFS_IO_API lfs::Result<SelectionChapter>
     capture_selection_chapter(
         const lfs::core::Scene& scene,

--- a/src/io/project/selection_chapter.cpp
+++ b/src/io/project/selection_chapter.cpp
@@ -1063,6 +1063,30 @@ namespace lfs::io::project {
             selected_node_uuids,
         const std::span<const lfs::core::Uuid>
             omit_node_uuids) {
+        std::unordered_set<lfs::core::Uuid> omitted(
+            omit_node_uuids.begin(), omit_node_uuids.end());
+        const auto collect_descendants =
+            [&](const lfs::core::SceneNode& node,
+                const auto& self) -> void {
+            for (const lfs::core::NodeId child_id :
+                 node.children) {
+                const lfs::core::SceneNode* child =
+                    scene.getNodeById(child_id);
+                if (child == nullptr) {
+                    continue;
+                }
+                omitted.insert(child->uuid);
+                self(*child, self);
+            }
+        };
+        for (const auto& uuid : omit_node_uuids) {
+            const auto* node = scene.getNodeByUuid(uuid);
+            if (node == nullptr) {
+                continue;
+            }
+            collect_descendants(*node, collect_descendants);
+        }
+
         CapturedSelectionState state;
         const auto metadata =
             scene.captureSelectionStateMetadata();
@@ -1079,9 +1103,7 @@ namespace lfs::io::project {
             const auto slices =
                 scene.capturePerNodeSelectionSlices(domain);
             for (const auto& [uuid, tensor] : slices) {
-                if (std::ranges::find(
-                        omit_node_uuids, uuid) !=
-                    omit_node_uuids.end()) {
+                if (omitted.contains(uuid)) {
                     continue;
                 }
                 if (!tensor.is_valid() ||
@@ -1125,9 +1147,7 @@ namespace lfs::io::project {
                  node->type == lfs::core::NodeType::KEYFRAME_GROUP)) {
                 continue;
             }
-            if (std::ranges::find(
-                    omit_node_uuids, uuid) !=
-                omit_node_uuids.end()) {
+            if (omitted.contains(uuid)) {
                 continue;
             }
             state.selected_node_uuids.push_back(uuid);

--- a/src/io/project/selection_chapter.cpp
+++ b/src/io/project/selection_chapter.cpp
@@ -1060,7 +1060,9 @@ namespace lfs::io::project {
     lfs::Result<CapturedSelectionState> capture_selection_state(
         const lfs::core::Scene& scene,
         const std::span<const lfs::core::Uuid>
-            selected_node_uuids) {
+            selected_node_uuids,
+        const std::span<const lfs::core::Uuid>
+            omit_node_uuids) {
         CapturedSelectionState state;
         const auto metadata =
             scene.captureSelectionStateMetadata();
@@ -1077,6 +1079,11 @@ namespace lfs::io::project {
             const auto slices =
                 scene.capturePerNodeSelectionSlices(domain);
             for (const auto& [uuid, tensor] : slices) {
+                if (std::ranges::find(
+                        omit_node_uuids, uuid) !=
+                    omit_node_uuids.end()) {
+                    continue;
+                }
                 if (!tensor.is_valid() ||
                     tensor.ndim() != 1) {
                     return selection_error(
@@ -1118,6 +1125,11 @@ namespace lfs::io::project {
                  node->type == lfs::core::NodeType::KEYFRAME_GROUP)) {
                 continue;
             }
+            if (std::ranges::find(
+                    omit_node_uuids, uuid) !=
+                omit_node_uuids.end()) {
+                continue;
+            }
             state.selected_node_uuids.push_back(uuid);
         }
         return state;
@@ -1155,10 +1167,13 @@ namespace lfs::io::project {
     lfs::Result<SelectionChapter> capture_selection_chapter(
         const lfs::core::Scene& scene,
         const std::span<const lfs::core::Uuid>
-            selected_node_uuids) {
+            selected_node_uuids,
+        const std::span<const lfs::core::Uuid>
+            omit_node_uuids) {
         auto state =
             capture_selection_state(
-                scene, selected_node_uuids);
+                scene, selected_node_uuids,
+                omit_node_uuids);
         if (!state) {
             return std::move(state).error();
         }

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -4161,7 +4161,8 @@ namespace lfs::vis::project {
         auto captured_selection =
             lfs::io::project::
                 capture_selection_chapter(
-                    scene, selected);
+                    scene, selected,
+                    omit_unbound_training);
         if (!captured_selection) {
             return lfs::Status::failure(
                 std::move(captured_selection).error());

--- a/tests/test_selection_chapter.cpp
+++ b/tests/test_selection_chapter.cpp
@@ -246,6 +246,70 @@ namespace {
             restored.captureSelectionStateMetadata();
         EXPECT_EQ(metadata.next_group_id, 2);
     }
+
+    TEST(SelectionChapterTest,
+         CaptureOmitsRequestedNodesFromSelectionAndSlices) {
+        const Uuid node_a = fixed_uuid(41);
+        const Uuid node_b = fixed_uuid(42);
+        Scene scene;
+        add_splat_placeholder(
+            scene, node_a, 3, "splat a");
+        add_splat_placeholder(
+            scene, node_b, 4, "splat b");
+        scene.applyPerNodeSelectionSlices(
+            SelectionDomain::Splat,
+            {
+                {node_a, mask_tensor({1, 0, 1})},
+                {node_b, mask_tensor({0, 1, 0, 1})},
+            });
+
+        const std::array selected = {node_a, node_b};
+        auto full =
+            lfs::io::project::capture_selection_chapter(
+                scene, selected);
+        ASSERT_TRUE(full)
+            << lfs::format_for_developer(full.error());
+
+        const std::array omit = {node_b};
+        auto omitted =
+            lfs::io::project::capture_selection_chapter(
+                scene, selected, omit);
+        ASSERT_TRUE(omitted)
+            << lfs::format_for_developer(omitted.error());
+        ASSERT_EQ(omitted->slices().size(), 1);
+        EXPECT_EQ(
+            omitted->slices()[0].node_uuid, node_a);
+        EXPECT_EQ(
+            omitted->selected_node_uuids(),
+            (std::vector<Uuid>{node_a}));
+        ASSERT_EQ(
+            omitted->groups().size(),
+            full->groups().size());
+        for (std::size_t i = 0;
+             i < omitted->groups().size(); ++i) {
+            EXPECT_EQ(
+                omitted->groups()[i].id,
+                full->groups()[i].id);
+            EXPECT_EQ(
+                omitted->groups()[i].name,
+                full->groups()[i].name);
+            EXPECT_EQ(
+                omitted->groups()[i].count,
+                full->groups()[i].count);
+            EXPECT_EQ(
+                omitted->groups()[i].locked,
+                full->groups()[i].locked);
+            EXPECT_EQ(
+                omitted->groups()[i].color,
+                full->groups()[i].color);
+        }
+        EXPECT_EQ(
+            omitted->active_group_id(),
+            full->active_group_id());
+        EXPECT_EQ(
+            omitted->next_group_id(),
+            full->next_group_id());
+    }
 #endif
 
     TEST(SelectionChapterTest,

--- a/tests/test_selection_chapter.cpp
+++ b/tests/test_selection_chapter.cpp
@@ -310,6 +310,81 @@ namespace {
             omitted->next_group_id(),
             full->next_group_id());
     }
+
+    TEST(SelectionChapterTest,
+         CaptureOmitsRequestedSubtreeFromSelectionAndSlices) {
+        const Uuid parent = fixed_uuid(51);
+        const Uuid sibling = fixed_uuid(52);
+        Scene scene;
+        add_splat_placeholder(
+            scene, parent, 3, "parent");
+        add_splat_placeholder(
+            scene, sibling, 4, "sibling");
+        const auto parent_id =
+            scene.getNodeIdByUuid(parent);
+        ASSERT_NE(parent_id, lfs::core::NULL_NODE);
+        const auto child_id =
+            scene.addCropBox("box", parent_id);
+        ASSERT_NE(child_id, lfs::core::NULL_NODE);
+        const Uuid child = scene.getNodeUuid(child_id);
+        scene.applyPerNodeSelectionSlices(
+            SelectionDomain::Splat,
+            {
+                {parent, mask_tensor({1, 0, 1})},
+                {sibling, mask_tensor({0, 1, 0, 1})},
+            });
+
+        const std::array selected = {
+            parent, child, sibling};
+        auto full =
+            lfs::io::project::capture_selection_chapter(
+                scene, selected);
+        ASSERT_TRUE(full)
+            << lfs::format_for_developer(full.error());
+        EXPECT_EQ(
+            full->selected_node_uuids(),
+            (std::vector<Uuid>{parent, child, sibling}));
+
+        const std::array omit = {parent};
+        auto omitted =
+            lfs::io::project::capture_selection_chapter(
+                scene, selected, omit);
+        ASSERT_TRUE(omitted)
+            << lfs::format_for_developer(omitted.error());
+        ASSERT_EQ(omitted->slices().size(), 1);
+        EXPECT_EQ(
+            omitted->slices()[0].node_uuid, sibling);
+        EXPECT_EQ(
+            omitted->selected_node_uuids(),
+            (std::vector<Uuid>{sibling}));
+        ASSERT_EQ(
+            omitted->groups().size(),
+            full->groups().size());
+        for (std::size_t i = 0;
+             i < omitted->groups().size(); ++i) {
+            EXPECT_EQ(
+                omitted->groups()[i].id,
+                full->groups()[i].id);
+            EXPECT_EQ(
+                omitted->groups()[i].name,
+                full->groups()[i].name);
+            EXPECT_EQ(
+                omitted->groups()[i].count,
+                full->groups()[i].count);
+            EXPECT_EQ(
+                omitted->groups()[i].locked,
+                full->groups()[i].locked);
+            EXPECT_EQ(
+                omitted->groups()[i].color,
+                full->groups()[i].color);
+        }
+        EXPECT_EQ(
+            omitted->active_group_id(),
+            full->active_group_id());
+        EXPECT_EQ(
+            omitted->next_group_id(),
+            full->next_group_id());
+    }
 #endif
 
     TEST(SelectionChapterTest,


### PR DESCRIPTION
During training, the periodic autosave failed with "The saved node selection has a missing owner" whenever the training model - or anything attached to it, like a crop box - was selected in the scene panel. Every autosave of a fresh run failed until the first checkpoint snapshot landed, so nothing was protecting the session in exactly the window that needs protecting. Reported on Discord with this error during a live run.

**Cause:** the training-time autosave deliberately leaves the in-progress model out of the saved scene, but it still saved the selection pointing at that model. The file validator rejects a selection that points at a node the file does not contain. The same mismatch existed one level deeper: leaving out the model also leaves out its children (a crop box drawn before training gets attached to the model), but a selected child still ended up in the saved selection.

**Fix:** the selection is now filtered the same way as the scene - the in-progress model and everything under it are left out of both. Selections and masks of all other nodes are saved exactly as before. Normal saves are unchanged.

**When saves happen now:**
- Training start: the project file is created, or you are asked before an existing run is overwritten.
- During training: a light autosave every few minutes (scene, selection, settings - no checkpoint data), plus full project saves at your checkpoint steps and on completion.
- Stop or error: nothing is written.
- The broken cases - autosave while the training model or its crop box is selected - now work.

**Verified:** two new regression tests plus the full selection/project suites (50 tests green), and live end-to-end runs over MCP: garden dataset, model selected (22 clean autosaves) and crop box selected (20 clean autosaves), where before the fix every autosave in these states failed.
