### PR TITLE
Use the same fast-math flags on every platform

### DIFF
--- a/src/training/rasterization/edge_compute/CMakeLists.txt
+++ b/src/training/rasterization/edge_compute/CMakeLists.txt
@@ -45,6 +45,10 @@ target_compile_options(edge_compute_backend PRIVATE
   $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Debug>>:-O0 -g -lineinfo -Xcompiler=/Od -Xcompiler=/Z7>
   $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:-O3 --use_fast_math --expt-relaxed-constexpr --diag-suppress=20012,186,221 -Xcompiler=/O2 -Xcompiler=/DNDEBUG>
 
+  # CUDA device code for non-Windows (same device flags as the MSVC branch)
+  $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<CONFIG:Debug>>:-O0 -g -lineinfo>
+  $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<CONFIG:Release>>:-O3 --use_fast_math --expt-relaxed-constexpr --diag-suppress=20012,186,221>
+
   # CUDA on Windows: Pass /utf-8 to MSVC when invoked by nvcc
   $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CXX_COMPILER_ID:MSVC>>:
     -Xcompiler=/utf-8

--- a/src/training/rasterization/fastgs/CMakeLists.txt
+++ b/src/training/rasterization/fastgs/CMakeLists.txt
@@ -48,6 +48,10 @@ target_compile_options(fastlfs_backend PRIVATE
   $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Debug>>:-O0 -g -lineinfo -Xcompiler=/Od -Xcompiler=/Z7>
   $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:-O3 --use_fast_math --expt-relaxed-constexpr --diag-suppress=20012,186,221 -Xcompiler=/O2 -Xcompiler=/DNDEBUG>
 
+  # CUDA device code for non-Windows (same device flags as the MSVC branch)
+  $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<CONFIG:Debug>>:-O0 -g -lineinfo>
+  $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<CONFIG:Release>>:-O3 --use_fast_math --expt-relaxed-constexpr --diag-suppress=20012,186,221>
+
   # CUDA on Windows: Pass /utf-8 to MSVC when invoked by nvcc
   $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CXX_COMPILER_ID:MSVC>>:
     -Xcompiler=/utf-8


### PR DESCRIPTION
Fixes #1763.

The training rasterizers (fastgs and edge-compute) compiled with fast-math on Windows but with exact IEEE math on Linux and macOS, so the platforms trained with different numerics and Linux paid roughly ten instructions per division. The Linux and macOS Release builds now get the same device flags as the MSVC branch (Debug keeps -O0 -g).

Measured before merging, Linux, RTX 4080:
- All gradient-check, rasterizer, warp-cull, boundary, loss and training-setup suites green with unchanged tolerances (observed gradient errors well inside the existing bars).
- bonsai 2000-iter bench, 3 runs each: 3.858 to 3.778 ms/iter (-2.1%).
- bonsai 30k at 500k cap: PSNR 32.476 vs 32.445 (-0.03 dB), SSIM unchanged.

Nothing changes for Windows.