### PR TITLE
Defer autosave until the scene goes quiet

### DIFF
--- a/src/visualizer/gui/gizmo_manager.cpp
+++ b/src/visualizer/gui/gizmo_manager.cpp
@@ -1724,6 +1724,7 @@ namespace lfs::vis::gui {
         }
 
         if (gizmo_changed && is_using) {
+            core::Scene::Transaction txn(scene_manager->getScene());
             if (node_gizmo_operation_ == GizmoOperation::Rotate) {
                 const glm::mat3 delta_rot = extractRotation(delta_matrix);
                 // Individual mode uses one drag-defined rotation path for the selection and

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -1357,6 +1357,10 @@ namespace lfs::vis::project {
                     json.value(
                         "autosave_dirty_epoch_threshold",
                         std::uint64_t{20}));
+            settings.autosave_quiet_seconds =
+                json.value(
+                    "autosave_quiet_seconds",
+                    std::uint64_t{2});
             settings.compaction_idle_seconds =
                 json.value(
                     "compaction_idle_seconds",
@@ -1486,6 +1490,9 @@ namespace lfs::vis::project {
                 {"autosave_dirty_epoch_threshold",
                  settings
                      .autosave_dirty_epoch_threshold},
+                {"autosave_quiet_seconds",
+                 settings
+                     .autosave_quiet_seconds},
                 {"compaction_idle_seconds",
                  settings
                      .compaction_idle_seconds},
@@ -3950,6 +3957,14 @@ namespace lfs::vis::project {
         if (autosave_failure_backoff_seconds_ !=
                 0 &&
             now < autosave_retry_not_before_) {
+            return;
+        }
+        if (settings_.autosave_quiet_seconds !=
+                0 &&
+            now - last_mutation_at_ <
+                std::chrono::seconds(
+                    settings_
+                        .autosave_quiet_seconds)) {
             return;
         }
         if (auto started = startAutosave();

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -82,6 +82,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_UntitledDirtySessionAutosavesToScratch_Test;
     class VisualizerImplResetTest_BlankUntitledSessionUpdateMaintenanceWritesNoScratch_Test;
     class VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWritesScratch_Test;
+    class VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWaitsForAutosaveQuietPeriod_Test;
     class VisualizerImplResetTest_SaveAsMigratesScratchAutosaveToSidecar_Test;
     class VisualizerImplResetTest_RecoveryDismissalPersistsAndNewerCandidateIsOffered_Test;
     class VisualizerImplResetTest_RecoverThenCleanQuitDoesNotReoffer_Test;
@@ -115,6 +116,7 @@ namespace lfs::vis::project {
         bool auto_save_on_close = false;
         std::uint64_t autosave_interval_seconds = 5 * 60;
         std::uint64_t autosave_dirty_epoch_threshold = 20;
+        std::uint64_t autosave_quiet_seconds = 2;
         std::uint64_t compaction_idle_seconds = 30;
         std::vector<ProjectMruEntry> mru;
         std::vector<DismissedRecoveryEntry> dismissed_recovery;
@@ -291,6 +293,7 @@ namespace lfs::vis::project {
         friend class lfs::vis::VisualizerImplResetTest_UntitledDirtySessionAutosavesToScratch_Test;
         friend class lfs::vis::VisualizerImplResetTest_BlankUntitledSessionUpdateMaintenanceWritesNoScratch_Test;
         friend class lfs::vis::VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWritesScratch_Test;
+        friend class lfs::vis::VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWaitsForAutosaveQuietPeriod_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsMigratesScratchAutosaveToSidecar_Test;
         friend class lfs::vis::VisualizerImplResetTest_RecoveryDismissalPersistsAndNewerCandidateIsOffered_Test;
         friend class lfs::vis::VisualizerImplResetTest_RecoverThenCleanQuitDoesNotReoffer_Test;

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -335,6 +335,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_UntitledDirtySessionAutosavesToScratch_Test;
         friend class VisualizerImplResetTest_BlankUntitledSessionUpdateMaintenanceWritesNoScratch_Test;
         friend class VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWritesScratch_Test;
+        friend class VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWaitsForAutosaveQuietPeriod_Test;
         friend class VisualizerImplResetTest_SaveAsMigratesScratchAutosaveToSidecar_Test;
         friend class VisualizerImplResetTest_RecoveryDismissalPersistsAndNewerCandidateIsOffered_Test;
         friend class VisualizerImplResetTest_RecoverThenCleanQuitDoesNotReoffer_Test;

--- a/tests/test_project_lifecycle.cpp
+++ b/tests/test_project_lifecycle.cpp
@@ -46,6 +46,9 @@ namespace {
             loaded->autosave_dirty_epoch_threshold,
             20u);
         EXPECT_EQ(
+            loaded->autosave_quiet_seconds,
+            2u);
+        EXPECT_EQ(
             loaded->compaction_idle_seconds,
             30u);
         EXPECT_TRUE(loaded->mru.empty());
@@ -109,6 +112,7 @@ namespace {
         settings.auto_save_on_close = false;
         settings.autosave_interval_seconds = 17;
         settings.autosave_dirty_epoch_threshold = 9;
+        settings.autosave_quiet_seconds = 7;
         settings.compaction_idle_seconds = 41;
         rememberProject(
             settings, first_uuid, old_path);

--- a/tests/test_scene_validity.cpp
+++ b/tests/test_scene_validity.cpp
@@ -21,6 +21,7 @@
 #include "core/cuda/sh_layout.cuh"
 #include "core/event_bridge/event_bridge.hpp"
 #include "core/event_bus.hpp"
+#include "core/events.hpp"
 #include "core/parameters.hpp"
 #include "core/pinned_memory_allocator.hpp"
 #include "core/point_cloud.hpp"
@@ -862,6 +863,51 @@ namespace lfs::python {
         EXPECT_EQ(consume_scene_mutation_flags(), combined);
         EXPECT_EQ(get_scene_mutation_flags(), 0u);
         EXPECT_EQ(consume_scene_mutation_flags(), 0u);
+    }
+
+    TEST_F(SceneValidityTest, TransactionBatchesSetNodeTransformIntoSingleSceneChanged) {
+        ASSERT_NE(dummy_scene_.addGroup("Left"), core::NULL_NODE);
+        ASSERT_NE(dummy_scene_.addGroup("Right"), core::NULL_NODE);
+        ASSERT_NE(dummy_scene_.addGroup("Front"), core::NULL_NODE);
+
+        int changed = 0;
+        std::uint32_t flags = 0;
+        auto handler = core::events::state::SceneChanged::when(
+            [&](const auto& event) {
+                ++changed;
+                flags = event.mutation_flags;
+            });
+
+        {
+            core::Scene::Transaction txn(dummy_scene_);
+            dummy_scene_.setNodeTransform(
+                "Left",
+                glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 0.0f, 0.0f)));
+            dummy_scene_.setNodeTransform(
+                "Right",
+                glm::translate(glm::mat4(1.0f), glm::vec3(-1.0f, 0.0f, 0.0f)));
+            dummy_scene_.setNodeTransform(
+                "Front",
+                glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, 1.0f)));
+            EXPECT_EQ(changed, 0);
+        }
+
+        EXPECT_EQ(changed, 1);
+        EXPECT_EQ(
+            flags,
+            static_cast<std::uint32_t>(
+                core::Scene::MutationType::TRANSFORM_CHANGED));
+
+        changed = 0;
+        dummy_scene_.setNodeTransform(
+            "Left",
+            glm::translate(glm::mat4(1.0f), glm::vec3(2.0f, 0.0f, 0.0f)));
+        dummy_scene_.setNodeTransform(
+            "Right",
+            glm::translate(glm::mat4(1.0f), glm::vec3(-2.0f, 0.0f, 0.0f)));
+        EXPECT_EQ(changed, 2);
+
+        (void)handler;
     }
 
     TEST_F(SceneValidityTest, SelectionGenerationPublishesToAppStore) {

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -2431,6 +2431,9 @@ namespace lfs::vis {
             lifecycle->last_autosave_at_ =
                 std::chrono::steady_clock::now() -
                 std::chrono::hours(1);
+            lifecycle->last_mutation_at_ =
+                std::chrono::steady_clock::now() -
+                std::chrono::hours(1);
             lifecycle->updateMaintenance();
             ASSERT_TRUE(pumpUntil(
                 viewer.work_queue_mutex_,
@@ -2443,6 +2446,70 @@ namespace lfs::vis {
                 lfs::io::project::scratch_autosave_path(
                     lifecycle->recovery_directory_,
                     lifecycle->document_->project_uuid());
+            EXPECT_TRUE(
+                std::filesystem::is_regular_file(
+                    scratch));
+            EXPECT_FALSE(
+                lifecycle->document_->source_path());
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           DirtyUntitledSessionUpdateMaintenanceWaitsForAutosaveQuietPeriod) {
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Untitled quiet maintenance"),
+                lfs::core::NULL_NODE);
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            EXPECT_FALSE(
+                lifecycle->isBlankUntitledSession());
+            lifecycle->settings_
+                .autosave_dirty_epoch_threshold = 1;
+            lifecycle->last_autosaved_dirty_epoch_ =
+                0;
+            lifecycle->last_autosaved_scene_serial_ =
+                0;
+            lifecycle->last_autosave_at_ =
+                std::chrono::steady_clock::now() -
+                std::chrono::hours(1);
+            lifecycle->last_mutation_at_ =
+                std::chrono::steady_clock::now();
+            lifecycle->updateMaintenance();
+            EXPECT_FALSE(viewer.jobs().anyRunning(
+                JobType::ProjectWrite));
+            EXPECT_FALSE(
+                lifecycle->project_write_job_
+                    .has_value());
+            const auto scratch =
+                lfs::io::project::scratch_autosave_path(
+                    lifecycle->recovery_directory_,
+                    lifecycle->document_->project_uuid());
+            EXPECT_FALSE(
+                std::filesystem::exists(scratch));
+
+            lifecycle->last_mutation_at_ =
+                std::chrono::steady_clock::now() -
+                std::chrono::hours(1);
+            lifecycle->updateMaintenance();
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
             EXPECT_TRUE(
                 std::filesystem::is_regular_file(
                     scratch));
@@ -4216,6 +4283,9 @@ namespace lfs::vis {
             lifecycle->last_autosave_at_ =
                 std::chrono::steady_clock::now() -
                 std::chrono::hours(1);
+            lifecycle->last_mutation_at_ =
+                std::chrono::steady_clock::now() -
+                std::chrono::hours(1);
 
             std::filesystem::rename(
                 project_path, backup_path);
@@ -4299,6 +4369,9 @@ namespace lfs::vis {
             lifecycle->last_autosaved_scene_serial_ =
                 0;
             lifecycle->last_autosave_at_ =
+                std::chrono::steady_clock::now() -
+                std::chrono::hours(1);
+            lifecycle->last_mutation_at_ =
                 std::chrono::steady_clock::now() -
                 std::chrono::hours(1);
 
@@ -5463,6 +5536,9 @@ namespace lfs::vis {
             lifecycle
                 ->last_autosaved_scene_serial_ = 0;
             lifecycle->last_autosave_at_ =
+                std::chrono::steady_clock::now() -
+                std::chrono::hours(1);
+            lifecycle->last_mutation_at_ =
                 std::chrono::steady_clock::now() -
                 std::chrono::hours(1);
             lifecycle->updateMaintenance();


### PR DESCRIPTION
Fixes #1739.

Dragging a model with the transform tools triggered autosave over and over mid-drag - a drag counts as many small edits, and each autosave froze the viewport for a moment while preparing the write.

When saves happen now:
- Autosave waits until editing pauses: it runs once the scene has been quiet for about 2 seconds, so a drag finishes smoothly and one autosave lands right after you let go.
- The usual triggers (time interval and change count) are unchanged - autosave just never fires mid-interaction anymore.
- Explicit saves are untouched.
- A drag also counts as one change per frame now instead of one per selected node.

Verified: 180 tests green across the maintenance, settings, and scene suites, including a new quiet-period test, and live on screen - a 13.5-second continuous gizmo drag produced zero autosaves during the drag and exactly one 2 seconds after release (previously several mid-drag).

The issue's side observation (model occasionally not following the gizmo) was not reproducible here; if it shows up again it deserves its own issue.