### PR TITLE
Crash recovery for unsaved sessions, with a clearer dialog that remembers Skip

### DIFF
--- a/src/core/include/core/user_paths.hpp
+++ b/src/core/include/core/user_paths.hpp
@@ -89,6 +89,8 @@ namespace lfs::core {
         [[nodiscard]] std::filesystem::path presetDir() const;
         [[nodiscard]] std::filesystem::path assetLibraryDir() const;
         [[nodiscard]] std::filesystem::path backupDir() const;
+        /** App-private crash-recovery files: `<root>/recovery`. */
+        [[nodiscard]] std::filesystem::path recoveryDir() const;
         [[nodiscard]] std::filesystem::path mcpLogDir() const;
         /** Append one complete JSONL record to an MCP session log below logs/mcp. */
         [[nodiscard]] lfs::Status

--- a/src/core/user_paths.cpp
+++ b/src/core/user_paths.cpp
@@ -346,7 +346,8 @@ namespace lfs::core {
     lfs::Status UserPaths::ensureDirectories() const {
         const std::filesystem::path directories[] = {
             config_dir_, data_dir_, cache_dir_, log_dir_, plugin_dir_, venv_dir_,
-            keymapDir(), presetDir(), assetLibraryDir(), backupDir()};
+            keymapDir(), presetDir(), assetLibraryDir(), backupDir(),
+            recoveryDir()};
         for (const auto& directory : directories) {
             std::error_code error;
             std::filesystem::create_directories(directory, error);
@@ -413,6 +414,9 @@ namespace lfs::core {
     std::filesystem::path UserPaths::presetDir() const { return data_dir_ / "presets"; }
     std::filesystem::path UserPaths::assetLibraryDir() const { return data_dir_ / "asset_library"; }
     std::filesystem::path UserPaths::backupDir() const { return data_dir_ / "backups"; }
+    std::filesystem::path UserPaths::recoveryDir() const {
+        return config_dir_.parent_path() / "recovery";
+    }
     std::filesystem::path UserPaths::mcpLogDir() const { return log_dir_ / "mcp"; }
     lfs::Status UserPaths::appendMcpLogLine(
         const std::filesystem::path& filename, const std::string& line) const {

--- a/src/io/include/io/project_document.hpp
+++ b/src/io/include/io/project_document.hpp
@@ -103,6 +103,9 @@ namespace lfs::io::project {
         // Terminal training writes wait out a transient in-process lock
         // holder instead of dropping the generation.
         std::chrono::milliseconds writer_lock_wait{0};
+        // Untitled crash-protection writes a complete master without binding
+        // the live document to that app-private path.
+        bool leave_unbound = false;
     };
 
     struct ProjectDocumentAutosaveOptions {
@@ -196,6 +199,8 @@ namespace lfs::io::project {
 
         [[nodiscard]] const std::optional<std::filesystem::path>&
         source_path() const noexcept;
+        // Keep the source reader for lazy payloads, but report no user path.
+        void forget_source_path() noexcept;
         [[nodiscard]] const ProjectReader* source_reader() const noexcept;
         [[nodiscard]] std::optional<lfs::core::Uuid>
         source_commit_uuid() const noexcept;

--- a/src/io/include/io/project_recovery.hpp
+++ b/src/io/include/io/project_recovery.hpp
@@ -32,6 +32,9 @@ namespace lfs::io::project {
             selected_path;
         std::uint64_t autosave_sequence = 0;
         lfs::core::Uuid snapshot_uuid;
+        lfs::core::Uuid commit_uuid;
+        std::uint64_t wallclock_unix_ns = 0;
+        bool untitled_scratch = false;
         std::vector<std::filesystem::path>
             deleted_paths;
         std::vector<std::string> diagnostics;
@@ -113,6 +116,16 @@ namespace lfs::io::project {
         const std::filesystem::path& master_path);
 
     [[nodiscard]] LFS_IO_API std::filesystem::path
+    scratch_autosave_path(
+        const std::filesystem::path& recovery_directory,
+        const lfs::core::Uuid& session_uuid);
+
+    [[nodiscard]] LFS_IO_API bool
+    is_scratch_autosave_path(
+        const std::filesystem::path& path,
+        const std::filesystem::path& recovery_directory);
+
+    [[nodiscard]] LFS_IO_API std::filesystem::path
     recovery_session_temp_path(
         const std::filesystem::path& master_path);
 
@@ -154,6 +167,20 @@ namespace lfs::io::project {
     LFS_IO_API void sweep_stale_licht_artifacts_for_known_masters(
         const std::vector<std::filesystem::path>& master_paths);
 
+    // Startup hygiene for app-private untitled crash files. A live session's
+    // writer lock is left untouched. Unreadable or empty unlocked files
+    // (no scene nodes and no payload chapters) are removed. Valid unlocked
+    // files with recoverable content are left for `scan_scratch_autosaves`.
+    LFS_IO_API void sweep_stale_scratch_autosaves(
+        const std::filesystem::path& recovery_directory);
+
+    // Best-effort delete of one scratch autosave and its `.lock` sibling.
+    // No-ops when the path is empty. Fails with Unavailable when the file
+    // is still held by a live session.
+    [[nodiscard]] LFS_IO_API lfs::Result<void>
+    remove_scratch_autosave(
+        const std::filesystem::path& scratch_path);
+
     // Acquires the master writer lock, validates every stable/temp/backup
     // sidecar candidate, deletes stale candidates, and applies the exact
     // §9 predicate. It also removes orphan compaction temps after the master
@@ -163,6 +190,23 @@ namespace lfs::io::project {
         inspect_autosave_recovery(
             const std::filesystem::path& master_path,
             const ReaderOptions& master_reader_options = {});
+
+    // Lock-probes `scratch_path`. Unavailable means a live session still
+    // holds it. A complete master with recoverable content becomes Offer
+    // with untitled_scratch. An empty master (no scene nodes / no payload
+    // chapters) is Invalid so sweep/scan can delete it.
+    [[nodiscard]] LFS_IO_API
+        lfs::Result<RecoveryInspection>
+        inspect_scratch_autosave(
+            const std::filesystem::path& scratch_path);
+
+    // Directory scan used at startup: MRU does not know these files.
+    // Live (locked) files are omitted. Invalid or empty unlocked files
+    // are deleted as part of the scan.
+    [[nodiscard]] LFS_IO_API
+        std::vector<RecoveryInspection>
+        scan_scratch_autosaves(
+            const std::filesystem::path& recovery_directory);
 
     // Acquires and retains the original master's OS writer lock, then
     // revalidates the selected complete bound sidecar under that lock.

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -1960,6 +1960,12 @@ namespace lfs::io::project {
         return impl_->source_path;
     }
 
+    void ProjectDocument::forget_source_path() noexcept {
+        if (impl_) {
+            impl_->source_path.reset();
+        }
+    }
+
     const ProjectReader* ProjectDocument::source_reader() const noexcept {
         return impl_->source_reader.get();
     }
@@ -3344,12 +3350,16 @@ namespace lfs::io::project {
         }
         writer.reset();
 
-        if (is_autosave) {
+        if (is_autosave || options.leave_unbound) {
+            ReaderOptions reader_options;
+            if (impl_->source_reader) {
+                reader_options =
+                    impl_->source_reader
+                        ->reader_options();
+            }
             auto reader =
                 ProjectReader::open(
-                    *normalized,
-                    impl_->source_reader
-                        ->reader_options());
+                    *normalized, reader_options);
             if (!reader) {
                 return std::move(reader).error();
             }

--- a/src/io/project/project_recovery.cpp
+++ b/src/io/project/project_recovery.cpp
@@ -6,6 +6,8 @@
 #include "io/project_recovery.hpp"
 
 #include "core/logger.hpp"
+#include "core/uuid.hpp"
+#include "io/project_chapters.hpp"
 #include "project_container_internal.hpp"
 #include "project_recovery_internal.hpp"
 
@@ -65,6 +67,49 @@ namespace lfs::io::project {
                     code, path, std::move(message),
                     std::move(detail), field);
             }
+        }
+
+        [[nodiscard]] bool is_scratch_payload_fourcc(
+            const Fourcc fourcc) {
+            return fourcc == FOURCC_SPLT ||
+                   fourcc == FOURCC_PCLD ||
+                   fourcc == FOURCC_MESH ||
+                   fourcc == FOURCC_CKPT ||
+                   fourcc == FOURCC_PPIS;
+        }
+
+        // Same content bar as New Project's blank untitled
+        // session: no scene nodes and no payload chapters.
+        [[nodiscard]] bool
+        scratch_has_recoverable_content(
+            const ProjectReader& reader) {
+            for (const auto& chunk : reader.chunks()) {
+                if (!chunk.is_live()) {
+                    continue;
+                }
+                if (is_scratch_payload_fourcc(
+                        chunk.key.fourcc)) {
+                    return true;
+                }
+                if (chunk.key.fourcc != FOURCC_SCNG) {
+                    continue;
+                }
+                auto bytes = reader.read_chunk(chunk);
+                if (!bytes) {
+                    continue;
+                }
+                auto chapter =
+                    SceneGraphChapter::from_bytes(
+                        *bytes);
+                if (!chapter) {
+                    continue;
+                }
+                auto nodes = chapter->nodes();
+                if (nodes && !nodes->empty()) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         [[nodiscard]] bool
@@ -765,6 +810,41 @@ namespace lfs::io::project {
         return result;
     }
 
+    std::filesystem::path scratch_autosave_path(
+        const std::filesystem::path& recovery_directory,
+        const lfs::core::Uuid& session_uuid) {
+        return recovery_directory /
+               (session_uuid.to_string() + ".licht");
+    }
+
+    bool is_scratch_autosave_path(
+        const std::filesystem::path& path,
+        const std::filesystem::path& recovery_directory) {
+        if (path.empty() || recovery_directory.empty()) {
+            return false;
+        }
+        const auto normalized_path =
+            path.lexically_normal();
+        const auto normalized_dir =
+            recovery_directory.lexically_normal();
+        if (normalized_path.parent_path() !=
+            normalized_dir) {
+            return false;
+        }
+        const auto name =
+            normalized_path.filename().string();
+        constexpr std::string_view extension = ".licht";
+        if (name.size() <= extension.size() ||
+            !name.ends_with(extension)) {
+            return false;
+        }
+        const auto stem = name.substr(
+            0, name.size() - extension.size());
+        const auto uuid =
+            lfs::core::Uuid::from_string(stem);
+        return uuid && !uuid->is_nil();
+    }
+
     std::filesystem::path recovery_session_temp_path(
         const std::filesystem::path& master_path) {
         return master_path.parent_path() /
@@ -1065,6 +1145,200 @@ namespace lfs::io::project {
         }
     }
 
+    lfs::Result<void> remove_scratch_autosave(
+        const std::filesystem::path& scratch_path) {
+        if (scratch_path.empty()) {
+            return {};
+        }
+        {
+            auto lock =
+                detail::WriterLock::acquire(
+                    scratch_path);
+            if (!lock) {
+                return lfs::Result<void>::failure(
+                    std::move(lock).error());
+            }
+            if (auto removed = remove_path(scratch_path);
+                !removed) {
+                return removed;
+            }
+        }
+        auto lock_path = scratch_path;
+        lock_path += ".lock";
+        std::error_code ignored;
+        std::filesystem::remove(lock_path, ignored);
+        return {};
+    }
+
+    lfs::Result<RecoveryInspection>
+    inspect_scratch_autosave(
+        const std::filesystem::path& scratch_path) {
+        auto lock =
+            detail::WriterLock::acquire(scratch_path);
+        if (!lock) {
+            return std::move(lock).error();
+        }
+        RecoveryInspection result;
+        result.untitled_scratch = true;
+        ReaderOptions inspection_options;
+        inspection_options
+            .allow_unsupported_inspection = true;
+        auto reader = ProjectReader::open(
+            scratch_path, inspection_options);
+        if (!reader) {
+            result.disposition =
+                RecoveryDisposition::Invalid;
+            result.diagnostics.push_back(
+                std::format(
+                    "{}: {}",
+                    scratch_path.filename().string(),
+                    lfs::format_for_developer(
+                        reader.error())));
+            return result;
+        }
+        if (reader->superblock().role !=
+            ContainerRole::Master) {
+            result.disposition =
+                RecoveryDisposition::Invalid;
+            result.diagnostics.push_back(
+                std::format(
+                    "{}: scratch recovery requires a complete master",
+                    scratch_path.filename().string()));
+            return result;
+        }
+        if (auto verified = reader->verify_all();
+            !verified) {
+            result.disposition =
+                RecoveryDisposition::Invalid;
+            result.diagnostics.push_back(
+                std::format(
+                    "{}: {}",
+                    scratch_path.filename().string(),
+                    lfs::format_for_developer(
+                        verified.error())));
+            return result;
+        }
+        if (!scratch_has_recoverable_content(*reader)) {
+            result.disposition =
+                RecoveryDisposition::Invalid;
+            result.diagnostics.push_back(
+                std::format(
+                    "{}: empty untitled scratch has no recoverable content",
+                    scratch_path.filename().string()));
+            return result;
+        }
+        result.disposition = RecoveryDisposition::Offer;
+        result.selected_path =
+            scratch_path.lexically_normal();
+        result.autosave_sequence =
+            reader->superblock().autosave_sequence;
+        result.snapshot_uuid =
+            reader->commit().snapshot_uuid;
+        result.commit_uuid =
+            reader->commit().commit_uuid;
+        result.wallclock_unix_ns =
+            reader->commit().wallclock_unix_ns;
+        return result;
+    }
+
+    void sweep_stale_scratch_autosaves(
+        const std::filesystem::path& recovery_directory) {
+        if (recovery_directory.empty()) {
+            return;
+        }
+        std::error_code error;
+        if (!std::filesystem::is_directory(
+                recovery_directory, error) ||
+            error) {
+            return;
+        }
+        std::vector<std::filesystem::path> candidates;
+        for (std::filesystem::directory_iterator
+                 iterator(recovery_directory, error),
+             end;
+             !error && iterator != end;
+             iterator.increment(error)) {
+            std::error_code type_error;
+            if (!iterator->is_regular_file(type_error) ||
+                type_error) {
+                continue;
+            }
+            const auto entry = iterator->path();
+            const auto filename =
+                entry.filename().string();
+            if (filename.ends_with(".lock")) {
+                continue;
+            }
+            candidates.push_back(entry);
+        }
+        for (const auto& entry : candidates) {
+            if (!is_scratch_autosave_path(
+                    entry, recovery_directory)) {
+                try_remove_unheld_artifact(entry, true);
+                continue;
+            }
+            auto inspection =
+                inspect_scratch_autosave(entry);
+            if (!inspection) {
+                if (inspection.error().code() ==
+                    lfs::ErrorCode::Unavailable) {
+                    continue;
+                }
+                try_remove_unheld_artifact(entry, true);
+                continue;
+            }
+            if (inspection->disposition ==
+                RecoveryDisposition::Invalid) {
+                try_remove_unheld_artifact(entry, true);
+            }
+        }
+    }
+
+    std::vector<RecoveryInspection>
+    scan_scratch_autosaves(
+        const std::filesystem::path& recovery_directory) {
+        std::vector<RecoveryInspection> result;
+        if (recovery_directory.empty()) {
+            return result;
+        }
+        std::error_code error;
+        if (!std::filesystem::is_directory(
+                recovery_directory, error) ||
+            error) {
+            return result;
+        }
+        for (std::filesystem::directory_iterator
+                 iterator(recovery_directory, error),
+             end;
+             !error && iterator != end;
+             iterator.increment(error)) {
+            std::error_code type_error;
+            if (!iterator->is_regular_file(type_error) ||
+                type_error) {
+                continue;
+            }
+            const auto entry = iterator->path();
+            if (!is_scratch_autosave_path(
+                    entry, recovery_directory)) {
+                continue;
+            }
+            auto inspection =
+                inspect_scratch_autosave(entry);
+            if (!inspection) {
+                continue;
+            }
+            if (inspection->disposition ==
+                RecoveryDisposition::Offer) {
+                result.push_back(std::move(*inspection));
+            } else if (
+                inspection->disposition ==
+                RecoveryDisposition::Invalid) {
+                try_remove_unheld_artifact(entry, true);
+            }
+        }
+        return result;
+    }
+
     namespace detail {
 
         lfs::Result<std::vector<ValidBoundAutosave>>
@@ -1133,6 +1407,7 @@ namespace lfs::io::project {
             std::uint64_t sequence = 0;
             std::uint64_t wallclock_unix_ns = 0;
             lfs::core::Uuid snapshot_uuid;
+            lfs::core::Uuid commit_uuid;
         };
         std::vector<Valid> valid;
         const auto stable =
@@ -1221,6 +1496,8 @@ namespace lfs::io::project {
                 .snapshot_uuid =
                     sidecar->superblock()
                         .sidecar_snapshot_uuid,
+                .commit_uuid =
+                    sidecar->commit().commit_uuid,
             });
         }
 
@@ -1288,6 +1565,10 @@ namespace lfs::io::project {
         result.selected_path = winner.path;
         result.autosave_sequence = winner.sequence;
         result.snapshot_uuid = winner.snapshot_uuid;
+        result.commit_uuid = winner.commit_uuid;
+        result.wallclock_unix_ns =
+            winner.wallclock_unix_ns;
+        result.untitled_scratch = false;
         return result;
     }
 

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -60,6 +60,9 @@ namespace lfs::vis {
     class VisualizerImplResetTest_RecoveredCloseDeletesTempAfterDocumentTeardown_Test;
     class VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
     class VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
+    class VisualizerImplResetTest_RecoveryDismissalPersistsAndNewerCandidateIsOffered_Test;
+    class VisualizerImplResetTest_StartupOffersScratchRecoveryAsUntitled_Test;
+    class VisualizerImplResetTest_StartupSweepsEmptyScratchAndDoesNotOffer_Test;
 
     namespace gui {
         class NativeScenePanel;
@@ -202,6 +205,9 @@ namespace lfs::vis {
             friend class lfs::vis::VisualizerImplResetTest_RecoveredCloseDeletesTempAfterDocumentTeardown_Test;
             friend class lfs::vis::VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
             friend class lfs::vis::VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
+            friend class lfs::vis::VisualizerImplResetTest_RecoveryDismissalPersistsAndNewerCandidateIsOffered_Test;
+            friend class lfs::vis::VisualizerImplResetTest_StartupOffersScratchRecoveryAsUntitled_Test;
+            friend class lfs::vis::VisualizerImplResetTest_StartupSweepsEmptyScratchAndDoesNotOffer_Test;
             [[nodiscard]] bool isPositionOverRightPanelResizeEdge(double x, double y) const;
             [[nodiscard]] VulkanViewportPassParams buildVulkanViewportParams(VkExtent2D extent,
                                                                              std::size_t frame_slot) const;

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -2398,6 +2398,14 @@
       "message": "Das Projektmodell ist zum Anzeigen verfügbar, aber das Training konnte nicht fortgesetzt werden. Prüfen Sie den Dataset-Pfad und die Protokolle."
     }
   },
+  "recovery": {
+    "crash_title": "LichtFeld Studio wurde unerwartet beendet",
+    "body": "Es wurde eine Wiederherstellungsdatei für {} gefunden. (gespeichert {})",
+    "unsaved_session": "eine ungespeicherte Sitzung",
+    "recover": "Wiederherstellen",
+    "open_saved": "Gespeicherte Datei öffnen",
+    "skip": "Überspringen und neu erstellen"
+  },
   "startup_recent": {
     "title": "Zuletzt verwendete Projekte",
     "open": "Öffnen",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -2398,6 +2398,14 @@
       "message": "The project model is available for viewing, but training could not be resumed. Check the dataset path and logs."
     }
   },
+  "recovery": {
+    "crash_title": "LichtFeld Studio closed unexpectedly",
+    "body": "A recovery file was found for {}. (saved {})",
+    "unsaved_session": "an unsaved session",
+    "recover": "Recover",
+    "open_saved": "Open saved",
+    "skip": "Skip and create new"
+  },
   "startup_recent": {
     "title": "Recent Projects",
     "open": "Open",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -2398,6 +2398,14 @@
       "message": "El modelo del proyecto está disponible para visualización, pero no se pudo reanudar el entrenamiento. Compruebe la ruta del conjunto de datos y los registros."
     }
   },
+  "recovery": {
+    "crash_title": "LichtFeld Studio se cerró inesperadamente",
+    "body": "Se encontró un archivo de recuperación para {}. (guardado {})",
+    "unsaved_session": "una sesión sin guardar",
+    "recover": "Recuperar",
+    "open_saved": "Abrir guardado",
+    "skip": "Omitir y crear nuevo"
+  },
   "startup_recent": {
     "title": "Proyectos recientes",
     "open": "Abrir",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -2399,6 +2399,14 @@
       "message": "Le modèle du projet est disponible pour la visualisation, mais l'entraînement n'a pas pu être repris. Vérifiez le chemin du jeu de données et les journaux."
     }
   },
+  "recovery": {
+    "crash_title": "LichtFeld Studio s'est fermé de façon inattendue",
+    "body": "Un fichier de récupération a été trouvé pour {}. (enregistré {})",
+    "unsaved_session": "une session non enregistrée",
+    "recover": "Récupérer",
+    "open_saved": "Ouvrir l'enregistrement",
+    "skip": "Ignorer et créer un nouveau"
+  },
   "startup_recent": {
     "title": "Projets récents",
     "open": "Ouvrir",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -2398,6 +2398,14 @@
       "message": "Il modello del progetto è disponibile per la visualizzazione, ma non è stato possibile riprendere l'addestramento. Controlla il percorso del dataset e i log."
     }
   },
+  "recovery": {
+    "crash_title": "LichtFeld Studio si è chiuso inaspettatamente",
+    "body": "È stato trovato un file di ripristino per {}. (salvato {})",
+    "unsaved_session": "una sessione non salvata",
+    "recover": "Ripristina",
+    "open_saved": "Apri salvato",
+    "skip": "Salta e crea nuovo"
+  },
   "startup_recent": {
     "title": "Progetti recenti",
     "open": "Apri",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -2398,6 +2398,14 @@
       "message": "プロジェクトモデルは表示できますが、学習を再開できませんでした。データセットのパスとログを確認してください。"
     }
   },
+  "recovery": {
+    "crash_title": "LichtFeld Studio が予期せず終了しました",
+    "body": "{} の復旧ファイルが見つかりました。（保存日時 {}）",
+    "unsaved_session": "未保存のセッション",
+    "recover": "復旧",
+    "open_saved": "保存済みを開く",
+    "skip": "スキップして新規作成"
+  },
   "startup_recent": {
     "title": "最近のプロジェクト",
     "open": "開く",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -2398,6 +2398,14 @@
       "message": "프로젝트 모델은 볼 수 있지만 학습을 재개할 수 없습니다. 데이터세트 경로와 로그를 확인하세요."
     }
   },
+  "recovery": {
+    "crash_title": "LichtFeld Studio가 예기치 않게 종료되었습니다",
+    "body": "{}의 복구 파일이 있습니다. (저장 시각 {})",
+    "unsaved_session": "저장되지 않은 세션",
+    "recover": "복구",
+    "open_saved": "저장된 파일 열기",
+    "skip": "건너뛰고 새로 만들기"
+  },
   "startup_recent": {
     "title": "최근 프로젝트",
     "open": "열기",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -2398,6 +2398,14 @@
       "message": "Het projectmodel is beschikbaar om te bekijken, maar training kon niet worden hervat. Controleer het datasetpad en de logboeken."
     }
   },
+  "recovery": {
+    "crash_title": "LichtFeld Studio is onverwacht afgesloten",
+    "body": "Er is een herstelbestand gevonden voor {}. (opgeslagen {})",
+    "unsaved_session": "een niet-opgeslagen sessie",
+    "recover": "Herstellen",
+    "open_saved": "Opgeslagen openen",
+    "skip": "Overslaan en nieuw maken"
+  },
   "startup_recent": {
     "title": "Recente projecten",
     "open": "Openen",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -2398,6 +2398,14 @@
       "message": "Model projektu jest dostępny do podglądu, ale nie udało się wznowić treningu. Sprawdź ścieżkę zestawu danych i logi."
     }
   },
+  "recovery": {
+    "crash_title": "LichtFeld Studio zostało nieoczekiwanie zamknięte",
+    "body": "Znaleziono plik odzyskiwania dla {}. (zapisano {})",
+    "unsaved_session": "niezapisana sesja",
+    "recover": "Odzyskaj",
+    "open_saved": "Otwórz zapisany",
+    "skip": "Pomiń i utwórz nowy"
+  },
   "startup_recent": {
     "title": "Ostatnie projekty",
     "open": "Otwórz",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -2398,6 +2398,14 @@
       "message": "项目模型可供查看，但无法恢复训练。请检查数据集路径和日志。"
     }
   },
+  "recovery": {
+    "crash_title": "LichtFeld Studio 意外关闭",
+    "body": "找到了 {} 的恢复文件。（保存于 {}）",
+    "unsaved_session": "未保存的会话",
+    "recover": "恢复",
+    "open_saved": "打开已保存",
+    "skip": "跳过并新建"
+  },
   "startup_recent": {
     "title": "最近的项目",
     "open": "打开",

--- a/src/visualizer/gui/rml_modal_overlay.hpp
+++ b/src/visualizer/gui/rml_modal_overlay.hpp
@@ -31,6 +31,9 @@ namespace lfs::vis {
     class VisualizerImplResetTest_RecoveredCloseDeletesTempAfterDocumentTeardown_Test;
     class VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
     class VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
+    class VisualizerImplResetTest_RecoveryDismissalPersistsAndNewerCandidateIsOffered_Test;
+    class VisualizerImplResetTest_StartupOffersScratchRecoveryAsUntitled_Test;
+    class VisualizerImplResetTest_StartupSweepsEmptyScratchAndDoesNotOffer_Test;
 } // namespace lfs::vis
 namespace lfs::vis::gui {
 
@@ -68,6 +71,9 @@ namespace lfs::vis::gui {
         friend class lfs::vis::VisualizerImplResetTest_RecoveredCloseDeletesTempAfterDocumentTeardown_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
+        friend class lfs::vis::VisualizerImplResetTest_RecoveryDismissalPersistsAndNewerCandidateIsOffered_Test;
+        friend class lfs::vis::VisualizerImplResetTest_StartupOffersScratchRecoveryAsUntitled_Test;
+        friend class lfs::vis::VisualizerImplResetTest_StartupSweepsEmptyScratchAndDoesNotOffer_Test;
         void initContext();
         bool syncTheme();
         void cacheElements();

--- a/src/visualizer/gui/string_keys.hpp
+++ b/src/visualizer/gui/string_keys.hpp
@@ -784,6 +784,15 @@ namespace lichtfeld::Strings {
         inline constexpr const char* EDIT_DELTA = "sequencer.edit_delta";
     } // namespace Sequencer
 
+    namespace Recovery {
+        inline constexpr const char* CRASH_TITLE = "recovery.crash_title";
+        inline constexpr const char* BODY = "recovery.body";
+        inline constexpr const char* UNSAVED_SESSION = "recovery.unsaved_session";
+        inline constexpr const char* RECOVER = "recovery.recover";
+        inline constexpr const char* OPEN_SAVED = "recovery.open_saved";
+        inline constexpr const char* SKIP = "recovery.skip";
+    } // namespace Recovery
+
     namespace DatasetRelocate {
         inline constexpr const char* TITLE = "dataset_relocate.title";
         inline constexpr const char* MESSAGE = "dataset_relocate.message";

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -24,6 +24,7 @@
 #include "gui/utils/native_file_dialog.hpp"
 #include "io/filesystem_utils.hpp"
 #include "io/loader.hpp"
+#include "io/project_container.hpp"
 #include "io/project_path.hpp"
 #include "io/project_recovery.hpp"
 #include "io/scene_chapter_adapter.hpp"
@@ -47,7 +48,9 @@
 #include <array>
 #include <cctype>
 #include <chrono>
+#include <cstddef>
 #include <cstring>
+#include <ctime>
 #include <cwctype>
 #include <exception>
 #include <filesystem>
@@ -1024,6 +1027,63 @@ namespace lfs::vis::project {
             return false;
         }
 
+        [[nodiscard]] bool hasUntitledCrashDirtyChapters(
+            const lfs::io::project::ProjectDocument&
+                document) {
+            for (const auto& chapter :
+                 document.dirty_chapters()) {
+                if (!isSessionSoftDirtyChapter(chapter)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        [[nodiscard]] std::string formatRecoverySavedTime(
+            const std::uint64_t wallclock_unix_ns,
+            const std::filesystem::path& path) {
+            std::time_t unix_seconds = 0;
+            if (wallclock_unix_ns != 0) {
+                unix_seconds = static_cast<std::time_t>(
+                    wallclock_unix_ns / 1'000'000'000ull);
+            } else {
+                std::error_code error;
+                const auto file_time =
+                    std::filesystem::last_write_time(
+                        path, error);
+                if (!error) {
+                    const auto system_time =
+                        std::chrono::clock_cast<
+                            std::chrono::system_clock>(
+                            file_time);
+                    unix_seconds =
+                        std::chrono::system_clock::to_time_t(
+                            system_time);
+                }
+            }
+            if (unix_seconds == 0) {
+                return "—";
+            }
+            std::tm local{};
+#ifdef _WIN32
+            if (localtime_s(&local, &unix_seconds) != 0) {
+                return "—";
+            }
+#else
+            if (localtime_r(&unix_seconds, &local) ==
+                nullptr) {
+                return "—";
+            }
+#endif
+            char buffer[32];
+            if (std::strftime(
+                    buffer, sizeof(buffer),
+                    "%Y-%m-%d %H:%M", &local) == 0) {
+                return "—";
+            }
+            return buffer;
+        }
+
         [[nodiscard]] bool hasSessionSoftDirtyChapters(
             const lfs::io::project::ProjectDocument&
                 document) {
@@ -1253,6 +1313,48 @@ namespace lfs::vis::project {
                     });
                 }
             }
+            const auto dismissed =
+                json.find("dismissed_recovery");
+            if (dismissed != json.end()) {
+                if (!dismissed->is_array()) {
+                    return fail<ProjectLifecycleSettings>(
+                        lfs::ErrorCode::DataLoss,
+                        "The dismissed-recovery list is invalid.",
+                        "dismissed_recovery must be an array",
+                        "settings.dismissed_recovery");
+                }
+                for (const auto& entry : *dismissed) {
+                    if (!entry.is_object()) {
+                        continue;
+                    }
+                    const auto path_text =
+                        entry.value(
+                            "sidecar_path",
+                            std::string{});
+                    if (path_text.empty()) {
+                        continue;
+                    }
+                    DismissedRecoveryEntry item;
+                    item.sidecar_path =
+                        lfs::core::utf8_to_path(
+                            path_text)
+                            .lexically_normal();
+                    item.autosave_sequence =
+                        entry.value(
+                            "autosave_sequence",
+                            std::uint64_t{0});
+                    if (const auto commit =
+                            lfs::core::Uuid::from_string(
+                                entry.value(
+                                    "commit_uuid",
+                                    std::string{}));
+                        commit) {
+                        item.commit_uuid = *commit;
+                    }
+                    settings.dismissed_recovery.push_back(
+                        std::move(item));
+                }
+            }
             return settings;
         } catch (const std::exception& exception) {
             // LFS-CENSUS-OK(empty-catch): JSON exceptions are converted to a typed settings error.
@@ -1278,6 +1380,19 @@ namespace lfs::vis::project {
                          entry.last_known_path)},
                 });
             }
+            Json dismissed = Json::array();
+            for (const auto& entry :
+                 settings.dismissed_recovery) {
+                dismissed.push_back({
+                    {"sidecar_path",
+                     lfs::core::path_to_utf8(
+                         entry.sidecar_path)},
+                    {"autosave_sequence",
+                     entry.autosave_sequence},
+                    {"commit_uuid",
+                     entry.commit_uuid.to_string()},
+                });
+            }
             const Json json{
                 {"version", 2},
                 {"reopen_last_project",
@@ -1294,6 +1409,8 @@ namespace lfs::vis::project {
                  settings
                      .compaction_idle_seconds},
                 {"mru", std::move(entries)},
+                {"dismissed_recovery",
+                 std::move(dismissed)},
             };
             if (const auto written = lfs::core::writeTextFileAtomically(
                     path, json.dump(2) + '\n');
@@ -1418,6 +1535,16 @@ namespace lfs::vis::project {
               }
               return paths->projectLifecycleFile();
           }()),
+          recovery_directory_([&settings_path] {
+              if (settings_path)
+                  return settings_path->parent_path() /
+                         "recovery";
+              const auto paths = lfs::core::UserPaths::resolve();
+              if (!paths) {
+                  return std::filesystem::path{};
+              }
+              return paths->recoveryDir();
+          }()),
           settings_persistence_enabled_(
               !lfs::core::environment::flag("LFS_SAFE_MODE", false) &&
               !settings_path_.empty()) {
@@ -1481,6 +1608,9 @@ namespace lfs::vis::project {
         if (discard_master) {
             removeDiscardedAutosaveArtifacts(
                 *discard_master);
+        }
+        if (close_discard_requested_) {
+            removeScratchAutosave();
         }
     }
 
@@ -2157,6 +2287,31 @@ namespace lfs::vis::project {
         if (project_write_thread_.joinable()) {
             project_write_thread_.request_stop();
         }
+    }
+
+    lfs::Result<void>
+    ProjectLifecycle::
+        waitOutBackgroundAutosaveForExplicitSave() {
+        if (!viewer_.jobs().anyRunning(
+                JobType::ProjectWrite)) {
+            return {};
+        }
+        if (project_write_purpose_ !=
+                ProjectWritePurpose::Autosave &&
+            project_write_purpose_ !=
+                ProjectWritePurpose::
+                    TrainingAutosave) {
+            return fail<void>(
+                lfs::ErrorCode::FailedPrecondition,
+                "A project write is already in progress.",
+                "Manual save, autosave, and compaction share one exclusive job slot",
+                "project.job");
+        }
+        // Autosave occupies the exclusive ProjectWrite
+        // slot. Join and settle it so a user Save / Save
+        // As never loses the slot to a background write.
+        joinPendingWrite();
+        return {};
     }
 
     void ProjectLifecycle::cleanupRecoverySession() {
@@ -2870,10 +3025,11 @@ namespace lfs::vis::project {
 
     lfs::Result<void>
     ProjectLifecycle::startAutosave() {
-        if (!document_ ||
-            !document_->source_path()) {
+        if (!document_) {
             return {};
         }
+        const bool untitled =
+            !document_->source_path();
         if (viewer_.jobs().anyRunning(
                 JobType::ProjectWrite)) {
             return {};
@@ -2883,7 +3039,8 @@ namespace lfs::vis::project {
             trainer->get_project_snapshot_metrics()
                 .writer_in_flight) {
             // Sidecar create requires the on-disk master
-            // commit to match the held source UUID.return {};
+            // commit to match the held source UUID.
+            return {};
         }
         if (auto adopted =
                 adoptSettledTrainerPublishOntoCurrentMaster();
@@ -2894,6 +3051,11 @@ namespace lfs::vis::project {
             std::memory_order_acquire);
         if (hydration != Hydration::Empty &&
             hydration != Hydration::Complete) {
+            return {};
+        }
+        if (untitled && isBlankUntitledSession()) {
+            last_autosave_at_ =
+                std::chrono::steady_clock::now();
             return {};
         }
 
@@ -2912,7 +3074,17 @@ namespace lfs::vis::project {
             !synchronized) {
             return synchronized;
         }
-        if (!hasHardDirtyChapters(*document_)) {
+        const bool untitled_crash_dirty =
+            untitled &&
+            (hasUntitledCrashDirtyChapters(
+                 *document_) ||
+             scene_dirty_.load(
+                 std::memory_order_acquire) ||
+             payload_dirty_.load(
+                 std::memory_order_acquire));
+        if (untitled ? !untitled_crash_dirty
+                     : !hasHardDirtyChapters(
+                           *document_)) {
             last_autosave_at_ =
                 std::chrono::steady_clock::now();
             return {};
@@ -2920,6 +3092,53 @@ namespace lfs::vis::project {
         if (training) {
             LOG_INFO(
                 "Training-time autosave is light-only (no checkpoint capture)");
+        }
+
+        const auto sequence =
+            autosave_sequence_ + 1;
+        const auto dirty_epoch =
+            document_->dirty_epoch();
+        const auto scene_serial =
+            scene_mutation_serial_.load(
+                std::memory_order_acquire);
+
+        if (untitled) {
+            if (auto locked = lockScratchAutosave();
+                !locked) {
+                return locked;
+            }
+            lfs::io::project::
+                ProjectDocumentSaveOptions options;
+            options.commit.kind =
+                lfs::io::project::CommitKind::
+                    Explicit;
+            options.commit.commit_uuid =
+                lfs::core::generate_uuid_v4();
+            options.file_uuid =
+                lfs::core::generate_uuid_v4();
+            options.index_compression =
+                lfs::io::project::
+                    IndexCompression::Zstd;
+            options.disk_reserve_bytes =
+                64ull * 1024 * 1024;
+            options.allow_existing_destination_replacement =
+                true;
+            options.leave_unbound = true;
+            options.writer_lock_lease = scratch_lock_;
+            auto started = startDocumentWrite(
+                ProjectWritePurpose::Autosave,
+                document_, *scratch_autosave_path_,
+                std::move(options));
+            if (!started) {
+                return started;
+            }
+            project_write_autosave_sequence_ =
+                sequence;
+            project_write_dirty_epoch_ =
+                dirty_epoch;
+            project_write_scene_serial_ =
+                scene_serial;
+            return {};
         }
 
         const auto base_commit_uuid =
@@ -2944,13 +3163,6 @@ namespace lfs::vis::project {
                     : "The master path disappeared after the project was opened",
                 "project.source_path");
         }
-        const auto sequence =
-            autosave_sequence_ + 1;
-        const auto dirty_epoch =
-            document_->dirty_epoch();
-        const auto scene_serial =
-            scene_mutation_serial_.load(
-                std::memory_order_acquire);
         const auto sidecar =
             lfs::io::project::
                 autosave_sidecar_path(
@@ -3344,6 +3556,7 @@ namespace lfs::vis::project {
                     developerError(
                         removed.error());
             }
+            removeScratchAutosave();
             declined_recovery_.reset();
             if (!cleanup_warning.empty()) {
                 LOG_WARN(
@@ -3591,6 +3804,9 @@ namespace lfs::vis::project {
                 JobType::ProjectWrite)) {
             return;
         }
+        if (isBlankUntitledSession()) {
+            return;
+        }
         const auto now =
             std::chrono::steady_clock::now();
         const bool training =
@@ -3622,8 +3838,7 @@ namespace lfs::vis::project {
             }
             return;
         }
-        if (!document_->source_path() ||
-            recovered_master_path_) {
+        if (recovered_master_path_) {
             return;
         }
         const auto scene_serial =
@@ -4672,13 +4887,10 @@ namespace lfs::vis::project {
                 "Only one project save may run at a time",
                 "project.save");
         }
-        if (viewer_.jobs().anyRunning(
-                JobType::ProjectWrite)) {
-            return fail<void>(
-                lfs::ErrorCode::FailedPrecondition,
-                "A project write is already in progress.",
-                "Manual save, autosave, and compaction share one exclusive job slot",
-                "project.job");
+        if (auto waited =
+                waitOutBackgroundAutosaveForExplicitSave();
+            !waited) {
+            return waited;
         }
         if (auto adopted =
                 adoptCompletedTrainingSnapshot();
@@ -4809,13 +5021,10 @@ namespace lfs::vis::project {
                 "Only one project save may run at a time",
                 "project.save");
         }
-        if (viewer_.jobs().anyRunning(
-                JobType::ProjectWrite)) {
-            return fail<void>(
-                lfs::ErrorCode::FailedPrecondition,
-                "A project write is already in progress.",
-                "Manual save, autosave, and compaction share one exclusive job slot",
-                "project.job");
+        if (auto waited =
+                waitOutBackgroundAutosaveForExplicitSave();
+            !waited) {
+            return waited;
         }
         if (auto adopted =
                 adoptCompletedTrainingSnapshot();
@@ -5004,10 +5213,17 @@ namespace lfs::vis::project {
         }
         const auto normalized_at =
             std::chrono::steady_clock::now();
+        const bool opening_scratch =
+            lfs::io::project::is_scratch_autosave_path(
+                *normalized, recovery_directory_);
         auto inspection =
-            lfs::io::project::
-                inspect_autosave_recovery(
-                    *normalized);
+            opening_scratch
+                ? lfs::io::project::
+                      inspect_scratch_autosave(
+                          *normalized)
+                : lfs::io::project::
+                      inspect_autosave_recovery(
+                          *normalized);
         if (!inspection) {
             return std::move(inspection).error();
         }
@@ -5024,18 +5240,40 @@ namespace lfs::vis::project {
                 lfs::io::project::
                     RecoveryDisposition::Offer &&
             inspection->selected_path) {
+            RecoveryCandidate candidate{
+                .master_path =
+                    opening_scratch
+                        ? std::filesystem::path{}
+                        : *normalized,
+                .selected_path =
+                    inspection->selected_path
+                        ->lexically_normal(),
+                .autosave_sequence =
+                    inspection->autosave_sequence,
+                .commit_uuid =
+                    inspection->commit_uuid,
+                .snapshot_uuid =
+                    inspection->snapshot_uuid,
+                .wallclock_unix_ns =
+                    inspection->wallclock_unix_ns,
+                .untitled_scratch = opening_scratch ||
+                                    inspection
+                                        ->untitled_scratch,
+            };
             const DeclinedRecoveryIdentity
                 offered_identity{
                     .sidecar_path =
-                        inspection->selected_path
-                            ->lexically_normal(),
+                        candidate.selected_path,
                     .autosave_sequence =
-                        inspection->autosave_sequence,
-                    .snapshot_uuid =
-                        inspection->snapshot_uuid,
+                        candidate.autosave_sequence,
+                    .commit_uuid =
+                        candidate.commit_uuid,
                 };
-            if (declined_recovery_ ==
-                offered_identity) {
+            if (isRecoveryDismissed(
+                    offered_identity)) {
+                if (candidate.untitled_scratch) {
+                    return ProjectOpenOutcome::Opened;
+                }
                 auto opened = openMaster(
                     *normalized, disposition);
                 if (!opened) {
@@ -5056,7 +5294,8 @@ namespace lfs::vis::project {
                     : (document_
                            ? document_->source_path()
                            : std::nullopt);
-            if (disposition ==
+            if (!candidate.untitled_scratch &&
+                disposition ==
                     ProjectSwitchDisposition::
                         DiscardChanges &&
                 current_master &&
@@ -5079,85 +5318,10 @@ namespace lfs::vis::project {
                     "Headless project resume performs recovery automatically",
                     "project.recovery");
             }
-            recovery_prompt_pending_ = true;
-            const auto master =
-                *normalized;
-            const auto sidecar =
-                *inspection->selected_path;
-            const auto prompt_epoch =
-                epoch_.load(std::memory_order_acquire);
-            const auto prompt_generation =
-                ++recovery_prompt_generation_;
-            lfs::core::ModalRequest request;
-            request.title =
-                "Recover Autosaved Project?";
-            request.body_rml =
-                "<p>A newer autosaved state is available for this project.</p>"
-                "<p>Recover it, or open the last explicitly saved state.</p>";
-            request.style =
-                lfs::core::ModalStyle::Warning;
-            request.width_dp = 500;
-            request.buttons = {
-                {"Recover", "primary"},
-                {"Open Saved", "secondary"},
-            };
-            request.on_result =
-                [this, master, sidecar,
-                 offered_identity,
-                 disposition, prompt_epoch,
-                 prompt_generation](
-                    const lfs::core::
-                        ModalResult& result) {
-                    if (epoch_.load(
-                            std::memory_order_acquire) !=
-                            prompt_epoch ||
-                        recovery_prompt_generation_ !=
-                            prompt_generation) {
-                        return;
-                    }
-                    recovery_prompt_pending_ =
-                        false;
-                    lfs::Result<void> opened;
-                    if (result.button_label ==
-                        "Recover") {
-                        opened = openRecovered(
-                            master, sidecar,
-                            disposition);
-                    } else {
-                        declined_recovery_ =
-                            offered_identity;
-                        opened = openMaster(
-                            master, disposition);
-                    }
-                    if (!opened) {
-                        LOG_ERROR(
-                            "Recovery decision failed: {}",
-                            developerError(
-                                opened.error()));
-                        publishProjectToast(
-                            opened.error(),
-                            gui::error_op::kOpenProject);
-                    }
-                };
-            request.on_cancel =
-                [this,
-                 previous_autosave_sequence,
-                 prompt_epoch,
-                 prompt_generation] {
-                    if (epoch_.load(
-                            std::memory_order_acquire) !=
-                            prompt_epoch ||
-                        recovery_prompt_generation_ !=
-                            prompt_generation) {
-                        return;
-                    }
-                    recovery_prompt_pending_ =
-                        false;
-                    autosave_sequence_ =
-                        previous_autosave_sequence;
-                };
-            gui->enqueueModal(
-                std::move(request));
+            enqueueRecoveryPrompt(
+                std::move(candidate),
+                disposition,
+                previous_autosave_sequence);
             return ProjectOpenOutcome::
                 RecoveryPromptPending;
         }
@@ -5461,7 +5625,11 @@ namespace lfs::vis::project {
                 std::memory_order_acquire);
         const auto shell_selected_nodes =
             selectedNodeUuids(viewer_);
-        {
+        const bool opened_scratch =
+            lfs::io::project::is_scratch_autosave_path(
+                *normalized, recovery_directory_);
+        if (!opened_scratch) {
+            removeScratchAutosave();
             const std::lock_guard lock(
                 settings_mutex_);
             rememberProject(
@@ -5469,11 +5637,13 @@ namespace lfs::vis::project {
                 candidate->project_uuid(),
                 *normalized);
         }
-        if (auto persisted = persistSettings();
-            !persisted) {
-            LOG_WARN(
-                "Project opened, but MRU settings failed: {}",
-                developerError(persisted.error()));
+        if (!opened_scratch) {
+            if (auto persisted = persistSettings();
+                !persisted) {
+                LOG_WARN(
+                    "Project opened, but MRU settings failed: {}",
+                    developerError(persisted.error()));
+            }
         }
         const auto lifecycle_installed_at =
             std::chrono::steady_clock::now();
@@ -6045,6 +6215,7 @@ namespace lfs::vis::project {
             removeDiscardedAutosaveArtifacts(
                 *discard_master);
         }
+        removeScratchAutosave();
         adopted_training_snapshot_count_ = 0;
         application_close_pending_ = false;
         suppress_training_adoption_ = false;
@@ -6129,20 +6300,7 @@ namespace lfs::vis::project {
                  ->isPausedAtCheckpointBaseline()) {
             return true;
         }
-        const auto* manager =
-            viewer_.getSceneManager();
-        const bool blank_untitled =
-            !document_->source_path() &&
-            hydration_.load(
-                std::memory_order_acquire) ==
-                Hydration::Empty &&
-            manager &&
-            manager->getScene().getNodes().empty() &&
-            !scene_dirty_.load(
-                std::memory_order_acquire) &&
-            !payload_dirty_.load(
-                std::memory_order_acquire);
-        if (blank_untitled) {
+        if (isBlankUntitledSession()) {
             return false;
         }
         if (scene_dirty_.load(
@@ -6195,6 +6353,19 @@ namespace lfs::vis::project {
         }
 
         if (!hasDirtyProject()) {
+            // Window-close X / File-Exit of a clean session: Skip any
+            // unanswered recovery offer and drop the untitled scratch.
+            // Emergency ForceExit never reaches this function, so crash
+            // files survive an X11/interrupt teardown.
+            if (recovery_prompt_pending_ &&
+                pending_recovery_candidate_) {
+                ++recovery_prompt_generation_;
+                const auto candidate =
+                    *pending_recovery_candidate_;
+                handleRecoverySkip(candidate);
+                recovery_prompt_pending_ = false;
+            }
+            removeScratchAutosave();
             return CloseSaveStatus::NotDirty;
         }
         if (viewer_.jobs().anyRunning(
@@ -6508,19 +6679,10 @@ namespace lfs::vis::project {
             last_unadoptable_training_snapshot_warning_
                 .clear();
         }
+        const bool blank_untitled =
+            isBlankUntitledSession();
         const auto* manager =
             viewer_.getSceneManager();
-        const bool blank_untitled =
-            !document_->source_path() &&
-            hydration_.load(
-                std::memory_order_acquire) ==
-                Hydration::Empty &&
-            manager &&
-            manager->getScene().getNodes().empty() &&
-            !scene_dirty_.load(
-                std::memory_order_acquire) &&
-            !payload_dirty_.load(
-                std::memory_order_acquire);
         const auto* trainer_manager =
             viewer_.getTrainerManager();
         const bool training_active =
@@ -6694,6 +6856,8 @@ namespace lfs::vis::project {
         lfs::io::project::
             sweep_stale_licht_artifacts_for_known_masters(
                 known);
+        lfs::io::project::sweep_stale_scratch_autosaves(
+            recovery_directory_);
 
         // Never auto-restore from MRU. Startup without an
         // explicit CLI project path leaves a blank session
@@ -6721,55 +6885,477 @@ namespace lfs::vis::project {
     }
 
     void ProjectLifecycle::offerStartupCrashRecovery() {
-        // Intentional closes remove the sidecar (#1652),
+        // Intentional closes remove crash files (#1652),
         // so an Offer here implies the previous session
-        // ended uncleanly. The yes/no decision stays with
-        // the existing Recover Autosaved Project? modal.
-        std::filesystem::path path;
-        {
-            const std::lock_guard lock(
-                settings_mutex_);
-            if (settings_.mru.empty()) {
-                return;
-            }
-            path = resolveProjectMruPath(
-                settings_.mru.front()
-                    .last_known_path);
-        }
-        std::error_code ec;
-        if (!std::filesystem::is_regular_file(
-                path, ec) ||
-            ec) {
-            return;
-        }
-        auto inspection =
-            lfs::io::project::
-                inspect_autosave_recovery(path);
-        if (!inspection) {
-            LOG_WARN(
-                "Startup recovery scan skipped for {}: {}",
-                lfs::core::path_to_utf8(path),
-                developerError(
-                    inspection.error()));
-            return;
-        }
-        if (inspection->disposition !=
-            lfs::io::project::
-                RecoveryDisposition::Offer) {
+        // ended uncleanly.
+        auto candidate = selectStartupRecoveryCandidate();
+        if (!candidate) {
             return;
         }
         LOG_INFO(
             "Unclean shutdown left a recoverable autosave for {}; offering recovery",
-            lfs::core::path_to_utf8(path));
-        if (auto opened = open(path); !opened) {
-            LOG_ERROR(
-                "Startup recovery open failed for {}: {}",
-                lfs::core::path_to_utf8(path),
-                developerError(
-                    opened.error()));
-        } else if (auto* gui = viewer_.getGuiManager()) {
-            gui->dismissStartupOverlay();
+            lfs::core::path_to_utf8(
+                candidate->untitled_scratch
+                    ? candidate->selected_path
+                    : candidate->master_path));
+        auto* gui = viewer_.getGuiManager();
+        if (!gui) {
+            return;
         }
+        const auto previous_autosave_sequence =
+            autosave_sequence_;
+        autosave_sequence_ = std::max(
+            autosave_sequence_,
+            candidate->autosave_sequence);
+        enqueueRecoveryPrompt(
+            std::move(*candidate),
+            ProjectSwitchDisposition::RequireClean,
+            previous_autosave_sequence);
+        gui->dismissStartupOverlay();
+    }
+
+    std::optional<ProjectLifecycle::RecoveryCandidate>
+    ProjectLifecycle::selectStartupRecoveryCandidate() {
+        std::vector<RecoveryCandidate> offers;
+        std::filesystem::path mru_path;
+        {
+            const std::lock_guard lock(
+                settings_mutex_);
+            if (!settings_.mru.empty()) {
+                mru_path = resolveProjectMruPath(
+                    settings_.mru.front()
+                        .last_known_path);
+            }
+        }
+        std::error_code ec;
+        if (!mru_path.empty() &&
+            std::filesystem::is_regular_file(
+                mru_path, ec) &&
+            !ec) {
+            auto inspection =
+                lfs::io::project::
+                    inspect_autosave_recovery(
+                        mru_path);
+            if (!inspection) {
+                LOG_WARN(
+                    "Startup recovery scan skipped for {}: {}",
+                    lfs::core::path_to_utf8(mru_path),
+                    developerError(
+                        inspection.error()));
+            } else if (
+                inspection->disposition ==
+                    lfs::io::project::
+                        RecoveryDisposition::Offer &&
+                inspection->selected_path) {
+                offers.push_back(RecoveryCandidate{
+                    .master_path = mru_path,
+                    .selected_path =
+                        inspection->selected_path
+                            ->lexically_normal(),
+                    .autosave_sequence =
+                        inspection->autosave_sequence,
+                    .commit_uuid =
+                        inspection->commit_uuid,
+                    .snapshot_uuid =
+                        inspection->snapshot_uuid,
+                    .wallclock_unix_ns =
+                        inspection->wallclock_unix_ns,
+                    .untitled_scratch = false,
+                });
+            }
+        }
+        for (auto& inspection :
+             lfs::io::project::scan_scratch_autosaves(
+                 recovery_directory_)) {
+            if (inspection.disposition !=
+                    lfs::io::project::
+                        RecoveryDisposition::Offer ||
+                !inspection.selected_path) {
+                continue;
+            }
+            offers.push_back(RecoveryCandidate{
+                .master_path = {},
+                .selected_path =
+                    inspection.selected_path
+                        ->lexically_normal(),
+                .autosave_sequence =
+                    inspection.autosave_sequence,
+                .commit_uuid = inspection.commit_uuid,
+                .snapshot_uuid =
+                    inspection.snapshot_uuid,
+                .wallclock_unix_ns =
+                    inspection.wallclock_unix_ns,
+                .untitled_scratch = true,
+            });
+        }
+        offers.erase(
+            std::remove_if(
+                offers.begin(), offers.end(),
+                [this](const RecoveryCandidate& candidate) {
+                    return isRecoveryDismissed(
+                        DeclinedRecoveryIdentity{
+                            .sidecar_path =
+                                candidate.selected_path,
+                            .autosave_sequence =
+                                candidate.autosave_sequence,
+                            .commit_uuid =
+                                candidate.commit_uuid,
+                        });
+                }),
+            offers.end());
+        if (offers.empty()) {
+            return std::nullopt;
+        }
+        return *std::ranges::max_element(
+            offers,
+            [](const RecoveryCandidate& lhs,
+               const RecoveryCandidate& rhs) {
+                if (lhs.wallclock_unix_ns !=
+                    rhs.wallclock_unix_ns) {
+                    return lhs.wallclock_unix_ns <
+                           rhs.wallclock_unix_ns;
+                }
+                return lhs.selected_path.generic_string() <
+                       rhs.selected_path.generic_string();
+            });
+    }
+
+    void ProjectLifecycle::enqueueRecoveryPrompt(
+        RecoveryCandidate candidate,
+        const ProjectSwitchDisposition disposition,
+        const std::uint64_t previous_autosave_sequence) {
+        auto* gui = viewer_.getGuiManager();
+        if (!gui) {
+            return;
+        }
+        recovery_prompt_pending_ = true;
+        pending_recovery_candidate_ = candidate;
+        const auto prompt_epoch =
+            epoch_.load(std::memory_order_acquire);
+        const auto prompt_generation =
+            ++recovery_prompt_generation_;
+        namespace Keys = lichtfeld::Strings::Recovery;
+        const auto display_name =
+            candidate.untitled_scratch
+                ? std::string(LOC(Keys::UNSAVED_SESSION))
+                : candidate.master_path.stem().string();
+        const auto saved_at = formatRecoverySavedTime(
+            candidate.wallclock_unix_ns,
+            candidate.selected_path);
+        const auto body = LOCF(
+            Keys::BODY, display_name, saved_at);
+        lfs::core::ModalRequest request;
+        request.title = LOC(Keys::CRASH_TITLE);
+        request.body_rml = std::format(
+            "<p>{}</p>",
+            lfs::vis::gui::escapeRmlText(body));
+        request.style = lfs::core::ModalStyle::Warning;
+        request.width_dp = 500;
+        request.buttons = {
+            {LOC(Keys::RECOVER), "primary"},
+        };
+        if (!candidate.untitled_scratch) {
+            request.buttons.push_back(
+                {LOC(Keys::OPEN_SAVED), "secondary"});
+        }
+        request.buttons.push_back(
+            {LOC(Keys::SKIP), "secondary"});
+        request.on_result =
+            [this, candidate, disposition,
+             previous_autosave_sequence, prompt_epoch,
+             prompt_generation](
+                const lfs::core::ModalResult& result) {
+                if (epoch_.load(
+                        std::memory_order_acquire) !=
+                        prompt_epoch ||
+                    recovery_prompt_generation_ !=
+                        prompt_generation) {
+                    return;
+                }
+                recovery_prompt_pending_ = false;
+                pending_recovery_candidate_.reset();
+                namespace ResultKeys =
+                    lichtfeld::Strings::Recovery;
+                lfs::Result<void> opened;
+                if (result.button_label ==
+                    LOC(ResultKeys::RECOVER)) {
+                    opened =
+                        candidate.untitled_scratch
+                            ? openScratchRecovered(
+                                  candidate.selected_path,
+                                  disposition)
+                            : openRecovered(
+                                  candidate.master_path,
+                                  candidate.selected_path,
+                                  disposition);
+                } else if (
+                    !candidate.untitled_scratch &&
+                    result.button_label ==
+                        LOC(ResultKeys::OPEN_SAVED)) {
+                    persistRecoveryDismissal(
+                        DeclinedRecoveryIdentity{
+                            .sidecar_path =
+                                candidate.selected_path,
+                            .autosave_sequence =
+                                candidate.autosave_sequence,
+                            .commit_uuid =
+                                candidate.commit_uuid,
+                        });
+                    opened = openMaster(
+                        candidate.master_path,
+                        disposition);
+                } else {
+                    handleRecoverySkip(candidate);
+                    autosave_sequence_ =
+                        previous_autosave_sequence;
+                    return;
+                }
+                if (!opened) {
+                    LOG_ERROR(
+                        "Recovery decision failed: {}",
+                        developerError(
+                            opened.error()));
+                    publishProjectToast(
+                        opened.error(),
+                        gui::error_op::kOpenProject);
+                }
+            };
+        request.on_cancel =
+            [this, candidate,
+             previous_autosave_sequence, prompt_epoch,
+             prompt_generation] {
+                if (epoch_.load(
+                        std::memory_order_acquire) !=
+                        prompt_epoch ||
+                    recovery_prompt_generation_ !=
+                        prompt_generation) {
+                    return;
+                }
+                recovery_prompt_pending_ = false;
+                pending_recovery_candidate_.reset();
+                handleRecoverySkip(candidate);
+                autosave_sequence_ =
+                    previous_autosave_sequence;
+            };
+        gui->enqueueModal(std::move(request));
+    }
+
+    void ProjectLifecycle::handleRecoverySkip(
+        const RecoveryCandidate& candidate) {
+        persistRecoveryDismissal(
+            DeclinedRecoveryIdentity{
+                .sidecar_path = candidate.selected_path,
+                .autosave_sequence =
+                    candidate.autosave_sequence,
+                .commit_uuid = candidate.commit_uuid,
+            });
+        if (candidate.untitled_scratch &&
+            !candidate.selected_path.empty()) {
+            if (auto removed =
+                    lfs::io::project::
+                        remove_scratch_autosave(
+                            candidate.selected_path);
+                !removed) {
+                LOG_WARN(
+                    "Could not remove skipped scratch autosave {}: {}",
+                    lfs::core::path_to_utf8(
+                        candidate.selected_path),
+                    developerError(removed.error()));
+            }
+        }
+        pending_recovery_candidate_.reset();
+    }
+
+    bool ProjectLifecycle::isRecoveryDismissed(
+        const DeclinedRecoveryIdentity& identity) const {
+        const auto matches =
+            [&identity](
+                const DismissedRecoveryEntry& stored) {
+                if (stored.sidecar_path.lexically_normal() !=
+                    identity.sidecar_path
+                        .lexically_normal()) {
+                    return false;
+                }
+                if (stored.autosave_sequence !=
+                    identity.autosave_sequence) {
+                    return false;
+                }
+                if (!stored.commit_uuid.is_nil() &&
+                    !identity.commit_uuid.is_nil()) {
+                    return stored.commit_uuid ==
+                           identity.commit_uuid;
+                }
+                return true;
+            };
+        if (declined_recovery_ &&
+            matches(*declined_recovery_)) {
+            return true;
+        }
+        const std::lock_guard lock(settings_mutex_);
+        return std::ranges::any_of(
+            settings_.dismissed_recovery, matches);
+    }
+
+    void ProjectLifecycle::persistRecoveryDismissal(
+        const DeclinedRecoveryIdentity& identity) {
+        declined_recovery_ = identity;
+        {
+            const std::lock_guard lock(settings_mutex_);
+            auto& entries = settings_.dismissed_recovery;
+            std::erase_if(
+                entries,
+                [&identity](
+                    const DismissedRecoveryEntry& stored) {
+                    return stored.sidecar_path
+                                   .lexically_normal() ==
+                               identity.sidecar_path
+                                   .lexically_normal() &&
+                           stored.autosave_sequence ==
+                               identity.autosave_sequence &&
+                           (stored.commit_uuid.is_nil() ||
+                            identity.commit_uuid.is_nil() ||
+                            stored.commit_uuid ==
+                                identity.commit_uuid);
+                });
+            entries.push_back(identity);
+            constexpr std::size_t kMaxDismissed = 64;
+            if (entries.size() > kMaxDismissed) {
+                entries.erase(
+                    entries.begin(),
+                    entries.begin() +
+                        static_cast<std::ptrdiff_t>(
+                            entries.size() -
+                            kMaxDismissed));
+            }
+        }
+        if (auto persisted = persistSettings();
+            !persisted) {
+            LOG_WARN(
+                "Could not persist recovery dismissal: {}",
+                developerError(persisted.error()));
+        }
+    }
+
+    lfs::Result<void>
+    ProjectLifecycle::openScratchRecovered(
+        const std::filesystem::path& scratch_path,
+        const ProjectSwitchDisposition disposition) {
+        auto opened = openMaster(
+            scratch_path, disposition);
+        if (!opened) {
+            return opened;
+        }
+        if (document_) {
+            document_->forget_source_path();
+            [[maybe_unused]] auto& project =
+                document_->edit_project();
+        }
+        scene_dirty_.store(
+            true, std::memory_order_release);
+        if (auto locked = lockScratchAutosave();
+            !locked) {
+            LOG_WARN(
+                "Recovered untitled session could not rebind scratch autosave: {}",
+                developerError(locked.error()));
+        }
+        return {};
+    }
+
+    std::filesystem::path
+    ProjectLifecycle::scratchAutosaveDirectory() const {
+        return recovery_directory_;
+    }
+
+    void ProjectLifecycle::removeScratchAutosave() {
+        const auto path = scratch_autosave_path_;
+        scratch_lock_.reset();
+        scratch_autosave_path_.reset();
+        if (!path || path->empty()) {
+            return;
+        }
+        if (auto removed =
+                lfs::io::project::remove_scratch_autosave(
+                    *path);
+            !removed) {
+            LOG_WARN(
+                "Could not remove scratch autosave {}: {}",
+                lfs::core::path_to_utf8(*path),
+                developerError(removed.error()));
+        }
+    }
+
+    bool ProjectLifecycle::isBlankUntitledSession()
+        const {
+        if (!document_ || document_->source_path()) {
+            return false;
+        }
+        if (hydration_.load(
+                std::memory_order_acquire) !=
+            Hydration::Empty) {
+            return false;
+        }
+        const auto* manager =
+            viewer_.getSceneManager();
+        if (!manager ||
+            !manager->getScene().getNodes().empty()) {
+            return false;
+        }
+        return !scene_dirty_.load(
+                   std::memory_order_acquire) &&
+               !payload_dirty_.load(
+                   std::memory_order_acquire);
+    }
+
+    lfs::Result<void>
+    ProjectLifecycle::ensureScratchAutosaveBinding() {
+        if (!document_) {
+            return fail<void>(
+                lfs::ErrorCode::FailedPrecondition,
+                "Untitled autosave has no document.",
+                "scratch binding requires a live project document",
+                "project.document");
+        }
+        if (recovery_directory_.empty()) {
+            return fail<void>(
+                lfs::ErrorCode::Unavailable,
+                "Untitled crash recovery has no storage location.",
+                "the user-storage recovery directory could not be resolved",
+                "project.recovery_directory");
+        }
+        const auto destination =
+            lfs::io::project::scratch_autosave_path(
+                recovery_directory_,
+                document_->project_uuid());
+        if (scratch_autosave_path_ &&
+            scratch_autosave_path_->lexically_normal() ==
+                destination.lexically_normal()) {
+            return {};
+        }
+        scratch_lock_.reset();
+        scratch_autosave_path_ = destination;
+        return {};
+    }
+
+    lfs::Result<void>
+    ProjectLifecycle::lockScratchAutosave() {
+        if (auto bound = ensureScratchAutosaveBinding();
+            !bound) {
+            return bound;
+        }
+        if (scratch_lock_ &&
+            scratch_lock_->owns(*scratch_autosave_path_)) {
+            return {};
+        }
+        scratch_lock_.reset();
+        auto lease =
+            lfs::io::project::WriterLockLease::acquire(
+                *scratch_autosave_path_);
+        if (!lease) {
+            return lfs::Result<void>::failure(
+                std::move(lease).error());
+        }
+        scratch_lock_ = std::move(*lease);
+        return {};
     }
 
 } // namespace lfs::vis::project

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -79,6 +79,13 @@ namespace lfs::vis {
     class VisualizerImplResetTest_NewProjectDiscardDeletesAutosaveSidecar_Test;
     class VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
     class VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
+    class VisualizerImplResetTest_UntitledDirtySessionAutosavesToScratch_Test;
+    class VisualizerImplResetTest_BlankUntitledSessionUpdateMaintenanceWritesNoScratch_Test;
+    class VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWritesScratch_Test;
+    class VisualizerImplResetTest_SaveAsMigratesScratchAutosaveToSidecar_Test;
+    class VisualizerImplResetTest_RecoveryDismissalPersistsAndNewerCandidateIsOffered_Test;
+    class VisualizerImplResetTest_StartupOffersScratchRecoveryAsUntitled_Test;
+    class VisualizerImplResetTest_StartupSweepsEmptyScratchAndDoesNotOffer_Test;
 } // namespace lfs::vis
 
 namespace lfs::vis::project {
@@ -91,6 +98,15 @@ namespace lfs::vis::project {
                                const ProjectMruEntry&) = default;
     };
 
+    struct DismissedRecoveryEntry {
+        std::filesystem::path sidecar_path;
+        std::uint64_t autosave_sequence = 0;
+        lfs::core::Uuid commit_uuid;
+
+        friend bool operator==(const DismissedRecoveryEntry&,
+                               const DismissedRecoveryEntry&) = default;
+    };
+
     struct ProjectLifecycleSettings {
         bool reopen_last_project = true;
         bool auto_save_on_close = false;
@@ -98,6 +114,7 @@ namespace lfs::vis::project {
         std::uint64_t autosave_dirty_epoch_threshold = 20;
         std::uint64_t compaction_idle_seconds = 30;
         std::vector<ProjectMruEntry> mru;
+        std::vector<DismissedRecoveryEntry> dismissed_recovery;
 
         friend bool operator==(const ProjectLifecycleSettings&,
                                const ProjectLifecycleSettings&) = default;
@@ -268,6 +285,13 @@ namespace lfs::vis::project {
         friend class lfs::vis::VisualizerImplResetTest_NewProjectDiscardDeletesAutosaveSidecar_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
+        friend class lfs::vis::VisualizerImplResetTest_UntitledDirtySessionAutosavesToScratch_Test;
+        friend class lfs::vis::VisualizerImplResetTest_BlankUntitledSessionUpdateMaintenanceWritesNoScratch_Test;
+        friend class lfs::vis::VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWritesScratch_Test;
+        friend class lfs::vis::VisualizerImplResetTest_SaveAsMigratesScratchAutosaveToSidecar_Test;
+        friend class lfs::vis::VisualizerImplResetTest_RecoveryDismissalPersistsAndNewerCandidateIsOffered_Test;
+        friend class lfs::vis::VisualizerImplResetTest_StartupOffersScratchRecoveryAsUntitled_Test;
+        friend class lfs::vis::VisualizerImplResetTest_StartupSweepsEmptyScratchAndDoesNotOffer_Test;
         enum class Hydration {
             Empty,
             ShellReady,
@@ -295,15 +319,16 @@ namespace lfs::vis::project {
             TrainingCloseSave,
         };
 
-        struct DeclinedRecoveryIdentity {
-            std::filesystem::path sidecar_path;
-            std::uint64_t autosave_sequence = 0;
-            lfs::core::Uuid snapshot_uuid;
+        using DeclinedRecoveryIdentity = DismissedRecoveryEntry;
 
-            friend bool operator==(
-                const DeclinedRecoveryIdentity&,
-                const DeclinedRecoveryIdentity&) =
-                default;
+        struct RecoveryCandidate {
+            std::filesystem::path master_path;
+            std::filesystem::path selected_path;
+            std::uint64_t autosave_sequence = 0;
+            lfs::core::Uuid commit_uuid;
+            lfs::core::Uuid snapshot_uuid;
+            std::uint64_t wallclock_unix_ns = 0;
+            bool untitled_scratch = false;
         };
 
         enum class DocumentSyncMode {
@@ -312,6 +337,30 @@ namespace lfs::vis::project {
         };
 
         void offerStartupCrashRecovery();
+        [[nodiscard]] std::optional<RecoveryCandidate>
+        selectStartupRecoveryCandidate();
+        void enqueueRecoveryPrompt(
+            RecoveryCandidate candidate,
+            ProjectSwitchDisposition disposition,
+            std::uint64_t previous_autosave_sequence);
+        void handleRecoverySkip(
+            const RecoveryCandidate& candidate);
+        [[nodiscard]] bool isRecoveryDismissed(
+            const DeclinedRecoveryIdentity& identity) const;
+        void persistRecoveryDismissal(
+            const DeclinedRecoveryIdentity& identity);
+        [[nodiscard]] lfs::Result<void>
+        openScratchRecovered(
+            const std::filesystem::path& scratch_path,
+            ProjectSwitchDisposition disposition);
+        [[nodiscard]] std::filesystem::path
+        scratchAutosaveDirectory() const;
+        void removeScratchAutosave();
+        [[nodiscard]] bool isBlankUntitledSession() const;
+        [[nodiscard]] lfs::Result<void>
+        ensureScratchAutosaveBinding();
+        [[nodiscard]] lfs::Result<void>
+        lockScratchAutosave();
         [[nodiscard]] lfs::Result<void>
         synchronizeDocumentFromViewer();
         [[nodiscard]] lfs::Result<void>
@@ -369,6 +418,8 @@ namespace lfs::vis::project {
         [[nodiscard]] bool
         isTrainingWriteWindowOpen() const;
         void cancelBackgroundAutosaveIfRunning();
+        [[nodiscard]] lfs::Result<void>
+        waitOutBackgroundAutosaveForExplicitSave();
         void cleanupRecoverySession();
         void removeDiscardedAutosaveArtifacts(
             const std::filesystem::path& master);
@@ -438,6 +489,7 @@ namespace lfs::vis::project {
         ProjectLifecycleSettings settings_;
         mutable std::mutex settings_mutex_;
         std::filesystem::path settings_path_;
+        std::filesystem::path recovery_directory_;
         bool settings_persistence_enabled_ = true;
         std::atomic<std::uint64_t> epoch_{0};
         std::atomic<std::uint64_t> scene_mutation_serial_{0};
@@ -505,8 +557,15 @@ namespace lfs::vis::project {
             recovery_session_;
         bool recovery_prompt_pending_ = false;
         std::uint64_t recovery_prompt_generation_ = 0;
+        std::optional<RecoveryCandidate>
+            pending_recovery_candidate_;
         std::optional<DeclinedRecoveryIdentity>
             declined_recovery_;
+        std::optional<std::filesystem::path>
+            scratch_autosave_path_;
+        std::optional<
+            lfs::io::project::WriterLockLease>
+            scratch_lock_;
         mutable std::mutex
             document_access_mutex_;
         std::optional<ProjectInfo>

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -329,6 +329,13 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_NewProjectDiscardDeletesAutosaveSidecar_Test;
         friend class VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
         friend class VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
+        friend class VisualizerImplResetTest_UntitledDirtySessionAutosavesToScratch_Test;
+        friend class VisualizerImplResetTest_BlankUntitledSessionUpdateMaintenanceWritesNoScratch_Test;
+        friend class VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWritesScratch_Test;
+        friend class VisualizerImplResetTest_SaveAsMigratesScratchAutosaveToSidecar_Test;
+        friend class VisualizerImplResetTest_RecoveryDismissalPersistsAndNewerCandidateIsOffered_Test;
+        friend class VisualizerImplResetTest_StartupOffersScratchRecoveryAsUntitled_Test;
+        friend class VisualizerImplResetTest_StartupSweepsEmptyScratchAndDoesNotOffer_Test;
         friend class VisualizerImplResetTest_LoadFileStopTrainingDefersDatasetLoad_Test;
         friend class VisualizerImplResetTest_LoadDatasetApiDoesNotDeferOrPrompt_Test;
 

--- a/tests/test_project_container.cpp
+++ b/tests/test_project_container.cpp
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "core/uuid.hpp"
 #include "io/project/crc32c.hpp"
 #include "io/project/project_container_internal.hpp"
 #include "io/project_container.hpp"
@@ -169,6 +170,19 @@ namespace {
         require_status(writer.write_chunk(key, payload));
         require_status(writer.commit());
         return read_file_bytes(path);
+    }
+
+    std::string recoverable_scene_graph_payload() {
+        SceneGraphChapter graph;
+        SceneNodeRecord node;
+        node.uuid = lfs::core::generate_uuid_v4();
+        node.type = "group";
+        node.name = "Recoverable";
+        require_status(graph.upsert_node(node));
+        const auto bytes = graph.to_bytes();
+        return std::string(
+            reinterpret_cast<const char*>(bytes.data()),
+            bytes.size());
     }
 
     void publish_complete_sidecar(
@@ -3328,6 +3342,97 @@ namespace {
         ASSERT_TRUE(removed)
             << lfs::format_for_developer(removed.error());
         EXPECT_FALSE(fs::exists(free_temp));
+    }
+
+    TEST(ProjectRecoveryScratch, PathResolutionUsesSessionUuid) {
+        TemporaryDirectory temporary;
+        const auto uuid = lfs::core::generate_uuid_v4();
+        const auto dir = temporary.path / "recovery";
+        const auto path = scratch_autosave_path(dir, uuid);
+        EXPECT_EQ(path.parent_path(), dir);
+        EXPECT_EQ(
+            path.filename().string(),
+            uuid.to_string() + ".licht");
+        EXPECT_TRUE(is_scratch_autosave_path(path, dir));
+        EXPECT_FALSE(is_scratch_autosave_path(
+            dir / "not-a-uuid.licht", dir));
+        EXPECT_FALSE(is_scratch_autosave_path(
+            path, temporary.path));
+    }
+
+    TEST(ProjectRecoveryScratch, ScanFindsScratchCandidate) {
+        TemporaryDirectory temporary;
+        const auto dir = temporary.path / "recovery";
+        fs::create_directories(dir);
+        const auto uuid = lfs::core::generate_uuid_v4();
+        const auto path = scratch_autosave_path(dir, uuid);
+        create_single_chunk_fixture(
+            path, 2001, 2002, 2003,
+            fixed_key("SCNG", 2004),
+            recoverable_scene_graph_payload());
+        auto found = scan_scratch_autosaves(dir);
+        ASSERT_EQ(found.size(), 1u);
+        EXPECT_EQ(
+            found[0].disposition,
+            RecoveryDisposition::Offer);
+        EXPECT_TRUE(found[0].untitled_scratch);
+        ASSERT_TRUE(found[0].selected_path);
+        EXPECT_EQ(
+            found[0].selected_path->lexically_normal(),
+            path.lexically_normal());
+        EXPECT_FALSE(found[0].commit_uuid.is_nil());
+    }
+
+    TEST(ProjectRecoveryScratch, RemoveDeletesUnlockedScratch) {
+        TemporaryDirectory temporary;
+        const auto dir = temporary.path / "recovery";
+        fs::create_directories(dir);
+        const auto uuid = lfs::core::generate_uuid_v4();
+        const auto path = scratch_autosave_path(dir, uuid);
+        create_single_chunk_fixture(
+            path, 2011, 2012, 2013,
+            fixed_key("SCNG", 2014),
+            recoverable_scene_graph_payload());
+        auto removed = remove_scratch_autosave(path);
+        ASSERT_TRUE(removed)
+            << lfs::format_for_developer(removed.error());
+        EXPECT_FALSE(fs::exists(path));
+    }
+
+    TEST(ProjectRecoveryScratch, SweepSkipsLiveLockedScratch) {
+        TemporaryDirectory temporary;
+        const auto dir = temporary.path / "recovery";
+        fs::create_directories(dir);
+        const auto uuid = lfs::core::generate_uuid_v4();
+        const auto path = scratch_autosave_path(dir, uuid);
+        create_single_chunk_fixture(
+            path, 2021, 2022, 2023,
+            fixed_key("SCNG", 2024),
+            recoverable_scene_graph_payload());
+        auto lease = WriterLockLease::acquire(path);
+        ASSERT_TRUE(lease)
+            << lfs::format_for_developer(lease.error());
+        sweep_stale_scratch_autosaves(dir);
+        EXPECT_TRUE(fs::is_regular_file(path));
+        auto found = scan_scratch_autosaves(dir);
+        EXPECT_TRUE(found.empty());
+    }
+
+    TEST(ProjectRecoveryScratch, SweepRemovesEmptyUnlockedScratch) {
+        TemporaryDirectory temporary;
+        const auto dir = temporary.path / "recovery";
+        fs::create_directories(dir);
+        const auto uuid = lfs::core::generate_uuid_v4();
+        const auto path = scratch_autosave_path(dir, uuid);
+        create_single_chunk_fixture(
+            path, 2031, 2032, 2033,
+            fixed_key("PROJ", 2034),
+            R"({"scratch":"empty"})");
+        ASSERT_TRUE(fs::is_regular_file(path));
+        sweep_stale_scratch_autosaves(dir);
+        EXPECT_FALSE(fs::exists(path));
+        auto found = scan_scratch_autosaves(dir);
+        EXPECT_TRUE(found.empty());
     }
 
     TEST(ProjectPathTest, IsPublishedLichtPathTable) {

--- a/tests/test_project_lifecycle.cpp
+++ b/tests/test_project_lifecycle.cpp
@@ -49,6 +49,40 @@ namespace {
             loaded->compaction_idle_seconds,
             30u);
         EXPECT_TRUE(loaded->mru.empty());
+        EXPECT_TRUE(loaded->dismissed_recovery.empty());
+    }
+
+    TEST(ProjectLifecycleSettingsTest,
+         RoundTripPersistsDismissedRecoveryIdentity) {
+        TemporaryDirectory temporary;
+        const auto settings_path =
+            temporary.path / "project_lifecycle.json";
+        const auto sidecar =
+            temporary.path / "scene.licht.autosave";
+        ProjectLifecycleSettings settings;
+        settings.dismissed_recovery.push_back({
+            .sidecar_path = sidecar,
+            .autosave_sequence = 4,
+            .commit_uuid = lfs::core::generate_uuid_v4(),
+        });
+        auto saved = saveProjectLifecycleSettings(
+            settings_path, settings);
+        ASSERT_TRUE(saved)
+            << lfs::format_for_developer(saved.error());
+        auto loaded =
+            loadProjectLifecycleSettings(settings_path);
+        ASSERT_TRUE(loaded)
+            << lfs::format_for_developer(loaded.error());
+        ASSERT_EQ(loaded->dismissed_recovery.size(), 1u);
+        EXPECT_EQ(
+            loaded->dismissed_recovery[0].sidecar_path.lexically_normal(),
+            sidecar.lexically_normal());
+        EXPECT_EQ(
+            loaded->dismissed_recovery[0].autosave_sequence,
+            4u);
+        EXPECT_EQ(
+            loaded->dismissed_recovery[0].commit_uuid,
+            settings.dismissed_recovery[0].commit_uuid);
     }
 
     TEST(ProjectLifecycleSettingsTest,

--- a/tests/test_user_paths.cpp
+++ b/tests/test_user_paths.cpp
@@ -98,6 +98,8 @@ namespace {
         EXPECT_TRUE(fs::is_directory(paths.venvDir()));
         EXPECT_EQ(paths.uiPreferencesFile(), paths.configDir() / "ui_preferences.json");
         EXPECT_EQ(paths.projectLifecycleFile(), paths.configDir() / "project_lifecycle.json");
+        EXPECT_EQ(paths.recoveryDir(), paths.configDir().parent_path() / "recovery");
+        EXPECT_TRUE(fs::is_directory(paths.recoveryDir()));
         EXPECT_FALSE(fs::exists(root_ / "LichtFeldStudio"));
     }
 

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -6,12 +6,14 @@
 #include "core/checkpoint_format.hpp"
 #include "core/error_bus.hpp"
 #include "core/event_bridge/event_bridge.hpp"
+#include "core/event_bridge/localization_manager.hpp"
 #include "core/event_bus.hpp"
 #include "core/events.hpp"
 #include "core/guarded_task.hpp"
 #include "core/main_loop.hpp"
 #include "core/scene.hpp"
 #include "core/services.hpp"
+#include "gui/string_keys.hpp"
 #include "input/input_controller.hpp"
 #include "io/project_chapters.hpp"
 #include "io/project_container.hpp"
@@ -894,7 +896,7 @@ namespace lfs::vis {
                 gui->rml_modal_overlay_->queue_mutex_, gui->rml_modal_overlay_->queue_);
             ASSERT_EQ(
                 request.title,
-                "Recover Autosaved Project?");
+                LOC(lichtfeld::Strings::Recovery::CRASH_TITLE));
             ASSERT_TRUE(request.on_cancel);
             request.on_cancel();
             EXPECT_TRUE(
@@ -918,26 +920,20 @@ namespace lfs::vis {
                           RecoveryPromptPending);
             request = takeModalRequest(
                 gui->rml_modal_overlay_->queue_mutex_, gui->rml_modal_overlay_->queue_);
+            ASSERT_EQ(request.buttons.size(), 3u);
+            EXPECT_EQ(
+                request.buttons[0].label,
+                LOC(lichtfeld::Strings::Recovery::RECOVER));
+            EXPECT_EQ(
+                request.buttons[1].label,
+                LOC(lichtfeld::Strings::Recovery::OPEN_SAVED));
+            EXPECT_EQ(
+                request.buttons[2].label,
+                LOC(lichtfeld::Strings::Recovery::SKIP));
             ASSERT_TRUE(request.on_cancel);
             request.on_cancel();
             EXPECT_FALSE(viewer.project_lifecycle_
                              ->recovery_prompt_pending_);
-
-            pending = viewer.projectOpen(
-                project_path,
-                ProjectSwitchDisposition::
-                    DiscardChanges);
-            ASSERT_TRUE(pending);
-            EXPECT_EQ(*pending,
-                      ProjectOpenOutcome::
-                          RecoveryPromptPending);
-            request = takeModalRequest(
-                gui->rml_modal_overlay_->queue_mutex_, gui->rml_modal_overlay_->queue_);
-            ASSERT_TRUE(request.on_result);
-            request.on_result(
-                lfs::core::ModalResult{
-                    .button_label =
-                        "Open Saved"});
             EXPECT_TRUE(
                 std::filesystem::is_regular_file(
                     sidecar));
@@ -1081,7 +1077,9 @@ namespace lfs::vis {
             ASSERT_TRUE(request.on_result);
             request.on_result(
                 lfs::core::ModalResult{
-                    .button_label = "Recover"});
+                    .button_label = LOC(
+                        lichtfeld::Strings::Recovery::
+                            RECOVER)});
             auto info = viewer.projectGetInfo();
             ASSERT_TRUE(info);
             EXPECT_TRUE(info->recovery_session);
@@ -1154,7 +1152,8 @@ namespace lfs::vis {
                           RecoveryPromptPending);
             auto request = takeModalRequest(
                 gui->rml_modal_overlay_->queue_mutex_, gui->rml_modal_overlay_->queue_);
-            request.on_result({.button_label = "Recover"});
+            request.on_result({.button_label = LOC(
+                                   lichtfeld::Strings::Recovery::RECOVER)});
             ASSERT_TRUE(viewer.project_lifecycle_
                             ->recovery_session_path_);
             const auto recovery_temp =
@@ -1230,7 +1229,8 @@ namespace lfs::vis {
                           RecoveryPromptPending);
             auto request = takeModalRequest(
                 gui->rml_modal_overlay_->queue_mutex_, gui->rml_modal_overlay_->queue_);
-            request.on_result({.button_label = "Recover"});
+            request.on_result({.button_label = LOC(
+                                   lichtfeld::Strings::Recovery::RECOVER)});
             const auto recovery_temp =
                 *viewer.project_lifecycle_
                      ->recovery_session_path_;
@@ -1288,7 +1288,8 @@ namespace lfs::vis {
                           RecoveryPromptPending);
             auto request = takeModalRequest(
                 gui->rml_modal_overlay_->queue_mutex_, gui->rml_modal_overlay_->queue_);
-            request.on_result({.button_label = "Recover"});
+            request.on_result({.button_label = LOC(
+                                   lichtfeld::Strings::Recovery::RECOVER)});
             recovery_temp =
                 *viewer.project_lifecycle_
                      ->recovery_session_path_;
@@ -1323,10 +1324,15 @@ namespace lfs::vis {
             ASSERT_EQ(untitled->hydration_state,
                       "empty");
             ASSERT_FALSE(untitled->path.has_value());
-            ASSERT_TRUE(viewer.project_lifecycle_
-                            ->startAutosave());
-            EXPECT_FALSE(viewer.jobs().anyRunning(
-                JobType::ProjectWrite));
+            auto first_autosave =
+                viewer.project_lifecycle_
+                    ->startAutosave();
+            ASSERT_TRUE(first_autosave)
+                << lfs::format_for_developer(
+                       first_autosave.error());
+            // Untitled scratch autosave may occupy the
+            // exclusive ProjectWrite slot. Save As below
+            // must wait that write out rather than refuse.
             EXPECT_EQ(viewer.project_lifecycle_
                           ->autosave_sequence_,
                       0u);
@@ -1841,8 +1847,9 @@ namespace lfs::vis {
                 gui->rml_modal_overlay_->queue_mutex_, gui->rml_modal_overlay_->queue_);
             EXPECT_EQ(
                 request.title,
-                "Recover Autosaved Project?");
-            request.on_result({.button_label = "Recover"});
+                LOC(lichtfeld::Strings::Recovery::CRASH_TITLE));
+            request.on_result({.button_label = LOC(
+                                   lichtfeld::Strings::Recovery::RECOVER)});
             ASSERT_TRUE(viewer.project_lifecycle_
                             ->recovery_session_);
             ASSERT_TRUE(viewer.project_lifecycle_
@@ -1901,6 +1908,452 @@ namespace lfs::vis {
             }
             EXPECT_FALSE(viewer.project_lifecycle_
                              ->document_->source_path());
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           UntitledDirtySessionAutosavesToScratch) {
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Untitled dirty"),
+                lfs::core::NULL_NODE);
+            auto started = viewer.project_lifecycle_
+                               ->startAutosave();
+            ASSERT_TRUE(started)
+                << lfs::format_for_developer(
+                       started.error());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            const auto scratch =
+                lfs::io::project::scratch_autosave_path(
+                    viewer.project_lifecycle_
+                        ->recovery_directory_,
+                    viewer.project_lifecycle_
+                        ->document_->project_uuid());
+            EXPECT_TRUE(
+                std::filesystem::is_regular_file(
+                    scratch));
+            EXPECT_FALSE(
+                viewer.project_lifecycle_
+                    ->document_->source_path());
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           BlankUntitledSessionUpdateMaintenanceWritesNoScratch) {
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            ASSERT_TRUE(lifecycle->document_);
+            EXPECT_TRUE(
+                lifecycle->isBlankUntitledSession());
+            lifecycle->settings_
+                .autosave_dirty_epoch_threshold = 1;
+            lifecycle->last_autosaved_dirty_epoch_ =
+                0;
+            lifecycle->last_autosaved_scene_serial_ =
+                0;
+            lifecycle->last_autosave_at_ =
+                std::chrono::steady_clock::now() -
+                std::chrono::hours(1);
+            lifecycle->updateMaintenance();
+            EXPECT_FALSE(viewer.jobs().anyRunning(
+                JobType::ProjectWrite));
+            const auto scratch =
+                lfs::io::project::scratch_autosave_path(
+                    lifecycle->recovery_directory_,
+                    lifecycle->document_->project_uuid());
+            EXPECT_FALSE(
+                std::filesystem::exists(scratch));
+            auto lock_path = scratch;
+            lock_path += ".lock";
+            EXPECT_FALSE(
+                std::filesystem::exists(lock_path));
+            EXPECT_FALSE(
+                lifecycle->scratch_autosave_path_);
+            EXPECT_FALSE(lifecycle->scratch_lock_);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           DirtyUntitledSessionUpdateMaintenanceWritesScratch) {
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Untitled dirty maintenance"),
+                lfs::core::NULL_NODE);
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            EXPECT_FALSE(
+                lifecycle->isBlankUntitledSession());
+            lifecycle->settings_
+                .autosave_dirty_epoch_threshold = 1;
+            lifecycle->last_autosaved_dirty_epoch_ =
+                0;
+            lifecycle->last_autosaved_scene_serial_ =
+                0;
+            lifecycle->last_autosave_at_ =
+                std::chrono::steady_clock::now() -
+                std::chrono::hours(1);
+            lifecycle->updateMaintenance();
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            const auto scratch =
+                lfs::io::project::scratch_autosave_path(
+                    lifecycle->recovery_directory_,
+                    lifecycle->document_->project_uuid());
+            EXPECT_TRUE(
+                std::filesystem::is_regular_file(
+                    scratch));
+            EXPECT_FALSE(
+                lifecycle->document_->source_path());
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           SaveAsMigratesScratchAutosaveToSidecar) {
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "migrated.licht";
+        const auto sidecar =
+            lfs::io::project::autosave_sidecar_path(
+                project_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Untitled before save as"),
+                lfs::core::NULL_NODE);
+            auto started = viewer.project_lifecycle_
+                               ->startAutosave();
+            ASSERT_TRUE(started)
+                << lfs::format_for_developer(
+                       started.error());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            const auto scratch =
+                lfs::io::project::scratch_autosave_path(
+                    viewer.project_lifecycle_
+                        ->recovery_directory_,
+                    viewer.project_lifecycle_
+                        ->document_->project_uuid());
+            ASSERT_TRUE(
+                std::filesystem::is_regular_file(
+                    scratch));
+            auto saved = viewer.projectSaveAs(
+                project_path, false);
+            ASSERT_TRUE(saved)
+                << lfs::format_for_developer(
+                       saved.error());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            EXPECT_FALSE(std::filesystem::exists(scratch));
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Dirty after save as"),
+                lfs::core::NULL_NODE);
+            auto sidecar_autosave =
+                viewer.project_lifecycle_
+                    ->startAutosave();
+            ASSERT_TRUE(sidecar_autosave)
+                << lfs::format_for_developer(
+                       sidecar_autosave.error());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            EXPECT_TRUE(
+                std::filesystem::is_regular_file(
+                    sidecar));
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           RecoveryDismissalPersistsAndNewerCandidateIsOffered) {
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "dismiss.licht";
+        write_recoverable_project(project_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            auto* const gui = viewer.getGuiManager();
+            ASSERT_NE(gui, nullptr);
+            installModalOverlay(
+                gui->rml_modal_overlay_,
+                gui->rmlui_manager_);
+            auto pending = viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges);
+            ASSERT_TRUE(pending);
+            EXPECT_EQ(
+                *pending,
+                ProjectOpenOutcome::
+                    RecoveryPromptPending);
+            auto request = takeModalRequest(
+                gui->rml_modal_overlay_->queue_mutex_,
+                gui->rml_modal_overlay_->queue_);
+            ASSERT_TRUE(request.on_cancel);
+            request.on_cancel();
+        }
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            auto* const gui = viewer.getGuiManager();
+            ASSERT_NE(gui, nullptr);
+            installModalOverlay(
+                gui->rml_modal_overlay_,
+                gui->rmlui_manager_);
+            auto opened = viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges);
+            ASSERT_TRUE(opened)
+                << lfs::format_for_developer(
+                       opened.error());
+            EXPECT_EQ(*opened, ProjectOpenOutcome::Opened);
+            {
+                auto& overlay =
+                    *gui->rml_modal_overlay_;
+                std::lock_guard lock(
+                    overlay.queue_mutex_);
+                EXPECT_TRUE(overlay.queue_.empty());
+            }
+        }
+        auto document =
+            lfs::test::licht::require_result_ptr(
+                lfs::io::project::ProjectDocument::open(
+                    project_path));
+        const auto base =
+            lfs::test::licht::require_result(
+                lfs::io::project::ProjectReader::open(
+                    project_path));
+        lfs::test::licht::require_status(
+            document->edit_view().dom().set(
+                "recovery_marker", "newer"));
+        (void)lfs::test::licht::require_result(
+            document->save_autosave(
+                lfs::io::project::
+                    autosave_sidecar_path(project_path),
+                {
+                    .file_uuid =
+                        lfs::core::generate_uuid_v4(),
+                    .base_explicit_commit_uuid =
+                        base.commit().commit_uuid,
+                    .autosave_sequence = 2,
+                    .snapshot_uuid =
+                        lfs::core::generate_uuid_v4(),
+                    .index_compression =
+                        lfs::io::project::
+                            IndexCompression::
+                                StoredForDeterministicTests,
+                    .disk_reserve_bytes = 0,
+                }));
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            auto* const gui = viewer.getGuiManager();
+            ASSERT_NE(gui, nullptr);
+            installModalOverlay(
+                gui->rml_modal_overlay_,
+                gui->rmlui_manager_);
+            auto pending = viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges);
+            ASSERT_TRUE(pending);
+            EXPECT_EQ(
+                *pending,
+                ProjectOpenOutcome::
+                    RecoveryPromptPending);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           StartupOffersScratchRecoveryAsUntitled) {
+        auto options = projectOptions();
+        std::filesystem::path scratch;
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Crash untitled"),
+                lfs::core::NULL_NODE);
+            auto started = viewer.project_lifecycle_
+                               ->startAutosave();
+            ASSERT_TRUE(started)
+                << lfs::format_for_developer(
+                       started.error());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            scratch =
+                lfs::io::project::scratch_autosave_path(
+                    viewer.project_lifecycle_
+                        ->recovery_directory_,
+                    viewer.project_lifecycle_
+                        ->document_->project_uuid());
+            ASSERT_TRUE(
+                std::filesystem::is_regular_file(
+                    scratch));
+        }
+        ASSERT_TRUE(std::filesystem::is_regular_file(scratch));
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            auto* const gui = viewer.getGuiManager();
+            ASSERT_NE(gui, nullptr);
+            installModalOverlay(
+                gui->rml_modal_overlay_,
+                gui->rmlui_manager_);
+            viewer.project_lifecycle_
+                ->openStartupProject(std::nullopt);
+            EXPECT_TRUE(viewer.project_lifecycle_
+                            ->recovery_prompt_pending_);
+            auto request = takeModalRequest(
+                gui->rml_modal_overlay_->queue_mutex_,
+                gui->rml_modal_overlay_->queue_);
+            EXPECT_EQ(
+                request.title,
+                LOC(lichtfeld::Strings::Recovery::
+                        CRASH_TITLE));
+            ASSERT_EQ(request.buttons.size(), 2u);
+            EXPECT_EQ(
+                request.buttons[0].label,
+                LOC(lichtfeld::Strings::Recovery::RECOVER));
+            EXPECT_EQ(
+                request.buttons[1].label,
+                LOC(lichtfeld::Strings::Recovery::SKIP));
+            request.on_result({.button_label = LOC(
+                                   lichtfeld::Strings::Recovery::RECOVER)});
+            ASSERT_TRUE(viewer.project_lifecycle_->document_);
+            EXPECT_FALSE(
+                viewer.project_lifecycle_->document_
+                    ->source_path());
+            EXPECT_TRUE(
+                viewer.project_lifecycle_->document_
+                    ->dirty());
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           StartupSweepsEmptyScratchAndDoesNotOffer) {
+        auto options = projectOptions();
+        const auto recovery_dir =
+            temporary_.path / "recovery";
+        std::filesystem::create_directories(recovery_dir);
+        const auto empty_scratch =
+            lfs::io::project::scratch_autosave_path(
+                recovery_dir,
+                lfs::core::generate_uuid_v4());
+        write_empty_project(empty_scratch);
+        ASSERT_TRUE(std::filesystem::is_regular_file(
+            empty_scratch));
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            auto* const gui = viewer.getGuiManager();
+            ASSERT_NE(gui, nullptr);
+            installModalOverlay(
+                gui->rml_modal_overlay_,
+                gui->rmlui_manager_);
+            viewer.project_lifecycle_
+                ->openStartupProject(std::nullopt);
+            EXPECT_FALSE(viewer.project_lifecycle_
+                             ->recovery_prompt_pending_);
+            {
+                auto& overlay =
+                    *gui->rml_modal_overlay_;
+                std::lock_guard lock(
+                    overlay.queue_mutex_);
+                EXPECT_TRUE(overlay.queue_.empty());
+            }
+            EXPECT_FALSE(
+                std::filesystem::exists(empty_scratch));
         }
     }
 


### PR DESCRIPTION
Three open items from the test plan, all in the crash-recovery flow:

**Unsaved sessions had no crash protection (#1642).** Autosave only worked for projects that already had a file. Sessions that were never saved now autosave into the app's own recovery folder under the user storage root - never to a location the user did not choose - as soon as they have real content. A blank session leaves nothing behind. Save As moves protection to the normal project sidecar and removes the scratch copy.

**Skipping a recovery did not stick (#1715).** The same file was offered again on every start. Skip - via the button, Escape, or closing a clean blank session - is now remembered; the same autosave is not offered again, a newer one is.

**The dialog was misleading (#1714).** It now says "LichtFeld Studio closed unexpectedly", names the project or "an unsaved session" with the save time, and offers Recover / Open saved (only when a saved file exists) / Skip and create new.

One shared fix found along the way: an explicit Save or Save As could fail with "a write is already in progress" if an autosave was running at that moment - for titled projects too. Explicit saves now wait out the background autosave.

**Verified:** 256 tests green across the recovery, lifecycle, document and container suites plus the python tier, and live on screen: an unsaved session got a scratch autosave within seconds; after a hard kill the new dialog appeared with the exact wording; Recover restored all 189 nodes as an untitled dirty session; Escape recorded the skip; a blank session killed mid-run left no files and triggered no offer on the next start.

Fixes #1642, #1715, #1714