### PR TITLE
Preserve calibrated camera frustums during training

### DIFF
--- a/src/rendering/raster_rendering_engine.cpp
+++ b/src/rendering/raster_rendering_engine.cpp
@@ -308,9 +308,13 @@ namespace lfs::rendering {
             const glm::mat4& visualizer_camera_to_world,
             const float scale) {
             std::vector<glm::vec3> points;
-            const int image_width = camera.image_width() > 0 ? camera.image_width() : camera.camera_width();
-            const int image_height = camera.image_height() > 0 ? camera.image_height() : camera.camera_height();
-            if (image_width <= 0 || image_height <= 0 || scale <= 0.0f) {
+            // Picking must follow the calibrated frustum, not the resolution
+            // selected for loading training images. Undistortion updates these
+            // calibration dimensions and FoVy together; training downscaling
+            // only changes the operational decode dimensions.
+            const int calibration_width = camera.camera_width();
+            const int calibration_height = camera.camera_height();
+            if (calibration_width <= 0 || calibration_height <= 0 || scale <= 0.0f) {
                 return points;
             }
 
@@ -338,12 +342,13 @@ namespace lfs::rendering {
                 return points;
             }
 
-            if (camera.focal_y() <= 0.0f) {
+            if (camera.FoVy() <= 0.0f) {
                 return points;
             }
 
-            const float aspect = static_cast<float>(image_width) / static_cast<float>(image_height);
-            const float fov_y = lfs::core::focal2fov(camera.focal_y(), image_height);
+            const float aspect = static_cast<float>(calibration_width) /
+                                 static_cast<float>(calibration_height);
+            const float fov_y = camera.FoVy();
             const float half_height = std::tan(fov_y * 0.5f) * scale;
             const float half_width = half_height * aspect;
 

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -2231,23 +2231,28 @@ namespace lfs::vis::gui {
             const lfs::core::Camera& camera,
             const glm::mat4& visualizer_camera_to_world,
             const float scale) {
-            const int image_width = camera.image_width() > 0 ? camera.image_width() : camera.camera_width();
-            const int image_height = camera.image_height() > 0 ? camera.image_height() : camera.camera_height();
-            if (image_width <= 0 || image_height <= 0 || scale <= 0.0f) {
+            // The frustum represents the calibrated camera rather than the
+            // resolution selected for loading training images. Undistortion
+            // updates these calibration dimensions and FoVy together, while
+            // training downscaling only changes operational decode dimensions.
+            const int calibration_width = camera.camera_width();
+            const int calibration_height = camera.camera_height();
+            if (calibration_width <= 0 || calibration_height <= 0 || scale <= 0.0f) {
                 return std::nullopt;
             }
 
             constexpr float kEquirectangularDisplayFov = 1.0472f;
             const bool equirectangular =
                 camera.camera_model_type() == lfs::core::CameraModelType::EQUIRECTANGULAR;
-            if (!equirectangular && camera.focal_y() <= 0.0f) {
+            if (!equirectangular && camera.FoVy() <= 0.0f) {
                 return std::nullopt;
             }
 
-            const float aspect = static_cast<float>(image_width) / static_cast<float>(image_height);
+            const float aspect = static_cast<float>(calibration_width) /
+                                 static_cast<float>(calibration_height);
             const float fov_y = equirectangular
                                     ? kEquirectangularDisplayFov
-                                    : lfs::core::focal2fov(camera.focal_y(), image_height);
+                                    : camera.FoVy();
             const float half_height = std::tan(fov_y * 0.5f);
             const float half_width = half_height * aspect;
 

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -2214,14 +2214,16 @@ namespace lfs::vis {
             const bool is_equirect =
                 node->camera->camera_model_type() == core::CameraModelType::EQUIRECTANGULAR;
             if (camera_frustum_scale > 0.0f &&
-                node->camera->image_width() > 0 &&
-                node->camera->image_height() > 0 &&
-                (is_equirect || node->camera->focal_y() > 0.0f)) {
-                const float aspect = static_cast<float>(node->camera->image_width()) /
-                                     static_cast<float>(node->camera->image_height());
+                node->camera->camera_width() > 0 &&
+                node->camera->camera_height() > 0 &&
+                (is_equirect || node->camera->FoVy() > 0.0f)) {
+                // Match selection bounds to the calibrated (or rectified)
+                // frustum independently of the training image resolution.
+                const float aspect = static_cast<float>(node->camera->camera_width()) /
+                                     static_cast<float>(node->camera->camera_height());
                 const float fov_y = is_equirect
                                         ? glm::radians(60.0f)
-                                        : core::focal2fov(node->camera->focal_y(), node->camera->image_height());
+                                        : node->camera->FoVy();
                 const float half_height = std::tan(fov_y * 0.5f);
                 const float half_width = half_height * aspect;
 

--- a/tests/python/test_camera_frustum_calibration_regressions.py
+++ b/tests/python/test_camera_frustum_calibration_regressions.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression checks for camera frustums under training image downscaling."""
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel_path: str) -> str:
+    return (PROJECT_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def _function(source: str, start: str, end: str) -> str:
+    return source[source.index(start) : source.index(end, source.index(start))]
+
+
+def _assert_uses_calibrated_frustum(source: str) -> None:
+    assert "camera_width()" in source
+    assert "camera_height()" in source
+    assert "FoVy()" in source
+    assert "image_width()" not in source
+    assert "image_height()" not in source
+    assert "focal2fov" not in source
+
+
+def test_displayed_frustum_ignores_training_image_resize():
+    gui_manager = _read("src/visualizer/gui/gui_manager.cpp")
+    frustum_model = _function(
+        gui_manager,
+        "cameraFrustumModelMatrix(",
+        "void appendEquirectangularCameraFrustum(",
+    )
+
+    _assert_uses_calibrated_frustum(frustum_model)
+
+
+def test_frustum_picking_uses_the_same_calibration_contract():
+    raster_engine = _read("src/rendering/raster_rendering_engine.cpp")
+    frustum_points = _function(
+        raster_engine,
+        "cameraFrustumWorldPoints(",
+        "projectFrustumPoint(",
+    )
+
+    _assert_uses_calibrated_frustum(frustum_points)
+
+
+def test_frustum_selection_bounds_ignore_training_image_resize():
+    scene_manager = _read("src/visualizer/scene/scene_manager.cpp")
+    camera_bounds = _function(
+        scene_manager,
+        "const bool is_equirect =",
+        "glm::vec2 screen_min",
+    )
+
+    assert "camera_width()" in camera_bounds
+    assert "camera_height()" in camera_bounds
+    assert "FoVy()" in camera_bounds
+    assert "image_width()" not in camera_bounds
+    assert "image_height()" not in camera_bounds
+    assert "focal2fov" not in camera_bounds


### PR DESCRIPTION
## Summary

Prevent camera frustums from shrinking or narrowing when training starts with downsampled images.

## Problem

Camera frustum geometry was derived from the mutable training image dimensions while continuing to use the original camera focal length.

When `resize_factor` or `max_width` reduced the operational image resolution, the resulting field of view became artificially narrower even though the underlying camera calibration had not changed.

This affected the displayed frustum as soon as training initialized the resized image dimensions.

## Changes

- derive camera frustum geometry from the calibrated camera width, height, and vertical field of view;
- keep frustum geometry independent of training image downscaling;
- preserve rectified calibration produced by camera undistortion;
- apply the same calibration contract to:
  - viewport frustum rendering;
  - software frustum picking;
  - scene selection bounds;
- retain the existing equirectangular camera representation.

## Regression coverage

Added regression checks ensuring that frustum rendering, picking, and selection:

- use calibrated camera dimensions and `FoVy`;
- do not depend on mutable training image dimensions;
- do not reconstruct the field of view from an unscaled focal length.

## Validation

Manually verified that camera frustums retain their original shape and size when training starts with scaled images.