### PR TITLE
Clean up save temporaries left by a crash toward a new file

### DIFF
--- a/src/io/include/io/project_recovery.hpp
+++ b/src/io/include/io/project_recovery.hpp
@@ -139,9 +139,13 @@ namespace lfs::io::project {
     // Best-effort removal of crash leftovers for one published master:
     // `.{master-filename}.saveas-*` staging files and this master's
     // compact/project-write/replace-backup temps, plus their `.lock`
-    // siblings. Skips anything still held. Never deletes the master
-    // file. `{master}.lock` is reclaimed only when
-    // `reclaim_master_lock` is true and the probe acquire succeeds.
+    // siblings. In the same directory, also considers those families
+    // when they name a master that is absent there (crashed Save As
+    // toward a never-created destination). Candidates whose master
+    // exists but is not this master are left to that master's sweep.
+    // Skips anything still held. Never deletes the master file.
+    // `{master}.lock` is reclaimed only when `reclaim_master_lock`
+    // is true and the probe acquire succeeds.
     LFS_IO_API void sweep_stale_licht_artifacts(
         const std::filesystem::path& master_path,
         bool reclaim_master_lock = false);

--- a/src/io/project/project_recovery.cpp
+++ b/src/io/project/project_recovery.cpp
@@ -367,6 +367,95 @@ namespace lfs::io::project {
                        suffix);
         }
 
+        [[nodiscard]] std::optional<std::string>
+        referenced_saveas_master_name(
+            const std::string_view filename) {
+            if (!filename.starts_with('.')) {
+                return std::nullopt;
+            }
+            constexpr std::string_view marker =
+                ".saveas-";
+            const auto marker_at =
+                filename.rfind(marker);
+            if (marker_at == std::string_view::npos ||
+                marker_at < 2) {
+                return std::nullopt;
+            }
+            return std::string(
+                filename.substr(1, marker_at - 1));
+        }
+
+        [[nodiscard]] std::optional<std::string>
+        referenced_write_temp_master_name(
+            const std::string_view filename) {
+            constexpr std::string_view tags[] = {
+                ".project-write.",
+                ".compact.",
+                ".replace-backup.",
+            };
+            auto tag_at = std::string_view::npos;
+            std::size_t tag_size = 0;
+            for (const auto tag : tags) {
+                const auto found = filename.find(tag);
+                if (found != std::string_view::npos &&
+                    found > 0 &&
+                    found < tag_at) {
+                    tag_at = found;
+                    tag_size = tag.size();
+                }
+            }
+            if (tag_at == std::string_view::npos) {
+                return std::nullopt;
+            }
+            const auto after =
+                filename.substr(tag_at + tag_size);
+            constexpr std::string_view tmp_marker =
+                ".tmp";
+            const auto tmp_at =
+                after.rfind(tmp_marker);
+            if (tmp_at == std::string_view::npos) {
+                return std::nullopt;
+            }
+            const auto extension = after.substr(
+                tmp_at + tmp_marker.size());
+            if (extension.empty() ||
+                !extension.starts_with('.')) {
+                return std::nullopt;
+            }
+            const auto stem =
+                filename.substr(0, tag_at);
+            const auto suffix =
+                std::string(tmp_marker) +
+                std::string(extension);
+            if (!is_write_temp_name(
+                    filename, stem, suffix)) {
+                return std::nullopt;
+            }
+            return std::string(stem) +
+                   std::string(extension);
+        }
+
+        [[nodiscard]] bool master_file_is_absent(
+            const std::filesystem::path& directory,
+            const std::string_view master_name) {
+            if (master_name.empty() ||
+                master_name == "." ||
+                master_name == ".." ||
+                master_name.find('/') !=
+                    std::string_view::npos ||
+                master_name.find('\\') !=
+                    std::string_view::npos) {
+                return false;
+            }
+            std::error_code error;
+            const bool present =
+                std::filesystem::exists(
+                    directory /
+                        std::string(master_name),
+                    error);
+            return !error && !present;
+        }
+
         [[nodiscard]] bool is_master_corrupt_aside(
             const std::string_view filename,
             const std::filesystem::path& master_path) {
@@ -830,6 +919,10 @@ namespace lfs::io::project {
 
         std::vector<std::filesystem::path> saveas_data;
         std::vector<std::filesystem::path> write_temp_data;
+        std::map<
+            std::string,
+            std::vector<std::filesystem::path>>
+            unreferenced_write_temps;
         std::error_code error;
         for (std::filesystem::directory_iterator
                  iterator(directory, error),
@@ -859,6 +952,27 @@ namespace lfs::io::project {
             if (is_write_temp_name(
                     data_name, stem, suffix)) {
                 write_temp_data.push_back(data);
+                continue;
+            }
+            if (const auto referenced =
+                    referenced_saveas_master_name(
+                        data_name);
+                referenced &&
+                *referenced != master_name &&
+                master_file_is_absent(
+                    directory, *referenced)) {
+                saveas_data.push_back(data);
+                continue;
+            }
+            if (const auto referenced =
+                    referenced_write_temp_master_name(
+                        data_name);
+                referenced &&
+                *referenced != master_name &&
+                master_file_is_absent(
+                    directory, *referenced)) {
+                unreferenced_write_temps[*referenced]
+                    .push_back(data);
             }
         }
         const auto unique_sorted =
@@ -872,9 +986,26 @@ namespace lfs::io::project {
             };
         unique_sorted(saveas_data);
         unique_sorted(write_temp_data);
+        for (auto& [_, temps] :
+             unreferenced_write_temps) {
+            unique_sorted(temps);
+        }
 
         for (const auto& data : saveas_data) {
             try_remove_unheld_artifact(data, true);
+        }
+        for (const auto& [referenced_name, temps] :
+             unreferenced_write_temps) {
+            auto acquired =
+                detail::WriterLock::acquire(
+                    directory / referenced_name);
+            if (!acquired) {
+                continue;
+            }
+            for (const auto& data : temps) {
+                try_remove_unheld_artifact(
+                    data, true);
+            }
         }
 
         std::error_code lock_exists_error;

--- a/tests/test_project_container.cpp
+++ b/tests/test_project_container.cpp
@@ -3221,6 +3221,36 @@ namespace {
         write_file_bytes(saveas, byte_vector("stale saveas staging"));
         write_file_bytes(saveas_lock, byte_vector("stale saveas lock"));
 
+        const fs::path other_master =
+            temporary.path / "other.licht";
+        write_file_bytes(other_master, byte_vector("foreign master"));
+        const fs::path foreign =
+            temporary.path / ".other.licht.saveas-bbbb.tmp";
+        write_file_bytes(foreign, byte_vector("foreign saveas staging"));
+        const fs::path foreign_compact =
+            temporary.path / "other.compact.1.2.3.tmp.licht";
+        write_file_bytes(foreign_compact, byte_vector("foreign compact"));
+
+        const fs::path ghost =
+            temporary.path / ".ghost.licht.saveas-xxxx.tmp";
+        auto ghost_lock = ghost;
+        ghost_lock += ".lock";
+        write_file_bytes(ghost, byte_vector("unreferenced saveas staging"));
+        write_file_bytes(ghost_lock, byte_vector("unreferenced saveas lock"));
+        const fs::path ghost_compact =
+            temporary.path / "ghost.compact.1.2.3.tmp.licht";
+        write_file_bytes(ghost_compact, byte_vector("unreferenced compact"));
+
+        const fs::path held_ghost =
+            temporary.path / ".ghost.licht.saveas-held.tmp";
+        auto held_ghost_lock = held_ghost;
+        held_ghost_lock += ".lock";
+        write_file_bytes(held_ghost, byte_vector("held ghost staging"));
+        write_file_bytes(held_ghost_lock, byte_vector("held ghost lock"));
+        auto held_ghost_lease = WriterLockLease::acquire(held_ghost);
+        ASSERT_TRUE(held_ghost_lease)
+            << lfs::format_for_developer(held_ghost_lease.error());
+
         const fs::path held_master =
             temporary.path / "startup-held.licht";
         create_single_chunk_fixture(
@@ -3240,6 +3270,14 @@ namespace {
         EXPECT_FALSE(fs::exists(master_lock));
         EXPECT_FALSE(fs::exists(saveas));
         EXPECT_FALSE(fs::exists(saveas_lock));
+        EXPECT_FALSE(fs::exists(ghost));
+        EXPECT_FALSE(fs::exists(ghost_lock));
+        EXPECT_FALSE(fs::exists(ghost_compact));
+        EXPECT_TRUE(fs::exists(other_master));
+        EXPECT_TRUE(fs::exists(foreign));
+        EXPECT_TRUE(fs::exists(foreign_compact));
+        EXPECT_TRUE(fs::exists(held_ghost));
+        EXPECT_TRUE(fs::exists(held_ghost_lock));
         EXPECT_TRUE(fs::exists(held_lock));
         EXPECT_FALSE(fs::exists(missing));
     }

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -3374,11 +3374,35 @@ namespace {
         const std::array<std::byte, 1> compact_bytes{std::byte{'c'}};
         write_file_bytes(compact, compact_bytes);
 
+        const fs::path other_master =
+            temporary.path / "other.licht";
+        const std::array<std::byte, 1> other_master_bytes{std::byte{'m'}};
+        write_file_bytes(other_master, other_master_bytes);
         const fs::path foreign =
             temporary.path /
             ".other.licht.saveas-bbbb.tmp";
         const std::array<std::byte, 1> foreign_bytes{std::byte{'f'}};
         write_file_bytes(foreign, foreign_bytes);
+        const fs::path foreign_compact =
+            temporary.path /
+            "other.compact.1.2.3.tmp.licht";
+        const std::array<std::byte, 1> foreign_compact_bytes{std::byte{'n'}};
+        write_file_bytes(foreign_compact, foreign_compact_bytes);
+
+        const fs::path ghost =
+            temporary.path /
+            ".ghost.licht.saveas-xxxx.tmp";
+        auto ghost_lock = ghost;
+        ghost_lock += ".lock";
+        const std::array<std::byte, 1> ghost_bytes{std::byte{'g'}};
+        const std::array<std::byte, 1> ghost_lock_bytes{std::byte{'q'}};
+        write_file_bytes(ghost, ghost_bytes);
+        write_file_bytes(ghost_lock, ghost_lock_bytes);
+        const fs::path ghost_compact =
+            temporary.path /
+            "ghost.compact.1.2.3.tmp.licht";
+        const std::array<std::byte, 1> ghost_compact_bytes{std::byte{'w'}};
+        write_file_bytes(ghost_compact, ghost_compact_bytes);
 
         const fs::path held =
             temporary.path /
@@ -3393,6 +3417,19 @@ namespace {
         ASSERT_TRUE(held_lease)
             << lfs::format_for_developer(held_lease.error());
 
+        const fs::path held_ghost =
+            temporary.path /
+            ".ghost.licht.saveas-held.tmp";
+        auto held_ghost_lock = held_ghost;
+        held_ghost_lock += ".lock";
+        const std::array<std::byte, 1> held_ghost_bytes{std::byte{'j'}};
+        const std::array<std::byte, 1> held_ghost_lock_bytes{std::byte{'p'}};
+        write_file_bytes(held_ghost, held_ghost_bytes);
+        write_file_bytes(held_ghost_lock, held_ghost_lock_bytes);
+        auto held_ghost_lease = WriterLockLease::acquire(held_ghost);
+        ASSERT_TRUE(held_ghost_lease)
+            << lfs::format_for_developer(held_ghost_lease.error());
+
         auto opened =
             require_result_ptr(ProjectDocument::open(master));
         ASSERT_TRUE(opened->source_path());
@@ -3400,9 +3437,16 @@ namespace {
         EXPECT_FALSE(fs::exists(owned));
         EXPECT_FALSE(fs::exists(owned_lock));
         EXPECT_FALSE(fs::exists(compact));
+        EXPECT_FALSE(fs::exists(ghost));
+        EXPECT_FALSE(fs::exists(ghost_lock));
+        EXPECT_FALSE(fs::exists(ghost_compact));
+        EXPECT_TRUE(fs::exists(other_master));
         EXPECT_TRUE(fs::exists(foreign));
+        EXPECT_TRUE(fs::exists(foreign_compact));
         EXPECT_TRUE(fs::exists(held));
         EXPECT_TRUE(fs::exists(held_lock));
+        EXPECT_TRUE(fs::exists(held_ghost));
+        EXPECT_TRUE(fs::exists(held_ghost_lock));
         auto master_lock = master;
         master_lock += ".lock";
         EXPECT_FALSE(fs::exists(master_lock));


### PR DESCRIPTION
Follow-up to #1708. One case was still uncovered: if the app dies in the middle of Save As toward a brand-new file, the big staging temp and its lock sit in a folder where the destination never came to exist - and since the cleanup sweeps are keyed on existing project files, nothing ever reclaimed them.

Sweeps now also remove staging and writer temporaries whose destination file does not exist in the swept folder. Same safety rules as #1708: exact name patterns only, a lock probe skips anything a running process still holds, and temporaries belonging to an existing neighboring project stay untouched.

**Verified:** new tests for the ghost-destination case (swept), an existing neighbor's temp (kept), and a held file (kept) - 81 tests green in the affected suites. Live: planted a 15MB staging temp plus lock for a never-created destination next to a real project, opened the project, and both were removed and logged.