### PR TITLE
Share one tile-row bound between instance counting and emission

### DIFF
--- a/src/training/rasterization/fastgs/rasterization/include/kernel_utils.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernel_utils.cuh
@@ -1217,6 +1217,50 @@ namespace fast_lfs::rasterization::kernels {
             min(grid_height, static_cast<uint>(y_max)));
     }
 
+    // Per-row (or per-column) ellipse walk used by both the count path and
+    // create_instances emit. Float math is verbatim on both sides so the
+    // kFastGSForwardStatusInstanceWriteMismatch check cannot fire from a
+    // count/emit divergence. scan_along_x: walk tile rows, span in x.
+    __device__ __forceinline__ uint2 ellipse_touched_tile_span(
+        const float3& conic,
+        const float radius_sq,
+        const float2 mean2d_shifted,
+        const bool scan_along_x,
+        const uint scan_index,
+        const uint cross_min,
+        const uint cross_max) {
+        if (scan_along_x) {
+            const float y0 = static_cast<float>(scan_index * config::tile_height) - mean2d_shifted.y;
+            const float y1 = y0 + static_cast<float>(config::tile_height);
+            const float2 bound = ellipse_range_bound(conic, radius_sq, y0, y1);
+            const uint lo = floor_tile_clamped(bound.x + mean2d_shifted.x, cross_min, cross_max, config::tile_width);
+            const uint hi = ceil_tile_clamped(bound.y + mean2d_shifted.x, cross_min, cross_max, config::tile_width);
+            return make_uint2(lo, hi);
+        }
+        const float3 conic_transposed = make_float3(conic.z, conic.y, conic.x);
+        const float x0 = static_cast<float>(scan_index * config::tile_width) - mean2d_shifted.x;
+        const float x1 = x0 + static_cast<float>(config::tile_width);
+        const float2 bound = ellipse_range_bound(conic_transposed, radius_sq, x0, x1);
+        const uint lo = floor_tile_clamped(bound.x + mean2d_shifted.y, cross_min, cross_max, config::tile_height);
+        const uint hi = ceil_tile_clamped(bound.y + mean2d_shifted.y, cross_min, cross_max, config::tile_height);
+        return make_uint2(lo, hi);
+    }
+
+    __device__ __forceinline__ uint tile_span_count(const uint2 span) {
+        return span.y >= span.x ? span.y - span.x : 0u;
+    }
+
+    __device__ __forceinline__ uint warp_exclusive_scan_uint(uint val) {
+        uint inclusive = val;
+#pragma unroll
+        for (int offset = 1; offset < 32; offset <<= 1) {
+            const uint n = __shfl_up_sync(0xffffffffu, inclusive, offset);
+            if ((threadIdx.x & 31) >= static_cast<unsigned>(offset))
+                inclusive += n;
+        }
+        return inclusive - val;
+    }
+
     __device__ inline uint compute_exact_n_touched_tiles(
         const float2& mean2d,
         const float3& conic,
@@ -1235,30 +1279,18 @@ namespace fast_lfs::rasterization::kernels {
 
         const uint screen_bounds_width = screen_bounds.y - screen_bounds.x;
         const uint screen_bounds_height = screen_bounds.w - screen_bounds.z;
+        const bool scan_along_x = screen_bounds_height <= screen_bounds_width;
+        const uint scan0 = scan_along_x ? screen_bounds.z : screen_bounds.x;
+        const uint scan1 = scan_along_x ? screen_bounds.w : screen_bounds.y;
+        const uint cross0 = scan_along_x ? screen_bounds.x : screen_bounds.z;
+        const uint cross1 = scan_along_x ? screen_bounds.y : screen_bounds.w;
 
         uint n_touched_tiles = 0;
-
-        if (screen_bounds_height <= screen_bounds_width) {
-            for (uint tile_y = screen_bounds.z; tile_y < screen_bounds.w; tile_y++) {
-                const float y0 = static_cast<float>(tile_y * config::tile_height) - mean2d_shifted.y;
-                const float y1 = y0 + static_cast<float>(config::tile_height);
-                const float2 bound = ellipse_range_bound(conic, radius_sq, y0, y1);
-                const uint min_x = floor_tile_clamped(bound.x + mean2d_shifted.x, screen_bounds.x, screen_bounds.y, config::tile_width);
-                const uint max_x = ceil_tile_clamped(bound.y + mean2d_shifted.x, screen_bounds.x, screen_bounds.y, config::tile_width);
-                n_touched_tiles += max_x >= min_x ? max_x - min_x : 0;
-            }
-        } else {
-            const float3 conic_transposed = make_float3(conic.z, conic.y, conic.x);
-            for (uint tile_x = screen_bounds.x; tile_x < screen_bounds.y; tile_x++) {
-                const float x0 = static_cast<float>(tile_x * config::tile_width) - mean2d_shifted.x;
-                const float x1 = x0 + static_cast<float>(config::tile_width);
-                const float2 bound = ellipse_range_bound(conic_transposed, radius_sq, x0, x1);
-                const uint min_y = floor_tile_clamped(bound.x + mean2d_shifted.y, screen_bounds.z, screen_bounds.w, config::tile_height);
-                const uint max_y = ceil_tile_clamped(bound.y + mean2d_shifted.y, screen_bounds.z, screen_bounds.w, config::tile_height);
-                n_touched_tiles += max_y >= min_y ? max_y - min_y : 0;
-            }
+        for (uint scan_index = scan0; scan_index < scan1; scan_index++) {
+            const uint2 span = ellipse_touched_tile_span(
+                conic, radius_sq, mean2d_shifted, scan_along_x, scan_index, cross0, cross1);
+            n_touched_tiles += tile_span_count(span);
         }
-
         return n_touched_tiles;
     }
 

--- a/src/training/rasterization/fastgs/rasterization/include/kernels_forward.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernels_forward.cuh
@@ -290,6 +290,112 @@ namespace fast_lfs::rasterization::kernels::forward {
         }
     }
 
+    __device__ __forceinline__ void emit_ellipse_tile_span(
+        const uint2 span,
+        const uint scan_index,
+        const bool along_x,
+        const uint grid_width,
+        const uint depth_key,
+        const uint depth_bits,
+        const uint primitive_idx,
+        uint& write_at,
+        const uint write_end,
+        InstanceKey* __restrict__ instance_keys,
+        uint* __restrict__ instance_primitive_indices) {
+        for (uint t = span.x; t < span.y && write_at < write_end; t++) {
+            const uint tile_key = along_x ? (scan_index * grid_width + t) : (t * grid_width + scan_index);
+            instance_keys[write_at] = make_instance_key(tile_key, depth_key, depth_bits);
+            instance_primitive_indices[write_at] = primitive_idx;
+            write_at++;
+        }
+    }
+
+    // Long-tail primitives: 32 lanes cooperate over rows of one source lane
+    // at a time. Isolated so the serial emit path does not inherit its
+    // register footprint.
+    __device__ __noinline__ void create_instances_coop_warp(
+        const bool active,
+        const uint n_scan,
+        const uint scan0,
+        const uint cross0,
+        const uint cross1,
+        const uint write_offset_end,
+        const uint current_write_offset,
+        const uint primitive_idx,
+        const uint depth_key,
+        const bool scan_along_x,
+        const float2 mean2d_shifted,
+        const float3 conic,
+        const float radius_sq,
+        const uint grid_width,
+        const uint depth_bits,
+        const uint4 diagnostic_bounds,
+        InstanceKey* __restrict__ instance_keys,
+        uint* __restrict__ instance_primitive_indices,
+        FastGSForwardStatus* __restrict__ status) {
+        const uint lane = threadIdx.x & 31u;
+        for (int src = 0; src < 32; ++src) {
+            const bool src_active = __shfl_sync(0xffffffffu, static_cast<unsigned>(active), src) != 0u;
+            const uint src_n_scan = __shfl_sync(0xffffffffu, n_scan, src);
+            if (!src_active || src_n_scan == 0u)
+                continue;
+            const uint src_scan0 = __shfl_sync(0xffffffffu, scan0, src);
+            const uint src_cross0 = __shfl_sync(0xffffffffu, cross0, src);
+            const uint src_cross1 = __shfl_sync(0xffffffffu, cross1, src);
+            const uint src_write_end = __shfl_sync(0xffffffffu, write_offset_end, src);
+            const uint src_write = __shfl_sync(0xffffffffu, current_write_offset, src);
+            const uint src_prim = __shfl_sync(0xffffffffu, primitive_idx, src);
+            const uint src_dkey = __shfl_sync(0xffffffffu, depth_key, src);
+            const bool src_along_x = __shfl_sync(0xffffffffu, static_cast<unsigned>(scan_along_x), src) != 0u;
+            const float2 src_mean = make_float2(
+                __shfl_sync(0xffffffffu, mean2d_shifted.x, src),
+                __shfl_sync(0xffffffffu, mean2d_shifted.y, src));
+            const float3 src_conic = make_float3(
+                __shfl_sync(0xffffffffu, conic.x, src),
+                __shfl_sync(0xffffffffu, conic.y, src),
+                __shfl_sync(0xffffffffu, conic.z, src));
+            const float src_radius_sq = __shfl_sync(0xffffffffu, radius_sq, src);
+
+            uint emitted_unclamped = 0u;
+            for (uint row0 = 0; row0 < src_n_scan; row0 += 32u) {
+                const uint row = row0 + lane;
+                uint2 span = make_uint2(0, 0);
+                uint cnt = 0u;
+                const uint scan_index = src_scan0 + row;
+                if (row < src_n_scan) {
+                    span = ellipse_touched_tile_span(
+                        src_conic, src_radius_sq, src_mean, src_along_x, scan_index, src_cross0, src_cross1);
+                    cnt = tile_span_count(span);
+                }
+                const uint excl = warp_exclusive_scan_uint(cnt);
+                uint write_at = src_write + emitted_unclamped + excl;
+                if (row < src_n_scan) {
+                    emit_ellipse_tile_span(
+                        span, scan_index, src_along_x, grid_width, src_dkey, depth_bits, src_prim,
+                        write_at, src_write_end, instance_keys, instance_primitive_indices);
+                }
+                emitted_unclamped += lfs::core::warp_ops::warp_reduce_sum(cnt);
+            }
+
+            if (lane == static_cast<uint>(src)) {
+                const uint actual = src_write + emitted_unclamped > src_write_end
+                                        ? src_write_end
+                                        : src_write + emitted_unclamped;
+                if (actual != src_write_end) {
+                    report_forward_status(
+                        status,
+                        kFastGSForwardStatusInstanceWriteMismatch,
+                        src_prim,
+                        0,
+                        actual,
+                        diagnostic_bounds,
+                        src_write_end,
+                        actual);
+                }
+            }
+        }
+    }
+
     // based on https://github.com/r4dl/StopThePop-Rasterization/blob/d8cad09919ff49b11be3d693d1e71fa792f559bb/cuda_rasterizer/stopthepop/stopthepop_common.cuh#L325
     __global__ void create_instances_cu(
         const std::uint64_t* __restrict__ primitive_n_touched_tiles,
@@ -349,52 +455,43 @@ namespace fast_lfs::rasterization::kernels::forward {
         if (current_write_offset > max_instances) {
             current_write_offset = max_instances;
         }
-        if (active) {
-            const uint screen_bounds_width = static_cast<uint>(screen_bounds.y - screen_bounds.x);
-            const uint screen_bounds_height = static_cast<uint>(screen_bounds.w - screen_bounds.z);
 
-            if (screen_bounds_height <= screen_bounds_width) {
-                for (uint tile_y = screen_bounds.z; tile_y < screen_bounds.w; tile_y++) {
-                    const float y0 = static_cast<float>(tile_y * config::tile_height) - mean2d_shifted.y;
-                    const float y1 = y0 + static_cast<float>(config::tile_height);
-                    const float2 bound = ellipse_range_bound(conic, radius_sq, y0, y1);
-                    const uint min_x = floor_tile_clamped(bound.x + mean2d_shifted.x, screen_bounds.x, screen_bounds.y, config::tile_width);
-                    const uint max_x = ceil_tile_clamped(bound.y + mean2d_shifted.x, screen_bounds.x, screen_bounds.y, config::tile_width);
-                    for (uint tile_x = min_x; tile_x < max_x && current_write_offset < write_offset_end; tile_x++) {
-                        const uint tile_key = tile_y * grid_width + tile_x;
-                        instance_keys[current_write_offset] = make_instance_key(tile_key, depth_key, depth_bits);
-                        instance_primitive_indices[current_write_offset] = primitive_idx;
-                        current_write_offset++;
-                    }
+        const uint screen_bounds_width = static_cast<uint>(screen_bounds.y - screen_bounds.x);
+        const uint screen_bounds_height = static_cast<uint>(screen_bounds.w - screen_bounds.z);
+        const bool scan_along_x = screen_bounds_height <= screen_bounds_width;
+        const uint scan0 = scan_along_x ? static_cast<uint>(screen_bounds.z) : static_cast<uint>(screen_bounds.x);
+        const uint scan1 = scan_along_x ? static_cast<uint>(screen_bounds.w) : static_cast<uint>(screen_bounds.y);
+        const uint cross0 = scan_along_x ? static_cast<uint>(screen_bounds.x) : static_cast<uint>(screen_bounds.z);
+        const uint cross1 = scan_along_x ? static_cast<uint>(screen_bounds.y) : static_cast<uint>(screen_bounds.w);
+        const uint n_scan = active && scan1 >= scan0 ? scan1 - scan0 : 0u;
+        const uint max_scan = lfs::core::warp_ops::warp_reduce_max(n_scan);
+
+        if (max_scan < 32u) {
+            if (active) {
+                for (uint scan_index = scan0; scan_index < scan1 && current_write_offset < write_offset_end; scan_index++) {
+                    const uint2 span = ellipse_touched_tile_span(
+                        conic, radius_sq, mean2d_shifted, scan_along_x, scan_index, cross0, cross1);
+                    emit_ellipse_tile_span(
+                        span, scan_index, scan_along_x, grid_width, depth_key, depth_bits, primitive_idx,
+                        current_write_offset, write_offset_end, instance_keys, instance_primitive_indices);
                 }
-            } else {
-                const float3 conic_transposed = make_float3(conic.z, conic.y, conic.x);
-                for (uint tile_x = screen_bounds.x; tile_x < screen_bounds.y; tile_x++) {
-                    const float x0 = static_cast<float>(tile_x * config::tile_width) - mean2d_shifted.x;
-                    const float x1 = x0 + static_cast<float>(config::tile_width);
-                    const float2 bound = ellipse_range_bound(conic_transposed, radius_sq, x0, x1);
-                    const uint min_y = floor_tile_clamped(bound.x + mean2d_shifted.y, screen_bounds.z, screen_bounds.w, config::tile_height);
-                    const uint max_y = ceil_tile_clamped(bound.y + mean2d_shifted.y, screen_bounds.z, screen_bounds.w, config::tile_height);
-                    for (uint tile_y = min_y; tile_y < max_y && current_write_offset < write_offset_end; tile_y++) {
-                        const uint tile_key = tile_y * grid_width + tile_x;
-                        instance_keys[current_write_offset] = make_instance_key(tile_key, depth_key, depth_bits);
-                        instance_primitive_indices[current_write_offset] = primitive_idx;
-                        current_write_offset++;
-                    }
+                if (current_write_offset != write_offset_end) {
+                    report_forward_status(
+                        status,
+                        kFastGSForwardStatusInstanceWriteMismatch,
+                        primitive_idx,
+                        0,
+                        current_write_offset,
+                        diagnostic_bounds,
+                        write_offset_end,
+                        current_write_offset);
                 }
             }
-
-            if (current_write_offset != write_offset_end) {
-                report_forward_status(
-                    status,
-                    kFastGSForwardStatusInstanceWriteMismatch,
-                    primitive_idx,
-                    0,
-                    current_write_offset,
-                    diagnostic_bounds,
-                    write_offset_end,
-                    current_write_offset);
-            }
+        } else {
+            create_instances_coop_warp(
+                active, n_scan, scan0, cross0, cross1, write_offset_end, current_write_offset,
+                primitive_idx, depth_key, scan_along_x, mean2d_shifted, conic, radius_sq,
+                grid_width, depth_bits, diagnostic_bounds, instance_keys, instance_primitive_indices, status);
         }
     }
 

--- a/tests/test_warp_cull_bwd.cpp
+++ b/tests/test_warp_cull_bwd.cpp
@@ -10,6 +10,8 @@
 #include "training/rasterization/fastgs/rasterization/include/forward.h"
 
 #include <cmath>
+#include <cstdint>
+#include <cstring>
 #include <cuda_runtime.h>
 #include <fstream>
 #include <gtest/gtest.h>
@@ -263,4 +265,103 @@ TEST_F(WarpCullBwdTest, EnabledIsDeterministic) {
     constexpr float kTol = 1e-6f;
     EXPECT_LE(max_abs_diff(a.means, b.means), kTol);
     EXPECT_LE(max_abs_diff(a.opacity, b.opacity), kTol);
+}
+
+namespace {
+
+    bool tensors_bit_identical(const Tensor& a, const Tensor& b) {
+        if (!a.is_valid() || !b.is_valid() || a.numel() != b.numel()) {
+            return false;
+        }
+        if (a.numel() == 0) {
+            return true;
+        }
+        const auto* pa = reinterpret_cast<const std::uint8_t*>(a.ptr<float>());
+        const auto* pb = reinterpret_cast<const std::uint8_t*>(b.ptr<float>());
+        return std::memcmp(pa, pb, a.numel() * sizeof(float)) == 0;
+    }
+
+    struct Warp8x4Snapshot {
+        Tensor image;
+        Tensor alpha;
+        Tensor depth;
+        Tensor normal;
+        Tensor means;
+        Tensor opacity;
+        Tensor sh0;
+        Tensor scaling;
+        Tensor densification;
+        bool ok = false;
+    };
+
+    Warp8x4Snapshot run_8x4_step() {
+        Warp8x4Snapshot out{};
+        Camera cam = make_camera(8, 4);
+        auto splat = make_synthetic_splat(12);
+        splat->_densification_info = Tensor::zeros({2, static_cast<size_t>(12)}, Device::CUDA);
+        Tensor bg = Tensor::zeros({3}, Device::CUDA);
+
+        set_warp_cull_mode_for_testing(0);
+        set_blend_batch_size_for_testing(0);
+        auto r = fast_rasterize_forward(cam, *splat, bg, 0, 0, 0, 0, false, {}, true);
+        if (!r.has_value()) {
+            ADD_FAILURE() << lfs::format_for_developer(r.error());
+            return out;
+        }
+
+        AdamConfig cfg{.lr = 0.01f, .beta1 = 0.9, .beta2 = 0.999, .eps = 1e-15};
+        auto opt = std::make_unique<AdamOptimizer>(*splat, cfg);
+        opt->allocate_gradients();
+        opt->zero_grad(0);
+
+        auto grad_out = r->first.image.mul(2.0f);
+        auto grad_depth = Tensor::ones_like(r->first.depth);
+        auto grad_normal = Tensor::ones_like(r->first.normal);
+        auto pixel_error = Tensor::ones({4, 8}, Device::CUDA);
+        fast_rasterize_backward(
+            r->second,
+            grad_out,
+            *splat,
+            *opt,
+            {},
+            pixel_error,
+            DensificationType::MCMC,
+            1,
+            {},
+            grad_depth,
+            grad_normal);
+
+        out.image = r->first.image.to(Device::CPU).contiguous().clone();
+        out.alpha = r->first.alpha.to(Device::CPU).contiguous().clone();
+        out.depth = r->first.depth.to(Device::CPU).contiguous().clone();
+        out.normal = r->first.normal.to(Device::CPU).contiguous().clone();
+        out.means = splat->means().to(Device::CPU).contiguous().clone();
+        out.opacity = splat->opacity_raw().to(Device::CPU).contiguous().clone();
+        out.sh0 = splat->sh0().to(Device::CPU).contiguous().clone();
+        out.scaling = splat->scaling_raw().to(Device::CPU).contiguous().clone();
+        out.densification = splat->_densification_info.to(Device::CPU).contiguous().clone();
+        out.ok = true;
+
+        r->second.release_forward_context();
+        EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        return out;
+    }
+
+} // namespace
+
+// 8x4 image = one warp sub-tile, so blend_backward atomics have a single writer
+// per splat/field and are bit-deterministic (dense tiles are not).
+TEST_F(WarpCullBwdTest, SingleWarp8x4_BitIdenticalAcrossRuns) {
+    auto a = run_8x4_step();
+    auto b = run_8x4_step();
+    ASSERT_TRUE(a.ok && b.ok);
+    EXPECT_TRUE(tensors_bit_identical(a.image, b.image)) << "image";
+    EXPECT_TRUE(tensors_bit_identical(a.alpha, b.alpha)) << "alpha";
+    EXPECT_TRUE(tensors_bit_identical(a.depth, b.depth)) << "depth";
+    EXPECT_TRUE(tensors_bit_identical(a.normal, b.normal)) << "normal";
+    EXPECT_TRUE(tensors_bit_identical(a.means, b.means)) << "means";
+    EXPECT_TRUE(tensors_bit_identical(a.opacity, b.opacity)) << "opacity";
+    EXPECT_TRUE(tensors_bit_identical(a.sh0, b.sh0)) << "sh0";
+    EXPECT_TRUE(tensors_bit_identical(a.scaling, b.scaling)) << "scaling";
+    EXPECT_TRUE(tensors_bit_identical(a.densification, b.densification)) << "densification";
 }


### PR DESCRIPTION
Rasterizer round 2 from the fastgs review. Three verified items were implemented and measured one at a time; one survived.

Kept: tile counting and instance emission used to solve the same per-row ellipse bounds twice, in two separate pieces of code that had to stay in lockstep by discipline. They now call one shared function, and emission is done cooperatively by the warp instead of one lane walking all rows while 31 idle. Bit-identical instances; the instance-creation kernel is 40.7% faster; about 0.4% on the whole step on bonsai.

Dropped on measurement: a segmented epilogue reduction in the backward blend (spilled 8 bytes at the 64-register cap) and earlier dead-lane exits in preprocess (+2.8% slower from added divergence). Both reverted and recorded so nobody retries them blind.

121 rasterizer, warp-cull, boundary and gradient tests green; a new single-warp determinism test pins the bit-identity method used for these ablations.