### PR TITLE
Keep autosave working after the first checkpoint save

### DIFF
--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -61,6 +61,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_SaveAsRoutesThroughFailedTerminalSnapshotAftermath_Test;
     class VisualizerImplResetTest_InfoSurvivesFailedTerminalSnapshotAftermath_Test;
     class VisualizerImplResetTest_AdoptCompletedTrainingSnapshotSkipsOpenWhenCountersEqual_Test;
+    class VisualizerImplResetTest_AdoptedStepBoundaryPublishRebasesAutosaveBase_Test;
     class VisualizerImplResetTest_EditModeSaveDropsFormerTrainingCheckpoint_Test;
 } // namespace lfs::vis
 
@@ -413,6 +414,7 @@ namespace lfs::training {
         friend class lfs::vis::VisualizerImplResetTest_SaveAsRoutesThroughFailedTerminalSnapshotAftermath_Test;
         friend class lfs::vis::VisualizerImplResetTest_InfoSurvivesFailedTerminalSnapshotAftermath_Test;
         friend class lfs::vis::VisualizerImplResetTest_AdoptCompletedTrainingSnapshotSkipsOpenWhenCountersEqual_Test;
+        friend class lfs::vis::VisualizerImplResetTest_AdoptedStepBoundaryPublishRebasesAutosaveBase_Test;
         friend class lfs::vis::VisualizerImplResetTest_EditModeSaveDropsFormerTrainingCheckpoint_Test;
         friend class lfs::vis::project::ProjectLifecycle;
         friend struct TrainerRetryTestAccess;

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -2870,6 +2870,18 @@ namespace lfs::vis::project {
                 JobType::ProjectWrite)) {
             return {};
         }
+        if (auto* trainer = viewer_.getTrainer();
+            trainer &&
+            trainer->get_project_snapshot_metrics()
+                .writer_in_flight) {
+            // Sidecar create requires the on-disk master
+            // commit to match the held source UUID.return {};
+        }
+        if (auto adopted =
+                adoptSettledTrainerPublishOntoCurrentMaster();
+            !adopted) {
+            return adopted;
+        }
         const auto hydration = hydration_.load(
             std::memory_order_acquire);
         if (hydration != Hydration::Empty &&
@@ -3270,6 +3282,20 @@ namespace lfs::vis::project {
             }
         }
         if (error.empty() &&
+            project_write_purpose_ ==
+                ProjectWritePurpose::
+                    TrainingAutosave) {
+            if (auto adopted =
+                    adoptSettledTrainerPublishOntoCurrentMaster();
+                !adopted) {
+                last_project_write_error_code_ =
+                    adopted.error().code();
+                error =
+                    developerError(
+                        adopted.error());
+            }
+        }
+        if (error.empty() &&
             (project_write_purpose_ ==
                  ProjectWritePurpose::
                      ExplicitSave ||
@@ -3535,6 +3561,23 @@ namespace lfs::vis::project {
 
     void ProjectLifecycle::updateMaintenance() {
         settleProjectWrite();
+        if (!viewer_.jobs().anyRunning(
+                JobType::ProjectWrite)) {
+            if (auto adopted =
+                    adoptSettledTrainerPublishOntoCurrentMaster();
+                !adopted) {
+                const auto warning =
+                    developerError(adopted.error());
+                if (warning !=
+                    last_unadoptable_training_snapshot_warning_) {
+                    last_unadoptable_training_snapshot_warning_ =
+                        warning;
+                    LOG_WARN(
+                        "Could not adopt the settled training project generation: {}",
+                        warning);
+                }
+            }
+        }
         if (!document_ ||
             viewer_.jobs().anyRunning(
                 JobType::ProjectWrite)) {
@@ -3796,6 +3839,37 @@ namespace lfs::vis::project {
                 metrics.last_path));
         bindTrainerSnapshotTarget();
         return {};
+    }
+
+    lfs::Result<void>
+    ProjectLifecycle::
+        adoptSettledTrainerPublishOntoCurrentMaster() {
+        // Step-boundary / sparsity publishes complete on the
+        // trainer writer, not through TrainingExplicitSave.
+        // Rebase only a successful append onto the bound master;
+        // Save As already rebinds via adopt(true) on settlement.
+        auto* trainer = viewer_.getTrainer();
+        if (!trainer || !document_ ||
+            !document_->source_path()) {
+            return {};
+        }
+        const auto metrics =
+            trainer->get_project_snapshot_metrics();
+        if (metrics.writer_in_flight ||
+            metrics.last_path.empty() ||
+            !metrics.last_writer_error.empty()) {
+            return {};
+        }
+        if (metrics.capture.completed_snapshots <=
+            adopted_training_snapshot_count_) {
+            return {};
+        }
+        if (document_->source_path()
+                ->lexically_normal() !=
+            metrics.last_path.lexically_normal()) {
+            return {};
+        }
+        return adoptCompletedTrainingSnapshot();
     }
 
     lfs::Result<void>

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -60,6 +60,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_SaveAsRoutesThroughFailedTerminalSnapshotAftermath_Test;
     class VisualizerImplResetTest_InfoSurvivesFailedTerminalSnapshotAftermath_Test;
     class VisualizerImplResetTest_AdoptCompletedTrainingSnapshotSkipsOpenWhenCountersEqual_Test;
+    class VisualizerImplResetTest_AdoptedStepBoundaryPublishRebasesAutosaveBase_Test;
     class VisualizerImplResetTest_TrainingAutosaveIsLightOnlyAndRecoversSpecifiedCkpt_Test;
     class VisualizerImplResetTest_TrainingAutosaveWithoutSpecifiedCkptStillWritesLightChapters_Test;
     class VisualizerImplResetTest_CancelExitDuringCloseSaveDoesNotClose_Test;
@@ -247,6 +248,7 @@ namespace lfs::vis::project {
         friend class lfs::vis::VisualizerImplResetTest_SaveAsRoutesThroughFailedTerminalSnapshotAftermath_Test;
         friend class lfs::vis::VisualizerImplResetTest_InfoSurvivesFailedTerminalSnapshotAftermath_Test;
         friend class lfs::vis::VisualizerImplResetTest_AdoptCompletedTrainingSnapshotSkipsOpenWhenCountersEqual_Test;
+        friend class lfs::vis::VisualizerImplResetTest_AdoptedStepBoundaryPublishRebasesAutosaveBase_Test;
         friend class lfs::vis::VisualizerImplResetTest_TrainingAutosaveIsLightOnlyAndRecoversSpecifiedCkpt_Test;
         friend class lfs::vis::VisualizerImplResetTest_TrainingAutosaveWithoutSpecifiedCkptStillWritesLightChapters_Test;
         friend class lfs::vis::VisualizerImplResetTest_CancelExitDuringCloseSaveDoesNotClose_Test;
@@ -372,6 +374,8 @@ namespace lfs::vis::project {
         [[nodiscard]] lfs::Result<void>
         adoptCompletedTrainingSnapshot(
             bool allow_during_application_close = false);
+        [[nodiscard]] lfs::Result<void>
+        adoptSettledTrainerPublishOntoCurrentMaster();
         [[nodiscard]] lfs::Result<std::vector<std::byte>>
         capturePreviewPng() const;
         [[nodiscard]] lfs::Result<void>

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -279,6 +279,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_SaveAsRoutesThroughFailedTerminalSnapshotAftermath_Test;
         friend class VisualizerImplResetTest_InfoSurvivesFailedTerminalSnapshotAftermath_Test;
         friend class VisualizerImplResetTest_AdoptCompletedTrainingSnapshotSkipsOpenWhenCountersEqual_Test;
+        friend class VisualizerImplResetTest_AdoptedStepBoundaryPublishRebasesAutosaveBase_Test;
         friend class VisualizerImplResetTest_TrainingAutosaveIsLightOnlyAndRecoversSpecifiedCkpt_Test;
         friend class VisualizerImplResetTest_TrainingAutosaveWithoutSpecifiedCkptStillWritesLightChapters_Test;
         friend class VisualizerImplResetTest_CancelExitDuringCloseSaveDoesNotClose_Test;

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -2995,6 +2995,105 @@ namespace {
         EXPECT_FALSE(fs::exists(sidecar));
     }
 
+    TEST(ProjectDocumentTest,
+         AutosaveSidecarCreateRejectsStaleBaseAndAcceptsRefreshedBase) {
+        TemporaryDirectory temporary;
+        const fs::path master =
+            temporary.path / "stale-base.licht";
+        const fs::path sidecar =
+            autosave_sidecar_path(master);
+        write_phase_a_fixture(master);
+
+        auto held = require_result_ptr(
+            ProjectDocument::open(master));
+        ASSERT_TRUE(held->source_commit_uuid());
+        const auto stale_base =
+            *held->source_commit_uuid();
+        require_status(
+            held->edit_view().dom().set(
+                "stale_base_marker",
+                std::string{"held"}));
+
+        {
+            auto advanced = require_result_ptr(
+                ProjectDocument::open(master));
+            require_status(
+                advanced->edit_view().dom().set(
+                    "trainer_append_marker",
+                    std::string{"generation-2"}));
+            auto advanced_save = advanced->save(
+                master, save_options(9970, 1600));
+            ASSERT_TRUE(advanced_save)
+                << lfs::format_for_developer(
+                       advanced_save.error());
+        }
+        ProjectReader disk =
+            require_result(ProjectReader::open(master));
+        EXPECT_NE(
+            disk.commit().commit_uuid, stale_base);
+        EXPECT_EQ(
+            *held->source_commit_uuid(), stale_base);
+
+        auto stale = held->save_autosave(
+            sidecar,
+            ProjectDocumentAutosaveOptions{
+                .file_uuid = fixed_uuid(9971),
+                .base_explicit_commit_uuid =
+                    stale_base,
+                .autosave_sequence = 1,
+                .snapshot_uuid = fixed_uuid(9972),
+                .index_compression =
+                    IndexCompression::
+                        StoredForDeterministicTests,
+                .disk_reserve_bytes = 0,
+            });
+        ASSERT_FALSE(stale);
+        EXPECT_EQ(
+            stale.error().code(),
+            lfs::ErrorCode::FailedPrecondition);
+        const auto stale_formatted =
+            lfs::format_for_developer(stale.error());
+        EXPECT_NE(
+            stale_formatted.find(
+                "The autosave base changed before publication."),
+            std::string::npos)
+            << stale_formatted;
+
+        auto refreshed = require_result_ptr(
+            ProjectDocument::open(master));
+        ASSERT_TRUE(refreshed->source_commit_uuid());
+        EXPECT_EQ(
+            *refreshed->source_commit_uuid(),
+            disk.commit().commit_uuid);
+        require_status(
+            refreshed->edit_view().dom().set(
+                "refreshed_base_marker",
+                std::string{"ok"}));
+        auto published = refreshed->save_autosave(
+            sidecar,
+            ProjectDocumentAutosaveOptions{
+                .file_uuid = fixed_uuid(9973),
+                .base_explicit_commit_uuid =
+                    *refreshed->source_commit_uuid(),
+                .autosave_sequence = 1,
+                .snapshot_uuid = fixed_uuid(9974),
+                .index_compression =
+                    IndexCompression::
+                        StoredForDeterministicTests,
+                .disk_reserve_bytes = 0,
+            });
+        ASSERT_TRUE(published)
+            << lfs::format_for_developer(
+                   published.error());
+        EXPECT_TRUE(fs::is_regular_file(sidecar));
+        ProjectReader overlay =
+            require_result(ProjectReader::open(sidecar));
+        EXPECT_EQ(
+            overlay.superblock()
+                .base_explicit_commit_uuid,
+            disk.commit().commit_uuid);
+    }
+
     LazyChunkValue make_autosave_checkpoint_payload(
         const Uuid& checkpoint_uuid) {
         auto model = make_splat(2);

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -5751,6 +5751,284 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
+           AdoptedStepBoundaryPublishRebasesAutosaveBase) {
+        // Trainer step-boundary appends advance the on-disk
+        // master without rebasing the GUI document. Settlement
+        // must adopt so the next autosave binds the new commit.
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "step-boundary-adopt.licht";
+        const auto sidecar =
+            lfs::io::project::autosave_sidecar_path(
+                project_path);
+        write_empty_project(project_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()
+                            ->ensureLoaded());
+            ASSERT_TRUE(viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    const auto info =
+                        viewer.projectGetInfo();
+                    return info &&
+                           info->hydration_state ==
+                               "complete";
+                }));
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            ASSERT_NE(lifecycle->document_, nullptr);
+            const auto stale_commit =
+                lifecycle->document_
+                    ->source_commit_uuid();
+            ASSERT_TRUE(stale_commit.has_value());
+
+            auto& scene = viewer.getScene();
+            const auto cameras =
+                scene.addGroup("Train cameras");
+            scene.addCamera(
+                "camera.png", cameras,
+                make_project_request_test_camera());
+            const auto model =
+                scene.addGroup("Train model");
+            scene.setTrainingModelNode(model);
+            viewer.getTrainerManager()->setTrainer(
+                std::make_unique<
+                    lfs::training::Trainer>(scene));
+            auto* const trainer = viewer.getTrainer();
+            ASSERT_NE(trainer, nullptr);
+            trainer->set_trainer_project_save_policy({
+                .on_completion = true,
+                .on_stop_or_error = false,
+                .at_step_boundaries = true,
+            });
+            auto& state_machine =
+                const_cast<TrainingStateMachine&>(
+                    viewer.getTrainerManager()
+                        ->getStateMachine());
+            if (state_machine.getState() ==
+                TrainingState::Idle) {
+                ASSERT_TRUE(state_machine.transitionTo(
+                    TrainingState::Ready));
+            }
+            ASSERT_TRUE(state_machine.transitionTo(
+                TrainingState::Running));
+
+            const auto checkpoint_uuid =
+                lfs::core::generate_uuid_v4();
+            const auto training_uuid =
+                lfs::core::generate_uuid_v4();
+            const auto root_uuid =
+                lfs::core::generate_uuid_v4();
+            {
+                auto on_disk =
+                    lfs::test::licht::require_result_ptr(
+                        lfs::io::project::
+                            ProjectDocument::open(
+                                project_path,
+                                {
+                                    .reader = {},
+                                    .geometry = {},
+                                    .defer_geometry_payloads =
+                                        true,
+                                }));
+                lfs::test::licht::require_status(
+                    on_disk->edit_scene_graph()
+                        .upsert_node(
+                            lfs::io::project::
+                                SceneNodeRecord{
+                                    .uuid = root_uuid,
+                                    .type = "group",
+                                    .name = "Root",
+                                    .child_order = 0,
+                                }));
+                lfs::test::licht::require_status(
+                    on_disk->edit_scene_graph()
+                        .upsert_node(
+                            lfs::io::project::
+                                SceneNodeRecord{
+                                    .uuid = training_uuid,
+                                    .type = "splat",
+                                    .name = "Training",
+                                    .parent_uuid = root_uuid,
+                                    .child_order = 0,
+                                    .payload =
+                                        lfs::io::project::
+                                            PayloadBinding{
+                                                .fourcc =
+                                                    "CKPT",
+                                                .instance_uuid =
+                                                    checkpoint_uuid,
+                                                .source_kind =
+                                                    "training",
+                                            },
+                                }));
+                lfs::test::licht::require_status(
+                    on_disk->edit_scene_graph()
+                        .set_training_model_uuid(
+                            training_uuid));
+                lfs::test::licht::require_status(
+                    on_disk->set_checkpoint(
+                        checkpoint_uuid,
+                        make_training_autosave_checkpoint_payload(
+                            checkpoint_uuid)));
+                lfs::test::licht::require_status(
+                    on_disk->edit_view().dom().set(
+                        "step_boundary_marker",
+                        std::string{"appended"}));
+                auto save_options =
+                    lfs::test::licht::
+                        deterministic_document_save_options(
+                            0x76000030, 2, 3);
+                save_options.commit.snapshot_uuid =
+                    checkpoint_uuid;
+                (void)lfs::test::licht::require_result(
+                    on_disk->save(
+                        project_path, save_options));
+            }
+
+            auto disk =
+                lfs::io::project::ProjectReader::open(
+                    project_path);
+            ASSERT_TRUE(disk)
+                << lfs::format_for_developer(
+                       disk.error());
+            const auto published_commit =
+                disk->commit().commit_uuid;
+            EXPECT_NE(
+                published_commit, *stale_commit);
+            EXPECT_EQ(
+                *lifecycle->document_
+                     ->source_commit_uuid(),
+                *stale_commit);
+            EXPECT_TRUE(
+                lifecycle->document_->checkpoint_uuids()
+                    .empty());
+            auto premature =
+                lifecycle->document_->save_autosave(
+                    sidecar,
+                    lfs::io::project::
+                        ProjectDocumentAutosaveOptions{
+                            .file_uuid =
+                                lfs::core::
+                                    generate_uuid_v4(),
+                            .base_explicit_commit_uuid =
+                                *stale_commit,
+                            .autosave_sequence = 1,
+                            .snapshot_uuid = {},
+                            .index_compression =
+                                lfs::io::project::
+                                    IndexCompression::
+                                        StoredForDeterministicTests,
+                            .disk_reserve_bytes = 0,
+                        });
+            ASSERT_FALSE(premature);
+            EXPECT_EQ(
+                premature.error().code(),
+                lfs::ErrorCode::FailedPrecondition);
+
+            ASSERT_NE(
+                trainer->project_snapshot_service_,
+                nullptr);
+            const auto bound_master =
+                *lifecycle->document_->source_path();
+            trainer->last_project_snapshot_path_ =
+                bound_master;
+            trainer->last_project_writer_error_
+                .clear();
+            trainer->project_snapshot_service_
+                ->testing_advance_completed_snapshots(
+                    1);
+            constexpr std::uint64_t request_id = 1;
+            {
+                std::lock_guard lock(
+                    trainer->project_snapshot_mutex_);
+                trainer->last_completed_project_request_id_ =
+                    request_id;
+            }
+
+            auto started = lifecycle->startTrainingWrite(
+                project::ProjectLifecycle::
+                    ProjectWritePurpose::
+                        TrainingAutosave,
+                request_id, bound_master,
+                lifecycle->document_->dirty_epoch(),
+                1);
+            ASSERT_TRUE(started)
+                << lfs::format_for_developer(
+                       started.error());
+            EXPECT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            EXPECT_FALSE(viewer.jobs().anyRunning(
+                JobType::ProjectWrite));
+
+            ASSERT_NE(lifecycle->document_, nullptr);
+            ASSERT_TRUE(
+                lifecycle->document_
+                    ->source_commit_uuid());
+            EXPECT_EQ(
+                *lifecycle->document_
+                     ->source_commit_uuid(),
+                published_commit);
+            EXPECT_FALSE(
+                lifecycle->document_->checkpoint_uuids()
+                    .empty());
+            const auto marker =
+                lifecycle->document_->view()
+                    .dom()
+                    .get_json("step_boundary_marker");
+            ASSERT_TRUE(marker.has_value());
+            EXPECT_EQ(*marker, "appended");
+
+            lfs::test::licht::require_status(
+                lifecycle->document_->edit_view()
+                    .dom()
+                    .set(
+                        "light_after_adopt",
+                        std::string{"dirty"}));
+            auto saved =
+                lifecycle->document_->save_autosave(
+                    sidecar,
+                    lfs::io::project::
+                        ProjectDocumentAutosaveOptions{
+                            .file_uuid =
+                                lfs::core::
+                                    generate_uuid_v4(),
+                            .base_explicit_commit_uuid =
+                                published_commit,
+                            .autosave_sequence = 1,
+                            .snapshot_uuid = {},
+                            .index_compression =
+                                lfs::io::project::
+                                    IndexCompression::
+                                        StoredForDeterministicTests,
+                            .disk_reserve_bytes = 0,
+                        });
+            ASSERT_TRUE(saved)
+                << lfs::format_for_developer(
+                       saved.error());
+            EXPECT_TRUE(
+                std::filesystem::is_regular_file(
+                    sidecar));
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
            CancelExitDuringCloseSaveDoesNotClose) {
         // CancelExit while CloseSaveState::Saving must
         // drop the close latch without aborting the


### PR DESCRIPTION
As soon as a training run wrote its first checkpoint into the project, every following autosave failed with "The autosave base changed before publication" and kept failing for the rest of the run (#1720, reported on Discord and reproduced deterministically on Linux). Crash protection quietly ended exactly when the most work was at stake.

**Cause:** the trainer's checkpoint append moves the project file forward, but the app kept validating autosaves against the state it held from before the append - and nothing ever re-based it during training.

**Fix:** when a trainer publish settles, the app now adopts it: the document reopens (lazily, no payload loading) onto the appended generation and autosave validates against the right base. A bonus: the in-training model gains its checkpoint binding at that moment, which also closes the capture window behind the earlier autosave-crash family. After adoption the document matches the file on disk, so autosave idles until something really changes instead of rewriting an always-dirty document every interval.

**Verified:** new regression tests plus the affected suites (143 green), and the live repro before/after: on the old binary the autosave fails one second after the append and retries forever; on this branch the append is adopted within 300ms, autosaves idle cleanly, and the next real scene change publishes again with zero failures.

Fixes #1720