### PR TITLE
Remove dead training-loop API and deduplicate save plumbing

### DIFF
--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -261,7 +261,7 @@ namespace {
         if (auto posted = lfs::vis::post_guarded_and_wait<void>(
                 viewer, context,
                 [emit = std::forward<EmitFn>(emit_fn)]() mutable
-                -> lfs::Result<void> {
+                    -> lfs::Result<void> {
                     emit();
                     return {};
                 },
@@ -286,6 +286,44 @@ namespace {
             return;
         }
         std::forward<EmitFn>(emit_fn)();
+    }
+
+    bool consume_project_save_started_and_wait(
+        lfs::vis::Visualizer* viewer,
+        bool wait,
+        const char* wait_task_name) {
+        const bool started =
+            viewer->consumeProjectSaveStarted();
+        if (!started || !wait) {
+            return started;
+        }
+        const lfs::core::TaskContext context{
+            .name = wait_task_name,
+            .domain = lfs::ErrorDomain::Python,
+            .operation_id =
+                lfs::OperationId::generate(),
+            .site = LFS_SOURCE_SITE_CURRENT(),
+        };
+        if (auto posted =
+                lfs::vis::post_guarded_and_wait<
+                    void>(
+                    *viewer, context,
+                    [viewer]()
+                        -> lfs::Result<void> {
+                        viewer
+                            ->projectWaitWrite();
+                        return {};
+                    },
+                    python_viewer_shutdown_error());
+            !posted) {
+            throw std::runtime_error(
+                std::format(
+                    "{} failed: {}",
+                    wait_task_name,
+                    lfs::format_for_developer(
+                        posted.error())));
+        }
+        return started;
     }
 
     std::expected<void, std::string> clear_scene_from_python() {
@@ -958,34 +996,11 @@ NB_MODULE(lichtfeld, m) {
                 return false;
             }
             const bool started =
-                viewer->consumeProjectSaveAsStarted();
+                consume_project_save_started_and_wait(
+                    viewer, wait,
+                    "python.project_save.wait");
             if (!started || !wait) {
                 return started;
-            }
-            const lfs::core::TaskContext context{
-                .name = "python.project_save.wait",
-                .domain = lfs::ErrorDomain::Python,
-                .operation_id =
-                    lfs::OperationId::generate(),
-                .site = LFS_SOURCE_SITE_CURRENT(),
-            };
-            if (auto posted =
-                    lfs::vis::post_guarded_and_wait<
-                        void>(
-                        *viewer, context,
-                        [viewer]()
-                            -> lfs::Result<void> {
-                            viewer
-                                ->projectWaitWrite();
-                            return {};
-                        },
-                        python_viewer_shutdown_error());
-                !posted) {
-                throw std::runtime_error(
-                    std::format(
-                        "python.project_save.wait failed: {}",
-                        lfs::format_for_developer(
-                            posted.error())));
             }
             auto poll = viewer->projectPollWrite();
             if (!poll) {
@@ -1014,38 +1029,9 @@ NB_MODULE(lichtfeld, m) {
             if (!viewer) {
                 return false;
             }
-            const bool started =
-                viewer->consumeProjectSaveAsStarted();
-            if (!started || !wait) {
-                return started;
-            }
-            const lfs::core::TaskContext context{
-                .name =
-                    "python.project_save_as.wait",
-                .domain = lfs::ErrorDomain::Python,
-                .operation_id =
-                    lfs::OperationId::generate(),
-                .site = LFS_SOURCE_SITE_CURRENT(),
-            };
-            if (auto posted =
-                    lfs::vis::post_guarded_and_wait<
-                        void>(
-                        *viewer, context,
-                        [viewer]()
-                            -> lfs::Result<void> {
-                            viewer
-                                ->projectWaitWrite();
-                            return {};
-                        },
-                        python_viewer_shutdown_error());
-                !posted) {
-                throw std::runtime_error(
-                    std::format(
-                        "python.project_save_as.wait failed: {}",
-                        lfs::format_for_developer(
-                            posted.error())));
-            }
-            return started;
+            return consume_project_save_started_and_wait(
+                viewer, wait,
+                "python.project_save_as.wait");
         },
         nb::arg("path") = "",
         nb::arg("wait") = false,

--- a/src/python/lfs_plugins/file_menu.py
+++ b/src/python/lfs_plugins/file_menu.py
@@ -16,6 +16,7 @@ from .layouts.menus import (
     register_menu,
 )
 from .import_panels import open_dataset_import_panel, open_resume_checkpoint_panel
+from .training_confirm import _confirm_stop_training_then, _project_has_path
 
 __lfs_menu_classes__ = ["FileMenu"]
 
@@ -74,37 +75,6 @@ def _open_checkpoint_import_checked(path: str) -> None:
         )
     if not open_resume_checkpoint_panel(path):
         raise RuntimeError("checkpoint import dialog is unavailable")
-
-
-def _training_is_active() -> bool:
-    probe = getattr(lf, "is_training_active", None)
-    if not callable(probe):
-        return False
-    try:
-        return bool(probe())
-    except Exception:
-        return False
-
-
-def _confirm_stop_training_then(callback) -> None:
-    if not _training_is_active():
-        callback(False)
-        return
-
-    tr = lf.ui.tr
-    yes_label = tr("common.yes")
-    no_label = tr("common.no")
-
-    def _on_result(button):
-        if button == yes_label:
-            callback(True)
-
-    lf.ui.confirm_dialog(
-        tr("project_switch.stop_training_title"),
-        tr("project_switch.stop_training_message"),
-        [yes_label, no_label],
-        _on_result,
-    )
 
 
 def _confirm_discard_then(title: str, callback) -> None:
@@ -402,7 +372,7 @@ def _show_exit_confirmation(training_in_progress: bool = False) -> None:
         )
         return
 
-    has_path = lf.project_has_path()
+    has_path = _project_has_path()
     save_label = (
         tr("common.save")
         if has_path
@@ -476,10 +446,7 @@ def _on_show_resume_checkpoint_popup(path: str):
 
 
 def _can_compact_project() -> bool:
-    try:
-        return bool(lf.project_has_path())
-    except Exception:
-        return False
+    return _project_has_path()
 
 
 @register_menu

--- a/src/python/lfs_plugins/import_panels.py
+++ b/src/python/lfs_plugins/import_panels.py
@@ -144,6 +144,7 @@ from .asset_manager_integration import (
 from .asset_index import resolve_asset_manager_storage_path
 from .types import Panel
 from .rml_keys import KI_ESCAPE, KI_RETURN
+from .training_confirm import _confirm_stop_training_then
 from .ui import RuntimeState
 from .url_downloader import (
     URLDownloadError,
@@ -272,16 +273,6 @@ def _load_watch_dirs_dialog_state(folder_id: str) -> bool:
     return True
 
 
-def _training_is_active() -> bool:
-    probe = getattr(lf, "is_training_active", None)
-    if not callable(probe):
-        return False
-    try:
-        return bool(probe())
-    except Exception:
-        return False
-
-
 def _project_is_dirty() -> bool:
     probe = getattr(lf, "project_is_dirty", None)
     if not callable(probe):
@@ -292,39 +283,14 @@ def _project_is_dirty() -> bool:
         return False
 
 
-def _confirm_stop_training_then(callback) -> None:
-    if not _training_is_active():
-        callback(False)
-        return
-
-    tr = lf.ui.tr
-    yes_label = tr("common.yes")
-    no_label = tr("common.no")
-
-    def _on_result(button):
-        if button == yes_label:
-            callback(True)
-
-    lf.ui.confirm_dialog(
-        tr("project_switch.stop_training_title"),
-        tr("project_switch.stop_training_message"),
-        [yes_label, no_label],
-        _on_result,
-    )
-
-
 def _save_current_project_like_close() -> bool:
     save = getattr(lf, "project_save", None)
     if not callable(save):
         return False
     try:
         result = save(True, False)
-    except TypeError:
-        try:
-            result = save()
-        except Exception:
-            return False
-    except Exception:
+    except Exception as exc:
+        lf.log.error(f"Failed to save current project: {exc}")
         return False
     return result is not False
 

--- a/src/python/lfs_plugins/startup_recent_panel.py
+++ b/src/python/lfs_plugins/startup_recent_panel.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import lichtfeld as lf
 
 from .rml_keys import KI_ESCAPE
+from .training_confirm import _project_has_path
 from .types import Panel
 
 __lfs_panel_classes__ = ["StartupRecentPanel"]
@@ -71,13 +72,8 @@ def should_show_startup_recent() -> bool:
         return False
     if not recent:
         return False
-    has_path = getattr(lf, "project_has_path", None)
-    if callable(has_path):
-        try:
-            if has_path():
-                return False
-        except Exception:
-            pass
+    if _project_has_path():
+        return False
     is_empty = getattr(lf.ui, "is_scene_empty", None)
     if callable(is_empty):
         try:

--- a/src/python/lfs_plugins/training_confirm.py
+++ b/src/python/lfs_plugins/training_confirm.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Shared training-stop confirms and project-path probes for plugin UI."""
+
+import lichtfeld as lf
+
+
+def _training_is_active() -> bool:
+    probe = getattr(lf, "is_training_active", None)
+    if not callable(probe):
+        return False
+    try:
+        return bool(probe())
+    except Exception:
+        return False
+
+
+def _confirm_stop_training_then(callback) -> None:
+    if not _training_is_active():
+        callback(False)
+        return
+
+    tr = lf.ui.tr
+    yes_label = tr("common.yes")
+    no_label = tr("common.no")
+
+    def _on_result(button):
+        if button == yes_label:
+            callback(True)
+
+    lf.ui.confirm_dialog(
+        tr("project_switch.stop_training_title"),
+        tr("project_switch.stop_training_message"),
+        [yes_label, no_label],
+        _on_result,
+    )
+
+
+def _project_has_path() -> bool:
+    probe = getattr(lf, "project_has_path", None)
+    if not callable(probe):
+        return False
+    try:
+        return bool(probe())
+    except Exception:
+        return False

--- a/src/python/lfs_plugins/training_panel.py
+++ b/src/python/lfs_plugins/training_panel.py
@@ -12,6 +12,7 @@ from . import rml_widgets as w
 from . import property_view
 from .property_view import parse_number as _parse_num
 from .scrub_fields import ScrubFieldController, ScrubFieldSpec
+from .training_confirm import _project_has_path
 from .types import Panel
 from .ui import RuntimeState, PanelStateBinding
 
@@ -2262,8 +2263,7 @@ class TrainingPanel(Panel):
         )
 
     def _project_is_bound(self):
-        has_path = getattr(lf, "project_has_path", None)
-        return bool(has_path()) if callable(has_path) else False
+        return _project_has_path()
 
     def _invoke_project_save_as(self):
         save_as = getattr(lf, "project_save_as", None)

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -8282,8 +8282,8 @@ namespace lfs::training {
         }
 
         // A dead train loop must not report an active pause: stale is_paused_
-        // keeps has_active_train_loop() true, so finished-trainer saves skip
-        // the synchronous flush and wait forever on a safe point.
+        // makes finished-trainer saves skip the synchronous flush and wait
+        // forever on a safe point.
         pause_requested_ = false;
         is_paused_ = false;
         {

--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -368,9 +368,6 @@ namespace lfs::training {
             std::function<std::optional<
                 ProjectSnapshotDocumentContext>()>
                 context_provider = {});
-        [[nodiscard]] bool has_active_train_loop() const {
-            return is_running_.load() || is_paused_.load();
-        }
         [[nodiscard]] bool can_flush_project_snapshot() const {
             return project_snapshot_service_ && strategy_ &&
                    scene_;

--- a/src/visualizer/include/visualizer/visualizer.hpp
+++ b/src/visualizer/include/visualizer/visualizer.hpp
@@ -216,9 +216,9 @@ namespace lfs::vis {
         projectPollWrite() {
             return ProjectWritePoll{};
         }
-        // True when the last ProjectSaveAs command started a write.
-        // Empty-path Save As that the user cancelled returns false.
-        [[nodiscard]] virtual bool consumeProjectSaveAsStarted() {
+        // True when the last ProjectSave or ProjectSaveAs command
+        // started a write. A cancelled save dialog returns false.
+        [[nodiscard]] virtual bool consumeProjectSaveStarted() {
             return false;
         }
         virtual void projectWaitWrite() {}

--- a/src/visualizer/training/training_manager.hpp
+++ b/src/visualizer/training/training_manager.hpp
@@ -109,8 +109,10 @@ namespace lfs::vis {
         [[nodiscard]] bool isCompletionPending() const {
             return completion_pending_.load(std::memory_order_acquire);
         }
-        // True while a training worker exists (running or paused mid-run).
-        // Checkpoint-installed paused trainers have no worker.
+        // True while a training completion is pending (running or paused
+        // mid-run). The reaper steals training_thread_ immediately, so
+        // joinable() is not the live-worker signal. Checkpoint-installed
+        // paused trainers have no worker and report false.
         [[nodiscard]] bool hasLiveTrainingThread() const;
         [[nodiscard]] bool isPublishingFinalSnapshot() const {
             return isCompletionPending() && !isTrainingActive();

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -1296,10 +1296,6 @@ namespace lfs::vis {
                 command.stop_training);
         });
 
-        cmd::LoadFile::when([this](const auto& command) {
-            deferDatasetLoadForTraining(command);
-        });
-
         const auto publish_project_error =
             [](std::string action, const auto& value,
                const char* operation) {
@@ -1352,7 +1348,7 @@ namespace lfs::vis {
 
         cmd::ProjectSave::when(
             [this, publish_project_error](const auto& command) {
-                project_save_as_started_ = false;
+                project_save_started_ = false;
                 auto has_path = projectHasPath();
                 if (!has_path) {
                     publish_project_error(
@@ -1378,7 +1374,7 @@ namespace lfs::vis {
                             gui::error_op::kSave);
                         return;
                     }
-                    project_save_as_started_ = true;
+                    project_save_started_ = true;
                     return;
                 }
                 if (auto saved = projectSave(
@@ -1390,13 +1386,13 @@ namespace lfs::vis {
                         gui::error_op::kSave);
                     return;
                 }
-                project_save_as_started_ = true;
+                project_save_started_ = true;
             });
 
         cmd::ProjectSaveAs::when(
             [this, publish_project_error](
                 const auto& command) {
-                project_save_as_started_ = false;
+                project_save_started_ = false;
                 auto path = command.path;
                 if (path.empty()) {
                     std::string default_name =
@@ -1429,7 +1425,7 @@ namespace lfs::vis {
                         gui::error_op::kSave);
                     return;
                 }
-                project_save_as_started_ = true;
+                project_save_started_ = true;
             });
 
         cmd::ProjectOpen::when(
@@ -3454,10 +3450,8 @@ namespace lfs::vis {
         return project_lifecycle_->pollWrite();
     }
 
-    bool VisualizerImpl::consumeProjectSaveAsStarted() {
-        const bool started = project_save_as_started_;
-        project_save_as_started_ = false;
-        return started;
+    bool VisualizerImpl::consumeProjectSaveStarted() {
+        return project_save_started_.exchange(false);
     }
 
     void VisualizerImpl::projectWaitWrite() {

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -118,7 +118,7 @@ namespace lfs::vis {
         projectGetInfo() override;
         lfs::Result<ProjectWritePoll>
         projectPollWrite() override;
-        bool consumeProjectSaveAsStarted() override;
+        bool consumeProjectSaveStarted() override;
         void projectWaitWrite() override;
         lfs::Result<ProjectMenuInfo>
         projectGetMenuInfo() override;
@@ -563,7 +563,7 @@ namespace lfs::vis {
         bool startup_plugin_preload_started_ = false;
         bool startup_project_open_attempted_ = false;
         bool close_save_notice_posted_ = false;
-        bool project_save_as_started_ = false;
+        std::atomic<bool> project_save_started_{false};
         std::optional<std::filesystem::path>
             pending_close_save_path_;
         std::jthread force_exit_completion_watcher_;

--- a/tests/python/test_import_dialog_panels.py
+++ b/tests/python/test_import_dialog_panels.py
@@ -100,6 +100,7 @@ def _install_lf_stub(monkeypatch, tmp_path):
     lf_stub = ModuleType("lichtfeld")
     lf_stub.log = SimpleNamespace(
         warn=lambda message: state.log_warnings.append(message),
+        error=lambda message: state.log_warnings.append(message),
     )
     lf_stub.ui = SimpleNamespace(
         PanelSpace=panel_space,
@@ -147,6 +148,7 @@ def import_dialog_module(monkeypatch, tmp_path):
         sys.path.insert(0, str(source_python))
 
     sys.modules.pop("lfs_plugins.import_panels", None)
+    sys.modules.pop("lfs_plugins.training_confirm", None)
     sys.modules.pop("lfs_plugins", None)
     state = _install_lf_stub(monkeypatch, tmp_path)
     module = import_module("lfs_plugins.import_panels")

--- a/tests/python/test_training_panel_regressions.py
+++ b/tests/python/test_training_panel_regressions.py
@@ -63,6 +63,7 @@ def training_panel_module(monkeypatch):
     if str(source_python) not in sys.path:
         sys.path.insert(0, str(source_python))
     sys.modules.pop("lfs_plugins.training_panel", None)
+    sys.modules.pop("lfs_plugins.training_confirm", None)
     sys.modules.pop("lfs_plugins", None)
     _install_lf_stub(monkeypatch)
     return import_module("lfs_plugins.training_panel")

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -7006,8 +7006,8 @@ namespace lfs::vis {
     TEST_F(VisualizerImplResetTest,
            SaveWhilePausedNoWorkerTrainerCompletes) {
         // Checkpoint-installed paused trainers have
-        // has_active_train_loop() true with no worker
-        // thread. File Save must still route through the
+        // is_paused() true with no live training thread.
+        // File Save must still route through the
         // trainer, inline-flush, and finish the
         // ProjectWrite job.
         if (!cuda_device_available()) {
@@ -7088,8 +7088,8 @@ namespace lfs::vis {
                 << lfs::format_for_developer(
                        snapshot_ready.error());
             trainer->is_paused_.store(true);
-            ASSERT_TRUE(
-                trainer->has_active_train_loop());
+            ASSERT_FALSE(trainer->is_running());
+            ASSERT_TRUE(trainer->is_paused());
             ASSERT_TRUE(
                 trainer->can_flush_project_snapshot());
 


### PR DESCRIPTION
Cleanup from reviewing the recent project-format fixes. No behavior changes except one documented tightening.

- Removed a leftover trainer method that reports a paused trainer as having a live worker thread. It has no production callers since #1707, and its answer causes a hang for anyone who reaches for it again. Its honest replacement now documents exactly what it returns.
- Removed a redundant second handler for dataset-load-during-training; one handler now owns that decision.
- The flag behind "did a save start" tracked every save kind but was still named after Save As, and was read from another thread without synchronization. Renamed to what it means and made atomic; its duplicated consumer code is now one helper.
- The stop-training confirmation and project-path probes existed as four slightly different copies across the Python plugins. They now live in one shared module. The save-before-load helper no longer silently swallows errors; it logs and reports failure.

Verified: full lifecycle fixture 122 green, Python fast tier 553 passed / 0 failed - no new failures against master.