### PR TITLE
Stop the 'frame timeline waits must increase strictly' present storm

### DIFF
--- a/src/rendering/vulkan_wait.hpp
+++ b/src/rendering/vulkan_wait.hpp
@@ -88,6 +88,50 @@ namespace lfs::rendering {
                                 std::uint64_t candidate_timeline = 0) noexcept;
 
     // ---------------------------------------------------------------------------
+    // GUI-frame timeline wait accounting (#1721)
+    //
+    // A Vulkan timeline wait is satisfied when the counter is >= the requested
+    // value, so repeating an already-covered wait is a no-op. The GUI present
+    // path re-requests the last VkSplat completion on frames that did not bump
+    // the timeline. Treating that as a contract violation made endFrame refuse
+    // submit, set framebuffer_resized_, and never recover.
+    //
+    // committed: last value included in a successful graphics-queue submit.
+    // pending:   max value queued on the current unsubmitted frame.
+    // ---------------------------------------------------------------------------
+
+    enum class FrameTimelineWaitAction : std::uint8_t {
+        Queue,            // requested > covered; add to this frame's submit
+        AlreadySatisfied, // requested <= covered; skip the wait
+    };
+
+    struct FrameTimelineWaitCursor {
+        std::uint64_t committed = 0;
+        std::uint64_t pending = 0;
+
+        [[nodiscard]] constexpr std::uint64_t covered() const noexcept {
+            return committed > pending ? committed : pending;
+        }
+
+        constexpr FrameTimelineWaitAction note(const std::uint64_t value) noexcept {
+            if (value <= covered()) {
+                return FrameTimelineWaitAction::AlreadySatisfied;
+            }
+            pending = value;
+            return FrameTimelineWaitAction::Queue;
+        }
+
+        constexpr void submit_accepted() noexcept {
+            if (pending > committed) {
+                committed = pending;
+            }
+            pending = 0;
+        }
+
+        constexpr void submit_rejected() noexcept { pending = 0; }
+    };
+
+    // ---------------------------------------------------------------------------
     // Vulkan PFN dispatch seam (Amendment 2: every begin→submit path call)
     // ---------------------------------------------------------------------------
 

--- a/src/visualizer/window/vulkan_context.cpp
+++ b/src/visualizer/window/vulkan_context.cpp
@@ -769,7 +769,7 @@ namespace lfs::vis {
         frame_timeline_waits_valid_ = true;
         {
             const std::lock_guard lock(timeline_value_tracker_mutex_);
-            last_frame_timeline_wait_values_.clear();
+            frame_timeline_wait_cursors_.clear();
             last_immediate_timeline_wait_values_.clear();
             last_immediate_timeline_signal_values_.clear();
         }
@@ -1019,6 +1019,12 @@ namespace lfs::vis {
                 active_frame_index_,
                 active_image_index_,
                 active_acquire_index_));
+        }
+        {
+            const std::lock_guard lock(timeline_value_tracker_mutex_);
+            for (auto& entry : frame_timeline_wait_cursors_) {
+                entry.second.submit_rejected();
+            }
         }
         frame_timeline_waits_.clear();
         frame_timeline_waits_valid_ = true;
@@ -1629,6 +1635,12 @@ namespace lfs::vis {
                  swapchain_extent_.height);
         // Counter retained until next prepareFrame reset so mid-frame readers still see it.
         result = vkQueueSubmit(graphics_queue_, 1, &submit_info, frame_fence);
+        if (result == VK_SUCCESS) {
+            const std::lock_guard lock(timeline_value_tracker_mutex_);
+            for (const auto& wait : frame_timeline_waits_) {
+                frame_timeline_wait_cursors_[wait.semaphore].submit_accepted();
+            }
+        }
         frame_timeline_waits_.clear();
         if (result != VK_SUCCESS) {
             frame_active_ = false;
@@ -2073,20 +2085,12 @@ namespace lfs::vis {
             return false;
         }
         const std::lock_guard lock(timeline_value_tracker_mutex_);
-        const std::uint64_t previous = last_frame_timeline_wait_values_[semaphore];
-        if (value <= previous) {
-            frame_timeline_waits_valid_ = false;
-            fail(std::format(
-                "Frame timeline waits must increase strictly (semaphore={:#x}, requested_value={}, previous_value={}, wait_stage={:#x}, frame_slot={}, image_index={})",
-                vkHandleValue(semaphore),
-                value,
-                previous,
-                static_cast<std::uint64_t>(wait_stage),
-                active_frame_index_,
-                active_image_index_));
-            return false;
+        auto& cursor = frame_timeline_wait_cursors_[semaphore];
+        if (cursor.note(value) == lfs::rendering::FrameTimelineWaitAction::AlreadySatisfied) {
+            // Timeline waits are satisfied at counter >= value. Re-requesting a
+            // value already queued this frame or submitted earlier is a no-op.
+            return true;
         }
-        last_frame_timeline_wait_values_[semaphore] = value;
         frame_timeline_waits_.push_back(FrameTimelineWait{
             .semaphore = semaphore,
             .value = value,
@@ -3606,8 +3610,8 @@ namespace lfs::vis {
         // exporter's handle. A stale handle must assert instead of being hidden
         // by the VUID-01742 suppression below.
         {
-            struct stat st_src {};
-            struct stat st_dup {};
+            struct stat st_src{};
+            struct stat st_dup{};
             const int st_src_rc = ::fstat(handle, &st_src);
             const int st_dup_rc = ::fstat(dup_fd, &st_dup);
             int kcmp_rc = 0;
@@ -3782,7 +3786,7 @@ namespace lfs::vis {
         }
         {
             const std::lock_guard lock(timeline_value_tracker_mutex_);
-            last_frame_timeline_wait_values_.erase(out.semaphore);
+            frame_timeline_wait_cursors_.erase(out.semaphore);
             last_immediate_timeline_wait_values_.erase(out.semaphore);
             last_immediate_timeline_signal_values_.erase(out.semaphore);
         }
@@ -3835,7 +3839,7 @@ namespace lfs::vis {
         const std::string scope = semaphore.diagnostic_scope;
         if (semaphore.semaphore != VK_NULL_HANDLE) {
             const std::lock_guard lock(timeline_value_tracker_mutex_);
-            last_frame_timeline_wait_values_.erase(semaphore.semaphore);
+            frame_timeline_wait_cursors_.erase(semaphore.semaphore);
             last_immediate_timeline_wait_values_.erase(semaphore.semaphore);
             last_immediate_timeline_signal_values_.erase(semaphore.semaphore);
             if (device_) {

--- a/src/visualizer/window/vulkan_context.hpp
+++ b/src/visualizer/window/vulkan_context.hpp
@@ -293,9 +293,11 @@ namespace lfs::vis {
         [[nodiscard]] bool waitForRetiredFrameSubmitSerial(std::uint64_t serial);
         [[nodiscard]] bool waitForImmediateSubmits();
         [[nodiscard]] bool deviceWaitIdle();
-        // Returns false if the wait was rejected (frame inactive / mono violation);
-        // endFrame will refuse submit when any wait fails. Callers that commit
-        // layout optimistically must not do so on false.
+        // Returns false if the wait was rejected (frame inactive / invalid edge);
+        // endFrame will refuse submit when any wait fails. A requested value that
+        // is already covered by a queued or submitted wait on the same semaphore
+        // is treated as already satisfied (success, no extra submit wait). Callers
+        // that commit layout optimistically must not do so on false.
         [[nodiscard]] bool addFrameTimelineWait(
             VkSemaphore semaphore,
             std::uint64_t value,
@@ -503,7 +505,8 @@ namespace lfs::vis {
         std::vector<FrameTimelineWait> frame_timeline_waits_;
         bool frame_timeline_waits_valid_ = true;
         std::mutex timeline_value_tracker_mutex_;
-        std::unordered_map<VkSemaphore, std::uint64_t> last_frame_timeline_wait_values_;
+        std::unordered_map<VkSemaphore, lfs::rendering::FrameTimelineWaitCursor>
+            frame_timeline_wait_cursors_;
         std::unordered_map<VkSemaphore, std::uint64_t> last_immediate_timeline_wait_values_;
         std::unordered_map<VkSemaphore, std::uint64_t> last_immediate_timeline_signal_values_;
         // image_available_ is sized to swapchain image count (not framesInFlight). We must

--- a/tests/test_vulkan_wait_bounded.cpp
+++ b/tests/test_vulkan_wait_bounded.cpp
@@ -1029,3 +1029,61 @@ TEST(VulkanWaitBounded, Phase7CP3Mesh2SplatFingerprintQuarantine) {
     EXPECT_EQ(map_mesh2splat_resource_disposition(true, false),
               Mesh2SplatResourceAction::RetainFenceAndCb);
 }
+
+// ---------------------------------------------------------------------------
+// #1721: GUI-frame timeline wait accounting. GPU-free cursor used by
+// VulkanContext::addFrameTimelineWait. Same-value re-wait after a no-submit
+// frame is not an error; a later bump still queues.
+// ---------------------------------------------------------------------------
+
+TEST(FrameTimelineWaitCursor, SameValueAfterNoSubmitRequeues) {
+    lfs::rendering::FrameTimelineWaitCursor cursor;
+    EXPECT_EQ(cursor.note(2331), lfs::rendering::FrameTimelineWaitAction::Queue);
+    EXPECT_EQ(cursor.pending, 2331u);
+    EXPECT_EQ(cursor.committed, 0u);
+
+    cursor.submit_rejected();
+    EXPECT_EQ(cursor.pending, 0u);
+    EXPECT_EQ(cursor.committed, 0u);
+
+    // No-submit frame: the wait never reached the GPU, so the same value
+    // must be queued again rather than treated as a contract violation.
+    EXPECT_EQ(cursor.note(2331), lfs::rendering::FrameTimelineWaitAction::Queue);
+    EXPECT_EQ(cursor.pending, 2331u);
+}
+
+TEST(FrameTimelineWaitCursor, SameValueAfterSubmitIsAlreadySatisfied) {
+    lfs::rendering::FrameTimelineWaitCursor cursor;
+    EXPECT_EQ(cursor.note(2331), lfs::rendering::FrameTimelineWaitAction::Queue);
+    cursor.submit_accepted();
+    EXPECT_EQ(cursor.committed, 2331u);
+    EXPECT_EQ(cursor.pending, 0u);
+
+    EXPECT_EQ(cursor.note(2331), lfs::rendering::FrameTimelineWaitAction::AlreadySatisfied);
+    EXPECT_EQ(cursor.note(2300), lfs::rendering::FrameTimelineWaitAction::AlreadySatisfied);
+    EXPECT_EQ(cursor.pending, 0u);
+    EXPECT_EQ(cursor.committed, 2331u);
+}
+
+TEST(FrameTimelineWaitCursor, BumpAfterSubmitQueues) {
+    lfs::rendering::FrameTimelineWaitCursor cursor;
+    EXPECT_EQ(cursor.note(2331), lfs::rendering::FrameTimelineWaitAction::Queue);
+    cursor.submit_accepted();
+
+    EXPECT_EQ(cursor.note(2332), lfs::rendering::FrameTimelineWaitAction::Queue);
+    EXPECT_EQ(cursor.pending, 2332u);
+    EXPECT_EQ(cursor.committed, 2331u);
+    cursor.submit_accepted();
+    EXPECT_EQ(cursor.committed, 2332u);
+    EXPECT_EQ(cursor.pending, 0u);
+}
+
+TEST(FrameTimelineWaitCursor, WithinFrameDuplicateIsAlreadySatisfied) {
+    lfs::rendering::FrameTimelineWaitCursor cursor;
+    EXPECT_EQ(cursor.note(10), lfs::rendering::FrameTimelineWaitAction::Queue);
+    EXPECT_EQ(cursor.note(10), lfs::rendering::FrameTimelineWaitAction::AlreadySatisfied);
+    EXPECT_EQ(cursor.note(11), lfs::rendering::FrameTimelineWaitAction::Queue);
+    EXPECT_EQ(cursor.pending, 11u);
+    cursor.submit_accepted();
+    EXPECT_EQ(cursor.committed, 11u);
+}


### PR DESCRIPTION
Reported on Discord (#1721, Windows): every ~5 minutes the viewport started logging "Frame timeline waits must increase strictly" on every frame and presents kept failing.

**Cause (proven from the code, no GPU bug involved):** our own check was stricter than Vulkan. A timeline wait is satisfied once the counter reaches the requested value, so asking twice for the same value is harmless - but we rejected it. Any frame that skips the scene render (during a UI transition, an export lock, or a suspended renderer) re-asks for the last completion value, so the first such frame tripped the check. Worse, a failed present never advanced the frame slot, so the next frame asked again and failed again: one hiccup became a permanent outage. The autosave tick is what lined up with the start of each burst in the report.

**Fix:** waits are tracked per semaphore as "queued this frame" vs "accepted by the GPU"; a request at or below what is already covered is treated as satisfied and queues nothing; a skipped or failed submit drops the queued value so it can be requested again. Producer-side strictly-increasing contracts are untouched.

**Verified:** new unit tests for the repeat-wait and failed-submit cases (144 green in the Vulkan/viewport suites), and a live run: training with repeated UI hide/show toggles and window captures - zero timeline errors, zero present failures. The original storm is Windows-only in the field; the mechanism is platform-independent, so I'd ask Kri-Soft to confirm on the next nightly.

Fixes #1721