### PR TITLE
Associate the .licht format and manage file associations from Preferences

### DIFF
--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -287,6 +287,62 @@ namespace {
         return lfs::core::LogLevel::Info; // Default
     }
 
+    std::expected<void, std::string> apply_view_path(
+        lfs::core::param::TrainingParameters& params, const std::string& view_path_str) {
+        const std::filesystem::path view_path = lfs::core::utf8_to_path(view_path_str);
+
+        if (!std::filesystem::exists(view_path)) {
+            return std::unexpected(
+                std::format("Path does not exist: {}", lfs::core::path_to_utf8(view_path)));
+        }
+
+        constexpr std::array<std::string_view, 13> SUPPORTED_EXTENSIONS = {
+            ".ply", ".sog", ".spz", ".rad", ".resume",
+            ".obj", ".fbx", ".gltf", ".glb", ".stl", ".dae", ".3ds", ".blend"};
+        const auto is_supported = [&](const std::filesystem::path& p) {
+            auto ext = p.extension().string();
+            std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+            return std::ranges::find(SUPPORTED_EXTENSIONS, ext) != SUPPORTED_EXTENSIONS.end();
+        };
+
+        if (std::filesystem::is_directory(view_path)) {
+            for (const auto& entry : std::filesystem::directory_iterator(view_path)) {
+                if (entry.is_regular_file() && is_supported(entry.path())) {
+                    params.view_paths.push_back(entry.path());
+                }
+            }
+            std::ranges::sort(params.view_paths);
+
+            if (params.view_paths.empty()) {
+                return std::unexpected(std::format(
+                    "No supported files found in: {}", lfs::core::path_to_utf8(view_path)));
+            }
+            LOG_DEBUG("Found {} view files in directory", params.view_paths.size());
+            return {};
+        }
+
+        auto extension = view_path.extension().string();
+        std::ranges::transform(
+            extension, extension.begin(),
+            [](const unsigned char character) {
+                return static_cast<char>(std::tolower(character));
+            });
+        if (extension == ".licht") {
+            if (!lfs::io::project::isPublishedLichtPath(view_path)) {
+                return std::unexpected(
+                    lfs::io::project::unpublishedLichtUserMessage(view_path));
+            }
+            params.project_path = view_path;
+            return {};
+        }
+        if (!is_supported(view_path)) {
+            return std::unexpected(std::format(
+                "Unsupported file format: {}", lfs::core::path_to_utf8(view_path)));
+        }
+        params.view_paths.push_back(view_path);
+        return {};
+    }
+
     std::expected<std::tuple<ParseResult, std::function<void()>>, std::string> parse_arguments(
         const std::vector<std::string>& args,
         lfs::core::param::TrainingParameters& params) {
@@ -632,62 +688,14 @@ namespace {
                 return std::make_tuple(ParseResult::Success, std::function<void()>{});
             }
 
-            // Viewer mode: file or directory
+            // Viewer mode: file or directory. Bare positional paths are rewritten to
+            // -v in parse_args_and_params so they share this branch.
             if (view_ply) {
                 const auto& view_path_str = ::args::get(view_ply);
                 if (!view_path_str.empty()) {
-                    const std::filesystem::path view_path = lfs::core::utf8_to_path(view_path_str);
-
-                    if (!std::filesystem::exists(view_path)) {
-                        return std::unexpected(std::format("Path does not exist: {}", lfs::core::path_to_utf8(view_path)));
-                    }
-
-                    constexpr std::array<std::string_view, 13> SUPPORTED_EXTENSIONS = {
-                        ".ply", ".sog", ".spz", ".rad", ".resume",
-                        ".obj", ".fbx", ".gltf", ".glb", ".stl", ".dae", ".3ds", ".blend"};
-                    const auto is_supported = [&](const std::filesystem::path& p) {
-                        auto ext = p.extension().string();
-                        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-                        return std::ranges::find(SUPPORTED_EXTENSIONS, ext) != SUPPORTED_EXTENSIONS.end();
-                    };
-
-                    if (std::filesystem::is_directory(view_path)) {
-                        for (const auto& entry : std::filesystem::directory_iterator(view_path)) {
-                            if (entry.is_regular_file() && is_supported(entry.path())) {
-                                params.view_paths.push_back(entry.path());
-                            }
-                        }
-                        std::ranges::sort(params.view_paths);
-
-                        if (params.view_paths.empty()) {
-                            return std::unexpected(std::format(
-                                "No supported files found in: {}", lfs::core::path_to_utf8(view_path)));
-                        }
-                        LOG_DEBUG("Found {} view files in directory", params.view_paths.size());
-                    } else {
-                        auto extension = view_path.extension().string();
-                        std::ranges::transform(
-                            extension, extension.begin(),
-                            [](const unsigned char character) {
-                                return static_cast<char>(
-                                    std::tolower(character));
-                            });
-                        if (extension == ".licht") {
-                            if (!lfs::io::project::isPublishedLichtPath(
-                                    view_path)) {
-                                return std::unexpected(
-                                    lfs::io::project::
-                                        unpublishedLichtUserMessage(
-                                            view_path));
-                            }
-                            params.project_path = view_path;
-                        } else if (!is_supported(view_path)) {
-                            return std::unexpected(std::format(
-                                "Unsupported file format: {}", lfs::core::path_to_utf8(view_path)));
-                        } else {
-                            params.view_paths.push_back(view_path);
-                        }
-                    }
+                    const auto applied = apply_view_path(params, view_path_str);
+                    if (!applied)
+                        return std::unexpected(applied.error());
                 }
 
                 if (gut) {

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -62,6 +62,7 @@
 #include "core/session_breadcrumb.hpp"
 #include "diagnostics/vram_profiler.hpp"
 #include "gui/rmlui/elements/loss_graph_element.hpp"
+#include "gui/utils/file_association.hpp"
 #include "internal/resource_paths.hpp"
 #include "io/filesystem_utils.hpp"
 #include "io/formats/colmap.hpp"
@@ -2171,6 +2172,27 @@ NB_MODULE(lichtfeld, m) {
             lfs::vis::saveCameraViewSnapPreference(enabled);
         },
         nb::arg("enabled"), "Enable or disable camera axis-view snapping");
+    m.def(
+        "file_associations_status", []() {
+            nb::list rows;
+            for (const auto& entry : lfs::vis::gui::fileAssociationsStatus()) {
+                nb::dict row;
+                row["extension"] = entry.extension;
+                row["registered"] = entry.registered;
+                rows.append(row);
+            }
+            return rows;
+        },
+        "Return whether LichtFeld Studio is registered as a handler for each known file extension (Windows only)");
+    m.def(
+        "file_association_set",
+        [](const std::string& extension, bool enabled) -> bool {
+            if (enabled)
+                return lfs::vis::gui::registerFileAssociation(extension);
+            return lfs::vis::gui::unregisterFileAssociation(extension);
+        },
+        nb::arg("extension"), nb::arg("enabled"),
+        "Register or unregister LichtFeld Studio as a handler for one file extension (Windows only)");
     m.def(
         "toggle_fullscreen", []() { lfs::core::events::ui::ToggleFullscreen{}.emit(); },
         "Toggle fullscreen mode");

--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -4683,7 +4683,7 @@ namespace lfs::python {
             "register_file_associations", []() -> bool {
                 return lfs::vis::gui::registerFileAssociations();
             },
-            "Register LichtFeld Studio as a supported handler for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz files (Windows only)");
+            "Register LichtFeld Studio as a supported handler for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht files (Windows only)");
 
         m.def(
             "open_file_association_settings", []() -> bool {
@@ -4695,13 +4695,13 @@ namespace lfs::python {
             "unregister_file_associations", []() -> bool {
                 return lfs::vis::gui::unregisterFileAssociations();
             },
-            "Remove LichtFeld Studio file associations for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz (Windows only)");
+            "Remove LichtFeld Studio file associations for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht (Windows only)");
 
         m.def(
             "are_file_associations_registered", []() -> bool {
                 return lfs::vis::gui::areFileAssociationsRegistered();
             },
-            "Check if LichtFeld Studio is the default handler for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz (Windows only)");
+            "Check if LichtFeld Studio is the default handler for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht (Windows only)");
 
         m.def("get_pivot_mode", &get_pivot_mode, "Get pivot mode (0=Origin, 1=Bounds)");
 

--- a/src/python/lfs_plugins/help_menu.py
+++ b/src/python/lfs_plugins/help_menu.py
@@ -21,7 +21,7 @@ class GettingStartedOperator(Operator):
 
 class SetDefaultAppOperator(Operator):
     label = "file_association.menu_register"
-    description = "Open Windows default app settings for splat files (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz)"
+    description = "Open Windows default app settings for splat and project files (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht)"
 
     def execute(self, context) -> set:
         lf.ui.register_file_associations()

--- a/src/python/lfs_plugins/preferences_panel.py
+++ b/src/python/lfs_plugins/preferences_panel.py
@@ -49,6 +49,7 @@ class PreferencesPanel(Panel):
         "view_snap",
         "key_bindings",
         "interface",
+        "file_associations",
         "mcp",
     )
 
@@ -70,6 +71,7 @@ class PreferencesPanel(Panel):
         self._mcp_safe_mode = False
         self._last_mcp_runtime_config = None
         self._document = None
+        self._file_associations = []
 
     def on_bind_model(self, ctx):
         self._read_mcp_preferences()
@@ -82,6 +84,8 @@ class PreferencesPanel(Panel):
         model.bind_func("show_appearance", lambda: self._section == "appearance")
         model.bind_func("show_input", lambda: self._section == "input")
         model.bind_func("show_interface", lambda: self._section == "interface")
+        model.bind_func("show_file_associations", self._show_file_associations)
+        model.bind_func("has_file_associations", self._has_file_associations)
         model.bind_func("show_mcp", lambda: self._section == "mcp")
         model.bind_func("show_section_reset", lambda: True)
         model.bind_func("reset_section_label", self._reset_section_label)
@@ -129,7 +133,9 @@ class PreferencesPanel(Panel):
         model.bind_event("show_appearance", lambda *_: self._set_section("appearance"))
         model.bind_event("show_input", lambda *_: self._set_section("input"))
         model.bind_event("show_interface", lambda *_: self._set_section("interface"))
+        model.bind_event("show_file_associations", lambda *_: self._set_section("file_associations"))
         model.bind_event("show_mcp", lambda *_: self._set_section("mcp"))
+        model.bind_event("set_file_association", self._on_set_file_association)
         model.bind_event("toggle_mcp_enabled", self._on_toggle_mcp_enabled)
         model.bind_event("mcp_port_change", self._on_mcp_port_change)
         model.bind_event("confirm_mcp_port", self._on_confirm_mcp_port)
@@ -141,8 +147,10 @@ class PreferencesPanel(Panel):
         model.bind_record_list("scene_upscaler_presets")
         model.bind_record_list("languages")
         model.bind_record_list("navigation_modes")
+        model.bind_record_list("file_associations")
         self._handle = model.get_handle()
         self._keymap.bind(model)
+        self._reload_file_associations()
 
     def on_mount(self, doc):
         # The title bar is a cancellation boundary for the drafted MCP port,
@@ -245,6 +253,7 @@ class PreferencesPanel(Panel):
                 for index, (_mode, label) in enumerate(self.NAVIGATION_OPTIONS)
             ],
         )
+        self._reload_file_associations()
 
     def _theme_index(self):
         current = lf.ui.get_theme()
@@ -635,9 +644,76 @@ class PreferencesPanel(Panel):
     def _on_open_mcp_log_folder(self, _handle, _event, _args):
         lf.ui.open_url(lf.ui.get_mcp_log_directory())
 
+    @staticmethod
+    def _coerce_bool(value):
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    def _file_association_status_rows(self):
+        getter = getattr(lf, "file_associations_status", None)
+        if not callable(getter):
+            return []
+        rows = getter()
+        if not rows:
+            return []
+        result = []
+        for row in rows:
+            extension = str(row.get("extension", "")).strip()
+            if not extension:
+                continue
+            result.append(
+                {
+                    "extension": extension,
+                    "registered": bool(row.get("registered", False)),
+                    "label": extension,
+                }
+            )
+        return result
+
+    def _reload_file_associations(self):
+        self._file_associations = self._file_association_status_rows()
+        if self._handle:
+            self._handle.update_record_list(
+                "file_associations",
+                [
+                    {
+                        "extension": row["extension"],
+                        "registered": row["registered"],
+                        "label": row["label"],
+                    }
+                    for row in self._file_associations
+                ],
+            )
+            dirty = getattr(self._handle, "dirty", None)
+            if callable(dirty):
+                dirty("has_file_associations")
+                dirty("show_file_associations")
+
+    def _has_file_associations(self):
+        return bool(self._file_associations)
+
+    def _show_file_associations(self):
+        return self._section == "file_associations" and self._has_file_associations()
+
+    def _on_set_file_association(self, _handle, _event, args):
+        if not args or len(args) < 2:
+            return
+        self._set_file_association(args[0], args[1])
+
+    def _set_file_association(self, extension, enabled):
+        setter = getattr(lf, "file_association_set", None)
+        if not callable(setter):
+            return False
+        ok = bool(setter(str(extension), self._coerce_bool(enabled)))
+        self._reload_file_associations()
+        return ok
+
     def _consume_section_request(self):
         section = lf.ui.take_preferences_section_request()
-        if section in ("general", "appearance", "input", "interface", "mcp"):
+        if section in ("general", "appearance", "input", "interface", "file_associations", "mcp"):
+            if section == "file_associations" and not self._has_file_associations():
+                return
             self._set_section(section)
 
     def _dirty_mcp(self):
@@ -679,8 +755,17 @@ class PreferencesPanel(Panel):
             return
         self._section = section
         if self._handle:
-            for name in ("show_general", "show_appearance", "show_input", "show_interface", "show_mcp",
-                          "show_section_reset", "reset_section_label"):
+            for name in (
+                "show_general",
+                "show_appearance",
+                "show_input",
+                "show_interface",
+                "show_file_associations",
+                "has_file_associations",
+                "show_mcp",
+                "show_section_reset",
+                "reset_section_label",
+            ):
                 self._handle.dirty(name)
 
     def _on_toggle_section(self, _handle, _event, args):

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -263,16 +263,19 @@ def stop_training() -> None:
 def reset_training() -> None:
     """Reset training state to initial"""
 
-def new_project(discard_changes: bool = False) -> None:
+def is_training_active() -> bool:
+    """Whether training is running or paused"""
+
+def new_project(discard_changes: bool = False, stop_training: bool = False) -> None:
     """Clear all project state and start a new project"""
 
-def project_save() -> None:
+def project_save(wait: bool = False, regenerate_preview: bool = True) -> bool:
     """Save the active .licht project, prompting for a path when needed"""
 
-def project_save_as(path: str = '') -> None:
+def project_save_as(path: str = '', wait: bool = False) -> bool:
     """Save the active project to a new .licht path"""
 
-def project_open(path: str = '', discard_changes: bool = False) -> ProjectOpenOutcome:
+def project_open(path: str = '', discard_changes: bool = False, stop_training: bool = False) -> ProjectOpenOutcome:
     """Open a .licht project"""
 
 def project_compact() -> None:
@@ -324,7 +327,7 @@ def clear_scene() -> None:
 def switch_to_edit_mode() -> None:
     """Switch from training to edit mode"""
 
-def load_file(path: str, is_dataset: bool = False, output_path: str = '', init_path: str = '', centralize_dataset: str = 'off', max_width: int | None = None, apply_auto_crop: bool = False, min_track_length: int | None = None) -> None:
+def load_file(path: str, is_dataset: bool = False, output_path: str = '', init_path: str = '', centralize_dataset: str = 'off', max_width: int | None = None, apply_auto_crop: bool = False, min_track_length: int | None = None, stop_training: bool = False) -> None:
     """Load a file (PLY, checkpoint) or dataset into the scene."""
 
 def load_config_file(path: str) -> None:
@@ -539,6 +542,16 @@ def get_camera_view_snap_enabled() -> bool:
 
 def set_camera_view_snap_enabled(enabled: bool) -> None:
     """Enable or disable camera axis-view snapping"""
+
+def file_associations_status() -> list:
+    """
+    Return whether LichtFeld Studio is registered as a handler for each known file extension (Windows only)
+    """
+
+def file_association_set(extension: str, enabled: bool) -> bool:
+    """
+    Register or unregister LichtFeld Studio as a handler for one file extension (Windows only)
+    """
 
 def toggle_fullscreen() -> None:
     """Toggle fullscreen mode"""

--- a/src/python/stubs/lichtfeld/scene.pyi
+++ b/src/python/stubs/lichtfeld/scene.pyi
@@ -787,6 +787,10 @@ class Camera:
         """Whether a depth map file exists"""
 
     @property
+    def has_image(self) -> bool:
+        """Whether the bound dataset image file exists"""
+
+    @property
     def uid(self) -> int:
         """Unique camera identifier"""
 

--- a/src/python/stubs/lichtfeld/ui/__init__.pyi
+++ b/src/python/stubs/lichtfeld/ui/__init__.pyi
@@ -2062,6 +2062,9 @@ def on_request_exit(callback: object) -> None:
 def on_project_switch_confirmation(callback: object) -> None:
     """Register callback for a dirty project-switch decision"""
 
+def on_stop_training_confirmation(callback: object) -> None:
+    """Register callback for a stop-training project-switch decision"""
+
 def on_open_camera_preview(callback: object) -> None:
     """Register callback for OpenCameraPreview event"""
 
@@ -2437,7 +2440,7 @@ def is_windows_platform() -> bool:
 
 def register_file_associations() -> bool:
     """
-    Register LichtFeld Studio as a supported handler for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz files (Windows only)
+    Register LichtFeld Studio as a supported handler for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht files (Windows only)
     """
 
 def open_file_association_settings() -> bool:
@@ -2447,12 +2450,12 @@ def open_file_association_settings() -> bool:
 
 def unregister_file_associations() -> bool:
     """
-    Remove LichtFeld Studio file associations for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz (Windows only)
+    Remove LichtFeld Studio file associations for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht (Windows only)
     """
 
 def are_file_associations_registered() -> bool:
     """
-    Check if LichtFeld Studio is the default handler for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz (Windows only)
+    Check if LichtFeld Studio is the default handler for .ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht (Windows only)
     """
 
 def get_pivot_mode() -> int:

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -785,6 +785,8 @@
     "language": "Sprache:",
     "select_language": "Sprache auswählen",
     "interface": "Oberfläche",
+    "file_associations": "Dateizuordnungen",
+    "file_associations_description": "LichtFeld Studio als Handler für jeden Dateityp registrieren oder entfernen.",
     "general": "Allgemein",
     "appearance": "Erscheinungsbild",
     "scene_rendering": "Szenen-Rendering",
@@ -2007,7 +2009,7 @@
   },
   "file_association": {
     "title": "Als Standardanwendung festlegen",
-    "message": "Möchten Sie LichtFeld Studio als Standardanwendung für Splat-Dateien (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz) festlegen?",
+    "message": "Möchten Sie LichtFeld Studio als Standardanwendung für Splat- und Projektdateien (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht) festlegen?",
     "yes": "Ja",
     "not_now": "Nicht jetzt",
     "dont_ask": "Nicht mehr fragen",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -785,6 +785,8 @@
     "language": "Language:",
     "select_language": "Select Language",
     "interface": "Interface",
+    "file_associations": "File Associations",
+    "file_associations_description": "Register or remove LichtFeld Studio as a handler for each file type.",
     "general": "General",
     "appearance": "Appearance",
     "scene_rendering": "Scene Rendering",
@@ -2007,7 +2009,7 @@
   },
   "file_association": {
     "title": "Set as Default Application",
-    "message": "Would you like to set LichtFeld Studio as the default application for splat files (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz)?",
+    "message": "Would you like to set LichtFeld Studio as the default application for splat and project files (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht)?",
     "yes": "Yes",
     "not_now": "Not Now",
     "dont_ask": "Don't Ask Again",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -785,6 +785,8 @@
     "language": "Idioma:",
     "select_language": "Seleccionar idioma",
     "interface": "Interfaz",
+    "file_associations": "Asociaciones de archivos",
+    "file_associations_description": "Registrar o quitar LichtFeld Studio como controlador de cada tipo de archivo.",
     "general": "General",
     "appearance": "Apariencia",
     "scene_rendering": "Renderizado de la escena",
@@ -2007,7 +2009,7 @@
   },
   "file_association": {
     "title": "Establecer como Aplicación Predeterminada",
-    "message": "¿Quieres establecer LichtFeld Studio como la aplicación predeterminada para los archivos de splat (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz)?",
+    "message": "¿Quieres establecer LichtFeld Studio como la aplicación predeterminada para los archivos de splat y de proyecto (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht)?",
     "yes": "Sí",
     "not_now": "Ahora no",
     "dont_ask": "No volver a preguntar",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -786,6 +786,8 @@
     "language": "Langue :",
     "select_language": "Sélectionner la Langue",
     "interface": "Interface",
+    "file_associations": "Associations de fichiers",
+    "file_associations_description": "Enregistrer ou retirer LichtFeld Studio comme gestionnaire pour chaque type de fichier.",
     "general": "Général",
     "appearance": "Apparence",
     "scene_rendering": "Rendu de la scène",
@@ -2008,7 +2010,7 @@
   },
   "file_association": {
     "title": "Définir comme application par défaut",
-    "message": "Souhaitez-vous définir LichtFeld Studio comme application par défaut pour les fichiers splat (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz) ?",
+    "message": "Souhaitez-vous définir LichtFeld Studio comme application par défaut pour les fichiers splat et projet (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht) ?",
     "yes": "Oui",
     "not_now": "Pas maintenant",
     "dont_ask": "Ne plus demander",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -785,6 +785,8 @@
     "language": "Lingua:",
     "select_language": "Seleziona Lingua",
     "interface": "Interfaccia",
+    "file_associations": "Associazioni file",
+    "file_associations_description": "Registra o rimuovi LichtFeld Studio come gestore per ogni tipo di file.",
     "general": "Generale",
     "appearance": "Aspetto",
     "scene_rendering": "Rendering della scena",
@@ -2007,7 +2009,7 @@
   },
   "file_association": {
     "title": "Imposta come applicazione predefinita",
-    "message": "Vuoi impostare LichtFeld Studio come applicazione predefinita per i file splat (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz)?",
+    "message": "Vuoi impostare LichtFeld Studio come applicazione predefinita per i file splat e di progetto (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht)?",
     "yes": "Sì",
     "not_now": "Non ora",
     "dont_ask": "Non chiedere più",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -785,6 +785,8 @@
     "language": "言語:",
     "select_language": "言語を選択",
     "interface": "インターフェース",
+    "file_associations": "ファイルの関連付け",
+    "file_associations_description": "ファイルの種類ごとに LichtFeld Studio を関連付けるか解除します。",
     "general": "一般",
     "appearance": "外観",
     "scene_rendering": "シーンレンダリング",
@@ -2007,7 +2009,7 @@
   },
   "file_association": {
     "title": "既定のアプリケーションに設定",
-    "message": "LichtFeld Studioをスプラットファイル（.ply、.sog、.spz、.rad、.usd、.usda、.usdc、.usdz）の既定のアプリケーションに設定しますか？",
+    "message": "LichtFeld Studioをスプラットおよびプロジェクトファイル（.ply、.sog、.spz、.rad、.usd、.usda、.usdc、.usdz、.licht）の既定のアプリケーションに設定しますか？",
     "yes": "はい",
     "not_now": "後で",
     "dont_ask": "今後表示しない",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -785,6 +785,8 @@
     "language": "언어:",
     "select_language": "언어 선택",
     "interface": "인터페이스",
+    "file_associations": "파일 연결",
+    "file_associations_description": "각 파일 형식별 LichtFeld Studio 연결을 등록하거나 해제합니다.",
     "general": "일반",
     "appearance": "모양",
     "scene_rendering": "장면 렌더링",
@@ -2007,7 +2009,7 @@
   },
   "file_association": {
     "title": "기본 응용 프로그램으로 설정",
-    "message": "LichtFeld Studio를 스플랫 파일(.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz)의 기본 응용 프로그램으로 설정하시겠습니까?",
+    "message": "LichtFeld Studio를 스플랫 및 프로젝트 파일(.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht)의 기본 응용 프로그램으로 설정하시겠습니까?",
     "yes": "예",
     "not_now": "나중에",
     "dont_ask": "다시 묻지 않기",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -785,6 +785,8 @@
     "language": "Taal:",
     "select_language": "Selecteer Taal",
     "interface": "Interface",
+    "file_associations": "Bestandskoppelingen",
+    "file_associations_description": "LichtFeld Studio als programma voor elk bestandstype registreren of verwijderen.",
     "general": "Algemeen",
     "appearance": "Uiterlijk",
     "scene_rendering": "Scènerendering",
@@ -2007,7 +2009,7 @@
   },
   "file_association": {
     "title": "Instellen als standaardtoepassing",
-    "message": "Wilt u LichtFeld Studio instellen als de standaardtoepassing voor splat-bestanden (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz)?",
+    "message": "Wilt u LichtFeld Studio instellen als de standaardtoepassing voor splat- en projectbestanden (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht)?",
     "yes": "Ja",
     "not_now": "Niet nu",
     "dont_ask": "Niet meer vragen",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -785,6 +785,8 @@
     "language": "Język:",
     "select_language": "Wybierz Język",
     "interface": "Interfejs",
+    "file_associations": "Skojarzenia plików",
+    "file_associations_description": "Zarejestruj lub usuń LichtFeld Studio jako program obsługujący każdy typ pliku.",
     "general": "Ogólne",
     "appearance": "Wygląd",
     "scene_rendering": "Renderowanie sceny",
@@ -2007,7 +2009,7 @@
   },
   "file_association": {
     "title": "Ustaw jako domyślną aplikację",
-    "message": "Czy chcesz ustawić LichtFeld Studio jako domyślną aplikację dla plików splat (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz)?",
+    "message": "Czy chcesz ustawić LichtFeld Studio jako domyślną aplikację dla plików splat i projektów (.ply, .sog, .spz, .rad, .usd, .usda, .usdc, .usdz, .licht)?",
     "yes": "Tak",
     "not_now": "Nie teraz",
     "dont_ask": "Nie pytaj ponownie",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -785,6 +785,8 @@
     "language": "语言：",
     "select_language": "选择语言",
     "interface": "界面",
+    "file_associations": "文件关联",
+    "file_associations_description": "为每种文件类型注册或取消 LichtFeld Studio 作为打开程序。",
     "general": "常规",
     "appearance": "外观",
     "scene_rendering": "场景渲染",
@@ -2007,7 +2009,7 @@
   },
   "file_association": {
     "title": "设为默认应用程序",
-    "message": "是否要将 LichtFeld Studio 设为 splat 文件（.ply、.sog、.spz、.rad、.usd、.usda、.usdc、.usdz）的默认应用程序？",
+    "message": "是否要将 LichtFeld Studio 设为 splat 和项目文件（.ply、.sog、.spz、.rad、.usd、.usda、.usdc、.usdz、.licht）的默认应用程序？",
     "yes": "是",
     "not_now": "暂不",
     "dont_ask": "不再询问",

--- a/src/visualizer/gui/rmlui/resources/preferences.rml
+++ b/src/visualizer/gui/rmlui/resources/preferences.rml
@@ -10,6 +10,7 @@
       <button class="btn preferences-nav-item" data-class-active="show_appearance" data-event-click="show_appearance">@tr:preferences.appearance</button>
       <button class="btn preferences-nav-item" data-class-active="show_input" data-event-click="show_input">@tr:preferences.input</button>
       <button class="btn preferences-nav-item" data-class-active="show_interface" data-event-click="show_interface">@tr:preferences.interface</button>
+      <button class="btn preferences-nav-item" data-class-active="show_file_associations" data-event-click="show_file_associations" data-if="has_file_associations">@tr:preferences.file_associations</button>
       <button class="btn preferences-nav-item" data-class-active="show_mcp" data-event-click="show_mcp">@tr:preferences.mcp</button>
     </div>
 
@@ -159,6 +160,23 @@
         </div>
         <div class="section-content" data-if="interface_expanded">
           <span class="preferences-description">@tr:preferences.interface_layout_description</span>
+        </div>
+      </div>
+
+      <div class="preferences-section" data-if="show_file_associations">
+        <div class="section-header text-accent" data-class-is-expanded="file_associations_expanded" data-event-click="toggle_section('file_associations')">
+          <span class="section-arrow text-accent" data-class-is-expanded="file_associations_expanded">&#x25B6;</span>
+          <span class="text-accent">@tr:preferences.file_associations</span>
+        </div>
+        <div class="section-content" data-if="file_associations_expanded">
+          <span class="preferences-description">@tr:preferences.file_associations_description</span>
+          <div data-for="row : file_associations">
+            <div class="preferences-row preferences-checkbox-row">
+              <span class="preferences-label">{{ row.label }}</span>
+              <input type="checkbox" data-checked="row.registered"
+                     data-event-change="set_file_association(row.extension, row.registered)" />
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/visualizer/gui/utils/file_association.cpp
+++ b/src/visualizer/gui/utils/file_association.cpp
@@ -33,16 +33,18 @@ namespace lfs::vis::gui {
             L"Software\\LichtFeldStudio\\Capabilities\\FileAssociations";
         constexpr wchar_t REGISTERED_APPLICATIONS_PATH[] = L"Software\\RegisteredApplications";
         constexpr wchar_t APPLICATION_DESCRIPTION[] =
-            L"LichtFeld Studio supports PLY, SOG, SPZ, RAD, USD, USDA, USDC, and USDZ splat files.";
+            L"LichtFeld Studio supports PLY, SOG, SPZ, RAD, USD, USDA, USDC, and USDZ splat files, and LICHT project files.";
 
-        constexpr std::array<ExtInfo, 7> EXTENSIONS = {{
+        constexpr std::array<ExtInfo, 9> EXTENSIONS = {{
             {L".ply", L"LichtFeldStudio.ply", L"PLY Point Cloud"},
             {L".sog", L"LichtFeldStudio.sog", L"SOG Gaussian Splat"},
             {L".spz", L"LichtFeldStudio.spz", L"SPZ Gaussian Splat"},
+            {L".rad", L"LichtFeldStudio.rad", L"RAD Gaussian Splat"},
             {L".usd", L"LichtFeldStudio.usd", L"USD Gaussian Splat"},
             {L".usda", L"LichtFeldStudio.usda", L"USDA Gaussian Splat"},
             {L".usdc", L"LichtFeldStudio.usdc", L"USDC Gaussian Splat"},
             {L".usdz", L"LichtFeldStudio.usdz", L"USDZ Gaussian Splat"},
+            {L".licht", L"LichtFeldStudio.licht", L"LichtFeld Studio Project"},
         }};
 
         bool setRegString(HKEY parent, const std::wstring& subkey, const std::wstring& value_name,
@@ -185,69 +187,98 @@ namespace lfs::vis::gui {
             return getRegString(HKEY_CURRENT_USER, user_choice_key, L"ProgId", out);
         }
 
-    } // namespace
+        struct AssociationPaths {
+            std::wstring exe_name;
+            std::wstring command;
+            std::wstring icon;
+            std::wstring classes;
+            std::wstring application_key;
+        };
 
-    bool registerFileAssociations() {
-        const auto exe_path = lfs::core::getExecutablePath();
-        const auto exe_path_w = exe_path.wstring();
-        const auto exe_name = exe_path.filename().wstring();
-        const auto command = L"\"" + exe_path_w + L"\" \"%1\"";
-        const auto icon = exe_path_w + L",0";
-        const auto classes = std::wstring(L"Software\\Classes\\");
-        const auto application_key = classes + L"Applications\\" + exe_name;
+        AssociationPaths currentAssociationPaths() {
+            const auto exe_path = lfs::core::getExecutablePath();
+            const auto exe_path_w = exe_path.wstring();
+            AssociationPaths paths;
+            paths.exe_name = exe_path.filename().wstring();
+            paths.command = L"\"" + exe_path_w + L"\" \"%1\"";
+            paths.icon = exe_path_w + L",0";
+            paths.classes = L"Software\\Classes\\";
+            paths.application_key = paths.classes + L"Applications\\" + paths.exe_name;
+            return paths;
+        }
 
-        bool ok = true;
-        for (const auto& ext : EXTENSIONS) {
-            const auto prog_key = classes + ext.prog_id;
+        std::string asciiFromWide(const wchar_t* text) {
+            std::string out;
+            for (; text && *text; ++text)
+                out.push_back(static_cast<char>(*text));
+            return out;
+        }
+
+        std::wstring normalizedWideExtension(std::string_view extension) {
+            std::wstring out;
+            if (extension.empty() || extension.front() != '.')
+                out.push_back(L'.');
+            for (const unsigned char character : extension) {
+                if (character >= 'A' && character <= 'Z')
+                    out.push_back(static_cast<wchar_t>(character - 'A' + 'a'));
+                else
+                    out.push_back(static_cast<wchar_t>(character));
+            }
+            return out;
+        }
+
+        const ExtInfo* findExtension(std::string_view extension) {
+            const auto needle = normalizedWideExtension(extension);
+            for (const auto& ext : EXTENSIONS) {
+                if (needle == ext.ext)
+                    return &ext;
+            }
+            return nullptr;
+        }
+
+        bool registerExtensionRows(const ExtInfo& ext, const AssociationPaths& paths) {
+            bool ok = true;
+            const auto prog_key = paths.classes + ext.prog_id;
             ok &= setRegString(HKEY_CURRENT_USER, prog_key, L"", ext.friendly_name);
-            ok &= setRegString(HKEY_CURRENT_USER, prog_key + L"\\DefaultIcon", L"", icon);
+            ok &= setRegString(HKEY_CURRENT_USER, prog_key + L"\\DefaultIcon", L"", paths.icon);
             ok &= setRegString(HKEY_CURRENT_USER, prog_key + L"\\shell\\open\\command", L"",
-                               command);
+                               paths.command);
 
-            const auto ext_key = classes + ext.ext;
+            const auto ext_key = paths.classes + ext.ext;
             // Register as an available handler only. Windows should keep the effective
             // default app decision in the system-managed Default Apps flow.
             ok &= setRegString(HKEY_CURRENT_USER, ext_key + L"\\OpenWithProgids", ext.prog_id,
                                L"");
-            ok &= setRegString(HKEY_CURRENT_USER, application_key + L"\\SupportedTypes", ext.ext,
-                               L"");
+            ok &= setRegString(HKEY_CURRENT_USER, paths.application_key + L"\\SupportedTypes",
+                               ext.ext, L"");
             ok &= setRegString(HKEY_CURRENT_USER, CAPABILITIES_FILE_ASSOCIATIONS_PATH, ext.ext,
                                ext.prog_id);
+            return ok;
         }
 
-        ok &= setRegString(HKEY_CURRENT_USER, CAPABILITIES_PATH, L"ApplicationName",
-                           REGISTERED_APP_NAME);
-        ok &= setRegString(HKEY_CURRENT_USER, CAPABILITIES_PATH, L"ApplicationDescription",
-                           APPLICATION_DESCRIPTION);
-        ok &= setRegString(HKEY_CURRENT_USER, REGISTERED_APPLICATIONS_PATH,
-                           REGISTERED_APP_NAME, CAPABILITIES_PATH);
-        ok &= setRegString(HKEY_CURRENT_USER, application_key, L"FriendlyAppName",
-                           REGISTERED_APP_NAME);
-        ok &= setRegString(HKEY_CURRENT_USER, application_key + L"\\DefaultIcon", L"", icon);
-        ok &= setRegString(HKEY_CURRENT_USER, application_key + L"\\shell\\open\\command", L"",
-                           command);
+        bool writeSharedAppKeys(const AssociationPaths& paths) {
+            bool ok = true;
+            ok &= setRegString(HKEY_CURRENT_USER, CAPABILITIES_PATH, L"ApplicationName",
+                               REGISTERED_APP_NAME);
+            ok &= setRegString(HKEY_CURRENT_USER, CAPABILITIES_PATH, L"ApplicationDescription",
+                               APPLICATION_DESCRIPTION);
+            ok &= setRegString(HKEY_CURRENT_USER, REGISTERED_APPLICATIONS_PATH,
+                               REGISTERED_APP_NAME, CAPABILITIES_PATH);
+            ok &= setRegString(HKEY_CURRENT_USER, paths.application_key, L"FriendlyAppName",
+                               REGISTERED_APP_NAME);
+            ok &= setRegString(HKEY_CURRENT_USER, paths.application_key + L"\\DefaultIcon", L"",
+                               paths.icon);
+            ok &= setRegString(HKEY_CURRENT_USER, paths.application_key + L"\\shell\\open\\command",
+                               L"", paths.command);
+            return ok;
+        }
 
-        SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
-
-        if (ok)
-            LOG_INFO("File associations registered successfully");
-        else
-            LOG_WARN("Some file associations failed to register");
-
-        return ok;
-    }
-
-    bool unregisterFileAssociations() {
-        const auto exe_path = lfs::core::getExecutablePath();
-        const auto exe_name = exe_path.filename().wstring();
-        const auto classes = std::wstring(L"Software\\Classes\\");
-        bool ok = true;
-
-        for (const auto& ext : EXTENSIONS) {
-            ok &= deleteRegTree(HKEY_CURRENT_USER, classes + ext.prog_id);
+        bool unregisterExtensionRows(const ExtInfo& ext, const AssociationPaths& paths) {
+            bool ok = true;
+            ok &= deleteRegTree(HKEY_CURRENT_USER, paths.classes + ext.prog_id);
 
             std::wstring current_default;
-            const auto ext_key = classes + ext.ext;
+            const auto ext_key = paths.classes + ext.ext;
             if (getRegString(HKEY_CURRENT_USER, ext_key, L"", current_default) &&
                 current_default == ext.prog_id) {
                 HKEY def_key;
@@ -265,15 +296,129 @@ namespace lfs::vis::gui {
                 RegDeleteValueW(owp_key, ext.prog_id);
                 RegCloseKey(owp_key);
             }
+
+            ok &= deleteRegValue(HKEY_CURRENT_USER, paths.application_key + L"\\SupportedTypes",
+                                 ext.ext);
+            ok &= deleteRegValue(HKEY_CURRENT_USER, CAPABILITIES_FILE_ASSOCIATIONS_PATH, ext.ext);
+            return ok;
         }
 
-        ok &= deleteRegTree(HKEY_CURRENT_USER, CAPABILITIES_FILE_ASSOCIATIONS_PATH);
-        ok &= deleteRegTree(HKEY_CURRENT_USER, CAPABILITIES_PATH);
-        ok &= deleteRegValue(HKEY_CURRENT_USER, REGISTERED_APPLICATIONS_PATH,
-                             REGISTERED_APP_NAME);
-        ok &= deleteRegTree(HKEY_CURRENT_USER, classes + L"Applications\\" + exe_name);
+        bool deleteSharedAppKeys(const AssociationPaths& paths) {
+            bool ok = true;
+            ok &= deleteRegTree(HKEY_CURRENT_USER, CAPABILITIES_FILE_ASSOCIATIONS_PATH);
+            ok &= deleteRegTree(HKEY_CURRENT_USER, CAPABILITIES_PATH);
+            ok &= deleteRegValue(HKEY_CURRENT_USER, REGISTERED_APPLICATIONS_PATH,
+                                 REGISTERED_APP_NAME);
+            ok &= deleteRegTree(HKEY_CURRENT_USER, paths.application_key);
+            return ok;
+        }
 
-        SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+        bool capabilitiesHasFileAssociations() {
+            HKEY key;
+            if (RegOpenKeyExW(HKEY_CURRENT_USER, CAPABILITIES_FILE_ASSOCIATIONS_PATH, 0, KEY_READ,
+                              &key) != ERROR_SUCCESS)
+                return false;
+            DWORD value_count = 0;
+            const LONG res =
+                RegQueryInfoKeyW(key, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                                 &value_count, nullptr, nullptr, nullptr, nullptr);
+            RegCloseKey(key);
+            return res == ERROR_SUCCESS && value_count > 0;
+        }
+
+        bool isProgIdInstalled(const ExtInfo& ext, const std::wstring& classes) {
+            HKEY key;
+            if (RegOpenKeyExW(HKEY_CURRENT_USER, (classes + ext.prog_id).c_str(), 0, KEY_READ,
+                              &key) != ERROR_SUCCESS)
+                return false;
+            RegCloseKey(key);
+            return true;
+        }
+
+        bool isEffectiveHandler(IApplicationAssociationRegistration* registration,
+                                const ExtInfo& ext, const std::wstring& classes) {
+            std::wstring current;
+            if (!queryEffectiveProgId(registration, ext.ext, current)) {
+                if (!queryUserChoiceProgId(ext.ext, current) &&
+                    !getRegString(HKEY_CURRENT_USER, classes + ext.ext, L"", current))
+                    return false;
+            }
+            return current == ext.prog_id;
+        }
+
+        void notifyAssociationChange() {
+            SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+        }
+
+    } // namespace
+
+    bool registerFileAssociation(std::string_view extension) {
+        const auto* ext = findExtension(extension);
+        if (!ext)
+            return false;
+
+        const auto paths = currentAssociationPaths();
+        bool ok = registerExtensionRows(*ext, paths);
+        ok &= writeSharedAppKeys(paths);
+        notifyAssociationChange();
+
+        if (ok)
+            LOG_INFO("File association registered for {}", asciiFromWide(ext->ext));
+        else
+            LOG_WARN("File association failed to register for {}", asciiFromWide(ext->ext));
+        return ok;
+    }
+
+    bool unregisterFileAssociation(std::string_view extension) {
+        const auto* ext = findExtension(extension);
+        if (!ext)
+            return false;
+
+        const auto paths = currentAssociationPaths();
+        bool ok = unregisterExtensionRows(*ext, paths);
+        if (!capabilitiesHasFileAssociations())
+            ok &= deleteSharedAppKeys(paths);
+        notifyAssociationChange();
+        LOG_INFO("File association unregistered for {}", asciiFromWide(ext->ext));
+        return ok;
+    }
+
+    std::vector<FileAssociationStatus> fileAssociationsStatus() {
+        std::vector<FileAssociationStatus> rows;
+        rows.reserve(EXTENSIONS.size());
+        const auto classes = std::wstring(L"Software\\Classes\\");
+        for (const auto& ext : EXTENSIONS) {
+            rows.push_back(FileAssociationStatus{
+                .extension = asciiFromWide(ext.ext),
+                .registered = isProgIdInstalled(ext, classes),
+            });
+        }
+        return rows;
+    }
+
+    bool registerFileAssociations() {
+        const auto paths = currentAssociationPaths();
+        bool ok = true;
+        for (const auto& ext : EXTENSIONS)
+            ok &= registerExtensionRows(ext, paths);
+        ok &= writeSharedAppKeys(paths);
+        notifyAssociationChange();
+
+        if (ok)
+            LOG_INFO("File associations registered successfully");
+        else
+            LOG_WARN("Some file associations failed to register");
+
+        return ok;
+    }
+
+    bool unregisterFileAssociations() {
+        const auto paths = currentAssociationPaths();
+        bool ok = true;
+        for (const auto& ext : EXTENSIONS)
+            ok &= unregisterExtensionRows(ext, paths);
+        ok &= deleteSharedAppKeys(paths);
+        notifyAssociationChange();
         LOG_INFO("File associations unregistered");
         return ok;
     }
@@ -292,13 +437,7 @@ namespace lfs::vis::gui {
 
         const auto classes = std::wstring(L"Software\\Classes\\");
         for (const auto& ext : EXTENSIONS) {
-            std::wstring current;
-            if (!queryEffectiveProgId(registration.get(), ext.ext, current)) {
-                if (!queryUserChoiceProgId(ext.ext, current) &&
-                    !getRegString(HKEY_CURRENT_USER, classes + ext.ext, L"", current))
-                    return false;
-            }
-            if (current != ext.prog_id)
+            if (!isEffectiveHandler(registration.get(), ext, classes))
                 return false;
         }
         return true;
@@ -334,6 +473,9 @@ namespace lfs::vis::gui {
     bool unregisterFileAssociations() { return false; }
     bool areFileAssociationsRegistered() { return false; }
     bool openFileAssociationSettings() { return false; }
+    bool registerFileAssociation(std::string_view) { return false; }
+    bool unregisterFileAssociation(std::string_view) { return false; }
+    std::vector<FileAssociationStatus> fileAssociationsStatus() { return {}; }
 
 #endif
 

--- a/src/visualizer/gui/utils/file_association.hpp
+++ b/src/visualizer/gui/utils/file_association.hpp
@@ -6,11 +6,23 @@
 
 #include <core/export.hpp>
 
+#include <string>
+#include <string_view>
+#include <vector>
+
 namespace lfs::vis::gui {
+
+    struct FileAssociationStatus {
+        std::string extension;
+        bool registered = false;
+    };
 
     LFS_VIS_API bool registerFileAssociations();
     LFS_VIS_API bool unregisterFileAssociations();
     LFS_VIS_API bool areFileAssociationsRegistered();
     LFS_VIS_API bool openFileAssociationSettings();
+    LFS_VIS_API bool registerFileAssociation(std::string_view extension);
+    LFS_VIS_API bool unregisterFileAssociation(std::string_view extension);
+    LFS_VIS_API std::vector<FileAssociationStatus> fileAssociationsStatus();
 
 } // namespace lfs::vis::gui

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -880,6 +880,7 @@ set(LFS_PYTHON_FAST_TESTS
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_plugin_system.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_plugin_templates.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_plugin_validator.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/test_preferences_panel.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_registry.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_rendering_panel_regressions.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_rendering_panel_simplify.py

--- a/tests/python/test_preferences_panel.py
+++ b/tests/python/test_preferences_panel.py
@@ -50,6 +50,8 @@ def preferences_panel_module(monkeypatch):
             "safe_mode": False,
         },
         set_mcp_calls=[],
+        file_associations=[],
+        file_association_set_calls=[],
         panel_enabled_calls=[],
         section_request="",
         render_settings=SimpleNamespace(
@@ -254,9 +256,23 @@ def preferences_panel_module(monkeypatch):
         get_captured_trigger=lambda: None,
         get_trigger_description=lambda *_a, **_k: "",
     )
+
+    def file_associations_status():
+        return [dict(row) for row in state.file_associations]
+
+    def file_association_set(extension, enabled):
+        state.file_association_set_calls.append((str(extension), bool(enabled)))
+        for row in state.file_associations:
+            if row["extension"] == extension:
+                row["registered"] = bool(enabled)
+                return True
+        return False
+
     lf_stub.get_render_settings = lambda: state.render_settings
     lf_stub.get_camera_navigation_mode = lambda: "orbit"
     lf_stub.get_camera_view_snap_enabled = lambda: False
+    lf_stub.file_associations_status = file_associations_status
+    lf_stub.file_association_set = file_association_set
 
     monkeypatch.setitem(sys.modules, "lichtfeld", lf_stub)
     sys.modules.pop("lfs_plugins.preferences_panel", None)
@@ -680,3 +696,60 @@ def test_mcp_failed_listener_does_not_advertise_inactive_endpoints(
     )
 
     assert panel._mcp_endpoint_text() == "preferences.mcp_no_active_endpoint"
+
+
+def test_file_associations_section_hidden_when_status_empty(preferences_panel_module):
+    module, _state = preferences_panel_module
+    panel = module.PreferencesPanel()
+    records = {}
+    panel._handle = SimpleNamespace(
+        update_record_list=lambda name, items: records.__setitem__(name, list(items)),
+        dirty=lambda *_a, **_k: None,
+    )
+
+    panel._reload_file_associations()
+
+    assert panel._has_file_associations() is False
+    panel._section = "file_associations"
+    assert panel._show_file_associations() is False
+    assert records.get("file_associations") == []
+
+    rml = (
+        Path(__file__).parent.parent.parent
+        / "src"
+        / "visualizer"
+        / "gui"
+        / "rmlui"
+        / "resources"
+        / "preferences.rml"
+    ).read_text(encoding="utf-8")
+    assert 'data-if="has_file_associations"' in rml
+    assert 'data-if="show_file_associations"' in rml
+    assert 'data-for="row : file_associations"' in rml
+
+
+def test_file_associations_rows_toggle_calls_set(preferences_panel_module):
+    module, state = preferences_panel_module
+    state.file_associations = [
+        {"extension": ".ply", "registered": False},
+        {"extension": ".licht", "registered": True},
+    ]
+    panel = module.PreferencesPanel()
+    records = {}
+    panel._handle = SimpleNamespace(
+        update_record_list=lambda name, items: records.__setitem__(name, list(items)),
+        dirty=lambda *_a, **_k: None,
+    )
+
+    panel._reload_file_associations()
+
+    assert panel._has_file_associations() is True
+    panel._section = "file_associations"
+    assert panel._show_file_associations() is True
+    assert [row["extension"] for row in records["file_associations"]] == [".ply", ".licht"]
+    assert [row["registered"] for row in records["file_associations"]] == [False, True]
+
+    panel._set_file_association(".ply", True)
+
+    assert state.file_association_set_calls == [(".ply", True)]
+    assert [row["registered"] for row in records["file_associations"]] == [True, True]

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -8,6 +8,7 @@
 #include "core/optimization_properties.hpp"
 #include "core/parameters.hpp"
 #include "core/property_registry.hpp"
+#include "io/project_path.hpp"
 
 #include <algorithm>
 #include <filesystem>
@@ -189,6 +190,56 @@ TEST(ArgumentParserTest, RemovedProjectAndRecoverFlagsAreUnknown) {
                 std::size(recover_flag)),
             recover_flag);
     EXPECT_FALSE(recover_parsed);
+}
+
+TEST(ArgumentParserTest, BarePositionalPlyAndLichtFollowViewFlag) {
+    const auto directory =
+        make_test_path("lfs_arg_parser_bare_positional");
+    const auto ply =
+        std::filesystem::path(directory) / "model.ply";
+    const auto project =
+        std::filesystem::path(directory) / "session.licht";
+    std::ofstream(ply).put('\n');
+    std::ofstream(project).put('\n');
+    const auto ply_text = ply.string();
+    const auto project_text = project.string();
+
+    const char* ply_argv[] = {
+        "LichtFeld-Studio",
+        ply_text.c_str(),
+    };
+    auto ply_parsed = lfs::core::args::parse_args_and_params(
+        static_cast<int>(std::size(ply_argv)), ply_argv);
+    ASSERT_TRUE(ply_parsed) << ply_parsed.error();
+    ASSERT_EQ((*ply_parsed)->view_paths.size(), 1u);
+    EXPECT_EQ((*ply_parsed)->view_paths.front(), ply);
+    EXPECT_FALSE((*ply_parsed)->project_path);
+
+    const char* project_argv[] = {
+        "LichtFeld-Studio",
+        project_text.c_str(),
+    };
+    auto project_parsed = lfs::core::args::parse_args_and_params(
+        static_cast<int>(std::size(project_argv)), project_argv);
+    ASSERT_TRUE(project_parsed) << project_parsed.error();
+    EXPECT_EQ((*project_parsed)->project_path, project);
+    EXPECT_TRUE((*project_parsed)->view_paths.empty());
+
+    const auto unpublished =
+        std::filesystem::path(directory) /
+        "session.project-write.1.tmp.licht";
+    std::ofstream(unpublished).put('\n');
+    const auto unpublished_text = unpublished.string();
+    const char* unpublished_argv[] = {
+        "LichtFeld-Studio",
+        unpublished_text.c_str(),
+    };
+    auto unpublished_parsed = lfs::core::args::parse_args_and_params(
+        static_cast<int>(std::size(unpublished_argv)), unpublished_argv);
+    ASSERT_FALSE(unpublished_parsed);
+    EXPECT_EQ(
+        unpublished_parsed.error(),
+        lfs::io::project::unpublishedLichtUserMessage(unpublished));
 }
 
 TEST(ArgumentParserTest, GuiViewProjectExtensionIsCaseInsensitive) {


### PR DESCRIPTION
Discord request from Kri-Soft: the default-application offer covered splat formats but not .licht itself.

- Windows now registers .licht (as "LichtFeld Studio Project") - and .rad, which the dialog promised but the registration list silently missed.
- Double-clicking a .licht file opens the project, with the same published-file check the -v flag uses; the two paths now share one implementation.
- Preferences gains a File Associations section: one checkbox per format, so associations can be added or removed individually instead of all-or-nothing. The menu entries and the startup offer still work and now run on the same per-format machinery. The section only appears on Windows.
- The offer dialog text lists .licht in all ten languages.

Verified: 41 parser tests green including new bare-path and unpublished-project cases, Python fast tier 577 passed / 0 failed with new Preferences-section tests, locale completeness green for 2230 keys. Registry writes are the same keys as before, sliced per format; Windows runtime behavior needs a quick manual check on a Windows box after merge.