### PR TITLE
Keep loading and training when dataset images are missing

### DIFF
--- a/src/core/camera.cpp
+++ b/src/core/camera.cpp
@@ -15,6 +15,8 @@
 #include <array>
 #include <cassert>
 #include <cuda_runtime.h>
+#include <format>
+#include <stdexcept>
 
 namespace lfs::core {
     static Tensor world_to_view(const Tensor& R, const Tensor& t) {
@@ -185,6 +187,7 @@ namespace lfs::core {
           _mask_path(std::move(other._mask_path)),
           _depth_path(std::move(other._depth_path)),
           _normal_path(std::move(other._normal_path)),
+          _has_image(other._has_image),
           _split(other._split),
           _camera_width(other._camera_width),
           _camera_height(other._camera_height),
@@ -240,6 +243,7 @@ namespace lfs::core {
             _mask_path = std::move(other._mask_path);
             _depth_path = std::move(other._depth_path);
             _normal_path = std::move(other._normal_path);
+            _has_image = other._has_image;
             _split = other._split;
             _camera_width = other._camera_width;
             _camera_height = other._camera_height;
@@ -289,6 +293,7 @@ namespace lfs::core {
           _mask_path(other._mask_path),
           _depth_path(other._depth_path),
           _normal_path(other._normal_path),
+          _has_image(other._has_image),
           _split(other._split),
           _camera_width(other._camera_width),
           _camera_height(other._camera_height),
@@ -348,6 +353,13 @@ namespace lfs::core {
 
     Tensor Camera::load_and_get_image(int resize_factor, int max_width, const bool output_uint8,
                                       const bool update_dimensions) {
+        if (!_has_image) {
+            throw std::runtime_error(std::format(
+                "Dataset image '{}' is missing: {}",
+                _image_name,
+                lfs::core::path_to_utf8(_image_path)));
+        }
+
         const ImageLoadParams params{
             .path = _image_path,
             .resize_factor = resize_factor,
@@ -376,7 +388,7 @@ namespace lfs::core {
 
     void Camera::load_image_size(int resize_factor, int max_width) {
         int w, h;
-        if (_undistort_prepared) {
+        if (_undistort_prepared || !_has_image) {
             w = _camera_width;
             h = _camera_height;
         } else {
@@ -423,6 +435,9 @@ namespace lfs::core {
     }
 
     size_t Camera::get_num_bytes_from_file(int resize_factor, int max_width) const {
+        if (!_has_image) {
+            return 0;
+        }
         auto result = get_image_info(_image_path);
 
         int w = std::get<0>(result);
@@ -449,6 +464,9 @@ namespace lfs::core {
     }
 
     size_t Camera::get_num_bytes_from_file() const {
+        if (!_has_image) {
+            return 0;
+        }
         auto [w, h, c] = get_image_info(_image_path);
         size_t num_bytes = w * h * c * sizeof(uint8_t);
         return num_bytes;

--- a/src/core/include/core/camera.hpp
+++ b/src/core/include/core/camera.hpp
@@ -177,6 +177,11 @@ namespace lfs::core {
         }
         bool has_alpha() const noexcept { return _has_alpha; }
         void set_has_alpha(bool v) noexcept { _has_alpha = v; }
+        // Set at dataset load when the bound image file is absent. Independent of
+        // scene-graph training_enabled (user disable). Dummy/test cameras keep the
+        // default true even if image_path does not exist.
+        bool has_image() const noexcept { return _has_image; }
+        void set_has_image(bool v) noexcept { _has_image = v; }
         CameraSplit split() const noexcept { return _split; }
         void set_split(const CameraSplit split) noexcept {
             assert((split == CameraSplit::Train || split == CameraSplit::Eval) && "Camera split must be Train or Eval");
@@ -224,6 +229,7 @@ namespace lfs::core {
         std::filesystem::path _depth_path;
         std::filesystem::path _normal_path;
         bool _has_alpha = false;
+        bool _has_image = true;
         CameraSplit _split = CameraSplit::Train;
         int _camera_width = 0;
         int _camera_height = 0;

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -222,6 +222,7 @@ add_library(lfs_io STATIC
 
         # Concrete loader implementations
         loaders/loader_utils.hpp
+        loaders/missing_dataset_images.hpp
         loaders/ply_loader.hpp
         loaders/ply_loader.cpp
         loaders/colmap_loader.hpp

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -9,6 +9,7 @@
 #include "core/path_utils.hpp"
 #include "io/atomic_output.hpp"
 #include "io/filesystem_utils.hpp"
+#include "io/loaders/missing_dataset_images.hpp"
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -924,6 +925,7 @@ namespace lfs::io {
 
         std::unordered_map<std::string, size_t> basename_only_metadata_counts;
         basename_only_metadata_counts.reserve(images.size());
+        std::vector<std::string> missing_images;
 
         for (size_t i = 0; i < images.size(); ++i) {
             if (should_poll_cancel(i)) {
@@ -971,13 +973,17 @@ namespace lfs::io {
             } else if (image_lookup.ambiguous()) {
                 return make_ambiguous_image_reference_error(images_path, image.name);
             } else {
-                return make_error(
-                    ErrorCode::PATH_NOT_FOUND,
-                    std::format("Image '{}' was not found under '{}'",
-                                image.name,
-                                lfs::core::path_to_utf8(images_path)),
-                    images_path / image_rel_path);
+                missing_images.push_back(image.name);
             }
+        }
+
+        if (!images.empty() && missing_images.size() == images.size()) {
+            return make_error(
+                ErrorCode::EMPTY_DATASET,
+                format_all_dataset_images_missing_message(
+                    missing_images,
+                    lfs::core::path_to_utf8(images_path)),
+                images_path);
         }
 
         return {};
@@ -2278,6 +2284,7 @@ namespace lfs::io {
         std::vector<std::shared_ptr<Camera>> cameras;
         cameras.reserve(images.size());
         SkipTally image_tally;
+        std::vector<std::string> missing_images;
 
         RecursiveFileCache image_cache(images_path, options.cancel_requested);
         MaskDirCache mask_cache(base_path, options.cancel_requested);
@@ -2311,14 +2318,10 @@ namespace lfs::io {
                     image_path = std::move(image_lookup.path);
                 } else if (image_lookup.ambiguous()) {
                     return make_ambiguous_image_reference_error(images_path, img.name);
-                } else {
-                    return make_error(ErrorCode::PATH_NOT_FOUND,
-                                      std::format("Image '{}' was not found under '{}'",
-                                                  img.name,
-                                                  lfs::core::path_to_utf8(images_path)),
-                                      image_path);
                 }
             }
+
+            const bool image_file_present = safe_is_regular_file(image_path);
 
             auto it = cam_map.find(img.camera_id);
             if (it == cam_map.end()) {
@@ -2541,7 +2544,7 @@ namespace lfs::io {
                 }
                 return *image_info;
             };
-            if (options.load_masks && !mask_path.empty()) {
+            if (image_file_present && options.load_masks && !mask_path.empty()) {
                 auto [img_w, img_h, img_c] = get_image_info_cached();
                 auto [mask_w, mask_h, mask_c] = lfs::core::get_image_info(mask_path);
                 if (img_w != mask_w || img_h != mask_h) {
@@ -2552,7 +2555,7 @@ namespace lfs::io {
                                       mask_path);
                 }
             }
-            if (options.load_depths && !depth_path.empty()) {
+            if (image_file_present && options.load_depths && !depth_path.empty()) {
                 auto [img_w, img_h, img_c] = get_image_info_cached();
                 auto [depth_w, depth_h, depth_c] = lfs::core::get_image_info(depth_path);
                 if (!sidecar_dimensions_match_contract(depth_w,
@@ -2568,7 +2571,7 @@ namespace lfs::io {
                                       depth_path);
                 }
             }
-            if (options.load_normals && !normal_path.empty()) {
+            if (image_file_present && options.load_normals && !normal_path.empty()) {
                 auto [img_w, img_h, img_c] = get_image_info_cached();
                 auto [normal_w, normal_h, normal_c] = lfs::core::get_image_info(normal_path);
                 if (!sidecar_dimensions_match_contract(normal_w,
@@ -2605,6 +2608,10 @@ namespace lfs::io {
                 normal_path);
 
             camera->precompute_undistortion();
+            if (!image_file_present) {
+                camera->set_has_image(false);
+                missing_images.push_back(img.name);
+            }
 
             cameras.push_back(std::move(camera));
         }
@@ -2615,11 +2622,26 @@ namespace lfs::io {
                               base_path);
         }
 
+        const bool any_present_image = std::any_of(
+            cameras.begin(), cameras.end(), [](const auto& camera) { return camera->has_image(); });
+        if (!any_present_image) {
+            return make_error(
+                ErrorCode::EMPTY_DATASET,
+                format_all_dataset_images_missing_message(
+                    missing_images,
+                    lfs::core::path_to_utf8(images_path)),
+                images_path);
+        }
+
         // Compute scene center as mean of camera positions
         Tensor scene_center_tensor = Tensor::from_vector(camera_positions, {cameras.size(), 3}, Device::CPU);
         Tensor scene_center = scene_center_tensor.mean({0}, false);
 
-        LOG_INFO("Training with {} images", cameras.size());
+        const size_t training_image_count = static_cast<size_t>(
+            std::count_if(cameras.begin(), cameras.end(), [](const auto& camera) {
+                return camera->has_image();
+            }));
+        LOG_INFO("Training with {} images ({} camera records)", training_image_count, cameras.size());
         if (depth_cache.has_depth_dirs()) {
             if (depth_matched_count == 0) {
                 LOG_WARN("Depth folder found but no depth map matched any of the {} images. "
@@ -2643,6 +2665,10 @@ namespace lfs::io {
         if (auto diagnostic = image_tally.to_diagnostic(
                 lfs::ErrorCode::DataLoss, "image(s) with an unusable camera")) {
             warnings.push_back(std::move(*diagnostic));
+        }
+        if (!missing_images.empty()) {
+            warnings.push_back(missing_dataset_images_diagnostic(missing_images));
+            notify_missing_dataset_images(missing_images);
         }
         return LoadOutcome<std::tuple<std::vector<std::shared_ptr<Camera>>, Tensor>>{
             std::make_tuple(std::move(cameras), scene_center), std::move(warnings)};

--- a/src/io/formats/colmap.hpp
+++ b/src/io/formats/colmap.hpp
@@ -44,6 +44,7 @@ namespace lfs::io {
         float _center_y = 0.f;
         std::string _image_name;
         std::filesystem::path _image_path;
+        bool _has_image = true;
         lfs::core::CameraModelType _camera_model_type = lfs::core::CameraModelType::PINHOLE;
         int _width = 0;
         int _height = 0;

--- a/src/io/formats/transforms.cpp
+++ b/src/io/formats/transforms.cpp
@@ -290,6 +290,10 @@ namespace lfs::io {
                 h = global_h;
             } else {
                 const auto image_path = GetTransformImagePath(dir_path, file_path);
+                std::error_code exists_error;
+                if (!std::filesystem::is_regular_file(image_path, exists_error)) {
+                    return {1, 1};
+                }
                 const auto info = lfs::core::get_image_info(image_path);
                 w = std::get<0>(info);
                 h = std::get<1>(info);
@@ -581,6 +585,10 @@ namespace lfs::io {
                 lfs::core::Tensor T = w2c.slice(0, 0, 3).slice(1, 3, 4).squeeze(1);
 
                 camdata._image_path = GetTransformImagePath(dir_path, frame.file_path);
+                camdata._has_image = [&] {
+                    std::error_code exists_error;
+                    return std::filesystem::is_regular_file(camdata._image_path, exists_error);
+                }();
 
                 camdata._image_name = lfs::core::path_to_utf8(camdata._image_path.filename());
 

--- a/src/io/formats/transforms.hpp
+++ b/src/io/formats/transforms.hpp
@@ -13,6 +13,10 @@
 
 namespace lfs::io {
 
+    std::filesystem::path GetTransformImagePath(
+        const std::filesystem::path& dir_path,
+        const std::string& frame_file_path);
+
     std::tuple<std::vector<CameraData>, lfs::core::Tensor, std::optional<std::tuple<std::vector<std::string>, std::vector<std::string>>>> read_transforms_cameras_and_images(
         const std::filesystem::path& transPath,
         const LoadOptions& options = {});

--- a/src/io/include/io/filesystem_utils.hpp
+++ b/src/io/include/io/filesystem_utils.hpp
@@ -104,6 +104,11 @@ namespace lfs::io {
         return fs::is_directory(path, ec);
     }
 
+    inline bool safe_is_regular_file(const fs::path& path) {
+        std::error_code ec;
+        return fs::is_regular_file(path, ec);
+    }
+
     // Case-insensitive file finding
     inline fs::path find_file_ci(const fs::path& dir, const std::string& target) {
         if (!safe_exists(dir) || !safe_is_directory(dir))

--- a/src/io/loaders/blender_loader.cpp
+++ b/src/io/loaders/blender_loader.cpp
@@ -12,6 +12,7 @@
 #include "io/error.hpp"
 #include "io/filesystem_utils.hpp"
 #include "io/loaders/loader_utils.hpp"
+#include "io/loaders/missing_dataset_images.hpp"
 #include <chrono>
 #include <filesystem>
 #include <format>
@@ -21,6 +22,7 @@
 #include <ranges>
 #include <span>
 #include <tuple>
+#include <vector>
 
 namespace lfs::io {
 
@@ -95,6 +97,29 @@ namespace lfs::io {
                     return make_error(ErrorCode::INVALID_DATASET,
                                       "Invalid transforms file: missing 'frames' array", transforms_file);
                 }
+
+                const auto base_path = transforms_file.parent_path();
+                std::vector<std::string> missing_images;
+                size_t referenced_images = 0;
+                for (const auto& frame : j["frames"]) {
+                    if (!frame.is_object() || !frame.contains("file_path") ||
+                        !frame["file_path"].is_string()) {
+                        continue;
+                    }
+                    ++referenced_images;
+                    const std::string file_path = frame["file_path"].get<std::string>();
+                    if (!safe_is_regular_file(GetTransformImagePath(base_path, file_path))) {
+                        missing_images.push_back(file_path);
+                    }
+                }
+                if (referenced_images > 0 && missing_images.size() == referenced_images) {
+                    return make_error(
+                        ErrorCode::EMPTY_DATASET,
+                        format_all_dataset_images_missing_message(
+                            missing_images,
+                            lfs::core::path_to_utf8(base_path)),
+                        base_path);
+                }
             } catch (const std::exception& e) {
                 return make_error(ErrorCode::MALFORMED_JSON,
                                   std::format("Invalid JSON: {}", e.what()), transforms_file);
@@ -129,6 +154,23 @@ namespace lfs::io {
             // Read transforms and create cameras
             auto [camera_infos, scene_center, train_val_split] =
                 read_transforms_cameras_and_images(transforms_file, options);
+
+            std::vector<std::string> missing_images;
+            for (const auto& info : camera_infos) {
+                if (!info._has_image) {
+                    missing_images.push_back(info._image_name.empty()
+                                                 ? lfs::core::path_to_utf8(info._image_path.filename())
+                                                 : info._image_name);
+                }
+            }
+            if (!camera_infos.empty() && missing_images.size() == camera_infos.size()) {
+                return make_error(
+                    ErrorCode::EMPTY_DATASET,
+                    format_all_dataset_images_missing_message(
+                        missing_images,
+                        lfs::core::path_to_utf8(transforms_file.parent_path())),
+                    transforms_file.parent_path());
+            }
 
             if (options.progress) {
                 options.progress(40.0f, std::format("Creating {} cameras...", camera_infos.size()));
@@ -226,7 +268,7 @@ namespace lfs::io {
                         }
                         return *image_info;
                     };
-                    if (options.load_masks && !mask_path.empty()) {
+                    if (info._has_image && options.load_masks && !mask_path.empty()) {
                         auto [img_w, img_h, img_c] = get_image_info_cached();
                         auto [mask_w, mask_h, mask_c] = lfs::core::get_image_info(mask_path);
                         if (img_w != mask_w || img_h != mask_h) {
@@ -237,7 +279,7 @@ namespace lfs::io {
                                               mask_path);
                         }
                     }
-                    if (options.load_depths && !depth_path.empty()) {
+                    if (info._has_image && options.load_depths && !depth_path.empty()) {
                         auto [img_w, img_h, img_c] = get_image_info_cached();
                         auto [depth_w, depth_h, depth_c] = lfs::core::get_image_info(depth_path);
                         if (img_w != depth_w || img_h != depth_h) {
@@ -248,7 +290,7 @@ namespace lfs::io {
                                               depth_path);
                         }
                     }
-                    if (options.load_normals && !normal_path.empty()) {
+                    if (info._has_image && options.load_normals && !normal_path.empty()) {
                         auto [img_w, img_h, img_c] = get_image_info_cached();
                         auto [normal_w, normal_h, normal_c] = lfs::core::get_image_info(normal_path);
                         if (img_w != normal_w || img_h != normal_h) {
@@ -280,11 +322,16 @@ namespace lfs::io {
                         depth_path,
                         normal_path);
 
+                    cam->set_has_image(info._has_image);
                     cameras.push_back(cam);
                 } catch (const std::exception& e) {
                     LOG_ERROR("Failed to create camera {}: {}", i, e.what());
                     throw;
                 }
+            }
+
+            if (!missing_images.empty()) {
+                notify_missing_dataset_images(missing_images);
             }
 
             const bool images_have_alpha = detect_camera_alpha(cameras, options.cancel_requested);
@@ -313,6 +360,9 @@ namespace lfs::io {
 
             std::shared_ptr<PointCloud> point_cloud;
             std::vector<std::string> warnings;
+            if (!missing_images.empty()) {
+                warnings.push_back(format_missing_dataset_images_warning(missing_images));
+            }
             if (std::filesystem::exists(pointcloud_path)) {
                 auto loaded_point_cloud = load_simple_ply_point_cloud(pointcloud_path, options);
                 point_cloud = std::make_shared<PointCloud>(

--- a/src/io/loaders/loader_utils.hpp
+++ b/src/io/loaders/loader_utils.hpp
@@ -31,6 +31,8 @@ namespace lfs::io {
             }
 
             const auto& cam = cameras[i];
+            if (!cam->has_image())
+                continue;
             auto ext = cam->image_path().extension().string();
             std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
             if (ext == ".jpg" || ext == ".jpeg")

--- a/src/io/loaders/missing_dataset_images.hpp
+++ b/src/io/loaders/missing_dataset_images.hpp
@@ -1,0 +1,115 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include "core/error.hpp"
+#include "core/error_bus.hpp"
+#include "core/logger.hpp"
+#include "io/error.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace lfs::io {
+
+    inline constexpr size_t kMaxMissingDatasetImageExamples = 5;
+
+    [[nodiscard]] inline std::string join_missing_dataset_image_examples(
+        const std::vector<std::string>& names,
+        const size_t max_examples = kMaxMissingDatasetImageExamples) {
+        const size_t shown = std::min(max_examples, names.size());
+        std::string joined;
+        for (size_t i = 0; i < shown; ++i) {
+            if (i != 0) {
+                joined += ", ";
+            }
+            joined += names[i];
+        }
+        if (names.size() > max_examples) {
+            joined += ", ...";
+        }
+        return joined;
+    }
+
+    [[nodiscard]] inline std::string format_missing_dataset_images_warning(
+        const std::vector<std::string>& names) {
+        const std::string examples = join_missing_dataset_image_examples(names);
+        if (names.size() == 1) {
+            return std::format(
+                "1 dataset image file is missing ({}). That camera stays in the scene with an "
+                "empty image preview and is excluded from training.",
+                examples);
+        }
+        return std::format(
+            "{} dataset image files are missing (examples: {}). Those cameras stay in the scene "
+            "with empty image previews and are excluded from training.",
+            names.size(),
+            examples);
+    }
+
+    [[nodiscard]] inline std::string format_all_dataset_images_missing_message(
+        const std::vector<std::string>& names,
+        const std::string_view location) {
+        const std::string examples = join_missing_dataset_image_examples(names);
+        return std::format(
+            "All {} dataset image files are missing under '{}'. Training cannot start with an "
+            "empty image set (examples: {}).",
+            names.size(),
+            location,
+            examples);
+    }
+
+    inline void log_missing_dataset_images(const std::vector<std::string>& names) {
+        if (names.empty()) {
+            return;
+        }
+        LOG_WARN("{}", format_missing_dataset_images_warning(names));
+        for (const auto& name : names) {
+            LOG_WARN("  missing dataset image: {}", name);
+        }
+    }
+
+    inline void notify_missing_dataset_images(const std::vector<std::string>& names) {
+        if (names.empty()) {
+            return;
+        }
+        const std::string summary = format_missing_dataset_images_warning(names);
+        log_missing_dataset_images(names);
+        lfs::ErrorBus::instance().publish(lfs::ErrorNotification{
+            .error = lfs::make_error(lfs::ErrorInit{
+                .code = lfs::ErrorCode::NotFound,
+                .domain = lfs::ErrorDomain::IO,
+                .severity = lfs::Severity::Warning,
+                .retryability = lfs::Retryability::NotRetryable,
+                .user_message = summary,
+                .detail = summary,
+                .detection = LFS_SOURCE_SITE_CURRENT(),
+                .fields = lfs::SmallFields{}
+                              .add("missing_count", static_cast<std::int64_t>(names.size()))
+                              .add("examples", join_missing_dataset_image_examples(names)),
+            }),
+            .surface = lfs::ErrorSurface::Toast,
+            .actions = {},
+            .operation_id = lfs::OperationId::generate(),
+        });
+    }
+
+    [[nodiscard]] inline Diagnostic missing_dataset_images_diagnostic(
+        const std::vector<std::string>& names) {
+        return Diagnostic{
+            .code = lfs::ErrorCode::NotFound,
+            .message = format_missing_dataset_images_warning(names),
+            .fields = lfs::SmallFields{}
+                          .add("missing_count", static_cast<std::int64_t>(names.size()))
+                          .add("examples", join_missing_dataset_image_examples(names)),
+        };
+    }
+
+} // namespace lfs::io

--- a/src/python/lfs/py_cameras.cpp
+++ b/src/python/lfs/py_cameras.cpp
@@ -95,6 +95,7 @@ namespace lfs::python {
     std::string PyCamera::depth_path() const { return lfs::core::path_to_utf8(cam_->depth_path()); }
     bool PyCamera::has_mask() const { return cam_->has_mask(); }
     bool PyCamera::has_depth() const { return cam_->has_depth(); }
+    bool PyCamera::has_image() const { return cam_->has_image(); }
     int PyCamera::uid() const { return cam_->uid(); }
 
     PyTensor PyCamera::rotation() const {
@@ -179,6 +180,7 @@ namespace lfs::python {
             .def_prop_ro("depth_path", &PyCamera::depth_path, "Full path to depth map file")
             .def_prop_ro("has_mask", &PyCamera::has_mask, "Whether a mask file exists")
             .def_prop_ro("has_depth", &PyCamera::has_depth, "Whether a depth map file exists")
+            .def_prop_ro("has_image", &PyCamera::has_image, "Whether the bound dataset image file exists")
             .def_prop_ro("uid", &PyCamera::uid, "Unique camera identifier")
             // Visualizer-space camera pose, directly compatible with render_view().
             .def_prop_ro("rotation", &PyCamera::rotation,

--- a/src/python/lfs/py_cameras.hpp
+++ b/src/python/lfs/py_cameras.hpp
@@ -45,6 +45,7 @@ namespace lfs::python {
         std::string depth_path() const;
         bool has_mask() const;
         bool has_depth() const;
+        bool has_image() const;
         int uid() const;
 
         // Render/view contract: visualizer camera pose and derived view matrix.

--- a/src/training/dataset.hpp
+++ b/src/training/dataset.hpp
@@ -252,6 +252,9 @@ namespace lfs::training {
             indices_.clear();
             if (included_images.has_value()) {
                 for (size_t i = 0; i < cameras_.size(); ++i) {
+                    if (!cameras_[i]->has_image()) {
+                        continue;
+                    }
                     // Simple filename matching without extension
                     auto img_name = cameras_[i]->image_name();
                     // Remove extension
@@ -267,6 +270,9 @@ namespace lfs::training {
                 }
             } else {
                 for (size_t i = 0; i < cameras_.size(); ++i) {
+                    if (!cameras_[i]->has_image()) {
+                        continue;
+                    }
                     const bool is_test = (i % config.test_every) == 0;
 
                     if (split_ == Split::ALL || (split_ == Split::TRAIN && !is_test) ||
@@ -329,6 +335,9 @@ namespace lfs::training {
             }
             size_t total_bytes = 0;
             for (const auto& cam : cameras_) {
+                if (!cam->has_image()) {
+                    continue;
+                }
                 total_bytes +=
                     cam->get_num_bytes_from_file(config_.resize_factor, config_.max_width);
             }

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -2759,6 +2759,13 @@ namespace lfs::training {
                 if (source_cameras.empty()) {
                     return std::unexpected("Scene has no active cameras enabled for training");
                 }
+                std::erase_if(source_cameras, [](const auto& camera) {
+                    return !camera || !camera->has_image();
+                });
+                if (source_cameras.empty()) {
+                    return std::unexpected(
+                        "Scene has no cameras with image files available for training");
+                }
 
                 if (params.optimization.enable_eval) {
                     for (const auto& camera : source_cameras) {
@@ -2778,6 +2785,13 @@ namespace lfs::training {
                 }
             } else if (base_dataset_) {
                 source_cameras = base_dataset_->get_cameras();
+                std::erase_if(source_cameras, [](const auto& camera) {
+                    return !camera || !camera->has_image();
+                });
+                if (source_cameras.empty()) {
+                    return std::unexpected(
+                        "Dataset has no cameras with image files available for training");
+                }
             } else {
                 return std::unexpected("No camera source available");
             }

--- a/src/visualizer/gui/gui_error_consumer.cpp
+++ b/src/visualizer/gui/gui_error_consumer.cpp
@@ -92,6 +92,9 @@ namespace lfs::vis::gui {
                 }
                 return Keys::FILE_OPEN_FAILED;
             case lfs::ErrorDomain::IO:
+                if (error.severity() == lfs::Severity::Warning) {
+                    return Keys::GENERIC;
+                }
                 if (op == error_op::kLoadDataset) {
                     return Keys::DATASET_LOAD_FAILED;
                 }

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -2484,11 +2484,13 @@ namespace lfs::vis::gui {
                         corner_depths[corner] = settings.equirectangular ? glm::length(view) : -view.z;
                     }
                     quad_visible = quad_visible && projectedQuadVisible(screen_points, panel);
-                    if (quad_visible) {
-                        thumbnail_cache.request(*camera);
-                    } else if (background_thumbnail_requests < kBackgroundThumbnailRequestsPerFrame &&
-                               thumbnail_cache.request(*camera)) {
-                        ++background_thumbnail_requests;
+                    if (camera->has_image()) {
+                        if (quad_visible) {
+                            thumbnail_cache.request(*camera);
+                        } else if (background_thumbnail_requests < kBackgroundThumbnailRequestsPerFrame &&
+                                   thumbnail_cache.request(*camera)) {
+                            ++background_thumbnail_requests;
+                        }
                     }
 
                     const auto placement = thumbnail_cache.placement(camera->uid());

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -2479,7 +2479,7 @@ namespace lfs::vis {
                     bool gt_loading = false;
 
                     if (gt_mode == GTComparisonMode::RGB) {
-                        if (camera->image_path().empty()) {
+                        if (camera->image_path().empty() || !camera->has_image()) {
                             gt_error = "RGB GT comparison requires a source image";
                         } else {
                             const bool undistort_requested =

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -448,6 +448,7 @@ set(TEST_FILES
     test_openmesh_bridge.cpp
     test_mesh_loader.cpp
     test_colmap_image_layout.cpp
+    test_missing_dataset_images.cpp
     test_colmap_points3d_text.cpp
     test_colmap_binary_error_taxonomy.cpp
     test_splat_simplify.cpp

--- a/tests/python/test_io_load.py
+++ b/tests/python/test_io_load.py
@@ -163,3 +163,85 @@ class TestLoadProgress:
         # Progress values should be in [0, 100] (percentage)
         for progress, _ in progress_calls:
             assert 0.0 <= progress <= 100.0
+
+
+_ONE_PIXEL_PNG = bytes(
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+        0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
+        0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+        0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ]
+)
+
+
+class TestMissingDatasetImages:
+    """Python-visible load warnings for missing dataset images."""
+
+    def test_transforms_load_warns_and_keeps_missing_camera(self, lf, tmp_path):
+        dataset = tmp_path / "missing_images"
+        dataset.mkdir()
+        (dataset / "present.png").write_bytes(_ONE_PIXEL_PNG)
+        (dataset / "transforms.json").write_text(
+            """{
+  "w": 1,
+  "h": 1,
+  "fl_x": 1.0,
+  "fl_y": 1.0,
+  "cx": 0.5,
+  "cy": 0.5,
+  "frames": [
+    {
+      "file_path": "present.png",
+      "transform_matrix": [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]
+    },
+    {
+      "file_path": "missing.png",
+      "transform_matrix": [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]
+    }
+  ]
+}
+"""
+        )
+
+        result = lf.io.load(str(dataset))
+        assert result.is_dataset is True
+        assert any("missing.png" in warning and "missing" in warning for warning in result.warnings)
+
+        cameras = result.cameras
+        assert cameras is not None
+        assert len(cameras) == 1
+        assert cameras[0].image_name == "present.png"
+        assert cameras[0].has_image is True
+
+        records = cameras.cameras()
+        assert len(records) == 2
+        by_name = {camera.image_name: camera for camera in records}
+        assert by_name["present.png"].has_image is True
+        assert by_name["missing.png"].has_image is False
+
+    def test_transforms_all_missing_fails(self, lf, tmp_path):
+        dataset = tmp_path / "all_missing_images"
+        dataset.mkdir()
+        (dataset / "transforms.json").write_text(
+            """{
+  "w": 1,
+  "h": 1,
+  "fl_x": 1.0,
+  "fl_y": 1.0,
+  "cx": 0.5,
+  "cy": 0.5,
+  "frames": [
+    {
+      "file_path": "missing.png",
+      "transform_matrix": [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]
+    }
+  ]
+}
+"""
+        )
+
+        with pytest.raises(RuntimeError, match="missing"):
+            lf.io.load(str(dataset))

--- a/tests/test_missing_dataset_images.cpp
+++ b/tests/test_missing_dataset_images.cpp
@@ -1,0 +1,371 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "io/formats/colmap.hpp"
+#include "io/formats/transforms.hpp"
+#include "io/loaders/blender_loader.hpp"
+#include "io/loaders/colmap_loader.hpp"
+#include "training/dataset.hpp"
+
+#include <cuda_runtime.h>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+    bool has_cuda_device() {
+        int device_count = 0;
+        return cudaGetDeviceCount(&device_count) == cudaSuccess && device_count > 0;
+    }
+
+    class MissingDatasetImagesTest : public ::testing::Test {
+    protected:
+        void SetUp() override {
+            temp_dir_ = fs::temp_directory_path() / "lfs_missing_dataset_images_test";
+            std::error_code ec;
+            fs::remove_all(temp_dir_, ec);
+            fs::create_directories(temp_dir_);
+        }
+
+        void TearDown() override {
+            std::error_code ec;
+            fs::remove_all(temp_dir_, ec);
+        }
+
+        void write_text_file(const fs::path& path, const std::string& contents) {
+            fs::create_directories(path.parent_path());
+            std::ofstream out(path, std::ios::binary);
+            ASSERT_TRUE(out.is_open()) << "Failed to open " << path;
+            out << contents;
+            out.close();
+            ASSERT_TRUE(out.good()) << "Failed to write " << path;
+        }
+
+        void write_bytes(const fs::path& path, const std::vector<char>& bytes) {
+            fs::create_directories(path.parent_path());
+            std::ofstream out(path, std::ios::binary);
+            ASSERT_TRUE(out.is_open()) << "Failed to open " << path;
+            out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+            out.close();
+            ASSERT_TRUE(out.good()) << "Failed to write " << path;
+        }
+
+        void write_png(const fs::path& path) {
+            static constexpr unsigned char png[] = {
+                0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+                0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+                0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+                0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+                0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+                0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82};
+            fs::create_directories(path.parent_path());
+            std::ofstream out(path, std::ios::binary);
+            ASSERT_TRUE(out.is_open()) << "Failed to open " << path;
+            out.write(reinterpret_cast<const char*>(png), sizeof(png));
+            out.close();
+            ASSERT_TRUE(out.good()) << "Failed to write " << path;
+        }
+
+        void write_colmap_text(const fs::path& dataset_dir, const std::vector<std::string>& image_names) {
+            write_text_file(dataset_dir / "cameras.txt", "1 PINHOLE 1 1 1 1 0.5 0.5\n");
+            std::ostringstream images;
+            for (size_t i = 0; i < image_names.size(); ++i) {
+                images << (i + 1) << " 1 0 0 0 0 0 0 1 " << image_names[i] << "\n";
+            }
+            write_text_file(dataset_dir / "images.txt", images.str());
+            fs::create_directories(dataset_dir / "images");
+        }
+
+        template <class T>
+        void append_pod(std::vector<char>& bytes, const T value) {
+            const auto* begin = reinterpret_cast<const char*>(&value);
+            bytes.insert(bytes.end(), begin, begin + sizeof(T));
+        }
+
+        void write_colmap_binary(const fs::path& dataset_dir, const std::vector<std::string>& image_names) {
+            std::vector<char> cameras;
+            append_pod(cameras, uint64_t{1});
+            append_pod(cameras, uint32_t{1});
+            append_pod(cameras, int32_t{1});
+            append_pod(cameras, uint64_t{1});
+            append_pod(cameras, uint64_t{1});
+            append_pod(cameras, 1.0);
+            append_pod(cameras, 1.0);
+            append_pod(cameras, 0.5);
+            append_pod(cameras, 0.5);
+            write_bytes(dataset_dir / "cameras.bin", cameras);
+
+            std::vector<char> images;
+            append_pod(images, static_cast<uint64_t>(image_names.size()));
+            for (size_t i = 0; i < image_names.size(); ++i) {
+                append_pod(images, static_cast<uint32_t>(i + 1));
+                append_pod(images, 1.0);
+                append_pod(images, 0.0);
+                append_pod(images, 0.0);
+                append_pod(images, 0.0);
+                append_pod(images, 0.0);
+                append_pod(images, 0.0);
+                append_pod(images, 0.0);
+                append_pod(images, uint32_t{1});
+                images.insert(images.end(), image_names[i].begin(), image_names[i].end());
+                images.push_back('\0');
+                append_pod(images, uint64_t{0});
+            }
+            write_bytes(dataset_dir / "images.bin", images);
+            fs::create_directories(dataset_dir / "images");
+        }
+
+        void write_transforms(const fs::path& dataset_dir, const std::vector<std::string>& image_names) {
+            const nlohmann::json identity = {
+                {1.0, 0.0, 0.0, 0.0},
+                {0.0, 1.0, 0.0, 0.0},
+                {0.0, 0.0, 1.0, 0.0},
+                {0.0, 0.0, 0.0, 1.0},
+            };
+            nlohmann::json frames = nlohmann::json::array();
+            for (const auto& name : image_names) {
+                frames.push_back({
+                    {"file_path", name},
+                    {"transform_matrix", identity},
+                });
+            }
+            nlohmann::json transforms = {
+                {"w", 1},
+                {"h", 1},
+                {"fl_x", 1.0},
+                {"fl_y", 1.0},
+                {"cx", 0.5},
+                {"cy", 0.5},
+                {"frames", frames},
+            };
+            write_text_file(dataset_dir / "transforms.json", transforms.dump());
+        }
+
+        void expect_partial_missing(
+            const std::vector<std::shared_ptr<lfs::core::Camera>>& cameras,
+            const std::vector<std::string>& warnings,
+            const std::string& missing_name,
+            const std::string& present_name) {
+            ASSERT_EQ(cameras.size(), 2u);
+            std::vector<std::string> missing;
+            std::vector<std::string> present;
+            for (const auto& camera : cameras) {
+                if (camera->has_image()) {
+                    present.push_back(camera->image_name());
+                } else {
+                    missing.push_back(camera->image_name());
+                }
+            }
+            ASSERT_EQ(missing.size(), 1u);
+            EXPECT_EQ(missing.front(), missing_name);
+            ASSERT_EQ(present.size(), 1u);
+            EXPECT_EQ(present.front(), present_name);
+
+            ASSERT_FALSE(warnings.empty());
+            bool found_warning = false;
+            for (const auto& warning : warnings) {
+                if (warning.find(missing_name) != std::string::npos &&
+                    warning.find("missing") != std::string::npos) {
+                    found_warning = true;
+                }
+                EXPECT_EQ(warning.find(present_name), std::string::npos);
+            }
+            EXPECT_TRUE(found_warning);
+
+            lfs::training::DatasetConfig config;
+            lfs::training::CameraDataset dataset(cameras, config, lfs::training::CameraDataset::Split::ALL);
+            EXPECT_EQ(dataset.size(), 1u);
+            EXPECT_EQ(dataset.get_camera(0)->image_name(), present_name);
+            EXPECT_EQ(dataset.get_cameras().size(), 2u);
+        }
+
+        fs::path temp_dir_;
+    };
+
+} // namespace
+
+TEST_F(MissingDatasetImagesTest, ColmapTextLoadsWhenOneImageIsMissing) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required";
+    }
+
+    const fs::path dataset_dir = temp_dir_ / "colmap_text";
+    write_colmap_text(dataset_dir, {"present.png", "missing.png"});
+    write_png(dataset_dir / "images" / "present.png");
+
+    auto result = lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images");
+    ASSERT_TRUE(result.has_value()) << result.error().format();
+
+    const auto& cameras = std::get<0>(result->value);
+    std::vector<std::string> warnings;
+    for (const auto& diagnostic : result->warnings) {
+        warnings.push_back(diagnostic.message);
+        EXPECT_EQ(diagnostic.code, lfs::ErrorCode::NotFound);
+    }
+    ASSERT_NO_FATAL_FAILURE(expect_partial_missing(cameras, warnings, "missing.png", "present.png"));
+}
+
+TEST_F(MissingDatasetImagesTest, ColmapTextAllMissingFails) {
+    const fs::path dataset_dir = temp_dir_ / "colmap_text_all_missing";
+    write_colmap_text(dataset_dir, {"missing_a.png", "missing_b.png"});
+
+    auto result = lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, lfs::io::ErrorCode::EMPTY_DATASET);
+    EXPECT_NE(result.error().message.find("All 2 dataset image files are missing"), std::string::npos);
+    EXPECT_NE(result.error().message.find("missing_a.png"), std::string::npos);
+}
+
+TEST_F(MissingDatasetImagesTest, ColmapTextValidationAllowsPartialMissing) {
+    const fs::path dataset_dir = temp_dir_ / "colmap_text_validate";
+    write_colmap_text(dataset_dir, {"present.png", "missing.png"});
+    write_png(dataset_dir / "images" / "present.png");
+
+    auto result = lfs::io::validate_colmap_dataset_layout(dataset_dir, "images");
+    ASSERT_TRUE(result.has_value()) << result.error().format();
+}
+
+TEST_F(MissingDatasetImagesTest, ColmapTextStillFailsWhenImagesFolderIsMissing) {
+    const fs::path dataset_dir = temp_dir_ / "colmap_text_no_folder";
+    write_text_file(dataset_dir / "cameras.txt", "1 PINHOLE 1 1 1 1 0.5 0.5\n");
+    write_text_file(dataset_dir / "images.txt", "1 1 0 0 0 0 0 0 1 missing.png\n");
+
+    auto result = lfs::io::validate_colmap_dataset_layout(dataset_dir, "images");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, lfs::io::ErrorCode::PATH_NOT_FOUND);
+}
+
+TEST_F(MissingDatasetImagesTest, ColmapTextResolvesMissingAgainstLoadResolutionFolder) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required";
+    }
+
+    const fs::path dataset_dir = temp_dir_ / "colmap_text_images_2";
+    write_colmap_text(dataset_dir, {"present.png", "missing.png"});
+    // images_2 applies scale_factor 2; 1x1 cameras become 0x0 and are skipped.
+    write_text_file(dataset_dir / "cameras.txt", "1 PINHOLE 2 2 1 1 0.5 0.5\n");
+    write_png(dataset_dir / "images" / "present.png");
+    write_png(dataset_dir / "images" / "missing.png");
+    write_png(dataset_dir / "images_2" / "present.png");
+
+    auto full_result = lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images");
+    ASSERT_TRUE(full_result.has_value()) << full_result.error().format();
+    EXPECT_TRUE(full_result->warnings.empty());
+
+    auto scaled_result = lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images_2");
+    ASSERT_TRUE(scaled_result.has_value()) << scaled_result.error().format();
+    const auto& cameras = std::get<0>(scaled_result->value);
+    std::vector<std::string> warnings;
+    for (const auto& diagnostic : scaled_result->warnings) {
+        warnings.push_back(diagnostic.message);
+    }
+    ASSERT_NO_FATAL_FAILURE(expect_partial_missing(cameras, warnings, "missing.png", "present.png"));
+}
+
+TEST_F(MissingDatasetImagesTest, ColmapBinaryLoadsWhenOneImageIsMissing) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required";
+    }
+
+    const fs::path dataset_dir = temp_dir_ / "colmap_bin";
+    write_colmap_binary(dataset_dir, {"present.png", "missing.png"});
+    write_png(dataset_dir / "images" / "present.png");
+
+    auto result = lfs::io::read_colmap_cameras_and_images(dataset_dir, "images");
+    ASSERT_TRUE(result.has_value()) << result.error().format();
+
+    const auto& cameras = std::get<0>(result->value);
+    std::vector<std::string> warnings;
+    for (const auto& diagnostic : result->warnings) {
+        warnings.push_back(diagnostic.message);
+        EXPECT_EQ(diagnostic.code, lfs::ErrorCode::NotFound);
+    }
+    ASSERT_NO_FATAL_FAILURE(expect_partial_missing(cameras, warnings, "missing.png", "present.png"));
+}
+
+TEST_F(MissingDatasetImagesTest, ColmapBinaryAllMissingFails) {
+    const fs::path dataset_dir = temp_dir_ / "colmap_bin_all_missing";
+    write_colmap_binary(dataset_dir, {"missing_a.png", "missing_b.png"});
+
+    auto result = lfs::io::read_colmap_cameras_and_images(dataset_dir, "images");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, lfs::io::ErrorCode::EMPTY_DATASET);
+    EXPECT_NE(result.error().message.find("All 2 dataset image files are missing"), std::string::npos);
+}
+
+TEST_F(MissingDatasetImagesTest, ColmapLoaderReportsMissingSet) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required";
+    }
+
+    const fs::path dataset_dir = temp_dir_ / "colmap_loader";
+    write_colmap_text(dataset_dir, {"present.png", "missing.png"});
+    write_png(dataset_dir / "images" / "present.png");
+
+    lfs::io::ColmapLoader loader;
+    auto result = loader.load(dataset_dir, {});
+    ASSERT_TRUE(result.has_value()) << result.error().format();
+    auto* scene = std::get_if<lfs::io::LoadedScene>(&result->data);
+    ASSERT_NE(scene, nullptr);
+    ASSERT_NO_FATAL_FAILURE(expect_partial_missing(scene->cameras, result->warnings, "missing.png", "present.png"));
+}
+
+TEST_F(MissingDatasetImagesTest, TransformsLoadsWhenOneImageIsMissing) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required";
+    }
+
+    const fs::path dataset_dir = temp_dir_ / "transforms";
+    write_transforms(dataset_dir, {"present.png", "missing.png"});
+    write_png(dataset_dir / "present.png");
+
+    lfs::io::BlenderLoader loader;
+    auto result = loader.load(dataset_dir, {});
+    ASSERT_TRUE(result.has_value()) << result.error().format();
+    auto* scene = std::get_if<lfs::io::LoadedScene>(&result->data);
+    ASSERT_NE(scene, nullptr);
+    ASSERT_NO_FATAL_FAILURE(expect_partial_missing(scene->cameras, result->warnings, "missing.png", "present.png"));
+}
+
+TEST_F(MissingDatasetImagesTest, TransformsAllMissingFails) {
+    const fs::path dataset_dir = temp_dir_ / "transforms_all_missing";
+    write_transforms(dataset_dir, {"missing_a.png", "missing_b.png"});
+
+    lfs::io::BlenderLoader loader;
+    auto result = loader.load(dataset_dir, {});
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, lfs::io::ErrorCode::EMPTY_DATASET);
+    EXPECT_NE(result.error().message.find("All 2 dataset image files are missing"), std::string::npos);
+}
+
+TEST_F(MissingDatasetImagesTest, TransformsValidateOnlyAllMissingFails) {
+    const fs::path dataset_dir = temp_dir_ / "transforms_validate_all_missing";
+    write_transforms(dataset_dir, {"missing_a.png", "missing_b.png"});
+
+    lfs::io::BlenderLoader loader;
+    auto result = loader.load(dataset_dir, {.validate_only = true});
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, lfs::io::ErrorCode::EMPTY_DATASET);
+}
+
+TEST_F(MissingDatasetImagesTest, TransformsRawReaderKeepsMissingCameraRecords) {
+    const fs::path dataset_dir = temp_dir_ / "transforms_raw";
+    write_transforms(dataset_dir, {"present.png", "missing.png"});
+    write_png(dataset_dir / "present.png");
+
+    auto [cameras, center, splits] =
+        lfs::io::read_transforms_cameras_and_images(dataset_dir / "transforms.json", {});
+    (void)center;
+    (void)splits;
+    ASSERT_EQ(cameras.size(), 2u);
+    EXPECT_TRUE(cameras[0]._has_image);
+    EXPECT_FALSE(cameras[1]._has_image);
+    EXPECT_EQ(cameras[1]._image_name, "missing.png");
+}

--- a/tests/test_python_io.cpp
+++ b/tests/test_python_io.cpp
@@ -571,6 +571,7 @@ end_header
 
 TEST_F(PythonIOTest, LoadTransformsDatasetCanBeCancelled) {
     const fs::path dataset_dir = temp_dir / "cancelled_transforms_dataset";
+    write_png(dataset_dir / "frame_0001.png");
     write_text_file(
         dataset_dir / "transforms_train.json",
         R"json({


### PR DESCRIPTION
Deleting or losing a few image files from a dataset made the whole dataset refuse to load (#1713). Now, for COLMAP binary, COLMAP text, and transforms.json alike:

- The dataset loads; cameras with a missing image keep their frustum in the scene with an empty preview.
- Those cameras are left out of training and evaluation - training runs on the images that exist.
- The user sees a warning with the count and example names; the full list goes to the log.
- A dataset with ALL images missing still fails with a clear message instead of starting an empty run.

The missing check respects the resolution folder actually used (images_2 and friends), and the new per-camera flag is separate from the user's own enable/disable toggle so the two can't get conflated.

**Verified:** new per-format tests (12) plus the loader suites (70) and the python tier, and live exactly as specified in the issue: removed ten images from a garden copy - before, the load hard-failed on the first missing file; after, it loads with the warning, shows 185 frustums with the ten empty, and trains on the remaining 175 (checked at iteration 2000+, no crash).

Fixes #1713