### PR TITLE
Skip unchanged selection capture during automatic saves

### DIFF
--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -1101,6 +1101,20 @@ namespace lfs::vis::project {
                 std::span<const std::byte>(rhs));
         }
 
+        [[nodiscard]] bool sameUuidSet(
+            const std::span<const lfs::core::Uuid> lhs,
+            const std::span<const lfs::core::Uuid> rhs) {
+            if (lhs.size() != rhs.size()) {
+                return false;
+            }
+            return std::ranges::all_of(
+                lhs, [&](const auto& uuid) {
+                    return std::ranges::find(
+                               rhs, uuid) !=
+                           rhs.end();
+                });
+        }
+
         [[nodiscard]] bool isSessionSoftDirtyChapter(
             const std::string_view fourcc) {
             return fourcc == "GUIL" || fourcc == "VIEW" ||
@@ -1671,6 +1685,7 @@ namespace lfs::vis::project {
             document_ =
                 std::make_shared<ProjectDocument>(
                     std::move(*created));
+            last_captured_selection_serial_.reset();
         } else {
             LOG_ERROR(
                 "Cannot create initial project document: {}",
@@ -3152,7 +3167,7 @@ namespace lfs::vis::project {
                         ? DocumentSyncMode::
                               LightTrainingAutosave
                         : DocumentSyncMode::
-                              Default);
+                              Autosave);
             !synchronized) {
             return synchronized;
         }
@@ -3684,6 +3699,7 @@ namespace lfs::vis::project {
                     std::make_shared<
                         ProjectDocument>(
                         std::move(*reopened));
+                last_captured_selection_serial_.reset();
                 cached_bound_checkpoint_iteration_
                     .reset();
             }
@@ -4123,6 +4139,7 @@ namespace lfs::vis::project {
         document_ =
             std::make_shared<ProjectDocument>(
                 std::move(*opened));
+        last_captured_selection_serial_.reset();
         cached_project_info_.reset();
         cached_bound_checkpoint_iteration_.reset();
         adopted_training_snapshot_count_ =
@@ -4356,7 +4373,8 @@ namespace lfs::vis::project {
         // retire the formerly resumable CKPT; otherwise validation correctly
         // rejects the now-orphaned checkpoint.  Keep it during lightweight
         // autosaves while a training session is still bound.
-        if (mode == DocumentSyncMode::Default &&
+        if ((mode == DocumentSyncMode::Default ||
+             mode == DocumentSyncMode::Autosave) &&
             training_uuid.is_nil()) {
             const auto checkpoint_uuids =
                 document_->checkpoint_uuids();
@@ -4607,120 +4625,142 @@ namespace lfs::vis::project {
                                    PayloadHydrationState::
                                        Loaded;
                 });
-        const auto selected =
+        const auto selection_serial =
+            selection_mutation_serial_.load(
+                std::memory_order_acquire);
+        const bool automatic_save =
+            mode == DocumentSyncMode::Autosave ||
+            mode == DocumentSyncMode::
+                        LightTrainingAutosave;
+        const auto live_selected_nodes =
             selectedNodeUuids(viewer_);
-        auto captured_selection =
-            lfs::io::project::
-                capture_selection_chapter(
-                    scene, selected,
-                    omit_unbound_training);
-        if (!captured_selection) {
-            return lfs::Status::failure(
-                std::move(captured_selection).error());
-        }
-        lfs::io::project::SelectionChapter
-            selection =
-                all_geometry_loaded
-                    ? std::move(*captured_selection)
-                    : document_->selection();
-        if (!all_geometry_loaded) {
-            if (auto groups = selection.set_groups(
-                    captured_selection->groups(),
-                    captured_selection
-                        ->active_group_id(),
-                    captured_selection
-                        ->next_group_id());
-                !groups) {
-                return groups;
+        // Node selection does not bump
+        // selection_mutation_serial_.
+        const bool skip_selection_capture =
+            automatic_save &&
+            last_captured_selection_serial_ ==
+                selection_serial &&
+            sameUuidSet(
+                live_selected_nodes,
+                document_->selection()
+                    .selected_node_uuids());
+        if (!skip_selection_capture) {
+            auto captured_selection =
+                lfs::io::project::
+                    capture_selection_chapter(
+                        scene, live_selected_nodes,
+                        omit_unbound_training);
+            if (!captured_selection) {
+                return lfs::Status::failure(
+                    std::move(captured_selection)
+                        .error());
             }
-            if (auto selected_result =
-                    selection
-                        .set_selected_node_uuids(
-                            captured_selection
-                                ->selected_node_uuids());
-                !selected_result) {
-                return selected_result;
-            }
+            lfs::io::project::SelectionChapter
+                selection =
+                    all_geometry_loaded
+                        ? std::move(*captured_selection)
+                        : document_->selection();
+            if (!all_geometry_loaded) {
+                if (auto groups = selection.set_groups(
+                        captured_selection->groups(),
+                        captured_selection
+                            ->active_group_id(),
+                        captured_selection
+                            ->next_group_id());
+                    !groups) {
+                    return groups;
+                }
+                if (auto selected_result =
+                        selection
+                            .set_selected_node_uuids(
+                                captured_selection
+                                    ->selected_node_uuids());
+                    !selected_result) {
+                    return selected_result;
+                }
 
-            for (const auto* node :
-                 scene.getNodes()) {
-                if (!node) {
-                    continue;
-                }
-                const bool geometry =
-                    node->type ==
-                        lfs::core::NodeType::SPLAT ||
-                    node->type ==
-                        lfs::core::NodeType::
-                            POINTCLOUD ||
-                    node->type ==
-                        lfs::core::NodeType::MESH;
-                if (!geometry) {
-                    continue;
-                }
-                if (node->payload_hydration !=
-                    lfs::core::
-                        PayloadHydrationState::
-                            Loaded) {
-                    continue;
-                }
-                static_cast<void>(
-                    selection.remove_slice(
-                        node->uuid,
+                for (const auto* node :
+                     scene.getNodes()) {
+                    if (!node) {
+                        continue;
+                    }
+                    const bool geometry =
+                        node->type ==
+                            lfs::core::NodeType::SPLAT ||
+                        node->type ==
+                            lfs::core::NodeType::
+                                POINTCLOUD ||
+                        node->type ==
+                            lfs::core::NodeType::MESH;
+                    if (!geometry) {
+                        continue;
+                    }
+                    if (node->payload_hydration !=
                         lfs::core::
-                            SelectionDomain::Splat));
-                static_cast<void>(
-                    selection.remove_slice(
-                        node->uuid,
-                        lfs::core::
-                            SelectionDomain::
-                                PointCloud));
-                for (const auto& slice :
-                     captured_selection->slices()) {
-                    if (slice.node_uuid ==
-                        node->uuid) {
-                        if (auto upsert =
-                                selection.upsert_slice(
-                                    slice);
-                            !upsert) {
-                            return upsert;
+                            PayloadHydrationState::
+                                Loaded) {
+                        continue;
+                    }
+                    static_cast<void>(
+                        selection.remove_slice(
+                            node->uuid,
+                            lfs::core::
+                                SelectionDomain::Splat));
+                    static_cast<void>(
+                        selection.remove_slice(
+                            node->uuid,
+                            lfs::core::
+                                SelectionDomain::
+                                    PointCloud));
+                    for (const auto& slice :
+                         captured_selection->slices()) {
+                        if (slice.node_uuid ==
+                            node->uuid) {
+                            if (auto upsert =
+                                    selection.upsert_slice(
+                                        slice);
+                                !upsert) {
+                                return upsert;
+                            }
                         }
                     }
                 }
-            }
-            const auto old_slices =
-                selection.slices();
-            for (const auto& slice :
-                 old_slices) {
-                if (!captured_scene_uuids.contains(
-                        slice.node_uuid)) {
-                    static_cast<void>(
-                        selection.remove_slice(
-                            slice.node_uuid,
-                            slice.domain));
+                const auto old_slices =
+                    selection.slices();
+                for (const auto& slice :
+                     old_slices) {
+                    if (!captured_scene_uuids.contains(
+                            slice.node_uuid)) {
+                        static_cast<void>(
+                            selection.remove_slice(
+                                slice.node_uuid,
+                                slice.domain));
+                    }
                 }
             }
-        }
-        auto old_selection =
-            lfs::io::project::
-                encode_selection_chapter(
-                    document_->selection());
-        auto new_selection =
-            lfs::io::project::
-                encode_selection_chapter(
-                    selection);
-        if (!old_selection) {
-            return lfs::Status::failure(
-                std::move(old_selection).error());
-        }
-        if (!new_selection) {
-            return lfs::Status::failure(
-                std::move(new_selection).error());
-        }
-        if (!sameBytes(
-                *old_selection, *new_selection)) {
-            document_->edit_selection() =
-                std::move(selection);
+            auto old_selection =
+                lfs::io::project::
+                    encode_selection_chapter(
+                        document_->selection());
+            auto new_selection =
+                lfs::io::project::
+                    encode_selection_chapter(
+                        selection);
+            if (!old_selection) {
+                return lfs::Status::failure(
+                    std::move(old_selection).error());
+            }
+            if (!new_selection) {
+                return lfs::Status::failure(
+                    std::move(new_selection).error());
+            }
+            if (!sameBytes(
+                    *old_selection, *new_selection)) {
+                document_->edit_selection() =
+                    std::move(selection);
+            }
+            last_captured_selection_serial_ =
+                selection_serial;
         }
 
         const auto project_root =
@@ -5710,6 +5750,7 @@ namespace lfs::vis::project {
         cached_project_info_.reset();
         cached_bound_checkpoint_iteration_.reset();
         document_ = candidate;
+        last_captured_selection_serial_.reset();
         bindTrainerSnapshotTarget();
         cleanupRecoverySession();
         // Removal runs only after the replacement
@@ -6349,6 +6390,7 @@ namespace lfs::vis::project {
         document_ =
             std::make_shared<ProjectDocument>(
                 std::move(*created));
+        last_captured_selection_serial_.reset();
         cleanupRecoverySession();
         if (discard_master) {
             removeDiscardedAutosaveArtifacts(

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -80,6 +80,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
     class VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
     class VisualizerImplResetTest_UntitledDirtySessionAutosavesToScratch_Test;
+    class VisualizerImplResetTest_AutosaveSkipsUnchangedSelectionCapture_Test;
     class VisualizerImplResetTest_BlankUntitledSessionUpdateMaintenanceWritesNoScratch_Test;
     class VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWritesScratch_Test;
     class VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWaitsForAutosaveQuietPeriod_Test;
@@ -291,6 +292,7 @@ namespace lfs::vis::project {
         friend class lfs::vis::VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
         friend class lfs::vis::VisualizerImplResetTest_UntitledDirtySessionAutosavesToScratch_Test;
+        friend class lfs::vis::VisualizerImplResetTest_AutosaveSkipsUnchangedSelectionCapture_Test;
         friend class lfs::vis::VisualizerImplResetTest_BlankUntitledSessionUpdateMaintenanceWritesNoScratch_Test;
         friend class lfs::vis::VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWritesScratch_Test;
         friend class lfs::vis::VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWaitsForAutosaveQuietPeriod_Test;
@@ -342,6 +344,7 @@ namespace lfs::vis::project {
 
         enum class DocumentSyncMode {
             Default,
+            Autosave,
             LightTrainingAutosave,
         };
 
@@ -505,6 +508,8 @@ namespace lfs::vis::project {
         std::uint64_t active_restore_ticket_ = 0;
         std::atomic<std::uint64_t>
             selection_mutation_serial_{0};
+        std::optional<std::uint64_t>
+            last_captured_selection_serial_;
         std::atomic<Hydration> hydration_{Hydration::Empty};
         std::atomic<bool> scene_dirty_{false};
         std::atomic<bool> payload_dirty_{false};

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -336,6 +336,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_StartupOffersRecoveryAfterUncleanShutdown_Test;
         friend class VisualizerImplResetTest_StartupWithCleanLastSessionLeavesBlankSession_Test;
         friend class VisualizerImplResetTest_UntitledDirtySessionAutosavesToScratch_Test;
+        friend class VisualizerImplResetTest_AutosaveSkipsUnchangedSelectionCapture_Test;
         friend class VisualizerImplResetTest_BlankUntitledSessionUpdateMaintenanceWritesNoScratch_Test;
         friend class VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWritesScratch_Test;
         friend class VisualizerImplResetTest_DirtyUntitledSessionUpdateMaintenanceWaitsForAutosaveQuietPeriod_Test;

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -2430,6 +2430,244 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
+           AutosaveSkipsUnchangedSelectionCapture) {
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(
+                viewer.getParameterManager()
+                    ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Untitled dirty"),
+                lfs::core::NULL_NODE);
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            ASSERT_TRUE(lifecycle->document_);
+            EXPECT_FALSE(
+                lifecycle
+                    ->last_captured_selection_serial_
+                    .has_value());
+
+            auto started = lifecycle->startAutosave();
+            ASSERT_TRUE(started)
+                << lfs::format_for_developer(
+                       started.error());
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+
+            ASSERT_TRUE(
+                lifecycle
+                    ->last_captured_selection_serial_
+                    .has_value());
+            const auto captured_serial =
+                *lifecycle
+                     ->last_captured_selection_serial_;
+            EXPECT_EQ(
+                captured_serial,
+                lifecycle->selection_mutation_serial_
+                    .load(std::memory_order_acquire));
+
+            auto groups =
+                lifecycle->document_->selection()
+                    .groups();
+            ASSERT_FALSE(groups.empty());
+            groups.front().name = "Mutated group";
+            ASSERT_TRUE(
+                lifecycle->document_->edit_selection()
+                    .set_groups(
+                        groups,
+                        lifecycle->document_
+                            ->selection()
+                            .active_group_id(),
+                        lifecycle->document_
+                            ->selection()
+                            .next_group_id()));
+            const auto mutated_epoch =
+                lifecycle->document_->dirty_epoch();
+
+            auto skipped =
+                lifecycle
+                    ->synchronizeDocumentFromViewer(
+                        project::ProjectLifecycle::
+                            DocumentSyncMode::
+                                Autosave);
+            ASSERT_TRUE(skipped)
+                << lfs::format_for_developer(
+                       skipped.error());
+            EXPECT_EQ(
+                lifecycle
+                    ->last_captured_selection_serial_,
+                captured_serial);
+            EXPECT_EQ(
+                lifecycle->document_->dirty_epoch(),
+                mutated_epoch);
+            ASSERT_FALSE(
+                lifecycle->document_->selection()
+                    .groups()
+                    .empty());
+            EXPECT_EQ(
+                lifecycle->document_->selection()
+                    .groups()
+                    .front()
+                    .name,
+                "Mutated group");
+            EXPECT_TRUE(
+                lifecycle->document_->selection()
+                    .selected_node_uuids()
+                    .empty());
+
+            const auto* untitled =
+                viewer.getScene().getNode(
+                    "Untitled dirty");
+            ASSERT_NE(untitled, nullptr);
+            const auto untitled_uuid =
+                untitled->uuid;
+            viewer.getSceneManager()->selectNode(
+                "Untitled dirty");
+            EXPECT_EQ(
+                lifecycle->selection_mutation_serial_
+                    .load(std::memory_order_acquire),
+                captured_serial);
+
+            auto node_recaptured =
+                lifecycle
+                    ->synchronizeDocumentFromViewer(
+                        project::ProjectLifecycle::
+                            DocumentSyncMode::
+                                Autosave);
+            ASSERT_TRUE(node_recaptured)
+                << lfs::format_for_developer(
+                       node_recaptured.error());
+            EXPECT_EQ(
+                lifecycle
+                    ->last_captured_selection_serial_,
+                captured_serial);
+            EXPECT_GT(
+                lifecycle->document_->dirty_epoch(),
+                mutated_epoch);
+            ASSERT_FALSE(
+                lifecycle->document_->selection()
+                    .groups()
+                    .empty());
+            EXPECT_NE(
+                lifecycle->document_->selection()
+                    .groups()
+                    .front()
+                    .name,
+                "Mutated group");
+            ASSERT_EQ(
+                lifecycle->document_->selection()
+                    .selected_node_uuids()
+                    .size(),
+                1u);
+            EXPECT_EQ(
+                lifecycle->document_->selection()
+                    .selected_node_uuids()
+                    .front(),
+                untitled_uuid);
+
+            auto groups_after_node =
+                lifecycle->document_->selection()
+                    .groups();
+            ASSERT_FALSE(groups_after_node.empty());
+            groups_after_node.front().name =
+                "Mutated group";
+            ASSERT_TRUE(
+                lifecycle->document_->edit_selection()
+                    .set_groups(
+                        groups_after_node,
+                        lifecycle->document_
+                            ->selection()
+                            .active_group_id(),
+                        lifecycle->document_
+                            ->selection()
+                            .next_group_id()));
+            const auto remutated_epoch =
+                lifecycle->document_->dirty_epoch();
+
+            lifecycle->markSceneMutation(
+                static_cast<std::uint32_t>(
+                    lfs::core::Scene::MutationType::
+                        SELECTION_CHANGED));
+            const auto bumped_serial =
+                lifecycle->selection_mutation_serial_
+                    .load(std::memory_order_acquire);
+            ASSERT_NE(bumped_serial, captured_serial);
+
+            auto recaptured =
+                lifecycle
+                    ->synchronizeDocumentFromViewer(
+                        project::ProjectLifecycle::
+                            DocumentSyncMode::
+                                Autosave);
+            ASSERT_TRUE(recaptured)
+                << lfs::format_for_developer(
+                       recaptured.error());
+            EXPECT_EQ(
+                lifecycle
+                    ->last_captured_selection_serial_,
+                bumped_serial);
+            EXPECT_GT(
+                lifecycle->document_->dirty_epoch(),
+                remutated_epoch);
+            ASSERT_FALSE(
+                lifecycle->document_->selection()
+                    .groups()
+                    .empty());
+            EXPECT_NE(
+                lifecycle->document_->selection()
+                    .groups()
+                    .front()
+                    .name,
+                "Mutated group");
+
+            auto recaptured_groups =
+                lifecycle->document_->selection()
+                    .groups();
+            ASSERT_FALSE(recaptured_groups.empty());
+            recaptured_groups.front().name =
+                "Explicit save must recapture";
+            ASSERT_TRUE(
+                lifecycle->document_->edit_selection()
+                    .set_groups(
+                        recaptured_groups,
+                        lifecycle->document_
+                            ->selection()
+                            .active_group_id(),
+                        lifecycle->document_
+                            ->selection()
+                            .next_group_id()));
+            auto explicit_sync =
+                lifecycle
+                    ->synchronizeDocumentFromViewer();
+            ASSERT_TRUE(explicit_sync)
+                << lfs::format_for_developer(
+                       explicit_sync.error());
+            ASSERT_FALSE(
+                lifecycle->document_->selection()
+                    .groups()
+                    .empty());
+            EXPECT_NE(
+                lifecycle->document_->selection()
+                    .groups()
+                    .front()
+                    .name,
+                "Explicit save must recapture");
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
            BlankUntitledSessionUpdateMaintenanceWritesNoScratch) {
         auto options = projectOptions();
         {


### PR DESCRIPTION
Follow-up to #1743, same goal: keep autosave from hitching the viewport.

Every autosave copied each model's per-gaussian selection mask off the GPU, changed or not - a synchronous render-thread stall and the largest remaining share of the autosave hitch.

When saves happen now:
- An automatic save (autosave, training light autosave) captures the selection only if it actually changed since the last capture - tracked by the existing selection change counter plus a cheap check of which nodes are selected. Otherwise the saved selection is carried forward unchanged.
- A save the user asks for still captures everything, every time.
- Opening, creating, or compacting a project resets the tracking, so the first autosave on a fresh document always captures.

Verified: a new test proves an unchanged selection is skipped, a mask edit triggers recapture, a node-selection change alone triggers recapture, and an explicit save always captures - 210 tests green across the autosave and lifecycle suites.