### PR TITLE
Fix the histogram icon disappearing after project flows

### DIFF
--- a/src/core/event_bridge/command_center.cpp
+++ b/src/core/event_bridge/command_center.cpp
@@ -78,13 +78,6 @@ namespace lfs::training {
         mutable_fields_.push_back({"shN", CommandTarget::Model, "[N,?]", "Higher-order SH coefficients", true});
     }
 
-    void CommandCenter::apply_training_paused(int iteration) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        snapshot_.iteration = iteration;
-        snapshot_.is_paused = true;
-        snapshot_.is_running = false;
-    }
-
     void CommandCenter::bind_state_events() {
         using lfs::core::events::state::TrainingPaused;
         auto& bridge = lfs::event::EventBridge::instance();
@@ -94,7 +87,10 @@ namespace lfs::training {
         }
         training_paused_handler_id_ = TrainingPaused::when(
             [this](const TrainingPaused& event) {
-                apply_training_paused(event.iteration);
+                std::lock_guard<std::mutex> lock(mutex_);
+                snapshot_.iteration = event.iteration;
+                snapshot_.is_paused = true;
+                snapshot_.is_running = false;
             });
     }
 

--- a/src/training/control/command_api.cpp
+++ b/src/training/control/command_api.cpp
@@ -190,14 +190,23 @@ namespace lfs::training {
         }
     }
 
+    void CommandCenter::reset_snapshot_locked() {
+        snapshot_ = {};
+        pending_commands_.clear();
+        phase_.store(TrainingPhase::Idle, std::memory_order_relaxed);
+    }
+
     void CommandCenter::clear_snapshot(const Trainer* trainer) {
         std::lock_guard<std::mutex> lock(mutex_);
         if (snapshot_.trainer != trainer) {
             return;
         }
-        snapshot_ = {};
-        pending_commands_.clear();
-        phase_.store(TrainingPhase::Idle, std::memory_order_relaxed);
+        reset_snapshot_locked();
+    }
+
+    void CommandCenter::reset_snapshot() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        reset_snapshot_locked();
     }
 
     TrainingSnapshot CommandCenter::snapshot() const {

--- a/src/training/control/command_api.hpp
+++ b/src/training/control/command_api.hpp
@@ -125,9 +125,10 @@ namespace lfs::training {
         void set_phase(TrainingPhase phase);
 
         void update_snapshot(const HookContext& ctx, int max_iterations, bool is_paused, bool is_running, bool stop_requested, TrainingPhase phase);
-        void apply_training_paused(int iteration);
         LFS_BRIDGE_API void bind_state_events();
         void clear_snapshot(const Trainer* trainer);
+        // Drop trainer-owned snapshot fields after teardown (no trainer loaded).
+        void reset_snapshot();
 
         [[nodiscard]] TrainingSnapshot snapshot() const;
         [[nodiscard]] std::vector<LossHistoryPoint> loss_history() const;
@@ -156,6 +157,8 @@ namespace lfs::training {
         static std::expected<void, std::string> apply_clamp(core::Tensor& tensor, const core::Tensor& mask_rows, const std::optional<double>& minv, const std::optional<double>& maxv);
 
         static std::expected<core::Tensor*, std::string> resolve_attribute(lfs::core::SplatData& model, const std::string& name, size_t& row_dim_out);
+
+        void reset_snapshot_locked();
 
         // Registry
         std::vector<OperationInfo> ops_;

--- a/src/visualizer/training/training_manager.cpp
+++ b/src/visualizer/training/training_manager.cpp
@@ -507,6 +507,9 @@ namespace lfs::vis {
         if (completion_reaper_.joinable()) {
             completion_reaper_.join();
         }
+        if (trainer_) {
+            lfs::training::CommandCenter::instance().reset_snapshot();
+        }
     }
 
     void TrainerManager::setTrainer(std::unique_ptr<lfs::training::Trainer> trainer) {
@@ -623,6 +626,9 @@ namespace lfs::vis {
                 return false;
             }
         }
+
+        // Pause events and no-thread stops do not run TrainingEnd's clear_snapshot.
+        lfs::training::CommandCenter::instance().reset_snapshot();
 
         {
             std::lock_guard<std::mutex> lock(trainer_lifetime_mutex_);

--- a/tests/python/test_histogram_panel.py
+++ b/tests/python/test_histogram_panel.py
@@ -179,6 +179,38 @@ def test_histogram_panel_uses_dirty_update_policy(histogram_panel_module):
     assert "update_interval_ms" not in histogram_panel_module.HistogramPanel.__dict__
 
 
+def test_histogram_mode_available_hides_when_paused(histogram_panel_module, monkeypatch):
+    from lfs_plugins import histogram_support as support
+
+    monkeypatch.setattr(
+        support.lf.ui, "get_content_type", lambda: "splat_files", raising=False
+    )
+    monkeypatch.setattr(
+        support.lf.ui, "is_point_cloud_forced", lambda: False, raising=False
+    )
+    monkeypatch.setattr(
+        support,
+        "RuntimeState",
+        SimpleNamespace(trainer_state=SimpleNamespace(value="idle")),
+    )
+
+    paused = SimpleNamespace(
+        has_scene=True,
+        num_gaussians=8,
+        is_training=False,
+        is_paused=True,
+    )
+    reset = SimpleNamespace(
+        has_scene=True,
+        num_gaussians=8,
+        is_training=False,
+        is_paused=False,
+    )
+
+    assert histogram_panel_module.histogram_mode_available(paused) is False
+    assert histogram_panel_module.histogram_mode_available(reset) is True
+
+
 def test_histogram_panel_requests_update_from_reactive_store(histogram_panel_module, monkeypatch):
     module = histogram_panel_module
     signals = SimpleNamespace(

--- a/tests/test_scene_validity.cpp
+++ b/tests/test_scene_validity.cpp
@@ -32,6 +32,7 @@
 #include "training/components/bilateral_grid.hpp"
 #include "training/components/ppisp.hpp"
 #include "training/components/ppisp_file.hpp"
+#include "training/control/command_api.hpp"
 #include "training/optimizer/adam_optimizer.hpp"
 #include "training/trainer.hpp"
 #include "training/training_setup.hpp"
@@ -382,6 +383,43 @@ namespace lfs::python {
 
         lfs::event::EventBridge::instance().unsubscribe(
             typeid(lfs::core::events::state::TrainingCompleted), id);
+    }
+
+    TEST(TrainerConstructionTest, ClearTrainerResetsPausedCommandCenterSnapshot) {
+        core::Scene scene;
+        const core::NodeId cameras = scene.addGroup("Cameras");
+        scene.addCamera("camera.png", cameras, make_test_camera());
+        lfs::vis::TrainerManager manager;
+        manager.setScene(&scene);
+        manager.setTrainer(std::make_unique<training::Trainer>(scene));
+
+        ASSERT_TRUE(transition_trainer_manager_for_test(manager, lfs::vis::TrainingState::Running));
+        ASSERT_TRUE(transition_trainer_manager_for_test(manager, lfs::vis::TrainingState::Paused));
+
+        auto& command_center = lfs::training::CommandCenter::instance();
+        command_center.reset_snapshot();
+        const lfs::training::HookContext context{.iteration = 8200};
+        command_center.update_snapshot(
+            context, 0, true, false, false, lfs::training::TrainingPhase::Idle);
+        {
+            const auto paused = command_center.snapshot();
+            ASSERT_TRUE(paused.is_paused);
+            EXPECT_FALSE(paused.is_running);
+            EXPECT_EQ(paused.iteration, 8200);
+            EXPECT_EQ(paused.trainer, nullptr);
+        }
+
+        ASSERT_TRUE(manager.clearTrainer());
+
+        const auto snapshot = command_center.snapshot();
+        EXPECT_FALSE(snapshot.is_paused);
+        EXPECT_FALSE(snapshot.is_running);
+        EXPECT_FALSE(snapshot.stop_requested);
+        EXPECT_EQ(snapshot.iteration, 0);
+        EXPECT_EQ(snapshot.max_iterations, 0);
+        EXPECT_EQ(snapshot.trainer, nullptr);
+        EXPECT_EQ(snapshot.phase, lfs::training::TrainingPhase::Idle);
+        EXPECT_EQ(manager.getState(), lfs::vis::TrainingState::Idle);
     }
 
     namespace {


### PR DESCRIPTION
After opening a paused project, stopping training, starting a New Project, and dragging in a .ply, the histogram toolbar icon was gone for the rest of the session (#1706).

**Cause:** the snapshot that feeds the Python UI context is only ever written by a live trainer. Tearing the trainer down left the last values latched, so the context kept reporting "paused" with no trainer loaded - and the histogram button hides while paused. Iteration and the other context fields were equally stale for any other consumer.

**Fix:** tearing down the trainer now resets that snapshot to its no-trainer state. One reset helper, called from the single teardown point (plus the destructor path that bypasses it).

**Verified:** new regression test asserting the snapshot clears on teardown (106 tests green in the affected suites plus the python tier), and the issue's exact 11-step flow live, twice: on the old binary the context probe shows is_paused=true and histogram availability false with the icon missing from the toolbar (screenshots); on this branch the same flow shows is_paused=false and availability true.

Fixes #1706