### PR TITLE
Let an explicit save refresh the preview after a recovery

### DIFF
--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -2679,12 +2679,13 @@ namespace lfs::io::project {
         const ProjectDocumentAutosaveOptions* autosave) {
         const bool is_autosave = autosave != nullptr;
         if (!options.preview_png.empty() &&
-            (options.commit.kind != CommitKind::Explicit ||
+            ((options.commit.kind != CommitKind::Explicit &&
+              options.commit.kind != CommitKind::Recovered) ||
              is_autosave)) {
             return fail<ProjectDocumentSaveReport>(
                 lfs::ErrorCode::FailedPrecondition,
                 "Only an explicit project save may regenerate the preview.",
-                "Autosave and recovered generations must carry THMB forward",
+                "Automatic saves must carry THMB forward",
                 "save.preview_png");
         }
         auto normalized = normalized_absolute_path(path);

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -1751,6 +1751,82 @@ namespace {
             invalid.error().code(),
             lfs::ErrorCode::
                 FailedPrecondition);
+
+        invalid_options.commit.kind =
+            CommitKind::Compaction;
+        auto compaction =
+            reopened->save(
+                path, invalid_options);
+        ASSERT_FALSE(compaction);
+        EXPECT_EQ(
+            compaction.error().code(),
+            lfs::ErrorCode::
+                FailedPrecondition);
+    }
+
+    TEST(ProjectDocumentTest,
+         RecoveredSaveAsRegeneratesPreviewOnDifferentDestination) {
+        TemporaryDirectory temporary;
+        const auto source =
+            temporary.path / "recovered-preview-source.licht";
+        const auto destination =
+            temporary.path / "recovered-preview-dest.licht";
+        auto document = make_empty_document(fixed_uuid(1990), 100);
+        auto first =
+            document->save(source, save_options(1991, 200));
+        ASSERT_TRUE(first)
+            << lfs::format_for_developer(
+                   first.error());
+
+        const auto preview = one_pixel_png();
+        auto recovered_options =
+            save_options(1994, 300);
+        recovered_options.commit.kind =
+            CommitKind::Recovered;
+        recovered_options.preview_png =
+            std::span<const std::byte>(preview);
+        auto saved = document->save_as(
+            destination, recovered_options);
+        ASSERT_TRUE(saved)
+            << lfs::format_for_developer(
+                   saved.error());
+
+        auto reader = ProjectReader::open(destination);
+        ASSERT_TRUE(reader);
+        EXPECT_EQ(
+            reader->commit().kind,
+            CommitKind::Recovered);
+        ASSERT_TRUE(reader->preview());
+        auto bytes = reader->read_preview();
+        ASSERT_TRUE(bytes);
+        EXPECT_EQ(*bytes, preview);
+    }
+
+    TEST(ProjectDocumentTest,
+         RecoveredSaveRegeneratesPreviewOnSamePath) {
+        TemporaryDirectory temporary;
+        const auto path =
+            temporary.path / "recovered-preview-same.licht";
+        auto document = make_empty_document(fixed_uuid(2000), 100);
+        const auto preview = one_pixel_png();
+        auto options = save_options(2001, 200);
+        options.commit.kind = CommitKind::Recovered;
+        options.preview_png =
+            std::span<const std::byte>(preview);
+        auto saved = document->save(path, options);
+        ASSERT_TRUE(saved)
+            << lfs::format_for_developer(
+                   saved.error());
+
+        auto reader = ProjectReader::open(path);
+        ASSERT_TRUE(reader);
+        EXPECT_EQ(
+            reader->commit().kind,
+            CommitKind::Recovered);
+        ASSERT_TRUE(reader->preview());
+        auto bytes = reader->read_preview();
+        ASSERT_TRUE(bytes);
+        EXPECT_EQ(*bytes, preview);
     }
 
     TEST(ProjectDocumentTest,


### PR DESCRIPTION
Fixes #1738.

After recovering a crashed project, File > Save failed with "Only an explicit project save may regenerate the preview". The first save after a recovery is stamped "recovered" so the file records where its content came from; the preview check only accepted "explicit" saves, so the combination was rejected.

When saves happen now:
- A save the user asks for (File > Save, Save As) always writes and refreshes the stored preview image, including the first save after a recovery.
- Autosaves and compactions never re-render the preview; they carry the existing one forward, as before.

Verified: 52 document tests green including two new ones for the exact rejected combination, and live on screen - crash, Recover, save succeeds, preview refreshed, no recovery offer on the next start.