### PR TITLE
Fix HTML viewer measurement tool input handling and resource lookup

### DIFF
--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -397,6 +397,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     endif ()
 endif ()
 
+if(LFS_DEV_IMPORT_SOURCE_RESOURCES AND NOT BUILD_PORTABLE)
+    target_compile_definitions(lfs_io PRIVATE
+        LFS_DEV_VIEWER_SOURCE_DIR="${PROJECT_SOURCE_DIR}/src/visualizer/gui/resources/viewer")
+endif()
+
 if(NOT BUILD_PORTABLE)
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/io
             DESTINATION include)

--- a/src/io/formats/html.cpp
+++ b/src/io/formats/html.cpp
@@ -13,10 +13,13 @@
 #include "sogs.hpp"
 
 #include <cmath>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace lfs::io {
 
@@ -36,8 +39,7 @@ namespace lfs::io {
         }
 
         // Viewer export resources (template/css/js/gizmo/measure-tool) are read
-        // from disk at export time rather than compiled in, so editing them
-        // needs no rebuild and no generated-header round trip.
+        // from disk at export time, so editing them needs no rebuild.
         Result<std::string> read_text_file(const std::filesystem::path& path) {
             std::ifstream file;
             if (!lfs::core::open_file_for_read(path, std::ios::binary, file)) {
@@ -53,17 +55,20 @@ namespace lfs::io {
 
         // Strips a trailing `export { ... };` statement (only whitespace may
         // follow it) so the source can be concatenated into a plain IIFE
-        // instead of a real ES module. Left untouched if not found trailing,
-        // since `export` is otherwise harmless dead syntax to us.
-        std::string strip_trailing_export(std::string_view js, std::string_view export_statement) {
+        // instead of a real ES module. Missing or non-trailing `export` is an
+        // error: inside the IIFE it is a SyntaxError and the viewer never starts.
+        Result<std::string> strip_trailing_export(std::string_view js, std::string_view export_statement,
+                                                  const std::filesystem::path& path) {
             std::string result(js);
             const size_t pos = result.rfind(export_statement);
             if (pos == std::string::npos) {
-                return result;
+                return make_error(ErrorCode::CORRUPTED_DATA,
+                                  "HTML viewer resource has no trailing export statement", path);
             }
             const size_t after = pos + export_statement.size();
             if (result.find_first_not_of(" \t\r\n", after) != std::string::npos) {
-                return result;
+                return make_error(ErrorCode::CORRUPTED_DATA,
+                                  "HTML viewer resource has no trailing export statement", path);
             }
             result.erase(pos);
             return result;
@@ -73,18 +78,47 @@ namespace lfs::io {
         // top-level declarations can't collide with index.js's own (they
         // share index.js's classes/constants only via closure), and exposed
         // via a single `window` hook the template calls after `main()` resolves.
-        std::string build_measure_tool_script(const std::string& gizmo_js, const std::string& measure_tool_js) {
-            const std::string gizmo_body = strip_trailing_export(gizmo_js, "export { Gizmo, TranslateGizmo };");
-            const std::string measure_body = strip_trailing_export(measure_tool_js, "export { initMeasureTool };");
+        Result<std::string> build_measure_tool_script(const std::string& gizmo_js,
+                                                      const std::string& measure_tool_js,
+                                                      const std::filesystem::path& gizmo_path,
+                                                      const std::filesystem::path& measure_tool_path) {
+            auto gizmo_body = strip_trailing_export(gizmo_js, "export { Gizmo, TranslateGizmo };", gizmo_path);
+            if (!gizmo_body) {
+                return std::unexpected(gizmo_body.error());
+            }
+            auto measure_body = strip_trailing_export(measure_tool_js, "export { initMeasureTool };",
+                                                      measure_tool_path);
+            if (!measure_body) {
+                return std::unexpected(measure_body.error());
+            }
 
             std::string wrapped;
-            wrapped.reserve(gizmo_body.size() + measure_body.size() + 128);
+            wrapped.reserve(gizmo_body->size() + measure_body->size() + 128);
             wrapped += "\n(function () {\n";
-            wrapped += gizmo_body;
+            wrapped += *gizmo_body;
             wrapped += "\n";
-            wrapped += measure_body;
+            wrapped += *measure_body;
             wrapped += "\nwindow.__lfsInitMeasureTool = initMeasureTool;\n})();\n";
             return wrapped;
+        }
+
+        Result<std::filesystem::path> resolve_viewer_resources_dir() {
+            std::vector<std::filesystem::path> candidates;
+            candidates.push_back(lfs::core::getViewerResourcesDir());
+#ifdef LFS_DEV_VIEWER_SOURCE_DIR
+            candidates.push_back(lfs::core::utf8_to_path(LFS_DEV_VIEWER_SOURCE_DIR));
+#endif
+            for (const auto& dir : candidates) {
+                if (std::filesystem::exists(dir / "viewer_template.html")) {
+                    return dir;
+                }
+            }
+
+            std::string error_msg = "Cannot find HTML viewer resources.\nSearched in:\n";
+            for (const auto& dir : candidates) {
+                error_msg += "  - " + lfs::core::path_to_utf8(dir) + "\n";
+            }
+            return make_error(ErrorCode::PATH_NOT_FOUND, error_msg);
         }
 
         std::string replace_placeholder(std::string_view input, std::string_view placeholder, std::string_view replacement) {
@@ -125,7 +159,10 @@ namespace lfs::io {
 
         Result<std::string> generate_html(const std::string& base64_sog,
                                           const std::optional<core::ProvenanceStamp>& provenance) {
-            const auto resource_dir = lfs::core::getViewerResourcesDir();
+            auto resource_dir_result = resolve_viewer_resources_dir();
+            if (!resource_dir_result)
+                return std::unexpected(resource_dir_result.error());
+            const auto& resource_dir = *resource_dir_result;
 
             auto tmpl_result = read_text_file(resource_dir / "viewer_template.html");
             if (!tmpl_result)
@@ -143,9 +180,15 @@ namespace lfs::io {
             if (!measure_tool_result)
                 return std::unexpected(measure_tool_result.error());
 
+            auto measure_script_result = build_measure_tool_script(*gizmo_result, *measure_tool_result,
+                                                                   resource_dir / "gizmo.js",
+                                                                   resource_dir / "measure-tool.js");
+            if (!measure_script_result)
+                return std::unexpected(measure_script_result.error());
+
             const auto& tmpl = *tmpl_result;
             const auto& css = *css_result;
-            const std::string js = *js_result + build_measure_tool_script(*gizmo_result, *measure_tool_result);
+            const std::string js = *js_result + *measure_script_result;
 
             std::string html{tmpl};
 

--- a/src/visualizer/gui/resources/viewer/gizmo.js
+++ b/src/visualizer/gui/resources/viewer/gizmo.js
@@ -350,12 +350,14 @@ class Gizmo extends EventHandler {
         this._onPointerDown = this._onPointerDown.bind(this);
         this._onPointerMove = this._onPointerMove.bind(this);
         this._onPointerUp = this._onPointerUp.bind(this);
+        this._onPointerCancel = this._onPointerCancel.bind(this);
         // Capture phase: on the event target itself, capturing listeners run
         // before bubbling ones (see the file header note), so this reliably
         // runs before the viewer's own bubble-phase camera-control listeners.
         this._device.canvas.addEventListener('pointerdown', this._onPointerDown, true);
         this._device.canvas.addEventListener('pointermove', this._onPointerMove, true);
         this._device.canvas.addEventListener('pointerup', this._onPointerUp, true);
+        this._device.canvas.addEventListener('pointercancel', this._onPointerCancel, true);
         this._handles.push(this._app.on('prerender', () => this.prerender()));
         this._handles.push(this._app.on('update', () => this.update()));
         this._handles.push(this._app.on('destroy', () => this.destroy()));
@@ -460,17 +462,27 @@ class Gizmo extends EventHandler {
     }
 
     _onPointerUp(e) {
-        if (!this.enabled || document.pointerLockElement) return;
         if (!this.mouseButtons[e.button]) return;
+        const wasDragging = this._activeDrag;
+        this._activeDrag = false;
+        if (!this.enabled || document.pointerLockElement) return;
         const selection = this._getSelection(e.offsetX, e.offsetY);
-        if (selection[0] || this._activeDrag) {
+        if (selection[0] || wasDragging) {
             if (this.preventDefault) e.preventDefault();
             e.stopImmediatePropagation();
         }
-        this._activeDrag = false;
         const { canvas } = this._device;
         canvas.releasePointerCapture(e.pointerId);
         this.fire(Gizmo.EVENT_POINTERUP, e.offsetX, e.offsetY, selection[0]);
+    }
+
+    _onPointerCancel(e) {
+        this._activeDrag = false;
+        const { canvas } = this._device;
+        canvas.releasePointerCapture(e.pointerId);
+        if (this.enabled) {
+            this.fire(Gizmo.EVENT_POINTERUP, e.offsetX, e.offsetY, null);
+        }
     }
 
     _updatePosition() {
@@ -569,6 +581,7 @@ class Gizmo extends EventHandler {
 
     detach() {
         this.enabled = false;
+        this._activeDrag = false;
         this.fire(Gizmo.EVENT_NODESDETACH);
         this.nodes = [];
     }
@@ -591,6 +604,7 @@ class Gizmo extends EventHandler {
         this._device.canvas.removeEventListener('pointerdown', this._onPointerDown, true);
         this._device.canvas.removeEventListener('pointermove', this._onPointerMove, true);
         this._device.canvas.removeEventListener('pointerup', this._onPointerUp, true);
+        this._device.canvas.removeEventListener('pointercancel', this._onPointerCancel, true);
         this._handles.forEach((handle) => handle.off());
         this.root.destroy();
     }

--- a/src/visualizer/gui/resources/viewer/index.css
+++ b/src/visualizer/gui/resources/viewer/index.css
@@ -259,9 +259,6 @@ button {
   background-color: #222;
   font-size: 13px;
 }
-#measurePanel > #measureLengthUnit {
-  color: #AAA;
-}
 #measurePanel > #measureClear {
   width: 24px;
   height: 24px;

--- a/src/visualizer/gui/resources/viewer/measure-tool.js
+++ b/src/visualizer/gui/resources/viewer/measure-tool.js
@@ -87,10 +87,6 @@ function initMeasureTool(global) {
     lengthInput.step = '0.01';
     lengthInput.min = '0.0001';
 
-    const lengthUnit = document.createElement('span');
-    lengthUnit.id = 'measureLengthUnit';
-    lengthUnit.textContent = 'm';
-
     const clearButton = document.createElement('button');
     clearButton.id = 'measureClear';
     clearButton.type = 'button';
@@ -99,7 +95,6 @@ function initMeasureTool(global) {
 
     panel.appendChild(lengthLabel);
     panel.appendChild(lengthInput);
-    panel.appendChild(lengthUnit);
     panel.appendChild(clearButton);
     panel.addEventListener('pointerdown', (e) => e.stopPropagation());
     document.getElementById('ui').appendChild(panel);
@@ -218,6 +213,7 @@ function initMeasureTool(global) {
     // ---- point picking on click (drag = camera navigation, not a pick) --
     const isPrimary = (e) => (e.pointerType === 'mouse' ? e.button === 0 : e.isPrimary);
     let clicked = false;
+    let picking = false;
     let downX = 0;
     let downY = 0;
 
@@ -237,6 +233,7 @@ function initMeasureTool(global) {
     const onPointerUp = async (e) => {
         if (!active || !clicked || !isPrimary(e)) return;
         clicked = false;
+        if (picking) return;
 
         let closestIdx = -1;
         for (let i = 0; i < points.length; i++) {
@@ -254,16 +251,19 @@ function initMeasureTool(global) {
         }
 
         if (points.length < 2) {
-            e.preventDefault();
-            e.stopPropagation();
             if (!picker) {
                 picker = new Picker(app, camera);
             }
-            const result = await picker.pick(e.offsetX, e.offsetY);
-            if (result) {
-                points.push(result.clone());
-                selection = points.length - 1;
-                syncGizmo();
+            picking = true;
+            try {
+                const result = await picker.pick(e.offsetX, e.offsetY);
+                if (result && points.length < 2) {
+                    points.push(result.clone());
+                    selection = points.length - 1;
+                    syncGizmo();
+                }
+            } finally {
+                picking = false;
             }
         }
     };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1000,6 +1000,15 @@ add_custom_target(run_full_tests
     COMMENT "Running fast and slow tests (excluding nightly)"
 )
 
+foreach(TEST_TARGET lichtfeld_tests)
+    add_custom_command(TARGET ${TEST_TARGET} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${TEST_TARGET}>/resources/viewer"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+            "${PROJECT_SOURCE_DIR}/src/visualizer/gui/resources/viewer"
+            "$<TARGET_FILE_DIR:${TEST_TARGET}>/resources/viewer"
+    )
+endforeach()
+
 # Platform-specific settings
 if(WIN32)
     # Copy Torch DLLs for testing on Windows

--- a/tests/test_python_io.cpp
+++ b/tests/test_python_io.cpp
@@ -1422,6 +1422,12 @@ TEST_F(PythonIOTest, HtmlExport) {
     EXPECT_TRUE(content.find("<!DOCTYPE html>") != std::string::npos ||
                 content.find("<html") != std::string::npos)
         << "Should be valid HTML";
+    EXPECT_TRUE(content.find("window.__lfsInitMeasureTool") != std::string::npos)
+        << "Should embed the measure tool init hook";
+    EXPECT_TRUE(content.find("export { Gizmo, TranslateGizmo };") == std::string::npos)
+        << "Gizmo export statement should be stripped";
+    EXPECT_TRUE(content.find("export { initMeasureTool };") == std::string::npos)
+        << "Measure-tool export statement should be stripped";
 }
 
 TEST_F(PythonIOTest, HtmlExportCancellationKeepsExistingTarget) {


### PR DESCRIPTION
Follow-up to #1773. Fixes the issues found in the second review round, all reproduced in headless Chromium on a real export and re-verified after the fix.

- **Camera follows the mouse after placing a point.** The `stopPropagation()` in the capture-phase pointerup skipped the camera controller's release handler on the same canvas, so its pointer id stayed set and every later mouse move orbited the camera with no button held. Removed.
- **Double-click with one point placed left three points and no panel.** Two picks in flight both pushed. Picks are now serialised and the count is re-checked after the await.
- **Escape mid-drag ate the next drag.** The gizmo's `_activeDrag` flag stayed set because the pointerup returned early while disabled. It is now cleared on detach, on pointerup regardless of enabled state, and on `pointercancel`.
- **A missing trailing `export` in gizmo.js / measure-tool.js produced a page that never starts.** Inside the IIFE it is a syntax error; the exporter now returns an error instead.
- **`export_html` failed from the gtests and the Python module.** The viewer resources are exe-relative and `build/tests` and the vcpkg interpreter have none. Added a dev-build fallback to the source tree (same guard as the locale dev import) and a copy next to `lichtfeld_tests`, so it also works with `LFS_DEV_IMPORT_SOURCE_RESOURCES=OFF`.
- Removed the hard-coded `m` unit label; scene units are whatever the reconstruction produced.

Tests: `PythonIOTest.HtmlExport*` and `ProvenanceTest.HtmlEmbedsStamp` pass (they fail on master); `HtmlExport` now also checks that the init hook is present and the export statements are stripped.
