### PR TITLE
Recheck dataset images when reopening a project

### DIFF
--- a/src/core/include/core/scene.hpp
+++ b/src/core/include/core/scene.hpp
@@ -509,6 +509,10 @@ namespace lfs::core {
         // touched.
         size_t rebaseCameraAssetPaths(const std::filesystem::path& old_root,
                                       const std::filesystem::path& new_root);
+        // Aligns each camera's has_image with whether its image_path is a regular
+        // file. Empty image_path is left unchanged (dummy/test cameras). Returns
+        // the image names of cameras whose files are currently missing.
+        std::vector<std::string> revalidateCameraImagePresence();
         [[nodiscard]] size_t getActiveCameraCount() const;
         [[nodiscard]] CameraTrainingCounts getCameraTrainingCounts(NodeId camera_group_id) const;
         void setCameraTrainingEnabled(const std::string& name, bool enabled);

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -17,12 +17,14 @@
 #include <cmath>
 #include <cuda_runtime.h>
 #include <exception>
+#include <filesystem>
 #include <functional>
 #include <glm/gtc/quaternion.hpp>
 #include <limits>
 #include <numeric>
 #include <ranges>
 #include <set>
+#include <system_error>
 #include <utility>
 
 namespace lfs::core {
@@ -4707,6 +4709,29 @@ namespace lfs::core {
             ++touched;
         }
         return touched;
+    }
+
+    std::vector<std::string> Scene::revalidateCameraImagePresence() {
+        std::vector<std::string> missing;
+        for (const auto& node : nodes_) {
+            if (node->type != NodeType::CAMERA || !node->camera) {
+                continue;
+            }
+            auto& camera = *node->camera;
+            const auto& image_path = camera.image_path();
+            if (image_path.empty()) {
+                continue;
+            }
+            std::error_code exists_error;
+            const bool exists = std::filesystem::is_regular_file(image_path, exists_error);
+            camera.set_has_image(exists);
+            if (!exists) {
+                missing.push_back(camera.image_name().empty()
+                                      ? path_to_utf8(image_path.filename())
+                                      : camera.image_name());
+            }
+        }
+        return missing;
     }
 
     size_t Scene::getActiveCameraCount() const {

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -24,6 +24,7 @@
 #include "gui/utils/native_file_dialog.hpp"
 #include "io/filesystem_utils.hpp"
 #include "io/loader.hpp"
+#include "io/loaders/missing_dataset_images.hpp"
 #include "io/project_container.hpp"
 #include "io/project_path.hpp"
 #include "io/project_recovery.hpp"
@@ -386,6 +387,15 @@ namespace lfs::vis::project {
             return detail;
         }
 
+        void revalidateHydratedCameraImages(
+            SceneManager& scene_manager) {
+            const auto missing =
+                scene_manager.getScene()
+                    .revalidateCameraImagePresence();
+            lfs::io::notify_missing_dataset_images(
+                missing);
+        }
+
         void installCheckpointTrainerWithDatasetRoot(
             VisualizerImpl& viewer,
             SceneManager& scene_manager,
@@ -411,6 +421,8 @@ namespace lfs::vis::project {
                     lfs::core::path_to_utf8(
                         dataset_root));
             }
+            revalidateHydratedCameraImages(
+                scene_manager);
             ckpt_params.dataset.data_path = dataset_root;
 
             // Reset path authority without re-applying
@@ -529,6 +541,8 @@ namespace lfs::vis::project {
                     lfs::core::path_to_utf8(
                         dataset_root));
             }
+            revalidateHydratedCameraImages(
+                scene_manager);
 
             auto* const parameter_manager =
                 viewer.getParameterManager();

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -309,6 +309,9 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_BoundCheckpointIterationCacheSkipsHeaderWhenWarm_Test;
         friend class VisualizerImplResetTest_SelectedGaussiansAndSelectionToolSurviveSaveAndReopen_Test;
         friend class VisualizerImplResetTest_DatasetProjectWithoutCheckpointReloadsTrainer_Test;
+        friend class VisualizerImplResetTest_HydratedDatasetReopenMarksDeletedImageMissing_Test;
+        friend class VisualizerImplResetTest_HydratedDatasetReopenIncludesRestoredImage_Test;
+        friend class VisualizerImplResetTest_HydratedDatasetReopenAllImagesMissingDoesNotCrash_Test;
         friend class VisualizerImplResetTest_MissingDatasetProjectArmsRelocationInsteadOfImport_Test;
         friend class VisualizerImplResetTest_RelocateProjectDatasetRestoresTrainerFromNewRoot_Test;
         friend class VisualizerImplResetTest_RelocateRejectsFolderWithoutDatasetElements_Test;

--- a/tests/test_missing_dataset_images.cpp
+++ b/tests/test_missing_dataset_images.cpp
@@ -1,6 +1,8 @@
 /* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "core/scene.hpp"
+#include "core/tensor.hpp"
 #include "io/formats/colmap.hpp"
 #include "io/formats/transforms.hpp"
 #include "io/loaders/blender_loader.hpp"
@@ -186,6 +188,31 @@ namespace {
             EXPECT_EQ(dataset.get_cameras().size(), 2u);
         }
 
+        std::shared_ptr<lfs::core::Camera> make_scene_camera(
+            const std::string& name,
+            const fs::path& image_path,
+            const int uid) {
+            const auto empty_distortion = lfs::core::Tensor::zeros(
+                {0}, lfs::core::Device::CPU, lfs::core::DataType::Float32);
+            return std::make_shared<lfs::core::Camera>(
+                lfs::core::Tensor::eye(3, lfs::core::Device::CPU),
+                lfs::core::Tensor::zeros({3}, lfs::core::Device::CPU),
+                1.0f, 1.0f, 0.5f, 0.5f, empty_distortion, empty_distortion,
+                lfs::core::CameraModelType::PINHOLE, name, image_path,
+                fs::path{}, 1, 1, uid);
+        }
+
+        lfs::core::Camera* camera_by_name(
+            lfs::core::Scene& scene,
+            const std::string& name) {
+            for (const auto& camera : scene.getAllCameras()) {
+                if (camera && camera->image_name() == name) {
+                    return camera.get();
+                }
+            }
+            return nullptr;
+        }
+
         fs::path temp_dir_;
     };
 
@@ -368,4 +395,108 @@ TEST_F(MissingDatasetImagesTest, TransformsRawReaderKeepsMissingCameraRecords) {
     EXPECT_TRUE(cameras[0]._has_image);
     EXPECT_FALSE(cameras[1]._has_image);
     EXPECT_EQ(cameras[1]._image_name, "missing.png");
+}
+
+TEST_F(MissingDatasetImagesTest, RevalidateMarksDeletedImageMissing) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required";
+    }
+
+    write_png(temp_dir_ / "present.png");
+    write_png(temp_dir_ / "missing.png");
+
+    lfs::core::Scene scene;
+    const auto group = scene.addCameraGroup("Training", scene.addGroup("Cameras"), 2);
+    ASSERT_NE(group, lfs::core::NULL_NODE);
+    ASSERT_NE(scene.addCamera("present.png", group,
+                              make_scene_camera("present.png", temp_dir_ / "present.png", 0)),
+              lfs::core::NULL_NODE);
+    ASSERT_NE(scene.addCamera("missing.png", group,
+                              make_scene_camera("missing.png", temp_dir_ / "missing.png", 1)),
+              lfs::core::NULL_NODE);
+
+    fs::remove(temp_dir_ / "missing.png");
+    const auto missing = scene.revalidateCameraImagePresence();
+    ASSERT_EQ(missing.size(), 1u);
+    EXPECT_EQ(missing.front(), "missing.png");
+
+    auto* present = camera_by_name(scene, "present.png");
+    auto* deleted = camera_by_name(scene, "missing.png");
+    ASSERT_NE(present, nullptr);
+    ASSERT_NE(deleted, nullptr);
+    EXPECT_TRUE(present->has_image());
+    EXPECT_FALSE(deleted->has_image());
+
+    lfs::training::DatasetConfig config;
+    lfs::training::CameraDataset dataset(
+        scene.getAllCameras(), config, lfs::training::CameraDataset::Split::ALL);
+    EXPECT_EQ(dataset.size(), 1u);
+    EXPECT_EQ(dataset.get_camera(0)->image_name(), "present.png");
+    EXPECT_EQ(dataset.get_cameras().size(), 2u);
+}
+
+TEST_F(MissingDatasetImagesTest, RevalidateIncludesRestoredImage) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required";
+    }
+
+    write_png(temp_dir_ / "present.png");
+
+    lfs::core::Scene scene;
+    const auto group = scene.addCameraGroup("Training", scene.addGroup("Cameras"), 2);
+    ASSERT_NE(group, lfs::core::NULL_NODE);
+    ASSERT_NE(scene.addCamera("present.png", group,
+                              make_scene_camera("present.png", temp_dir_ / "present.png", 0)),
+              lfs::core::NULL_NODE);
+    auto restored = make_scene_camera("restored.png", temp_dir_ / "restored.png", 1);
+    restored->set_has_image(false);
+    ASSERT_NE(scene.addCamera("restored.png", group, restored), lfs::core::NULL_NODE);
+
+    write_png(temp_dir_ / "restored.png");
+    const auto missing = scene.revalidateCameraImagePresence();
+    EXPECT_TRUE(missing.empty());
+
+    auto* present = camera_by_name(scene, "present.png");
+    auto* included = camera_by_name(scene, "restored.png");
+    ASSERT_NE(present, nullptr);
+    ASSERT_NE(included, nullptr);
+    EXPECT_TRUE(present->has_image());
+    EXPECT_TRUE(included->has_image());
+
+    lfs::training::DatasetConfig config;
+    lfs::training::CameraDataset dataset(
+        scene.getAllCameras(), config, lfs::training::CameraDataset::Split::ALL);
+    EXPECT_EQ(dataset.size(), 2u);
+    EXPECT_EQ(dataset.get_cameras().size(), 2u);
+}
+
+TEST_F(MissingDatasetImagesTest, RevalidateAllMissingExcludesEveryCamera) {
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device required";
+    }
+
+    lfs::core::Scene scene;
+    const auto group = scene.addCameraGroup("Training", scene.addGroup("Cameras"), 2);
+    ASSERT_NE(group, lfs::core::NULL_NODE);
+    ASSERT_NE(scene.addCamera("missing_a.png", group,
+                              make_scene_camera("missing_a.png", temp_dir_ / "missing_a.png", 0)),
+              lfs::core::NULL_NODE);
+    ASSERT_NE(scene.addCamera("missing_b.png", group,
+                              make_scene_camera("missing_b.png", temp_dir_ / "missing_b.png", 1)),
+              lfs::core::NULL_NODE);
+
+    const auto missing = scene.revalidateCameraImagePresence();
+    ASSERT_EQ(missing.size(), 2u);
+
+    for (const auto& camera : scene.getAllCameras()) {
+        ASSERT_NE(camera, nullptr);
+        EXPECT_FALSE(camera->has_image());
+    }
+
+    lfs::training::DatasetConfig config;
+    lfs::training::CameraDataset dataset(
+        scene.getAllCameras(), config, lfs::training::CameraDataset::Split::ALL);
+    EXPECT_EQ(dataset.size(), 0u);
+    EXPECT_EQ(dataset.get_cameras().size(), 2u);
+    EXPECT_TRUE(scene.hasTrainingData());
 }

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -29,6 +29,7 @@
 #include "tools/unified_tool_registry.hpp"
 #include "training/checkpoint.hpp"
 #include "training/components/ppisp_file.hpp"
+#include "training/dataset.hpp"
 #include "training/strategies/mcmc.hpp"
 #include "training/trainer.hpp"
 #include "training/training_state.hpp"
@@ -487,6 +488,78 @@ namespace {
         options.commit.snapshot_uuid = {};
         (void)lfs::test::licht::require_result(
             document->save(project_path, options));
+    }
+
+    void write_dataset_project_with_named_cameras(
+        const std::filesystem::path& project_path,
+        const std::filesystem::path& dataset_path,
+        const std::vector<std::pair<std::string, bool>>&
+            camera_images) {
+        auto document =
+            lfs::test::licht::make_empty_document(
+                lfs::core::generate_uuid_v4(), 1);
+        lfs::core::Scene source;
+        const auto dataset =
+            source.addDataset("Dataset");
+        const auto cameras = source.addCameraGroup(
+            "Training", dataset, camera_images.size());
+        for (int i = 0;
+             i < static_cast<int>(camera_images.size());
+             ++i) {
+            const auto& [name, has_image] =
+                camera_images[static_cast<size_t>(i)];
+            auto camera =
+                make_project_request_test_camera(
+                    dataset_path / name, i, name);
+            camera->set_has_image(has_image);
+            source.addCamera(name, cameras, camera);
+        }
+        document->edit_scene_graph() =
+            lfs::test::licht::require_result(
+                lfs::io::project::capture_scene_graph(
+                    source, {}));
+
+        auto parameters =
+            lfs::test::licht::require_result(
+                document->parameters().snapshot());
+        parameters.dataset.data_path = dataset_path;
+        parameters.mrnf_session.iterations = 1234;
+        parameters.mrnf_current.iterations = 1234;
+        lfs::test::licht::require_status(
+            document->edit_parameters().set_snapshot(
+                parameters));
+
+        const auto reference =
+            lfs::test::licht::require_result(
+                lfs::io::project::upsert_path_reference(
+                    document->edit_references(),
+                    project_path.parent_path(),
+                    dataset_path, "dataset",
+                    "dataset"));
+        lfs::test::licht::require_status(
+            document->edit_project()
+                .set_dataset_reference(reference));
+
+        auto options =
+            lfs::test::licht::
+                deterministic_document_save_options(
+                    0x76000011, 1, 2);
+        options.commit.snapshot_uuid = {};
+        (void)lfs::test::licht::require_result(
+            document->save(project_path, options));
+    }
+
+    lfs::core::Camera* camera_by_image_name(
+        lfs::core::Scene& scene,
+        const std::string& name) {
+        for (const auto& camera :
+             scene.getAllCameras()) {
+            if (camera &&
+                camera->image_name() == name) {
+                return camera.get();
+            }
+        }
+        return nullptr;
     }
 
     void write_non_dataset_project_with_stale_dataset_params(
@@ -8543,6 +8616,261 @@ namespace lfs::vis {
         EXPECT_EQ(
             viewer.getTrainer()->getParams().optimization.iterations,
             1234);
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           HydratedDatasetReopenMarksDeletedImageMissing) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto dataset_path =
+            temporary_.path /
+            "hydrated-deleted-image-source";
+        write_transforms_dataset_with_cameras(
+            dataset_path, 2);
+        const auto project_path =
+            temporary_.path /
+            "hydrated-deleted-image.licht";
+        write_dataset_project_with_named_cameras(
+            project_path, dataset_path,
+            {{"frame_0001.png", true},
+             {"frame_0002.png", true}});
+        std::filesystem::remove(
+            dataset_path / "frame_0002.png");
+
+        CapturingErrorConsumer consumer;
+        auto subscription =
+            lfs::ErrorBus::instance().subscribe(
+                consumer);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                viewer.getGuiManager()
+                    ->asyncTasks()
+                    .pollImportCompletion();
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       viewer.getTrainerManager()
+                           ->hasTrainer() &&
+                       !viewer.jobs().anyRunning(
+                           JobType::Import) &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
+            }));
+
+        auto* present = camera_by_image_name(
+            viewer.getScene(), "frame_0001.png");
+        auto* deleted = camera_by_image_name(
+            viewer.getScene(), "frame_0002.png");
+        ASSERT_NE(present, nullptr);
+        ASSERT_NE(deleted, nullptr);
+        EXPECT_TRUE(present->has_image());
+        EXPECT_FALSE(deleted->has_image());
+
+        lfs::training::DatasetConfig config;
+        lfs::training::CameraDataset dataset(
+            viewer.getScene().getAllCameras(), config,
+            lfs::training::CameraDataset::Split::ALL);
+        EXPECT_EQ(dataset.size(), 1u);
+        EXPECT_EQ(dataset.get_camera(0)->image_name(),
+                  "frame_0001.png");
+        EXPECT_EQ(dataset.get_cameras().size(), 2u);
+
+        EXPECT_TRUE(std::ranges::any_of(
+            consumer.user_messages,
+            [](const std::string& message) {
+                return message.find(
+                           "frame_0002.png") !=
+                           std::string::npos &&
+                       message.find("missing") !=
+                           std::string::npos;
+            }));
+        EXPECT_TRUE(std::ranges::none_of(
+            consumer.user_messages,
+            [](const std::string& message) {
+                return message.find(
+                           "frame_0001.png") !=
+                       std::string::npos;
+            }));
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           HydratedDatasetReopenIncludesRestoredImage) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto dataset_path =
+            temporary_.path /
+            "hydrated-restored-image-source";
+        write_transforms_dataset_with_cameras(
+            dataset_path, 2);
+        const auto missing_path =
+            dataset_path / "frame_0002.png";
+        std::filesystem::remove(missing_path);
+        const auto project_path =
+            temporary_.path /
+            "hydrated-restored-image.licht";
+        write_dataset_project_with_named_cameras(
+            project_path, dataset_path,
+            {{"frame_0001.png", true},
+             {"frame_0002.png", false}});
+        lfs::test::licht::write_file_bytes(
+            missing_path,
+            lfs::test::licht::one_pixel_png());
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                viewer.getGuiManager()
+                    ->asyncTasks()
+                    .pollImportCompletion();
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       viewer.getTrainerManager()
+                           ->hasTrainer() &&
+                       !viewer.jobs().anyRunning(
+                           JobType::Import) &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
+            }));
+
+        auto* present = camera_by_image_name(
+            viewer.getScene(), "frame_0001.png");
+        auto* restored = camera_by_image_name(
+            viewer.getScene(), "frame_0002.png");
+        ASSERT_NE(present, nullptr);
+        ASSERT_NE(restored, nullptr);
+        EXPECT_TRUE(present->has_image());
+        EXPECT_TRUE(restored->has_image());
+
+        lfs::training::DatasetConfig config;
+        lfs::training::CameraDataset dataset(
+            viewer.getScene().getAllCameras(), config,
+            lfs::training::CameraDataset::Split::ALL);
+        EXPECT_EQ(dataset.size(), 2u);
+        EXPECT_EQ(dataset.get_cameras().size(), 2u);
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           HydratedDatasetReopenAllImagesMissingDoesNotCrash) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto dataset_path =
+            temporary_.path /
+            "hydrated-all-missing-source";
+        write_transforms_dataset_with_cameras(
+            dataset_path, 2);
+        const auto project_path =
+            temporary_.path /
+            "hydrated-all-missing.licht";
+        write_dataset_project_with_named_cameras(
+            project_path, dataset_path,
+            {{"frame_0001.png", true},
+             {"frame_0002.png", true}});
+        std::filesystem::remove(
+            dataset_path / "frame_0001.png");
+        std::filesystem::remove(
+            dataset_path / "frame_0002.png");
+
+        CapturingErrorConsumer consumer;
+        auto subscription =
+            lfs::ErrorBus::instance().subscribe(
+                consumer);
+
+        auto options = projectOptions();
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()
+                        ->ensureLoaded());
+        ASSERT_TRUE(viewer.getWindowManager()->init());
+        auto opened = viewer.projectOpen(
+            project_path,
+            ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(opened)
+            << lfs::format_for_developer(
+                   opened.error());
+        viewer.noteGuiSessionRestoreOwnerReady(1);
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                viewer.getGuiManager()
+                    ->asyncTasks()
+                    .pollImportCompletion();
+                const auto info = viewer.projectGetInfo();
+                return info &&
+                       info->hydration_state ==
+                           "complete" &&
+                       viewer.getTrainerManager()
+                           ->hasTrainer() &&
+                       !viewer.jobs().anyRunning(
+                           JobType::Import) &&
+                       !viewer.jobs().anyRunning(
+                           JobType::ProjectOpen);
+            }));
+
+        EXPECT_TRUE(
+            viewer.getScene().hasTrainingData());
+        for (const auto& camera :
+             viewer.getScene().getAllCameras()) {
+            ASSERT_NE(camera, nullptr);
+            EXPECT_FALSE(camera->has_image());
+        }
+
+        lfs::training::DatasetConfig config;
+        lfs::training::CameraDataset dataset(
+            viewer.getScene().getAllCameras(), config,
+            lfs::training::CameraDataset::Split::ALL);
+        EXPECT_EQ(dataset.size(), 0u);
+        EXPECT_EQ(dataset.get_cameras().size(), 2u);
+
+        EXPECT_TRUE(std::ranges::any_of(
+            consumer.user_messages,
+            [](const std::string& message) {
+                return message.find(
+                           "dataset image") !=
+                           std::string::npos &&
+                       message.find("missing") !=
+                           std::string::npos;
+            }));
+
+        auto* const trainer = viewer.getTrainer();
+        ASSERT_NE(trainer, nullptr);
+        auto initialized = trainer->initialize(
+            trainer->getParams());
+        ASSERT_FALSE(initialized);
+        EXPECT_NE(
+            initialized.error().find(
+                "no cameras with image files available for training"),
+            std::string::npos);
     }
 
     TEST_F(VisualizerImplResetTest,


### PR DESCRIPTION
Found while reviewing the recent project-format fixes.

A project remembers which dataset images existed when it was saved. If a file changed on disk since then, reopening trusted the stale answer: one deleted image aborted the whole training run with "DataLoader ended unexpectedly", and an image that came back stayed excluded forever.

Reopening now rechecks the files on disk after loading, in both directions. Missing files show the same "N dataset images are missing" notice the dataset loaders already use, and those cameras are skipped instead of killing the run. If every image is gone, training refuses to start with a clear message instead of crashing.

Verified: new tests for deleted-after-save, restored-after-save, and all-missing, plus the full lifecycle fixture - 137 tests green.