### PR TITLE
Match project-switch refusals by tag instead of message text

### DIFF
--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -32,6 +32,7 @@
 #include "io/selection_chapter.hpp"
 #include "ipc/view_context.hpp"
 #include "operation/undo_history.hpp"
+#include "project/project_switch_error.hpp"
 #include "project/session_state.hpp"
 #include "rendering/image_layout.hpp"
 #include "rendering/vulkan_external_tensor.hpp"
@@ -1805,7 +1806,7 @@ namespace lfs::vis::project {
                     lfs::ErrorCode::FailedPrecondition,
                     "Stop training before switching projects.",
                     "Project switching is blocked while training is active",
-                    "project.training");
+                    kProjectSwitchTrainingActiveField);
             }
         }
         if (disposition ==
@@ -1815,7 +1816,7 @@ namespace lfs::vis::project {
                 lfs::ErrorCode::FailedPrecondition,
                 "The current project has unsaved changes.",
                 "Save the current project or retry with explicit discard authorization",
-                "project.dirty");
+                kProjectSwitchDirtyField);
         }
         return {};
     }

--- a/src/visualizer/project/project_switch_error.hpp
+++ b/src/visualizer/project/project_switch_error.hpp
@@ -1,0 +1,61 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "core/error.hpp"
+
+#include <string_view>
+#include <variant>
+
+namespace lfs::vis::project {
+
+    // Machine-readable identities for the two project-switch preflight refusals.
+    // User-facing copy may be reworded or localized; control flow matches these
+    // field tags, not `user_message()`.
+    inline constexpr std::string_view kProjectSwitchTrainingActiveField =
+        "project.switch.training_active";
+    inline constexpr std::string_view kProjectSwitchDirtyField =
+        "project.switch.dirty";
+
+    namespace detail {
+
+        [[nodiscard]] inline std::string_view
+        detectionField(const lfs::Error& error) noexcept {
+            for (const auto& frame : error.frames()) {
+                for (const auto& entry : frame.fields.entries()) {
+                    if (entry.key != "field") {
+                        continue;
+                    }
+                    if (const auto* value =
+                            std::get_if<std::string>(&entry.value)) {
+                        return *value;
+                    }
+                }
+            }
+            return {};
+        }
+
+        [[nodiscard]] inline bool isProjectSwitchError(
+            const lfs::Error& error,
+            const std::string_view field) noexcept {
+            return error.code() == lfs::ErrorCode::FailedPrecondition &&
+                   detectionField(error) == field;
+        }
+
+    } // namespace detail
+
+    [[nodiscard]] inline bool
+    isDirtyProjectSwitchError(const lfs::Error& error) noexcept {
+        return detail::isProjectSwitchError(error, kProjectSwitchDirtyField);
+    }
+
+    [[nodiscard]] inline bool
+    isTrainingProjectSwitchError(const lfs::Error& error) noexcept {
+        return detail::isProjectSwitchError(
+            error, kProjectSwitchTrainingActiveField);
+    }
+
+} // namespace lfs::vis::project

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -33,6 +33,7 @@
 #include "operator/ops/selection_ops.hpp"
 #include "operator/ops/transform_ops.hpp"
 #include "preferences.hpp"
+#include "project/project_switch_error.hpp"
 #include "python/python_runtime.hpp"
 #include "python/runner.hpp"
 #include "rendering/coordinate_conventions.hpp"
@@ -130,25 +131,8 @@ namespace lfs::vis {
             }
         }
 
-        [[nodiscard]] bool
-        isDirtyProjectSwitchError(
-            const lfs::Error& error) noexcept {
-            return error.code() ==
-                       lfs::ErrorCode::
-                           FailedPrecondition &&
-                   error.user_message() ==
-                       "The current project has unsaved changes.";
-        }
-
-        [[nodiscard]] bool
-        isTrainingProjectSwitchError(
-            const lfs::Error& error) noexcept {
-            return error.code() ==
-                       lfs::ErrorCode::
-                           FailedPrecondition &&
-                   error.user_message() ==
-                       "Stop training before switching projects.";
-        }
+        using project::isDirtyProjectSwitchError;
+        using project::isTrainingProjectSwitchError;
 
         void wakeEventLoopViaServices() {
             if (auto* const window_manager = services().windowOrNull()) {

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -36,6 +36,7 @@
 #include "visualizer/core/data_loading_service.hpp"
 #include "visualizer/include/visualizer/visualizer.hpp"
 #include "visualizer/post_work_utils.hpp"
+#include "visualizer/project/project_switch_error.hpp"
 #include "visualizer/visualizer_impl.hpp"
 
 #include <algorithm>
@@ -3691,6 +3692,41 @@ namespace lfs::vis {
                     1u);
             }
         }
+    }
+
+    TEST(ProjectSwitchErrorTest, PredicatesMatchFieldTagNotUserMessage) {
+        const auto make_tagged = [](const std::string_view field,
+                                    std::string message) {
+            return lfs::make_error(lfs::ErrorInit{
+                .code = lfs::ErrorCode::FailedPrecondition,
+                .domain = lfs::ErrorDomain::App,
+                .user_message = std::move(message),
+                .detection = LFS_SOURCE_SITE_CURRENT(),
+                .fields = lfs::SmallFields{}.add("field", field),
+            });
+        };
+
+        const auto rewritten_training = make_tagged(
+            lfs::vis::project::kProjectSwitchTrainingActiveField,
+            "rewritten training switch copy");
+        EXPECT_TRUE(lfs::vis::project::isTrainingProjectSwitchError(
+            rewritten_training));
+        EXPECT_FALSE(lfs::vis::project::isDirtyProjectSwitchError(
+            rewritten_training));
+
+        const auto rewritten_dirty = make_tagged(
+            lfs::vis::project::kProjectSwitchDirtyField,
+            "rewritten dirty switch copy");
+        EXPECT_TRUE(lfs::vis::project::isDirtyProjectSwitchError(
+            rewritten_dirty));
+        EXPECT_FALSE(lfs::vis::project::isTrainingProjectSwitchError(
+            rewritten_dirty));
+
+        const auto message_only = make_tagged(
+            "project.training",
+            "Stop training before switching projects.");
+        EXPECT_FALSE(lfs::vis::project::isTrainingProjectSwitchError(
+            message_only));
     }
 
     TEST_F(VisualizerImplResetTest,


### PR DESCRIPTION
Found while reviewing the recent project-format fixes.

The "stop training before switching projects" and "unsaved changes" confirmations were triggered by comparing the error's user-facing sentence character by character. Any reword or translation of those sentences would silently turn the prompts back into dead-end error messages - the exact bug #1719 fixed.

Both refusals now carry a machine-readable tag, defined once in a shared header next to the predicates that match them. The visible wording is unchanged and can now be edited freely.

Verified: a new test asserts the prompts trigger on the tag even with a rewritten message (and not on the old message with a different tag); full lifecycle fixture 123 green.