### PR TITLE
Revert invalid MSVC D9025 warning suppression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1295,7 +1295,6 @@ if(LFS_FAST_COMPILE AND MSVC)
             target_compile_options(${target} PRIVATE
                 $<$<COMPILE_LANGUAGE:CXX>:/Od>
                 $<$<COMPILE_LANGUAGE:CXX>:/Ob0>
-                $<$<COMPILE_LANGUAGE:CXX>:/wd9025>
             )
         endif()
     endfunction()


### PR DESCRIPTION
## Summary

Reverts #1664.

That PR attempted to suppress the expected MSVC `D9025` optimization override diagnostics by adding `/wd9025`. However, `D9025` is a command-line diagnostic rather than a suppressible compiler warning number.

MSVC therefore interprets `/wd9025` as invalid and emits an additional `D9014` warning, increasing Windows build noise instead of reducing it.

## Change

- Remove the invalid `/wd9025` option.
- Preserve the existing fast-compile `/Od` and `/Ob0` behavior unchanged.
- Restore the behavior that existed before #1664.

This intentionally does not attempt another suppression mechanism. The original optimization override diagnostics may remain, but the additional invalid-option warning is removed.