### PR TITLE
Ask to stop training when switching projects

### DIFF
--- a/src/core/include/core/events.hpp
+++ b/src/core/include/core/events.hpp
@@ -65,12 +65,13 @@ namespace lfs::core {
             EVENT(ShowDatasetLoadPopup, std::filesystem::path dataset_path;);
             EVENT(ShowVideoExtractor, std::filesystem::path video_path;);
             EVENT(ShowResumeCheckpointPopup, std::filesystem::path checkpoint_path;);
-            EVENT(NewProject, bool discard_changes = false;);
+            EVENT(NewProject, bool discard_changes = false; bool stop_training = false;);
             EVENT(ProjectSave, );
             EVENT(ProjectSaveAs, std::filesystem::path path;);
-            EVENT(ProjectOpen, std::filesystem::path path; bool discard_changes = false;);
+            EVENT(ProjectOpen, std::filesystem::path path; bool discard_changes = false; bool stop_training = false;);
             EVENT(ProjectCompact, );
             EVENT(ShowProjectSwitchConfirmation, bool new_project = false; std::filesystem::path path;);
+            EVENT(ShowStopTrainingConfirmation, bool new_project = false; std::filesystem::path path; bool discard_changes = false;);
             EVENT(SetReopenLastProject, bool enabled;);
             EVENT(SetAutoSaveOnClose, bool enabled;);
             EVENT(SetProjectAutosaveInterval, std::uint64_t seconds;);

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -261,7 +261,7 @@ namespace {
         if (auto posted = lfs::vis::post_guarded_and_wait<void>(
                 viewer, context,
                 [emit = std::forward<EmitFn>(emit_fn)]() mutable
-                -> lfs::Result<void> {
+                    -> lfs::Result<void> {
                     emit();
                     return {};
                 },
@@ -917,18 +917,29 @@ NB_MODULE(lichtfeld, m) {
         },
         "Reset training state to initial");
     m.def(
-        "new_project", [](const bool discard_changes) {
+        "is_training_active",
+        []() {
+            const auto* trainer_manager =
+                lfs::python::get_trainer_manager();
+            return trainer_manager &&
+                   trainer_manager->isTrainingActive();
+        },
+        "Whether training is running or paused");
+    m.def(
+        "new_project", [](const bool discard_changes, const bool stop_training) {
             nb::gil_scoped_release release;
             emit_project_cmd_marshaled(
                 "python.new_project",
-                [discard_changes] {
+                [discard_changes, stop_training] {
                     lfs::core::events::cmd::NewProject{
                         .discard_changes =
-                            discard_changes}
+                            discard_changes,
+                        .stop_training =
+                            stop_training}
                         .emit();
                 });
         },
-        nb::arg("discard_changes") = false, "Clear all project state and start a new project");
+        nb::arg("discard_changes") = false, nb::arg("stop_training") = false, "Clear all project state and start a new project");
     m.def(
         "project_save", []() {
             nb::gil_scoped_release release;
@@ -996,19 +1007,25 @@ NB_MODULE(lichtfeld, m) {
     m.def(
         "project_open",
         [](const std::string& path,
-           const bool discard_changes) {
+           const bool discard_changes,
+           const bool stop_training) {
             const auto project_path =
                 python_utf8_path(path);
-            if (project_path.empty()) {
+            if (project_path.empty() || stop_training) {
                 nb::gil_scoped_release release;
                 emit_project_cmd_marshaled(
-                    "python.project_open_dialog",
-                    [discard_changes] {
+                    project_path.empty()
+                        ? "python.project_open_dialog"
+                        : "python.project_open",
+                    [project_path, discard_changes,
+                     stop_training] {
                         lfs::core::events::cmd::
                             ProjectOpen{
-                                .path = {},
+                                .path = project_path,
                                 .discard_changes =
-                                    discard_changes}
+                                    discard_changes,
+                                .stop_training =
+                                    stop_training}
                                 .emit();
                     });
                 return lfs::vis::
@@ -1037,6 +1054,7 @@ NB_MODULE(lichtfeld, m) {
         },
         nb::arg("path") = "",
         nb::arg("discard_changes") = false,
+        nb::arg("stop_training") = false,
         "Open a .licht project");
     m.def(
         "project_compact", []() {

--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -255,6 +255,8 @@ namespace lfs::python {
         lfs::event::HandlerId g_request_exit_handler_id = 0;
         nb::object
             g_project_switch_confirmation_callback;
+        nb::object
+            g_stop_training_confirmation_callback;
         nb::object g_open_camera_preview_callback;
         nb::object g_save_asset_callback;
 
@@ -3696,6 +3698,39 @@ namespace lfs::python {
             "Register callback for a dirty project-switch decision");
 
         m.def(
+            "on_stop_training_confirmation",
+            [](nb::object callback) {
+                g_stop_training_confirmation_callback =
+                    callback;
+                lfs::core::events::cmd::
+                    ShowStopTrainingConfirmation::
+                        when([](const auto& event) {
+                            if (g_stop_training_confirmation_callback &&
+                                !g_stop_training_confirmation_callback
+                                     .is_none()) {
+                                nb::gil_scoped_acquire
+                                    guard;
+                                try {
+                                    g_stop_training_confirmation_callback(
+                                        event.new_project,
+                                        lfs::core::
+                                            path_to_utf8(
+                                                event.path),
+                                        event.discard_changes);
+                                } catch (
+                                    const std::
+                                        exception& error) {
+                                    LOG_ERROR(
+                                        "Stop-training confirmation callback error: {}",
+                                        error.what());
+                                }
+                            }
+                        });
+            },
+            nb::arg("callback"),
+            "Register callback for a stop-training project-switch decision");
+
+        m.def(
             "on_open_camera_preview",
             [](nb::object callback) {
                 g_open_camera_preview_callback = callback;
@@ -5158,6 +5193,8 @@ namespace lfs::python {
                 g_request_exit_handler_id = 0;
             }
             g_project_switch_confirmation_callback =
+                nb::object();
+            g_stop_training_confirmation_callback =
                 nb::object();
             g_open_camera_preview_callback = nb::object();
         };

--- a/src/python/lfs_plugins/file_menu.py
+++ b/src/python/lfs_plugins/file_menu.py
@@ -20,6 +20,37 @@ from .import_panels import open_dataset_import_panel, open_resume_checkpoint_pan
 __lfs_menu_classes__ = ["FileMenu"]
 
 
+def _training_is_active() -> bool:
+    probe = getattr(lf, "is_training_active", None)
+    if not callable(probe):
+        return False
+    try:
+        return bool(probe())
+    except Exception:
+        return False
+
+
+def _confirm_stop_training_then(callback) -> None:
+    if not _training_is_active():
+        callback(False)
+        return
+
+    tr = lf.ui.tr
+    yes_label = tr("common.yes")
+    no_label = tr("common.no")
+
+    def _on_result(button):
+        if button == yes_label:
+            callback(True)
+
+    lf.ui.confirm_dialog(
+        tr("project_switch.stop_training_title"),
+        tr("project_switch.stop_training_message"),
+        [yes_label, no_label],
+        _on_result,
+    )
+
+
 def _confirm_discard_then(title: str, callback) -> None:
     if not lf.project_is_dirty():
         callback()
@@ -40,6 +71,13 @@ def _confirm_discard_then(title: str, callback) -> None:
     )
 
 
+def _confirm_switch_then(title: str, callback) -> None:
+    _confirm_discard_then(
+        title,
+        lambda: _confirm_stop_training_then(callback),
+    )
+
+
 def _offer_remove_missing_recent(path: str) -> None:
     tr = lf.ui.tr
     remove_label = tr("menu.file.remove_from_recent")
@@ -56,9 +94,21 @@ def _offer_remove_missing_recent(path: str) -> None:
     )
 
 
-def _open_recent_checked(path: str) -> None:
+def _open_project(path: str, discard_changes: bool, stop_training: bool = False):
+    if stop_training:
+        return lf.project_open(path, discard_changes, True)
+    return lf.project_open(path, discard_changes)
+
+
+def _new_project(discard_changes: bool, stop_training: bool = False):
+    if stop_training:
+        return lf.new_project(discard_changes, True)
+    return lf.new_project(discard_changes)
+
+
+def _open_recent_checked(path: str, stop_training: bool = False) -> None:
     try:
-        lf.project_open(path, True)
+        _open_project(path, True, stop_training)
     except FileNotFoundError:
         # NotFoundError subclasses FileNotFoundError (see startup_recent_panel).
         _offer_remove_missing_recent(path)
@@ -75,9 +125,9 @@ def _open_recent_project(path: str) -> None:
     if not Path(path).is_file():
         _offer_remove_missing_recent(path)
         return
-    _confirm_discard_then(
+    _confirm_switch_then(
         lf.ui.tr("menu.file.open_project"),
-        lambda: _open_recent_checked(path),
+        lambda stop_training: _open_recent_checked(path, stop_training),
     )
 
 
@@ -103,9 +153,9 @@ class NewProjectOperator(Operator):
     description = "Clear the scene to start a new project"
 
     def execute(self, context) -> set:
-        _confirm_discard_then(
+        _confirm_switch_then(
             lf.ui.tr("menu.file.new_project"),
-            lambda: lf.new_project(True),
+            lambda stop_training: _new_project(True, stop_training),
         )
         return {"FINISHED"}
 
@@ -115,9 +165,9 @@ class OpenProjectOperator(Operator):
     description = "Open a LichtFeld project"
 
     def execute(self, context) -> set:
-        _confirm_discard_then(
+        _confirm_switch_then(
             lf.ui.tr("menu.file.open_project"),
-            lambda: lf.project_open("", True),
+            lambda stop_training: _open_project("", True, stop_training),
         )
         return {"FINISHED"}
 
@@ -317,11 +367,36 @@ def _show_project_switch_confirmation(
 ) -> None:
     if new_project:
         title = lf.ui.tr("menu.file.new_project")
-        callback = lambda: lf.new_project(True)
+        callback = lambda stop_training: _new_project(True, stop_training)
     else:
         title = lf.ui.tr("menu.file.open_project")
-        callback = lambda: lf.project_open(path, True)
-    _confirm_discard_then(title, callback)
+        callback = lambda stop_training: _open_project(
+            path, True, stop_training
+        )
+    _confirm_switch_then(title, callback)
+
+
+def _show_stop_training_confirmation(
+    new_project: bool, path: str, discard_changes: bool = False
+) -> None:
+    tr = lf.ui.tr
+    yes_label = tr("common.yes")
+    no_label = tr("common.no")
+
+    def _on_result(button):
+        if button != yes_label:
+            return
+        if new_project:
+            _new_project(discard_changes, True)
+        else:
+            _open_project(path, discard_changes, True)
+
+    lf.ui.confirm_dialog(
+        tr("project_switch.stop_training_title"),
+        tr("project_switch.stop_training_message"),
+        [yes_label, no_label],
+        _on_result,
+    )
 
 
 def _on_show_dataset_load_popup(path: str):
@@ -445,6 +520,9 @@ def register():
     lf.ui.on_request_exit(_show_exit_confirmation)
     lf.ui.on_project_switch_confirmation(
         _show_project_switch_confirmation
+    )
+    lf.ui.on_stop_training_confirmation(
+        _show_stop_training_confirmation
     )
 
 

--- a/src/python/lfs_plugins/panels.py
+++ b/src/python/lfs_plugins/panels.py
@@ -230,23 +230,16 @@ def register_builtin_panels():
                 step()
             except Exception as e:
                 lf.log.error(
-                    "register_builtin_panels: step '%s' failed: %s\n%s",
-                    name,
-                    e,
-                    traceback.format_exc(),
+                    f"register_builtin_panels: step '{name}' failed: {e}\n{traceback.format_exc()}"
                 )
                 failed.append(name)
         if failed:
             lf.log.error(
-                "register_builtin_panels: %d step(s) failed: %s",
-                len(failed),
-                ", ".join(failed),
+                f"register_builtin_panels: {len(failed)} step(s) failed: {', '.join(failed)}"
             )
         return True
     except Exception as e:
         lf.log.error(
-            "register_builtin_panels failed: %s\n%s",
-            e,
-            traceback.format_exc(),
+            f"register_builtin_panels failed: {e}\n{traceback.format_exc()}"
         )
         return False

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -733,7 +733,9 @@
     "undo": "Rückgängig",
     "redo": "Wiederholen",
     "edit": "Bearbeiten",
-    "double_click_reset": "Doppelklick zum Zurücksetzen"
+    "double_click_reset": "Doppelklick zum Zurücksetzen",
+    "yes": "Ja",
+    "no": "Nein"
   },
   "status": {
     "ready": "Bereit",
@@ -1236,6 +1238,10 @@
     "stop_and_save": "Stoppen & Speichern",
     "discard_and_exit": "Verwerfen & Beenden",
     "exit": "Beenden"
+  },
+  "project_switch": {
+    "stop_training_title": "Training beenden?",
+    "stop_training_message": "Das Training muss beendet werden, bevor das Projekt gewechselt werden kann. Aktuelle Sitzung beenden?"
   },
   "load_dataset_popup": {
     "title": "Datensatz laden",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -733,7 +733,9 @@
     "undo": "Undo",
     "redo": "Redo",
     "edit": "Edit",
-    "double_click_reset": "dbl-click reset"
+    "double_click_reset": "dbl-click reset",
+    "yes": "Yes",
+    "no": "No"
   },
   "status": {
     "ready": "Ready",
@@ -1236,6 +1238,10 @@
     "stop_and_save": "Stop & Save",
     "discard_and_exit": "Discard & Exit",
     "exit": "Exit"
+  },
+  "project_switch": {
+    "stop_training_title": "Stop Training?",
+    "stop_training_message": "Training must be stopped before switching projects. Stop the current session?"
   },
   "load_dataset_popup": {
     "title": "Load Dataset",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -733,7 +733,9 @@
     "undo": "Deshacer",
     "redo": "Rehacer",
     "edit": "Editar",
-    "double_click_reset": "doble clic para restablecer"
+    "double_click_reset": "doble clic para restablecer",
+    "yes": "Sí",
+    "no": "No"
   },
   "status": {
     "ready": "Listo",
@@ -1236,6 +1238,10 @@
     "stop_and_save": "Detener y guardar",
     "discard_and_exit": "Descartar y salir",
     "exit": "Salir"
+  },
+  "project_switch": {
+    "stop_training_title": "¿Detener el entrenamiento?",
+    "stop_training_message": "El entrenamiento debe detenerse antes de cambiar de proyecto. ¿Detener la sesión actual?"
   },
   "load_dataset_popup": {
     "title": "Cargar Dataset",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -734,7 +734,9 @@
     "undo": "Annuler",
     "redo": "Rétablir",
     "edit": "Éditer",
-    "double_click_reset": "double-clic pour réinitialiser"
+    "double_click_reset": "double-clic pour réinitialiser",
+    "yes": "Oui",
+    "no": "Non"
   },
   "status": {
     "ready": "Prêt",
@@ -1237,6 +1239,10 @@
     "stop_and_save": "Arrêter et enregistrer",
     "discard_and_exit": "Ignorer et quitter",
     "exit": "Quitter"
+  },
+  "project_switch": {
+    "stop_training_title": "Arrêter l'entraînement ?",
+    "stop_training_message": "L'entraînement doit être arrêté avant de changer de projet. Arrêter la session en cours ?"
   },
   "load_dataset_popup": {
     "title": "Charger Dataset",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -733,7 +733,9 @@
     "undo": "Annulla",
     "redo": "Ripeti",
     "edit": "Modifica",
-    "double_click_reset": "doppio clic per resettare"
+    "double_click_reset": "doppio clic per resettare",
+    "yes": "Sì",
+    "no": "No"
   },
   "status": {
     "ready": "Pronto",
@@ -1236,6 +1238,10 @@
     "stop_and_save": "Interrompi e salva",
     "discard_and_exit": "Scarta ed esci",
     "exit": "Esci"
+  },
+  "project_switch": {
+    "stop_training_title": "Interrompere l'addestramento?",
+    "stop_training_message": "L'addestramento deve essere interrotto prima di cambiare progetto. Interrompere la sessione corrente?"
   },
   "load_dataset_popup": {
     "title": "Carica Dataset",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -733,7 +733,9 @@
     "undo": "元に戻す",
     "redo": "やり直す",
     "edit": "編集",
-    "double_click_reset": "ダブルクリックでリセット"
+    "double_click_reset": "ダブルクリックでリセット",
+    "yes": "はい",
+    "no": "いいえ"
   },
   "status": {
     "ready": "準備完了",
@@ -1236,6 +1238,10 @@
     "stop_and_save": "停止して保存",
     "discard_and_exit": "破棄して終了",
     "exit": "終了"
+  },
+  "project_switch": {
+    "stop_training_title": "トレーニングを停止しますか？",
+    "stop_training_message": "プロジェクトを切り替える前にトレーニングを停止する必要があります。現在のセッションを停止しますか？"
   },
   "load_dataset_popup": {
     "title": "データセットを読み込む",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -733,7 +733,9 @@
     "undo": "실행 취소",
     "redo": "다시 실행",
     "edit": "편집",
-    "double_click_reset": "더블클릭하여 재설정"
+    "double_click_reset": "더블클릭하여 재설정",
+    "yes": "예",
+    "no": "아니요"
   },
   "status": {
     "ready": "준비됨",
@@ -1236,6 +1238,10 @@
     "stop_and_save": "중지 및 저장",
     "discard_and_exit": "폐기 후 종료",
     "exit": "종료"
+  },
+  "project_switch": {
+    "stop_training_title": "훈련을 중단할까요?",
+    "stop_training_message": "프로젝트를 전환하려면 훈련을 먼저 중단해야 합니다. 현재 세션을 중단할까요?"
   },
   "load_dataset_popup": {
     "title": "데이터셋 불러오기",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -733,7 +733,9 @@
     "undo": "Ongedaan maken",
     "redo": "Opnieuw uitvoeren",
     "edit": "Bewerken",
-    "double_click_reset": "dubbelklik om te resetten"
+    "double_click_reset": "dubbelklik om te resetten",
+    "yes": "Ja",
+    "no": "Nee"
   },
   "status": {
     "ready": "Gereed",
@@ -1236,6 +1238,10 @@
     "stop_and_save": "Stoppen en opslaan",
     "discard_and_exit": "Verwerpen en afsluiten",
     "exit": "Afsluiten"
+  },
+  "project_switch": {
+    "stop_training_title": "Training stoppen?",
+    "stop_training_message": "De training moet worden gestopt voordat u van project wisselt. Huidige sessie stoppen?"
   },
   "load_dataset_popup": {
     "title": "Dataset Laden",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -733,7 +733,9 @@
     "undo": "Cofnij",
     "redo": "Ponów",
     "edit": "Edytuj",
-    "double_click_reset": "podwójne kliknięcie resetuje"
+    "double_click_reset": "podwójne kliknięcie resetuje",
+    "yes": "Tak",
+    "no": "Nie"
   },
   "status": {
     "ready": "Gotowy",
@@ -1236,6 +1238,10 @@
     "stop_and_save": "Zatrzymaj i zapisz",
     "discard_and_exit": "Odrzuć i wyjdź",
     "exit": "Zakończ"
+  },
+  "project_switch": {
+    "stop_training_title": "Zatrzymać trening?",
+    "stop_training_message": "Trening trzeba zatrzymać przed zmianą projektu. Zatrzymać bieżącą sesję?"
   },
   "load_dataset_popup": {
     "title": "Wczytaj Zbiór Danych",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -733,7 +733,9 @@
     "undo": "撤销",
     "redo": "重做",
     "edit": "编辑",
-    "double_click_reset": "双击重置"
+    "double_click_reset": "双击重置",
+    "yes": "是",
+    "no": "否"
   },
   "status": {
     "ready": "就绪",
@@ -1236,6 +1238,10 @@
     "stop_and_save": "停止并保存",
     "discard_and_exit": "丢弃并退出",
     "exit": "退出"
+  },
+  "project_switch": {
+    "stop_training_title": "停止训练？",
+    "stop_training_message": "切换项目前必须停止训练。是否停止当前会话？"
   },
   "load_dataset_popup": {
     "title": "加载数据集",

--- a/src/visualizer/gui/string_keys.hpp
+++ b/src/visualizer/gui/string_keys.hpp
@@ -287,6 +287,8 @@ namespace lichtfeld::Strings {
 
     namespace Common {
         inline constexpr const char* OK = "common.ok";
+        inline constexpr const char* YES = "common.yes";
+        inline constexpr const char* NO = "common.no";
         inline constexpr const char* CANCEL = "common.cancel";
         inline constexpr const char* CLOSE = "common.close";
         inline constexpr const char* SAVE = "common.save";

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -1539,7 +1539,8 @@ namespace lfs::vis::project {
 
     lfs::Result<void>
     ProjectLifecycle::preflightSwitch(
-        const ProjectSwitchDisposition disposition) {
+        const ProjectSwitchDisposition disposition,
+        const bool allow_active_training) {
         if (close_save_state_.load(
                 std::memory_order_acquire) ==
             CloseSaveState::Saving) {
@@ -1559,14 +1560,21 @@ namespace lfs::vis::project {
         }
         if (const auto* trainer =
                 viewer_.getTrainerManager();
-            trainer &&
-            (trainer->isTrainingActive() ||
-             trainer->isCompletionPending())) {
-            return fail<void>(
-                lfs::ErrorCode::FailedPrecondition,
-                "Stop training before switching projects.",
-                "Project switching is blocked while training is active",
-                "project.training");
+            trainer) {
+            const bool publish_in_flight =
+                trainer->isCompletionPending() &&
+                !trainer->isTrainingActive();
+            const bool training_active =
+                trainer->isTrainingActive();
+            if (publish_in_flight ||
+                (training_active &&
+                 !allow_active_training)) {
+                return fail<void>(
+                    lfs::ErrorCode::FailedPrecondition,
+                    "Stop training before switching projects.",
+                    "Project switching is blocked while training is active",
+                    "project.training");
+            }
         }
         if (disposition ==
                 ProjectSwitchDisposition::RequireClean &&

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -161,7 +161,8 @@ namespace lfs::vis::project {
         [[nodiscard]] ProjectMenuInfo menuInfo() const;
         [[nodiscard]] lfs::Result<void>
         preflightSwitch(
-            ProjectSwitchDisposition disposition);
+            ProjectSwitchDisposition disposition,
+            bool allow_active_training = false);
 
         void openStartupProject(
             const std::optional<std::filesystem::path>& explicit_path);

--- a/src/visualizer/training/training_manager.hpp
+++ b/src/visualizer/training/training_manager.hpp
@@ -33,6 +33,7 @@ namespace lfs::vis {
     // Forward declarations
     class VisualizerImpl;
     class VisualizerImplResetTest_ForceExitWhileStoppingArmsWatcher_Test;
+    class VisualizerImplResetTest_NewProjectWhileCompletionPendingStillErrors_Test;
     class VisualizerImplResetTest_SaveWhilePausedTrainingRoutesThroughLiveTrainer_Test;
     class VisualizerImplResetTest_SaveWhileStoppingStillBlocksUntilSnapshotPublished_Test;
     class VisualizerImplResetTest_SaveAsWhilePausedTrainingRoutesThroughLiveTrainer_Test;
@@ -210,6 +211,7 @@ namespace lfs::vis {
         };
 
         friend class VisualizerImplResetTest_ForceExitWhileStoppingArmsWatcher_Test;
+        friend class VisualizerImplResetTest_NewProjectWhileCompletionPendingStillErrors_Test;
         friend class VisualizerImplResetTest_SaveWhilePausedTrainingRoutesThroughLiveTrainer_Test;
         friend class VisualizerImplResetTest_SaveWhileStoppingStillBlocksUntilSnapshotPublished_Test;
         friend class VisualizerImplResetTest_SaveAsWhilePausedTrainingRoutesThroughLiveTrainer_Test;

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -140,6 +140,16 @@ namespace lfs::vis {
                        "The current project has unsaved changes.";
         }
 
+        [[nodiscard]] bool
+        isTrainingProjectSwitchError(
+            const lfs::Error& error) noexcept {
+            return error.code() ==
+                       lfs::ErrorCode::
+                           FailedPrecondition &&
+                   error.user_message() ==
+                       "Stop training before switching projects.";
+        }
+
         void wakeEventLoopViaServices() {
             if (auto* const window_manager = services().windowOrNull()) {
                 window_manager->wakeEventLoop();
@@ -1282,7 +1292,8 @@ namespace lfs::vis {
                     ? ProjectSwitchDisposition::
                           DiscardChanges
                     : ProjectSwitchDisposition::
-                          RequireClean);
+                          RequireClean,
+                command.stop_training);
         });
 
         const auto publish_project_error =
@@ -1410,8 +1421,7 @@ namespace lfs::vis {
             });
 
         cmd::ProjectOpen::when(
-            [this, publish_project_error](
-                const auto& command) {
+            [this](const auto& command) {
                 auto path = command.path;
                 if (path.empty()) {
                     path =
@@ -1420,29 +1430,14 @@ namespace lfs::vis {
                 if (path.empty()) {
                     return;
                 }
-                if (auto opened = projectOpen(
-                        path,
-                        command.discard_changes
-                            ? ProjectSwitchDisposition::
-                                  DiscardChanges
-                            : ProjectSwitchDisposition::
-                                  RequireClean);
-                    !opened) {
-                    if (isDirtyProjectSwitchError(
-                            opened.error())) {
-                        cmd::
-                            ShowProjectSwitchConfirmation{
-                                .new_project =
-                                    false,
-                                .path = path}
-                                .emit();
-                        return;
-                    }
-                    publish_project_error(
-                        "Open Project",
-                        opened.error(),
-                        gui::error_op::kOpenProject);
-                }
+                handleOpenProject(
+                    path,
+                    command.discard_changes
+                        ? ProjectSwitchDisposition::
+                              DiscardChanges
+                        : ProjectSwitchDisposition::
+                              RequireClean,
+                    command.stop_training);
             });
 
         cmd::ProjectCompact::when(
@@ -2759,8 +2754,26 @@ namespace lfs::vis {
         return std::unexpected("Scene clear request was rejected");
     }
 
+    bool VisualizerImpl::shouldDeferProjectSwitchForTraining() const {
+        return trainer_manager_ &&
+               (trainer_manager_->isTrainingActive() ||
+                !trainer_manager_->canPerform(TrainingAction::ClearScene) ||
+                trainer_manager_->isCompletionPending());
+    }
+
+    void VisualizerImpl::requestStopThenPendingAction() {
+        if (!trainer_manager_) {
+            return;
+        }
+        trainer_manager_->suppressCompletionNotification();
+        if (trainer_manager_->canStop()) {
+            trainer_manager_->stopTraining();
+        }
+    }
+
     void VisualizerImpl::handleNewProject(
-        const ProjectSwitchDisposition disposition) {
+        const ProjectSwitchDisposition disposition,
+        const bool stop_training) {
         if (pending_training_action_ ==
                 PendingTrainingAction::CloseSave ||
             pending_training_action_ ==
@@ -2773,7 +2786,7 @@ namespace lfs::vis {
         if (auto preflight =
                 project_lifecycle_
                     ->preflightSwitch(
-                        disposition);
+                        disposition, stop_training);
             !preflight) {
             if (isDirtyProjectSwitchError(
                     preflight.error())) {
@@ -2781,6 +2794,22 @@ namespace lfs::vis {
                     ShowProjectSwitchConfirmation{
                         .new_project = true,
                         .path = {}}
+                        .emit();
+                return;
+            }
+            if (!stop_training &&
+                isTrainingProjectSwitchError(
+                    preflight.error()) &&
+                trainer_manager_ &&
+                trainer_manager_->isTrainingActive()) {
+                lfs::core::events::cmd::
+                    ShowStopTrainingConfirmation{
+                        .new_project = true,
+                        .path = {},
+                        .discard_changes =
+                            disposition ==
+                            ProjectSwitchDisposition::
+                                DiscardChanges}
                         .emit();
                 return;
             }
@@ -2804,20 +2833,16 @@ namespace lfs::vis {
         pending_view_paths_.clear();
         pending_dataset_path_.clear();
         pending_auto_train_ = false;
+        pending_open_path_.clear();
         if (pending_training_action_ == PendingTrainingAction::Reset) {
             pending_training_action_ = PendingTrainingAction::None;
         }
 
-        if (trainer_manager_ &&
-            (!trainer_manager_->canPerform(TrainingAction::ClearScene) ||
-             trainer_manager_->isCompletionPending())) {
+        if (shouldDeferProjectSwitchForTraining()) {
             pending_training_action_ = PendingTrainingAction::NewProject;
             pending_new_project_disposition_ =
                 disposition;
-            trainer_manager_->suppressCompletionNotification();
-            if (trainer_manager_->canStop()) {
-                trainer_manager_->stopTraining();
-            }
+            requestStopThenPendingAction();
             return;
         }
 
@@ -2848,6 +2873,107 @@ namespace lfs::vis {
         }
     }
 
+    void VisualizerImpl::handleOpenProject(
+        const std::filesystem::path& path,
+        const ProjectSwitchDisposition disposition,
+        const bool stop_training) {
+        if (pending_training_action_ ==
+                PendingTrainingAction::CloseSave ||
+            pending_training_action_ ==
+                PendingTrainingAction::CloseDiscard) {
+            return;
+        }
+        if (!project_lifecycle_) {
+            return;
+        }
+        if (auto preflight =
+                project_lifecycle_
+                    ->preflightSwitch(
+                        disposition, stop_training);
+            !preflight) {
+            if (isDirtyProjectSwitchError(
+                    preflight.error())) {
+                lfs::core::events::cmd::
+                    ShowProjectSwitchConfirmation{
+                        .new_project = false,
+                        .path = path}
+                        .emit();
+                return;
+            }
+            if (!stop_training &&
+                isTrainingProjectSwitchError(
+                    preflight.error()) &&
+                trainer_manager_ &&
+                trainer_manager_->isTrainingActive()) {
+                lfs::core::events::cmd::
+                    ShowStopTrainingConfirmation{
+                        .new_project = false,
+                        .path = path,
+                        .discard_changes =
+                            disposition ==
+                            ProjectSwitchDisposition::
+                                DiscardChanges}
+                        .emit();
+                return;
+            }
+            LOG_ERROR(
+                "Open Project preflight failed: {}",
+                lfs::format_for_developer(
+                    preflight.error()));
+            lfs::Error contextual = preflight.error();
+            lfs::ErrorBus::instance().publish(lfs::ErrorNotification{
+                .error = std::move(contextual).with_context(gui::error_op::kOpenProject, LFS_SOURCE_SITE_CURRENT()),
+                .surface = lfs::ErrorSurface::Toast,
+                .actions = {},
+                .operation_id = lfs::OperationId::generate(),
+            });
+            return;
+        }
+        if (gui_manager_) {
+            gui_manager_->asyncTasks().cancelImport();
+        }
+
+        if (shouldDeferProjectSwitchForTraining()) {
+            pending_training_action_ =
+                PendingTrainingAction::OpenProject;
+            pending_open_path_ = path;
+            pending_open_disposition_ = disposition;
+            requestStopThenPendingAction();
+            return;
+        }
+
+        pending_training_action_ = PendingTrainingAction::None;
+        performOpenProject(path, disposition);
+    }
+
+    void VisualizerImpl::performOpenProject(
+        const std::filesystem::path& path,
+        const ProjectSwitchDisposition disposition) {
+        if (auto opened = projectOpen(path, disposition);
+            !opened) {
+            if (isDirtyProjectSwitchError(
+                    opened.error())) {
+                lfs::core::events::cmd::
+                    ShowProjectSwitchConfirmation{
+                        .new_project = false,
+                        .path = path}
+                        .emit();
+                return;
+            }
+            LOG_ERROR(
+                "Open Project failed: {}",
+                lfs::format_for_developer(
+                    opened.error()));
+            lfs::Error contextual = opened.error();
+            lfs::ErrorBus::instance().publish(lfs::ErrorNotification{
+                .error = std::move(contextual).with_context(gui::error_op::kOpenProject, LFS_SOURCE_SITE_CURRENT()),
+                .surface = lfs::ErrorSurface::Toast,
+                .actions = {},
+                .operation_id = lfs::OperationId::generate(),
+            });
+        }
+    }
+
     void VisualizerImpl::resetProjectState(const bool reset_panel_registry) {
         if (trainer_manager_) {
             trainer_manager_->clearRestoredProjectMetrics();
@@ -2866,6 +2992,9 @@ namespace lfs::vis {
         pending_training_action_ = PendingTrainingAction::None;
         pending_training_action_posted_ = false;
         pending_new_project_disposition_ =
+            ProjectSwitchDisposition::RequireClean;
+        pending_open_path_.clear();
+        pending_open_disposition_ =
             ProjectSwitchDisposition::RequireClean;
         gui_session_restore_.clear();
         pending_project_tools_restore_.reset();
@@ -3478,6 +3607,21 @@ namespace lfs::vis {
                 ProjectSwitchDisposition::
                     RequireClean;
             break;
+        case PendingTrainingAction::OpenProject: {
+            const auto path =
+                std::exchange(
+                    pending_open_path_, {});
+            const auto disposition =
+                std::exchange(
+                    pending_open_disposition_,
+                    ProjectSwitchDisposition::
+                        RequireClean);
+            if (!path.empty()) {
+                performOpenProject(
+                    path, disposition);
+            }
+            break;
+        }
         case PendingTrainingAction::CloseSave: {
             if (pending_close_save_path_) {
                 const auto path =

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -233,6 +233,12 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_ResetTrainingPreservesExplicitInitPath_Test;
         friend class VisualizerImplResetTest_DirtyProjectSwitchRequiresExplicitDiscardAuthorization_Test;
         friend class VisualizerImplResetTest_NewProjectDirtyGateRunsBelowEveryCommandEntry_Test;
+        friend class VisualizerImplResetTest_NewProjectWhileTrainingPromptsInsteadOfErroring_Test;
+        friend class VisualizerImplResetTest_NewProjectStopTrainingThenSwitchWritesNoProject_Test;
+        friend class VisualizerImplResetTest_OpenProjectWhileTrainingPromptsInsteadOfErroring_Test;
+        friend class VisualizerImplResetTest_OpenProjectStopTrainingThenSwitchWritesNoProject_Test;
+        friend class VisualizerImplResetTest_NewProjectWhileCompletionPendingStillErrors_Test;
+        friend class VisualizerImplResetTest_ProjectOpenApiWhileTrainingStillErrors_Test;
         friend class VisualizerImplResetTest_FileExitWithDefaultSettingsNeedsPrompt_Test;
         friend class VisualizerImplResetTest_FileExitRoutesThroughCloseSaveWhenAutoSaveOnCloseEnabled_Test;
         friend class VisualizerImplResetTest_CloseSavePendingActionSkipsPreviewRegen_Test;
@@ -365,9 +371,20 @@ namespace lfs::vis {
         void handleTrainingCompleted(const lfs::core::events::state::TrainingCompleted& event);
         void handleLoadConfigFile(const std::filesystem::path& path);
         void handleNewProject(
-            ProjectSwitchDisposition disposition);
+            ProjectSwitchDisposition disposition,
+            bool stop_training = false);
         void performNewProject(
             ProjectSwitchDisposition disposition);
+        void handleOpenProject(
+            const std::filesystem::path& path,
+            ProjectSwitchDisposition disposition,
+            bool stop_training = false);
+        void performOpenProject(
+            const std::filesystem::path& path,
+            ProjectSwitchDisposition disposition);
+        [[nodiscard]] bool
+        shouldDeferProjectSwitchForTraining() const;
+        void requestStopThenPendingAction();
         void schedulePendingTrainingAction();
         void performPendingTrainingAction();
         void requestApplicationClose();
@@ -497,6 +514,7 @@ namespace lfs::vis {
             None,
             Reset,
             NewProject,
+            OpenProject,
             CloseSave,
             CloseDiscard,
         };
@@ -504,6 +522,10 @@ namespace lfs::vis {
         bool pending_training_action_posted_ = false;
         ProjectSwitchDisposition
             pending_new_project_disposition_ =
+                ProjectSwitchDisposition::RequireClean;
+        std::filesystem::path pending_open_path_;
+        ProjectSwitchDisposition
+            pending_open_disposition_ =
                 ProjectSwitchDisposition::RequireClean;
         int pending_training_completion_refresh_frames_ = 0;
         bool gui_frame_rendered_ = false;

--- a/tests/python/test_file_menu_recent.py
+++ b/tests/python/test_file_menu_recent.py
@@ -28,12 +28,19 @@ def _load_file_menu(monkeypatch, recent_paths=()):
         return f"tr:{key}"
 
     opened = []
+    opened_stop_training = []
+    new_projects = []
     removed = []
     confirm_dialogs = []
     message_dialogs = []
+    training_active = False
 
-    def project_open(path, discard=False):
+    def project_open(path, discard=False, stop_training=False):
         opened.append((path, discard))
+        opened_stop_training.append(stop_training)
+
+    def new_project(discard=False, stop_training=False):
+        new_projects.append((discard, stop_training))
 
     def project_remove_recent_file(path):
         removed.append(path)
@@ -56,8 +63,12 @@ def _load_file_menu(monkeypatch, recent_paths=()):
     lf_stub.project_is_dirty = lambda: False
     lf_stub.project_has_path = lambda: False
     lf_stub.project_open = project_open
+    lf_stub.new_project = new_project
+    lf_stub.is_training_active = lambda: training_active
     lf_stub.project_remove_recent_file = project_remove_recent_file
     lf_stub.project_open_calls = opened
+    lf_stub.project_open_stop_training = opened_stop_training
+    lf_stub.new_project_calls = new_projects
     lf_stub.project_remove_recent_file_calls = removed
     lf_stub.confirm_dialogs = confirm_dialogs
     lf_stub.message_dialogs = message_dialogs
@@ -246,4 +257,74 @@ def test_compact_project_enabled_only_with_durable_path(monkeypatch):
     file_menu.lf.project_has_path = raise_missing
     guarded = _compact_project_item(file_menu)
     assert guarded["enabled"] is False
+
+
+def test_new_project_while_training_prompts_instead_of_switching(monkeypatch):
+    file_menu = _load_file_menu(monkeypatch)
+    file_menu.lf.is_training_active = lambda: True
+
+    file_menu.NewProjectOperator().execute(None)
+
+    assert file_menu.lf.new_project_calls == []
+    assert len(file_menu.lf.confirm_dialogs) == 1
+    title, message, buttons, callback = file_menu.lf.confirm_dialogs[0]
+    assert title == "tr:project_switch.stop_training_title"
+    assert message == "tr:project_switch.stop_training_message"
+    assert buttons == ["tr:common.yes", "tr:common.no"]
+
+    callback("tr:common.no")
+    assert file_menu.lf.new_project_calls == []
+
+    callback("tr:common.yes")
+    assert file_menu.lf.new_project_calls == [(True, True)]
+
+
+def test_open_recent_while_training_prompts_instead_of_opening(
+    monkeypatch, tmp_path
+):
+    project = tmp_path / "training.licht"
+    project.write_bytes(b"")
+    path = str(project)
+    file_menu = _load_file_menu(monkeypatch, [path])
+    file_menu.lf.is_training_active = lambda: True
+
+    _recent_item_callback(file_menu)()
+
+    assert file_menu.lf.project_open_calls == []
+    assert file_menu.lf.message_dialogs == []
+    assert len(file_menu.lf.confirm_dialogs) == 1
+    title, _message, buttons, callback = file_menu.lf.confirm_dialogs[0]
+    assert title == "tr:project_switch.stop_training_title"
+    assert buttons == ["tr:common.yes", "tr:common.no"]
+
+    callback("tr:common.no")
+    assert file_menu.lf.project_open_calls == []
+    assert file_menu.lf.project_open_stop_training == []
+
+    callback("tr:common.yes")
+    assert file_menu.lf.project_open_calls == [(path, True)]
+    assert file_menu.lf.project_open_stop_training == [True]
+
+
+def test_stop_training_confirmation_yes_retries_with_stop_flag(monkeypatch):
+    file_menu = _load_file_menu(monkeypatch)
+
+    file_menu._show_stop_training_confirmation(True, "", True)
+    assert len(file_menu.lf.confirm_dialogs) == 1
+    _title, _message, buttons, callback = file_menu.lf.confirm_dialogs[0]
+    assert buttons == ["tr:common.yes", "tr:common.no"]
+
+    callback("tr:common.no")
+    assert file_menu.lf.new_project_calls == []
+
+    callback("tr:common.yes")
+    assert file_menu.lf.new_project_calls == [(True, True)]
+
+    file_menu._show_stop_training_confirmation(
+        False, "/tmp/other.licht", False
+    )
+    _title, _message, _buttons, open_callback = file_menu.lf.confirm_dialogs[1]
+    open_callback("tr:common.yes")
+    assert file_menu.lf.project_open_calls == [("/tmp/other.licht", False)]
+    assert file_menu.lf.project_open_stop_training == [True]
 

--- a/tests/python/test_panels_registration.py
+++ b/tests/python/test_panels_registration.py
@@ -178,6 +178,8 @@ def _install_recording_lf(monkeypatch):
         on_show_dataset_load_popup=lambda cb: None,
         on_show_resume_checkpoint_popup=lambda cb: None,
         on_request_exit=lambda cb: None,
+        on_project_switch_confirmation=lambda cb: None,
+        on_stop_training_confirmation=lambda cb: None,
         set_cancel_operator_callback=lambda cb: None,
         set_save_asset_callback=lambda cb: None,
         ops=SimpleNamespace(cancel_modal=lambda: None),

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -4,6 +4,7 @@
 #include <SDL3/SDL.h>
 
 #include "core/checkpoint_format.hpp"
+#include "core/error_bus.hpp"
 #include "core/event_bridge/event_bridge.hpp"
 #include "core/event_bus.hpp"
 #include "core/events.hpp"
@@ -60,6 +61,23 @@ namespace {
         [[nodiscard]] std::string name()
             const override {
             return "test.noop";
+        }
+    };
+
+    class CapturingErrorConsumer final
+        : public lfs::NativeErrorConsumer {
+    public:
+        std::vector<std::string> user_messages;
+
+        void on_error(
+            const lfs::ErrorNotification& notification,
+            const lfs::ErrorDeliveryInfo&) noexcept override {
+            try {
+                user_messages.emplace_back(
+                    std::string(
+                        notification.error.user_message()));
+            } catch (...) {
+            }
         }
     };
 
@@ -329,6 +347,36 @@ namespace {
             lfs::core::CameraModelType::PINHOLE,
             "camera.png", image_path,
             std::filesystem::path{}, 64, 64, 0);
+    }
+
+    bool arm_running_trainer(lfs::vis::VisualizerImpl& viewer) {
+        auto& scene = viewer.getScene();
+        const auto cameras =
+            scene.addGroup("Train cameras");
+        scene.addCamera(
+            "camera.png", cameras,
+            make_project_request_test_camera());
+        auto* const trainer_manager =
+            viewer.getTrainerManager();
+        if (!trainer_manager) {
+            return false;
+        }
+        trainer_manager->setTrainer(
+            std::make_unique<lfs::training::Trainer>(
+                scene));
+        auto& state_machine =
+            const_cast<lfs::vis::TrainingStateMachine&>(
+                trainer_manager->getStateMachine());
+        if (state_machine.getState() ==
+            lfs::vis::TrainingState::Idle) {
+            if (!state_machine.transitionTo(
+                    lfs::vis::TrainingState::Ready)) {
+                return false;
+            }
+        }
+        return state_machine.transitionTo(
+                   lfs::vis::TrainingState::Running) &&
+               trainer_manager->isTrainingActive();
     }
 
     void write_minimal_transforms_dataset(const std::filesystem::path& dataset_path) {
@@ -2507,6 +2555,388 @@ namespace lfs::vis {
             EXPECT_EQ(
                 viewer.getScene().getNodeCount(),
                 0u);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           NewProjectWhileTrainingPromptsInsteadOfErroring) {
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_TRUE(arm_running_trainer(viewer));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Keep while training"),
+                lfs::core::NULL_NODE);
+
+            CapturingErrorConsumer consumer;
+            auto subscription =
+                lfs::ErrorBus::instance().subscribe(
+                    consumer);
+            bool prompted = false;
+            lfs::core::events::cmd::
+                ShowStopTrainingConfirmation::
+                    when([&](const auto& event) {
+                        prompted = true;
+                        EXPECT_TRUE(event.new_project);
+                        EXPECT_TRUE(
+                            event.discard_changes);
+                    });
+
+            lfs::core::events::cmd::NewProject{
+                .discard_changes = true}
+                .emit();
+
+            EXPECT_TRUE(prompted);
+            EXPECT_TRUE(
+                std::none_of(
+                    consumer.user_messages.begin(),
+                    consumer.user_messages.end(),
+                    [](const std::string& message) {
+                        return message ==
+                               "Stop training before switching projects.";
+                    }));
+            EXPECT_TRUE(
+                viewer.getTrainerManager()
+                    ->isTrainingActive());
+            EXPECT_NE(
+                viewer.getScene().getNode(
+                    "Keep while training"),
+                nullptr);
+            EXPECT_EQ(
+                viewer.pending_training_action_,
+                VisualizerImpl::PendingTrainingAction::
+                    None);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           NewProjectStopTrainingThenSwitchWritesNoProject) {
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "stop-then-new.licht";
+        write_empty_project(project_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_TRUE(viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(arm_running_trainer(viewer));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Cleared after stop"),
+                lfs::core::NULL_NODE);
+            auto* const trainer = viewer.getTrainer();
+            ASSERT_NE(trainer, nullptr);
+            EXPECT_FALSE(
+                trainer->trainer_project_save_policy()
+                    .on_stop_or_error);
+            const auto write_time_before =
+                std::filesystem::last_write_time(
+                    project_path);
+
+            lfs::core::events::cmd::NewProject{
+                .discard_changes = true,
+                .stop_training = true}
+                .emit();
+            EXPECT_EQ(
+                viewer.pending_training_action_,
+                VisualizerImpl::PendingTrainingAction::
+                    NewProject);
+            EXPECT_FALSE(viewer.jobs().anyRunning(
+                JobType::ProjectWrite));
+
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return viewer.getScene().getNode(
+                               "Cleared after stop") ==
+                               nullptr &&
+                           !viewer.getTrainerManager()
+                                ->isTrainingActive() &&
+                           !viewer.getTrainerManager()
+                                ->isCompletionPending();
+                }));
+            EXPECT_FALSE(viewer.jobs().anyRunning(
+                JobType::ProjectWrite));
+            EXPECT_EQ(
+                std::filesystem::last_write_time(
+                    project_path),
+                write_time_before);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           OpenProjectWhileTrainingPromptsInsteadOfErroring) {
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "open-while-training.licht";
+        write_empty_project(project_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_TRUE(arm_running_trainer(viewer));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Keep while training"),
+                lfs::core::NULL_NODE);
+
+            CapturingErrorConsumer consumer;
+            auto subscription =
+                lfs::ErrorBus::instance().subscribe(
+                    consumer);
+            bool prompted = false;
+            std::filesystem::path prompted_path;
+            lfs::core::events::cmd::
+                ShowStopTrainingConfirmation::
+                    when([&](const auto& event) {
+                        prompted = true;
+                        prompted_path = event.path;
+                        EXPECT_FALSE(event.new_project);
+                        EXPECT_TRUE(
+                            event.discard_changes);
+                    });
+
+            lfs::core::events::cmd::ProjectOpen{
+                .path = project_path,
+                .discard_changes = true}
+                .emit();
+
+            EXPECT_TRUE(prompted);
+            EXPECT_EQ(prompted_path, project_path);
+            EXPECT_TRUE(
+                std::none_of(
+                    consumer.user_messages.begin(),
+                    consumer.user_messages.end(),
+                    [](const std::string& message) {
+                        return message ==
+                               "Stop training before switching projects.";
+                    }));
+            EXPECT_TRUE(
+                viewer.getTrainerManager()
+                    ->isTrainingActive());
+            EXPECT_NE(
+                viewer.getScene().getNode(
+                    "Keep while training"),
+                nullptr);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           OpenProjectStopTrainingThenSwitchWritesNoProject) {
+        const auto& temporary = temporary_.path;
+        const auto current_path =
+            temporary / "open-stop-current.licht";
+        const auto target_path =
+            temporary / "open-stop-target.licht";
+        write_empty_project(current_path);
+        write_empty_project(target_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_TRUE(viewer.projectOpen(
+                current_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(arm_running_trainer(viewer));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Cleared after open"),
+                lfs::core::NULL_NODE);
+            auto* const trainer = viewer.getTrainer();
+            ASSERT_NE(trainer, nullptr);
+            EXPECT_FALSE(
+                trainer->trainer_project_save_policy()
+                    .on_stop_or_error);
+            const auto write_time_before =
+                std::filesystem::last_write_time(
+                    current_path);
+
+            lfs::core::events::cmd::ProjectOpen{
+                .path = target_path,
+                .discard_changes = true,
+                .stop_training = true}
+                .emit();
+            EXPECT_EQ(
+                viewer.pending_training_action_,
+                VisualizerImpl::PendingTrainingAction::
+                    OpenProject);
+            EXPECT_FALSE(viewer.jobs().anyRunning(
+                JobType::ProjectWrite));
+
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return viewer.getScene().getNode(
+                               "Cleared after open") ==
+                               nullptr &&
+                           !viewer.getTrainerManager()
+                                ->isTrainingActive() &&
+                           !viewer.getTrainerManager()
+                                ->isCompletionPending();
+                }));
+            EXPECT_FALSE(viewer.jobs().anyRunning(
+                JobType::ProjectWrite));
+            EXPECT_EQ(
+                std::filesystem::last_write_time(
+                    current_path),
+                write_time_before);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           ProjectOpenApiWhileTrainingStillErrors) {
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "api-while-training.licht";
+        write_empty_project(project_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            ASSERT_TRUE(arm_running_trainer(viewer));
+
+            CapturingErrorConsumer consumer;
+            auto subscription =
+                lfs::ErrorBus::instance().subscribe(
+                    consumer);
+            bool prompted = false;
+            lfs::core::events::cmd::
+                ShowStopTrainingConfirmation::
+                    when([&](const auto&) {
+                        prompted = true;
+                    });
+
+            const auto blocked = viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges);
+            ASSERT_FALSE(blocked);
+            EXPECT_EQ(
+                blocked.error().code(),
+                lfs::ErrorCode::FailedPrecondition);
+            EXPECT_EQ(
+                blocked.error().user_message(),
+                "Stop training before switching projects.");
+            EXPECT_FALSE(prompted);
+            EXPECT_TRUE(consumer.user_messages.empty());
+            EXPECT_TRUE(
+                viewer.getTrainerManager()
+                    ->isTrainingActive());
+
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            const auto new_blocked =
+                lifecycle->newProject(
+                    ProjectSwitchDisposition::
+                        DiscardChanges);
+            ASSERT_FALSE(new_blocked);
+            EXPECT_EQ(
+                new_blocked.error().user_message(),
+                "Stop training before switching projects.");
+            EXPECT_TRUE(
+                viewer.getTrainerManager()
+                    ->isTrainingActive());
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           NewProjectWhileCompletionPendingStillErrors) {
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_TRUE(arm_running_trainer(viewer));
+            auto* const trainer_manager =
+                viewer.getTrainerManager();
+            auto& state_machine =
+                const_cast<TrainingStateMachine&>(
+                    trainer_manager->getStateMachine());
+            ASSERT_TRUE(state_machine.transitionTo(
+                TrainingState::Stopping));
+            ASSERT_FALSE(
+                trainer_manager->isTrainingActive());
+            trainer_manager->completion_pending_.store(
+                true, std::memory_order_release);
+            trainer_manager->training_joined_ = false;
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Keep while publishing"),
+                lfs::core::NULL_NODE);
+
+            CapturingErrorConsumer consumer;
+            auto subscription =
+                lfs::ErrorBus::instance().subscribe(
+                    consumer);
+            bool prompted = false;
+            lfs::core::events::cmd::
+                ShowStopTrainingConfirmation::
+                    when([&](const auto&) {
+                        prompted = true;
+                    });
+
+            lfs::core::events::cmd::NewProject{
+                .discard_changes = true}
+                .emit();
+
+            EXPECT_FALSE(prompted);
+            EXPECT_TRUE(
+                std::any_of(
+                    consumer.user_messages.begin(),
+                    consumer.user_messages.end(),
+                    [](const std::string& message) {
+                        return message ==
+                               "Stop training before switching projects.";
+                    }));
+            EXPECT_NE(
+                viewer.getScene().getNode(
+                    "Keep while publishing"),
+                nullptr);
+
+            trainer_manager->completion_pending_.store(
+                false, std::memory_order_release);
+            trainer_manager->training_joined_ = true;
         }
     }
 


### PR DESCRIPTION
Starting a new project or opening another one during training showed a hard error telling the user to stop training first (#1688). Per the issue, it is now a question: "Training must be stopped before switching projects. Stop the current session?" - Yes stops the run and continues with the switch, No changes nothing. Stopping writes no project file, matching the stop policy. A save still being published keeps the hard refusal, and scripted callers (MCP, headless) keep the plain error instead of a dialog.

**Verified:** new C++ and python regression tests (100 + 14 green in the touched suites), and the full flow live on screen: invoked New Project at training step 5404, saw the new dialog, clicked No - training continued; invoked again, clicked Yes - training stopped with nothing written and the app landed in a fresh empty project. All ten locales updated.

Fixes #1688