### PR TITLE
Make resumed training runs save their results

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -348,11 +348,6 @@ namespace lfs::app {
                 cli_params.save_project_at_iteration;
             checkpoint_params.save_project_path =
                 cli_params.save_project_path;
-            if (checkpoint_params.save_project_at_iteration &&
-                checkpoint_params.save_project_path.empty()) {
-                checkpoint_params.save_project_path =
-                    checkpoint_params.dataset.output_path / "project.licht";
-            }
             checkpoint_params.cli_iterations_set =
                 cli_params.cli_iterations_set;
 
@@ -497,7 +492,8 @@ namespace lfs::app {
                         }
                         training::grant_headless_project_saves(
                             *installed->trainer,
-                            effective_params);
+                            effective_params,
+                            *params->resume_project);
                         manager->setTrainer(
                             std::move(installed->trainer));
                     } else {
@@ -712,7 +708,8 @@ namespace lfs::app {
                     auto trainer =
                         std::move(installed->trainer);
                     training::grant_headless_project_saves(
-                        *trainer, project->params);
+                        *trainer, project->params,
+                        *params->resume_project);
                     LOG_INFO(
                         "Project display hydration complete; full "
                         "trainer state restored at iteration {}",

--- a/src/app/mcp_gui_tools.cpp
+++ b/src/app/mcp_gui_tools.cpp
@@ -2428,10 +2428,12 @@ namespace lfs::app {
                 return trainer_manager ? trainer_manager->lastTrainingError() : std::nullopt;
             }});
 
-        // CommandCenter's generated session.resume only sets the trainer flag. A
-        // checkpoint-installed trainer has no worker yet, so route GUI MCP session
-        // controls through TrainerManager to keep the state machine and worker
-        // flags in sync.
+        // CommandCenter's generated session.pause/stop only set trainer flags. A
+        // checkpoint-installed trainer has no worker yet, so route GUI MCP pause
+        // and stop through TrainerManager. session.resume keeps the canResume()
+        // guard (resume-only; training.start starts a fresh run) then goes through
+        // VisualizerImpl::startTraining so a paused ungranted trainer shares the
+        // training.start save-grant gate.
         registry.register_tool(
             McpTool{
                 .name = "session.pause",
@@ -2478,8 +2480,7 @@ namespace lfs::app {
                     if (!trainer_manager->canResume())
                         return std::unexpected(std::string(trainer_manager->getActionBlockedReason(
                             vis::TrainingAction::Resume)));
-                    trainer_manager->resumeTraining();
-                    return {};
+                    return viewer_impl->startTraining();
                 });
                 if (!result)
                     return json{{"error", result.error()}};

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -483,7 +483,7 @@ namespace {
                 {"save-project-at-iter"});
             ::args::ValueFlag<std::string> save_project_path(
                 output_group, "path",
-                "Destination for --save-project-at-iter (default: <output>/project.licht)",
+                "Destination for --save-project-at-iter. If omitted, the bound project path is used",
                 {"save-project-path"});
 
             // =============================================================================
@@ -1301,13 +1301,6 @@ lfs::core::args::parse_args_and_params(int argc, const char* const argv[]) {
     }
     apply_step_scaling(*params);
     apply_ppisp_defaults(*params);
-
-    if (params->save_project_at_iteration &&
-        params->save_project_path.empty() &&
-        !params->dataset.output_path.empty()) {
-        params->save_project_path =
-            params->dataset.output_path / "project.licht";
-    }
 
     if (auto error = params->validate(); !error.empty())
         return std::unexpected("ERROR: " + error);

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -360,9 +360,8 @@ namespace lfs::core {
             std::optional<std::filesystem::path> resume_project = std::nullopt;
 
             // Headless/integration-test trigger for the production training
-            // snapshot path. When --save-project-at-iter is set and this path
-            // is empty, the argument parser materializes
-            // <output>/project.licht.
+            // snapshot path. Empty unless the user passed --save-project-path;
+            // the trainer then falls back to the bound project destination.
             std::optional<size_t> save_project_at_iteration = std::nullopt;
             std::filesystem::path save_project_path;
 

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -7573,25 +7573,55 @@ namespace lfs::training {
                         static_cast<std::size_t>(
                             std::numeric_limits<int>::
                                 max())) {
+                    TrainerProjectSavePolicy policy;
+                    std::optional<std::filesystem::path> bound;
+                    {
+                        std::lock_guard lock(project_snapshot_mutex_);
+                        policy = trainer_project_save_policy_;
+                        if (live_project_path_ && !live_project_path_->empty())
+                            bound = *live_project_path_;
+                    }
                     const int target =
                         static_cast<int>(
                             *project_hook);
-                    if (iter + 1 == target &&
-                        !prepared_project_snapshot_) {
-                        prepare_project_snapshot_at_safe_point(
-                            target,
+                    std::filesystem::path
+                        project_hook_destination =
                             getParams()
-                                .save_project_path);
+                                .save_project_path;
+                    if (project_hook_destination
+                            .empty() &&
+                        bound) {
+                        project_hook_destination =
+                            *bound;
                     }
-                    if (iter == target) {
-                        if (!prepared_project_snapshot_) {
-                            prepare_project_snapshot_at_safe_point(
-                                iter,
-                                getParams()
-                                    .save_project_path);
+                    const bool may_save_at_project_hook =
+                        policy
+                            .at_step_boundaries &&
+                        !project_hook_destination
+                             .empty();
+                    if (!may_save_at_project_hook) {
+                        if (iter + 1 == target ||
+                            iter == target) {
+                            LOG_DEBUG(
+                                "Skipping save-project-at-iter project save at iteration {}: trainer-initiated saves are not authorized",
+                                iter);
                         }
-                        capture_project_snapshot_at_safe_point(
-                            iter);
+                    } else {
+                        if (iter + 1 == target &&
+                            !prepared_project_snapshot_) {
+                            prepare_project_snapshot_at_safe_point(
+                                target,
+                                project_hook_destination);
+                        }
+                        if (iter == target) {
+                            if (!prepared_project_snapshot_) {
+                                prepare_project_snapshot_at_safe_point(
+                                    iter,
+                                    project_hook_destination);
+                            }
+                            capture_project_snapshot_at_safe_point(
+                                iter);
+                        }
                     }
                 }
 

--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -55,6 +55,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_StartConflictSeesDiskCheckpointAfterTrainerReplacement_Test;
     class VisualizerImplResetTest_SaveAsRoutesThroughFinishedTrainer_Test;
     class VisualizerImplResetTest_SaveWhilePausedTrainingRoutesThroughLiveTrainer_Test;
+    class VisualizerImplResetTest_SaveWhilePausedNoWorkerTrainerCompletes_Test;
     class VisualizerImplResetTest_SaveWhileStoppingStillBlocksUntilSnapshotPublished_Test;
     class VisualizerImplResetTest_SaveAsWhilePausedTrainingRoutesThroughLiveTrainer_Test;
     class VisualizerImplResetTest_SaveAsRoutesThroughFailedTerminalSnapshotAftermath_Test;
@@ -406,6 +407,7 @@ namespace lfs::training {
         friend class lfs::vis::VisualizerImplResetTest_StartConflictSeesDiskCheckpointAfterTrainerReplacement_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsRoutesThroughFinishedTrainer_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveWhilePausedTrainingRoutesThroughLiveTrainer_Test;
+        friend class lfs::vis::VisualizerImplResetTest_SaveWhilePausedNoWorkerTrainerCompletes_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveWhileStoppingStillBlocksUntilSnapshotPublished_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsWhilePausedTrainingRoutesThroughLiveTrainer_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsRoutesThroughFailedTerminalSnapshotAftermath_Test;

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -1175,14 +1175,18 @@ namespace lfs::training {
 
     void grant_headless_project_saves(
         Trainer& trainer,
-        const lfs::core::param::TrainingParameters& params) {
-        if (params.dataset.output_path.empty()) {
+        const lfs::core::param::TrainingParameters& params,
+        const std::filesystem::path& destination) {
+        if (destination.empty() &&
+            params.dataset.output_path.empty()) {
             LOG_WARN(
                 "Headless project saves not granted: no output path is set");
             return;
         }
         trainer.set_live_project_snapshot(
-            params.dataset.output_path / "project.licht");
+            destination.empty()
+                ? params.dataset.output_path / "project.licht"
+                : destination);
         trainer.set_trainer_project_save_policy({
             .on_completion = true,
             .on_stop_or_error = true,

--- a/src/training/training_setup.hpp
+++ b/src/training/training_setup.hpp
@@ -10,6 +10,7 @@
 #include "io/loader.hpp"
 #include "io/project_recovery.hpp"
 #include <expected>
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <string>
@@ -38,7 +39,8 @@ namespace lfs::training {
     // trainer its standing save destination and triggers here.
     void grant_headless_project_saves(
         Trainer& trainer,
-        const lfs::core::param::TrainingParameters& params);
+        const lfs::core::param::TrainingParameters& params,
+        const std::filesystem::path& destination = {});
 
     /// Construct + initialize Trainer on the live scene, then stream the
     /// document's CKPT payload via load_checkpoint(istream). Does not clear

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -2633,9 +2633,18 @@ namespace lfs::vis::project {
             // saveAs publishes on a worker. Join the
             // untitled create so the document has a
             // source path before the trainer is bound
-            // and training starts.
-            if (project_write_purpose_ ==
-                    ProjectWritePurpose::SaveAs &&
+            // and training starts. When the trainer is
+            // training-active (including a paused
+            // checkpoint-installed trainer), saveAs
+            // routes through startTrainingWrite with
+            // TrainingExplicitSave. jobs() exclusivity
+            // means the saveAs we just issued is the
+            // only write that can be running.
+            if ((project_write_purpose_ ==
+                     ProjectWritePurpose::SaveAs ||
+                 project_write_purpose_ ==
+                     ProjectWritePurpose::
+                         TrainingExplicitSave) &&
                 project_write_thread_.joinable()) {
                 project_write_thread_.join();
                 settleProjectWrite();
@@ -2838,7 +2847,8 @@ namespace lfs::vis::project {
             trainer->request_project_save(
                 destination, std::move(preview),
                 std::move(*context));
-        if (!trainer->has_active_train_loop() &&
+        auto* const manager = viewer_.getTrainerManager();
+        if (manager && !manager->hasLiveTrainingThread() &&
             trainer->can_flush_project_snapshot()) {
             trainer->consume_requested_project_snapshot(
                 trainer->project_snapshot_iteration());
@@ -4602,6 +4612,8 @@ namespace lfs::vis::project {
         if (auto* trainer = viewer_.getTrainer();
             trainer &&
             viewer_.getTrainerManager() &&
+            (viewer_.getTrainerManager()->hasLiveTrainingThread() ||
+             trainer->can_flush_project_snapshot()) &&
             (viewer_.getTrainerManager()->isTrainingActive() ||
              viewer_.getTrainerManager()->isCompletionPending())) {
             if (viewer_.getTrainerManager()->isPublishingFinalSnapshot()) {
@@ -4735,6 +4747,8 @@ namespace lfs::vis::project {
         if (auto* trainer = viewer_.getTrainer();
             trainer &&
             viewer_.getTrainerManager() &&
+            (viewer_.getTrainerManager()->hasLiveTrainingThread() ||
+             trainer->can_flush_project_snapshot()) &&
             (viewer_.getTrainerManager()->isTrainingActive() ||
              viewer_.getTrainerManager()->isCompletionPending() ||
              canFlushFinishedTrainerSnapshot())) {
@@ -4784,7 +4798,8 @@ namespace lfs::vis::project {
                         *normalized,
                         std::move(preview),
                         std::move(*context));
-            if (!trainer->has_active_train_loop() &&
+            if (!viewer_.getTrainerManager()
+                     ->hasLiveTrainingThread() &&
                 trainer->can_flush_project_snapshot()) {
                 trainer
                     ->consume_requested_project_snapshot(

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -54,6 +54,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_StartConflictSeesDiskCheckpointAfterTrainerReplacement_Test;
     class VisualizerImplResetTest_SaveAsRoutesThroughFinishedTrainer_Test;
     class VisualizerImplResetTest_SaveWhilePausedTrainingRoutesThroughLiveTrainer_Test;
+    class VisualizerImplResetTest_SaveWhilePausedNoWorkerTrainerCompletes_Test;
     class VisualizerImplResetTest_SaveWhileStoppingStillBlocksUntilSnapshotPublished_Test;
     class VisualizerImplResetTest_SaveAsWhilePausedTrainingRoutesThroughLiveTrainer_Test;
     class VisualizerImplResetTest_SaveAsRoutesThroughFailedTerminalSnapshotAftermath_Test;
@@ -239,6 +240,7 @@ namespace lfs::vis::project {
         friend class lfs::vis::VisualizerImplResetTest_StartConflictSeesDiskCheckpointAfterTrainerReplacement_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsRoutesThroughFinishedTrainer_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveWhilePausedTrainingRoutesThroughLiveTrainer_Test;
+        friend class lfs::vis::VisualizerImplResetTest_SaveWhilePausedNoWorkerTrainerCompletes_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveWhileStoppingStillBlocksUntilSnapshotPublished_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsWhilePausedTrainingRoutesThroughLiveTrainer_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsRoutesThroughFailedTerminalSnapshotAftermath_Test;

--- a/src/visualizer/training/training_manager.cpp
+++ b/src/visualizer/training/training_manager.cpp
@@ -650,6 +650,13 @@ namespace lfs::vis {
         return true;
     }
 
+    bool TrainerManager::hasLiveTrainingThread() const {
+        // stopTraining's no-thread branch uses this same flag: the reaper
+        // steals training_thread_ immediately, so joinable() is not the
+        // live-worker signal.
+        return isCompletionPending();
+    }
+
     bool TrainerManager::isPausedAtCheckpointBaseline() const {
         if (!trainer_ || !checkpoint_baseline_iteration_) {
             return false;

--- a/src/visualizer/training/training_manager.hpp
+++ b/src/visualizer/training/training_manager.hpp
@@ -108,6 +108,9 @@ namespace lfs::vis {
         [[nodiscard]] bool isCompletionPending() const {
             return completion_pending_.load(std::memory_order_acquire);
         }
+        // True while a training worker exists (running or paused mid-run).
+        // Checkpoint-installed paused trainers have no worker.
+        [[nodiscard]] bool hasLiveTrainingThread() const;
         [[nodiscard]] bool isPublishingFinalSnapshot() const {
             return isCompletionPending() && !isTrainingActive();
         }

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -3013,6 +3013,24 @@ namespace lfs::vis {
         if (!trainer_manager_)
             return std::unexpected("Trainer manager not initialized");
         if (trainer_manager_->isPaused()) {
+            if (project_lifecycle_) {
+                if (auto* const trainer = getTrainer()) {
+                    const auto policy =
+                        trainer->trainer_project_save_policy();
+                    if (!policy.on_completion &&
+                        !policy.on_stop_or_error &&
+                        !policy.at_step_boundaries) {
+                        if (auto prepared =
+                                project_lifecycle_
+                                    ->prepareTrainingStartProject();
+                            !prepared) {
+                            return std::unexpected(
+                                lfs::format_for_developer(
+                                    prepared.error()));
+                        }
+                    }
+                }
+            }
             trainer_manager_->resumeTraining();
             return {};
         }

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -266,9 +266,12 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_CloseSaveRoutesTrainingSnapshotToLiveDocument_Test;
         friend class VisualizerImplResetTest_TrainerOwnedSaveTargetsLiveDocumentPath_Test;
         friend class VisualizerImplResetTest_StartTrainingPreparesProjectAndGrantsSaves_Test;
+        friend class VisualizerImplResetTest_PausedUngrantedStartTrainingGrantsAndBinds_Test;
+        friend class VisualizerImplResetTest_PausedGrantedStartTrainingDoesNotRecreateProject_Test;
         friend class VisualizerImplResetTest_StartConflictSeesDiskCheckpointAfterTrainerReplacement_Test;
         friend class VisualizerImplResetTest_SaveAsRoutesThroughFinishedTrainer_Test;
         friend class VisualizerImplResetTest_SaveWhilePausedTrainingRoutesThroughLiveTrainer_Test;
+        friend class VisualizerImplResetTest_SaveWhilePausedNoWorkerTrainerCompletes_Test;
         friend class VisualizerImplResetTest_SaveWhileStoppingStillBlocksUntilSnapshotPublished_Test;
         friend class VisualizerImplResetTest_SaveAsWhilePausedTrainingRoutesThroughLiveTrainer_Test;
         friend class VisualizerImplResetTest_SaveAsRoutesThroughFailedTerminalSnapshotAftermath_Test;

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -103,7 +103,7 @@ TEST(ArgumentParserTest, HeadlessResumeSelectsEmbeddedCheckpointFlow) {
 }
 
 TEST(ArgumentParserTest,
-     TrainingSaveProjectAtIterDefaultsToOutputProjectLicht) {
+     TrainingSaveProjectAtIterLeavesPathEmptyWithoutSaveProjectPath) {
     const auto data_path =
         make_test_path("lfs_arg_parser_save_project_data");
     const auto output_path =
@@ -125,9 +125,7 @@ TEST(ArgumentParserTest,
     EXPECT_EQ(
         (*parsed)->save_project_at_iteration,
         std::optional<size_t>(7000));
-    EXPECT_EQ(
-        (*parsed)->save_project_path,
-        std::filesystem::path(output_path) / "project.licht");
+    EXPECT_TRUE((*parsed)->save_project_path.empty());
 }
 
 TEST(ArgumentParserTest,

--- a/tests/test_checkpoint_resume.cpp
+++ b/tests/test_checkpoint_resume.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -12,9 +13,11 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <iterator>
+#include <memory>
 #include <optional>
 #include <sstream>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -1641,6 +1644,22 @@ namespace {
             lfs::training::TrainingSnapshotService::
                 reset_process_pinned_d2h_calibration_for_testing();
         }
+
+        template <typename Predicate>
+        [[nodiscard]] bool waitUntil(
+            Predicate&& condition,
+            const std::chrono::milliseconds timeout =
+                std::chrono::seconds(10)) {
+            const auto deadline =
+                std::chrono::steady_clock::now() + timeout;
+            while (!condition() &&
+                   std::chrono::steady_clock::now() <
+                       deadline) {
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(2));
+            }
+            return condition();
+        }
     };
 
     TEST_F(ProjectCheckpointTrainerInstall,
@@ -1920,6 +1939,18 @@ namespace {
         std::filesystem::remove_all(output_path, ec);
     }
 
+    std::shared_ptr<lfs::core::Camera> make_grant_test_camera() {
+        return std::make_shared<lfs::core::Camera>(
+            lfs::core::Tensor::eye(3, lfs::core::Device::CPU),
+            lfs::core::Tensor::zeros(
+                {3}, lfs::core::Device::CPU),
+            100.0f, 100.0f, 32.0f, 32.0f,
+            lfs::core::Tensor(), lfs::core::Tensor(),
+            lfs::core::CameraModelType::PINHOLE,
+            "camera.png", std::filesystem::path{},
+            std::filesystem::path{}, 64, 64, 0);
+    }
+
     lfs::core::param::TrainingParameters make_tiny_headless_params(
         const std::filesystem::path& output_path,
         const int iterations) {
@@ -1955,6 +1986,7 @@ namespace {
         auto params = make_tiny_headless_params(
             output_path, iterations);
         params.optimization.save_steps = {1, 2};
+        params.save_project_at_iteration = 2;
 
         lfs::core::Scene scene;
         ASSERT_TRUE(
@@ -1991,6 +2023,70 @@ namespace {
         EXPECT_FALSE(found_licht)
             << "ungranted trainer wrote a .licht file under "
             << output_path;
+
+        std::filesystem::remove_all(output_path, ec);
+    }
+
+    TEST_F(ProjectCheckpointTrainerInstall,
+           GrantedTrainerSaveAtIterWithoutPathWritesBoundFile) {
+        const auto output_path =
+            std::filesystem::temp_directory_path() /
+            "lfs_test_granted_save_at_iter_bound";
+        std::error_code ec;
+        std::filesystem::remove_all(output_path, ec);
+        std::filesystem::create_directories(output_path);
+
+        constexpr int iterations = 3;
+        auto params = make_tiny_headless_params(
+            output_path, iterations);
+        params.optimization.save_steps = {};
+        params.save_project_at_iteration = 2;
+        ASSERT_TRUE(params.save_project_path.empty());
+
+        lfs::core::Scene scene;
+        ASSERT_TRUE(
+            lfs::training::loadTrainingDataIntoScene(
+                params, scene))
+            << "load training data failed";
+        ASSERT_TRUE(
+            lfs::training::initializeTrainingModel(
+                params, scene))
+            << "init model failed";
+        auto trainer =
+            std::make_unique<lfs::training::Trainer>(
+                scene);
+        auto init = trainer->initialize(params);
+        ASSERT_TRUE(init)
+            << "Failed to init trainer: " << init.error();
+        const auto bound_path =
+            output_path / "project.licht";
+        trainer->set_live_project_snapshot(bound_path);
+        trainer->set_trainer_project_save_policy({
+            .on_completion = false,
+            .on_stop_or_error = false,
+            .at_step_boundaries = true,
+        });
+        auto train = trainer->train();
+        ASSERT_TRUE(train)
+            << "granted save-at-iter train failed: "
+            << lfs::format_for_developer(train.error());
+        ASSERT_TRUE(waitUntil([&] {
+            const auto metrics =
+                trainer->get_project_snapshot_metrics();
+            return !metrics.writer_in_flight &&
+                   std::filesystem::is_regular_file(
+                       bound_path) &&
+                   metrics.last_path.lexically_normal() ==
+                       bound_path.lexically_normal();
+        })) << "timed out waiting for trainer project publish to "
+            << bound_path;
+        trainer->shutdown();
+        EXPECT_TRUE(std::filesystem::is_regular_file(
+            bound_path));
+        EXPECT_EQ(
+            trainer->get_project_snapshot_metrics()
+                .last_path.lexically_normal(),
+            bound_path.lexically_normal());
 
         std::filesystem::remove_all(output_path, ec);
     }
@@ -2087,6 +2183,65 @@ namespace {
             << metrics.last_writer_error;
         trainer->shutdown();
 
+        std::filesystem::remove_all(output_path, ec);
+    }
+
+    TEST_F(ProjectCheckpointTrainerInstall,
+           GrantHeadlessProjectSavesBindsOverrideAndFallback) {
+        const auto output_path =
+            std::filesystem::temp_directory_path() /
+            "lfs_test_grant_headless_bind";
+        std::error_code ec;
+        std::filesystem::remove_all(output_path, ec);
+        std::filesystem::create_directories(output_path);
+
+        lfs::core::Scene scene;
+        const auto cameras = scene.addGroup("Cameras");
+        scene.addCamera(
+            "camera.png", cameras, make_grant_test_camera());
+        auto trainer =
+            std::make_unique<lfs::training::Trainer>(
+                scene);
+
+        lfs::core::param::TrainingParameters params;
+        params.dataset.output_path = output_path;
+        lfs::training::grant_headless_project_saves(
+            *trainer, params);
+        {
+            const auto bound = trainer->bound_project_path();
+            ASSERT_TRUE(bound.has_value());
+            EXPECT_EQ(
+                bound->lexically_normal(),
+                (output_path / "project.licht")
+                    .lexically_normal());
+        }
+
+        const auto override_path =
+            output_path / "resumed.licht";
+        lfs::training::grant_headless_project_saves(
+            *trainer, params, override_path);
+        {
+            const auto bound = trainer->bound_project_path();
+            ASSERT_TRUE(bound.has_value());
+            EXPECT_EQ(
+                bound->lexically_normal(),
+                override_path.lexically_normal());
+        }
+
+        trainer->set_live_project_snapshot(std::nullopt);
+        trainer->set_trainer_project_save_policy({});
+        params.dataset.output_path.clear();
+        lfs::training::grant_headless_project_saves(
+            *trainer, params);
+        EXPECT_FALSE(
+            trainer->bound_project_path().has_value());
+        const auto policy =
+            trainer->trainer_project_save_policy();
+        EXPECT_FALSE(policy.on_completion);
+        EXPECT_FALSE(policy.on_stop_or_error);
+        EXPECT_FALSE(policy.at_step_boundaries);
+
+        trainer->shutdown();
         std::filesystem::remove_all(output_path, ec);
     }
 

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -4652,6 +4652,178 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
+           PausedUngrantedStartTrainingGrantsAndBinds) {
+        const auto& temporary = temporary_.path;
+        const auto output_path =
+            temporary / "paused-ungranted-out";
+        std::filesystem::create_directories(output_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()
+                            ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            ASSERT_FALSE(lifecycle->hasSourcePath());
+
+            auto& scene = viewer.getScene();
+            const auto cameras =
+                scene.addGroup("Train cameras");
+            scene.addCamera(
+                "camera.png", cameras,
+                make_project_request_test_camera());
+            const auto model =
+                scene.addGroup("Train model");
+            scene.setTrainingModelNode(model);
+            auto* const trainer_manager =
+                viewer.getTrainerManager();
+            ASSERT_NE(trainer_manager, nullptr);
+            trainer_manager->setTrainerFromCheckpoint(
+                std::make_unique<
+                    lfs::training::Trainer>(scene),
+                0);
+            ASSERT_TRUE(trainer_manager->isPaused());
+            auto* const trainer = viewer.getTrainer();
+            ASSERT_NE(trainer, nullptr);
+            auto params = trainer->getParams();
+            params.dataset.output_path = output_path;
+            trainer->setParams(params);
+            const auto ungranted =
+                trainer->trainer_project_save_policy();
+            EXPECT_FALSE(ungranted.on_completion);
+            EXPECT_FALSE(ungranted.on_stop_or_error);
+            EXPECT_FALSE(ungranted.at_step_boundaries);
+
+            auto started = viewer.startTraining();
+            ASSERT_TRUE(started)
+                << started.error();
+            EXPECT_FALSE(trainer_manager->isPaused());
+            const auto policy =
+                trainer->trainer_project_save_policy();
+            EXPECT_TRUE(policy.on_completion);
+            EXPECT_TRUE(policy.at_step_boundaries);
+            EXPECT_FALSE(policy.on_stop_or_error);
+            ASSERT_TRUE(lifecycle->hasSourcePath());
+            const auto bound =
+                trainer->bound_project_path();
+            ASSERT_TRUE(bound.has_value());
+            EXPECT_EQ(
+                bound->lexically_normal(),
+                (output_path / "project.licht")
+                    .lexically_normal());
+
+            if (trainer_manager->canStop()) {
+                trainer_manager->stopTraining();
+            }
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !trainer_manager
+                                ->isCompletionPending();
+                }));
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           PausedGrantedStartTrainingDoesNotRecreateProject) {
+        const auto& temporary = temporary_.path;
+        const auto output_path =
+            temporary / "paused-granted-out";
+        std::filesystem::create_directories(output_path);
+        const auto already_bound =
+            temporary / "already-bound.licht";
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()
+                            ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            ASSERT_FALSE(lifecycle->hasSourcePath());
+
+            auto& scene = viewer.getScene();
+            const auto cameras =
+                scene.addGroup("Train cameras");
+            scene.addCamera(
+                "camera.png", cameras,
+                make_project_request_test_camera());
+            const auto model =
+                scene.addGroup("Train model");
+            scene.setTrainingModelNode(model);
+            auto* const trainer_manager =
+                viewer.getTrainerManager();
+            ASSERT_NE(trainer_manager, nullptr);
+            trainer_manager->setTrainerFromCheckpoint(
+                std::make_unique<
+                    lfs::training::Trainer>(scene),
+                0);
+            ASSERT_TRUE(trainer_manager->isPaused());
+            auto* const trainer = viewer.getTrainer();
+            ASSERT_NE(trainer, nullptr);
+            auto params = trainer->getParams();
+            params.dataset.output_path = output_path;
+            trainer->setParams(params);
+            const lfs::training::Trainer::
+                TrainerProjectSavePolicy granted{
+                    .on_completion = true,
+                    .on_stop_or_error = false,
+                    .at_step_boundaries = true,
+                };
+            trainer->set_trainer_project_save_policy(
+                granted);
+            trainer->set_live_project_snapshot(
+                already_bound);
+
+            auto started = viewer.startTraining();
+            ASSERT_TRUE(started)
+                << started.error();
+            EXPECT_FALSE(trainer_manager->isPaused());
+            const auto policy =
+                trainer->trainer_project_save_policy();
+            EXPECT_EQ(
+                policy.on_completion,
+                granted.on_completion);
+            EXPECT_EQ(
+                policy.on_stop_or_error,
+                granted.on_stop_or_error);
+            EXPECT_EQ(
+                policy.at_step_boundaries,
+                granted.at_step_boundaries);
+            EXPECT_FALSE(lifecycle->hasSourcePath());
+            const auto bound =
+                trainer->bound_project_path();
+            ASSERT_TRUE(bound.has_value());
+            EXPECT_EQ(
+                bound->lexically_normal(),
+                already_bound.lexically_normal());
+            EXPECT_FALSE(std::filesystem::exists(
+                output_path / "project.licht"));
+
+            if (trainer_manager->canStop()) {
+                trainer_manager->stopTraining();
+            }
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !trainer_manager
+                                ->isCompletionPending();
+                }));
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
            StartConflictSeesDiskCheckpointAfterTrainerReplacement) {
         // Reset Training replaces the trainer, so snapshot
         // adoption via metrics is gone while the master
@@ -4906,13 +5078,13 @@ namespace lfs::vis {
             {
                 std::lock_guard lock(
                     trainer->project_snapshot_mutex_);
-                ASSERT_TRUE(
+                EXPECT_FALSE(
                     trainer->requested_project_path_);
-                EXPECT_EQ(
-                    trainer->requested_project_path_
-                        ->lexically_normal(),
-                    destination.lexically_normal());
             }
+            const auto metrics =
+                trainer->get_project_snapshot_metrics();
+            EXPECT_GT(
+                metrics.last_failed_request_id, 0u);
         }
     }
 
@@ -5016,6 +5188,126 @@ namespace lfs::vis {
             trainer_manager->completion_pending_.store(
                 false, std::memory_order_release);
             trainer_manager->training_joined_ = true;
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           SaveWhilePausedNoWorkerTrainerCompletes) {
+        // Checkpoint-installed paused trainers have
+        // has_active_train_loop() true with no worker
+        // thread. File Save must still route through the
+        // trainer, inline-flush, and finish the
+        // ProjectWrite job.
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "paused-no-worker-save.licht";
+        write_empty_project(project_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()
+                            ->ensureLoaded());
+            ASSERT_TRUE(viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    const auto info =
+                        viewer.projectGetInfo();
+                    return info &&
+                           info->hydration_state ==
+                               "complete";
+                }));
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+
+            auto& scene = viewer.getScene();
+            const auto cameras =
+                scene.addGroup("Train cameras");
+            scene.addCamera(
+                "camera.png", cameras,
+                make_project_request_test_camera());
+            const auto model = scene.addSplat(
+                "Train model",
+                lfs::test::licht::make_splat(2));
+            ASSERT_NE(model, lfs::core::NULL_NODE);
+            scene.setTrainingModelNode(model);
+            auto* const trainer_manager =
+                viewer.getTrainerManager();
+            ASSERT_NE(trainer_manager, nullptr);
+            trainer_manager->setTrainerFromCheckpoint(
+                std::make_unique<
+                    lfs::training::Trainer>(scene),
+                0);
+            ASSERT_TRUE(trainer_manager->isPaused());
+            ASSERT_FALSE(
+                trainer_manager
+                    ->hasLiveTrainingThread());
+            auto* const trainer = viewer.getTrainer();
+            ASSERT_NE(trainer, nullptr);
+            auto* const scene_splat =
+                scene.getTrainingModel();
+            ASSERT_NE(scene_splat, nullptr);
+            trainer->strategy_ =
+                std::make_unique<lfs::training::MCMC>(
+                    *scene_splat);
+            auto opt =
+                lfs::core::param::
+                    OptimizationParameters::
+                        mcmc_defaults();
+            opt.max_cap = 2;
+            opt.sh_degree = 0;
+            trainer->strategy_->initialize(opt);
+            auto snapshot_ready =
+                trainer
+                    ->initialize_project_snapshot_service();
+            ASSERT_TRUE(snapshot_ready)
+                << lfs::format_for_developer(
+                       snapshot_ready.error());
+            trainer->is_paused_.store(true);
+            ASSERT_TRUE(
+                trainer->has_active_train_loop());
+            ASSERT_TRUE(
+                trainer->can_flush_project_snapshot());
+
+            auto saved = lifecycle->save(false);
+            ASSERT_TRUE(saved)
+                << lfs::format_for_developer(
+                       saved.error());
+            EXPECT_EQ(
+                lifecycle->project_write_purpose_,
+                project::ProjectLifecycle::
+                    ProjectWritePurpose::
+                        TrainingExplicitSave);
+            EXPECT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            EXPECT_FALSE(viewer.jobs().anyRunning(
+                JobType::ProjectWrite));
+            EXPECT_TRUE(std::filesystem::is_regular_file(
+                project_path));
+            const auto metrics =
+                trainer->get_project_snapshot_metrics();
+            EXPECT_GT(
+                metrics.last_completed_request_id, 0u);
+            EXPECT_EQ(
+                metrics.last_path.lexically_normal(),
+                project_path.lexically_normal());
         }
     }
 
@@ -5291,13 +5583,13 @@ namespace lfs::vis {
             {
                 std::lock_guard lock(
                     trainer->project_snapshot_mutex_);
-                ASSERT_TRUE(
+                EXPECT_FALSE(
                     trainer->requested_project_path_);
-                EXPECT_EQ(
-                    trainer->requested_project_path_
-                        ->lexically_normal(),
-                    destination.lexically_normal());
             }
+            const auto metrics =
+                trainer->get_project_snapshot_metrics();
+            EXPECT_GT(
+                metrics.last_failed_request_id, 0u);
         }
     }
 


### PR DESCRIPTION
Three ways training results silently went missing, all fixed:

**Resumed runs never saved.** Loading a checkpoint for training installs the trainer paused, and pressing Start only resumed it - no save permission was ever granted, so the whole run ended with no project file and only a log line. Start now sets up the project and grants saves exactly like a fresh start. Resume from MCP goes through the same gate and still refuses trainers that are not paused.

**Fixing that exposed a freeze.** Saving a project through a paused trainer that has no worker thread queued a request nobody ever picked up - the save job waited forever. This was also reachable today with File > Save on a freshly reopened paused project. The save now completes immediately in that state.

**Command line fixes.** `--resume project.licht` used to write results into `output/project.licht` instead of the project being resumed; it now appends to the resumed file. `--save-project-at-iter` wrote through its own unchecked channel with an invented default destination; it now follows the same save rules as every other checkpoint save, defaulting to the bound project file.

**Verified:** 214 tests green including new regression tests for every fix (one of which caught the freeze). Live checks: resumed a saved paused project and watched the checkpoint save land at its mark on screen and on disk; pause and stop write nothing; resume on a never-started trainer is refused; headless resume appends to the resumed file while the divergent output folder stays empty; save-at-iter lands in the bound project at the requested iteration.