### PR TITLE
Tear down native panels and GUI globals when the GUI shuts down

### DIFF
--- a/src/core/event_bridge/localization_manager.cpp
+++ b/src/core/event_bridge/localization_manager.cpp
@@ -83,6 +83,18 @@ namespace lfs::event {
         return true;
     }
 
+    void LocalizationManager::reset() {
+        const std::lock_guard lock(mutex_);
+        locales_dir_.clear();
+        current_language_.clear();
+        current_strings_.clear();
+        fallback_strings_.clear();
+        warned_missing_keys_.clear();
+        available_languages_.clear();
+        language_names_.clear();
+        overrides_.clear();
+    }
+
     const char* LocalizationManager::get(std::string_view key) const {
         thread_local std::array<std::string, 8> result_buffers;
         thread_local size_t next_result_buffer = 0;

--- a/src/core/event_bridge/localization_manager.hpp
+++ b/src/core/event_bridge/localization_manager.hpp
@@ -21,6 +21,7 @@ namespace lfs::event {
         static LocalizationManager& getInstance();
 
         bool initialize(const std::string& locales_dir);
+        void reset();
         // Returns a pointer into thread-local storage. The pointer remains valid
         // until a subsequent get()/getEnglishFallback() call on the same thread
         // reuses that ring-buffer slot; copy it when retaining the value.

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -41,6 +41,7 @@
 #include "gui/utils/file_association.hpp"
 #include "gui/utils/native_file_dialog.hpp"
 #include "gui/vulkan_ui_texture.hpp"
+#include "tools/unified_tool_registry.hpp"
 
 #include "gui/gpu_memory_query.hpp"
 #include "gui/gui_focus_state.hpp"
@@ -3940,6 +3941,7 @@ namespace lfs::vis::gui {
             lfs::python::acquire_gil_main_thread();
 
         lfs::python::shutdown_python_ui_resources();
+        lfs::python::invoke_python_cleanup();
         lfs::python::set_modal_enqueue_callback({});
         lfs::python::set_global_context_menu(nullptr);
 
@@ -3958,7 +3960,14 @@ namespace lfs::vis::gui {
             if (panel)
                 panel->releaseRendererResources();
         }
-        PanelRegistry::instance().unregister_all_non_native();
+        PanelRegistry::instance().unregister_all();
+        native_scene_panel_.reset();
+        native_panel_storage_.clear();
+        lfs::python::set_rml_manager(nullptr);
+        lfs::vis::setThemeChangeCallback({});
+        lfs::event::LocalizationManager::getInstance().reset();
+        UnifiedToolRegistry::instance().clearActiveTool();
+        UnifiedToolRegistry::instance().clearActiveSubmode();
         rmlui_manager_.shutdown();
 
         if (need_gil)

--- a/src/visualizer/gui/panel_registry.cpp
+++ b/src/visualizer/gui/panel_registry.cpp
@@ -398,6 +398,21 @@ apply_registered_chrome:
         }
     }
 
+    void PanelRegistry::unregister_all() {
+        {
+            std::lock_guard lock(mutex_);
+            const bool changed = !panels_.empty() || !floating_interactions_.empty();
+            panels_.clear();
+            floating_interactions_.clear();
+            if (changed)
+                ++registration_revision_;
+        }
+        {
+            std::lock_guard poll_lock(poll_mutex_);
+            poll_cache_.clear();
+        }
+    }
+
     void PanelRegistry::reload_rml_resources() {
         std::vector<std::shared_ptr<IPanel>> panels;
         {

--- a/src/visualizer/gui/panel_registry.hpp
+++ b/src/visualizer/gui/panel_registry.hpp
@@ -358,6 +358,7 @@ namespace lfs::vis::gui {
         bool register_panel(PanelInfo info);
         void unregister_panel(const std::string& id);
         void unregister_all_non_native();
+        void unregister_all();
 
         float render_panels(const PanelRenderOptions& options, const PanelDrawContext& ctx);
         bool has_panels(PanelSpace space) const;

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -11,6 +11,7 @@
 #include "core/error_reporter.hpp"
 #include "core/event_bridge/event_bridge.hpp"
 #include "core/event_bridge/localization_manager.hpp"
+#include "core/executable_path.hpp"
 #include "core/guarded_task.hpp"
 #include "core/logger.hpp"
 #include "core/memory_pressure.hpp"
@@ -345,6 +346,10 @@ namespace lfs::vis {
 
         callback_cleanup_.clear();
         stopForceExitCompletionWatcher();
+        UnifiedToolRegistry::instance().clearActiveTool();
+        UnifiedToolRegistry::instance().clearActiveSubmode();
+        editor_context_.setActiveTool(ToolType::None);
+        editor_context_.clearActiveOperator();
         trainer_manager_.reset();
         tool_context_.reset();
         if (gui_manager_) {
@@ -1870,13 +1875,17 @@ namespace lfs::vis {
         if (scene_manager_)
             scene_manager_->initSelectionService();
 
-        {
-            LOG_TIMER("startup.python.ensure_initialized");
-            (void)python::ensure_initialized();
-        }
-        {
-            LOG_TIMER("startup.python.builtin_ui_registered");
-            python::ensure_builtin_ui_registered();
+        if (lfs::core::getPythonModuleDir().empty()) {
+            LOG_WARN("Python module not found next to executable; skipping Python init");
+        } else {
+            {
+                LOG_TIMER("startup.python.ensure_initialized");
+                (void)python::ensure_initialized();
+            }
+            {
+                LOG_TIMER("startup.python.builtin_ui_registered");
+                python::ensure_builtin_ui_registered();
+            }
         }
         {
             LOG_TIMER("startup.window.showWindow");


### PR DESCRIPTION
Found while running the full GPU suite for another branch: `ctest -R lichtfeld.fast` segfaulted in `RmlUIManager::createContext`, and four `PanelRegistryAnimationDemandTest` / `PanelLayoutRenderDemandTest` assertions failed, but only when `VisualizerImplResetTest.LoadDatasetApiDoesNotDeferOrPrompt` (#1726) ran earlier in the same process.

Root cause: `PanelRegistry` is process-global and `GuiManager::shutdown` only unregistered the non-native panels. The native scene panel outlived its `GuiManager` with a dangling `RmlUIManager*`; the next GUI bring-up rendered that stale panel (crash) and its leftover animation demand leaked into the registry assertions.

- `PanelRegistry::unregister_all` drops native panels, floating interactions and the poll cache; shutdown destroys the native panels before the RmlUI manager and clears the theme callback, the Python RML manager pointer, localization strings and the active tool.
- `VisualizerImpl::initialize` skips Python bring-up when no `lichtfeld` module exists next to the executable (the test binary's case) instead of latching the Python runtime into a permanent failed state for the rest of the process.

Verified: the pinned reproducer (`LoadDatasetApiDoesNotDeferOrPrompt:Panel*`) passes, `VisualizerImplResetTest.*` 139 green, and the full fast filter runs to completion with the crash gone (3871 passed / 26 skipped; the three remaining failures, `TensorKernelFusion.WhereSameShapePeakMemoryNoCloneBuffers`, `CudaEventPoolTest.EventAcquireFailureSynchronizesProducerFallback`, `InputControllerFocusTest.DeleteNodeShortcutFiresWhenViewportFocused`, are unrelated and pre-existing). Note for the suite itself: the fast filter takes ~92 s on an RTX 4090 box, above the 60 s ctest budget, with or without this change.