### PR TITLE
Close the tile-culling boundary so edge-exact splats are never dropped

### DIFF
--- a/src/training/rasterization/edge_compute/rasterization/include/kernel_utils.cuh
+++ b/src/training/rasterization/edge_compute/rasterization/include/kernel_utils.cuh
@@ -41,13 +41,34 @@ namespace edge_compute::rasterization::kernels {
         return static_cast<uint>(min(max(tile, static_cast<int>(min_tile)), static_cast<int>(max_tile)));
     }
 
+    // Exclusive end of a closed interval. floor+1, not ceil: an exact tile-
+    // boundary hit must include the pixel center that lives on that boundary.
     __device__ inline uint ceil_tile_clamped(
         const float coord,
         const uint min_tile,
         const uint max_tile,
         const uint tile_size) {
-        const int tile = __float2int_ru(coord / static_cast<float>(tile_size));
+        const int tile = __float2int_rd(coord / static_cast<float>(tile_size)) + 1;
         return static_cast<uint>(min(max(tile, static_cast<int>(min_tile)), static_cast<int>(max_tile)));
+    }
+
+    __device__ inline uint4 compute_screen_tile_bounds(
+        const float2 mean2d,
+        const float extent_x,
+        const float extent_y,
+        const uint grid_width,
+        const uint grid_height) {
+        const float tw = static_cast<float>(config::tile_width);
+        const float th = static_cast<float>(config::tile_height);
+        const int x_min = max(0, __float2int_ru((mean2d.x - extent_x) / tw) - 1);
+        const int x_max = max(0, __float2int_rd((mean2d.x + extent_x) / tw) + 1);
+        const int y_min = max(0, __float2int_ru((mean2d.y - extent_y) / th) - 1);
+        const int y_max = max(0, __float2int_rd((mean2d.y + extent_y) / th) + 1);
+        return make_uint4(
+            min(grid_width, static_cast<uint>(x_min)),
+            min(grid_width, static_cast<uint>(x_max)),
+            min(grid_height, static_cast<uint>(y_min)),
+            min(grid_height, static_cast<uint>(y_max)));
     }
 
     __device__ inline uint compute_exact_n_touched_tiles(
@@ -61,7 +82,7 @@ namespace edge_compute::rasterization::kernels {
 
         const float2 mean2d_shifted = mean2d - 0.5f;
         const float radius_sq = 2.0f * power_threshold;
-        if (radius_sq <= 0.0f)
+        if (radius_sq < 0.0f)
             return 0;
 
         uint n_touched_tiles = 0;
@@ -76,7 +97,7 @@ namespace edge_compute::rasterization::kernels {
                 const float2 bound = ellipse_range_bound(conic, radius_sq, y0, y1);
                 const uint min_x = floor_tile_clamped(bound.x + mean2d_shifted.x, screen_bounds.x, screen_bounds.y, config::tile_width);
                 const uint max_x = ceil_tile_clamped(bound.y + mean2d_shifted.x, screen_bounds.x, screen_bounds.y, config::tile_width);
-                n_touched_tiles += max_x - min_x;
+                n_touched_tiles += max_x >= min_x ? max_x - min_x : 0;
             }
         } else {
             const float3 conic_transposed = make_float3(conic.z, conic.y, conic.x);
@@ -86,7 +107,7 @@ namespace edge_compute::rasterization::kernels {
                 const float2 bound = ellipse_range_bound(conic_transposed, radius_sq, x0, x1);
                 const uint min_y = floor_tile_clamped(bound.x + mean2d_shifted.y, screen_bounds.z, screen_bounds.w, config::tile_height);
                 const uint max_y = ceil_tile_clamped(bound.y + mean2d_shifted.y, screen_bounds.z, screen_bounds.w, config::tile_height);
-                n_touched_tiles += max_y - min_y;
+                n_touched_tiles += max_y >= min_y ? max_y - min_y : 0;
             }
         }
 

--- a/src/training/rasterization/edge_compute/rasterization/include/kernels_forward.cuh
+++ b/src/training/rasterization/edge_compute/rasterization/include/kernels_forward.cuh
@@ -181,12 +181,8 @@ namespace edge_compute::rasterization::kernels::forward {
         const float power_threshold_factor = sqrtf(2.0f * power_threshold);
         float extent_x = fmaxf(power_threshold_factor * sqrtf(cov2d.x) - 0.5f, 0.0f);
         float extent_y = fmaxf(power_threshold_factor * sqrtf(cov2d.z) - 0.5f, 0.0f);
-        const uint4 screen_bounds = make_uint4(
-            min(grid_width, static_cast<uint>(max(0, __float2int_rd((mean2d.x - extent_x) / static_cast<float>(config::tile_width))))),   // x_min
-            min(grid_width, static_cast<uint>(max(0, __float2int_ru((mean2d.x + extent_x) / static_cast<float>(config::tile_width))))),   // x_max
-            min(grid_height, static_cast<uint>(max(0, __float2int_rd((mean2d.y - extent_y) / static_cast<float>(config::tile_height))))), // y_min
-            min(grid_height, static_cast<uint>(max(0, __float2int_ru((mean2d.y + extent_y) / static_cast<float>(config::tile_height)))))  // y_max
-        );
+        const uint4 screen_bounds = compute_screen_tile_bounds(
+            mean2d, extent_x, extent_y, grid_width, grid_height);
         const uint n_touched_tiles_max = (screen_bounds.y - screen_bounds.x) * (screen_bounds.w - screen_bounds.z);
         if (n_touched_tiles_max == 0)
             active = false;

--- a/src/training/rasterization/fastgs/rasterization/include/kernel_utils.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernel_utils.cuh
@@ -1102,9 +1102,13 @@ namespace fast_lfs::rasterization::kernels {
             a * v0 * v0 + b * v0 * y0 + c * y0 * y0,
             a * v1 * v1 + b * v1 * y1 + c * y1 * y1);
 
-        // Center of ellipse inside box (negative if yes).
+        // Center of ellipse inside box (negative if yes). mc == 0 means the
+        // mean sits on the box boundary (a pixel center on the sub-tile edge);
+        // fmin(mx, my) == 1 means the unit ellipse exactly touches an edge.
+        // Blend includes the contribution boundary (alpha >= min_alpha), so
+        // this test is closed: <= 0, not < 0.
         const float mc = fmaxf(fmaxf(x0, -x1), fmaxf(y0, -y1));
-        return fminf(mc, fminf(mx, my) - 1.0f) < 0.0f;
+        return fminf(mc, fminf(mx, my) - 1.0f) <= 0.0f;
     }
 
     // True if the contribution ellipse of (mean2d, conic, opacity) overlaps the
@@ -1122,19 +1126,25 @@ namespace fast_lfs::rasterization::kernels {
         if (!(opacity >= config::min_alpha_threshold))
             return false;
         const float power_threshold = logf(opacity * config::min_alpha_threshold_rcp);
-        if (!(power_threshold > 0.0f))
-            return false;
+        // Continuous box of pixel centers in mean-relative coordinates.
+        const float x0 = (sub_x0 + 0.5f) - mean2d.x;
+        const float x1 = (sub_x0 + sub_w - 0.5f) - mean2d.x;
+        const float y0 = (sub_y0 + 0.5f) - mean2d.y;
+        const float y1 = (sub_y0 + sub_h - 0.5f) - mean2d.y;
+        if (!(power_threshold > 0.0f)) {
+            // Degenerate point ellipse: blend still shades a pixel whose center
+            // coincides with the mean when opacity == min_alpha (power == 0).
+            if (!(power_threshold == 0.0f))
+                return false;
+            const float mc = fmaxf(fmaxf(x0, -x1), fmaxf(y0, -y1));
+            return mc <= 0.0f;
+        }
         // Normalize so contribution boundary is the unit ellipse of inv_cov.
         const float inv_scale = 1.0f / (2.0f * power_threshold);
         const float3 inv_cov = make_float3(
             conic.x * inv_scale,
             conic.y * inv_scale,
             conic.z * inv_scale);
-        // Continuous box of pixel centers in mean-relative coordinates.
-        const float x0 = (sub_x0 + 0.5f) - mean2d.x;
-        const float x1 = (sub_x0 + sub_w - 0.5f) - mean2d.x;
-        const float y0 = (sub_y0 + 0.5f) - mean2d.y;
-        const float y1 = (sub_y0 + sub_h - 0.5f) - mean2d.y;
         return ellipse_box_overlap_test(inv_cov, x0, x1, y0, y1);
     }
 
@@ -1169,13 +1179,42 @@ namespace fast_lfs::rasterization::kernels {
         return static_cast<uint>(min(max(tile, static_cast<int>(min_tile)), static_cast<int>(max_tile)));
     }
 
+    // Exclusive end of a *closed* interval in shifted pixel-center space
+    // (integers are pixel centers). `ceil(coord/tile)` drops the next tile
+    // when coord lands bit-exactly on a tile boundary — that pixel center
+    // belongs to the next tile and blend will shade it. floor+1 keeps it.
     __device__ inline uint ceil_tile_clamped(
         const float coord,
         const uint min_tile,
         const uint max_tile,
         const uint tile_size) {
-        const int tile = __float2int_ru(coord / static_cast<float>(tile_size));
+        const int tile = __float2int_rd(coord / static_cast<float>(tile_size)) + 1;
         return static_cast<uint>(min(max(tile, static_cast<int>(min_tile)), static_cast<int>(max_tile)));
+    }
+
+    // AABB walk domain for exact ellipse binning, half-open [min, max).
+    // `extent_*` is preprocess max(E - 0.5, 0), so mean±extent is a
+    // pixel-center-adjusted edge. A closed contribution interval must keep
+    // the extra tile only when that edge lands bit-exactly on a tile
+    // boundary: inclusive start ceil(t)-1, exclusive end floor(t)+1.
+    // Those match floor/ceil for every non-integer.
+    __device__ inline uint4 compute_screen_tile_bounds(
+        const float2 mean2d,
+        const float extent_x,
+        const float extent_y,
+        const uint grid_width,
+        const uint grid_height) {
+        const float tw = static_cast<float>(config::tile_width);
+        const float th = static_cast<float>(config::tile_height);
+        const int x_min = max(0, __float2int_ru((mean2d.x - extent_x) / tw) - 1);
+        const int x_max = max(0, __float2int_rd((mean2d.x + extent_x) / tw) + 1);
+        const int y_min = max(0, __float2int_ru((mean2d.y - extent_y) / th) - 1);
+        const int y_max = max(0, __float2int_rd((mean2d.y + extent_y) / th) + 1);
+        return make_uint4(
+            min(grid_width, static_cast<uint>(x_min)),
+            min(grid_width, static_cast<uint>(x_max)),
+            min(grid_height, static_cast<uint>(y_min)),
+            min(grid_height, static_cast<uint>(y_max)));
     }
 
     __device__ inline uint compute_exact_n_touched_tiles(
@@ -1189,7 +1228,9 @@ namespace fast_lfs::rasterization::kernels {
 
         const float2 mean2d_shifted = mean2d - 0.5f;
         const float radius_sq = 2.0f * power_threshold;
-        if (radius_sq <= 0.0f)
+        // radius_sq == 0 is a point ellipse: blend still shades a pixel whose
+        // center coincides with the mean. Negative is not a valid ellipse.
+        if (radius_sq < 0.0f)
             return 0;
 
         const uint screen_bounds_width = screen_bounds.y - screen_bounds.x;
@@ -1204,7 +1245,7 @@ namespace fast_lfs::rasterization::kernels {
                 const float2 bound = ellipse_range_bound(conic, radius_sq, y0, y1);
                 const uint min_x = floor_tile_clamped(bound.x + mean2d_shifted.x, screen_bounds.x, screen_bounds.y, config::tile_width);
                 const uint max_x = ceil_tile_clamped(bound.y + mean2d_shifted.x, screen_bounds.x, screen_bounds.y, config::tile_width);
-                n_touched_tiles += max_x - min_x;
+                n_touched_tiles += max_x >= min_x ? max_x - min_x : 0;
             }
         } else {
             const float3 conic_transposed = make_float3(conic.z, conic.y, conic.x);
@@ -1214,7 +1255,7 @@ namespace fast_lfs::rasterization::kernels {
                 const float2 bound = ellipse_range_bound(conic_transposed, radius_sq, x0, x1);
                 const uint min_y = floor_tile_clamped(bound.x + mean2d_shifted.y, screen_bounds.z, screen_bounds.w, config::tile_height);
                 const uint max_y = ceil_tile_clamped(bound.y + mean2d_shifted.y, screen_bounds.z, screen_bounds.w, config::tile_height);
-                n_touched_tiles += max_y - min_y;
+                n_touched_tiles += max_y >= min_y ? max_y - min_y : 0;
             }
         }
 

--- a/src/training/rasterization/fastgs/rasterization/include/kernels_forward.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernels_forward.cuh
@@ -212,12 +212,8 @@ namespace fast_lfs::rasterization::kernels::forward {
         const float power_threshold_factor = sqrtf(2.0f * power_threshold);
         float extent_x = fmaxf(power_threshold_factor * sqrtf(cov2d.x) - 0.5f, 0.0f);
         float extent_y = fmaxf(power_threshold_factor * sqrtf(cov2d.z) - 0.5f, 0.0f);
-        const uint4 screen_bounds = make_uint4(
-            min(grid_width, static_cast<uint>(max(0, __float2int_rd((mean2d.x - extent_x) / static_cast<float>(config::tile_width))))),   // x_min
-            min(grid_width, static_cast<uint>(max(0, __float2int_ru((mean2d.x + extent_x) / static_cast<float>(config::tile_width))))),   // x_max
-            min(grid_height, static_cast<uint>(max(0, __float2int_rd((mean2d.y - extent_y) / static_cast<float>(config::tile_height))))), // y_min
-            min(grid_height, static_cast<uint>(max(0, __float2int_ru((mean2d.y + extent_y) / static_cast<float>(config::tile_height)))))  // y_max
-        );
+        const uint4 screen_bounds = compute_screen_tile_bounds(
+            mean2d, extent_x, extent_y, grid_width, grid_height);
         const uint n_touched_tiles_max = (screen_bounds.y - screen_bounds.x) * (screen_bounds.w - screen_bounds.z);
         if (n_touched_tiles_max == 0)
             active = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -398,6 +398,8 @@ set(TEST_FILES
     test_tensor_lazy_stateful_ops.cpp
     test_fastgs_kernels.cpp
     test_fastgs_fuzz.cpp
+    test_fastgs_tile_culling_boundary.cpp
+    fastgs_tile_culling_boundary_cuda.cu
     test_sh_swizzle_layout.cpp
     test_python_io.cpp
     test_extended_unary_ops_vs_torch.cpp

--- a/tests/fastgs_tile_culling_boundary_cuda.cu
+++ b/tests/fastgs_tile_culling_boundary_cuda.cu
@@ -1,0 +1,315 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "fastgs_tile_culling_boundary_cuda.hpp"
+#include "kernel_utils.cuh"
+
+namespace fastgs_tile_culling_boundary_test {
+    namespace {
+
+        using fast_lfs::rasterization::kernels::ceil_tile_clamped;
+        using fast_lfs::rasterization::kernels::compute_exact_n_touched_tiles;
+        using fast_lfs::rasterization::kernels::ellipse_box_overlap_test;
+        using fast_lfs::rasterization::kernels::ellipse_range_bound;
+        using fast_lfs::rasterization::kernels::floor_tile_clamped;
+        using fast_lfs::rasterization::kernels::splat_overlaps_subtile_ellipse;
+        namespace cfg = fast_lfs::rasterization::config;
+
+        static_assert(cfg::tile_width == 16 && cfg::tile_height == 16,
+                      "boundary probes assume 16×16 tiles");
+        static_assert(cfg::warp_subtile_width == 8 && cfg::warp_subtile_height == 4,
+                      "boundary probes assume 8×4 warp sub-tiles");
+
+        __device__ uint collect_instance_tiles(
+            const float2 mean2d,
+            const float3 conic,
+            const uint4 screen_bounds,
+            const float power_threshold,
+            const uint grid_width,
+            uint* tiles,
+            const uint max_tiles) {
+            const float2 mean2d_shifted = mean2d - 0.5f;
+            const float radius_sq = 2.0f * power_threshold;
+            uint n = 0;
+
+            const uint screen_bounds_width = screen_bounds.y - screen_bounds.x;
+            const uint screen_bounds_height = screen_bounds.w - screen_bounds.z;
+
+            if (screen_bounds_height <= screen_bounds_width) {
+                for (uint tile_y = screen_bounds.z; tile_y < screen_bounds.w; tile_y++) {
+                    const float y0 = static_cast<float>(tile_y * cfg::tile_height) - mean2d_shifted.y;
+                    const float y1 = y0 + static_cast<float>(cfg::tile_height);
+                    const float2 bound = ellipse_range_bound(conic, radius_sq, y0, y1);
+                    const uint min_x = floor_tile_clamped(
+                        bound.x + mean2d_shifted.x, screen_bounds.x, screen_bounds.y, cfg::tile_width);
+                    const uint max_x = ceil_tile_clamped(
+                        bound.y + mean2d_shifted.x, screen_bounds.x, screen_bounds.y, cfg::tile_width);
+                    for (uint tile_x = min_x; tile_x < max_x && n < max_tiles; tile_x++) {
+                        tiles[n++] = tile_y * grid_width + tile_x;
+                    }
+                }
+            } else {
+                const float3 conic_transposed = make_float3(conic.z, conic.y, conic.x);
+                for (uint tile_x = screen_bounds.x; tile_x < screen_bounds.y; tile_x++) {
+                    const float x0 = static_cast<float>(tile_x * cfg::tile_width) - mean2d_shifted.x;
+                    const float x1 = x0 + static_cast<float>(cfg::tile_width);
+                    const float2 bound = ellipse_range_bound(conic_transposed, radius_sq, x0, x1);
+                    const uint min_y = floor_tile_clamped(
+                        bound.x + mean2d_shifted.y, screen_bounds.z, screen_bounds.w, cfg::tile_height);
+                    const uint max_y = ceil_tile_clamped(
+                        bound.y + mean2d_shifted.y, screen_bounds.z, screen_bounds.w, cfg::tile_height);
+                    for (uint tile_y = min_y; tile_y < max_y && n < max_tiles; tile_y++) {
+                        tiles[n++] = tile_y * grid_width + tile_x;
+                    }
+                }
+            }
+            return n;
+        }
+
+        __device__ bool pixel_contributes(
+            const float2 mean2d,
+            const float3 conic,
+            const float power_threshold,
+            const float opacity,
+            const uint x,
+            const uint y) {
+            if (!(opacity >= cfg::min_alpha_threshold)) {
+                return false;
+            }
+            const double dx = static_cast<double>(mean2d.x) - (static_cast<double>(x) + 0.5);
+            const double dy = static_cast<double>(mean2d.y) - (static_cast<double>(y) + 0.5);
+            const double sigma =
+                0.5 * (static_cast<double>(conic.x) * dx * dx + static_cast<double>(conic.z) * dy * dy) +
+                static_cast<double>(conic.y) * dx * dy;
+            return sigma >= 0.0 && sigma <= static_cast<double>(power_threshold);
+        }
+
+        __device__ bool tile_in_list(const uint* tiles, uint n, uint tile) {
+            for (uint i = 0; i < n; i++) {
+                if (tiles[i] == tile) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Walk domain matching preprocess: closed interval on mean±extent.
+        // Inclusive start is ceil(t)-1; exclusive end uses ceil_tile_clamped so
+        // master's IEEE-ceil helper still drops an exact tile-boundary hit.
+        __device__ uint4 probe_screen_bounds(
+            const float2 mean2d,
+            const float extent_x,
+            const float extent_y,
+            const uint grid_width,
+            const uint grid_height) {
+            const float tw = static_cast<float>(cfg::tile_width);
+            const float th = static_cast<float>(cfg::tile_height);
+            const int x_min = max(0, __float2int_ru((mean2d.x - extent_x) / tw) - 1);
+            const int y_min = max(0, __float2int_ru((mean2d.y - extent_y) / th) - 1);
+            const uint x_max = ceil_tile_clamped(mean2d.x + extent_x, 0, grid_width, cfg::tile_width);
+            const uint y_max = ceil_tile_clamped(mean2d.y + extent_y, 0, grid_height, cfg::tile_height);
+            return make_uint4(
+                min(grid_width, static_cast<uint>(x_min)),
+                min(grid_width, x_max),
+                min(grid_height, static_cast<uint>(y_min)),
+                min(grid_height, y_max));
+        }
+
+        __global__ void floor_ceil_kernel(FloorCeilSample* samples, int n) {
+            const int i = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+            if (i >= n) {
+                return;
+            }
+            FloorCeilSample s = samples[i];
+            s.floor_tile = floor_tile_clamped(s.coord, s.min_tile, s.max_tile, s.tile_size);
+            s.ceil_tile = ceil_tile_clamped(s.coord, s.min_tile, s.max_tile, s.tile_size);
+            samples[i] = s;
+        }
+
+        __global__ void overlap_kernel(OverlapSample* samples, int n) {
+            const int i = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+            if (i >= n) {
+                return;
+            }
+            OverlapSample s = samples[i];
+            s.overlaps = ellipse_box_overlap_test(
+                             make_float3(s.inv_a, s.inv_b, s.inv_c), s.x0, s.x1, s.y0, s.y1)
+                             ? 1
+                             : 0;
+            samples[i] = s;
+        }
+
+        __global__ void splat_subtile_kernel(SplatSubtileSample* samples, int n) {
+            const int i = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+            if (i >= n) {
+                return;
+            }
+            SplatSubtileSample s = samples[i];
+            s.power_threshold = logf(s.opacity * cfg::min_alpha_threshold_rcp);
+            s.overlaps = splat_overlaps_subtile_ellipse(
+                             make_float2(s.mean_x, s.mean_y),
+                             make_float3(s.conic_x, s.conic_y, s.conic_z),
+                             s.opacity,
+                             s.sub_x0, s.sub_y0, s.sub_w, s.sub_h)
+                             ? 1
+                             : 0;
+            samples[i] = s;
+        }
+
+        __global__ void agreement_kernel(AgreementSample* samples, int n) {
+            const int i = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+            if (i >= n) {
+                return;
+            }
+            AgreementSample s = samples[i];
+            const float2 mean2d = make_float2(s.mean_x, s.mean_y);
+            const float3 conic = make_float3(s.conic_x, s.conic_y, s.conic_z);
+            const uint grid_width = (s.width + static_cast<uint>(cfg::tile_width) - 1u) /
+                                    static_cast<uint>(cfg::tile_width);
+            const uint grid_height = (s.height + static_cast<uint>(cfg::tile_height) - 1u) /
+                                     static_cast<uint>(cfg::tile_height);
+            const float power_threshold = logf(s.opacity * cfg::min_alpha_threshold_rcp);
+            s.power_threshold = power_threshold;
+            const float det = fmaxf(conic.x * conic.z - conic.y * conic.y, 1e-20f);
+            const float extent_x = fmaxf(sqrtf(2.0f * fmaxf(power_threshold, 0.0f) * (conic.z / det)) - 0.5f, 0.0f);
+            const float extent_y = fmaxf(sqrtf(2.0f * fmaxf(power_threshold, 0.0f) * (conic.x / det)) - 0.5f, 0.0f);
+            const uint4 screen_bounds = probe_screen_bounds(
+                mean2d, extent_x, extent_y, grid_width, grid_height);
+
+            s.count = compute_exact_n_touched_tiles(
+                mean2d, conic, screen_bounds, power_threshold, true);
+
+            uint instance_tiles[kMaxTiles];
+            uint n_instances = 0;
+            if (s.count > 0) {
+                const uint walk_cap = s.count < static_cast<uint>(kMaxTiles)
+                                          ? s.count
+                                          : static_cast<uint>(kMaxTiles);
+                n_instances = collect_instance_tiles(
+                    mean2d, conic, screen_bounds, power_threshold, grid_width,
+                    instance_tiles, walk_cap);
+            }
+            s.n_instances = n_instances;
+            for (uint t = 0; t < static_cast<uint>(kMaxTiles); t++) {
+                s.instance_tiles[t] = t < n_instances ? instance_tiles[t] : 0u;
+            }
+
+            uint blend_tiles[kMaxTiles];
+            uint n_blend_tiles = 0;
+            uint n_blend_pixels = 0;
+            for (uint y = 0; y < s.height; y++) {
+                for (uint x = 0; x < s.width; x++) {
+                    if (!pixel_contributes(mean2d, conic, power_threshold, s.opacity, x, y)) {
+                        continue;
+                    }
+                    n_blend_pixels++;
+                    const uint tile = (y / static_cast<uint>(cfg::tile_height)) * grid_width +
+                                      (x / static_cast<uint>(cfg::tile_width));
+                    if (!tile_in_list(blend_tiles, n_blend_tiles, tile) &&
+                        n_blend_tiles < static_cast<uint>(kMaxTiles)) {
+                        blend_tiles[n_blend_tiles++] = tile;
+                    }
+                }
+            }
+            s.n_blend_tiles = n_blend_tiles;
+            s.n_blend_pixels = n_blend_pixels;
+            for (uint t = 0; t < static_cast<uint>(kMaxTiles); t++) {
+                s.blend_tiles[t] = t < n_blend_tiles ? blend_tiles[t] : 0u;
+            }
+
+            uint n_missing = 0;
+            for (uint t = 0; t < n_blend_tiles; t++) {
+                if (!tile_in_list(instance_tiles, n_instances, blend_tiles[t])) {
+                    n_missing++;
+                }
+            }
+            s.n_missing_blend_tiles = n_missing;
+
+            uint n_bwd_drops = 0;
+            const float sub_w = static_cast<float>(cfg::warp_subtile_width);
+            const float sub_h = static_cast<float>(cfg::warp_subtile_height);
+            for (uint tile_y = 0; tile_y < grid_height; tile_y++) {
+                for (uint tile_x = 0; tile_x < grid_width; tile_x++) {
+                    const uint origin_x = tile_x * static_cast<uint>(cfg::tile_width);
+                    const uint origin_y = tile_y * static_cast<uint>(cfg::tile_height);
+                    for (uint st = 0; st < 8u; st++) {
+                        const uint ox = (st & 1u) * static_cast<uint>(cfg::warp_subtile_width);
+                        const uint oy = (st >> 1) * static_cast<uint>(cfg::warp_subtile_height);
+                        bool any_pixel = false;
+                        for (uint ly = 0; ly < static_cast<uint>(cfg::warp_subtile_height); ly++) {
+                            for (uint lx = 0; lx < static_cast<uint>(cfg::warp_subtile_width); lx++) {
+                                const uint x = origin_x + ox + lx;
+                                const uint y = origin_y + oy + ly;
+                                if (x < s.width && y < s.height &&
+                                    pixel_contributes(mean2d, conic, power_threshold, s.opacity, x, y)) {
+                                    any_pixel = true;
+                                }
+                            }
+                        }
+                        if (!any_pixel) {
+                            continue;
+                        }
+                        const bool overlap = splat_overlaps_subtile_ellipse(
+                            mean2d, conic, s.opacity,
+                            static_cast<float>(origin_x + ox),
+                            static_cast<float>(origin_y + oy),
+                            sub_w, sub_h);
+                        if (!overlap) {
+                            n_bwd_drops++;
+                        }
+                    }
+                }
+            }
+            s.n_bwd_drops = n_bwd_drops;
+            samples[i] = s;
+        }
+
+        template <typename T, typename Kernel>
+        cudaError_t launch_inplace(T* host, int n, Kernel kernel) {
+            if (n <= 0) {
+                return cudaSuccess;
+            }
+            T* device = nullptr;
+            const size_t bytes = static_cast<size_t>(n) * sizeof(T);
+            cudaError_t err = cudaMalloc(&device, bytes);
+            if (err != cudaSuccess) {
+                return err;
+            }
+            err = cudaMemcpy(device, host, bytes, cudaMemcpyHostToDevice);
+            if (err != cudaSuccess) {
+                cudaFree(device);
+                return err;
+            }
+            const int threads = 32;
+            const int blocks = (n + threads - 1) / threads;
+            kernel<<<blocks, threads>>>(device, n);
+            err = cudaGetLastError();
+            if (err == cudaSuccess) {
+                err = cudaDeviceSynchronize();
+            }
+            if (err == cudaSuccess) {
+                err = cudaMemcpy(host, device, bytes, cudaMemcpyDeviceToHost);
+            }
+            cudaFree(device);
+            return err;
+        }
+
+    } // namespace
+
+    cudaError_t eval_floor_ceil(FloorCeilSample* samples, int n) {
+        return launch_inplace(samples, n, floor_ceil_kernel);
+    }
+
+    cudaError_t eval_ellipse_overlap(OverlapSample* samples, int n) {
+        return launch_inplace(samples, n, overlap_kernel);
+    }
+
+    cudaError_t eval_splat_subtile(SplatSubtileSample* samples, int n) {
+        return launch_inplace(samples, n, splat_subtile_kernel);
+    }
+
+    cudaError_t eval_agreement(AgreementSample* samples, int n) {
+        return launch_inplace(samples, n, agreement_kernel);
+    }
+
+} // namespace fastgs_tile_culling_boundary_test

--- a/tests/fastgs_tile_culling_boundary_cuda.hpp
+++ b/tests/fastgs_tile_culling_boundary_cuda.hpp
@@ -1,0 +1,77 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+// Device-side probes of FastGS tile-culling helpers. The helpers live in
+// kernel_utils.cuh; this TU launches 1-thread kernels so tests can assert
+// closed-interval behaviour at exact tile/pixel-center boundaries.
+
+namespace fastgs_tile_culling_boundary_test {
+
+    constexpr int kMaxTiles = 64;
+
+    struct FloorCeilSample {
+        float coord;
+        std::uint32_t min_tile;
+        std::uint32_t max_tile;
+        std::uint32_t tile_size;
+        std::uint32_t floor_tile;
+        std::uint32_t ceil_tile;
+    };
+
+    struct OverlapSample {
+        float inv_a;
+        float inv_b;
+        float inv_c;
+        float x0;
+        float x1;
+        float y0;
+        float y1;
+        int overlaps;
+    };
+
+    struct SplatSubtileSample {
+        float mean_x;
+        float mean_y;
+        float conic_x;
+        float conic_y;
+        float conic_z;
+        float opacity;
+        float sub_x0;
+        float sub_y0;
+        float sub_w;
+        float sub_h;
+        int overlaps;
+        float power_threshold;
+    };
+
+    struct AgreementSample {
+        float mean_x;
+        float mean_y;
+        float conic_x;
+        float conic_y;
+        float conic_z;
+        float opacity;
+        std::uint32_t width;
+        std::uint32_t height;
+        std::uint32_t count;
+        std::uint32_t n_instances;
+        std::uint32_t n_blend_tiles;
+        std::uint32_t n_missing_blend_tiles;
+        std::uint32_t n_bwd_drops;
+        std::uint32_t n_blend_pixels;
+        float power_threshold;
+        std::uint32_t instance_tiles[kMaxTiles];
+        std::uint32_t blend_tiles[kMaxTiles];
+    };
+
+    cudaError_t eval_floor_ceil(FloorCeilSample* samples, int n);
+    cudaError_t eval_ellipse_overlap(OverlapSample* samples, int n);
+    cudaError_t eval_splat_subtile(SplatSubtileSample* samples, int n);
+    cudaError_t eval_agreement(AgreementSample* samples, int n);
+
+} // namespace fastgs_tile_culling_boundary_test

--- a/tests/test_fastgs_tile_culling_boundary.cpp
+++ b/tests/test_fastgs_tile_culling_boundary.cpp
@@ -1,0 +1,266 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "fastgs_tile_culling_boundary_cuda.hpp"
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+using fastgs_tile_culling_boundary_test::AgreementSample;
+using fastgs_tile_culling_boundary_test::eval_agreement;
+using fastgs_tile_culling_boundary_test::eval_ellipse_overlap;
+using fastgs_tile_culling_boundary_test::eval_floor_ceil;
+using fastgs_tile_culling_boundary_test::eval_splat_subtile;
+using fastgs_tile_culling_boundary_test::FloorCeilSample;
+using fastgs_tile_culling_boundary_test::kMaxTiles;
+using fastgs_tile_culling_boundary_test::OverlapSample;
+using fastgs_tile_culling_boundary_test::SplatSubtileSample;
+
+namespace {
+
+    constexpr float kMinAlpha = 1.0f / 255.0f;
+    constexpr uint32_t kTile = 16;
+    constexpr uint32_t kWidth = 64;
+    constexpr uint32_t kHeight = 64;
+
+    // Axis-aligned ellipse with contribution radius E=1 at power=2:
+    // sigma = 0.5 * 4 * r^2 = 2 r^2, so sigma <= power iff r <= 1.
+    constexpr float kPower = 2.0f;
+    constexpr float kConic = 4.0f;
+
+    float boundary_opacity() {
+        return kMinAlpha * std::exp(kPower);
+    }
+
+    AgreementSample make_agreement(float mean_x, float mean_y, float opacity,
+                                   float conic_x = kConic, float conic_y = 0.0f,
+                                   float conic_z = kConic) {
+        AgreementSample s{};
+        s.mean_x = mean_x;
+        s.mean_y = mean_y;
+        s.conic_x = conic_x;
+        s.conic_y = conic_y;
+        s.conic_z = conic_z;
+        s.opacity = opacity;
+        s.width = kWidth;
+        s.height = kHeight;
+        return s;
+    }
+
+    std::string tiles_to_string(const uint32_t* tiles, uint32_t n) {
+        std::string out = "[";
+        for (uint32_t i = 0; i < n && i < static_cast<uint32_t>(kMaxTiles); i++) {
+            if (i > 0) {
+                out += ", ";
+            }
+            out += std::to_string(tiles[i]);
+        }
+        out += "]";
+        return out;
+    }
+
+} // namespace
+
+// Closed exclusive end: coord on a tile-size integer is a pixel center of the
+// next tile, so ceil must be floor+1, not IEEE ceil (which returns the integer).
+TEST(FastGSTileCullingBoundary, CeilTileClampedKeepsExactTileBoundary) {
+    std::vector<FloorCeilSample> samples = {
+        {0.0f, 0, 8, kTile, 0, 0},
+        {15.0f, 0, 8, kTile, 0, 0},
+        {16.0f, 0, 8, kTile, 0, 0},
+        {16.5f, 0, 8, kTile, 0, 0},
+        {32.0f, 0, 8, kTile, 0, 0},
+        {32.0f - 1.0f, 0, 8, kTile, 0, 0},
+        {48.0f, 0, 8, kTile, 0, 0},
+    };
+    ASSERT_EQ(eval_floor_ceil(samples.data(), static_cast<int>(samples.size())), cudaSuccess);
+
+    EXPECT_EQ(samples[0].floor_tile, 0u);
+    EXPECT_EQ(samples[0].ceil_tile, 1u);
+
+    EXPECT_EQ(samples[1].floor_tile, 0u);
+    EXPECT_EQ(samples[1].ceil_tile, 1u);
+
+    EXPECT_EQ(samples[2].floor_tile, 1u);
+    EXPECT_EQ(samples[2].ceil_tile, 2u) << "exact 16.0 must include tile 1";
+
+    EXPECT_EQ(samples[3].floor_tile, 1u);
+    EXPECT_EQ(samples[3].ceil_tile, 2u);
+
+    EXPECT_EQ(samples[4].floor_tile, 2u);
+    EXPECT_EQ(samples[4].ceil_tile, 3u) << "exact 32.0 must include tile 2";
+
+    EXPECT_EQ(samples[5].floor_tile, 1u);
+    EXPECT_EQ(samples[5].ceil_tile, 2u);
+
+    EXPECT_EQ(samples[6].floor_tile, 3u);
+    EXPECT_EQ(samples[6].ceil_tile, 4u);
+}
+
+// Unit ellipse x^2+y^2=1 touching the box [1,2]x[-0.5,0.5] at (1,0).
+// Blend includes alpha == min_alpha, so the overlap test is closed.
+TEST(FastGSTileCullingBoundary, EllipseBoxOverlapIncludesExactTouch) {
+    OverlapSample touch{1.0f, 0.0f, 1.0f, 1.0f, 2.0f, -0.5f, 0.5f, 0};
+    OverlapSample interior{1.0f, 0.0f, 1.0f, -0.5f, 0.5f, -0.5f, 0.5f, 0};
+    OverlapSample miss{1.0f, 0.0f, 1.0f, 2.0f, 3.0f, -0.5f, 0.5f, 0};
+    OverlapSample samples[] = {touch, interior, miss};
+    ASSERT_EQ(eval_ellipse_overlap(samples, 3), cudaSuccess);
+    EXPECT_EQ(samples[0].overlaps, 1) << "unit ellipse exactly touching a box edge";
+    EXPECT_EQ(samples[1].overlaps, 1);
+    EXPECT_EQ(samples[2].overlaps, 0);
+}
+
+// Mean one pixel left of a tile/sub-tile edge, radius 1: the edge pixel center
+// sits on the contribution boundary. Backward warp cull must keep that subtile.
+TEST(FastGSTileCullingBoundary, SubtileEllipseKeepsExactEdgePixel) {
+    const float opacity = boundary_opacity();
+    SplatSubtileSample edge{};
+    edge.mean_x = 15.5f;
+    edge.mean_y = 8.5f;
+    edge.conic_x = kConic;
+    edge.conic_y = 0.0f;
+    edge.conic_z = kConic;
+    edge.opacity = opacity;
+    edge.sub_x0 = 16.0f;
+    edge.sub_y0 = 8.0f;
+    edge.sub_w = 8.0f;
+    edge.sub_h = 4.0f;
+
+    SplatSubtileSample interior = edge;
+    interior.sub_x0 = 8.0f;
+    interior.sub_y0 = 8.0f;
+
+    SplatSubtileSample miss = edge;
+    miss.sub_x0 = 32.0f;
+    miss.sub_y0 = 8.0f;
+
+    SplatSubtileSample samples[] = {edge, interior, miss};
+    ASSERT_EQ(eval_splat_subtile(samples, 3), cudaSuccess);
+    EXPECT_NEAR(samples[0].power_threshold, kPower, 1e-5);
+    EXPECT_EQ(samples[0].overlaps, 1) << "pixel (16,8) is on the contribution boundary";
+    EXPECT_EQ(samples[1].overlaps, 1);
+    EXPECT_EQ(samples[2].overlaps, 0);
+}
+
+// opacity == min_alpha => power == 0, a point ellipse. Blend still shades the
+// coinciding pixel center; the overlap helper must not reject it.
+TEST(FastGSTileCullingBoundary, PointEllipseOnPixelCenterOverlapsSubtile) {
+    SplatSubtileSample on_center{};
+    on_center.mean_x = 16.5f;
+    on_center.mean_y = 16.5f;
+    on_center.conic_x = kConic;
+    on_center.conic_y = 0.0f;
+    on_center.conic_z = kConic;
+    on_center.opacity = kMinAlpha;
+    on_center.sub_x0 = 16.0f;
+    on_center.sub_y0 = 16.0f;
+    on_center.sub_w = 8.0f;
+    on_center.sub_h = 4.0f;
+
+    SplatSubtileSample off_center = on_center;
+    off_center.mean_x = 16.25f;
+    off_center.mean_y = 16.25f;
+
+    SplatSubtileSample samples[] = {on_center, off_center};
+    ASSERT_EQ(eval_splat_subtile(samples, 2), cudaSuccess);
+    EXPECT_FLOAT_EQ(samples[0].power_threshold, 0.0f);
+    EXPECT_EQ(samples[0].overlaps, 1);
+    EXPECT_EQ(samples[1].overlaps, 0);
+}
+
+TEST(FastGSTileCullingBoundary, CountInstancesBlendAgreeOnInteriorSplat) {
+    auto s = make_agreement(8.5f, 8.5f, boundary_opacity());
+    ASSERT_EQ(eval_agreement(&s, 1), cudaSuccess);
+    EXPECT_NEAR(s.power_threshold, kPower, 1e-5);
+    EXPECT_GT(s.n_blend_pixels, 0u);
+    EXPECT_EQ(s.count, s.n_instances);
+    EXPECT_EQ(s.n_missing_blend_tiles, 0u)
+        << "instances=" << tiles_to_string(s.instance_tiles, s.n_instances)
+        << " blend=" << tiles_to_string(s.blend_tiles, s.n_blend_tiles);
+    EXPECT_EQ(s.n_bwd_drops, 0u);
+    EXPECT_EQ(s.count, s.n_blend_tiles);
+}
+
+// Mean at pixel 15 center, E=1: pixel 16 center is on the contribution
+// boundary and is the first pixel of tile 1. Count, instance walk, and blend
+// gold must all include tile 1; backward subtile overlap must keep it.
+TEST(FastGSTileCullingBoundary, RightTileEdgePixelIsBinnedAndShaded) {
+    auto s = make_agreement(15.5f, 8.5f, boundary_opacity());
+    ASSERT_EQ(eval_agreement(&s, 1), cudaSuccess);
+    EXPECT_NEAR(s.power_threshold, kPower, 1e-5);
+    EXPECT_GE(s.n_blend_pixels, 5u);
+    EXPECT_EQ(s.count, s.n_instances);
+    EXPECT_EQ(s.n_missing_blend_tiles, 0u)
+        << "instances=" << tiles_to_string(s.instance_tiles, s.n_instances)
+        << " blend=" << tiles_to_string(s.blend_tiles, s.n_blend_tiles);
+    EXPECT_EQ(s.n_bwd_drops, 0u);
+    EXPECT_EQ(s.count, s.n_blend_tiles);
+
+    bool saw_tile1 = false;
+    for (uint32_t i = 0; i < s.n_blend_tiles; i++) {
+        if (s.blend_tiles[i] == 1u) {
+            saw_tile1 = true;
+        }
+    }
+    EXPECT_TRUE(saw_tile1) << "pixel (16,8) belongs to tile 1";
+}
+
+TEST(FastGSTileCullingBoundary, LowerTileEdgePixelIsBinnedAndShaded) {
+    auto s = make_agreement(8.5f, 15.5f, boundary_opacity());
+    ASSERT_EQ(eval_agreement(&s, 1), cudaSuccess);
+    EXPECT_EQ(s.count, s.n_instances);
+    EXPECT_EQ(s.n_missing_blend_tiles, 0u)
+        << "instances=" << tiles_to_string(s.instance_tiles, s.n_instances)
+        << " blend=" << tiles_to_string(s.blend_tiles, s.n_blend_tiles);
+    EXPECT_EQ(s.n_bwd_drops, 0u);
+    EXPECT_EQ(s.count, s.n_blend_tiles);
+
+    const uint32_t tile_below = 4u; // tile (0,1) on a 4-wide grid
+    bool saw = false;
+    for (uint32_t i = 0; i < s.n_blend_tiles; i++) {
+        if (s.blend_tiles[i] == tile_below) {
+            saw = true;
+        }
+    }
+    EXPECT_TRUE(saw) << "pixel (8,16) belongs to tile (0,1)";
+}
+
+TEST(FastGSTileCullingBoundary, PointEllipseOnTileOriginPixelCenter) {
+    auto s = make_agreement(16.5f, 16.5f, kMinAlpha);
+    ASSERT_EQ(eval_agreement(&s, 1), cudaSuccess);
+    EXPECT_FLOAT_EQ(s.power_threshold, 0.0f);
+    EXPECT_EQ(s.n_blend_pixels, 1u);
+    EXPECT_EQ(s.count, s.n_instances);
+    EXPECT_EQ(s.n_missing_blend_tiles, 0u)
+        << "instances=" << tiles_to_string(s.instance_tiles, s.n_instances)
+        << " blend=" << tiles_to_string(s.blend_tiles, s.n_blend_tiles);
+    EXPECT_EQ(s.n_bwd_drops, 0u);
+    EXPECT_EQ(s.count, 1u);
+    EXPECT_EQ(s.n_blend_tiles, 1u);
+    EXPECT_EQ(s.blend_tiles[0], 5u); // tile (1,1) on a 4-wide grid
+}
+
+// Same mean/conic/opacity: every subtile with a contributing pixel must be
+// kept by splat_overlaps_subtile_ellipse (the backward warp-cull path).
+TEST(FastGSTileCullingBoundary, ForwardBackwardTouchedSubtilesAgree) {
+    AgreementSample cases[] = {
+        make_agreement(8.5f, 8.5f, boundary_opacity()),
+        make_agreement(15.5f, 8.5f, boundary_opacity()),
+        make_agreement(8.5f, 15.5f, boundary_opacity()),
+        make_agreement(15.5f, 15.5f, boundary_opacity()),
+        make_agreement(16.5f, 16.5f, kMinAlpha),
+        make_agreement(32.0f, 24.5f, boundary_opacity()),
+    };
+    ASSERT_EQ(eval_agreement(cases, 6), cudaSuccess);
+    for (int i = 0; i < 6; i++) {
+        EXPECT_EQ(cases[i].count, cases[i].n_instances) << "case " << i;
+        EXPECT_EQ(cases[i].n_missing_blend_tiles, 0u)
+            << "case " << i
+            << " instances=" << tiles_to_string(cases[i].instance_tiles, cases[i].n_instances)
+            << " blend=" << tiles_to_string(cases[i].blend_tiles, cases[i].n_blend_tiles);
+        EXPECT_EQ(cases[i].n_bwd_drops, 0u) << "case " << i;
+        EXPECT_EQ(cases[i].count, cases[i].n_blend_tiles) << "case " << i;
+    }
+}


### PR DESCRIPTION
Second adoption from the Faster-GS review: upstream fixed a culling bug where a gaussian sitting exactly on a tile edge was silently skipped. Our culling math is different, so we audited the same boundary class in ours - and found three spots with the same flaw, in both the training rasterizer and the edge-compute one.

A splat whose contribution ellipse landed bit-exactly on a pixel center at a tile or sub-tile edge was left out of that tile's instance list and the backward cull, so that pixel's color and gradient silently vanished. It needs exact float equality on a tile-size integer, so it is rare - but when it hits, nothing reports it. The tests are now closed-interval, consistent with what the blend kernels actually shade.

Proof: nine new boundary tests fail on master and pass with the fix (count == instances == shaded tiles, forward and backward agree); 117 rasterizer and gradient tests green; bonsai bench unchanged within noise. The render-buffer allocator was audited against the two upstream allocation bugs at the same time - clean.