### PR TITLE
Keep Morton reorder in place for exportable splat storage

### DIFF
--- a/src/training/morton_reorder.cpp
+++ b/src/training/morton_reorder.cpp
@@ -25,15 +25,6 @@ namespace lfs::training::morton {
         using core::Tensor;
         using core::TensorShape;
 
-        [[nodiscard]] std::size_t prim_capacity(const core::SplatData& splat) {
-            const auto n = static_cast<std::size_t>(splat.size());
-            if (!splat.means().is_valid()) {
-                return n;
-            }
-            const auto cap = splat.means().capacity();
-            return std::max(cap > 0 ? cap : n, n);
-        }
-
         void permute_dim0_prefix(Tensor& tensor, const Tensor& perm) {
             const std::size_t n = perm.numel();
             if (!tensor.is_valid() || tensor.numel() == 0 || n == 0) {
@@ -68,11 +59,10 @@ namespace lfs::training::morton {
             tensor = std::move(dest);
         }
 
-        void permute_named_param(
-            core::SplatData& splat,
-            Tensor& tensor,
-            const Tensor& perm,
-            std::string_view name) {
+        // Gather through a private scratch buffer and copy back into the live
+        // tensor. The exportable allocator returns views at fixed region
+        // offsets per name, so a fresh "allocation" would alias the source.
+        void permute_named_param(Tensor& tensor, const Tensor& perm) {
             const std::size_t n = perm.numel();
             if (!tensor.is_valid() || tensor.numel() == 0 || n == 0) {
                 return;
@@ -81,11 +71,10 @@ namespace lfs::training::morton {
                 permute_dim0_prefix(tensor, perm);
                 return;
             }
-            const std::size_t cap = std::max(tensor.capacity() > 0 ? tensor.capacity() : n, n);
-            Tensor dest = splat.allocate_named_param(tensor.shape(), cap, tensor.dtype(), name);
-            dest.set_stream(tensor.stream());
-            tensor.index_select_into(dest, 0, perm, BoundaryMode::Assert);
-            tensor = std::move(dest);
+            Tensor scratch = Tensor::zeros_direct(tensor.shape(), n, tensor.device(), tensor.dtype());
+            scratch.set_stream(tensor.stream());
+            tensor.index_select_into(scratch, 0, perm, BoundaryMode::Assert);
+            tensor.copy_from(scratch);
         }
 
         void permute_shN(core::SplatData& splat, const Tensor& perm, cudaStream_t stream) {
@@ -105,28 +94,29 @@ namespace lfs::training::morton {
                 return;
             }
 
-            const std::size_t cap = prim_capacity(splat);
             const std::size_t logical = core::sh_swizzled_float_count(n, rest);
-            const std::size_t cap_floats = core::sh_swizzled_float_count(cap, rest);
-            Tensor dest = splat.allocate_named_param(
-                TensorShape({logical}),
-                std::max(logical, cap_floats),
-                DataType::Float32,
-                "SplatData.shN");
-            dest.set_name("splat.shN");
-            dest.set_stream(stream);
+            if (live.numel() < logical) {
+                throw std::runtime_error("Morton reorder: shN storage smaller than its logical size");
+            }
+            Tensor scratch = Tensor::zeros_direct(
+                TensorShape({logical}), logical, Device::CUDA, DataType::Float32);
+            scratch.set_stream(stream);
             if (live.stream() != stream) {
                 live.set_stream(stream);
             }
             core::shN_swizzled_gather_self_i64(
                 live.ptr<float>(),
-                dest.ptr<float>(),
+                scratch.ptr<float>(),
                 perm.ptr<std::int64_t>(),
                 n,
                 0,
                 rest,
                 stream);
-            live = std::move(dest);
+            if (live.numel() == logical) {
+                live.copy_from(scratch);
+            } else {
+                live.slice(0, 0, logical).copy_from(scratch);
+            }
             if (expanded) {
                 (void)sh_value::commit_shN_after_mutation(splat);
             }
@@ -312,11 +302,11 @@ namespace lfs::training::morton {
             return result;
         }
 
-        permute_named_param(splat, splat.means(), result.permutation, "SplatData.means");
-        permute_named_param(splat, splat.sh0(), result.permutation, "SplatData.sh0");
-        permute_named_param(splat, splat.scaling_raw(), result.permutation, "SplatData.scaling");
-        permute_named_param(splat, splat.rotation_raw(), result.permutation, "SplatData.rotation");
-        permute_named_param(splat, splat.opacity_raw(), result.permutation, "SplatData.opacity");
+        permute_named_param(splat.means(), result.permutation);
+        permute_named_param(splat.sh0(), result.permutation);
+        permute_named_param(splat.scaling_raw(), result.permutation);
+        permute_named_param(splat.rotation_raw(), result.permutation);
+        permute_named_param(splat.opacity_raw(), result.permutation);
         permute_shN(splat, result.permutation, stream);
 
         if (splat._densification_info.is_valid() && splat._densification_info.numel() > 0) {

--- a/tests/test_morton_reorder.cpp
+++ b/tests/test_morton_reorder.cpp
@@ -7,6 +7,7 @@
 #include "core/scene.hpp"
 #include "core/sh_value_quant.hpp"
 #include "core/splat_data.hpp"
+#include "core/splat_exportable_storage.hpp"
 #include "core/tensor.hpp"
 #include "lfs/training/joint_adam_codec.hpp"
 #include "lfs/training/morton_reorder.hpp"
@@ -443,20 +444,14 @@ TEST(MortonReorderTest, PermuteWritesNPrimsAndLeavesCapacityTailZero) {
 
     const bool shN_same_storage = splat.shN().data_ptr() == shN_ptr_before;
     const bool bounds_same_storage = splat.shN_value_bounds().data_ptr() == bounds_ptr_before;
-    if (shN_same_storage) {
-        EXPECT_TRUE(bytes_all_equal(shN_tail, kPoison))
-            << "in-place shN capacity tail [n, cap) was overwritten";
-    } else {
-        EXPECT_TRUE(bytes_all_equal(shN_tail, 0))
-            << "replaced shN capacity tail [n, cap) is neither zero nor left untouched";
-    }
-    if (bounds_same_storage) {
-        EXPECT_TRUE(bytes_all_equal(bounds_tail, kPoison))
-            << "in-place shN bounds capacity tail was overwritten";
-    } else {
-        EXPECT_TRUE(bytes_all_equal(bounds_tail, 0))
-            << "replaced shN bounds capacity tail is neither zero nor left untouched";
-    }
+    // In-place storage may keep the poisoned tail or re-zero it (the q16 commit
+    // zero-fills [n, cap)); replaced storage must come back zeroed. Anything else
+    // is a stray write past n.
+    const auto tail_ok = [&](const std::vector<std::uint8_t>& tail, const bool same_storage) {
+        return bytes_all_equal(tail, 0) || (same_storage && bytes_all_equal(tail, kPoison));
+    };
+    EXPECT_TRUE(tail_ok(shN_tail, shN_same_storage)) << "shN capacity tail [n, cap) holds stray data";
+    EXPECT_TRUE(tail_ok(bounds_tail, bounds_same_storage)) << "shN bounds capacity tail holds stray data";
 
     std::vector<std::uint16_t> codes(splat.shN().numel());
     ASSERT_EQ(cudaMemcpy(codes.data(), splat.shN().data_ptr(),
@@ -606,4 +601,66 @@ TEST(MortonReorderTest, TrainingLossStaysContinuousAndCountMatches) {
             << "loss diverged at sample " << i << " off=" << off_losses[i]
             << " on=" << on_losses[i];
     }
+}
+
+// The exportable allocator hands out views at fixed region offsets per parameter
+// name (the GUI renders straight from that block). A permute that gathers into a
+// freshly "allocated" tensor of the same name therefore gathers a buffer into
+// itself; rows must still come out exactly permuted.
+TEST(MortonReorderTest, ExportableAliasingAllocatorPermutesRowsExactly) {
+    constexpr size_t n = 4096;
+    constexpr int sh_degree = 1;
+    auto storage_result = SplatExportableStorage::create(n, sh_degree, 0, n * 2);
+    ASSERT_TRUE(storage_result.has_value()) << storage_result.error();
+    auto storage = std::move(*storage_result);
+
+    auto splat = make_mixed_splat(n, sh_degree);
+    const auto means_before = splat.means().cpu().contiguous();
+    const auto sh0_before = splat.sh0().cpu().contiguous();
+    const auto scale_before = splat.scaling_raw().cpu().contiguous();
+    const auto rot_before = splat.rotation_raw().cpu().contiguous();
+    const auto opa_before = splat.opacity_raw().cpu().contiguous();
+    const auto shN_before = splat.shN_canonical().cpu().contiguous();
+
+    {
+        auto ok = storage.rebindSplatData(splat, storage.make_allocator());
+        ASSERT_TRUE(ok.has_value()) << ok.error();
+    }
+    splat.set_tensor_allocator(storage.make_allocator());
+    ASSERT_TRUE(splat.means().has_exportable_provenance());
+
+    const auto result = morton::apply_morton_reorder(splat, nullptr);
+    ASSERT_TRUE(result.applied);
+    ASSERT_EQ(result.permutation.numel(), n);
+    const auto perm = result.permutation.cpu().contiguous();
+    const auto* ip = perm.ptr<std::int64_t>();
+
+    // Rows must still live in the exportable block after the reorder.
+    EXPECT_TRUE(splat.means().has_exportable_provenance());
+    EXPECT_TRUE(splat.opacity_raw().has_exportable_provenance());
+
+    const auto check_rows = [&](const Tensor& before, const Tensor& after_gpu,
+                                const size_t row_floats, const char* what) {
+        const auto after = after_gpu.cpu().contiguous();
+        const auto* b = before.ptr<float>();
+        const auto* a = after.ptr<float>();
+        size_t mismatches = 0;
+        for (size_t i = 0; i < n; ++i) {
+            const auto src = static_cast<size_t>(ip[i]);
+            for (size_t k = 0; k < row_floats; ++k) {
+                if (a[i * row_floats + k] != b[src * row_floats + k]) {
+                    ++mismatches;
+                    break;
+                }
+            }
+        }
+        EXPECT_EQ(mismatches, 0u) << what << ": " << mismatches << " of " << n
+                                  << " rows differ from the permuted source";
+    };
+    check_rows(means_before, splat.means(), 3, "means");
+    check_rows(sh0_before, splat.sh0(), 3, "sh0");
+    check_rows(scale_before, splat.scaling_raw(), 3, "scaling");
+    check_rows(rot_before, splat.rotation_raw(), 4, "rotation");
+    check_rows(opa_before, splat.opacity_raw(), 1, "opacity");
+    check_rows(shN_before, splat.shN_canonical(), 3 * 3, "shN");
 }


### PR DESCRIPTION
Users reported that the training view turned into empty/transparent splats the moment the Morton reorder ran (every 5000 iterations by default).

In the GUI the model lives in exportable storage that the viewer renders from directly. Its allocator returns a view at a fixed offset for a given parameter name, so the reorder's "allocate a destination under the same name, gather into it" pattern gathered each buffer into itself and corrupted the rows on screen. With quantized SH the fp32 gather target also did not fit the q16 region, so the reorder aborted half-way.

The reorder now gathers through a private scratch buffer and copies the result back into the live tensors, which stay in place. Headless training was never affected (plain CUDA allocator).

Adds a regression test that binds a model to real exportable storage, reorders it and checks every row against the permutation. The capacity-tail test now accepts the in-place re-zeroed tail.

Full suite: 4082 pass; the 5 `VisualizerImplResetTest` failures on this machine are pre-existing (identical on master).