### PR TITLE
Fix Delete inside text fields deleting the selected model

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -5716,6 +5716,10 @@ namespace lfs::vis::gui {
         } else if (auto* const wm = viewer_->getWindowManager()) {
             wm->refreshResizeCursor();
         }
+        // Re-sample after every Rml surface has processed input so the next
+        // SDL key (handleKey) sees text focus even when GUI frames are idle.
+        if (rmlui_manager_.wantsTextInput())
+            guiFocusState().want_text_input = true;
         syncWindowTextInput(viewer_->getWindow());
 
         if (vulkan_gui_) {

--- a/src/visualizer/gui/rml_right_panel.cpp
+++ b/src/visualizer/gui/rml_right_panel.cpp
@@ -4,6 +4,7 @@
 
 #include "gui/rml_right_panel.hpp"
 #include "core/logger.hpp"
+#include "gui/gui_focus_state.hpp"
 #include "gui/panel_layout.hpp"
 #include "gui/rmlui/rml_document_utils.hpp"
 #include "gui/rmlui/rml_input_utils.hpp"
@@ -432,6 +433,8 @@ namespace lfs::vis::gui {
             wants_input_ = wants_keyboard_ || last_over_interactive_ ||
                            previous_cursor_request != CursorRequest::None;
             cursor_request_ = previous_cursor_request;
+            if (rml_input::wantsTextInput(focused_before))
+                guiFocusState().want_text_input = true;
             return;
         }
 
@@ -583,6 +586,8 @@ namespace lfs::vis::gui {
         auto* focused = rml_context_->GetFocusElement();
         wants_keyboard_ = rml_input::hasFocusedKeyboardTarget(focused);
         wants_input_ = wants_input_ || wants_keyboard_;
+        if (rml_input::wantsTextInput(focused))
+            guiFocusState().want_text_input = true;
     }
 
     void RmlRightPanel::render(const RightPanelLayout& layout,

--- a/src/visualizer/gui/rml_viewport_overlay.cpp
+++ b/src/visualizer/gui/rml_viewport_overlay.cpp
@@ -7,6 +7,7 @@
 #include "gui/gui_focus_state.hpp"
 #include "gui/panel_layout.hpp"
 #include "gui/rmlui/rml_document_utils.hpp"
+#include "gui/rmlui/rml_input_utils.hpp"
 #include "gui/rmlui/rml_theme.hpp"
 #include "gui/rmlui/rml_tooltip.hpp"
 #include "gui/rmlui/rmlui_manager.hpp"
@@ -73,6 +74,17 @@ namespace lfs::vis::gui {
                     return true;
             }
             return false;
+        }
+
+        // Keep guiFocusState in sync with the overlay's live RmlUi focus so
+        // InputController shortcut dispatch sees text editing on the next key.
+        bool publishOverlayTextFocus(Rml::Element* focused) {
+            if (!rml_input::wantsTextInput(focused))
+                return false;
+            auto& focus = guiFocusState();
+            focus.want_capture_keyboard = true;
+            focus.want_text_input = true;
+            return true;
         }
 
     } // namespace
@@ -722,10 +734,7 @@ namespace lfs::vis::gui {
             !input.text_inputs.empty() || input.has_text_editing;
         const bool vram_drag_capture = vram_hud_ && vram_hud_->isCapturingPointer();
         auto* const focused_before = rml_context_->GetFocusElement();
-        const bool focused_text_target =
-            focused_before &&
-            (focused_before->GetTagName() == "input" ||
-             focused_before->GetTagName() == "textarea");
+        const bool focused_text_target = rml_input::wantsTextInput(focused_before);
         if (mouse_pos_valid_ && !mouse_moved && !pointer_event && !pointer_drag &&
             !keyboard_event && !vram_drag_capture) {
             wants_input_ = hovered_interactive_ || focused_text_target;
@@ -738,8 +747,7 @@ namespace lfs::vis::gui {
             } else {
                 tooltip_.setHover({}, nullptr);
             }
-            if (focused_text_target)
-                guiFocusState().want_capture_keyboard = true;
+            publishOverlayTextFocus(focused_before);
             return;
         }
         auto* const point_element = is_inside
@@ -838,11 +846,8 @@ namespace lfs::vis::gui {
         // (e.g. the Annotations / Drill-down filter <input>). This must run regardless of
         // over_interactive, because a text input keeps focus even when the mouse roams away.
         if (auto* focused = rml_context_->GetFocusElement()) {
-            const auto tag = focused->GetTagName();
-            const bool is_text_target = tag == "input" || tag == "textarea";
-            if (is_text_target) {
+            if (publishOverlayTextFocus(focused)) {
                 wants_input_ = true;
-                guiFocusState().want_capture_keyboard = true;
                 // Numpad digit and period scancodes must be suppressed from
                 // ProcessKeyDown / ProcessKeyUp when a text input is focused,
                 // otherwise RmlUi treats them as navigation keys (Home, End,

--- a/src/visualizer/input/input_bindings.cpp
+++ b/src/visualizer/input/input_bindings.cpp
@@ -1990,48 +1990,6 @@ namespace lfs::vis::input {
 
     ShortcutScope shortcutScopeForAction(const Action action) {
         switch (action) {
-        case Action::TOOL_SELECT:
-        case Action::TOOL_TRANSLATE:
-        case Action::TOOL_ROTATE:
-        case Action::TOOL_SCALE:
-        case Action::TOOL_MIRROR:
-        case Action::TOOL_ALIGN:
-        case Action::TOGGLE_UI:
-        case Action::TOGGLE_FULLSCREEN:
-        case Action::TOGGLE_PERFORMANCE_HUD:
-        case Action::OPEN_PREFERENCES:
-        case Action::SELECT_MODE_CENTERS:
-        case Action::SELECT_MODE_RECTANGLE:
-        case Action::SELECT_MODE_POLYGON:
-        case Action::SELECT_MODE_LASSO:
-        case Action::SELECT_MODE_RINGS:
-        case Action::SELECT_MODE_COLOR:
-        case Action::SELECT_MODE_BOX:
-        case Action::SELECT_MODE_SPHERE:
-        case Action::UNDO:
-        case Action::REDO:
-        case Action::DELETE_SELECTED:
-        case Action::DELETE_NODE:
-        case Action::INVERT_SELECTION:
-        case Action::DESELECT_ALL:
-        case Action::SELECT_ALL:
-        case Action::COPY_SELECTION:
-        case Action::CUT_SELECTION:
-        case Action::PASTE_SELECTION:
-        case Action::TOGGLE_DEPTH_MODE:
-        case Action::TOGGLE_SELECTION_DEPTH_FILTER:
-        case Action::TOGGLE_SELECTION_CROP_FILTER:
-        case Action::SEQUENCER_ADD_KEYFRAME:
-        case Action::SEQUENCER_UPDATE_KEYFRAME:
-        case Action::SEQUENCER_PLAY_PAUSE:
-        case Action::TOGGLE_SPLIT_VIEW:
-        case Action::TOGGLE_INDEPENDENT_SPLIT_VIEW:
-        case Action::TOGGLE_GT_COMPARISON:
-        case Action::TOGGLE_CAMERA_FRUSTUMS:
-        case Action::TOGGLE_GRID:
-        case Action::CYCLE_SELECTION_VIS:
-            return ShortcutScope::GlobalWhenNotTextEditing;
-
         case Action::TOGGLE_MCP_SERVER:
         case Action::TOGGLE_MCP_BINDING:
             return ShortcutScope::Global;
@@ -2056,7 +2014,8 @@ namespace lfs::vis::input {
             return ShortcutScope::Viewport;
 
         default:
-            return ShortcutScope::Global;
+            // Scene, tool, and edit key shortcuts yield to a focused text widget.
+            return ShortcutScope::GlobalWhenNotTextEditing;
         }
     }
 

--- a/tests/test_input_controller_focus.cpp
+++ b/tests/test_input_controller_focus.cpp
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/editor_context.hpp"
+#include "core/event_bridge/event_bridge.hpp"
 #include "core/event_bridge/scoped_handler.hpp"
 #include "core/events.hpp"
 #include "core/services.hpp"
@@ -14,6 +15,8 @@
 #include "python/python_runtime.hpp"
 #include "rendering/coordinate_conventions.hpp"
 #include "rendering/rendering_manager.hpp"
+#include "scene/scene_manager.hpp"
+#include "tools/tool_base.hpp"
 #include "visualizer/visualizer.hpp"
 
 #include <cstdint>
@@ -27,6 +30,7 @@
 #include <optional>
 #include <string>
 #include <variant>
+#include <vector>
 
 namespace lfs::vis {
 
@@ -64,6 +68,7 @@ namespace lfs::vis {
             void SetUp() override {
                 isolateInputProfileHome();
                 input::InputBindings::setPersistenceEnabled(false);
+                lfs::event::EventBridge::instance().clear_all();
                 services().clear();
                 gui::guiFocusState().reset();
             }
@@ -72,6 +77,7 @@ namespace lfs::vis {
                 setRuntimeServiceControls({});
                 gui::guiFocusState().reset();
                 services().clear();
+                lfs::event::EventBridge::instance().clear_all();
                 input::InputBindings::setPersistenceEnabled(true);
                 restoreHome();
             }
@@ -250,6 +256,95 @@ namespace lfs::vis {
 
         EXPECT_EQ(toggle_gt_count, 0);
         EXPECT_EQ(toggle_split_count, 0);
+    }
+
+    TEST_F(InputControllerFocusTest, DeleteNodeShortcutDoesNotFireDuringTextEntry) {
+        Viewport viewport(200, 200);
+        InputController controller(nullptr, viewport);
+        input::InputRouter router;
+        router.setInputController(&controller);
+        controller.setInputRouter(&router);
+
+        SceneManager scene_manager;
+        scene_manager.getScene().addGroup("delete_me");
+        scene_manager.selectNode("delete_me");
+        ASSERT_EQ(scene_manager.getSelectedNodeNames(), std::vector<std::string>{"delete_me"});
+
+        ToolContext tool_context(nullptr, &scene_manager, &viewport, nullptr);
+        controller.setToolContext(&tool_context);
+
+        lfs::event::ScopedHandler handlers;
+        int remove_ply_count = 0;
+        handlers.subscribe<core::events::cmd::RemovePLY>(
+            [&](const auto&) { ++remove_ply_count; });
+
+        auto& focus = gui::guiFocusState();
+        focus.want_capture_keyboard = true;
+        focus.want_text_input = true;
+        focus.any_item_active = true;
+
+        router.focusViewportKeyboard();
+        controller.handleKey(input::KEY_DELETE, input::ACTION_PRESS, input::KEYMOD_NONE);
+
+        EXPECT_EQ(remove_ply_count, 0);
+        EXPECT_EQ(input::shortcutScopeForAction(input::Action::DELETE_NODE),
+                  input::ShortcutScope::GlobalWhenNotTextEditing);
+    }
+
+    TEST_F(InputControllerFocusTest, DeleteNodeShortcutFiresWhenViewportFocused) {
+        Viewport viewport(200, 200);
+        InputController controller(nullptr, viewport);
+        input::InputRouter router;
+        router.setInputController(&controller);
+        controller.setInputRouter(&router);
+
+        SceneManager scene_manager;
+        scene_manager.getScene().addGroup("delete_me");
+        scene_manager.selectNode("delete_me");
+        ASSERT_EQ(scene_manager.getSelectedNodeNames(), std::vector<std::string>{"delete_me"});
+
+        ToolContext tool_context(nullptr, &scene_manager, &viewport, nullptr);
+        controller.setToolContext(&tool_context);
+
+        lfs::event::ScopedHandler handlers;
+        int remove_ply_count = 0;
+        handlers.subscribe<core::events::cmd::RemovePLY>(
+            [&](const auto& cmd) {
+                ++remove_ply_count;
+                EXPECT_EQ(cmd.name, "delete_me");
+            });
+
+        router.focusViewportKeyboard();
+        controller.handleKey(input::KEY_DELETE, input::ACTION_PRESS, input::KEYMOD_NONE);
+
+        EXPECT_EQ(remove_ply_count, 1);
+    }
+
+    TEST_F(InputControllerFocusTest, TransformToolShortcutDoesNotFireDuringTextEntry) {
+        Viewport viewport(200, 200);
+        InputController controller(nullptr, viewport);
+        input::InputRouter router;
+        router.setInputController(&controller);
+        controller.setInputRouter(&router);
+
+        lfs::event::ScopedHandler handlers;
+        int toolbar_tool_count = 0;
+        handlers.subscribe<core::events::tools::SetToolbarTool>(
+            [&](const auto&) { ++toolbar_tool_count; });
+
+        auto& focus = gui::guiFocusState();
+        focus.want_capture_keyboard = true;
+        focus.want_text_input = true;
+        focus.any_item_active = true;
+
+        router.focusViewportKeyboard();
+        controller.handleKey(input::KEY_2, input::ACTION_PRESS, input::KEYMOD_NONE);
+
+        EXPECT_EQ(toolbar_tool_count, 0);
+        EXPECT_EQ(input::shortcutScopeForAction(input::Action::TOOL_TRANSLATE),
+                  input::ShortcutScope::GlobalWhenNotTextEditing);
+        EXPECT_EQ(input::shortcutScopeForAction(input::Action::CYCLE_PLY),
+                  input::ShortcutScope::GlobalWhenNotTextEditing);
     }
 
     TEST_F(InputControllerFocusTest, ProjectSaveShortcutRemainsGlobalDuringTextEntry) {
@@ -1221,7 +1316,7 @@ namespace lfs::vis {
         std::ifstream persisted(profile_path);
         ASSERT_TRUE(persisted.is_open());
         const std::string contents((std::istreambuf_iterator<char>(persisted)), {});
-        EXPECT_NE(contents.find("\"version\": 22"), std::string::npos);
+        EXPECT_NE(contents.find("\"version\": 23"), std::string::npos); // PROFILE_VERSION
         EXPECT_NE(contents.find("Toggle MCP Server"), std::string::npos);
         EXPECT_NE(contents.find("Toggle MCP Local/Network Binding"), std::string::npos);
 


### PR DESCRIPTION
Typing in one of the transform tool's number fields and pressing Delete removed the whole selected model (#1695). The text field had keyboard focus visually, but the shortcut system never learned about it, so the Delete-node shortcut fired anyway.

The transform overlay (and the right panel, which had the same gap) now report text focus through the same mechanism the rest of the UI already uses. On top of the spot fix, the shortcut rules are inverted to be safe by default: every shortcut now yields to a focused text field unless it is explicitly marked global - so this class of bug cannot come back with the next new shortcut.

Delete in the viewport still deletes the selected node; arrows, backspace, and copy/paste chords inside text fields are unchanged.

**Verified:** new focus regression tests (72 input tests green; also repairs a stale profile-version assertion that made one existing test fail on master), plus the reporter's exact steps live: clicked into the X field, typed, arrow-left, Delete - the model survived and only the digit was deleted; clicking the viewport and pressing Delete still removed the node.

Fixes #1695