### PR TITLE
Ask to save before a new dataset replaces the open project

### DIFF
--- a/src/core/include/core/events.hpp
+++ b/src/core/include/core/events.hpp
@@ -58,7 +58,7 @@ namespace lfs::core {
             EVENT(ResumeTraining, );
             EVENT(StopTraining, );
             EVENT(ResetTraining, );
-            EVENT(LoadFile, std::filesystem::path path; bool is_dataset; std::filesystem::path output_path = {}; std::filesystem::path init_path = {}; std::string centralize_dataset = {}; std::optional<int> max_width = {}; std::optional<int> min_track_length = {}; bool apply_auto_crop = false;);
+            EVENT(LoadFile, std::filesystem::path path; bool is_dataset; std::filesystem::path output_path = {}; std::filesystem::path init_path = {}; std::string centralize_dataset = {}; std::optional<int> max_width = {}; std::optional<int> min_track_length = {}; bool apply_auto_crop = false; bool stop_training = false;);
             EVENT(LoadCheckpointForTraining, std::filesystem::path checkpoint_path; std::filesystem::path dataset_path; std::filesystem::path output_path;);
             EVENT(ImportColmapCameras, std::filesystem::path sparse_path;);
             EVENT(LoadConfigFile, std::filesystem::path path;);
@@ -66,7 +66,7 @@ namespace lfs::core {
             EVENT(ShowVideoExtractor, std::filesystem::path video_path;);
             EVENT(ShowResumeCheckpointPopup, std::filesystem::path checkpoint_path;);
             EVENT(NewProject, bool discard_changes = false; bool stop_training = false;);
-            EVENT(ProjectSave, );
+            EVENT(ProjectSave, bool regenerate_preview = true;);
             EVENT(ProjectSaveAs, std::filesystem::path path;);
             EVENT(ProjectOpen, std::filesystem::path path; bool discard_changes = false; bool stop_training = false;);
             EVENT(ProjectCompact, );

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -941,14 +941,60 @@ NB_MODULE(lichtfeld, m) {
         },
         nb::arg("discard_changes") = false, nb::arg("stop_training") = false, "Clear all project state and start a new project");
     m.def(
-        "project_save", []() {
+        "project_save",
+        [](const bool wait, const bool regenerate_preview) {
             nb::gil_scoped_release release;
             emit_project_cmd_marshaled(
-                "python.project_save", [] {
-                    lfs::core::events::cmd::ProjectSave{}
+                "python.project_save",
+                [regenerate_preview] {
+                    lfs::core::events::cmd::ProjectSave{
+                        .regenerate_preview =
+                            regenerate_preview}
                         .emit();
                 });
+            auto* const viewer =
+                lfs::python::get_visualizer();
+            if (!viewer) {
+                return false;
+            }
+            const bool started =
+                viewer->consumeProjectSaveAsStarted();
+            if (!started || !wait) {
+                return started;
+            }
+            const lfs::core::TaskContext context{
+                .name = "python.project_save.wait",
+                .domain = lfs::ErrorDomain::Python,
+                .operation_id =
+                    lfs::OperationId::generate(),
+                .site = LFS_SOURCE_SITE_CURRENT(),
+            };
+            if (auto posted =
+                    lfs::vis::post_guarded_and_wait<
+                        void>(
+                        *viewer, context,
+                        [viewer]()
+                            -> lfs::Result<void> {
+                            viewer
+                                ->projectWaitWrite();
+                            return {};
+                        },
+                        python_viewer_shutdown_error());
+                !posted) {
+                throw std::runtime_error(
+                    std::format(
+                        "python.project_save.wait failed: {}",
+                        lfs::format_for_developer(
+                            posted.error())));
+            }
+            auto poll = viewer->projectPollWrite();
+            if (!poll) {
+                return false;
+            }
+            return poll->error.empty();
         },
+        nb::arg("wait") = false,
+        nb::arg("regenerate_preview") = true,
         "Save the active .licht project, prompting for a path when needed");
     m.def(
         "project_save_as",
@@ -1309,7 +1355,8 @@ NB_MODULE(lichtfeld, m) {
            const std::string& centralize_dataset,
            std::optional<int> max_width,
            bool apply_auto_crop,
-           std::optional<int> min_track_length) {
+           std::optional<int> min_track_length,
+           bool stop_training) {
             nb::gil_scoped_release release;
             lfs::core::events::cmd::LoadFile{
                 .path = python_utf8_path(path),
@@ -1319,7 +1366,8 @@ NB_MODULE(lichtfeld, m) {
                 .centralize_dataset = centralize_dataset,
                 .max_width = max_width,
                 .min_track_length = min_track_length,
-                .apply_auto_crop = apply_auto_crop}
+                .apply_auto_crop = apply_auto_crop,
+                .stop_training = stop_training}
                 .emit();
         },
         nb::arg("path"), nb::arg("is_dataset") = false,
@@ -1328,6 +1376,7 @@ NB_MODULE(lichtfeld, m) {
         nb::arg("max_width") = nb::none(),
         nb::arg("apply_auto_crop") = false,
         nb::arg("min_track_length") = nb::none(),
+        nb::arg("stop_training") = false,
         "Load a file (PLY, checkpoint) or dataset into the scene.");
 
     m.def(

--- a/src/python/lfs_plugins/import_panels.py
+++ b/src/python/lfs_plugins/import_panels.py
@@ -272,6 +272,83 @@ def _load_watch_dirs_dialog_state(folder_id: str) -> bool:
     return True
 
 
+def _training_is_active() -> bool:
+    probe = getattr(lf, "is_training_active", None)
+    if not callable(probe):
+        return False
+    try:
+        return bool(probe())
+    except Exception:
+        return False
+
+
+def _project_is_dirty() -> bool:
+    probe = getattr(lf, "project_is_dirty", None)
+    if not callable(probe):
+        return False
+    try:
+        return bool(probe())
+    except Exception:
+        return False
+
+
+def _confirm_stop_training_then(callback) -> None:
+    if not _training_is_active():
+        callback(False)
+        return
+
+    tr = lf.ui.tr
+    yes_label = tr("common.yes")
+    no_label = tr("common.no")
+
+    def _on_result(button):
+        if button == yes_label:
+            callback(True)
+
+    lf.ui.confirm_dialog(
+        tr("project_switch.stop_training_title"),
+        tr("project_switch.stop_training_message"),
+        [yes_label, no_label],
+        _on_result,
+    )
+
+
+def _save_current_project_like_close() -> bool:
+    save = getattr(lf, "project_save", None)
+    if not callable(save):
+        return False
+    try:
+        result = save(True, False)
+    except TypeError:
+        try:
+            result = save()
+        except Exception:
+            return False
+    except Exception:
+        return False
+    return result is not False
+
+
+def _confirm_save_before_dataset_load(on_save, on_discard) -> None:
+    tr = lf.ui.tr
+    save_label = tr("load_dataset_popup.save_and_load")
+    discard_label = tr("load_dataset_popup.load_without_saving")
+    cancel_label = tr("common.cancel")
+
+    def _on_result(button):
+        if button == save_label:
+            on_save()
+        elif button == discard_label:
+            on_discard()
+
+    lf.ui.confirm_dialog(
+        tr("load_dataset_popup.save_title"),
+        tr("load_dataset_popup.save_message"),
+        [save_label, discard_label, cancel_label],
+        _on_result,
+    )
+
+
 def _tr(key: str) -> str:
     return lf.ui.tr(key)
 
@@ -1185,30 +1262,54 @@ class DatasetImportPanel(_ImportDialogPanel):
         init_path = self._init_path.strip()
         ppisp_sidecar_path = self._ppisp_sidecar_path.strip()
         centralize_dataset = self._centralize_dataset
-
-        params = lf.optimization_params()
-        if params and params.has_params():
-            params.ppisp_sidecar_path = ppisp_sidecar_path
-            params.ppisp_freeze_from_sidecar = bool(ppisp_sidecar_path)
-            if ppisp_sidecar_path:
-                params.ppisp = True
-
-        lf.ui.set_panel_enabled(self.id, False)
-        register_catalog_asset_path(dataset_path, is_dataset=True, select=True)
+        output_path = self._output_path.strip()
+        max_width = self._max_width
+        apply_auto_crop = self._apply_auto_crop
+        min_track_length = self._min_track_length
         clear_scene_on_load = self._clear_scene_on_load
-        self._clear_scene_on_load = False
-        if clear_scene_on_load:
-            lf.clear_scene()
-        lf.load_file(
-            dataset_path,
-            is_dataset=True,
-            output_path=self._output_path.strip(),
-            init_path=init_path,
-            centralize_dataset=centralize_dataset,
-            max_width=self._max_width,
-            apply_auto_crop=self._apply_auto_crop,
-            min_track_length=self._min_track_length,
-        )
+
+        def _commit(stop_training: bool) -> None:
+            params = lf.optimization_params()
+            if params and params.has_params():
+                params.ppisp_sidecar_path = ppisp_sidecar_path
+                params.ppisp_freeze_from_sidecar = bool(ppisp_sidecar_path)
+                if ppisp_sidecar_path:
+                    params.ppisp = True
+
+            self._clear_scene_on_load = False
+            lf.ui.set_panel_enabled(self.id, False)
+            register_catalog_asset_path(dataset_path, is_dataset=True, select=True)
+            if clear_scene_on_load:
+                lf.clear_scene()
+            load_kwargs = {
+                "path": dataset_path,
+                "is_dataset": True,
+                "output_path": output_path,
+                "init_path": init_path,
+                "centralize_dataset": centralize_dataset,
+                "max_width": max_width,
+                "apply_auto_crop": apply_auto_crop,
+                "min_track_length": min_track_length,
+            }
+            if stop_training:
+                load_kwargs["stop_training"] = True
+            lf.load_file(**load_kwargs)
+
+        def _save_then_commit(stop_training: bool) -> None:
+            if not _save_current_project_like_close():
+                return
+            _commit(stop_training)
+
+        def _after_stop(stop_training: bool) -> None:
+            if not _project_is_dirty():
+                _commit(stop_training)
+                return
+            _confirm_save_before_dataset_load(
+                lambda: _save_then_commit(stop_training),
+                lambda: _commit(stop_training),
+            )
+
+        _confirm_stop_training_then(_after_stop)
 
     def _on_do_cancel(self, _handle=None, _ev=None, _args=None):
         self._clear_scene_on_load = False

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -902,6 +902,8 @@ namespace lfs::vis::gui {
         cmd::LoadFile::when([this](const auto& cmd) {
             if (!cmd.is_dataset)
                 return;
+            if (viewer_->deferDatasetLoadForTraining(cmd))
+                return;
             const auto* const data_loader = viewer_->getDataLoader();
             if (!data_loader) {
                 LOG_ERROR("LoadFile: no data loader");

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1263,7 +1263,11 @@
     "min_track_length": "Minimale Spurlänge",
     "min_track_length_hint": "Behält Sparse-Punkte, die in mindestens so vielen Bildern beobachtet wurden. 0 deaktiviert die Filterung.",
     "min_track_length_init_warning": "Wird ignoriert, solange Init PLY gesetzt ist.",
-    "apply_auto_crop": "Auto-Zuschnitt anwenden"
+    "apply_auto_crop": "Auto-Zuschnitt anwenden",
+    "save_title": "Projekt speichern?",
+    "save_message": "Aktuelles Projekt speichern, bevor der neue Datensatz geladen wird?",
+    "save_and_load": "Speichern und laden",
+    "load_without_saving": "Laden ohne Speichern"
   },
   "notification": {
     "dropped_not_recognized": "Das abgelegte",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1263,7 +1263,11 @@
     "min_track_length": "Minimum Track Length",
     "min_track_length_hint": "Keeps sparse points observed in at least this many images. 0 disables filtering.",
     "min_track_length_init_warning": "Ignored while Init PLY is set.",
-    "apply_auto_crop": "Apply Auto Crop"
+    "apply_auto_crop": "Apply Auto Crop",
+    "save_title": "Save Project?",
+    "save_message": "Save the current project before loading the new dataset?",
+    "save_and_load": "Save and Load",
+    "load_without_saving": "Load without saving"
   },
   "notification": {
     "dropped_not_recognized": "The dropped",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -1263,7 +1263,11 @@
     "min_track_length": "Longitud mínima de pista",
     "min_track_length_hint": "Conserva los puntos Sparse observados en al menos este número de imágenes. 0 desactiva el filtrado.",
     "min_track_length_init_warning": "Se ignora mientras se haya definido Init PLY.",
-    "apply_auto_crop": "Aplicar Recorte Automático"
+    "apply_auto_crop": "Aplicar Recorte Automático",
+    "save_title": "¿Guardar el proyecto?",
+    "save_message": "¿Guardar el proyecto actual antes de cargar el nuevo dataset?",
+    "save_and_load": "Guardar y cargar",
+    "load_without_saving": "Cargar sin guardar"
   },
   "notification": {
     "dropped_not_recognized": "El elemento soltado",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1264,7 +1264,11 @@
     "min_track_length": "Longueur minimale de piste",
     "min_track_length_hint": "Conserve les points Sparse observés dans au moins ce nombre d'images. 0 désactive le filtrage.",
     "min_track_length_init_warning": "Ignoré lorsqu'un Init PLY est défini.",
-    "apply_auto_crop": "Appliquer le recadrage automatique"
+    "apply_auto_crop": "Appliquer le recadrage automatique",
+    "save_title": "Enregistrer le projet ?",
+    "save_message": "Enregistrer le projet actuel avant de charger le nouveau dataset ?",
+    "save_and_load": "Enregistrer et charger",
+    "load_without_saving": "Charger sans enregistrer"
   },
   "notification": {
     "dropped_not_recognized": "L'élément déposé",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1263,7 +1263,11 @@
     "min_track_length": "Lunghezza minima traccia",
     "min_track_length_hint": "Mantiene i punti sparsi osservati in almeno questo numero di immagini. 0 disattiva il filtro.",
     "min_track_length_init_warning": "Ignorato quando è impostato Init PLY.",
-    "apply_auto_crop": "Applica ritaglio automatico"
+    "apply_auto_crop": "Applica ritaglio automatico",
+    "save_title": "Salvare il progetto?",
+    "save_message": "Salvare il progetto corrente prima di caricare il nuovo dataset?",
+    "save_and_load": "Salva e carica",
+    "load_without_saving": "Carica senza salvare"
   },
   "notification": {
     "dropped_not_recognized": "L'elemento trascinato",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1263,7 +1263,11 @@
     "min_track_length": "最小トラック長",
     "min_track_length_hint": "少なくともこの枚数の画像で観測された Sparse 点を保持します。0 でフィルタリングを無効にします。",
     "min_track_length_init_warning": "初期化 PLY が設定されている間は無視されます。",
-    "apply_auto_crop": "自動クロップを適用"
+    "apply_auto_crop": "自動クロップを適用",
+    "save_title": "プロジェクトを保存しますか？",
+    "save_message": "新しいデータセットを読み込む前に、現在のプロジェクトを保存しますか？",
+    "save_and_load": "保存して読み込む",
+    "load_without_saving": "保存せずに読み込む"
   },
   "notification": {
     "dropped_not_recognized": "ドロップされた",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1263,7 +1263,11 @@
     "min_track_length": "최소 트랙 길이",
     "min_track_length_hint": "최소 이 수의 이미지에서 관측된 Sparse 점을 유지합니다. 0이면 필터링을 비활성화합니다.",
     "min_track_length_init_warning": "초기화 PLY가 설정된 동안에는 무시됩니다.",
-    "apply_auto_crop": "자동 자르기 적용"
+    "apply_auto_crop": "자동 자르기 적용",
+    "save_title": "프로젝트를 저장할까요?",
+    "save_message": "새 데이터셋을 불러오기 전에 현재 프로젝트를 저장할까요?",
+    "save_and_load": "저장하고 불러오기",
+    "load_without_saving": "저장하지 않고 불러오기"
   },
   "notification": {
     "dropped_not_recognized": "드롭된",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1263,7 +1263,11 @@
     "min_track_length": "Minimale spoorlengte",
     "min_track_length_hint": "Behoudt Sparse-punten die in minstens zoveel afbeeldingen zijn waargenomen. 0 schakelt de filtering uit.",
     "min_track_length_init_warning": "Wordt genegeerd zolang Init PLY is ingesteld.",
-    "apply_auto_crop": "Automatisch bijsnijden toepassen"
+    "apply_auto_crop": "Automatisch bijsnijden toepassen",
+    "save_title": "Project opslaan?",
+    "save_message": "Het huidige project opslaan voordat de nieuwe dataset wordt geladen?",
+    "save_and_load": "Opslaan en laden",
+    "load_without_saving": "Laden zonder opslaan"
   },
   "notification": {
     "dropped_not_recognized": "Het gesleepte",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1263,7 +1263,11 @@
     "min_track_length": "Minimalna długość ścieżki",
     "min_track_length_hint": "Zachowuje punkty Sparse obserwowane w co najmniej tylu obrazach. 0 wyłącza filtrowanie.",
     "min_track_length_init_warning": "Ignorowane, gdy ustawiono Init PLY.",
-    "apply_auto_crop": "Zastosuj automatyczne kadrowanie"
+    "apply_auto_crop": "Zastosuj automatyczne kadrowanie",
+    "save_title": "Zapisać projekt?",
+    "save_message": "Zapisać bieżący projekt przed wczytaniem nowego zbioru danych?",
+    "save_and_load": "Zapisz i wczytaj",
+    "load_without_saving": "Wczytaj bez zapisywania"
   },
   "notification": {
     "dropped_not_recognized": "Upuszczony",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -1263,7 +1263,11 @@
     "min_track_length": "最小轨迹长度",
     "min_track_length_hint": "保留至少在这么多图像中观测到的 Sparse 点。0 可禁用筛选。",
     "min_track_length_init_warning": "设置初始 PLY 时将被忽略。",
-    "apply_auto_crop": "应用自动裁剪"
+    "apply_auto_crop": "应用自动裁剪",
+    "save_title": "保存项目？",
+    "save_message": "加载新数据集前要保存当前项目吗？",
+    "save_and_load": "保存并加载",
+    "load_without_saving": "不保存并加载"
   },
   "notification": {
     "dropped_not_recognized": "拖放的",

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -1296,6 +1296,10 @@ namespace lfs::vis {
                 command.stop_training);
         });
 
+        cmd::LoadFile::when([this](const auto& command) {
+            deferDatasetLoadForTraining(command);
+        });
+
         const auto publish_project_error =
             [](std::string action, const auto& value,
                const char* operation) {
@@ -1347,7 +1351,8 @@ namespace lfs::vis {
             });
 
         cmd::ProjectSave::when(
-            [this, publish_project_error](const auto&) {
+            [this, publish_project_error](const auto& command) {
+                project_save_as_started_ = false;
                 auto has_path = projectHasPath();
                 if (!has_path) {
                     publish_project_error(
@@ -1363,22 +1368,29 @@ namespace lfs::vis {
                         return;
                     }
                     if (auto saved =
-                            projectSaveAsFromDialog(path, true);
+                            projectSaveAsFromDialog(
+                                path,
+                                command.regenerate_preview);
                         !saved) {
                         publish_project_error(
                             "Save Project",
                             saved.error(),
                             gui::error_op::kSave);
+                        return;
                     }
+                    project_save_as_started_ = true;
                     return;
                 }
-                if (auto saved = projectSave(true);
+                if (auto saved = projectSave(
+                        command.regenerate_preview);
                     !saved) {
                     publish_project_error(
                         "Save Project",
                         saved.error(),
                         gui::error_op::kSave);
+                    return;
                 }
+                project_save_as_started_ = true;
             });
 
         cmd::ProjectSaveAs::when(
@@ -2771,6 +2783,28 @@ namespace lfs::vis {
         }
     }
 
+    bool VisualizerImpl::deferDatasetLoadForTraining(
+        const lfs::core::events::cmd::LoadFile& cmd) {
+        if (!cmd.is_dataset || !cmd.stop_training) {
+            return false;
+        }
+        if (pending_training_action_ ==
+                PendingTrainingAction::CloseSave ||
+            pending_training_action_ ==
+                PendingTrainingAction::CloseDiscard) {
+            return true;
+        }
+        if (!shouldDeferProjectSwitchForTraining()) {
+            return false;
+        }
+        pending_load_file_ = cmd;
+        pending_load_file_->stop_training = false;
+        pending_training_action_ =
+            PendingTrainingAction::LoadDataset;
+        requestStopThenPendingAction();
+        return true;
+    }
+
     void VisualizerImpl::handleNewProject(
         const ProjectSwitchDisposition disposition,
         const bool stop_training) {
@@ -2996,6 +3030,7 @@ namespace lfs::vis {
         pending_open_path_.clear();
         pending_open_disposition_ =
             ProjectSwitchDisposition::RequireClean;
+        pending_load_file_.reset();
         gui_session_restore_.clear();
         pending_project_tools_restore_.reset();
         hydration_terminal_restore_ticket_.reset();
@@ -3619,6 +3654,17 @@ namespace lfs::vis {
             if (!path.empty()) {
                 performOpenProject(
                     path, disposition);
+            }
+            break;
+        }
+        case PendingTrainingAction::LoadDataset: {
+            auto command =
+                std::exchange(
+                    pending_load_file_,
+                    std::nullopt);
+            if (command) {
+                command->stop_training = false;
+                command->emit();
             }
             break;
         }

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -97,6 +97,11 @@ namespace lfs::vis {
         lfs::Result<void> projectSaveAsExplicit(
             const std::filesystem::path& path,
             bool regenerate_preview = true);
+        // Interactive dataset LoadFile with stop_training: wait for the
+        // trainer, then replay the load. Returns true when the caller
+        // must not start the import now.
+        bool deferDatasetLoadForTraining(
+            const lfs::core::events::cmd::LoadFile& cmd);
         lfs::Result<ProjectOpenOutcome>
         projectOpen(
             const std::filesystem::path& path,
@@ -324,6 +329,8 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_NewProjectDiscardDeletesAutosaveSidecar_Test;
         friend class VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
         friend class VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
+        friend class VisualizerImplResetTest_LoadFileStopTrainingDefersDatasetLoad_Test;
+        friend class VisualizerImplResetTest_LoadDatasetApiDoesNotDeferOrPrompt_Test;
 
         // Allow ToolContext to access GUI manager for logging
         friend class ToolContext;
@@ -516,6 +523,7 @@ namespace lfs::vis {
             Reset,
             NewProject,
             OpenProject,
+            LoadDataset,
             CloseSave,
             CloseDiscard,
         };
@@ -528,6 +536,8 @@ namespace lfs::vis {
         ProjectSwitchDisposition
             pending_open_disposition_ =
                 ProjectSwitchDisposition::RequireClean;
+        std::optional<lfs::core::events::cmd::LoadFile>
+            pending_load_file_;
         int pending_training_completion_refresh_frames_ = 0;
         bool gui_frame_rendered_ = false;
         bool startup_plugin_preload_started_ = false;

--- a/tests/python/test_import_dialog_panels.py
+++ b/tests/python/test_import_dialog_panels.py
@@ -48,6 +48,11 @@ def _install_lf_stub(monkeypatch, tmp_path):
         load_file_calls=[],
         load_checkpoint_calls=[],
         clear_scene_calls=0,
+        confirm_dialogs=[],
+        project_save_calls=[],
+        dirty=False,
+        training_active=False,
+        project_save_result=True,
         dataset_browse_path=str(tmp_path / "dataset_browse"),
         output_browse_path=str(tmp_path / "output_browse"),
         init_browse_path=str(tmp_path / "seed.ply"),
@@ -69,19 +74,28 @@ def _install_lf_stub(monkeypatch, tmp_path):
         centralize_dataset="off",
         max_width=None,
         min_track_length=None,
+        stop_training=False,
         **_kwargs,
     ):
-        state.load_file_calls.append(
-            {
-                "path": path,
-                "is_dataset": is_dataset,
-                "output_path": output_path,
-                "init_path": init_path,
-                "centralize_dataset": centralize_dataset,
-                "max_width": max_width,
-                "min_track_length": min_track_length,
-            }
-        )
+        recorded = {
+            "path": path,
+            "is_dataset": is_dataset,
+            "output_path": output_path,
+            "init_path": init_path,
+            "centralize_dataset": centralize_dataset,
+            "max_width": max_width,
+            "min_track_length": min_track_length,
+        }
+        if stop_training:
+            recorded["stop_training"] = True
+        state.load_file_calls.append(recorded)
+
+    def _confirm_dialog(title, message, buttons, callback=None):
+        state.confirm_dialogs.append((title, message, buttons, callback))
+
+    def _project_save(*args, **kwargs):
+        state.project_save_calls.append((args, kwargs))
+        return state.project_save_result
 
     lf_stub = ModuleType("lichtfeld")
     lf_stub.log = SimpleNamespace(
@@ -97,10 +111,14 @@ def _install_lf_stub(monkeypatch, tmp_path):
         set_save_asset_callback=lambda _callback: None,
         open_dataset_folder_dialog=lambda: state.output_browse_path,
         open_ply_file_dialog=lambda _start_dir="": state.init_browse_path,
+        confirm_dialog=_confirm_dialog,
     )
     lf_stub.detect_dataset_info = lambda path: state.dataset_infos[str(path)]
     lf_stub.is_dataset_path = lambda path: str(path) in state.dataset_infos
     lf_stub.optimization_params = lambda: None
+    lf_stub.project_is_dirty = lambda: state.dirty
+    lf_stub.is_training_active = lambda: state.training_active
+    lf_stub.project_save = _project_save
     lf_stub.clear_scene = lambda: setattr(
         state,
         "clear_scene_calls",
@@ -245,6 +263,164 @@ def test_dataset_import_panel_show_and_load(import_dialog_module):
         }
     ]
     assert state.panel_enabled_calls[-1] == ("lfs.dataset_import", False)
+    assert state.confirm_dialogs == []
+
+
+def test_dataset_import_dirty_project_prompts_before_load(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+    state.dirty = True
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+    panel._on_do_load()
+
+    assert state.load_file_calls == []
+    assert state.panel_enabled_calls[-1] == ("lfs.dataset_import", True)
+    assert len(state.confirm_dialogs) == 1
+    title, message, buttons, callback = state.confirm_dialogs[0]
+    assert title == "load_dataset_popup.save_title"
+    assert message == "load_dataset_popup.save_message"
+    assert buttons == [
+        "load_dataset_popup.save_and_load",
+        "load_dataset_popup.load_without_saving",
+        "common.cancel",
+    ]
+    assert callback is not None
+
+
+def test_dataset_import_save_and_load_saves_then_loads(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+    state.dirty = True
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+    panel._on_do_load()
+    _title, _message, _buttons, callback = state.confirm_dialogs[0]
+    callback("load_dataset_popup.save_and_load")
+
+    assert state.project_save_calls == [((True, False), {})]
+    assert len(state.load_file_calls) == 1
+    assert state.load_file_calls[0]["path"] == str(state.dataset_info.base_path)
+    assert state.load_file_calls[0]["is_dataset"] is True
+    assert "stop_training" not in state.load_file_calls[0]
+    assert state.panel_enabled_calls[-1] == ("lfs.dataset_import", False)
+
+
+def test_dataset_import_load_without_saving_skips_save(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+    state.dirty = True
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+    panel._on_do_load()
+    _title, _message, _buttons, callback = state.confirm_dialogs[0]
+    callback("load_dataset_popup.load_without_saving")
+
+    assert state.project_save_calls == []
+    assert len(state.load_file_calls) == 1
+    assert state.load_file_calls[0]["path"] == str(state.dataset_info.base_path)
+    assert state.panel_enabled_calls[-1] == ("lfs.dataset_import", False)
+
+
+def test_dataset_import_cancel_leaves_project_untouched(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+    state.dirty = True
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+    panel._on_do_load()
+    _title, _message, _buttons, callback = state.confirm_dialogs[0]
+    callback("common.cancel")
+
+    assert state.project_save_calls == []
+    assert state.load_file_calls == []
+    assert state.panel_enabled_calls[-1] == ("lfs.dataset_import", True)
+
+
+def test_dataset_import_failed_save_cancels_load(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+    state.dirty = True
+    state.project_save_result = False
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+    panel._on_do_load()
+    _title, _message, _buttons, callback = state.confirm_dialogs[0]
+    callback("load_dataset_popup.save_and_load")
+
+    assert state.project_save_calls == [((True, False), {})]
+    assert state.load_file_calls == []
+    assert state.panel_enabled_calls[-1] == ("lfs.dataset_import", True)
+
+
+def test_dataset_import_training_prompts_stop_before_save(import_dialog_module):
+    module, state = import_dialog_module
+    panel = module.DatasetImportPanel()
+    panel._handle = _HandleStub()
+    state.dirty = True
+    state.training_active = True
+
+    assert panel.show(str(state.dataset_info.base_path)) is True
+    panel._on_do_load()
+
+    assert state.load_file_calls == []
+    assert len(state.confirm_dialogs) == 1
+    title, message, buttons, stop_callback = state.confirm_dialogs[0]
+    assert title == "project_switch.stop_training_title"
+    assert message == "project_switch.stop_training_message"
+    assert buttons == ["common.yes", "common.no"]
+
+    stop_callback("common.no")
+    assert state.load_file_calls == []
+    assert state.project_save_calls == []
+    assert len(state.confirm_dialogs) == 1
+
+    stop_callback("common.yes")
+    assert len(state.confirm_dialogs) == 2
+    save_title, _save_message, save_buttons, save_callback = state.confirm_dialogs[1]
+    assert save_title == "load_dataset_popup.save_title"
+    assert save_buttons[0] == "load_dataset_popup.save_and_load"
+
+    save_callback("load_dataset_popup.load_without_saving")
+    assert state.project_save_calls == []
+    assert state.load_file_calls == [
+        {
+            "path": str(state.dataset_info.base_path),
+            "is_dataset": True,
+            "output_path": str(Path(state.dataset_info.base_path) / "output"),
+            "init_path": "",
+            "centralize_dataset": "off",
+            "max_width": 3840,
+            "min_track_length": 0,
+            "stop_training": True,
+        }
+    ]
+
+
+def test_dataset_import_load_file_direct_skips_prompt(import_dialog_module):
+    module, state = import_dialog_module
+    state.dirty = True
+    state.training_active = True
+
+    module.lf.load_file("/mcp/dataset", is_dataset=True)
+
+    assert state.confirm_dialogs == []
+    assert state.load_file_calls == [
+        {
+            "path": "/mcp/dataset",
+            "is_dataset": True,
+            "output_path": "",
+            "init_path": "",
+            "centralize_dataset": "off",
+            "max_width": None,
+            "min_track_length": None,
+        }
+    ]
 
 
 def test_dataset_import_panel_can_clear_scene_on_confirm(import_dialog_module):

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -2817,6 +2817,141 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
+           LoadFileStopTrainingDefersDatasetLoad) {
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_TRUE(arm_running_trainer(viewer));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Keep until dataset load"),
+                lfs::core::NULL_NODE);
+
+            bool stop_prompted = false;
+            bool switch_prompted = false;
+            lfs::core::events::cmd::
+                ShowStopTrainingConfirmation::
+                    when([&](const auto&) {
+                        stop_prompted = true;
+                    });
+            lfs::core::events::cmd::
+                ShowProjectSwitchConfirmation::
+                    when([&](const auto&) {
+                        switch_prompted = true;
+                    });
+
+            const auto dataset_path =
+                temporary_.path / "deferred-dataset";
+            lfs::core::events::cmd::LoadFile{
+                .path = dataset_path,
+                .is_dataset = true}
+                .emit();
+            EXPECT_EQ(
+                viewer.pending_training_action_,
+                VisualizerImpl::PendingTrainingAction::
+                    None);
+
+            lfs::core::events::cmd::LoadFile{
+                .path = dataset_path,
+                .is_dataset = true,
+                .stop_training = true}
+                .emit();
+
+            EXPECT_FALSE(stop_prompted);
+            EXPECT_FALSE(switch_prompted);
+            EXPECT_EQ(
+                viewer.pending_training_action_,
+                VisualizerImpl::PendingTrainingAction::
+                    LoadDataset);
+            ASSERT_TRUE(viewer.pending_load_file_);
+            EXPECT_EQ(
+                viewer.pending_load_file_->path,
+                dataset_path);
+            EXPECT_FALSE(
+                viewer.pending_load_file_
+                    ->stop_training);
+            EXPECT_NE(
+                viewer.getScene().getNode(
+                    "Keep until dataset load"),
+                nullptr);
+
+            auto* const gui = viewer.getGuiManager();
+            ASSERT_NE(gui, nullptr);
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    gui->asyncTasks()
+                        .pollImportCompletion();
+                    return viewer.pending_training_action_ ==
+                               VisualizerImpl::PendingTrainingAction::
+                                   None &&
+                           !viewer.pending_load_file_ &&
+                           !viewer.getTrainerManager()
+                                ->isTrainingActive() &&
+                           !viewer.getTrainerManager()
+                                ->isCompletionPending() &&
+                           !viewer.jobs().anyRunning(
+                               JobType::Import);
+                }));
+            EXPECT_EQ(
+                gui->asyncTasks().getImportPath(),
+                dataset_path.filename().string());
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           LoadDatasetApiDoesNotDeferOrPrompt) {
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            ASSERT_TRUE(arm_running_trainer(viewer));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Keep on mcp load"),
+                lfs::core::NULL_NODE);
+
+            bool stop_prompted = false;
+            bool switch_prompted = false;
+            lfs::core::events::cmd::
+                ShowStopTrainingConfirmation::
+                    when([&](const auto&) {
+                        stop_prompted = true;
+                    });
+            lfs::core::events::cmd::
+                ShowProjectSwitchConfirmation::
+                    when([&](const auto&) {
+                        switch_prompted = true;
+                    });
+
+            const auto blocked = viewer.loadDataset(
+                temporary_.path / "mcp-dataset");
+            ASSERT_FALSE(blocked);
+            EXPECT_FALSE(stop_prompted);
+            EXPECT_FALSE(switch_prompted);
+            EXPECT_EQ(
+                viewer.pending_training_action_,
+                VisualizerImpl::PendingTrainingAction::
+                    None);
+            EXPECT_FALSE(viewer.pending_load_file_);
+            EXPECT_NE(
+                viewer.getScene().getNode(
+                    "Keep on mcp load"),
+                nullptr);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
            ProjectOpenApiWhileTrainingStillErrors) {
         const auto& temporary = temporary_.path;
         const auto project_path =


### PR DESCRIPTION
Dragging or importing a new dataset over an unsaved project silently threw the project away (#1717, test-plan case LICHT021). The import panel's Load now asks first: Save and Load / Load without saving / Cancel - same behavior family as the app-exit prompt, untitled projects included (they get the native Save As dialog). Clean projects and scripted loads (MCP, headless, project restore) are unchanged - no prompt.

Bonus fix found while wiring it: dataset import also bypassed the stop-training question from #1688 and could fail into a cleared scene during a run; the import commit now chains stop-then-load the same way New Project does.

**Verified:** new C++ and python regression tests (103 + 44 green in the touched suites, all ten locales updated), plus live click-through on screen: dirty project -> Load shows the three-button prompt (screenshot); Cancel changes nothing; Load without saving proceeds and writes nothing; a clean project loads with no prompt. The Save-and-Load dialog chain is covered by the python tests.

Fixes #1717