### PR TITLE
Trim backward blend dispatch to the cull modes that are actually used

### DIFF
--- a/src/training/rasterization/fastgs/rasterization/include/kernels_backward.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernels_backward.cuh
@@ -457,6 +457,11 @@ namespace fast_lfs::rasterization::kernels::backward {
         return {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
     }
 
+    // Reverse-order index into [0, T_eff): high contributor first.
+    __device__ __forceinline__ int reverse_tile_primitive_idx(const int T_eff, const int reverse_i) {
+        return T_eff - reverse_i - 1;
+    }
+
     // ---------------------------------------------------------------------------
     // blend_backward_cu — warp-level sub-tile culling reverse walk.
     //
@@ -660,11 +665,11 @@ namespace fast_lfs::rasterization::kernels::backward {
         float pixel_error1 = 1.0f;
         if constexpr (DENSIFICATION_TYPE != DensificationType::None) {
             if constexpr (DENSIFICATION_TYPE == DensificationType::MCMC) {
-                pixel_error0 = densification_error_map[pixel_idx0];
-                pixel_error1 = densification_error_map[pixel_idx1];
+                pixel_error0 = inside0 ? densification_error_map[pixel_idx0] : 1.0f;
+                pixel_error1 = inside1 ? densification_error_map[pixel_idx1] : 1.0f;
             } else if (densification_error_map != nullptr) {
-                pixel_error0 = densification_error_map[pixel_idx0];
-                pixel_error1 = densification_error_map[pixel_idx1];
+                pixel_error0 = inside0 ? densification_error_map[pixel_idx0] : 1.0f;
+                pixel_error1 = inside1 ? densification_error_map[pixel_idx1] : 1.0f;
             }
         }
 
@@ -695,14 +700,13 @@ namespace fast_lfs::rasterization::kernels::backward {
         const bool stage_depth = grad_depth_map != nullptr;
 
         // Reverse walk: batch_base is reverse-order index into [0, T_eff).
-        // tile_primitive_idx = T_eff - reverse_i - 1  (high index first).
         for (int batch_base = 0; batch_base < T_eff; batch_base += batch_size) {
             const int n_batch = min(batch_size, T_eff - batch_base);
 
             // Collaborative fetch (one block.sync per batch — not per splat).
             if (static_cast<int>(thread_rank) < n_batch) {
                 const int reverse_i = batch_base + static_cast<int>(thread_rank);
-                const int tile_primitive_idx = T_eff - reverse_i - 1;
+                const int tile_primitive_idx = reverse_tile_primitive_idx(T_eff, reverse_i);
                 const uint instance_idx =
                     tile_instance_range.x + static_cast<uint>(tile_primitive_idx);
                 uint primitive_idx = instance_primitive_indices[instance_idx];
@@ -806,7 +810,7 @@ namespace fast_lfs::rasterization::kernels::backward {
                             continue;
                     }
 
-                    const int tile_primitive_idx = T_eff - batch_base - j - 1;
+                    const int tile_primitive_idx = reverse_tile_primitive_idx(T_eff, batch_base + j);
                     const uint primitive_idx = s_prim_idx[j];
                     const float2 mean2d = s_mean2d[j];
                     const float4 conic_opacity = s_conic_opacity[j];

--- a/src/training/rasterization/fastgs/rasterization/src/backward.cu
+++ b/src/training/rasterization/fastgs/rasterization/src/backward.cu
@@ -77,9 +77,13 @@ void fast_lfs::rasterization::backward(
         const int warp_cull_mode = warp_cull_mode_for_testing();
         const int blend_batch_override = blend_batch_size_for_testing();
 
-        // Backward blend (template dispatch eliminates densification branch from inner loop)
-        auto launch_blend_backward_typed = [&]<DensificationType DENS_TYPE, bool NORMAL_CHANNEL>() {
-            auto launch_cull = [&]<int WARP_CULL_MODE>() {
+        // Backward blend (template dispatch eliminates densification branch from inner loop).
+        // Production instantiates WARP_CULL_MODE=0 only (3 dens × 2 normal = 6).
+        // Modes 1/2 are test-only (set_warp_cull_mode_for_testing); WarpCullBwd drives
+        // DensificationType::None and no normal channel, so those two stay off the
+        // production nest.
+        auto launch_blend_backward_typed =
+            [&]<DensificationType DENS_TYPE, bool NORMAL_CHANNEL, int WARP_CULL_MODE>() {
                 kernels::backward::blend_backward_cu<DENS_TYPE, NORMAL_CHANNEL, WARP_CULL_MODE>
                     <<<n_tiles, config::block_size_blend_backward, 0, stream>>>(
                         per_tile_buffers.instance_ranges,
@@ -114,26 +118,23 @@ void fast_lfs::rasterization::backward(
                         blend_batch_override);
                 LFS_CUDA_LAUNCH_CHECK(stream, "fastgs.backward.blend_backward");
             };
-            if (warp_cull_mode == 1)
-                launch_cull.template operator()<1>();
-            else if (warp_cull_mode == 2)
-                launch_cull.template operator()<2>();
-            else
-                launch_cull.template operator()<0>();
-        };
-        auto launch_blend_backward = [&]<DensificationType DENS_TYPE>() {
+        auto launch_production = [&]<DensificationType DENS_TYPE>() {
             if (grad_normal != nullptr && grad_normal_helper != nullptr) {
-                launch_blend_backward_typed.template operator()<DENS_TYPE, true>();
+                launch_blend_backward_typed.template operator()<DENS_TYPE, true, 0>();
             } else {
-                launch_blend_backward_typed.template operator()<DENS_TYPE, false>();
+                launch_blend_backward_typed.template operator()<DENS_TYPE, false, 0>();
             }
         };
-        if (densification_type == DensificationType::MRNF && densification_info != nullptr) {
-            launch_blend_backward.template operator()<DensificationType::MRNF>();
+        if (warp_cull_mode == 1) {
+            launch_blend_backward_typed.template operator()<DensificationType::None, false, 1>();
+        } else if (warp_cull_mode == 2) {
+            launch_blend_backward_typed.template operator()<DensificationType::None, false, 2>();
+        } else if (densification_type == DensificationType::MRNF && densification_info != nullptr) {
+            launch_production.template operator()<DensificationType::MRNF>();
         } else if (densification_info != nullptr && densification_error_map != nullptr) {
-            launch_blend_backward.template operator()<DensificationType::MCMC>();
+            launch_production.template operator()<DensificationType::MCMC>();
         } else {
-            launch_blend_backward.template operator()<DensificationType::None>();
+            launch_production.template operator()<DensificationType::None>();
         }
         check_cuda_with_fastgs_status(cudaGetLastError(), "blend_backward", fastgs_status, "blend_backward", static_cast<uint64_t>(n_primitives), n_tiles_u64);
         sync_fastgs_phase_if_requested("blend_backward", fastgs_status, "blend_backward", static_cast<uint64_t>(n_primitives), n_tiles_u64);


### PR DESCRIPTION
Follow-up to #1762 from the critical review of that change (the review landed after the merge, so this is the polish as its own PR).

- The culling mode became a compile-time parameter in #1762, which made the build emit 18 backward blend kernel variants. Only mode 0 is used in production; modes 1 and 2 exist for the warp-cull tests. Production dispatch now instantiates mode 0 only and the two test modes stay reachable exactly where those tests need them: 18 variants down to 8, smaller object, slightly faster compile.
- The hoisted per-pixel error read is now explicitly guarded for off-image pixels (it was in bounds before only because the index is clamped).
- The reverse-walk index formula lives in one helper instead of two places.

Gradients are unchanged (bit-identical). Registers unchanged at 64; one variant's stack usage dropped from 40 to 8 bytes. 120 rasterizer and gradient tests green.