### PR TITLE
Attach q16 bounds before the SH degree on every model rebuild

### DIFF
--- a/src/core/include/core/splat_data.hpp
+++ b/src/core/include/core/splat_data.hpp
@@ -388,6 +388,10 @@ namespace lfs::core {
         // unclassifiable Float16 storage). Internal maintenance helper.
         void verify_or_resize_non_q16_shN(size_t n, size_t cap, uint32_t layout_rest);
         void set_active_sh_degree(int sh_degree);
+        // Attach optional q16 bounds, then set the active SH degree.
+        // Reconstruct/migrate paths that copy pad-dropped codes must pass the
+        // bounds so the tripwire never sees codes without them (#1616, #1678).
+        void set_active_sh_degree(int sh_degree, Tensor shN_value_bounds);
         void set_max_sh_degree(int sh_degree);
         bool set_sh_degree(int sh_degree);
 

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -3609,10 +3609,11 @@ namespace lfs::core {
                     src.opacity_raw().clone(),
                     src.get_scene_scale(),
                     lfs::core::SplatData::ShNLayout::Swizzled);
-                result->set_active_sh_degree(active_sh);
-                if (src.shN_value_quantized() && src.shN_value_bounds().is_valid()) {
-                    result->shN_value_bounds() = src.shN_value_bounds().clone();
-                }
+                result->set_active_sh_degree(
+                    active_sh,
+                    (src.shN_value_quantized() && src.shN_value_bounds().is_valid())
+                        ? src.shN_value_bounds().clone()
+                        : lfs::core::Tensor{});
                 return result;
             }
 
@@ -3713,10 +3714,11 @@ namespace lfs::core {
                         src->opacity_raw(),
                         src->get_scene_scale(),
                         lfs::core::SplatData::ShNLayout::Swizzled);
-                    result->set_active_sh_degree(active_sh);
-                    if (src->shN_value_quantized() && src->shN_value_bounds().is_valid()) {
-                        result->shN_value_bounds() = src->shN_value_bounds();
-                    }
+                    result->set_active_sh_degree(
+                        active_sh,
+                        (src->shN_value_quantized() && src->shN_value_bounds().is_valid())
+                            ? src->shN_value_bounds()
+                            : lfs::core::Tensor{});
                     return result;
                 }
 

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -1080,6 +1080,17 @@ namespace lfs::core {
         _active_sh_degree = target_degree;
     }
 
+    void SplatData::set_active_sh_degree(int sh_degree, Tensor shN_value_bounds) {
+        if (shN_value_bounds.is_valid() && shN_value_bounds.numel() > 0) {
+            _shN_value_bounds = std::move(shN_value_bounds);
+            if (_shN.is_valid() && _shN.shape().rank() > 0 &&
+                _shN.capacity() < _shN.shape()[0]) {
+                _shN.reserve(_shN.shape()[0]);
+            }
+        }
+        set_active_sh_degree(sh_degree);
+    }
+
     // Non-quantized shN maintenance shared by the degree setters. IEEE f16 is only
     // accepted when the sizing matches its declared topology; a Float16 buffer that
     // matches neither ieee-f16 nor a legal grow target is q16 codes whose bounds were

--- a/src/core/splat_exportable_storage.cpp
+++ b/src/core/splat_exportable_storage.cpp
@@ -865,10 +865,7 @@ namespace lfs::core {
                               std::move(opacity),
                               scene_scale,
                               SplatData::ShNLayout::Swizzled);
-            if (shN_bounds.is_valid()) {
-                rebound.shN_value_bounds() = std::move(shN_bounds);
-            }
-            rebound.set_active_sh_degree(active_sh);
+            rebound.set_active_sh_degree(active_sh, std::move(shN_bounds));
             if (deleted.is_valid()) {
                 rebound.deleted() = std::move(deleted);
                 // Preserve soft-delete content across exportable rebind; force a

--- a/src/io/loader_service.cpp
+++ b/src/io/loader_service.cpp
@@ -132,13 +132,7 @@ namespace lfs::io {
                                           copy_to_allocator(model.opacity_raw(), "SplatData.opacity"),
                                           scene_scale,
                                           lfs::core::SplatData::ShNLayout::Swizzled);
-            if (shN_q16) {
-                // Codes and bounds are one declared representation. Install the
-                // bounds before active-degree validation so pad-dropped codes are
-                // never reinterpreted as IEEE f16 during a degraded re-home.
-                migrated.shN_value_bounds() = std::move(shN_bounds);
-            }
-            migrated.set_active_sh_degree(active_sh);
+            migrated.set_active_sh_degree(active_sh, std::move(shN_bounds));
             if (deleted.is_valid()) {
                 migrated.deleted() = std::move(deleted);
             }

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -467,11 +467,7 @@ namespace lfs::training {
                                               std::move(opacity),
                                               scene_scale,
                                               lfs::core::SplatData::ShNLayout::Swizzled);
-                if (shN_bounds.is_valid()) {
-                    // Codes and bounds are one declared representation; install before degree validation.
-                    migrated.shN_value_bounds() = std::move(shN_bounds);
-                }
-                migrated.set_active_sh_degree(active_sh);
+                migrated.set_active_sh_degree(active_sh, std::move(shN_bounds));
                 if (deleted.is_valid()) {
                     migrated.deleted() = std::move(deleted);
                 }

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -118,15 +118,6 @@ namespace lfs::vis {
             return name;
         }
 
-        // Codes and bounds are one declared representation; install before degree validation.
-        void installShNValueBounds(lfs::core::SplatData& dst, lfs::core::Tensor bounds) {
-            dst.shN_value_bounds() = std::move(bounds);
-            auto& shN = dst.shN_raw();
-            if (shN.is_valid() && shN.shape().rank() > 0 && shN.capacity() < shN.shape()[0]) {
-                shN.reserve(shN.shape()[0]);
-            }
-        }
-
         [[nodiscard]] std::unique_ptr<lfs::core::SplatData> cloneSplatDataToCpu(
             const lfs::core::SplatData& src) {
             auto shN = src.clone_shN_storage();
@@ -144,9 +135,9 @@ namespace lfs::vis {
                 src.opacity_raw().cpu(),
                 src.get_scene_scale(),
                 lfs::core::SplatData::ShNLayout::Swizzled);
-            if (src.shN_value_quantized())
-                installShNValueBounds(*result, src.shN_value_bounds().cpu());
-            result->set_active_sh_degree(src.get_active_sh_degree());
+            result->set_active_sh_degree(
+                src.get_active_sh_degree(),
+                src.shN_value_quantized() ? src.shN_value_bounds().cpu() : lfs::core::Tensor{});
             return result;
         }
 
@@ -4693,9 +4684,9 @@ namespace lfs::vis {
             src.scaling_raw().cuda(), src.rotation_raw().cuda(), src.opacity_raw().cuda(),
             src.get_scene_scale(),
             lfs::core::SplatData::ShNLayout::Swizzled);
-        if (src.shN_value_quantized())
-            installShNValueBounds(*data, src.shN_value_bounds().cuda());
-        data->set_active_sh_degree(src.get_active_sh_degree());
+        data->set_active_sh_degree(
+            src.get_active_sh_degree(),
+            src.shN_value_quantized() ? src.shN_value_bounds().cuda() : lfs::core::Tensor{});
 
         const std::string name = makeUniqueCounterNodeName(scene_, "Selection", clipboard_counter_);
         if (auto allocator = makeExternalSplatAllocator()) {
@@ -4845,9 +4836,10 @@ namespace lfs::vis {
                     entry.data->scaling_raw().cuda(), entry.data->rotation_raw().cuda(), entry.data->opacity_raw().cuda(),
                     entry.data->get_scene_scale(),
                     lfs::core::SplatData::ShNLayout::Swizzled);
-                if (entry.data->shN_value_quantized())
-                    installShNValueBounds(*paste_data, entry.data->shN_value_bounds().cuda());
-                paste_data->set_active_sh_degree(entry.data->get_active_sh_degree());
+                paste_data->set_active_sh_degree(
+                    entry.data->get_active_sh_degree(),
+                    entry.data->shN_value_quantized() ? entry.data->shN_value_bounds().cuda()
+                                                      : lfs::core::Tensor{});
 
                 if (auto allocator = makeExternalSplatAllocator()) {
                     if (auto migrated = lfs::io::migrateSplatTensorsToAllocator(*paste_data, allocator);

--- a/tests/test_exportable_storage.cpp
+++ b/tests/test_exportable_storage.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <stdexcept>
 #include <string_view>
 #include <vector>
 
@@ -51,6 +52,42 @@ namespace {
         for (std::size_t i = 0; i < floats; ++i) {
             EXPECT_FLOAT_EQ(host[i], base + static_cast<float>(i)) << "index " << i;
         }
+    }
+
+    // SH1 pad-dropped q16 cells (9/prim) != IEEE-f16 floats (12/prim). N is not a
+    // reorder multiple so padding is also exercised. Matches the #1678 prune size class.
+    constexpr std::size_t kQ16Sh1N = 33;
+    constexpr int kQ16Sh1Degree = 1;
+
+    [[nodiscard]] uint32_t q16_sh1_rest() {
+        return static_cast<uint32_t>(sh_rest_coefficients_for_degree(kQ16Sh1Degree));
+    }
+
+    SplatData make_direct_q16_sh1(const bool with_bounds, const int active_sh) {
+        const auto rest = q16_sh1_rest();
+        const size_t cells = sh_value_quant::sh_value_u16_count(kQ16Sh1N, rest);
+        const size_t bounds_n = sh_value_quant::n_bounds_for_prims(kQ16Sh1N) * 2u;
+        Tensor means = Tensor::zeros({kQ16Sh1N, 3}, Device::CUDA);
+        Tensor sh0 = Tensor::zeros({kQ16Sh1N, 1, 3}, Device::CUDA);
+        Tensor scaling = Tensor::zeros({kQ16Sh1N, 3}, Device::CUDA);
+        Tensor rotation = Tensor::zeros({kQ16Sh1N, 4}, Device::CUDA);
+        Tensor opacity = Tensor::zeros({kQ16Sh1N, 1}, Device::CUDA);
+        Tensor shN = Tensor::zeros_direct(
+            TensorShape({cells}), cells, Device::CUDA, DataType::Float16);
+        Tensor bounds = Tensor::zeros({bounds_n}, Device::CUDA, DataType::Float32);
+        SplatData model(kQ16Sh1Degree,
+                        std::move(means),
+                        std::move(sh0),
+                        std::move(shN),
+                        std::move(scaling),
+                        std::move(rotation),
+                        std::move(opacity),
+                        1.0f,
+                        SplatData::ShNLayout::Swizzled);
+        if (with_bounds) {
+            model.set_active_sh_degree(active_sh, std::move(bounds));
+        }
+        return model;
     }
 
 } // namespace
@@ -1272,4 +1309,71 @@ TEST(SplatExportableStorageTest, Q16BindPtrsSurviveGrowUnderHeldView) {
               storage.live_region_ptr(SplatExportableStorage::ShN));
     EXPECT_TRUE(q16.generation_checked);
     EXPECT_EQ(q16.generation, storage.generation());
+}
+
+// #1678: pad-dropped q16 codes whose cell count differs from IEEE-f16 floats
+// (SH1) must not be treated as corrupted when bounds are installed with the
+// degree setter. One-arg set_active_sh_degree is the tripwire; the two-arg
+// helper attaches bounds first.
+TEST(SplatExportableStorageTest, SetActiveShDegreeInstallsQ16BoundsBeforeValidation) {
+    require_cuda();
+
+    const auto rest = q16_sh1_rest();
+    ASSERT_NE(sh_value_quant::sh_value_u16_count(kQ16Sh1N, rest),
+              sh_swizzled_float_count(kQ16Sh1N, rest));
+
+    {
+        SplatData missing_bounds = make_direct_q16_sh1(/*with_bounds=*/false, /*active_sh=*/1);
+        ASSERT_TRUE(missing_bounds.shN_raw().is_valid());
+        ASSERT_EQ(missing_bounds.shN_raw().dtype(), DataType::Float16);
+        ASSERT_EQ(static_cast<size_t>(missing_bounds.shN_raw().numel()),
+                  sh_value_quant::sh_value_u16_count(kQ16Sh1N, rest));
+        ASSERT_FALSE(missing_bounds.shN_value_quantized());
+        EXPECT_THROW(missing_bounds.set_active_sh_degree(1), std::runtime_error);
+    }
+
+    SplatData model = make_direct_q16_sh1(/*with_bounds=*/true, /*active_sh=*/0);
+    EXPECT_EQ(model.get_active_sh_degree(), 0);
+    EXPECT_TRUE(model.shN_value_quantized());
+    EXPECT_NO_THROW(model.set_active_sh_degree(1));
+    EXPECT_EQ(model.get_active_sh_degree(), 1);
+}
+
+// Post-prune path: q16 lives on cuda.direct allocations, then
+// migrateTrainingModelToAllocator copies codes+bounds into exportable storage
+// and restores the active degree. Previously set_active_sh_degree ran before
+// bounds were attached and threw "q16 codes without bounds".
+TEST(SplatExportableStorageTest, MigrateQ16Sh1DirectAllocationsAppliesDegree) {
+    require_cuda();
+
+    const auto rest = q16_sh1_rest();
+    ASSERT_NE(sh_value_quant::sh_value_u16_count(kQ16Sh1N, rest),
+              sh_swizzled_float_count(kQ16Sh1N, rest));
+
+    constexpr std::size_t kCap = 128;
+    constexpr int kActiveSh = 0;
+
+    SplatData model = make_direct_q16_sh1(/*with_bounds=*/true, kActiveSh);
+    ASSERT_TRUE(model.shN_value_quantized());
+    ASSERT_EQ(model.get_active_sh_degree(), kActiveSh);
+    ASSERT_NE(model.means_raw().external_storage_kind(), "splat.exportable");
+
+    auto storage_result = SplatExportableStorage::create(kCap, kQ16Sh1Degree, 0, kCap);
+    if (!storage_result) {
+        FAIL() << storage_result.error();
+    }
+    auto storage = std::move(*storage_result);
+
+    lfs::core::param::TrainingParameters params;
+    params.optimization.sh_degree = kQ16Sh1Degree;
+    params.optimization.max_cap = static_cast<int>(kCap);
+
+    auto result = lfs::training::migrateTrainingModelToAllocator(
+        params, model, storage.make_allocator());
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(model.get_active_sh_degree(), kActiveSh);
+    EXPECT_TRUE(model.shN_value_quantized());
+    EXPECT_EQ(model.means_raw().external_storage_kind(), "splat.exportable");
+    EXPECT_EQ(static_cast<std::size_t>(model.shN_raw().capacity()),
+              sh_value_quant::sh_value_u16_count(kCap, rest));
 }


### PR DESCRIPTION
Issue #1678: a sparsity prune ended training with "shN storage: q16 codes without bounds - corrupted state" on healthy data. The reporter's analysis is right: when a model is rebuilt from q16 codes, the degree setter ran before the value bounds were attached, so the corruption check fired. One note: the exact line they cite was already reordered by #1616 on Aug 14 - their build (734d4916) is from Aug 11 - so a current nightly should not hit that site anymore.

What this PR adds on top: the rule now has a home. `set_active_sh_degree(degree, bounds)` installs the bounds and applies the degree in one call, every rebuild path uses it, and two remaining rebuild sites in scene.cpp that still did it in the wrong order are fixed. The live-model setter keeps its loud check, so real corruption still throws.

**Verified:** new regression test reproducing the SH1 cell-count mismatch through the migrate path, 136 tests green across the storage/scene suites; full audit table of every degree-setter call site in the branch notes.

Fixes #1678