### PR TITLE
Make the I/O discipline allowlist exact

### DIFF
--- a/tools/check_io_discipline.py
+++ b/tools/check_io_discipline.py
@@ -5,19 +5,21 @@
 
 This is a conservative line-based heuristic, not a C++ parser. It scans
 src/io, src/sequencer, src/visualizer/project, and src/training. Use an
-allowlist for reviewed exceptions. Findings print as file:line messages and
-the process exits non-zero when any remain.
+allowlist of exact path:line exceptions. Findings print as file:line
+messages and the process exits non-zero when any remain.
 """
 
 from __future__ import annotations
 
 import argparse
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ALLOWLIST = PROJECT_ROOT / "tools" / "io_discipline_allowlist.txt"
 DEFAULT_ROOTS = (
     PROJECT_ROOT / "src" / "io",
     PROJECT_ROOT / "src" / "sequencer",
@@ -28,7 +30,27 @@ SOURCE_SUFFIXES = {".cpp", ".hpp", ".h", ".cc"}
 SETG_CALL = re.compile(r"\bsetg\s*\(")
 STREAM_CTOR = re.compile(r"\bstd::(ifstream|ofstream)\s+[A-Za-z_]\w*\s*\(")
 OPEN_CALL = re.compile(r"\b(open_file_for_read|open_file_for_write)\s*\(")
-LINE_COMMENT = re.compile(r"//.*$")
+
+ALLOWLIST_HEADER = """\
+# Reviewed exceptions for tools/check_io_discipline.py.
+# Entries are <repo-relative-path>:<exact stripped source line>.
+# A finding is allowed only when the file's repo-relative path equals the
+# entry path exactly and the flagged line, stripped, equals the entry's line
+# text exactly. Suffix path matching and substring token matching are not used.
+# Blank lines and # comments are ignored.
+#
+# Regenerated with: python3 tools/check_io_discipline.py --write-allowlist
+"""
+KIND_SECTION_HEADERS = {
+    "setg": (
+        "# --- setg: windowed or bounded get areas "
+        "(MSVC stores get-area length as int)"
+    ),
+    "text-mode": (
+        "# --- text-mode: deliberate line-oriented or /proc reads "
+        "(not structured binary)"
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -37,6 +59,9 @@ class Finding:
     line: int
     kind: str
     text: str
+
+
+_WRITE_ALLOWLIST_TO_DEFAULT = object()
 
 
 def parse_args() -> argparse.Namespace:
@@ -51,25 +76,59 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--allowlist",
         type=Path,
-        default=PROJECT_ROOT / "tools" / "io_discipline_allowlist.txt",
-        help="file:token entries; blank lines and # comments are ignored",
+        default=DEFAULT_ALLOWLIST,
+        help=(
+            "exact <repo-relative-path>:<stripped line> entries; "
+            "blank lines and # comments are ignored"
+        ),
+    )
+    parser.add_argument(
+        "--write-allowlist",
+        nargs="?",
+        const=_WRITE_ALLOWLIST_TO_DEFAULT,
+        default=None,
+        metavar="FILE",
+        help=(
+            "write current findings as exact <path>:<stripped line> entries "
+            "(default destination: --allowlist; does not apply the existing allowlist)"
+        ),
     )
     return parser.parse_args()
 
 
-def load_allowlist(path: Path) -> list[tuple[str, str]]:
+def load_allowlist(path: Path) -> set[tuple[str, str]]:
     if not path.exists():
-        return []
-    entries: list[tuple[str, str]] = []
+        return set()
+    entries: set[tuple[str, str]] = set()
     for line in path.read_text(encoding="utf-8").splitlines():
         entry = line.strip()
         if not entry or entry.startswith("#"):
             continue
         if ":" not in entry:
-            raise ValueError(f"allowlist entries must be file:token, got {entry!r}")
-        file_part, token = entry.split(":", 1)
-        entries.append((file_part, token))
+            raise ValueError(
+                "allowlist entries must be "
+                "<repo-relative-path>:<exact stripped source line>, "
+                f"got {entry!r}"
+            )
+        file_part, line_text = entry.split(":", 1)
+        file_part = file_part.strip()
+        line_text = line_text.strip()
+        if not file_part or not line_text:
+            raise ValueError(
+                "allowlist entries must be "
+                "<repo-relative-path>:<exact stripped source line>, "
+                f"got {entry!r}"
+            )
+        entries.add((file_part, line_text))
     return entries
+
+
+def allowlist_key(path: Path, text: str) -> tuple[str, str]:
+    return path.relative_to(PROJECT_ROOT).as_posix(), text.strip()
+
+
+def is_allowed(path: Path, line: str, allowlist: set[tuple[str, str]]) -> bool:
+    return allowlist_key(path, line) in allowlist
 
 
 def code_without_line_comment(line: str) -> str:
@@ -118,17 +177,7 @@ def argument_list(lines: list[str], line_index: int, open_col: int) -> str | Non
     return None
 
 
-def is_allowed(path: Path, line: str, allowlist: list[tuple[str, str]]) -> bool:
-    relative = path.relative_to(PROJECT_ROOT).as_posix()
-    for file_part, token in allowlist:
-        if relative != file_part and not relative.endswith("/" + file_part):
-            continue
-        if token in line:
-            return True
-    return False
-
-
-def scan_file(path: Path, allowlist: list[tuple[str, str]]) -> list[Finding]:
+def scan_file(path: Path) -> list[Finding]:
     source = path.read_text(encoding="utf-8")
     lines = source.splitlines()
     findings: list[Finding] = []
@@ -137,16 +186,12 @@ def scan_file(path: Path, allowlist: list[tuple[str, str]]) -> list[Finding]:
         stripped = code.lstrip()
         if stripped.startswith("#"):
             continue
-        for match in SETG_CALL.finditer(code):
-            if is_allowed(path, line, allowlist):
-                continue
+        for _match in SETG_CALL.finditer(code):
             findings.append(Finding(path, line_number, "setg", line.strip()))
         for pattern in (STREAM_CTOR, OPEN_CALL):
             for match in pattern.finditer(code):
                 args = argument_list(lines, line_number - 1, match.end() - 1)
                 if args is None or "binary" in args:
-                    continue
-                if is_allowed(path, line, allowlist):
                     continue
                 findings.append(
                     Finding(path, line_number, "text-mode", line.strip())
@@ -154,27 +199,97 @@ def scan_file(path: Path, allowlist: list[tuple[str, str]]) -> list[Finding]:
     return findings
 
 
-def main() -> int:
-    args = parse_args()
-    allowlist = load_allowlist(args.allowlist)
+def collect_findings(roots: list[Path]) -> list[Finding]:
     findings: list[Finding] = []
-    roots = [
-        (root if root.is_absolute() else PROJECT_ROOT / root).resolve()
-        for root in (args.root or DEFAULT_ROOTS)
-    ]
     for root in roots:
         if not root.is_relative_to(PROJECT_ROOT):
             raise ValueError(f"scan root must be inside the project: {root}")
         for path in sorted(root.rglob("*")):
             if not path.is_file() or path.suffix not in SOURCE_SUFFIXES:
                 continue
-            findings.extend(scan_file(path, allowlist))
+            findings.extend(scan_file(path))
+    return findings
 
-    if findings:
-        print(f"I/O discipline violations: {len(findings)}")
-        for finding in findings:
+
+def display_path(path: Path) -> str:
+    try:
+        return path.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def allowlist_entry(finding: Finding) -> str:
+    relative_path, text = allowlist_key(finding.path, finding.text)
+    return f"{relative_path}:{text}"
+
+
+def write_allowlist(path: Path, findings: list[Finding]) -> int:
+    seen: set[tuple[str, str]] = set()
+    grouped: dict[str, list[str]] = {}
+    for finding in findings:
+        key = allowlist_key(finding.path, finding.text)
+        if key in seen:
+            continue
+        seen.add(key)
+        grouped.setdefault(finding.kind, []).append(allowlist_entry(finding))
+
+    chunks = [ALLOWLIST_HEADER.rstrip(), ""]
+    kinds = [kind for kind in ("setg", "text-mode") if kind in grouped]
+    kinds.extend(kind for kind in grouped if kind not in {"setg", "text-mode"})
+    for kind in kinds:
+        header = KIND_SECTION_HEADERS.get(kind, f"# --- {kind}")
+        chunks.append(header)
+        chunks.extend(grouped[kind])
+        chunks.append("")
+    path.write_text("\n".join(chunks).rstrip() + "\n", encoding="utf-8")
+    return len(seen)
+
+
+def main() -> int:
+    args = parse_args()
+    roots = [
+        (root if root.is_absolute() else PROJECT_ROOT / root).resolve()
+        for root in (args.root or DEFAULT_ROOTS)
+    ]
+    findings = collect_findings(roots)
+
+    if args.write_allowlist is not None:
+        dest = (
+            args.allowlist
+            if args.write_allowlist is _WRITE_ALLOWLIST_TO_DEFAULT
+            else Path(args.write_allowlist)
+        )
+        try:
+            count = write_allowlist(dest, findings)
+        except OSError as error:
+            print(
+                f"error: cannot write allowlist '{dest}': {error}",
+                file=sys.stderr,
+            )
+            return 2
+        print(f"wrote allowlist: {display_path(dest)}", file=sys.stderr)
+        print(f"{count} entries", file=sys.stderr)
+        return 0
+
+    allowlist = load_allowlist(args.allowlist)
+    remaining = [
+        finding
+        for finding in findings
+        if not is_allowed(finding.path, finding.text, allowlist)
+    ]
+
+    if remaining:
+        allowlist_display = display_path(args.allowlist)
+        print(f"I/O discipline violations: {len(remaining)}")
+        for finding in remaining:
             relative_path = finding.path.relative_to(PROJECT_ROOT).as_posix()
             print(f"{relative_path}:{finding.line}: [{finding.kind}] {finding.text}")
+            print(f"  allowlist as: {relative_path}:{finding.text}")
+        print(
+            "To allowlist a reviewed exception, add "
+            "`<repo-relative-path>:<exact stripped source line>` "
+            f"to {allowlist_display} (or regenerate with --write-allowlist)."
+        )
         return 1
     print("No I/O discipline violations found.")
     return 0

--- a/tools/io_discipline_allowlist.txt
+++ b/tools/io_discipline_allowlist.txt
@@ -1,36 +1,34 @@
 # Reviewed exceptions for tools/check_io_discipline.py.
-# Entries are file:token. A finding is allowed when the path matches and token
-# is a substring of the flagged line. Blank lines and # comments are ignored.
+# Entries are <repo-relative-path>:<exact stripped source line>.
+# A finding is allowed only when the file's repo-relative path equals the
+# entry path exactly and the flagged line, stripped, equals the entry's line
+# text exactly. Suffix path matching and substring token matching are not used.
+# Blank lines and # comments are ignored.
+#
+# Regenerated with: python3 tools/check_io_discipline.py --write-allowlist
 
 # --- setg: windowed or bounded get areas (MSVC stores get-area length as int)
-# Token is `setg` because class names do not appear on the setg lines.
-# project_container.cpp covers PositionalStreambuf, FramedLogicalStreambuf
-# (windowed), and the shuffle 8MiB gather window.
-src/io/project/span_streambuf.hpp:setg
-src/io/project/project_container.cpp:setg
-# Crc32cCountingStreambuf uses setp on a 256KiB array, not setg.
-src/io/project/project_writer.cpp:Crc32cCountingStreambuf
+src/io/project/project_container.cpp:setg(buffer_.data(), buffer_.data(), buffer_.data());
+src/io/project/project_container.cpp:setg(
+src/io/project/project_container.cpp:setg(nullptr, nullptr, nullptr);
+src/io/project/project_container.cpp:setg(first, first, first + static_cast<std::ptrdiff_t>(count));
+src/io/project/project_container.cpp:setg(window_.data(), window_.data(), window_.data() + count);
+src/io/project/span_streambuf.hpp:setg(eback(),
+src/io/project/span_streambuf.hpp:setg(first, first, first);
+src/io/project/span_streambuf.hpp:setg(first, first,
 
 # --- text-mode: deliberate line-oriented or /proc reads (not structured binary)
-
-# COLMAP .txt read/write (line-oriented, \r stripped)
-src/io/formats/colmap.cpp:open_file_for_read
-src/io/formats/colmap.cpp:std::ifstream
-src/io/formats/colmap.cpp:std::ofstream
-
-# ASCII PLY header verification (getline, \r stripped)
-src/io/formats/ply.cpp:std::ifstream stream(path)
-
-# Transforms train/test split lists
-src/io/formats/transforms.cpp:train.txt
-src/io/formats/transforms.cpp:test.txt
-
-# Metrics CSV/TXT
-src/training/metrics/metrics.cpp:open_file_for_write
-
-# /proc reads
-src/io/cache_image_loader.cpp:/proc/meminfo
-src/io/ply_to_rad_lod.cpp:/proc/meminfo
-src/io/formats/rad.cpp:/proc/meminfo
-src/training/training_snapshot_service.cpp:/proc/self/status
-src/training/training_snapshot_service.cpp:/proc/meminfo
+src/io/cache_image_loader.cpp:std::ifstream meminfo("/proc/meminfo");
+src/io/formats/colmap.cpp:if (!lfs::core::open_file_for_read(file_path, file)) {
+src/io/formats/colmap.cpp:std::ifstream points_stream(points_path);
+src/io/formats/colmap.cpp:std::ofstream stream(path, std::ios::trunc);
+src/io/formats/ply.cpp:std::ifstream stream(path);
+src/io/formats/rad.cpp:std::ifstream meminfo("/proc/meminfo");
+src/io/formats/transforms.cpp:if (!lfs::core::open_file_for_read(dir_path / "train.txt", train_file)) {
+src/io/formats/transforms.cpp:if (!lfs::core::open_file_for_read(dir_path / "test.txt", val_file)) {
+src/io/ply_to_rad_lod.cpp:std::ifstream meminfo("/proc/meminfo");
+src/training/metrics/metrics.cpp:if (lfs::core::open_file_for_write(csv_path_, csv_file)) {
+src/training/metrics/metrics.cpp:if (lfs::core::open_file_for_write(csv_path_, std::ios::app, csv_file)) {
+src/training/metrics/metrics.cpp:if (!lfs::core::open_file_for_write(txt_path_, report_file)) {
+src/training/training_snapshot_service.cpp:std::ifstream input("/proc/self/status");
+src/training/training_snapshot_service.cpp:std::ifstream input("/proc/meminfo");


### PR DESCRIPTION
The CI gate that blocks unsafe file I/O patterns (#1712) had a loophole: allowlist entries matched by substring, so one reviewed exception in a file quietly exempted every future violation of the same kind in that file - exactly the class the gate exists to catch.

Entries are now exact path plus exact source line. The allowlist was regenerated for the current tree, violations print a copy-paste allowlist line, and --write-allowlist regenerates it. Verified: gate green on the current tree, a planted violation fails the build, and the old loophole patterns no longer match.