### PR TITLE
One source of truth for what goes into a saved project

### DIFF
--- a/src/io/include/io/capture_omit_filter.hpp
+++ b/src/io/include/io/capture_omit_filter.hpp
@@ -1,0 +1,56 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "core/scene.hpp"
+#include "core/uuid.hpp"
+
+#include <span>
+#include <unordered_set>
+
+namespace lfs::io::project {
+
+    // Closes omit roots over scene descendants once. Unresolvable roots stay
+    // in the set. KEYFRAME exclusion is orthogonal and lives in each capture.
+    class CaptureOmitFilter {
+    public:
+        CaptureOmitFilter(
+            const lfs::core::Scene& scene,
+            std::span<const lfs::core::Uuid> omit_roots) {
+            omitted_.insert(omit_roots.begin(), omit_roots.end());
+            for (const auto& uuid : omit_roots) {
+                const auto* node = scene.getNodeByUuid(uuid);
+                if (node == nullptr) {
+                    continue;
+                }
+                collect_descendants(scene, *node);
+            }
+        }
+
+        [[nodiscard]] bool omits(
+            const lfs::core::Uuid& uuid) const noexcept {
+            return omitted_.contains(uuid);
+        }
+
+    private:
+        void collect_descendants(
+            const lfs::core::Scene& scene,
+            const lfs::core::SceneNode& node) {
+            for (const lfs::core::NodeId child_id : node.children) {
+                const lfs::core::SceneNode* child =
+                    scene.getNodeById(child_id);
+                if (child == nullptr) {
+                    continue;
+                }
+                omitted_.insert(child->uuid);
+                collect_descendants(scene, *child);
+            }
+        }
+
+        std::unordered_set<lfs::core::Uuid> omitted_;
+    };
+
+} // namespace lfs::io::project

--- a/src/io/include/io/project_document.hpp
+++ b/src/io/include/io/project_document.hpp
@@ -132,6 +132,7 @@ namespace lfs::io::project {
 
     enum class ProjectDocumentDegradedState : std::uint8_t {
         MissingActiveCamera = 1,
+        MissingPlySequenceNode = 2,
     };
 
     struct ProjectDocumentSaveReport {

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -979,6 +979,35 @@ namespace lfs::io::project {
                     }
                 }
             }
+
+            bool missing_ply_owner = false;
+            if (const auto clips =
+                    sequencer.dom().get_json("ply_sequences");
+                clips && clips->is_array()) {
+                for (const auto& clip : *clips) {
+                    if (!clip.is_object()) {
+                        continue;
+                    }
+                    const auto owner = clip.find("node_uuid");
+                    if (owner == clip.end() || owner->is_null()) {
+                        continue;
+                    }
+                    auto uuid = parse_session_uuid(
+                        *owner, "SEQR.ply_sequences.node_uuid");
+                    if (!uuid) {
+                        return lfs::Result<void>::failure(
+                            std::move(uuid).error());
+                    }
+                    if (!nodes_by_uuid.contains(*uuid)) {
+                        missing_ply_owner = true;
+                    }
+                }
+            }
+            if (missing_ply_owner) {
+                degraded_states.push_back(
+                    ProjectDocumentDegradedState::MissingPlySequenceNode);
+            }
+
             for (const auto& selected : selection.selected_node_uuids()) {
                 if (!nodes_by_uuid.contains(selected)) {
                     return fail<void>(

--- a/src/io/project/scene_chapter_adapter.cpp
+++ b/src/io/project/scene_chapter_adapter.cpp
@@ -6,6 +6,7 @@
 #include "io/scene_chapter_adapter.hpp"
 
 #include "core/path_utils.hpp"
+#include "io/capture_omit_filter.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -426,10 +427,9 @@ namespace lfs::io::project {
         const std::span<const lfs::core::Uuid> omit_node_uuids) {
         CapturedSceneGraphState result;
         const lfs::core::Uuid training_uuid = scene.getTrainingModelNodeUuid();
-        std::unordered_set<lfs::core::Uuid> omitted(
-            omit_node_uuids.begin(), omit_node_uuids.end());
+        const CaptureOmitFilter omit_filter(scene, omit_node_uuids);
         result.training_model_uuid =
-            training_uuid.is_nil() || omitted.contains(training_uuid)
+            training_uuid.is_nil() || omit_filter.omits(training_uuid)
                 ? std::optional<lfs::core::Uuid>{}
                 : std::optional<lfs::core::Uuid>{training_uuid};
 
@@ -439,7 +439,7 @@ namespace lfs::io::project {
         for (const lfs::core::SceneNode* node : all_nodes) {
             if (node->type == lfs::core::NodeType::KEYFRAME ||
                 node->type == lfs::core::NodeType::KEYFRAME_GROUP ||
-                omitted.contains(node->uuid)) {
+                omit_filter.omits(node->uuid)) {
                 excluded.insert(node->id);
             }
         }

--- a/src/io/project/selection_chapter.cpp
+++ b/src/io/project/selection_chapter.cpp
@@ -5,6 +5,7 @@
 #include "io/selection_chapter.hpp"
 
 #include "chapter_binary_utils.hpp"
+#include "io/capture_omit_filter.hpp"
 
 #include <algorithm>
 #include <array>
@@ -1063,29 +1064,8 @@ namespace lfs::io::project {
             selected_node_uuids,
         const std::span<const lfs::core::Uuid>
             omit_node_uuids) {
-        std::unordered_set<lfs::core::Uuid> omitted(
-            omit_node_uuids.begin(), omit_node_uuids.end());
-        const auto collect_descendants =
-            [&](const lfs::core::SceneNode& node,
-                const auto& self) -> void {
-            for (const lfs::core::NodeId child_id :
-                 node.children) {
-                const lfs::core::SceneNode* child =
-                    scene.getNodeById(child_id);
-                if (child == nullptr) {
-                    continue;
-                }
-                omitted.insert(child->uuid);
-                self(*child, self);
-            }
-        };
-        for (const auto& uuid : omit_node_uuids) {
-            const auto* node = scene.getNodeByUuid(uuid);
-            if (node == nullptr) {
-                continue;
-            }
-            collect_descendants(*node, collect_descendants);
-        }
+        const CaptureOmitFilter omit_filter(
+            scene, omit_node_uuids);
 
         CapturedSelectionState state;
         const auto metadata =
@@ -1103,7 +1083,7 @@ namespace lfs::io::project {
             const auto slices =
                 scene.capturePerNodeSelectionSlices(domain);
             for (const auto& [uuid, tensor] : slices) {
-                if (omitted.contains(uuid)) {
+                if (omit_filter.omits(uuid)) {
                     continue;
                 }
                 if (!tensor.is_valid() ||
@@ -1147,7 +1127,7 @@ namespace lfs::io::project {
                  node->type == lfs::core::NodeType::KEYFRAME_GROUP)) {
                 continue;
             }
-            if (omitted.contains(uuid)) {
+            if (omit_filter.omits(uuid)) {
                 continue;
             }
             state.selected_node_uuids.push_back(uuid);

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -3194,18 +3194,20 @@ namespace lfs::vis::gui {
 
     SceneTreeSessionChrome GuiManager::captureSceneTreeChrome(
         const lfs::core::Scene& scene) const {
-        return native_scene_panel_
-                   ? native_scene_panel_->captureTreeChrome(scene)
-                   : SceneTreeSessionChrome{};
+        if (native_scene_panel_)
+            return native_scene_panel_->captureTreeChrome(scene);
+        return pending_scene_tree_chrome_;
     }
 
     void GuiManager::applySceneTreeChrome(
         const SceneTreeSessionChrome& chrome) {
+        pending_scene_tree_chrome_ = chrome;
         if (native_scene_panel_)
             native_scene_panel_->applyTreeChrome(chrome);
     }
 
     void GuiManager::resetSceneTreeChrome() {
+        pending_scene_tree_chrome_ = {};
         if (native_scene_panel_)
             native_scene_panel_->resetTreeChrome();
     }

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -371,6 +371,7 @@ namespace lfs::vis {
             // Native panel wrapper storage (registered with PanelRegistry)
             std::vector<std::shared_ptr<IPanel>> native_panel_storage_;
             std::shared_ptr<NativeScenePanel> native_scene_panel_;
+            SceneTreeSessionChrome pending_scene_tree_chrome_;
             uint64_t panel_frame_serial_ = 0;
             uint8_t ui_layout_settle_frames_ = 0;
             EditorContextUpdateStamp last_editor_context_update_stamp_;

--- a/src/visualizer/gui/scene_panel_native.cpp
+++ b/src/visualizer/gui/scene_panel_native.cpp
@@ -1179,6 +1179,8 @@ namespace lfs::vis::gui {
                 collapsedUuidsFromIds(scene, tree_el_->collapsedIds());
             chrome.models_collapsed = tree_el_->modelsCollapsed();
             chrome.filter_text = tree_el_->filterText();
+        } else if (pending_tree_chrome_) {
+            chrome = *pending_tree_chrome_;
         }
         if (filter_input_el_) {
             chrome.filter_text =

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -4300,6 +4300,17 @@ namespace lfs::vis::project {
             return lfs::Status::failure(
                 std::move(captured_scene).error());
         }
+        std::unordered_set<lfs::core::Uuid>
+            captured_scene_uuids;
+        if (const auto captured_nodes =
+                captured_scene->nodes();
+            captured_nodes) {
+            captured_scene_uuids.reserve(
+                captured_nodes->size());
+            for (const auto& node : *captured_nodes) {
+                captured_scene_uuids.insert(node.uuid);
+            }
+        }
         const auto old_scene_bytes =
             document_->scene_graph().to_bytes();
         const auto new_scene_bytes =
@@ -4323,6 +4334,41 @@ namespace lfs::vis::project {
                     document_->remove_checkpoint(uuid));
             }
             if (!checkpoint_uuids.empty()) {
+                cached_bound_checkpoint_iteration_.reset();
+            }
+        }
+        // Light autosave omits the unbound live training
+        // node from SCNG. Drop CKPT chapters that node no
+        // longer binds; otherwise V21 rejects the sidecar.
+        if (mode ==
+                DocumentSyncMode::
+                    LightTrainingAutosave &&
+            !omit_unbound_training.empty()) {
+            std::unordered_set<lfs::core::Uuid>
+                bound_checkpoints;
+            if (const auto nodes =
+                    document_->scene_graph().nodes();
+                nodes) {
+                for (const auto& node : *nodes) {
+                    if (node.payload &&
+                        node.payload->fourcc == "CKPT") {
+                        bound_checkpoints.insert(
+                            node.payload->instance_uuid);
+                    }
+                }
+            }
+            const auto checkpoint_uuids =
+                document_->checkpoint_uuids();
+            bool removed_any = false;
+            for (const auto& uuid : checkpoint_uuids) {
+                if (!bound_checkpoints.contains(uuid)) {
+                    static_cast<void>(
+                        document_->remove_checkpoint(
+                            uuid));
+                    removed_any = true;
+                }
+            }
+            if (removed_any) {
                 cached_bound_checkpoint_iteration_.reset();
             }
         }
@@ -4565,8 +4611,6 @@ namespace lfs::vis::project {
                 return selected_result;
             }
 
-            std::unordered_set<lfs::core::Uuid>
-                live_geometry;
             for (const auto* node :
                  scene.getNodes()) {
                 if (!node) {
@@ -4583,7 +4627,6 @@ namespace lfs::vis::project {
                 if (!geometry) {
                     continue;
                 }
-                live_geometry.insert(node->uuid);
                 if (node->payload_hydration !=
                     lfs::core::
                         PayloadHydrationState::
@@ -4618,7 +4661,7 @@ namespace lfs::vis::project {
                 selection.slices();
             for (const auto& slice :
                  old_slices) {
-                if (!live_geometry.contains(
+                if (!captured_scene_uuids.contains(
                         slice.node_uuid)) {
                     static_cast<void>(
                         selection.remove_slice(
@@ -4744,7 +4787,8 @@ namespace lfs::vis::project {
         if (!viewer_.isProjectSessionRestorePending()) {
             auto session =
                 viewer_.captureProjectSession(
-                    &staged_references, project_root);
+                    &staged_references, project_root,
+                    omit_unbound_training);
             if (!session) {
                 return lfs::Status::failure(
                     std::move(session).error());

--- a/src/visualizer/project/session_state.cpp
+++ b/src/visualizer/project/session_state.cpp
@@ -21,6 +21,7 @@
 #include "gui/scene_tree_session.hpp"
 #include "gui/ui_context.hpp"
 #include "input/input_controller.hpp"
+#include "io/capture_omit_filter.hpp"
 #include "io/video/video_export_options.hpp"
 #include "rendering/render_constants.hpp"
 #include "rendering/rendering_manager.hpp"
@@ -313,7 +314,7 @@ namespace lfs::vis::project {
         template <typename Owner, typename Member>
         JsonField<Owner> required_field(
             const std::string_view name,
-            Member Owner::*member) {
+            Member Owner::* member) {
             return {
                 .name = name,
                 .write = [member](const Owner& source) { return Json(source.*member); },
@@ -332,7 +333,7 @@ namespace lfs::vis::project {
         template <typename Owner, typename Member>
         JsonField<Owner> optional_field(
             const std::string_view name,
-            Member Owner::*member) {
+            Member Owner::* member) {
             return {
                 .name = name,
                 .write = [member](const Owner& source) { return Json(source.*member); },
@@ -350,7 +351,7 @@ namespace lfs::vis::project {
         template <typename Owner>
         JsonField<Owner> vec3_field(
             const std::string_view name,
-            glm::vec3 Owner::*member) {
+            glm::vec3 Owner::* member) {
             return {
                 .name = name,
                 .write = [member](const Owner& source) { return vec3_json(source.*member); },
@@ -374,7 +375,7 @@ namespace lfs::vis::project {
                   typename AfterAssign = std::nullptr_t>
         JsonField<Owner> enum_field(
             const std::string_view name,
-            Enum Owner::*member,
+            Enum Owner::* member,
             const int minimum,
             const int maximum,
             const std::string_view invalid_detail,
@@ -466,7 +467,7 @@ namespace lfs::vis::project {
         template <typename Owner, std::size_t Size>
         JsonField<Owner> array_field(
             const std::string_view name,
-            std::array<float, Size> Owner::*member) {
+            std::array<float, Size> Owner::* member) {
             return custom_field<Owner>(
                 name,
                 [member](const Owner& source) {
@@ -502,7 +503,7 @@ namespace lfs::vis::project {
         template <typename Owner>
         JsonField<Owner> nullable_positive_float_field(
             const std::string_view name,
-            std::optional<float> Owner::*member) {
+            std::optional<float> Owner::* member) {
             return custom_field<Owner>(
                 name,
                 [member](const Owner& source) {
@@ -1587,7 +1588,7 @@ namespace lfs::vis::project {
             using Panel = gui::PanelProjectState;
             const auto nullable_float = [](
                                             const std::string_view name,
-                                            float Panel::*member) {
+                                            float Panel::* member) {
                 return custom_field<Panel>(
                     name,
                     [member](const Panel& panel) {
@@ -1899,7 +1900,9 @@ namespace lfs::vis::project {
         const std::vector<
             CameraBookmarkProjectState>& bookmarks,
         lfs::io::project::ReferencesChapter* references,
-        const std::filesystem::path& project_root) {
+        const std::filesystem::path& project_root,
+        const std::span<const lfs::core::Uuid>
+            omit_node_uuids) {
         auto result = retained;
         const auto* gui_manager =
             viewer.getGuiManager();
@@ -1916,6 +1919,9 @@ namespace lfs::vis::project {
                 "GUI session capture requires initialized GUI, window, renderer, and input owners",
                 "session.capture");
         }
+        const lfs::io::project::CaptureOmitFilter
+            omit_filter(
+                viewer.getScene(), omit_node_uuids);
 
         const auto layout =
             gui_manager->panelLayout()
@@ -1940,8 +1946,14 @@ namespace lfs::vis::project {
                 gui_manager->captureSceneTreeChrome(
                     viewer.getScene());
             Json collapsed = Json::array();
-            for (const auto& uuid : tree.collapsed_uuids)
+            for (const auto& uuid : tree.collapsed_uuids) {
+                const auto parsed =
+                    lfs::core::Uuid::from_string(uuid);
+                if (parsed && omit_filter.omits(*parsed)) {
+                    continue;
+                }
                 collapsed.push_back(uuid);
+            }
             fixed_payload["scene_tree"] = Json{
                 {"collapsed_uuids", std::move(collapsed)},
                 {"models_collapsed", tree.models_collapsed},
@@ -2406,7 +2418,9 @@ namespace lfs::vis::project {
             controller.saveToJson().dump());
         Json clips = Json::array();
         if (const auto* clip =
-                controller.plySequence()) {
+                controller.plySequence();
+            clip &&
+            !omit_filter.omits(clip->node_uuid)) {
             const auto retained_clips =
                 result.sequencer.dom()
                     .get_json("ply_sequences");
@@ -2572,7 +2586,9 @@ namespace lfs::vis::project {
             merged_clips->is_array()) {
             Json current_clips = Json::array();
             if (const auto* clip =
-                    controller.plySequence()) {
+                    controller.plySequence();
+                clip &&
+                !omit_filter.omits(clip->node_uuid)) {
                 const auto clip_uuid =
                     clip->node_uuid.to_string();
                 for (auto& entry :

--- a/src/visualizer/project/session_state.hpp
+++ b/src/visualizer/project/session_state.hpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -164,7 +165,9 @@ namespace lfs::vis {
                     CameraBookmarkProjectState>& bookmarks,
                 lfs::io::project::ReferencesChapter* references =
                     nullptr,
-                const std::filesystem::path& project_root = {});
+                const std::filesystem::path& project_root = {},
+                std::span<const lfs::core::Uuid> omit_node_uuids =
+                    {});
 
         LFS_VIS_API void applyGuiSession(
             VisualizerImpl& viewer,

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -3046,12 +3046,13 @@ namespace lfs::vis {
         lfs::io::project::ProjectSessionChapters>
     VisualizerImpl::captureProjectSession(
         lfs::io::project::ReferencesChapter* references,
-        const std::filesystem::path& project_root)
-        const {
+        const std::filesystem::path& project_root,
+        const std::span<const lfs::core::Uuid>
+            omit_node_uuids) const {
         return project::captureGuiSession(
             *this, retained_project_session_,
             camera_bookmarks_, references,
-            project_root);
+            project_root, omit_node_uuids);
     }
 
     project::GuiSessionRestoreTicket VisualizerImpl::

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -163,7 +164,9 @@ namespace lfs::vis {
             lfs::io::project::ReferencesChapter*
                 references = nullptr,
             const std::filesystem::path& project_root =
-                {}) const;
+                {},
+            std::span<const lfs::core::Uuid>
+                omit_node_uuids = {}) const;
         [[nodiscard]] project::GuiSessionRestoreTicket
         stagePreparedProjectSessionRestore(
             project::PreparedGuiSessionRestore prepared);
@@ -340,6 +343,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_LoadDatasetApiDoesNotDeferOrPrompt_Test;
         friend class VisualizerImplResetTest_PreTrainingProjectSaveRestoresCameraEnabledAndHidden_Test;
         friend class VisualizerImplResetTest_PostTrainingProjectSaveRestoresCameraEnabledAndHidden_Test;
+        friend class VisualizerImplResetTest_CaptureOmitsPlySequenceClipAndCollapsedUuid_Test;
 
         // Allow ToolContext to access GUI manager for logging
         friend class ToolContext;

--- a/tests/test_p5_session_chapters.cpp
+++ b/tests/test_p5_session_chapters.cpp
@@ -441,6 +441,81 @@ namespace {
     }
 
     TEST(P5SessionChapterTest,
+         MissingPlySequenceOwnerIsDocumentedDegradedState) {
+        const auto missing = lfs::core::generate_uuid_v4();
+
+        auto document = ProjectDocument::create(
+            lfs::core::generate_uuid_v4(), 100);
+        ASSERT_TRUE(document);
+        require_status(document->edit_sequencer().dom().set_json(
+            "ply_sequences",
+            Json::array({Json{
+                {"node_name", "legacy clip"},
+                {"node_uuid", missing.to_string()},
+                {"fps", 24.0},
+            }})));
+        lfs::core::Scene scene;
+        auto plan = document->stage_hydration(scene);
+        ASSERT_TRUE(plan)
+            << lfs::format_for_developer(plan.error());
+        EXPECT_NE(
+            std::ranges::find(
+                document->degraded_states(),
+                ProjectDocumentDegradedState::MissingPlySequenceNode),
+            document->degraded_states().end());
+
+        TemporaryDirectory temporary;
+        const auto path =
+            temporary.path / "dangling-seqr.licht";
+        auto saved = document->save(
+            path,
+            ProjectDocumentSaveOptions{
+                .disk_reserve_bytes = 0,
+            });
+        ASSERT_TRUE(saved)
+            << lfs::format_for_developer(saved.error());
+        auto reopened = ProjectDocument::open(path);
+        ASSERT_TRUE(reopened)
+            << lfs::format_for_developer(reopened.error());
+        EXPECT_NE(
+            std::ranges::find(
+                reopened->degraded_states(),
+                ProjectDocumentDegradedState::MissingPlySequenceNode),
+            reopened->degraded_states().end());
+    }
+
+    TEST(P5SessionChapterTest,
+         SequencerClipOwnerPresentInSceneGraphIsNotDegraded) {
+        const auto owner = lfs::core::generate_uuid_v4();
+        auto document = ProjectDocument::create(
+            lfs::core::generate_uuid_v4(), 100);
+        ASSERT_TRUE(document);
+        require_status(document->edit_scene_graph().upsert_node(
+            SceneNodeRecord{
+                .uuid = owner,
+                .type = "group",
+                .name = "clip owner",
+                .child_order = 0,
+            }));
+        require_status(document->edit_sequencer().dom().set_json(
+            "ply_sequences",
+            Json::array({Json{
+                {"node_name", "owned clip"},
+                {"node_uuid", owner.to_string()},
+                {"fps", 24.0},
+            }})));
+        lfs::core::Scene scene;
+        auto plan = document->stage_hydration(scene);
+        ASSERT_TRUE(plan)
+            << lfs::format_for_developer(plan.error());
+        EXPECT_EQ(
+            std::ranges::find(
+                document->degraded_states(),
+                ProjectDocumentDegradedState::MissingPlySequenceNode),
+            document->degraded_states().end());
+    }
+
+    TEST(P5SessionChapterTest,
          EditorWorkspaceCaptureUsesEveryRealOpenBuffer) {
         using namespace lfs::vis::editor;
 

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -42,6 +42,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <unordered_set>
 #include <vector>
 
 #include <cuda_runtime.h>
@@ -3405,6 +3406,110 @@ namespace {
         EXPECT_EQ(
             saved->snapshot_uuid,
             overlay.commit().snapshot_uuid);
+    }
+
+    TEST(ProjectDocumentTest,
+         UnboundCheckpointIsRemovedWhenCapturedSceneHasNoBinding) {
+        const auto training_uuid = fixed_uuid(9970);
+        const auto checkpoint_uuid = fixed_uuid(9971);
+        auto document = make_empty_document(fixed_uuid(9972), 100);
+        require_status(document->edit_scene_graph().upsert_node(
+            SceneNodeRecord{
+                .uuid = training_uuid,
+                .type = "splat",
+                .name = "Training",
+                .child_order = 0,
+                .payload = PayloadBinding{
+                    .fourcc = "CKPT",
+                    .instance_uuid = checkpoint_uuid,
+                    .source_kind = "training",
+                },
+            }));
+        require_status(
+            document->edit_scene_graph().set_training_model_uuid(
+                training_uuid));
+        require_status(document->set_checkpoint(
+            checkpoint_uuid,
+            make_autosave_checkpoint_payload(checkpoint_uuid)));
+        ASSERT_EQ(document->checkpoint_uuids().size(), 1u);
+
+        document->edit_scene_graph() = SceneGraphChapter{};
+        Scene live;
+        auto before_prune = document->stage_hydration(live);
+        ASSERT_FALSE(before_prune);
+        EXPECT_EQ(
+            before_prune.error().code(), lfs::ErrorCode::DataLoss);
+
+        std::unordered_set<Uuid> bound;
+        if (const auto nodes = document->scene_graph().nodes();
+            nodes) {
+            for (const auto& node : *nodes) {
+                if (node.payload && node.payload->fourcc == "CKPT") {
+                    bound.insert(node.payload->instance_uuid);
+                }
+            }
+        }
+        for (const auto& uuid : document->checkpoint_uuids()) {
+            if (!bound.contains(uuid)) {
+                EXPECT_TRUE(document->remove_checkpoint(uuid));
+            }
+        }
+        EXPECT_TRUE(document->checkpoint_uuids().empty());
+
+        Scene after_scene;
+        auto after_prune = document->stage_hydration(after_scene);
+        ASSERT_TRUE(after_prune)
+            << lfs::format_for_developer(after_prune.error());
+
+        TemporaryDirectory temporary;
+        const auto path =
+            temporary.path / "ckpt-omit-prune.licht";
+        (void)require_result(
+            document->save(path, save_options(9973, 200)));
+        auto reopened = require_result_ptr(ProjectDocument::open(path));
+        EXPECT_TRUE(reopened->checkpoint_uuids().empty());
+    }
+
+    TEST(ProjectDocumentTest,
+         BoundCheckpointSurvivesWhenCapturedSceneStillBindsIt) {
+        const auto training_uuid = fixed_uuid(9974);
+        const auto checkpoint_uuid = fixed_uuid(9975);
+        auto document = make_empty_document(fixed_uuid(9976), 100);
+        require_status(document->edit_scene_graph().upsert_node(
+            SceneNodeRecord{
+                .uuid = training_uuid,
+                .type = "splat",
+                .name = "Training",
+                .child_order = 0,
+                .payload = PayloadBinding{
+                    .fourcc = "CKPT",
+                    .instance_uuid = checkpoint_uuid,
+                    .source_kind = "training",
+                },
+            }));
+        require_status(
+            document->edit_scene_graph().set_training_model_uuid(
+                training_uuid));
+        require_status(document->set_checkpoint(
+            checkpoint_uuid,
+            make_autosave_checkpoint_payload(checkpoint_uuid)));
+
+        std::unordered_set<Uuid> bound;
+        if (const auto nodes = document->scene_graph().nodes();
+            nodes) {
+            for (const auto& node : *nodes) {
+                if (node.payload && node.payload->fourcc == "CKPT") {
+                    bound.insert(node.payload->instance_uuid);
+                }
+            }
+        }
+        for (const auto& uuid : document->checkpoint_uuids()) {
+            if (!bound.contains(uuid)) {
+                static_cast<void>(document->remove_checkpoint(uuid));
+            }
+        }
+        ASSERT_EQ(document->checkpoint_uuids().size(), 1u);
+        EXPECT_EQ(document->checkpoint_uuids().front(), checkpoint_uuid);
     }
 
     TEST(ProjectDocumentTest,

--- a/tests/test_selection_chapter.cpp
+++ b/tests/test_selection_chapter.cpp
@@ -2,6 +2,8 @@
  *
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "io/capture_omit_filter.hpp"
+#include "io/scene_chapter_adapter.hpp"
 #include "io/selection_chapter.hpp"
 #include "licht_test_support.hpp"
 
@@ -16,6 +18,7 @@
 #include <span>
 #include <stdexcept>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 namespace {
@@ -27,6 +30,9 @@ namespace {
     using lfs::core::SelectionDomain;
     using lfs::core::Tensor;
     using lfs::core::Uuid;
+    using lfs::io::project::CaptureOmitFilter;
+    using lfs::io::project::SceneGraphChapter;
+    using lfs::io::project::SceneNodeRecord;
     using lfs::io::project::SelectionChapter;
     using lfs::io::project::SelectionMaskEncoding;
     using lfs::io::project::SelectionMaskSlice;
@@ -384,6 +390,173 @@ namespace {
         EXPECT_EQ(
             omitted->next_group_id(),
             full->next_group_id());
+    }
+
+    TEST(CaptureOmitFilterTest,
+         ClosesRootsOverDescendantsAndKeepsUnresolvableUuids) {
+        const Uuid parent = fixed_uuid(71);
+        const Uuid child = fixed_uuid(72);
+        const Uuid grandchild = fixed_uuid(73);
+        const Uuid sibling = fixed_uuid(74);
+        const Uuid missing = fixed_uuid(75);
+        Scene scene;
+        const auto parent_id = scene.restoreNodeWithUuid(
+            Scene::RestoreNodeDesc{
+                .uuid = parent,
+                .type = NodeType::GROUP,
+                .name = "parent",
+            });
+        ASSERT_NE(parent_id, lfs::core::NULL_NODE);
+        const auto child_id = scene.restoreNodeWithUuid(
+            Scene::RestoreNodeDesc{
+                .uuid = child,
+                .type = NodeType::GROUP,
+                .name = "child",
+                .parent = parent_id,
+            });
+        ASSERT_NE(child_id, lfs::core::NULL_NODE);
+        ASSERT_NE(
+            scene.restoreNodeWithUuid(
+                Scene::RestoreNodeDesc{
+                    .uuid = grandchild,
+                    .type = NodeType::GROUP,
+                    .name = "grandchild",
+                    .parent = child_id,
+                }),
+            lfs::core::NULL_NODE);
+        ASSERT_NE(
+            scene.restoreNodeWithUuid(
+                Scene::RestoreNodeDesc{
+                    .uuid = sibling,
+                    .type = NodeType::GROUP,
+                    .name = "sibling",
+                }),
+            lfs::core::NULL_NODE);
+
+        const std::array roots = {parent, missing};
+        const CaptureOmitFilter filter(scene, roots);
+        EXPECT_TRUE(filter.omits(parent));
+        EXPECT_TRUE(filter.omits(child));
+        EXPECT_TRUE(filter.omits(grandchild));
+        EXPECT_TRUE(filter.omits(missing));
+        EXPECT_FALSE(filter.omits(sibling));
+    }
+
+    TEST(SceneGraphChapterTest,
+         CaptureWithPreClosedOmitSetMatchesOmitRoots) {
+        const Uuid parent = fixed_uuid(81);
+        const Uuid child = fixed_uuid(82);
+        const Uuid grandchild = fixed_uuid(83);
+        const Uuid sibling = fixed_uuid(84);
+        Scene scene;
+        const auto parent_id = scene.restoreNodeWithUuid(
+            Scene::RestoreNodeDesc{
+                .uuid = parent,
+                .type = NodeType::GROUP,
+                .name = "parent",
+            });
+        ASSERT_NE(parent_id, lfs::core::NULL_NODE);
+        const auto child_id = scene.restoreNodeWithUuid(
+            Scene::RestoreNodeDesc{
+                .uuid = child,
+                .type = NodeType::GROUP,
+                .name = "child",
+                .parent = parent_id,
+            });
+        ASSERT_NE(child_id, lfs::core::NULL_NODE);
+        ASSERT_NE(
+            scene.restoreNodeWithUuid(
+                Scene::RestoreNodeDesc{
+                    .uuid = grandchild,
+                    .type = NodeType::GROUP,
+                    .name = "grandchild",
+                    .parent = child_id,
+                }),
+            lfs::core::NULL_NODE);
+        ASSERT_NE(
+            scene.restoreNodeWithUuid(
+                Scene::RestoreNodeDesc{
+                    .uuid = sibling,
+                    .type = NodeType::GROUP,
+                    .name = "sibling",
+                }),
+            lfs::core::NULL_NODE);
+
+        const std::array roots = {parent};
+        const std::array closed = {
+            parent, child, grandchild};
+        auto from_roots =
+            lfs::io::project::capture_scene_graph(
+                scene,
+                lfs::io::project::ScenePayloadBindings{},
+                roots);
+        ASSERT_TRUE(from_roots)
+            << lfs::format_for_developer(
+                   from_roots.error());
+        auto from_closed =
+            lfs::io::project::capture_scene_graph(
+                scene,
+                lfs::io::project::ScenePayloadBindings{},
+                closed);
+        ASSERT_TRUE(from_closed)
+            << lfs::format_for_developer(
+                   from_closed.error());
+        EXPECT_EQ(
+            from_roots->to_bytes(),
+            from_closed->to_bytes());
+        const auto nodes = from_roots->nodes();
+        ASSERT_TRUE(nodes);
+        std::vector<Uuid> uuids;
+        uuids.reserve(nodes->size());
+        for (const auto& node : *nodes) {
+            uuids.push_back(node.uuid);
+        }
+        EXPECT_EQ(uuids, (std::vector<Uuid>{sibling}));
+    }
+
+    TEST(SelectionChapterTest,
+         PartialLoadMergeDropsSlicesAbsentFromCapturedSceneGraph) {
+        const Uuid omitted = fixed_uuid(91);
+        const Uuid kept = fixed_uuid(92);
+        SelectionChapter previous;
+        ASSERT_TRUE(previous.upsert_slice(
+            SelectionMaskSlice{
+                .node_uuid = omitted,
+                .domain = SelectionDomain::Splat,
+                .mask = {0, 0, 0},
+            }));
+        ASSERT_TRUE(previous.upsert_slice(
+            SelectionMaskSlice{
+                .node_uuid = kept,
+                .domain = SelectionDomain::Splat,
+                .mask = {0, 0},
+            }));
+
+        SceneGraphChapter captured_scene;
+        ASSERT_TRUE(captured_scene.upsert_node(
+            SceneNodeRecord{
+                .uuid = kept,
+                .type = "group",
+                .name = "kept",
+                .child_order = 0,
+            }));
+        const auto captured_nodes = captured_scene.nodes();
+        ASSERT_TRUE(captured_nodes);
+        std::unordered_set<Uuid> keep;
+        keep.reserve(captured_nodes->size());
+        for (const auto& node : *captured_nodes) {
+            keep.insert(node.uuid);
+        }
+
+        const auto old_slices = previous.slices();
+        for (const auto& slice : old_slices) {
+            if (!keep.contains(slice.node_uuid)) {
+                static_cast<void>(previous.remove_slice(
+                    slice.node_uuid, slice.domain));
+            }
+        }
+        ASSERT_EQ(previous.slices().size(), 1u);
+        EXPECT_EQ(previous.slices()[0].node_uuid, kept);
     }
 #endif
 

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -13,6 +13,7 @@
 #include "core/main_loop.hpp"
 #include "core/scene.hpp"
 #include "core/services.hpp"
+#include "gui/scene_tree_session.hpp"
 #include "gui/string_keys.hpp"
 #include "input/input_controller.hpp"
 #include "io/project_chapters.hpp"
@@ -20,6 +21,7 @@
 #include "io/project_document.hpp"
 #include "io/project_path.hpp"
 #include "io/project_recovery.hpp"
+#include "io/session_chapters.hpp"
 #include "licht_test_support.hpp"
 #include "operation/undo_history.hpp"
 #include "python/python_runtime.hpp"
@@ -36,6 +38,7 @@
 #include "visualizer/visualizer_impl.hpp"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -989,6 +992,151 @@ namespace lfs::vis {
         EXPECT_EQ(lfs::event::EventBridge::instance().handler_count(
                       typeid(lfs::core::events::cmd::ResetTraining)),
                   0u);
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           CaptureOmitsPlySequenceClipAndCollapsedUuid) {
+        using Json = lfs::io::JsonChapterDom::Json;
+        using namespace lfs::io::project;
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_NE(viewer.getGuiManager(), nullptr);
+        ASSERT_NE(viewer.getRenderingManager(), nullptr);
+        viewer.input_controller_ =
+            std::make_unique<InputController>(
+                nullptr, viewer.getViewport());
+        ASSERT_NE(viewer.getInputController(), nullptr);
+
+        const auto kept_id =
+            viewer.getScene().addGroup("kept");
+        const auto omitted_id =
+            viewer.getScene().addGroup("omitted");
+        ASSERT_NE(kept_id, lfs::core::NULL_NODE);
+        ASSERT_NE(omitted_id, lfs::core::NULL_NODE);
+        const auto kept_uuid =
+            viewer.getScene().getNodeUuid(kept_id);
+        const auto omitted_uuid =
+            viewer.getScene().getNodeUuid(omitted_id);
+
+        viewer.getGuiManager()->sequencer().setPlySequence(
+            temporary_.path / "frames",
+            "omitted",
+            {temporary_.path / "frames" / "frame_0001.ply"},
+            {"frame_0001"},
+            24.0f,
+            omitted_uuid,
+            {omitted_uuid});
+        gui::SceneTreeSessionChrome chrome;
+        chrome.collapsed_uuids = {
+            omitted_uuid.to_string(),
+            kept_uuid.to_string(),
+        };
+        viewer.getGuiManager()->applySceneTreeChrome(
+            chrome);
+
+        const auto collapsed_from =
+            [](const GuiLayoutChapter& chapter) {
+                Json root = lfs::test::licht::json_root(
+                    chapter.dom());
+                std::vector<std::string> collapsed;
+                for_each_fixed_arrangement_payload(
+                    root, [&](const Json& payload) {
+                        const auto tree =
+                            payload.find("scene_tree");
+                        if (tree == payload.end() ||
+                            !tree->is_object()) {
+                            return;
+                        }
+                        const auto uuids =
+                            tree->find("collapsed_uuids");
+                        if (uuids == tree->end() ||
+                            !uuids->is_array()) {
+                            return;
+                        }
+                        collapsed = uuids->get<
+                            std::vector<std::string>>();
+                    });
+                return collapsed;
+            };
+
+        auto full = viewer.captureProjectSession();
+        ASSERT_TRUE(full)
+            << lfs::format_for_developer(full.error());
+        const Json full_seq =
+            lfs::test::licht::json_root(
+                full->sequencer.dom());
+        ASSERT_EQ(full_seq["ply_sequences"].size(), 1u);
+        EXPECT_EQ(
+            full_seq["ply_sequences"][0]["node_uuid"],
+            omitted_uuid.to_string());
+        const auto full_collapsed =
+            collapsed_from(full->gui_layout);
+        EXPECT_NE(
+            std::ranges::find(
+                full_collapsed, omitted_uuid.to_string()),
+            full_collapsed.end());
+        EXPECT_NE(
+            std::ranges::find(
+                full_collapsed, kept_uuid.to_string()),
+            full_collapsed.end());
+
+        const std::array omit = {omitted_uuid};
+        auto omitted = viewer.captureProjectSession(
+            nullptr, {}, omit);
+        ASSERT_TRUE(omitted)
+            << lfs::format_for_developer(
+                   omitted.error());
+        const Json omitted_seq =
+            lfs::test::licht::json_root(
+                omitted->sequencer.dom());
+        EXPECT_TRUE(omitted_seq["ply_sequences"].empty());
+        const auto omitted_collapsed =
+            collapsed_from(omitted->gui_layout);
+        EXPECT_EQ(
+            std::ranges::find(
+                omitted_collapsed,
+                omitted_uuid.to_string()),
+            omitted_collapsed.end());
+        EXPECT_NE(
+            std::ranges::find(
+                omitted_collapsed,
+                kept_uuid.to_string()),
+            omitted_collapsed.end());
+
+        auto document = ProjectDocument::create(
+            lfs::core::generate_uuid_v4(), 100);
+        ASSERT_TRUE(document);
+        lfs::test::licht::require_status(
+            document->edit_scene_graph().upsert_node(
+                SceneNodeRecord{
+                    .uuid = kept_uuid,
+                    .type = "group",
+                    .name = "kept",
+                    .child_order = 0,
+                }));
+        document->edit_sequencer() =
+            std::move(omitted->sequencer);
+        document->edit_gui_layout() =
+            std::move(omitted->gui_layout);
+        const auto path =
+            temporary_.path / "filtered-session.licht";
+        auto saved = document->save(
+            path,
+            ProjectDocumentSaveOptions{
+                .disk_reserve_bytes = 0,
+            });
+        ASSERT_TRUE(saved)
+            << lfs::format_for_developer(saved.error());
+        auto reopened = ProjectDocument::open(path);
+        ASSERT_TRUE(reopened)
+            << lfs::format_for_developer(
+                   reopened.error());
+        EXPECT_EQ(
+            std::ranges::find(
+                reopened->degraded_states(),
+                ProjectDocumentDegradedState::
+                    MissingPlySequenceNode),
+            reopened->degraded_states().end());
     }
 
     TEST_F(VisualizerImplResetTest,


### PR DESCRIPTION
The autosave crash fixed in #1704 was the third time two parts of the save code disagreed about which scene nodes belong in the file: the scene graph dropped a node's whole subtree, the selection kept exact ids only, and the session capture still referenced nodes the same save had removed. Each mismatch showed up as a failed save or a file with dangling references.

This makes that impossible by construction: one filter decides the omitted set (roots plus descendants, computed once) and every chapter capture - scene graph, selection, session - uses it. The duplicate logic is deleted. Three smaller consistency gaps from the same audit are closed too: the partial-load selection merge keys on the saved scene instead of the live one, a training-time autosave that omits the in-progress model also drops checkpoints nothing binds, and a sequencer clip pointing at a missing node opens as a degraded state rather than an error, so existing files keep loading.

No change to normal saves: with nothing omitted the written chapters are byte-identical, which the tests assert.

**Verified:** filter/equivalence/carry-forward/checkpoint/degraded tests (174 + 97 green across the selection, document, session, and visualizer suites, python tier green), and the original live scenario: crop box selected during training with fast autosaves - 15 autosaves, zero failures.