### PR TITLE
Fail loud when the writer lock cannot prove its identity

### DIFF
--- a/src/io/project/project_container_internal.hpp
+++ b/src/io/project/project_container_internal.hpp
@@ -136,6 +136,13 @@ namespace lfs::io::project::detail {
         std::filesystem::path path_;
     };
 
+#ifndef _WIN32
+    // True when `fd` still names `lock_path`. False if the path is missing or
+    // a different inode. fstat failure is an error, never a match.
+    [[nodiscard]] lfs::Result<bool>
+    writer_lock_fd_matches_path(int fd, const std::filesystem::path& lock_path);
+#endif
+
     struct AtomicReplaceState {
         std::optional<std::filesystem::path> backup_path;
     };

--- a/src/io/project/project_file.cpp
+++ b/src/io/project/project_file.cpp
@@ -414,7 +414,7 @@ namespace lfs::io::project::detail {
         }
         return static_cast<std::uint64_t>(size.QuadPart);
 #else
-        struct stat status {};
+        struct stat status{};
         if (::fstat(fd_, &status) != 0 || status.st_size < 0) {
             const int error = errno;
             return project_error(native_error_code(error, false),
@@ -687,6 +687,28 @@ namespace lfs::io::project::detail {
 #endif
     }
 
+#ifndef _WIN32
+    lfs::Result<bool> writer_lock_fd_matches_path(
+        const int fd, const std::filesystem::path& lock_path) {
+        struct stat fd_status{};
+        if (::fstat(fd, &fd_status) != 0) {
+            const int error = errno;
+            return project_error(
+                native_error_code(error, true),
+                "The project writer lock could not be opened.",
+                std::format("lockfile fstat failed: {}", std::strerror(error)), lock_path,
+                std::nullopt, "writer_lock", error, std::strerror(error));
+        }
+        struct stat path_status{};
+        if (::stat(lock_path.c_str(), &path_status) != 0 ||
+            fd_status.st_dev != path_status.st_dev ||
+            fd_status.st_ino != path_status.st_ino) {
+            return false;
+        }
+        return true;
+    }
+#endif
+
     lfs::Result<WriterLock> WriterLock::acquire(const std::filesystem::path& project_path) {
         auto lock_path = project_path;
         lock_path += ".lock";
@@ -769,20 +791,19 @@ namespace lfs::io::project::detail {
                     std::format("flock denied the held lock: {}", std::strerror(error)),
                     lock_path, std::nullopt, "writer_lock", error, std::strerror(error));
             }
-            struct stat fd_status {};
-            if (::fstat(fd, &fd_status) != 0) {
-                return WriterLock(lock_path, fd);
+            auto identity = writer_lock_fd_matches_path(fd, lock_path);
+            if (!identity) {
+                ::flock(fd, LOCK_UN);
+                ::close(fd);
+                return std::move(identity).error();
             }
-            struct stat path_status {};
-            if (::stat(lock_path.c_str(), &path_status) != 0 ||
-                fd_status.st_dev != path_status.st_dev ||
-                fd_status.st_ino != path_status.st_ino) {
-                if (attempt + 1 < kAcquireAttempts) {
-                    ::flock(fd, LOCK_UN);
-                    ::close(fd);
-                    continue;
-                }
-                return WriterLock(lock_path, fd);
+            if (!*identity) {
+                // Drop the stale fd and retry. The last attempt falls out of
+                // the loop so the exhaustion error below is returned instead
+                // of a compromised lock.
+                ::flock(fd, LOCK_UN);
+                ::close(fd);
+                continue;
             }
             return WriterLock(lock_path, fd);
         }

--- a/tests/test_project_container.cpp
+++ b/tests/test_project_container.cpp
@@ -39,9 +39,12 @@
 
 #ifndef _WIN32
 #include <csignal>
+#include <fcntl.h>
 #include <limits.h>
 #include <sched.h>
+#include <sys/file.h>
 #include <sys/mount.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #endif
@@ -3244,6 +3247,89 @@ namespace {
         }
         EXPECT_FALSE(fs::exists(lock_path));
     }
+
+#ifndef _WIN32
+    TEST(ProjectContainerWriter, WriterLockFdMatchesCurrentLockPath) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "lock-identity.licht";
+        auto lock_path = path;
+        lock_path += ".lock";
+        const int fd =
+            ::open(lock_path.c_str(), O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+        ASSERT_GE(fd, 0);
+        ASSERT_EQ(::flock(fd, LOCK_EX | LOCK_NB), 0);
+        auto identity = detail::writer_lock_fd_matches_path(fd, lock_path);
+        ::flock(fd, LOCK_UN);
+        ::close(fd);
+        ASSERT_TRUE(identity) << lfs::format_for_developer(identity.error());
+        EXPECT_TRUE(*identity);
+    }
+
+    TEST(ProjectContainerWriter, WriterLockFdMismatchOnReplacedLockFile) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "lock-replaced.licht";
+        auto lock_path = path;
+        lock_path += ".lock";
+        const int stale =
+            ::open(lock_path.c_str(), O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+        ASSERT_GE(stale, 0);
+        ASSERT_EQ(::flock(stale, LOCK_EX | LOCK_NB), 0);
+        ASSERT_EQ(::unlink(lock_path.c_str()), 0);
+        const int current =
+            ::open(lock_path.c_str(), O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+        ASSERT_GE(current, 0);
+        auto stale_identity =
+            detail::writer_lock_fd_matches_path(stale, lock_path);
+        auto current_identity =
+            detail::writer_lock_fd_matches_path(current, lock_path);
+        auto missing_identity = detail::writer_lock_fd_matches_path(
+            stale, temporary.path / "missing.licht.lock");
+        ::flock(stale, LOCK_UN);
+        ::close(stale);
+        ::close(current);
+        ASSERT_TRUE(stale_identity)
+            << lfs::format_for_developer(stale_identity.error());
+        EXPECT_FALSE(*stale_identity);
+        ASSERT_TRUE(current_identity)
+            << lfs::format_for_developer(current_identity.error());
+        EXPECT_TRUE(*current_identity);
+        ASSERT_TRUE(missing_identity)
+            << lfs::format_for_developer(missing_identity.error());
+        EXPECT_FALSE(*missing_identity);
+    }
+
+    TEST(ProjectContainerWriter, WriterLockFdFstatFailureIsError) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "lock-fstat.licht";
+        auto lock_path = path;
+        lock_path += ".lock";
+        const int fd =
+            ::open(lock_path.c_str(), O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+        ASSERT_GE(fd, 0);
+        ASSERT_EQ(::close(fd), 0);
+        auto identity = detail::writer_lock_fd_matches_path(fd, lock_path);
+        ASSERT_FALSE(identity);
+        EXPECT_EQ(identity.error().code(), lfs::ErrorCode::Internal);
+        EXPECT_NE(std::string(identity.error().detail()).find("lockfile fstat failed"),
+                  std::string::npos);
+        ASSERT_TRUE(identity.error().native().has_value());
+        EXPECT_EQ(identity.error().native()->code, EBADF);
+    }
+
+    TEST(ProjectContainerWriter, WriterLockAcquireFailsWhenLockPathIsDirectory) {
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "dir-lock.licht";
+        auto lock_path = path;
+        lock_path += ".lock";
+        fs::create_directory(lock_path);
+        auto lock = detail::WriterLock::acquire(path);
+        ASSERT_FALSE(lock);
+        EXPECT_NE(lock.error().code(), lfs::ErrorCode::Unavailable);
+        EXPECT_NE(std::string(lock.error().detail()).find("lockfile open failed"),
+                  std::string::npos);
+        EXPECT_TRUE(fs::is_directory(lock_path));
+    }
+#endif
 
     TEST(ProjectContainerWriter,
          StartupSweepRemovesStaleMasterLockAndSaveasTemp) {


### PR DESCRIPTION
Found while reviewing the recent lock-file fixes (#1708).

The one-writer lock validates after locking that its file handle still points at the real lock file (another process may have won a race and replaced it). Two escape hatches undermined that check: if the validation call itself failed, or if the mismatch persisted through all retries, the code returned a working lock anyway - a lock it just proved might not guard anything. Two app instances could then both believe they own the project.

Now both cases fail with a clear error instead of returning a compromised lock. Normal acquisition and the already-locked case are unchanged.

Verified: new tests for the identity check (match, replaced file, missing file, failed validation) plus the full container and document suites - 113 tests green.