### PR TITLE
Log when adding a keyframe replaces an existing one

### DIFF
--- a/src/visualizer/gui/sequencer_ui_manager.cpp
+++ b/src/visualizer/gui/sequencer_ui_manager.cpp
@@ -378,6 +378,7 @@ namespace lfs::vis::gui {
                                                           std::abs(kf.time - time) < REPLACE_EPSILON_S;
                                                });
             if (existing != keyframes.end()) {
+                LOG_INFO("Replaced keyframe {} at t={:.3f}s instead of adding a new one", existing->id, time);
                 controller_.updateKeyframeById(existing->id, position, rotation, focal_mm);
             } else {
                 lfs::sequencer::Keyframe kf;


### PR DESCRIPTION
Adding a keyframe within REPLACE_EPSILON_S (10ms) of an existing one intentionally replaces it, matching Blender/After Effects/Maya. That's fine in the GUI, where you can see it happen, but the same event handler backs the MCP `sequencer.add_keyframe` tool, so a script adding a batch of keyframes can lose some of them with no signal at all. This is easy to hit because SequencerController::seek clamps to the clip duration, so several adds beyond the end of the clip can land on the same clamped playhead and collapse into one keyframe.

This adds a LOG_INFO in the replace branch of cmd::SequencerAddKeyframe::when, naming the replaced keyframe id and the time, so a caller can at least find the swap in the log even though nothing in the MCP response signals it directly.

No existing test reaches this handler: the sequencer MCP tool tests build their own lightweight FakeSequencerBackend that doesn't go through SequencerUIManager, and nothing else instantiates it either. I verified the fix by reading: the replace/add branch itself is unchanged, the log line sits directly on the path already taken when `existing != keyframes.end()`, and the live MCP wiring in mcp_gui_tools.cpp emits the exact same cmd::SequencerAddKeyframe event the GUI does, so one log line covers both paths.

Fixes #1544
