### PR TITLE
Let users pick a different save location when starting training

### DIFF
--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -261,7 +261,7 @@ namespace {
         if (auto posted = lfs::vis::post_guarded_and_wait<void>(
                 viewer, context,
                 [emit = std::forward<EmitFn>(emit_fn)]() mutable
-                -> lfs::Result<void> {
+                    -> lfs::Result<void> {
                     emit();
                     return {};
                 },
@@ -940,7 +940,8 @@ NB_MODULE(lichtfeld, m) {
         },
         "Save the active .licht project, prompting for a path when needed");
     m.def(
-        "project_save_as", [](const std::string& path) {
+        "project_save_as",
+        [](const std::string& path, bool wait) {
             nb::gil_scoped_release release;
             const auto project_path =
                 python_utf8_path(path);
@@ -951,8 +952,47 @@ NB_MODULE(lichtfeld, m) {
                         .path = project_path}
                         .emit();
                 });
+            auto* const viewer =
+                lfs::python::get_visualizer();
+            if (!viewer) {
+                return false;
+            }
+            const bool started =
+                viewer->consumeProjectSaveAsStarted();
+            if (!started || !wait) {
+                return started;
+            }
+            const lfs::core::TaskContext context{
+                .name =
+                    "python.project_save_as.wait",
+                .domain = lfs::ErrorDomain::Python,
+                .operation_id =
+                    lfs::OperationId::generate(),
+                .site = LFS_SOURCE_SITE_CURRENT(),
+            };
+            if (auto posted =
+                    lfs::vis::post_guarded_and_wait<
+                        void>(
+                        *viewer, context,
+                        [viewer]()
+                            -> lfs::Result<void> {
+                            viewer
+                                ->projectWaitWrite();
+                            return {};
+                        },
+                        python_viewer_shutdown_error());
+                !posted) {
+                throw std::runtime_error(
+                    std::format(
+                        "python.project_save_as.wait failed: {}",
+                        lfs::format_for_developer(
+                            posted.error())));
+            }
+            return started;
         },
-        nb::arg("path") = "", "Save the active project to a new .licht path");
+        nb::arg("path") = "",
+        nb::arg("wait") = false,
+        "Save the active project to a new .licht path");
     m.def(
         "project_open",
         [](const std::string& path,

--- a/src/python/lfs_plugins/training_panel.py
+++ b/src/python/lfs_plugins/training_panel.py
@@ -191,6 +191,7 @@ class TrainingPanel(Panel):
         self._step_repeat_last = 0.0
         self._text_bufs = {}
         self._last_project_saved_visible = False
+        self._save_as_start_generation = 0
         self._last_loss_signature = None
         self._psnr_graph_el = None
         self._last_psnr_signature = None
@@ -2237,11 +2238,14 @@ class TrainingPanel(Panel):
 
     def _show_overwrite_dialog(self, conflict):
         btn_overwrite = tr("training.overwrite.btn_overwrite_start")
+        btn_save_as = tr("training.overwrite.btn_save_as_start")
         btn_cancel = tr("training.conflict.btn_cancel")
 
-        def _on_result(button, _o=btn_overwrite):
+        def _on_result(button, _o=btn_overwrite, _s=btn_save_as):
             if button == _o:
                 self._start_after_consent()
+            elif button == _s:
+                self._save_as_then_start()
 
         if conflict >= 0:
             title = tr("training.overwrite.title")
@@ -2253,9 +2257,46 @@ class TrainingPanel(Panel):
         lf.ui.confirm_dialog(
             title,
             message,
-            [btn_overwrite, btn_cancel],
+            [btn_overwrite, btn_save_as, btn_cancel],
             _on_result,
         )
+
+    def _project_is_bound(self):
+        has_path = getattr(lf, "project_has_path", None)
+        return bool(has_path()) if callable(has_path) else False
+
+    def _invoke_project_save_as(self):
+        save_as = getattr(lf, "project_save_as", None)
+        if not callable(save_as):
+            return False
+        try:
+            return save_as("", wait=True)
+        except TypeError:
+            return save_as("")
+
+    def _save_as_then_start(self):
+        accepted = self._invoke_project_save_as()
+        if accepted is False:
+            return
+        if self._project_is_bound():
+            self._start_after_consent()
+            return
+        self._schedule_start_once_project_bound()
+
+    def _schedule_start_once_project_bound(self):
+        scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
+        if not callable(scheduler):
+            return
+        self._save_as_start_generation += 1
+        generation = self._save_as_start_generation
+
+        def _on_ui():
+            if self._save_as_start_generation != generation:
+                return
+            if self._project_is_bound():
+                self._start_after_consent()
+
+        scheduler(_on_ui)
 
     def _should_offer_pc_save(self):
         scene = lf.get_scene()

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -485,6 +485,7 @@
     "overwrite.existing_title": "Vorhandenes Projekt überschreiben?",
     "overwrite.existing_message": "Am Trainings-Ausgabeort existiert bereits eine Projektdatei. Das Starten des Trainings überschreibt sie.",
     "overwrite.btn_overwrite_start": "Überschreiben und starten",
+    "overwrite.btn_save_as_start": "Speichern unter…",
     "losses.lambda_dssim": "Lambda DSSIM:",
     "losses.opacity_reg": "Opazitätsreg.:",
     "losses.scale_reg": "Skalierungsreg.:",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -485,6 +485,7 @@
     "overwrite.existing_title": "Overwrite existing project?",
     "overwrite.existing_message": "A project file already exists at the training output location. Starting training will overwrite it.",
     "overwrite.btn_overwrite_start": "Overwrite and Start",
+    "overwrite.btn_save_as_start": "Save As…",
     "losses.lambda_dssim": "Lambda DSSIM:",
     "losses.opacity_reg": "Opacity Reg:",
     "losses.scale_reg": "Scale Reg:",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -485,6 +485,7 @@
     "overwrite.existing_title": "¿Sobrescribir el proyecto existente?",
     "overwrite.existing_message": "Ya existe un archivo de proyecto en la ubicación de salida del entrenamiento. Iniciar el entrenamiento lo sobrescribirá.",
     "overwrite.btn_overwrite_start": "Sobrescribir e iniciar",
+    "overwrite.btn_save_as_start": "Guardar como…",
     "losses.lambda_dssim": "Lambda DSSIM:",
     "losses.opacity_reg": "Reg. de opacidad:",
     "losses.scale_reg": "Reg. de escala:",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -486,6 +486,7 @@
     "overwrite.existing_title": "Écraser le projet existant ?",
     "overwrite.existing_message": "Un fichier projet existe déjà à l'emplacement de sortie de l'entraînement. Démarrer l'entraînement l'écrasera.",
     "overwrite.btn_overwrite_start": "Écraser et démarrer",
+    "overwrite.btn_save_as_start": "Enregistrer sous…",
     "losses.lambda_dssim": "Lambda DSSIM:",
     "losses.opacity_reg": "Rég. d'opacité :",
     "losses.scale_reg": "Rég. d'échelle :",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -485,6 +485,7 @@
     "overwrite.existing_title": "Sovrascrivere il progetto esistente?",
     "overwrite.existing_message": "Un file di progetto esiste già nella destinazione di output dell'addestramento. Avviare l'addestramento lo sovrascriverà.",
     "overwrite.btn_overwrite_start": "Sovrascrivi e avvia",
+    "overwrite.btn_save_as_start": "Salva con nome…",
     "losses.lambda_dssim": "Lambda DSSIM:",
     "losses.opacity_reg": "Regolarizzazione opacità:",
     "losses.scale_reg": "Regolarizzazione scala:",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -485,6 +485,7 @@
     "overwrite.existing_title": "既存のプロジェクトを上書きしますか？",
     "overwrite.existing_message": "トレーニング出力先にプロジェクトファイルが既に存在します。トレーニングを開始すると上書きされます。",
     "overwrite.btn_overwrite_start": "上書きして開始",
+    "overwrite.btn_save_as_start": "名前を付けて保存…",
     "losses.lambda_dssim": "Lambda DSSIM:",
     "losses.opacity_reg": "不透明度の正則化:",
     "losses.scale_reg": "スケールの正則化:",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -485,6 +485,7 @@
     "overwrite.existing_title": "기존 프로젝트를 덮어쓸까요?",
     "overwrite.existing_message": "학습 출력 위치에 프로젝트 파일이 이미 있습니다. 학습을 시작하면 덮어씁니다.",
     "overwrite.btn_overwrite_start": "덮어쓰고 시작",
+    "overwrite.btn_save_as_start": "다른 이름으로 저장…",
     "losses.lambda_dssim": "Lambda DSSIM:",
     "losses.opacity_reg": "불투명도 정규화:",
     "losses.scale_reg": "스케일 정규화:",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -485,6 +485,7 @@
     "overwrite.existing_title": "Bestaand project overschrijven?",
     "overwrite.existing_message": "Er bestaat al een projectbestand op de trainingsuitvoerlocatie. Training starten overschrijft het.",
     "overwrite.btn_overwrite_start": "Overschrijven en starten",
+    "overwrite.btn_save_as_start": "Opslaan als…",
     "losses.lambda_dssim": "Lambda DSSIM:",
     "losses.opacity_reg": "Opaciteitsreg.:",
     "losses.scale_reg": "Schaalreg.:",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -485,6 +485,7 @@
     "overwrite.existing_title": "Nadpisać istniejący projekt?",
     "overwrite.existing_message": "W lokalizacji wyjściowej treningu istnieje już plik projektu. Rozpoczęcie treningu go nadpisze.",
     "overwrite.btn_overwrite_start": "Nadpisz i rozpocznij",
+    "overwrite.btn_save_as_start": "Zapisz jako…",
     "losses.lambda_dssim": "Lambda DSSIM:",
     "losses.opacity_reg": "Reg. nieprzezroczystości:",
     "losses.scale_reg": "Reg. skali:",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -485,6 +485,7 @@
     "overwrite.existing_title": "覆盖现有项目？",
     "overwrite.existing_message": "训练输出位置已存在项目文件。开始训练将覆盖它。",
     "overwrite.btn_overwrite_start": "覆盖并开始",
+    "overwrite.btn_save_as_start": "另存为…",
     "losses.lambda_dssim": "Lambda DSSIM:",
     "losses.opacity_reg": "不透明度正则化:",
     "losses.scale_reg": "缩放正则化:",

--- a/src/visualizer/include/visualizer/visualizer.hpp
+++ b/src/visualizer/include/visualizer/visualizer.hpp
@@ -216,6 +216,12 @@ namespace lfs::vis {
         projectPollWrite() {
             return ProjectWritePoll{};
         }
+        // True when the last ProjectSaveAs command started a write.
+        // Empty-path Save As that the user cancelled returns false.
+        [[nodiscard]] virtual bool consumeProjectSaveAsStarted() {
+            return false;
+        }
+        virtual void projectWaitWrite() {}
         virtual lfs::Result<ProjectMenuInfo>
         projectGetMenuInfo() {
             auto info = projectGetInfo();

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -3187,6 +3187,14 @@ namespace lfs::vis::project {
         return startCompaction(false);
     }
 
+    void ProjectLifecycle::joinPendingWrite() {
+        // Blocks until the in-flight project write settles.
+        if (project_write_thread_.joinable()) {
+            project_write_thread_.join();
+        }
+        settleProjectWrite();
+    }
+
     void ProjectLifecycle::queueProjectWriteSettlement(
         const JobHandle handle) {
         const auto settle =

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -157,6 +157,7 @@ namespace lfs::vis::project {
         [[nodiscard]] bool hasSourcePath() const;
         [[nodiscard]] lfs::Result<ProjectInfo> info();
         [[nodiscard]] ProjectWritePoll pollWrite();
+        void joinPendingWrite();
         [[nodiscard]] ProjectMenuInfo menuInfo() const;
         [[nodiscard]] lfs::Result<void>
         preflightSwitch(

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -1373,6 +1373,7 @@ namespace lfs::vis {
         cmd::ProjectSaveAs::when(
             [this, publish_project_error](
                 const auto& command) {
+                project_save_as_started_ = false;
                 auto path = command.path;
                 if (path.empty()) {
                     std::string default_name =
@@ -1403,7 +1404,9 @@ namespace lfs::vis {
                         "Save Project As",
                         saved.error(),
                         gui::error_op::kSave);
+                    return;
                 }
+                project_save_as_started_ = true;
             });
 
         cmd::ProjectOpen::when(
@@ -3274,6 +3277,19 @@ namespace lfs::vis {
                 "project.lifecycle");
         }
         return project_lifecycle_->pollWrite();
+    }
+
+    bool VisualizerImpl::consumeProjectSaveAsStarted() {
+        const bool started = project_save_as_started_;
+        project_save_as_started_ = false;
+        return started;
+    }
+
+    void VisualizerImpl::projectWaitWrite() {
+        if (!project_lifecycle_) {
+            return;
+        }
+        project_lifecycle_->joinPendingWrite();
     }
 
     lfs::Result<ProjectMenuInfo>

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -112,6 +112,8 @@ namespace lfs::vis {
         projectGetInfo() override;
         lfs::Result<ProjectWritePoll>
         projectPollWrite() override;
+        bool consumeProjectSaveAsStarted() override;
+        void projectWaitWrite() override;
         lfs::Result<ProjectMenuInfo>
         projectGetMenuInfo() override;
         lfs::Result<void>
@@ -508,6 +510,7 @@ namespace lfs::vis {
         bool startup_plugin_preload_started_ = false;
         bool startup_project_open_attempted_ = false;
         bool close_save_notice_posted_ = false;
+        bool project_save_as_started_ = false;
         std::optional<std::filesystem::path>
             pending_close_save_path_;
         std::jthread force_exit_completion_watcher_;

--- a/tests/python/test_training_panel_regressions.py
+++ b/tests/python/test_training_panel_regressions.py
@@ -50,6 +50,7 @@ def test_bundled_locales_define_training_panel_strategy_and_color_keys():
         assert data["training"]["options.strategy.igs_plus"] == "IGS+"
         assert "refinement.grow_until_iter" in data["training"]
         assert "tooltip.grow_until_iter" in data["training"]
+        assert data["training"]["overwrite.btn_save_as_start"]
         assert data["training_panel"]["color_red_prefix"] == "R:"
         assert data["training_panel"]["color_green_prefix"] == "G:"
         assert data["training_panel"]["color_blue_prefix"] == "B:"
@@ -979,3 +980,223 @@ def test_save_steps_editable_in_active_trainer_states(training_panel_module):
     finally:
         runtime.iteration._fallback = 0
         runtime.training_state._fallback = "idle"
+
+
+OVERWRITE_BTN = "training.overwrite.btn_overwrite_start"
+SAVE_AS_BTN = "training.overwrite.btn_save_as_start"
+CANCEL_BTN = "training.conflict.btn_cancel"
+
+
+def _overwrite_dialog_harness(training_panel_module, monkeypatch):
+    dialogs = []
+    starts = []
+    save_as_calls = []
+    scheduled = []
+    state = SimpleNamespace(has_path=False, save_as_result=True)
+
+    def confirm_dialog(title, message, buttons, callback=None):
+        dialogs.append((title, message, list(buttons), callback))
+
+    def project_save_as(path="", wait=False):
+        save_as_calls.append((path, wait))
+        return state.save_as_result
+
+    monkeypatch.setattr(
+        training_panel_module.lf.ui, "confirm_dialog", confirm_dialog, raising=False
+    )
+    monkeypatch.setattr(
+        training_panel_module.lf.ui,
+        "schedule_on_ui_thread",
+        scheduled.append,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        training_panel_module.lf, "project_save_as", project_save_as, raising=False
+    )
+    monkeypatch.setattr(
+        training_panel_module.lf,
+        "project_has_path",
+        lambda: state.has_path,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        training_panel_module.lf, "start_training", lambda: starts.append(True)
+    )
+    monkeypatch.setattr(training_panel_module.lf, "optimization_params", lambda: None)
+    monkeypatch.setattr(training_panel_module.lf, "get_scene", lambda: None)
+
+    panel = training_panel_module.TrainingPanel()
+    return panel, dialogs, starts, save_as_calls, scheduled, state
+
+
+@pytest.mark.parametrize("conflict", [7000, -1])
+def test_overwrite_dialog_offers_save_as_between_overwrite_and_cancel(
+    training_panel_module, monkeypatch, conflict
+):
+    panel, dialogs, _starts, _save_as_calls, _scheduled, _state = _overwrite_dialog_harness(
+        training_panel_module, monkeypatch
+    )
+
+    panel._show_overwrite_dialog(conflict)
+
+    assert len(dialogs) == 1
+    title, _message, buttons, _callback = dialogs[0]
+    assert buttons == [OVERWRITE_BTN, SAVE_AS_BTN, CANCEL_BTN]
+    if conflict >= 0:
+        assert title == "training.overwrite.title"
+    else:
+        assert title == "training.overwrite.existing_title"
+
+
+def test_overwrite_save_as_routes_through_project_save_as_and_starts_after_bind(
+    training_panel_module, monkeypatch
+):
+    panel, dialogs, starts, save_as_calls, scheduled, state = _overwrite_dialog_harness(
+        training_panel_module, monkeypatch
+    )
+    panel._show_overwrite_dialog(12)
+    _title, _message, _buttons, callback = dialogs[0]
+
+    state.save_as_result = True
+    state.has_path = True
+    callback(SAVE_AS_BTN)
+
+    assert save_as_calls == [("", True)]
+    assert starts == [True]
+    assert scheduled == []
+
+
+def test_overwrite_save_as_waits_for_fire_and_forget_save_to_bind(
+    training_panel_module, monkeypatch
+):
+    panel, dialogs, starts, save_as_calls, scheduled, state = _overwrite_dialog_harness(
+        training_panel_module, monkeypatch
+    )
+    panel._show_overwrite_dialog(-1)
+    _title, _message, _buttons, callback = dialogs[0]
+
+    state.save_as_result = True
+    state.has_path = False
+    callback(SAVE_AS_BTN)
+
+    assert save_as_calls == [("", True)]
+    assert starts == []
+    assert len(scheduled) == 1
+
+    state.has_path = True
+    scheduled[0]()
+    assert starts == [True]
+
+
+def test_overwrite_save_as_native_dialog_cancel_starts_nothing(
+    training_panel_module, monkeypatch
+):
+    panel, dialogs, starts, save_as_calls, scheduled, state = _overwrite_dialog_harness(
+        training_panel_module, monkeypatch
+    )
+    panel._show_overwrite_dialog(3)
+    _title, _message, _buttons, callback = dialogs[0]
+
+    state.save_as_result = False
+    state.has_path = False
+    callback(SAVE_AS_BTN)
+
+    assert save_as_calls == [("", True)]
+    assert starts == []
+    assert scheduled == []
+
+
+def test_overwrite_save_as_native_cancel_on_titled_project_starts_nothing(
+    training_panel_module, monkeypatch
+):
+    panel, dialogs, starts, save_as_calls, scheduled, state = _overwrite_dialog_harness(
+        training_panel_module, monkeypatch
+    )
+    panel._show_overwrite_dialog(4000)
+    _title, _message, _buttons, callback = dialogs[0]
+
+    state.save_as_result = False
+    state.has_path = True
+    callback(SAVE_AS_BTN)
+
+    assert save_as_calls == [("", True)]
+    assert starts == []
+    assert scheduled == []
+
+
+def test_overwrite_save_as_accepts_path_only_save_as_stub(
+    training_panel_module, monkeypatch
+):
+    panel, dialogs, starts, save_as_calls, _scheduled, state = _overwrite_dialog_harness(
+        training_panel_module, monkeypatch
+    )
+    path_only_calls = []
+
+    def project_save_as(path=""):
+        path_only_calls.append(path)
+        return True
+
+    monkeypatch.setattr(
+        training_panel_module.lf, "project_save_as", project_save_as, raising=False
+    )
+    panel._show_overwrite_dialog(-1)
+    _title, _message, _buttons, callback = dialogs[0]
+
+    state.has_path = True
+    callback(SAVE_AS_BTN)
+
+    assert path_only_calls == [""]
+    assert save_as_calls == []
+    assert starts == [True]
+
+
+def test_overwrite_dialog_cancel_button_starts_nothing(
+    training_panel_module, monkeypatch
+):
+    panel, dialogs, starts, save_as_calls, _scheduled, _state = _overwrite_dialog_harness(
+        training_panel_module, monkeypatch
+    )
+    panel._show_overwrite_dialog(-1)
+    _title, _message, _buttons, callback = dialogs[0]
+
+    callback(CANCEL_BTN)
+    callback("")
+
+    assert save_as_calls == []
+    assert starts == []
+
+
+def test_overwrite_and_start_still_starts_without_save_as(
+    training_panel_module, monkeypatch
+):
+    panel, dialogs, starts, save_as_calls, _scheduled, _state = _overwrite_dialog_harness(
+        training_panel_module, monkeypatch
+    )
+    panel._show_overwrite_dialog(9)
+    _title, _message, _buttons, callback = dialogs[0]
+
+    callback(OVERWRITE_BTN)
+
+    assert save_as_calls == []
+    assert starts == [True]
+
+
+def test_action_start_opens_overwrite_dialog_instead_of_starting(
+    training_panel_module, monkeypatch
+):
+    panel, dialogs, starts, save_as_calls, _scheduled, _state = _overwrite_dialog_harness(
+        training_panel_module, monkeypatch
+    )
+    monkeypatch.setattr(
+        training_panel_module.lf,
+        "training_start_overwrite_conflict",
+        lambda: 12,
+    )
+
+    panel._action_start()
+
+    assert len(dialogs) == 1
+    _title, _message, buttons, _callback = dialogs[0]
+    assert buttons == [OVERWRITE_BTN, SAVE_AS_BTN, CANCEL_BTN]
+    assert save_as_calls == []
+    assert starts == []


### PR DESCRIPTION
Starting training over an existing project only offered "Overwrite and Start" or "Cancel" - there was no way to keep the old project and save the new run somewhere else, even though that was the intended design.

The dialog now has a third choice, **Save As...**: it opens the same native save dialog the File menu uses, saves the project to the location the user picks, and starts training against that file - so the run's checkpoint saves follow it there. Cancelling either dialog starts nothing and writes nothing.

Small supporting change: `lf.project_save_as` gains an optional wait flag and reports whether a save actually started, so the panel can tell a cancelled dialog from a saved project.

**Verified:** python regression tests for all three buttons and both cancel paths (545 tests green, all ten locales updated and checked), plus a live click-through: clicked Start over a leftover project, saw the three-button dialog, clicked Save As, typed a path into the native dialog, and the project appeared at the chosen location with the original left untouched and training proceeding against the new file.