### PR TITLE
Stop leaving lock files and stranded save temporaries behind

### DIFF
--- a/src/io/include/io/project_recovery.hpp
+++ b/src/io/include/io/project_recovery.hpp
@@ -136,6 +136,20 @@ namespace lfs::io::project {
         const std::filesystem::path& master_path,
         RecoveryInspection& into);
 
+    // Best-effort removal of crash leftovers for one published master:
+    // `.{master-filename}.saveas-*` staging files and this master's
+    // compact/project-write/replace-backup temps, plus their `.lock`
+    // siblings. Skips anything still held. Never deletes the master
+    // file. `{master}.lock` is reclaimed only when
+    // `reclaim_master_lock` is true and the probe acquire succeeds.
+    LFS_IO_API void sweep_stale_licht_artifacts(
+        const std::filesystem::path& master_path,
+        bool reclaim_master_lock = false);
+
+    // Startup entry: skip missing masters, never fails the caller.
+    LFS_IO_API void sweep_stale_licht_artifacts_for_known_masters(
+        const std::vector<std::filesystem::path>& master_paths);
+
     // Acquires the master writer lock, validates every stable/temp/backup
     // sidecar candidate, deletes stale candidates, and applies the exact
     // §9 predicate. It also removes orphan compaction temps after the master

--- a/src/io/project/project_container_internal.hpp
+++ b/src/io/project/project_container_internal.hpp
@@ -113,7 +113,7 @@ namespace lfs::io::project::detail {
         WriterLock& operator=(const WriterLock&) = delete;
         WriterLock(WriterLock&& other) noexcept;
         WriterLock& operator=(WriterLock&& other) noexcept;
-        ~WriterLock();
+        ~WriterLock() noexcept;
 
         [[nodiscard]] static lfs::Result<WriterLock>
         acquire(const std::filesystem::path& project_path);

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -7,6 +7,7 @@
 
 #include "core/logger.hpp"
 #include "io/loader.hpp"
+#include "io/project_recovery.hpp"
 #include "project_container_internal.hpp"
 #include "project_framing.hpp"
 #include "span_streambuf.hpp"
@@ -1950,6 +1951,7 @@ namespace lfs::io::project {
                 chapter_scan_finished,
                 open_finished),
             milliseconds(open_started, open_finished));
+        sweep_stale_licht_artifacts(*normalized, false);
         return ProjectDocument(std::move(impl));
     }
 
@@ -3461,8 +3463,18 @@ namespace lfs::io::project {
                         lfs::core::generate_uuid_v4().to_string());
 
         const auto remove_temporary = [&temporary] {
-            std::error_code ignored;
-            std::filesystem::remove(temporary, ignored);
+            std::error_code error;
+            if (!std::filesystem::remove(temporary, error) &&
+                error) {
+                LOG_WARN(
+                    "Could not remove Save As staging file {}: {}",
+                    temporary.string(),
+                    error.message());
+            }
+            auto lock_path = temporary;
+            lock_path += ".lock";
+            std::error_code lock_error;
+            std::filesystem::remove(lock_path, lock_error);
         };
         if (!std::filesystem::copy_file(
                 original_path, temporary,
@@ -3605,41 +3617,36 @@ namespace lfs::io::project {
         }
 
         lfs::core::Uuid expected_commit_uuid;
+        std::optional<lfs::Error> staged_failure;
         {
             auto staged_reader =
                 ProjectReader::open(temporary);
             if (!staged_reader) {
-                auto cause =
+                staged_failure =
                     std::move(staged_reader).error();
-                auto restored =
-                    rebind_preserving_dirty_lazy(
-                        original_path);
-                remove_temporary();
-                if (!restored) {
-                    return std::move(cause)
-                        .with_suppressed(
-                            std::move(restored).error());
-                }
-                return cause;
-            }
-            if (auto verified =
+            } else if (
+                auto verified =
                     staged_reader->verify_all();
                 !verified) {
-                auto cause =
+                staged_failure =
                     std::move(verified).error();
-                auto restored =
-                    rebind_preserving_dirty_lazy(
-                        original_path);
-                remove_temporary();
-                if (!restored) {
-                    return std::move(cause)
-                        .with_suppressed(
-                            std::move(restored).error());
-                }
-                return cause;
+            } else {
+                expected_commit_uuid =
+                    staged_reader->commit()
+                        .commit_uuid;
             }
-            expected_commit_uuid =
-                staged_reader->commit().commit_uuid;
+        }
+        if (staged_failure) {
+            auto restored =
+                rebind_preserving_dirty_lazy(
+                    original_path);
+            remove_temporary();
+            if (!restored) {
+                return std::move(*staged_failure)
+                    .with_suppressed(
+                        std::move(restored).error());
+            }
+            return std::move(*staged_failure);
         }
 
         auto post_save_dirty = impl_->dirty;

--- a/src/io/project/project_file.cpp
+++ b/src/io/project/project_file.cpp
@@ -22,11 +22,10 @@
 #include <utility>
 
 #ifdef _WIN32
-#include <fileapi.h>
-#include <handleapi.h>
-#include <ioapiset.h>
-#include <processthreadsapi.h>
-#include <synchapi.h>
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
 #else
 #include <fcntl.h>
 #include <sys/file.h>
@@ -415,7 +414,7 @@ namespace lfs::io::project::detail {
         }
         return static_cast<std::uint64_t>(size.QuadPart);
 #else
-        struct stat status {};
+        struct stat status{};
         if (::fstat(fd_, &status) != 0 || status.st_size < 0) {
             const int error = errno;
             return project_error(native_error_code(error, false),
@@ -666,16 +665,24 @@ namespace lfs::io::project::detail {
         return *this;
     }
 
-    WriterLock::~WriterLock() {
+    WriterLock::~WriterLock() noexcept {
 #ifdef _WIN32
         if (handle_ != INVALID_HANDLE_VALUE) {
             UnlockFileEx(handle_, 0, 1, 0, &operation_);
             CloseHandle(handle_);
+            handle_ = INVALID_HANDLE_VALUE;
+            // Best-effort: a contender that still has a share-delete handle
+            // makes this fail, and that contender's release deletes the name.
+            DeleteFileW(path_.wstring().c_str());
         }
 #else
         if (fd_ >= 0) {
+            // Unlink while still holding flock so a waiter cannot bind a new
+            // inode until we drop the lock. acquire() retries on inode mismatch.
+            ::unlink(path_.c_str());
             ::flock(fd_, LOCK_UN);
             ::close(fd_);
+            fd_ = -1;
         }
 #endif
     }
@@ -686,57 +693,103 @@ namespace lfs::io::project::detail {
         if (auto parent = ensure_parent_directory(lock_path); !parent) {
             return std::move(parent).error();
         }
+        constexpr int kAcquireAttempts = 5;
 #ifdef _WIN32
-        HANDLE handle =
-            CreateFileW(lock_path.wstring().c_str(), GENERIC_READ | GENERIC_WRITE,
-                        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, CREATE_NEW,
-                        FILE_ATTRIBUTE_NORMAL, nullptr);
-        if (handle == INVALID_HANDLE_VALUE && GetLastError() == ERROR_FILE_EXISTS) {
-            handle = CreateFileW(lock_path.wstring().c_str(), GENERIC_READ | GENERIC_WRITE,
-                                 FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
-                                 FILE_ATTRIBUTE_NORMAL, nullptr);
+        const DWORD share_mode =
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
+        DWORD last_error = 0;
+        for (int attempt = 0; attempt < kAcquireAttempts; ++attempt) {
+            HANDLE handle = CreateFileW(lock_path.wstring().c_str(),
+                                        GENERIC_READ | GENERIC_WRITE, share_mode, nullptr,
+                                        CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (handle == INVALID_HANDLE_VALUE && GetLastError() == ERROR_FILE_EXISTS) {
+                handle = CreateFileW(lock_path.wstring().c_str(), GENERIC_READ | GENERIC_WRITE,
+                                     share_mode, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+                                     nullptr);
+            }
+            if (handle == INVALID_HANDLE_VALUE) {
+                last_error = GetLastError();
+                const bool retryable = last_error == ERROR_ACCESS_DENIED ||
+                                       last_error == ERROR_DELETE_PENDING ||
+                                       last_error == ERROR_FILE_NOT_FOUND;
+                if (retryable && attempt + 1 < kAcquireAttempts) {
+                    Sleep(1);
+                    continue;
+                }
+                return project_error(
+                    native_error_code(static_cast<int>(last_error), true),
+                    "The project writer lock could not be opened.",
+                    std::format("CreateFileW lockfile failed with Windows error {}", last_error),
+                    lock_path, std::nullopt, "writer_lock",
+                    static_cast<std::int64_t>(last_error), "Win32");
+            }
+            OVERLAPPED operation{};
+            const DWORD flags = LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY;
+            if (!LockFileEx(handle, flags, 0, 1, 0, &operation)) {
+                const DWORD error = GetLastError();
+                CloseHandle(handle);
+                return project_error(
+                    lfs::ErrorCode::Unavailable, "The project is already open for writing.",
+                    std::format("LockFileEx denied the held lock with Windows error {}", error),
+                    lock_path, std::nullopt, "writer_lock", static_cast<std::int64_t>(error),
+                    "Win32");
+            }
+            WriterLock result(lock_path, handle);
+            result.operation_ = operation;
+            return result;
         }
-        if (handle == INVALID_HANDLE_VALUE) {
-            const DWORD error = GetLastError();
-            return project_error(native_error_code(static_cast<int>(error), true),
-                                 "The project writer lock could not be opened.",
-                                 std::format("CreateFileW lockfile failed with Windows error {}",
-                                             error),
-                                 lock_path, std::nullopt, "writer_lock",
-                                 static_cast<std::int64_t>(error), "Win32");
-        }
-        WriterLock result(lock_path, handle);
-        const DWORD flags = LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY;
-        if (!LockFileEx(handle, flags, 0, 1, 0, &result.operation_)) {
-            const DWORD error = GetLastError();
-            return project_error(
-                lfs::ErrorCode::Unavailable, "The project is already open for writing.",
-                std::format("LockFileEx denied the held lock with Windows error {}", error),
-                lock_path, std::nullopt, "writer_lock", static_cast<std::int64_t>(error), "Win32");
-        }
-        return result;
+        return project_error(native_error_code(static_cast<int>(last_error), true),
+                             "The project writer lock could not be opened.",
+                             std::format("CreateFileW lockfile failed with Windows error {}",
+                                         last_error),
+                             lock_path, std::nullopt, "writer_lock",
+                             static_cast<std::int64_t>(last_error), "Win32");
 #else
-        int fd = ::open(lock_path.c_str(), O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
-        if (fd < 0 && errno == EEXIST) {
-            fd = ::open(lock_path.c_str(), O_RDWR | O_CLOEXEC);
+        for (int attempt = 0; attempt < kAcquireAttempts; ++attempt) {
+            int fd = ::open(lock_path.c_str(), O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+            if (fd < 0 && errno == EEXIST) {
+                fd = ::open(lock_path.c_str(), O_RDWR | O_CLOEXEC);
+            }
+            if (fd < 0) {
+                const int error = errno;
+                if (error == ENOENT && attempt + 1 < kAcquireAttempts) {
+                    continue;
+                }
+                return project_error(
+                    native_error_code(error, true),
+                    "The project writer lock could not be opened.",
+                    std::format("lockfile open failed: {}", std::strerror(error)), lock_path,
+                    std::nullopt, "writer_lock", error, std::strerror(error));
+            }
+            if (::flock(fd, LOCK_EX | LOCK_NB) != 0) {
+                const int error = errno;
+                ::close(fd);
+                return project_error(
+                    lfs::ErrorCode::Unavailable, "The project is already open for writing.",
+                    std::format("flock denied the held lock: {}", std::strerror(error)),
+                    lock_path, std::nullopt, "writer_lock", error, std::strerror(error));
+            }
+            struct stat fd_status{};
+            if (::fstat(fd, &fd_status) != 0) {
+                return WriterLock(lock_path, fd);
+            }
+            struct stat path_status{};
+            if (::stat(lock_path.c_str(), &path_status) != 0 ||
+                fd_status.st_dev != path_status.st_dev ||
+                fd_status.st_ino != path_status.st_ino) {
+                if (attempt + 1 < kAcquireAttempts) {
+                    ::flock(fd, LOCK_UN);
+                    ::close(fd);
+                    continue;
+                }
+                return WriterLock(lock_path, fd);
+            }
+            return WriterLock(lock_path, fd);
         }
-        if (fd < 0) {
-            const int error = errno;
-            return project_error(native_error_code(error, true),
-                                 "The project writer lock could not be opened.",
-                                 std::format("lockfile open failed: {}", std::strerror(error)),
-                                 lock_path, std::nullopt, "writer_lock", error,
-                                 std::strerror(error));
-        }
-        if (::flock(fd, LOCK_EX | LOCK_NB) != 0) {
-            const int error = errno;
-            ::close(fd);
-            return project_error(
-                lfs::ErrorCode::Unavailable, "The project is already open for writing.",
-                std::format("flock denied the held lock: {}", std::strerror(error)), lock_path,
-                std::nullopt, "writer_lock", error, std::strerror(error));
-        }
-        return WriterLock(lock_path, fd);
+        return project_error(lfs::ErrorCode::Unavailable,
+                             "The project writer lock could not be opened.",
+                             "lockfile open exhausted inode-mismatch retries", lock_path,
+                             std::nullopt, "writer_lock");
 #endif
     }
 

--- a/src/io/project/project_recovery.cpp
+++ b/src/io/project/project_recovery.cpp
@@ -15,6 +15,7 @@
 #include <format>
 #include <limits>
 #include <map>
+#include <optional>
 #include <ranges>
 #include <set>
 #include <type_traits>
@@ -498,6 +499,66 @@ namespace lfs::io::project {
             }
         }
 
+        [[nodiscard]] std::filesystem::path
+        path_without_lock_suffix(
+            const std::filesystem::path& path) {
+            const auto name =
+                path.filename().string();
+            constexpr std::string_view suffix =
+                ".lock";
+            if (name.size() > suffix.size() &&
+                name.ends_with(suffix)) {
+                return path.parent_path() /
+                       name.substr(
+                           0,
+                           name.size() -
+                               suffix.size());
+            }
+            return path;
+        }
+
+        void try_remove_unheld_artifact(
+            const std::filesystem::path& data_path,
+            const bool remove_data) {
+            auto lock_path = data_path;
+            lock_path += ".lock";
+            std::error_code exists_error;
+            const bool lock_existed =
+                std::filesystem::exists(
+                    lock_path, exists_error) &&
+                !exists_error;
+            {
+                auto lock =
+                    detail::WriterLock::acquire(
+                        data_path);
+                if (!lock) {
+                    return;
+                }
+                if (remove_data) {
+                    std::error_code error;
+                    if (std::filesystem::remove(
+                            data_path, error) &&
+                        !error) {
+                        LOG_INFO(
+                            "Removed stale project artifact {}",
+                            data_path.string());
+                    }
+                }
+            }
+            if (!lock_existed) {
+                return;
+            }
+            exists_error.clear();
+            if (std::filesystem::exists(
+                    lock_path, exists_error) &&
+                !exists_error) {
+                return;
+            }
+            LOG_INFO(
+                "Removed stale project artifact {}",
+                lock_path.string());
+        }
+
     } // namespace
 
     struct RecoverySession::State {
@@ -746,6 +807,133 @@ namespace lfs::io::project {
             into, std::move(corrupt_asides));
     }
 
+    void sweep_stale_licht_artifacts(
+        const std::filesystem::path& master_path,
+        const bool reclaim_master_lock) {
+        if (master_path.empty()) {
+            return;
+        }
+        const auto directory =
+            master_path.parent_path().empty()
+                ? std::filesystem::path{"."}
+                : master_path.parent_path();
+        const auto master_name =
+            master_path.filename().string();
+        const auto saveas_prefix =
+            "." + master_name + ".saveas-";
+        const auto stem =
+            master_path.stem().string();
+        const auto suffix =
+            ".tmp" + master_path.extension().string();
+        const auto master_lock_name =
+            master_name + ".lock";
+
+        std::vector<std::filesystem::path> saveas_data;
+        std::vector<std::filesystem::path> write_temp_data;
+        std::error_code error;
+        for (std::filesystem::directory_iterator
+                 iterator(directory, error),
+             end;
+             !error && iterator != end;
+             iterator.increment(error)) {
+            std::error_code type_error;
+            if (!iterator->is_regular_file(
+                    type_error) ||
+                type_error) {
+                continue;
+            }
+            const auto entry = iterator->path();
+            const auto filename =
+                entry.filename().string();
+            if (filename == master_lock_name) {
+                continue;
+            }
+            const auto data =
+                path_without_lock_suffix(entry);
+            const auto data_name =
+                data.filename().string();
+            if (data_name.starts_with(saveas_prefix)) {
+                saveas_data.push_back(data);
+                continue;
+            }
+            if (is_write_temp_name(
+                    data_name, stem, suffix)) {
+                write_temp_data.push_back(data);
+            }
+        }
+        const auto unique_sorted =
+            [](std::vector<std::filesystem::path>&
+                   paths) {
+                std::ranges::sort(paths);
+                paths.erase(
+                    std::unique(
+                        paths.begin(), paths.end()),
+                    paths.end());
+            };
+        unique_sorted(saveas_data);
+        unique_sorted(write_temp_data);
+
+        for (const auto& data : saveas_data) {
+            try_remove_unheld_artifact(data, true);
+        }
+
+        std::error_code lock_exists_error;
+        auto master_lock_path = master_path;
+        master_lock_path += ".lock";
+        const bool master_lock_existed =
+            reclaim_master_lock &&
+            std::filesystem::exists(
+                master_lock_path,
+                lock_exists_error) &&
+            !lock_exists_error;
+
+        std::optional<detail::WriterLock> master_guard;
+        if (reclaim_master_lock ||
+            !write_temp_data.empty()) {
+            auto acquired =
+                detail::WriterLock::acquire(
+                    master_path);
+            if (acquired) {
+                master_guard.emplace(
+                    std::move(*acquired));
+            }
+        }
+        if (master_guard) {
+            for (const auto& data : write_temp_data) {
+                try_remove_unheld_artifact(
+                    data, true);
+            }
+        }
+        master_guard.reset();
+        if (master_lock_existed) {
+            lock_exists_error.clear();
+            if (!std::filesystem::exists(
+                    master_lock_path,
+                    lock_exists_error) ||
+                lock_exists_error) {
+                LOG_INFO(
+                    "Removed stale project artifact {}",
+                    master_lock_path.string());
+            }
+        }
+    }
+
+    void sweep_stale_licht_artifacts_for_known_masters(
+        const std::vector<std::filesystem::path>&
+            master_paths) {
+        for (const auto& master_path : master_paths) {
+            std::error_code error;
+            if (master_path.empty() ||
+                !std::filesystem::is_regular_file(
+                    master_path, error) ||
+                error) {
+                continue;
+            }
+            sweep_stale_licht_artifacts(
+                master_path, true);
+        }
+    }
+
     namespace detail {
 
         lfs::Result<std::vector<ValidBoundAutosave>>
@@ -802,6 +990,8 @@ namespace lfs::io::project {
         RecoveryInspection result;
         sweep_orphan_project_artifacts(
             master_path, result);
+        sweep_stale_licht_artifacts(
+            master_path, false);
         for (const auto& temp :
              recovery_session_temps(master_path)) {
             best_effort_remove_into(result, temp);

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -6574,6 +6574,21 @@ namespace lfs::vis::project {
     void ProjectLifecycle::openStartupProject(
         const std::optional<
             std::filesystem::path>& explicit_path) {
+        std::vector<std::filesystem::path> known;
+        {
+            const std::lock_guard lock(
+                settings_mutex_);
+            known.reserve(settings_.mru.size());
+            for (const auto& entry : settings_.mru) {
+                known.push_back(
+                    resolveProjectMruPath(
+                        entry.last_known_path));
+            }
+        }
+        lfs::io::project::
+            sweep_stale_licht_artifacts_for_known_masters(
+                known);
+
         // Never auto-restore from MRU. Startup without an
         // explicit CLI project path leaves a blank session
         // after a clean previous session; the

--- a/tests/test_project_container.cpp
+++ b/tests/test_project_container.cpp
@@ -2081,7 +2081,9 @@ namespace {
             ASSERT_FALSE(second);
             EXPECT_EQ(second.error().code(), lfs::ErrorCode::Unavailable);
         }
-        EXPECT_TRUE(fs::exists(fs::path(path.string() + ".lock")));
+        const auto lock_path = fs::path(path.string() + ".lock");
+        EXPECT_FALSE(fs::exists(lock_path));
+        write_file_bytes(lock_path, byte_vector("stale lock is not authority"));
 
         ProjectWriter writer = require_result(ProjectWriter::create(
             path, fixture_create_options(403)));
@@ -3144,7 +3146,8 @@ namespace {
     }
 
     TEST(ProjectContainerWriter, InspectLeavesMasterLockFile) {
-        // Would fail if sweep started unlinking .lock siblings (O7).
+        // Would fail if inspect left a permanent {master}.lock after
+        // releasing the writer lock (O7: sweep still skips a held lock).
         TemporaryDirectory temporary;
         const fs::path master = temporary.path / "keep-lock.licht";
         create_single_chunk_fixture(
@@ -3155,7 +3158,90 @@ namespace {
             << lfs::format_for_developer(inspection.error());
         auto lock_path = master;
         lock_path += ".lock";
+        EXPECT_FALSE(fs::exists(lock_path));
+    }
+
+    TEST(ProjectContainerWriter, WriterLockReleaseDeletesLockFile) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "lock-hygiene.licht";
+        auto lock_path = path;
+        lock_path += ".lock";
+        {
+            auto lock = detail::WriterLock::acquire(path);
+            ASSERT_TRUE(lock)
+                << lfs::format_for_developer(lock.error());
+            EXPECT_TRUE(fs::exists(lock_path));
+        }
+        EXPECT_FALSE(fs::exists(lock_path));
+    }
+
+    TEST(ProjectContainerWriter,
+         WriterLockContentionLoserErrorsWinnerReleaseDeletes) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "lock-contend.licht";
+        auto lock_path = path;
+        lock_path += ".lock";
+        std::optional<detail::WriterLock> winner;
+        {
+            auto acquired = detail::WriterLock::acquire(path);
+            ASSERT_TRUE(acquired)
+                << lfs::format_for_developer(acquired.error());
+            winner.emplace(std::move(*acquired));
+        }
+        auto loser = detail::WriterLock::acquire(path);
+        ASSERT_FALSE(loser);
+        EXPECT_EQ(loser.error().code(), lfs::ErrorCode::Unavailable);
         EXPECT_TRUE(fs::exists(lock_path));
+        winner.reset();
+        EXPECT_FALSE(fs::exists(lock_path));
+        {
+            auto reacquired = detail::WriterLock::acquire(path);
+            ASSERT_TRUE(reacquired)
+                << lfs::format_for_developer(reacquired.error());
+        }
+        EXPECT_FALSE(fs::exists(lock_path));
+    }
+
+    TEST(ProjectContainerWriter,
+         StartupSweepRemovesStaleMasterLockAndSaveasTemp) {
+        TemporaryDirectory temporary;
+        const fs::path master =
+            temporary.path / "startup-hygiene.licht";
+        create_single_chunk_fixture(
+            master, 1101, 1102, 1103, fixed_key("PROJ", 1104),
+            R"({"master":"startup-hygiene"})");
+        auto master_lock = master;
+        master_lock += ".lock";
+        write_file_bytes(master_lock, byte_vector("stale master lock"));
+        const fs::path saveas =
+            temporary.path /
+            ".startup-hygiene.licht.saveas-deadbeef.tmp";
+        auto saveas_lock = saveas;
+        saveas_lock += ".lock";
+        write_file_bytes(saveas, byte_vector("stale saveas staging"));
+        write_file_bytes(saveas_lock, byte_vector("stale saveas lock"));
+
+        const fs::path held_master =
+            temporary.path / "startup-held.licht";
+        create_single_chunk_fixture(
+            held_master, 1105, 1106, 1107, fixed_key("PROJ", 1108),
+            R"({"master":"startup-held"})");
+        auto held = WriterLockLease::acquire(held_master);
+        ASSERT_TRUE(held)
+            << lfs::format_for_developer(held.error());
+        auto held_lock = held_master;
+        held_lock += ".lock";
+        EXPECT_TRUE(fs::exists(held_lock));
+
+        const fs::path missing = temporary.path / "missing.licht";
+        sweep_stale_licht_artifacts_for_known_masters(
+            {master, held_master, missing});
+
+        EXPECT_FALSE(fs::exists(master_lock));
+        EXPECT_FALSE(fs::exists(saveas));
+        EXPECT_FALSE(fs::exists(saveas_lock));
+        EXPECT_TRUE(fs::exists(held_lock));
+        EXPECT_FALSE(fs::exists(missing));
     }
 
     TEST(ProjectContainerWriter,

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -72,6 +72,7 @@ namespace {
     using lfs::test::licht::require_result_ptr;
     using lfs::test::licht::require_status;
     using lfs::test::licht::TemporaryDirectory;
+    using lfs::test::licht::write_file_bytes;
 
     Uuid fixed_uuid(const std::uint64_t tag) {
         return lfs::test::licht::fixed_uuid_in_namespace(0x70000000, tag);
@@ -3318,6 +3319,93 @@ namespace {
             document->save(destination, append_options);
         ASSERT_TRUE(appended)
             << lfs::format_for_developer(appended.error());
+    }
+
+    TEST(ProjectDocumentTest,
+         SaveAsFailureRemovesStagingTempAndLock) {
+        TemporaryDirectory temporary;
+        const fs::path source =
+            temporary.path / "saveas-fail-source.licht";
+        const fs::path destination =
+            temporary.path / "saveas-fail-dest.licht";
+        write_phase_a_fixture(source);
+        auto document =
+            require_result_ptr(ProjectDocument::open(source));
+        auto options = save_options(9970, 500);
+        options.disk_reserve_bytes =
+            std::numeric_limits<std::uint64_t>::max() / 2;
+        auto saved = document->save_as(destination, options);
+        ASSERT_FALSE(saved);
+        EXPECT_FALSE(fs::exists(destination));
+        auto destination_lock = destination;
+        destination_lock += ".lock";
+        EXPECT_FALSE(fs::exists(destination_lock));
+        for (const auto& entry :
+             fs::directory_iterator(temporary.path)) {
+            const auto name =
+                entry.path().filename().string();
+            EXPECT_EQ(name.find(".saveas-"), std::string::npos)
+                << name;
+            EXPECT_FALSE(name.ends_with(".lock")) << name;
+        }
+        EXPECT_TRUE(fs::is_regular_file(source));
+    }
+
+    TEST(ProjectDocumentTest,
+         OpenSweepsOwnedSaveasTempsAndSkipsForeignAndHeld) {
+        TemporaryDirectory temporary;
+        const fs::path master =
+            temporary.path / "open-sweep.licht";
+        write_phase_a_fixture(master);
+
+        const fs::path owned =
+            temporary.path /
+            ".open-sweep.licht.saveas-aaaa.tmp";
+        auto owned_lock = owned;
+        owned_lock += ".lock";
+        const std::array<std::byte, 1> owned_bytes{std::byte{'o'}};
+        const std::array<std::byte, 1> owned_lock_bytes{std::byte{'l'}};
+        write_file_bytes(owned, owned_bytes);
+        write_file_bytes(owned_lock, owned_lock_bytes);
+
+        const fs::path compact =
+            temporary.path /
+            "open-sweep.compact.1.2.3.tmp.licht";
+        const std::array<std::byte, 1> compact_bytes{std::byte{'c'}};
+        write_file_bytes(compact, compact_bytes);
+
+        const fs::path foreign =
+            temporary.path /
+            ".other.licht.saveas-bbbb.tmp";
+        const std::array<std::byte, 1> foreign_bytes{std::byte{'f'}};
+        write_file_bytes(foreign, foreign_bytes);
+
+        const fs::path held =
+            temporary.path /
+            ".open-sweep.licht.saveas-held.tmp";
+        auto held_lock = held;
+        held_lock += ".lock";
+        const std::array<std::byte, 1> held_bytes{std::byte{'h'}};
+        const std::array<std::byte, 1> held_lock_bytes{std::byte{'k'}};
+        write_file_bytes(held, held_bytes);
+        write_file_bytes(held_lock, held_lock_bytes);
+        auto held_lease = WriterLockLease::acquire(held);
+        ASSERT_TRUE(held_lease)
+            << lfs::format_for_developer(held_lease.error());
+
+        auto opened =
+            require_result_ptr(ProjectDocument::open(master));
+        ASSERT_TRUE(opened->source_path());
+
+        EXPECT_FALSE(fs::exists(owned));
+        EXPECT_FALSE(fs::exists(owned_lock));
+        EXPECT_FALSE(fs::exists(compact));
+        EXPECT_TRUE(fs::exists(foreign));
+        EXPECT_TRUE(fs::exists(held));
+        EXPECT_TRUE(fs::exists(held_lock));
+        auto master_lock = master;
+        master_lock += ".lock";
+        EXPECT_FALSE(fs::exists(master_lock));
     }
 
     TEST(ProjectDocumentTest,


### PR DESCRIPTION
Project folders were filling up with zero-byte `.lock` files and orphaned `.saveas-*.tmp` staging files of 100-300MB (reported on Discord with a screenshot of a folder full of both). Three causes, all fixed:

**Lock files were never deleted.** Releasing a lock only closed it; the marker file stayed forever, one per project and one per save. Locks are now deleted on release, with the standard race-safe handling on both Linux and Windows. A crashed app cannot clean up after itself, so the next start does it: startup sweeps the recent-projects list and reclaims crash leftovers automatically.

**Failed saves could strand their staging file.** Cleanup existed but silently ignored deletion failures and never removed the staging file's own lock. Failures are now logged and the lock is removed with the temp.

**Nothing ever swept old orphans.** Opening a project now cleans stale staging files, writer temps, and their locks that belong to that project - with a lock probe so files a running process still holds are never touched, and files belonging to other projects in the same folder are left alone.

**Verified:** new tests for lock deletion, contention, failed-save cleanup, and the sweeps (owned files removed, foreign and in-use files kept) - 184 tests green across the affected suites. Live: a clean run now leaves only `project.licht` where the identical run previously leaked a lock file; opening a project removed a planted 20MB stranded temp plus its lock while keeping a neighboring project's file; app startup automatically removed real leftover lock files from earlier sessions.