### PR TITLE
Keep per-camera enabled and hidden state when reopening a project saved before training

### DIFF
--- a/src/io/include/io/project_chapters.hpp
+++ b/src/io/include/io/project_chapters.hpp
@@ -353,6 +353,10 @@ namespace lfs::io::project {
         std::string depth_path;
         std::string normal_path;
         bool has_alpha = false;
+        // Load-time image presence (#1713). Independent of the node-level
+        // training_enabled flag (user disable, #1716). Absent in older SCNG
+        // camera objects; parsers default this to true.
+        bool has_image = true;
         std::string split = "train";
 
         friend bool operator==(const CameraRecord&, const CameraRecord&) = default;

--- a/src/io/project/project_chapters.cpp
+++ b/src/io/project/project_chapters.cpp
@@ -2266,6 +2266,8 @@ namespace lfs::io::project {
             auto normal_path =
                 required<std::string>(value, "normal_path", "SCNG", field);
             auto has_alpha = required<bool>(value, "has_alpha", "SCNG", field);
+            auto has_image =
+                optional<bool>(value, "has_image", "SCNG", field);
             auto split = required<std::string>(value, "split", "SCNG", field);
             if (!rotation) {
                 return std::move(rotation).error();
@@ -2283,7 +2285,8 @@ namespace lfs::io::project {
                     first_error(uid, camera_id, focal_x, focal_y, center_x, center_y,
                                 model, camera_width, camera_height, image_width,
                                 image_height, image_name, image_path, mask_path,
-                                depth_path, normal_path, has_alpha, split)) {
+                                depth_path, normal_path, has_alpha, has_image,
+                                split)) {
                 return std::move(*error);
             }
             if (*camera_width < 0 || *camera_height < 0 || *image_width < 0 ||
@@ -2318,6 +2321,7 @@ namespace lfs::io::project {
                 .depth_path = std::move(*depth_path),
                 .normal_path = std::move(*normal_path),
                 .has_alpha = *has_alpha,
+                .has_image = has_image->value_or(true),
                 .split = std::move(*split),
             };
         }
@@ -2345,6 +2349,7 @@ namespace lfs::io::project {
                 {"depth_path", value.depth_path},
                 {"normal_path", value.normal_path},
                 {"has_alpha", value.has_alpha},
+                {"has_image", value.has_image},
                 {"split", value.split},
             };
         }

--- a/src/io/project/scene_chapter_adapter.cpp
+++ b/src/io/project/scene_chapter_adapter.cpp
@@ -203,6 +203,7 @@ namespace lfs::io::project {
             result.depth_path = lfs::core::path_to_utf8(camera.depth_path());
             result.normal_path = lfs::core::path_to_utf8(camera.normal_path());
             result.has_alpha = camera.has_alpha();
+            result.has_image = camera.has_image();
             result.split =
                 camera.split() == lfs::core::CameraSplit::Train ? "train" : "eval";
             return result;
@@ -406,6 +407,7 @@ namespace lfs::io::project {
                 lfs::core::utf8_to_path(value.normal_path));
             camera->set_image_dimensions(value.image_width, value.image_height);
             camera->set_has_alpha(value.has_alpha);
+            camera->set_has_image(value.has_image);
             camera->set_split(value.split == "train" ? lfs::core::CameraSplit::Train
                                                      : lfs::core::CameraSplit::Eval);
             return camera;

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -502,6 +502,103 @@ namespace lfs::vis::project {
                 lfs::core::path_to_utf8(dataset_root));
         }
 
+        // Pre-training (and relocated-dataset) projects have cameras in
+        // the already-hydrated SCNG. Do not LoadFile/re-import: that
+        // rebuilds cameras from the folder and drops node-level
+        // training_enabled / visible. Missing-image cameras stay
+        // Camera::has_image, never a user disable.
+        void installTrainerFromHydratedDatasetScene(
+            VisualizerImpl& viewer,
+            SceneManager& scene_manager,
+            const std::filesystem::path& dataset_root,
+            const std::filesystem::path& output_path,
+            const std::filesystem::path& rebase_from =
+                {}) {
+            if (!rebase_from.empty() &&
+                rebase_from.lexically_normal() !=
+                    dataset_root.lexically_normal()) {
+                const auto rebased =
+                    scene_manager.getScene()
+                        .rebaseCameraAssetPaths(
+                            rebase_from, dataset_root);
+                LOG_INFO(
+                    "Rebased {} camera asset path(s) from {} to {}",
+                    rebased,
+                    lfs::core::path_to_utf8(
+                        rebase_from),
+                    lfs::core::path_to_utf8(
+                        dataset_root));
+            }
+
+            auto* const parameter_manager =
+                viewer.getParameterManager();
+            auto* const trainer_manager =
+                viewer.getTrainerManager();
+            auto* const data_loader =
+                viewer.getDataLoader();
+            if (!parameter_manager ||
+                !trainer_manager) {
+                notifyTrainerRestoreFailure(
+                    viewer,
+                    "Project has no trainer manager or parameter manager");
+                return;
+            }
+            if (!data_loader) {
+                notifyTrainerRestoreFailure(
+                    viewer,
+                    "Project dataset loader is unavailable");
+                return;
+            }
+            if (!scene_manager.getScene()
+                     .hasTrainingData()) {
+                notifyTrainerRestoreFailure(
+                    viewer,
+                    "Hydrated scene has no cameras");
+                return;
+            }
+            if (trainer_manager->hasTrainer()) {
+                if (!trainer_manager->clearTrainer()) {
+                    notifyTrainerRestoreFailure(
+                        viewer,
+                        "Previous training worker is still stopping");
+                    return;
+                }
+            }
+
+            auto params =
+                parameter_manager->createForDataset(
+                    dataset_root, output_path);
+            data_loader->setParameters(params);
+            scene_manager.setDatasetPath(dataset_root);
+            parameter_manager->getDatasetConfig()
+                .data_path = dataset_root;
+
+            try {
+                auto trainer = std::make_unique<
+                    lfs::training::Trainer>(
+                    scene_manager.getScene());
+                trainer->setParams(params);
+                trainer_manager->setScene(
+                    &scene_manager.getScene());
+                trainer_manager->setTrainer(
+                    std::move(trainer));
+            } catch (const std::exception& error) {
+                notifyTrainerRestoreFailure(
+                    viewer, error.what());
+                return;
+            }
+            if (!trainer_manager->hasTrainer()) {
+                notifyTrainerRestoreFailure(
+                    viewer,
+                    "Hydrated dataset trainer install was rejected");
+                return;
+            }
+            LOG_INFO(
+                "Project trainer restored from hydrated scene cameras (dataset={})",
+                lfs::core::path_to_utf8(
+                    dataset_root));
+        }
+
     } // namespace
 
     // After display hydration, stream CKPT into a
@@ -566,27 +663,10 @@ namespace lfs::vis::project {
                 return;
             }
 
-            auto* const data_loader = viewer_.getDataLoader();
-            if (!data_loader) {
-                notifyTrainerRestoreFailure(
-                    viewer_,
-                    "Project dataset loader is unavailable");
-                return;
-            }
-            auto params = parameter_manager->createForDataset(
-                *dataset_root,
-                report.pending_parameters.dataset.output_path);
-            data_loader->setParameters(params);
-            scene_manager.setDatasetPath(*dataset_root);
-            lfs::core::events::cmd::LoadFile{
-                .path = *dataset_root,
-                .is_dataset = true,
-                .output_path = params.dataset.output_path,
-            }
-                .emit();
-            LOG_INFO(
-                "Queued project dataset reload for trainer restoration; the hydrated scene will be rebuilt from the dataset (dataset={})",
-                lfs::core::path_to_utf8(*dataset_root));
+            installTrainerFromHydratedDatasetScene(
+                viewer_, scene_manager, *dataset_root,
+                report.pending_parameters.dataset
+                    .output_path);
             return;
         }
         if (report.checkpoint_header->iteration < 0) {
@@ -1808,58 +1888,37 @@ namespace lfs::vis::project {
         std::filesystem::path output_path) {
         const auto epoch =
             epoch_.load(std::memory_order_acquire);
+        const auto old_root = missing_path;
         beginPendingDatasetRelocation(
             std::move(missing_path),
             [this, epoch,
-             output_path = std::move(output_path)](
+             output_path = std::move(output_path),
+             old_root](
                 const std::filesystem::path& new_root) {
                 if (!viewer_.postWork({
                         .run =
                             [this, epoch, output_path,
-                             new_root] {
+                             old_root, new_root] {
                                 if (epoch_.load(
                                         std::memory_order_acquire) !=
                                     epoch) {
                                     return;
                                 }
-                                auto* parameter_manager =
-                                    viewer_
-                                        .getParameterManager();
-                                auto* data_loader =
-                                    viewer_.getDataLoader();
                                 auto* scene_manager =
                                     viewer_
                                         .getSceneManager();
-                                if (!parameter_manager ||
-                                    !data_loader ||
-                                    !scene_manager) {
+                                if (!scene_manager) {
                                     notifyTrainerRestoreFailure(
                                         viewer_,
                                         "Project dataset loader is unavailable");
                                     return;
                                 }
-                                auto params =
-                                    parameter_manager
-                                        ->createForDataset(
-                                            new_root,
-                                            output_path);
-                                data_loader->setParameters(
-                                    params);
-                                scene_manager->setDatasetPath(
-                                    new_root);
-                                lfs::core::events::cmd::
-                                    LoadFile{
-                                        .path = new_root,
-                                        .is_dataset = true,
-                                        .output_path =
-                                            params.dataset
-                                                .output_path,
-                                    }
-                                        .emit();
-                                LOG_INFO(
-                                    "Queued project dataset reload for trainer restoration; the hydrated scene will be rebuilt from the dataset (dataset={})",
-                                    lfs::core::path_to_utf8(
-                                        new_root));
+                                installTrainerFromHydratedDatasetScene(
+                                    viewer_,
+                                    *scene_manager,
+                                    new_root,
+                                    output_path,
+                                    old_root);
                             },
                         .cancel = {},
                     })) {

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -314,7 +314,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_RelocateCheckpointProjectDatasetRestoresTrainerFromNewRoot_Test;
         friend class VisualizerImplResetTest_DatasetProjectWithoutReferenceIsNotRecoveredFromContainingDirectory_Test;
         friend class VisualizerImplResetTest_NonDatasetProjectInsideDatasetRootIsNotReimported_Test;
-        friend class VisualizerImplResetTest_OpeningAnotherProjectCancelsPendingDatasetRestoreImport_Test;
+        friend class VisualizerImplResetTest_OpeningAnotherProjectAfterHydratedCameraRestoreReplacesTrainer_Test;
         friend class VisualizerImplResetTest_NonDatasetSaveDoesNotBindStaleDatasetPath_Test;
         friend class VisualizerImplResetTest_TrainingCheckpointReopenRestoresPausedResumableState_Test;
         friend class VisualizerImplResetTest_ErrorFinishedCheckpointProjectReopensPausedAndResumable_Test;
@@ -338,6 +338,8 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_StartupSweepsEmptyScratchAndDoesNotOffer_Test;
         friend class VisualizerImplResetTest_LoadFileStopTrainingDefersDatasetLoad_Test;
         friend class VisualizerImplResetTest_LoadDatasetApiDoesNotDeferOrPrompt_Test;
+        friend class VisualizerImplResetTest_PreTrainingProjectSaveRestoresCameraEnabledAndHidden_Test;
+        friend class VisualizerImplResetTest_PostTrainingProjectSaveRestoresCameraEnabledAndHidden_Test;
 
         // Allow ToolContext to access GUI manager for logging
         friend class ToolContext;

--- a/tests/test_project_chapters.cpp
+++ b/tests/test_project_chapters.cpp
@@ -618,4 +618,130 @@ namespace {
             << "scale pass took " << std::chrono::duration<double>(elapsed).count() << "s";
     }
 
+    CameraRecord make_chapter_camera(const bool has_image = true) {
+        CameraRecord camera;
+        camera.uid = 3;
+        camera.camera_id = 1;
+        camera.rotation = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+        camera.translation = {0.0f, 0.0f, 1.0f};
+        camera.focal_x = 800.0f;
+        camera.focal_y = 800.0f;
+        camera.center_x = 640.0f;
+        camera.center_y = 360.0f;
+        camera.camera_width = 1280;
+        camera.camera_height = 720;
+        camera.image_width = 1280;
+        camera.image_height = 720;
+        camera.image_name = "frame_0003.png";
+        camera.image_path = "images/frame_0003.png";
+        camera.split = "train";
+        camera.has_image = has_image;
+        return camera;
+    }
+
+    TEST(ProjectChapterTest,
+         SceneGraphCameraVisibleAndTrainingEnabledRoundTripSeparatesHasImage) {
+        const auto hidden_id =
+            uuid_literal("53000000-0000-4000-8000-000000000001");
+        const auto disabled_id =
+            uuid_literal("53000000-0000-4000-8000-000000000002");
+        const auto missing_id =
+            uuid_literal("53000000-0000-4000-8000-000000000003");
+
+        SceneGraphChapter chapter;
+        ASSERT_TRUE(chapter.upsert_node(SceneNodeRecord{
+            .uuid = hidden_id,
+            .type = "camera",
+            .name = "hidden",
+            .child_order = 0,
+            .visible = false,
+            .training_enabled = true,
+            .camera = make_chapter_camera(true),
+        }));
+        auto disabled_camera = make_chapter_camera(true);
+        disabled_camera.uid = 1;
+        disabled_camera.image_name = "frame_0001.png";
+        ASSERT_TRUE(chapter.upsert_node(SceneNodeRecord{
+            .uuid = disabled_id,
+            .type = "camera",
+            .name = "disabled",
+            .child_order = 1,
+            .visible = true,
+            .training_enabled = false,
+            .camera = std::move(disabled_camera),
+        }));
+        auto missing_camera = make_chapter_camera(false);
+        missing_camera.uid = 2;
+        missing_camera.image_name = "frame_0002.png";
+        ASSERT_TRUE(chapter.upsert_node(SceneNodeRecord{
+            .uuid = missing_id,
+            .type = "camera",
+            .name = "missing-image",
+            .child_order = 2,
+            .visible = true,
+            .training_enabled = true,
+            .camera = std::move(missing_camera),
+        }));
+
+        auto reparsed =
+            SceneGraphChapter::from_bytes(chapter.to_bytes());
+        ASSERT_TRUE(reparsed)
+            << lfs::format_for_developer(reparsed.error());
+        auto nodes = reparsed->nodes();
+        ASSERT_TRUE(nodes)
+            << lfs::format_for_developer(nodes.error());
+        ASSERT_EQ(nodes->size(), 3u);
+
+        EXPECT_EQ((*nodes)[0].uuid, hidden_id);
+        EXPECT_FALSE((*nodes)[0].visible);
+        EXPECT_TRUE((*nodes)[0].training_enabled);
+        ASSERT_TRUE((*nodes)[0].camera);
+        EXPECT_TRUE((*nodes)[0].camera->has_image);
+
+        EXPECT_EQ((*nodes)[1].uuid, disabled_id);
+        EXPECT_TRUE((*nodes)[1].visible);
+        EXPECT_FALSE((*nodes)[1].training_enabled);
+        ASSERT_TRUE((*nodes)[1].camera);
+        EXPECT_TRUE((*nodes)[1].camera->has_image);
+
+        EXPECT_EQ((*nodes)[2].uuid, missing_id);
+        EXPECT_TRUE((*nodes)[2].visible);
+        EXPECT_TRUE((*nodes)[2].training_enabled);
+        ASSERT_TRUE((*nodes)[2].camera);
+        EXPECT_FALSE((*nodes)[2].camera->has_image);
+    }
+
+    TEST(ProjectChapterTest, SceneGraphCameraHasImageDefaultsTrueWhenAbsent) {
+        const auto node_id =
+            uuid_literal("53000000-0000-4000-8000-000000000010");
+        SceneGraphChapter chapter;
+        ASSERT_TRUE(chapter.upsert_node(SceneNodeRecord{
+            .uuid = node_id,
+            .type = "camera",
+            .name = "legacy-camera",
+            .child_order = 0,
+            .visible = true,
+            .training_enabled = false,
+            .camera = make_chapter_camera(false),
+        }));
+
+        auto dumped =
+            lfs::io::JsonChapterDom::Json::parse(chapter.dom().dump());
+        ASSERT_EQ(dumped["nodes"].size(), 1);
+        ASSERT_TRUE(dumped["nodes"][0].contains("camera"));
+        dumped["nodes"][0]["camera"].erase("has_image");
+        EXPECT_FALSE(dumped["nodes"][0]["camera"].contains("has_image"));
+
+        auto reparsed = SceneGraphChapter::parse(dumped.dump());
+        ASSERT_TRUE(reparsed)
+            << lfs::format_for_developer(reparsed.error());
+        auto found = reparsed->find(node_id);
+        ASSERT_TRUE(found)
+            << lfs::format_for_developer(found.error());
+        ASSERT_TRUE(*found);
+        EXPECT_FALSE((*found)->training_enabled);
+        ASSERT_TRUE((*found)->camera);
+        EXPECT_TRUE((*found)->camera->has_image);
+    }
+
 } // namespace

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -44,6 +44,8 @@
 #include <tuple>
 #include <vector>
 
+#include <cuda_runtime.h>
+
 #if defined(__linux__)
 #include <csignal>
 #include <fcntl.h>
@@ -953,6 +955,128 @@ namespace {
         EXPECT_EQ(live.getNodeUuid(root_node->children[0]), first);
         EXPECT_EQ(live.getNodeUuid(root_node->children[1]), second);
         EXPECT_EQ(live.getNodeUuid(root_node->children[2]), third);
+    }
+
+    bool cuda_device_available() {
+        int count = 0;
+        return cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+    }
+
+    std::shared_ptr<lfs::core::Camera> make_adapter_test_camera(
+        const std::string& image_name, const int uid) {
+        const auto empty_distortion = Tensor::zeros(
+            {0}, Device::CPU, DataType::Float32);
+        return std::make_shared<lfs::core::Camera>(
+            Tensor::eye(3, Device::CPU),
+            Tensor::zeros({3}, Device::CPU),
+            100.0f, 100.0f, 32.0f, 32.0f,
+            empty_distortion, empty_distortion,
+            lfs::core::CameraModelType::PINHOLE,
+            image_name, std::filesystem::path{},
+            std::filesystem::path{}, 64, 64, uid);
+    }
+
+    TEST(SceneChapterAdapterTest,
+         CameraVisibleTrainingEnabledAndHasImageRoundTripIndependently) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+
+        Scene source;
+        const auto dataset = source.addDataset("Dataset");
+        const auto group =
+            source.addCameraGroup("Training", dataset, 3);
+        ASSERT_NE(dataset, lfs::core::NULL_NODE);
+        ASSERT_NE(group, lfs::core::NULL_NODE);
+
+        auto disabled = make_adapter_test_camera("frame_0001.png", 1);
+        auto missing = make_adapter_test_camera("frame_0002.png", 2);
+        missing->set_has_image(false);
+        auto hidden = make_adapter_test_camera("frame_0003.png", 3);
+
+        const auto disabled_id =
+            source.addCamera("frame_0001.png", group, disabled);
+        const auto missing_id =
+            source.addCamera("frame_0002.png", group, missing);
+        const auto hidden_id =
+            source.addCamera("frame_0003.png", group, hidden);
+        ASSERT_NE(disabled_id, lfs::core::NULL_NODE);
+        ASSERT_NE(missing_id, lfs::core::NULL_NODE);
+        ASSERT_NE(hidden_id, lfs::core::NULL_NODE);
+
+        source.setCameraTrainingEnabled(disabled_id, false);
+        source.setNodeVisibility(hidden_id, false);
+
+        auto chapter = capture_scene_graph(source, ScenePayloadBindings{});
+        ASSERT_TRUE(chapter)
+            << lfs::format_for_developer(chapter.error());
+        auto captured_nodes = chapter->nodes();
+        ASSERT_TRUE(captured_nodes)
+            << lfs::format_for_developer(captured_nodes.error());
+        const auto captured_disabled = std::ranges::find_if(
+            *captured_nodes, [](const auto& node) {
+                return node.name == "frame_0001.png";
+            });
+        const auto captured_missing = std::ranges::find_if(
+            *captured_nodes, [](const auto& node) {
+                return node.name == "frame_0002.png";
+            });
+        const auto captured_hidden = std::ranges::find_if(
+            *captured_nodes, [](const auto& node) {
+                return node.name == "frame_0003.png";
+            });
+        ASSERT_NE(captured_disabled, captured_nodes->end());
+        ASSERT_NE(captured_missing, captured_nodes->end());
+        ASSERT_NE(captured_hidden, captured_nodes->end());
+        EXPECT_TRUE(captured_disabled->visible);
+        EXPECT_FALSE(captured_disabled->training_enabled);
+        ASSERT_TRUE(captured_disabled->camera);
+        EXPECT_TRUE(captured_disabled->camera->has_image);
+        EXPECT_TRUE(captured_missing->visible);
+        EXPECT_TRUE(captured_missing->training_enabled);
+        ASSERT_TRUE(captured_missing->camera);
+        EXPECT_FALSE(captured_missing->camera->has_image);
+        EXPECT_FALSE(captured_hidden->visible);
+        EXPECT_TRUE(captured_hidden->training_enabled);
+        ASSERT_TRUE(captured_hidden->camera);
+        EXPECT_TRUE(captured_hidden->camera->has_image);
+
+        Scene live;
+        auto restored =
+            hydrate_scene_graph(*chapter, live, ScenePayloadResolver{});
+        ASSERT_TRUE(restored)
+            << lfs::format_for_developer(restored.error());
+
+        const auto* live_disabled = live.getNode("frame_0001.png");
+        const auto* live_missing = live.getNode("frame_0002.png");
+        const auto* live_hidden = live.getNode("frame_0003.png");
+        ASSERT_NE(live_disabled, nullptr);
+        ASSERT_NE(live_missing, nullptr);
+        ASSERT_NE(live_hidden, nullptr);
+        EXPECT_TRUE(live_disabled->visible.get());
+        EXPECT_FALSE(live_disabled->training_enabled);
+        ASSERT_NE(live_disabled->camera, nullptr);
+        EXPECT_TRUE(live_disabled->camera->has_image());
+        EXPECT_TRUE(live_missing->visible.get());
+        EXPECT_TRUE(live_missing->training_enabled);
+        ASSERT_NE(live_missing->camera, nullptr);
+        EXPECT_FALSE(live_missing->camera->has_image());
+        EXPECT_FALSE(live_hidden->visible.get());
+        EXPECT_TRUE(live_hidden->training_enabled);
+        ASSERT_NE(live_hidden->camera, nullptr);
+        EXPECT_TRUE(live_hidden->camera->has_image());
+
+        const auto active = live.getActiveCameras();
+        ASSERT_EQ(active.size(), 2u);
+        EXPECT_TRUE(std::ranges::none_of(active, [](const auto& camera) {
+            return camera && camera->uid() == 1;
+        }));
+        EXPECT_TRUE(std::ranges::any_of(active, [](const auto& camera) {
+            return camera && camera->uid() == 2;
+        }));
+        EXPECT_TRUE(std::ranges::any_of(active, [](const auto& camera) {
+            return camera && camera->uid() == 3;
+        }));
     }
 
     TEST(ProjectDocumentTest,

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -43,6 +43,7 @@
 #include <cstring>
 #include <deque>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <future>
 #include <gtest/gtest.h>
@@ -334,7 +335,9 @@ namespace {
 
     std::shared_ptr<lfs::core::Camera>
     make_project_request_test_camera(
-        const std::filesystem::path& image_path = {}) {
+        const std::filesystem::path& image_path = {},
+        const int uid = 0,
+        const std::string& image_name = "camera.png") {
         const auto empty_distortion =
             lfs::core::Tensor::zeros(
                 {0}, lfs::core::Device::CPU,
@@ -347,8 +350,8 @@ namespace {
             100.0F, 100.0F, 32.0F, 32.0F,
             empty_distortion, empty_distortion,
             lfs::core::CameraModelType::PINHOLE,
-            "camera.png", image_path,
-            std::filesystem::path{}, 64, 64, 0);
+            image_name, image_path,
+            std::filesystem::path{}, 64, 64, uid);
     }
 
     bool arm_running_trainer(lfs::vis::VisualizerImpl& viewer) {
@@ -381,11 +384,35 @@ namespace {
                trainer_manager->isTrainingActive();
     }
 
-    void write_minimal_transforms_dataset(const std::filesystem::path& dataset_path) {
+    void write_transforms_dataset_with_cameras(
+        const std::filesystem::path& dataset_path,
+        const int camera_count) {
         std::filesystem::create_directories(dataset_path);
         const auto png = lfs::test::licht::one_pixel_png();
-        lfs::test::licht::write_file_bytes(dataset_path / "frame_0001.png", png);
-        const auto transforms = lfs::test::licht::byte_vector(R"({
+        std::string frames;
+        for (int i = 0; i < camera_count; ++i) {
+            const auto name =
+                std::format("frame_{:04}.png", i + 1);
+            lfs::test::licht::write_file_bytes(
+                dataset_path / name, png);
+            if (i != 0) {
+                frames += ",\n";
+            }
+            frames += std::format(
+                R"(    {{
+      "file_path": "{}",
+      "transform_matrix": [
+        [1.0, 0.0, 0.0, {}],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0]
+      ]
+    }})",
+                name, static_cast<float>(i));
+        }
+        const auto transforms =
+            lfs::test::licht::byte_vector(std::format(
+                R"({{
   "fl_x": 1.0,
   "fl_y": 1.0,
   "cx": 0.5,
@@ -393,20 +420,19 @@ namespace {
   "w": 1,
   "h": 1,
   "frames": [
-    {
-      "file_path": "frame_0001.png",
-      "transform_matrix": [
-        [1.0, 0.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0, 0.0],
-        [0.0, 0.0, 1.0, 0.0],
-        [0.0, 0.0, 0.0, 1.0]
-      ]
-    }
+{}
   ]
-}
-)");
+}}
+)",
+                frames));
         lfs::test::licht::write_file_bytes(
             dataset_path / "transforms.json", transforms);
+    }
+
+    void write_minimal_transforms_dataset(
+        const std::filesystem::path& dataset_path) {
+        write_transforms_dataset_with_cameras(
+            dataset_path, 1);
     }
 
     void write_dataset_project_without_checkpoint(
@@ -629,6 +655,149 @@ namespace {
             lfs::test::licht::
                 deterministic_document_save_options(
                     0x76000010, 1, 2);
+        options.commit.snapshot_uuid = checkpoint_uuid;
+        (void)lfs::test::licht::require_result(
+            document->save(path, options));
+    }
+
+    const lfs::core::SceneNode*
+    camera_node_by_uid(const lfs::core::Scene& scene,
+                       const int uid) {
+        for (const auto* node : scene.getNodes()) {
+            if (node &&
+                node->type == lfs::core::NodeType::CAMERA &&
+                node->camera &&
+                node->camera->uid() == uid) {
+                return node;
+            }
+        }
+        return nullptr;
+    }
+
+    void expect_first_disabled_third_hidden(
+        const lfs::core::Scene& scene) {
+        const auto* first = camera_node_by_uid(scene, 0);
+        const auto* second = camera_node_by_uid(scene, 1);
+        const auto* third = camera_node_by_uid(scene, 2);
+        ASSERT_NE(first, nullptr);
+        ASSERT_NE(second, nullptr);
+        ASSERT_NE(third, nullptr);
+        EXPECT_FALSE(first->training_enabled);
+        EXPECT_TRUE(first->visible.get());
+        EXPECT_TRUE(second->training_enabled);
+        EXPECT_TRUE(second->visible.get());
+        EXPECT_TRUE(third->training_enabled);
+        EXPECT_FALSE(third->visible.get());
+
+        const auto disabled =
+            scene.getTrainingDisabledCameraUids();
+        EXPECT_TRUE(disabled.contains(0));
+        EXPECT_FALSE(disabled.contains(1));
+        EXPECT_FALSE(disabled.contains(2));
+
+        const auto active = scene.getActiveCameras();
+        EXPECT_TRUE(std::ranges::none_of(
+            active, [](const auto& camera) {
+                return camera && camera->uid() == 0;
+            }));
+        EXPECT_TRUE(std::ranges::any_of(
+            active, [](const auto& camera) {
+                return camera && camera->uid() == 1;
+            }));
+        EXPECT_TRUE(std::ranges::any_of(
+            active, [](const auto& camera) {
+                return camera && camera->uid() == 2;
+            }));
+    }
+
+    void add_flagged_training_cameras(
+        lfs::core::Scene& scene,
+        const lfs::core::NodeId parent,
+        const std::filesystem::path& dataset_path) {
+        const auto cameras = scene.addCameraGroup(
+            "Training cameras", parent, 3);
+        if (cameras == lfs::core::NULL_NODE) {
+            throw std::runtime_error(
+                "failed to create camera group");
+        }
+        for (int i = 0; i < 3; ++i) {
+            const auto name =
+                std::format("frame_{:04}.png", i + 1);
+            const auto id = scene.addCamera(
+                name, cameras,
+                make_project_request_test_camera(
+                    dataset_path / name, i, name));
+            if (id == lfs::core::NULL_NODE) {
+                throw std::runtime_error(
+                    "failed to create camera node");
+            }
+        }
+        const auto* first = camera_node_by_uid(scene, 0);
+        const auto* third = camera_node_by_uid(scene, 2);
+        if (!first || !third) {
+            throw std::runtime_error(
+                "failed to resolve flagged cameras");
+        }
+        scene.setCameraTrainingEnabled(first->id, false);
+        scene.setNodeVisibility(third->id, false);
+    }
+
+    void write_resumable_flagged_three_camera_project(
+        const std::filesystem::path& path,
+        const lfs::core::Uuid& training_uuid,
+        const lfs::core::Uuid& checkpoint_uuid,
+        const std::filesystem::path& dataset_path) {
+        auto document = lfs::test::licht::make_empty_document(
+            lfs::core::generate_uuid_v4(), 1);
+        lfs::core::Scene source;
+        const auto root = source.addDataset("Dataset");
+        add_flagged_training_cameras(
+            source, root, dataset_path);
+        const auto training = source.restoreNodeWithUuid(
+            lfs::core::Scene::RestoreNodeDesc{
+                .uuid = training_uuid,
+                .type = lfs::core::NodeType::SPLAT,
+                .name = "Training",
+                .parent = root,
+                .gaussian_count = 2,
+                .model = lfs::test::licht::make_splat(2),
+            });
+        if (training == lfs::core::NULL_NODE) {
+            throw std::runtime_error(
+                "failed to create training fixture node");
+        }
+        source.setTrainingModelNode(training);
+        auto scene_chapter = lfs::test::licht::require_result(
+            lfs::io::project::capture_scene_graph(
+                source,
+                lfs::io::project::ScenePayloadBindings{
+                    {training_uuid,
+                     lfs::io::project::PayloadBinding{
+                         .fourcc = "CKPT",
+                         .instance_uuid = checkpoint_uuid,
+                         .source_kind = "training",
+                     }},
+                }));
+        document->edit_scene_graph() =
+            std::move(scene_chapter);
+        lfs::test::licht::require_status(
+            document->set_checkpoint(
+                checkpoint_uuid,
+                make_training_autosave_checkpoint_payload(
+                    checkpoint_uuid, dataset_path)));
+        const auto reference =
+            lfs::test::licht::require_result(
+                lfs::io::project::upsert_path_reference(
+                    document->edit_references(),
+                    path.parent_path(), dataset_path,
+                    "dataset", "dataset"));
+        lfs::test::licht::require_status(
+            document->edit_project().set_dataset_reference(
+                reference));
+        auto options =
+            lfs::test::licht::
+                deterministic_document_save_options(
+                    0x76000011, 1, 2);
         options.commit.snapshot_uuid = checkpoint_uuid;
         (void)lfs::test::licht::require_result(
             document->save(path, options));
@@ -8360,22 +8529,27 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           OpeningAnotherProjectCancelsPendingDatasetRestoreImport) {
+           OpeningAnotherProjectAfterHydratedCameraRestoreReplacesTrainer) {
+        // Pre-training open used to queue a dataset re-import
+        // that a later open had to cancel. Hydrated SCNG is now
+        // the source of truth, so the first open installs a Ready
+        // trainer synchronously. Opening another project must still
+        // complete hydration and replace that trainer.
         if (!cuda_device_available()) {
             GTEST_SKIP() << "CUDA device unavailable";
         }
         const auto dataset_path =
             temporary_.path /
-            "dataset-pending-restore-import";
+            "dataset-hydrated-restore-switch";
         write_minimal_transforms_dataset(dataset_path);
         const auto project_a =
             temporary_.path /
-            "dataset-pending-restore-a.licht";
+            "dataset-hydrated-restore-a.licht";
         write_dataset_project_without_checkpoint(
             project_a, dataset_path);
         const auto project_b =
             temporary_.path /
-            "ply-only-pending-restore-b.licht";
+            "ply-only-hydrated-restore-b.licht";
         write_non_dataset_project_with_stale_dataset_params(
             project_b, dataset_path);
 
@@ -8398,9 +8572,18 @@ namespace lfs::vis {
                 return info &&
                        info->hydration_state ==
                            "complete" &&
-                       viewer.jobs().anyRunning(
-                           JobType::Import);
+                       viewer.getTrainerManager()
+                           ->hasTrainer() &&
+                       !viewer.jobs().anyRunning(
+                           JobType::Import) &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
             }));
+
+        EXPECT_FALSE(viewer.jobs().anyRunning(
+            JobType::Import));
+        EXPECT_TRUE(
+            viewer.getTrainerManager()->hasTrainer());
 
         auto opened_b = viewer.projectOpen(
             project_b,
@@ -8420,7 +8603,9 @@ namespace lfs::vis {
                        info->hydration_state ==
                            "complete" &&
                        !viewer.jobs().anyRunning(
-                           JobType::Import);
+                           JobType::Import) &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
             }));
 
         EXPECT_NE(
@@ -8854,6 +9039,181 @@ namespace lfs::vis {
             EXPECT_TRUE(
                 combined->has_tensor_allocator());
         }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           PreTrainingProjectSaveRestoresCameraEnabledAndHidden) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto project_path =
+            temporary_.path /
+            "pre-train-camera-flags.licht";
+        const auto dataset_path =
+            temporary_.path /
+            "pre-train-camera-flags-dataset";
+        write_transforms_dataset_with_cameras(
+            dataset_path, 3);
+
+        {
+            auto options = projectOptions();
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()
+                            ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            auto untitled = viewer.projectGetInfo();
+            ASSERT_TRUE(untitled);
+            ASSERT_FALSE(untitled->path.has_value());
+
+            auto& scene = viewer.getScene();
+            const auto dataset = scene.addDataset("Dataset");
+            ASSERT_NE(dataset, lfs::core::NULL_NODE);
+            add_flagged_training_cameras(
+                scene, dataset, dataset_path);
+            viewer.getSceneManager()->changeContentType(
+                SceneManager::ContentType::Dataset);
+            viewer.getSceneManager()->setDatasetPath(
+                dataset_path);
+            expect_first_disabled_third_hidden(scene);
+
+            auto saved = viewer.projectSaveAs(
+                project_path, false);
+            ASSERT_TRUE(saved)
+                << lfs::format_for_developer(
+                       saved.error());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_, [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            ASSERT_TRUE(
+                std::filesystem::is_regular_file(
+                    project_path));
+        }
+
+        {
+            auto saved =
+                lfs::test::licht::require_result_ptr(
+                    lfs::io::project::ProjectDocument::
+                        open(project_path));
+            auto nodes = saved->scene_graph().nodes();
+            ASSERT_TRUE(nodes)
+                << lfs::format_for_developer(
+                       nodes.error());
+            EXPECT_TRUE(std::ranges::any_of(
+                *nodes, [](const auto& node) {
+                    return node.type == "camera" &&
+                           !node.training_enabled;
+                }));
+            EXPECT_TRUE(std::ranges::any_of(
+                *nodes, [](const auto& node) {
+                    return node.type == "camera" &&
+                           !node.visible;
+                }));
+        }
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                viewer.getGuiManager()
+                    ->asyncTasks()
+                    .pollImportCompletion();
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       viewer.getTrainerManager()
+                           ->hasTrainer() &&
+                       !viewer.jobs().anyRunning(
+                           JobType::Import);
+            }));
+
+        EXPECT_FALSE(viewer.jobs().anyRunning(
+            JobType::Import));
+        expect_first_disabled_third_hidden(
+            viewer.getScene());
+        ASSERT_NE(viewer.getTrainer(), nullptr);
+        ASSERT_NE(viewer.getTrainer()->getScene(),
+                  nullptr);
+        expect_first_disabled_third_hidden(
+            *viewer.getTrainer()->getScene());
+        EXPECT_EQ(
+            viewer.getScene().getActiveCameras().size(),
+            2u);
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           PostTrainingProjectSaveRestoresCameraEnabledAndHidden) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto project_path =
+            temporary_.path /
+            "post-train-camera-flags.licht";
+        const auto dataset_path =
+            temporary_.path /
+            "post-train-camera-flags-dataset";
+        write_transforms_dataset_with_cameras(
+            dataset_path, 3);
+        write_resumable_flagged_three_camera_project(
+            project_path,
+            lfs::core::generate_uuid_v4(),
+            lfs::core::generate_uuid_v4(),
+            dataset_path);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       viewer.getTrainerManager()
+                           ->hasTrainer();
+            }));
+
+        auto* const manager = viewer.getTrainerManager();
+        ASSERT_NE(manager, nullptr);
+        EXPECT_TRUE(manager->isPaused());
+        expect_first_disabled_third_hidden(
+            viewer.getScene());
+        ASSERT_NE(viewer.getTrainer(), nullptr);
+        ASSERT_NE(viewer.getTrainer()->getScene(),
+                  nullptr);
+        expect_first_disabled_third_hidden(
+            *viewer.getTrainer()->getScene());
+        EXPECT_EQ(
+            viewer.getScene().getActiveCameras().size(),
+            2u);
+        EXPECT_TRUE(viewer.getTrainer()->isInitialized());
     }
 
 } // namespace lfs::vis


### PR DESCRIPTION
Test-plan case LICHT008.02 (#1716): disable a camera for training, hide another, save the project before training starts, reopen - both settings were gone.

**Cause:** reopening a project saved before training re-imported the dataset folder after the saved scene had already been restored, and the re-import reset every camera to its defaults. Projects saved during or after training never hit this because they rebuild the trainer from the restored scene instead.

**Fix:** the no-checkpoint case now restores the trainer from the saved scene as well, and never re-imports. Reset Training and an explicit dataset import still rebuild from the folder on purpose - that is what the tester noticed as "reset re-enables cameras", and it stays that way. The missing-image marker from #1713 is stored as its own field so a missing image is never mistaken for a user disable.

**Verified:** new round-trip and restore tests (164 green in the touched suites), and the tester's exact steps live: disabled camera 1, hid camera 3, saved before training, closed and reopened - camera 1 is the only training-disabled camera, camera 3 is still hidden, and the log shows the project restored from the saved scene with no folder re-import.

Fixes #1716