### PR TITLE
Keep the Python test suite isolated and the startup chooser dismissing after open

### DIFF
--- a/src/python/lfs_plugins/startup_recent_panel.py
+++ b/src/python/lfs_plugins/startup_recent_panel.py
@@ -259,8 +259,6 @@ class StartupRecentPanel(Panel):
 
         try:
             outcome = lf.project_open(path_text, True)
-            if outcome == lf.ProjectOpenOutcome.RECOVERY_PROMPT_PENDING:
-                return
         except Exception as exc:
             # NotFoundError subclasses FileNotFoundError; other open failures
             # surface their error text on the same user-visible path.
@@ -269,6 +267,15 @@ class StartupRecentPanel(Panel):
             else:
                 message = str(exc).strip() or missing_message
             self._report_open_error(message)
+            return
+
+        # Keep the chooser open while a crash-recovery prompt is pending.
+        recovery_pending = getattr(
+            getattr(lf, "ProjectOpenOutcome", None),
+            "RECOVERY_PROMPT_PENDING",
+            None,
+        )
+        if recovery_pending is not None and outcome == recovery_pending:
             return
 
         self._dismiss()

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -127,9 +127,34 @@ def isolate_lichtfeld_module_overrides():
     before = {name: module for name, module in sys.modules.items() if is_managed(name)}
     yield
 
-    for name in [name for name in sys.modules if is_managed(name) and name not in before]:
+    extras = {
+        name: sys.modules[name]
+        for name in list(sys.modules)
+        if is_managed(name) and name not in before
+    }
+    for name, module in extras.items():
         del sys.modules[name]
+        parent_name, dot, attr = name.rpartition(".")
+        if not dot:
+            continue
+        parent = sys.modules.get(parent_name)
+        if parent is not None and getattr(parent, attr, None) is module:
+            delattr(parent, attr)
+
     sys.modules.update(before)
+
+    # `sys.modules.pop("lfs_plugins.types")` + reimport rebinds the live
+    # package attribute even after the original module is restored in
+    # sys.modules. Native register_class looks up Operator via
+    # import("lfs_plugins.types"), while tests do `from lfs_plugins import
+    # types`; those must be the same object.
+    for name, module in before.items():
+        parent_name, dot, attr = name.rpartition(".")
+        if not dot:
+            continue
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr, module)
 
 
 @pytest.fixture

--- a/tests/python/test_asset_manager_panel.py
+++ b/tests/python/test_asset_manager_panel.py
@@ -40,7 +40,12 @@ def _install_lf_stub(monkeypatch):
             LEFT_DOCK="LEFT_DOCK",
         ),
         PanelHeightMode=SimpleNamespace(FILL="FILL", CONTENT="CONTENT"),
+        PanelOption=SimpleNamespace(
+            DEFAULT_CLOSED="DEFAULT_CLOSED",
+            HIDE_HEADER="HIDE_HEADER",
+        ),
         tr=lambda key: key,
+        set_save_asset_callback=lambda _callback: None,
     )
     lf_stub.log = _LogStub()
     monkeypatch.setitem(sys.modules, "lichtfeld", lf_stub)


### PR DESCRIPTION
Pinned while running the full Python suite for another branch; all three are independent of it.

- `test_asset_manager_panel.py`: the `lf.ui` fake predates `PanelOption` (#1629) and `set_save_asset_callback`, so 34 of its 39 tests died at import. The fake now has both; no assertion needed changing.
- Startup chooser: `_open_path` compared the recovery outcome inside the same `try` that treats any exception as an open failure. When `ProjectOpenOutcome` is unavailable (the test fake, or a stripped runtime) a successful open was reported as an error and the chooser never dismissed. The enum is now resolved after `project_open` returns, so a successful open always dismisses and only a pending recovery prompt keeps the chooser up.
- `conftest.isolate_lichtfeld_module_overrides`: it restored `sys.modules` but left re-imported submodules bound on their parent packages, so after `test_plugin_api_surface` the `lfs_plugins.types` attribute and the module `register_class` imports were different objects and 14 property-schema tests failed with "cls must be a subclass of Panel, Operator, or Menu". Teardown now rebinds restored modules onto their parents.

Verified: the three files pass alone and in both orders of the leaking pair, and the full suite (`tests/python`, minus the GL-bound icon cache test) is 1553 passed / 53 skipped / 0 failed.