### PR TITLE
Fix Python UI callback teardown ordering

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1310,9 +1310,12 @@ namespace lfs::app {
             mcp::setActiveMcpHttpServer(nullptr);
             mcp_http.stop();
 
-            python::finalize();
-
+            // GuiManager drains scheduled Python UI work while tearing down the
+            // viewer. Keep the runtime/GIL available until that work and the
+            // Python-backed UI resources have been released.
             viewer.reset();
+
+            python::finalize();
 
             core::teardown_gpu_before_exit();
 


### PR DESCRIPTION
## Summary

Fix application shutdown ordering so pending Python UI callbacks are drained while the embedded Python runtime and GIL are still available.

## Changes

- destroy the interactive viewer and its GUI resources before finalizing Python;
- allow `GuiManager` to drain scheduled Python UI callbacks during teardown;
- preserve the existing MCP shutdown, GPU teardown, and clean-exit ordering;
- prevent intermittent `Unable to run scheduled Python UI callback: Python GIL is unavailable` errors when closing the application, particularly during or shortly after training.