### PR TITLE
Train fisheye cameras natively on the fastgs rasterizer

### DIFF
--- a/src/core/cuda/undistort/undistort.cu
+++ b/src/core/cuda/undistort/undistort.cu
@@ -746,9 +746,9 @@ namespace lfs::core {
         params.dst_cx = cx * static_cast<float>(params.dst_width) / static_cast<float>(width);
         params.dst_cy = cy * static_cast<float>(params.dst_height) / static_cast<float>(height);
 
-        LOG_INFO("Undistort: %dx%d -> %dx%d, fx=%.1f->%.1f, fy=%.1f->%.1f",
-                 width, height, params.dst_width, params.dst_height,
-                 fx, params.dst_fx, fy, params.dst_fy);
+        LOG_DEBUG("Undistort: %dx%d -> %dx%d, fx=%.1f->%.1f, fy=%.1f->%.1f",
+                  width, height, params.dst_width, params.dst_height,
+                  fx, params.dst_fx, fy, params.dst_fy);
 
         return params;
     }

--- a/src/core/cuda/undistort/undistort.cu
+++ b/src/core/cuda/undistort/undistort.cu
@@ -747,9 +747,9 @@ namespace lfs::core {
         params.dst_cx = cx * static_cast<float>(params.dst_width) / static_cast<float>(width);
         params.dst_cy = cy * static_cast<float>(params.dst_height) / static_cast<float>(height);
 
-        LOG_INFO("Undistort: %dx%d -> %dx%d, fx=%.1f->%.1f, fy=%.1f->%.1f",
-                 width, height, params.dst_width, params.dst_height,
-                 fx, params.dst_fx, fy, params.dst_fy);
+        LOG_DEBUG("Undistort: %dx%d -> %dx%d, fx=%.1f->%.1f, fy=%.1f->%.1f",
+                  width, height, params.dst_width, params.dst_height,
+                  fx, params.dst_fx, fy, params.dst_fy);
 
         return params;
     }

--- a/src/training/kernels/depth_loss.hpp
+++ b/src/training/kernels/depth_loss.hpp
@@ -114,6 +114,8 @@ namespace lfs::training::kernels {
 
     // Scale-and-shift-invariant depth supervision on alpha-normalized expected
     // depth in inverse-depth space using a fixed per-camera anchor alignment.
+    // FastGS pinhole writes camera-z into the depth map; Kannala-Brandt fisheye
+    // writes ray length D=|P|. Compare the prior against that same quantity.
     // The loss is alpha-weighted Geman-McClure plus a gradient-alignment term.
     // Emits gradients w.r.t. both the accumulated depth map and the alpha map.
     // anchor: fixed per-camera alignment; invalid or null anchors disable the

--- a/src/training/rasterization/fast_rasterizer.cpp
+++ b/src/training/rasterization/fast_rasterizer.cpp
@@ -9,6 +9,7 @@
 #include "core/sh_value_quant.hpp"
 #include "core/splat_exportable_storage.hpp"
 #include "core/tensor/internal/tensor_serialization.hpp"
+#include "fisheye_kb.cuh"
 #include "lfs/training/sh_value_storage.hpp"
 #include "training/kernels/grad_alpha.hpp"
 #include "training/rasterization/fastgs/rasterization/include/forward.h"
@@ -302,6 +303,30 @@ namespace lfs::training {
 
         auto [fx, fy, cx, cy] = viewpoint_camera.get_intrinsics();
 
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE;
+        float fisheye_k1 = 0.0f, fisheye_k2 = 0.0f, fisheye_k3 = 0.0f, fisheye_k4 = 0.0f;
+        float fisheye_theta_max = 0.0f;
+        if (viewpoint_camera.camera_model_type() == core::CameraModelType::FISHEYE) {
+            camera_kind = FastGSCameraKind::FISHEYE;
+            const auto radial = viewpoint_camera.radial_distortion();
+            if (radial.is_valid() && radial.numel() > 0) {
+                auto radial_cpu = radial.to(core::Device::CPU).contiguous();
+                const float* kptr = radial_cpu.ptr<float>();
+                fisheye_k1 = kptr[0];
+                if (radial.numel() > 1)
+                    fisheye_k2 = kptr[1];
+                if (radial.numel() > 2)
+                    fisheye_k3 = kptr[2];
+                if (radial.numel() > 3)
+                    fisheye_k4 = kptr[3];
+            }
+            // Full-image, unadjusted principal point. Training tiles shift
+            // cx/cy and shrink w/h; theta_max must not follow them.
+            fisheye_theta_max = fast_lfs::rasterization::fisheye_kb::kb_theta_max_from_intrinsics(
+                fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4,
+                full_width, full_height, fx, fy, cx, cy);
+        }
+
         // Adjust camera center point for tile rendering
         // When rendering a tile at offset, the principal point shifts
         const float cx_adjusted = cx - static_cast<float>(tile_x_offset);
@@ -448,7 +473,13 @@ namespace lfs::training {
                  gaussian_model._max_screen_share.ndim() == 1 &&
                  gaussian_model._max_screen_share.numel() >= static_cast<size_t>(n_primitives))
                     ? gaussian_model._max_screen_share.ptr<float>()
-                    : nullptr);
+                    : nullptr,
+                camera_kind,
+                fisheye_k1,
+                fisheye_k2,
+                fisheye_k3,
+                fisheye_k4,
+                fisheye_theta_max);
         } catch (const std::exception& e) {
             // Dump all input data for debugging
             dump_crash_data(
@@ -538,6 +569,7 @@ namespace lfs::training {
 
         // background is composed inside blend_cu (single write).
         // No separate full-image compose pass.
+        // Depth is camera-z for pinhole and ray length D=|P| for Kannala-Brandt fisheye.
 
         render_output.image = image;
         render_output.alpha = alpha;
@@ -579,6 +611,12 @@ namespace lfs::training {
         ctx.near_plane = near_plane;
         ctx.far_plane = far_plane;
         ctx.mip_filter = mip_filter;
+        ctx.camera_kind = camera_kind;
+        ctx.fisheye_k1 = fisheye_k1;
+        ctx.fisheye_k2 = fisheye_k2;
+        ctx.fisheye_k3 = fisheye_k3;
+        ctx.fisheye_k4 = fisheye_k4;
+        ctx.fisheye_theta_max = fisheye_theta_max;
 
         // Store tile information
         ctx.tile_x_offset = tile_x_offset;
@@ -846,7 +884,13 @@ namespace lfs::training {
             fused_adam.mean_step_far_mask,
             fused_adam.mean_step_far_mask_n,
             fused_extra_gradients.edge_weight_map,
-            fused_extra_gradients.edge_score_out);
+            fused_extra_gradients.edge_score_out,
+            ctx.camera_kind,
+            ctx.fisheye_k1,
+            ctx.fisheye_k2,
+            ctx.fisheye_k3,
+            ctx.fisheye_k4,
+            ctx.fisheye_theta_max);
 
         ctx.mark_forward_context_released();
 

--- a/src/training/rasterization/fast_rasterizer.cpp
+++ b/src/training/rasterization/fast_rasterizer.cpp
@@ -9,6 +9,7 @@
 #include "core/sh_value_quant.hpp"
 #include "core/splat_exportable_storage.hpp"
 #include "core/tensor/internal/tensor_serialization.hpp"
+#include "fisheye_kb.cuh"
 #include "lfs/training/sh_value_storage.hpp"
 #include "training/kernels/grad_alpha.hpp"
 #include "training/rasterization/fastgs/rasterization/include/forward.h"
@@ -302,6 +303,30 @@ namespace lfs::training {
 
         auto [fx, fy, cx, cy] = viewpoint_camera.get_intrinsics();
 
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE;
+        float fisheye_k1 = 0.0f, fisheye_k2 = 0.0f, fisheye_k3 = 0.0f, fisheye_k4 = 0.0f;
+        float fisheye_theta_max = 0.0f;
+        if (viewpoint_camera.camera_model_type() == core::CameraModelType::FISHEYE) {
+            camera_kind = FastGSCameraKind::FISHEYE;
+            const auto radial = viewpoint_camera.radial_distortion();
+            if (radial.is_valid() && radial.numel() > 0) {
+                auto radial_cpu = radial.to(core::Device::CPU).contiguous();
+                const float* kptr = radial_cpu.ptr<float>();
+                fisheye_k1 = kptr[0];
+                if (radial.numel() > 1)
+                    fisheye_k2 = kptr[1];
+                if (radial.numel() > 2)
+                    fisheye_k3 = kptr[2];
+                if (radial.numel() > 3)
+                    fisheye_k4 = kptr[3];
+            }
+            // Full-image, unadjusted principal point. Training tiles shift
+            // cx/cy and shrink w/h; theta_max must not follow them.
+            fisheye_theta_max = fast_lfs::rasterization::fisheye_kb::kb_theta_max_from_intrinsics(
+                fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4,
+                full_width, full_height, fx, fy, cx, cy);
+        }
+
         // Adjust camera center point for tile rendering
         // When rendering a tile at offset, the principal point shifts
         const float cx_adjusted = cx - static_cast<float>(tile_x_offset);
@@ -443,7 +468,13 @@ namespace lfs::training {
                 raster_stream,
                 shN_bounds_ptr,
                 shN_n_cells,
-                shN_bits);
+                shN_bits,
+                camera_kind,
+                fisheye_k1,
+                fisheye_k2,
+                fisheye_k3,
+                fisheye_k4,
+                fisheye_theta_max);
         } catch (const std::exception& e) {
             // Dump all input data for debugging
             dump_crash_data(
@@ -533,6 +564,7 @@ namespace lfs::training {
 
         // background is composed inside blend_cu (single write).
         // No separate full-image compose pass.
+        // Depth is camera-z for pinhole and ray length D=|P| for Kannala-Brandt fisheye.
 
         render_output.image = image;
         render_output.alpha = alpha;
@@ -574,6 +606,12 @@ namespace lfs::training {
         ctx.near_plane = near_plane;
         ctx.far_plane = far_plane;
         ctx.mip_filter = mip_filter;
+        ctx.camera_kind = camera_kind;
+        ctx.fisheye_k1 = fisheye_k1;
+        ctx.fisheye_k2 = fisheye_k2;
+        ctx.fisheye_k3 = fisheye_k3;
+        ctx.fisheye_k4 = fisheye_k4;
+        ctx.fisheye_theta_max = fisheye_theta_max;
 
         // Store tile information
         ctx.tile_x_offset = tile_x_offset;
@@ -832,7 +870,13 @@ namespace lfs::training {
             &fused_adam,
             bwd_shN_bounds_ptr,
             bwd_shN_n_cells,
-            bwd_shN_bits);
+            bwd_shN_bits,
+            ctx.camera_kind,
+            ctx.fisheye_k1,
+            ctx.fisheye_k2,
+            ctx.fisheye_k3,
+            ctx.fisheye_k4,
+            ctx.fisheye_theta_max);
 
         ctx.mark_forward_context_released();
 

--- a/src/training/rasterization/fast_rasterizer.hpp
+++ b/src/training/rasterization/fast_rasterizer.hpp
@@ -67,6 +67,12 @@ namespace lfs::training {
         float near_plane = 0.0f;
         float far_plane = 0.0f;
         bool mip_filter = false;
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE;
+        float fisheye_k1 = 0.0f;
+        float fisheye_k2 = 0.0f;
+        float fisheye_k3 = 0.0f;
+        float fisheye_k4 = 0.0f;
+        float fisheye_theta_max = 0.0f;
 
         // Tile information (for tile-based training)
         int tile_x_offset = 0; // Horizontal offset of this tile
@@ -124,6 +130,12 @@ namespace lfs::training {
             near_plane = std::exchange(other.near_plane, 0.0f);
             far_plane = std::exchange(other.far_plane, 0.0f);
             mip_filter = std::exchange(other.mip_filter, false);
+            camera_kind = std::exchange(other.camera_kind, FastGSCameraKind::PINHOLE);
+            fisheye_k1 = std::exchange(other.fisheye_k1, 0.0f);
+            fisheye_k2 = std::exchange(other.fisheye_k2, 0.0f);
+            fisheye_k3 = std::exchange(other.fisheye_k3, 0.0f);
+            fisheye_k4 = std::exchange(other.fisheye_k4, 0.0f);
+            fisheye_theta_max = std::exchange(other.fisheye_theta_max, 0.0f);
             tile_x_offset = std::exchange(other.tile_x_offset, 0);
             tile_y_offset = std::exchange(other.tile_y_offset, 0);
             tile_width = std::exchange(other.tile_width, 0);

--- a/src/training/rasterization/fastgs/rasterization/include/backward.h
+++ b/src/training/rasterization/fastgs/rasterization/include/backward.h
@@ -57,6 +57,12 @@ namespace fast_lfs::rasterization {
         const float2* shN_value_bounds,
         const uint shN_value_n_cells,
         const uint shN_value_bits,
-        cudaStream_t stream);
+        cudaStream_t stream,
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE,
+        float fisheye_k1 = 0.0f,
+        float fisheye_k2 = 0.0f,
+        float fisheye_k3 = 0.0f,
+        float fisheye_k4 = 0.0f,
+        float fisheye_theta_max = 0.0f);
 
 } // namespace fast_lfs::rasterization

--- a/src/training/rasterization/fastgs/rasterization/include/backward.h
+++ b/src/training/rasterization/fastgs/rasterization/include/backward.h
@@ -63,6 +63,12 @@ namespace fast_lfs::rasterization {
         const int mean_step_far_mask_n,
         const float* edge_weight_map,
         float* edge_score_out,
-        cudaStream_t stream);
+        cudaStream_t stream,
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE,
+        float fisheye_k1 = 0.0f,
+        float fisheye_k2 = 0.0f,
+        float fisheye_k3 = 0.0f,
+        float fisheye_k4 = 0.0f,
+        float fisheye_theta_max = 0.0f);
 
 } // namespace fast_lfs::rasterization

--- a/src/training/rasterization/fastgs/rasterization/include/fisheye_kb.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/fisheye_kb.cuh
@@ -1,0 +1,439 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+// Kannala-Brandt (COLMAP OPENCV_FISHEYE) projection, Jacobian, and dJ/dP.
+// Single source of truth for FastGS native fisheye: forward, backward, and tests
+// all include this header. Do not duplicate these formulas elsewhere.
+//
+// Camera point P = (x, y, z) is in the OpenCV camera frame (P = W * mean).
+// Depth for FISHEYE is ray length D = |P|, not camera-z. Gaussians past the
+// polynomial foldover (theta_d' <= 0) are culled. The EWA affine footprint
+// is knowingly approximate near the image rim. The fisheye footprint is
+// composited without the 2D dilation.
+
+#include <cmath>
+#include <cuda_runtime.h>
+
+#ifndef __CUDACC__
+#ifndef __host__
+#define __host__
+#endif
+#ifndef __device__
+#define __device__
+#endif
+#endif
+
+namespace fast_lfs::rasterization::fisheye_kb {
+
+    constexpr double kPi = 3.14159265358979323846;
+    constexpr double kThetaMaxMarginRad = 0.5 * kPi / 180.0; // 0.5 degree
+    constexpr float kOnAxisDFloat = 1.0e-4f;
+    constexpr double kOnAxisDDouble = 1.0e-8;
+    constexpr float kMinRayLength = 1.0e-8f;
+
+    template <typename T>
+    __host__ __device__ inline T kb_on_axis_d() {
+        if constexpr (sizeof(T) == sizeof(float)) {
+            return static_cast<T>(kOnAxisDFloat);
+        } else {
+            return static_cast<T>(kOnAxisDDouble);
+        }
+    }
+
+    template <typename T>
+    __host__ __device__ inline T kb_abs(T x) {
+#ifdef __CUDA_ARCH__
+        if constexpr (sizeof(T) == sizeof(float)) {
+            return fabsf(x);
+        } else {
+            return fabs(x);
+        }
+#else
+        return std::abs(x);
+#endif
+    }
+
+    template <typename T>
+    __host__ __device__ inline T kb_sqrt(T x) {
+#ifdef __CUDA_ARCH__
+        if constexpr (sizeof(T) == sizeof(float)) {
+            return sqrtf(x);
+        } else {
+            return sqrt(x);
+        }
+#else
+        return std::sqrt(x);
+#endif
+    }
+
+    template <typename T>
+    __host__ __device__ inline T kb_hypot(T x, T y) {
+        return kb_sqrt(x * x + y * y);
+    }
+
+    template <typename T>
+    __host__ __device__ inline T kb_atan2(T y, T x) {
+#ifdef __CUDA_ARCH__
+        if constexpr (sizeof(T) == sizeof(float)) {
+            return atan2f(y, x);
+        } else {
+            return atan2(y, x);
+        }
+#else
+        return std::atan2(y, x);
+#endif
+    }
+
+    template <typename T>
+    __host__ __device__ inline T kb_min(T a, T b) {
+        return a < b ? a : b;
+    }
+
+    template <typename T>
+    __host__ __device__ inline T kb_max(T a, T b) {
+        return a > b ? a : b;
+    }
+
+    // theta_d = theta * (1 + t2*(k1 + t2*(k2 + t2*(k3 + t2*k4)))), t2 = theta^2
+    template <typename T>
+    __host__ __device__ inline T kb_theta_d(T theta, T k1, T k2, T k3, T k4) {
+        const T t2 = theta * theta;
+        return theta * (T(1) + t2 * (k1 + t2 * (k2 + t2 * (k3 + t2 * k4))));
+    }
+
+    // d(theta_d)/d(theta)
+    template <typename T>
+    __host__ __device__ inline T kb_theta_d_prime(T theta, T k1, T k2, T k3, T k4) {
+        const T t2 = theta * theta;
+        return T(1) + t2 * (T(3) * k1 + t2 * (T(5) * k2 + t2 * (T(7) * k3 + t2 * T(9) * k4)));
+    }
+
+    // d^2(theta_d)/d(theta)^2
+    template <typename T>
+    __host__ __device__ inline T kb_theta_d_dbl_prime(T theta, T k1, T k2, T k3, T k4) {
+        const T t2 = theta * theta;
+        return theta * (T(6) * k1 + t2 * (T(20) * k2 + t2 * (T(42) * k3 + t2 * T(72) * k4)));
+    }
+
+    template <typename T>
+    struct KbProjection {
+        T px, py;
+        T J00, J01, J02, J10, J11, J12;
+        T theta, theta_d, theta_d_prime, theta_d_dbl_prime;
+        T x, y, z, d, D, D2, d2;
+        T A, B;
+        bool on_axis;
+        bool finite;
+    };
+
+    template <typename T>
+    __host__ __device__ inline KbProjection<T> kb_project(
+        T x, T y, T z,
+        T fx, T fy, T cx, T cy,
+        T k1, T k2, T k3, T k4) {
+        KbProjection<T> o{};
+        o.x = x;
+        o.y = y;
+        o.z = z;
+        o.d2 = x * x + y * y;
+        o.d = kb_sqrt(o.d2);
+        o.D2 = o.d2 + z * z;
+        o.D = kb_sqrt(o.D2);
+        o.theta = kb_atan2(o.d, z);
+        o.px = cx;
+        o.py = cy;
+        o.finite = o.D >= static_cast<T>(kMinRayLength);
+        o.on_axis = o.d < kb_on_axis_d<T>();
+
+        if (!o.finite) {
+            return o;
+        }
+
+        if (o.on_axis) {
+            // Closed-form on-axis limit: general formulas are 0/0.
+            // J = diag(fx/z, fy/z, 0), pixel = (cx, cy). Same branch on host
+            // and device. |z| below the ray-length guard is not finite.
+            if (kb_abs(z) < static_cast<T>(kMinRayLength)) {
+                o.finite = false;
+                return o;
+            }
+            const T inv_z = T(1) / z;
+            o.J00 = fx * inv_z;
+            o.J01 = T(0);
+            o.J02 = T(0);
+            o.J10 = T(0);
+            o.J11 = fy * inv_z;
+            o.J12 = T(0);
+            o.theta_d = kb_theta_d(o.theta, k1, k2, k3, k4);
+            o.theta_d_prime = kb_theta_d_prime(o.theta, k1, k2, k3, k4);
+            o.theta_d_dbl_prime = kb_theta_d_dbl_prime(o.theta, k1, k2, k3, k4);
+            o.A = T(0);
+            o.B = T(0);
+            return o;
+        }
+
+        o.theta_d = kb_theta_d(o.theta, k1, k2, k3, k4);
+        o.theta_d_prime = kb_theta_d_prime(o.theta, k1, k2, k3, k4);
+        o.theta_d_dbl_prime = kb_theta_d_dbl_prime(o.theta, k1, k2, k3, k4);
+
+        o.px = cx + fx * o.theta_d * x / o.d;
+        o.py = cy + fy * o.theta_d * y / o.d;
+
+        o.A = o.theta_d_prime / (o.D2 * o.d2);
+        o.B = o.theta_d / (o.d * o.d * o.d);
+
+        const T Axyz = o.A * x * y * z;
+        const T Bxy = o.B * x * y;
+        o.J00 = fx * (o.A * x * x * z + o.B * y * y);
+        o.J01 = fx * (Axyz - Bxy);
+        o.J02 = -fx * o.theta_d_prime * x / o.D2;
+        o.J10 = fy * (Axyz - Bxy);
+        o.J11 = fy * (o.A * y * y * z + o.B * x * x);
+        o.J12 = -fy * o.theta_d_prime * y / o.D2;
+        return o;
+    }
+
+    // First theta in (0, pi) where theta_d' <= 0, else pi.
+    template <typename T>
+    __host__ __device__ inline T kb_theta_foldover(T k1, T k2, T k3, T k4) {
+        const T pi = static_cast<T>(kPi);
+        constexpr int kSamples = 128;
+        T prev = T(0);
+        for (int i = 1; i <= kSamples; ++i) {
+            const T th = pi * static_cast<T>(i) / static_cast<T>(kSamples);
+            if (kb_theta_d_prime(th, k1, k2, k3, k4) <= T(0)) {
+                T lo = prev;
+                T hi = th;
+                for (int j = 0; j < 40; ++j) {
+                    const T mid = T(0.5) * (lo + hi);
+                    if (kb_theta_d_prime(mid, k1, k2, k3, k4) <= T(0)) {
+                        hi = mid;
+                    } else {
+                        lo = mid;
+                    }
+                }
+                return hi;
+            }
+            prev = th;
+        }
+        return pi;
+    }
+
+    // min(foldover, theta whose image radius reaches the farthest corner) + 0.5 deg,
+    // never exceeding foldover. Corner solve uses f = max(fx, fy).
+    template <typename T>
+    __host__ __device__ inline T kb_theta_max(
+        T k1, T k2, T k3, T k4,
+        T width, T height,
+        T fx, T fy, T cx, T cy) {
+        const T fold = kb_theta_foldover(k1, k2, k3, k4);
+        const T r00 = kb_hypot(cx, cy);
+        const T r10 = kb_hypot(width - cx, cy);
+        const T r01 = kb_hypot(cx, height - cy);
+        const T r11 = kb_hypot(width - cx, height - cy);
+        const T r_target = kb_max(kb_max(r00, r10), kb_max(r01, r11));
+        const T f = kb_max(fx, fy); // conservative when fx != fy
+
+        const T fold_safe = fold * T(0.999999);
+        T theta_corner;
+        if (f * kb_theta_d(fold_safe, k1, k2, k3, k4) < r_target) {
+            theta_corner = fold;
+        } else {
+            T lo = T(0);
+            T hi = fold;
+            for (int i = 0; i < 50; ++i) {
+                const T mid = T(0.5) * (lo + hi);
+                if (f * kb_theta_d(mid, k1, k2, k3, k4) < r_target) {
+                    lo = mid;
+                } else {
+                    hi = mid;
+                }
+            }
+            theta_corner = hi;
+            for (int i = 0; i < 6; ++i) {
+                const T g = f * kb_theta_d(theta_corner, k1, k2, k3, k4) - r_target;
+                const T gp = f * kb_theta_d_prime(theta_corner, k1, k2, k3, k4);
+                if (kb_abs(gp) < T(1e-20)) {
+                    break;
+                }
+                const T next = theta_corner - g / gp;
+                if (next <= T(0) || next >= fold) {
+                    break;
+                }
+                theta_corner = next;
+            }
+        }
+
+        T tmax = kb_min(fold, theta_corner) + static_cast<T>(kThetaMaxMarginRad);
+        // Stay strictly below foldover so theta_d' stays positive in kernels.
+        if (tmax >= fold) {
+            tmax = fold_safe;
+        }
+        if (tmax < T(1e-4)) {
+            tmax = T(1e-4);
+        }
+        return tmax;
+    }
+
+    // Host wrapper: theta_max in double with the full image and unadjusted
+    // principal point (not a training tile).
+    __host__ inline float kb_theta_max_from_intrinsics(
+        float k1, float k2, float k3, float k4,
+        int width, int height,
+        float fx, float fy, float cx, float cy) {
+        return static_cast<float>(kb_theta_max(
+            static_cast<double>(k1), static_cast<double>(k2),
+            static_cast<double>(k3), static_cast<double>(k4),
+            static_cast<double>(width), static_cast<double>(height),
+            static_cast<double>(fx), static_cast<double>(fy),
+            static_cast<double>(cx), static_cast<double>(cy)));
+    }
+
+    // Shared dJ/dP temporaries. dC, dE, dF, dGx, dGy are derivatives of the
+    // unscaled J factors (J00 = fx*C, J01 = fx*E, J02 = fx*Gx, ...).
+    template <typename T>
+    struct KbJPartials {
+        T dC[3];
+        T dE[3];
+        T dF[3];
+        T dGx[3];
+        T dGy[3];
+        bool on_axis;
+        T inv_z2;
+    };
+
+    template <typename T>
+    __host__ __device__ inline KbJPartials<T> kb_j_partials(const KbProjection<T>& p) {
+        KbJPartials<T> o{};
+        o.on_axis = p.on_axis;
+        if (!p.finite) {
+            return o;
+        }
+        if (p.on_axis) {
+            o.inv_z2 = T(1) / (p.z * p.z);
+            return o;
+        }
+
+        const T x = p.x, y = p.y, z = p.z;
+        const T d = p.d, D2 = p.D2, d2 = p.d2;
+        const T tdp = p.theta_d_prime;
+        const T td = p.theta_d;
+        const T tdpp = p.theta_d_dbl_prime;
+        const T A = p.A;
+        const T B = p.B;
+        const T inv_D2 = T(1) / D2;
+        const T inv_d = T(1) / d;
+
+        // dtheta/dP = (x z, y z, -d^2) / (D^2 d)
+        const T dth_x = x * z * inv_D2 * inv_d;
+        const T dth_y = y * z * inv_D2 * inv_d;
+        const T dth_z = -d * inv_D2;
+        const T dtdp_x = tdpp * dth_x;
+        const T dtdp_y = tdpp * dth_y;
+        const T dtdp_z = tdpp * dth_z;
+        const T dtd_x = tdp * dth_x;
+        const T dtd_y = tdp * dth_y;
+        const T dtd_z = tdp * dth_z;
+
+        const T dD2_x = T(2) * x, dD2_y = T(2) * y, dD2_z = T(2) * z;
+        const T dd2_x = T(2) * x, dd2_y = T(2) * y;
+        const T dd_x = x * inv_d, dd_y = y * inv_d;
+
+        // A = theta_d' / (D^2 d^2), B = theta_d / d^3. Form dA/dB without
+        // dividing by theta_d' or theta_d (those hit 0 at foldover / origin).
+        const T inv_D2_d2 = inv_D2 / d2;
+        const T inv_d3 = inv_d * inv_d * inv_d;
+        const T dA_x = dtdp_x * inv_D2_d2 - A * (dD2_x * inv_D2 + dd2_x / d2);
+        const T dA_y = dtdp_y * inv_D2_d2 - A * (dD2_y * inv_D2 + dd2_y / d2);
+        const T dA_z = dtdp_z * inv_D2_d2 - A * (dD2_z * inv_D2);
+        const T dB_x = dtd_x * inv_d3 - T(3) * B * dd_x * inv_d;
+        const T dB_y = dtd_y * inv_d3 - T(3) * B * dd_y * inv_d;
+        const T dB_z = dtd_z * inv_d3;
+
+        // C = A x^2 z + B y^2
+        o.dC[0] = dA_x * x * x * z + A * T(2) * x * z + dB_x * y * y;
+        o.dC[1] = dA_y * x * x * z + dB_y * y * y + B * T(2) * y;
+        o.dC[2] = dA_z * x * x * z + A * x * x + dB_z * y * y;
+        // E = A x y z - B x y
+        o.dE[0] = dA_x * x * y * z + A * y * z - dB_x * x * y - B * y;
+        o.dE[1] = dA_y * x * y * z + A * x * z - dB_y * x * y - B * x;
+        o.dE[2] = dA_z * x * y * z + A * x * y - dB_z * x * y;
+        // F = A y^2 z + B x^2
+        o.dF[0] = dA_x * y * y * z + dB_x * x * x + B * T(2) * x;
+        o.dF[1] = dA_y * y * y * z + A * T(2) * y * z + dB_y * x * x;
+        o.dF[2] = dA_z * y * y * z + A * y * y + dB_z * x * x;
+        // Gx = -theta_d' * x / D^2
+        const T inv_D2_sq = inv_D2 * inv_D2;
+        o.dGx[0] = -dtdp_x * x * inv_D2 - tdp * inv_D2 + tdp * x * T(2) * x * inv_D2_sq;
+        o.dGx[1] = -dtdp_y * x * inv_D2 + tdp * x * T(2) * y * inv_D2_sq;
+        o.dGx[2] = -dtdp_z * x * inv_D2 + tdp * x * T(2) * z * inv_D2_sq;
+        // Gy = -theta_d' * y / D^2
+        o.dGy[0] = -dtdp_x * y * inv_D2 + tdp * y * T(2) * x * inv_D2_sq;
+        o.dGy[1] = -dtdp_y * y * inv_D2 - tdp * inv_D2 + tdp * y * T(2) * y * inv_D2_sq;
+        o.dGy[2] = -dtdp_z * y * inv_D2 + tdp * y * T(2) * z * inv_D2_sq;
+        return o;
+    }
+
+    // dJ_ij / dP_k as a (2,3,3) tensor. Used by tests against golden dJdP_fd.
+    template <typename T>
+    __host__ __device__ inline void kb_dJ_dP(
+        const KbProjection<T>& p,
+        T fx, T fy,
+        T dJdP[2][3][3]) {
+        for (int i = 0; i < 2; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                for (int k = 0; k < 3; ++k) {
+                    dJdP[i][j][k] = T(0);
+                }
+            }
+        }
+        const KbJPartials<T> g = kb_j_partials(p);
+        if (!p.finite) {
+            return;
+        }
+        if (g.on_axis) {
+            dJdP[0][0][2] = -fx * g.inv_z2;
+            dJdP[1][1][2] = -fy * g.inv_z2;
+            return;
+        }
+        for (int k = 0; k < 3; ++k) {
+            dJdP[0][0][k] = fx * g.dC[k];
+            dJdP[0][1][k] = fx * g.dE[k];
+            dJdP[0][2][k] = fx * g.dGx[k];
+            dJdP[1][0][k] = fy * g.dE[k];
+            dJdP[1][1][k] = fy * g.dF[k];
+            dJdP[1][2][k] = fy * g.dGy[k];
+        }
+    }
+
+    // Contract dL_dJ through dJ/dP into dL_dP. Shared temporaries computed once.
+    template <typename T>
+    __host__ __device__ inline void kb_contract_dL_dJ(
+        const KbProjection<T>& p,
+        T fx, T fy,
+        T dL_dJ00, T dL_dJ01, T dL_dJ02,
+        T dL_dJ10, T dL_dJ11, T dL_dJ12,
+        T& dL_dx, T& dL_dy, T& dL_dz) {
+        const KbJPartials<T> g = kb_j_partials(p);
+        if (!p.finite) {
+            return;
+        }
+        if (g.on_axis) {
+            dL_dz += dL_dJ00 * (-fx * g.inv_z2) + dL_dJ11 * (-fy * g.inv_z2);
+            return;
+        }
+        const T sx0 = fx * dL_dJ00;
+        const T sx1 = fx * dL_dJ01;
+        const T sx2 = fx * dL_dJ02;
+        const T sy0 = fy * dL_dJ10;
+        const T sy1 = fy * dL_dJ11;
+        const T sy2 = fy * dL_dJ12;
+        dL_dx += sx0 * g.dC[0] + sx1 * g.dE[0] + sx2 * g.dGx[0] + sy0 * g.dE[0] + sy1 * g.dF[0] + sy2 * g.dGy[0];
+        dL_dy += sx0 * g.dC[1] + sx1 * g.dE[1] + sx2 * g.dGx[1] + sy0 * g.dE[1] + sy1 * g.dF[1] + sy2 * g.dGy[1];
+        dL_dz += sx0 * g.dC[2] + sx1 * g.dE[2] + sx2 * g.dGx[2] + sy0 * g.dE[2] + sy1 * g.dF[2] + sy2 * g.dGy[2];
+    }
+
+} // namespace fast_lfs::rasterization::fisheye_kb

--- a/src/training/rasterization/fastgs/rasterization/include/forward.h
+++ b/src/training/rasterization/fastgs/rasterization/include/forward.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "helper_math.h"
+#include "rasterization_config.h"
 #include <cstddef>
 #include <cstdint>
 #include <cuda_runtime.h>
@@ -92,6 +93,12 @@ namespace fast_lfs::rasterization {
         const float far,
         bool mip_filter,
         cudaStream_t stream,
-        float* max_screen_share = nullptr);
+        float* max_screen_share = nullptr,
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE,
+        float fisheye_k1 = 0.0f,
+        float fisheye_k2 = 0.0f,
+        float fisheye_k3 = 0.0f,
+        float fisheye_k4 = 0.0f,
+        float fisheye_theta_max = 0.0f);
 
 } // namespace fast_lfs::rasterization

--- a/src/training/rasterization/fastgs/rasterization/include/forward.h
+++ b/src/training/rasterization/fastgs/rasterization/include/forward.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "helper_math.h"
+#include "rasterization_config.h"
 #include <cstddef>
 #include <cstdint>
 #include <cuda_runtime.h>
@@ -84,6 +85,12 @@ namespace fast_lfs::rasterization {
         const float near,
         const float far,
         bool mip_filter,
-        cudaStream_t stream);
+        cudaStream_t stream,
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE,
+        float fisheye_k1 = 0.0f,
+        float fisheye_k2 = 0.0f,
+        float fisheye_k3 = 0.0f,
+        float fisheye_k4 = 0.0f,
+        float fisheye_theta_max = 0.0f);
 
 } // namespace fast_lfs::rasterization

--- a/src/training/rasterization/fastgs/rasterization/include/kernels_backward.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernels_backward.cuh
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "buffer_utils.h"
+#include "fisheye_kb.cuh"
 #include "helper_math.h"
 #include "kernel_utils.cuh"
 #include "lfs/core/warp_reduce.cuh"
@@ -13,6 +14,7 @@
 #include "utils.h"
 #include <cooperative_groups.h>
 #include <cstdint>
+#include <type_traits>
 namespace cg = cooperative_groups;
 
 namespace fast_lfs::rasterization::kernels::backward {
@@ -34,7 +36,7 @@ namespace fast_lfs::rasterization::kernels::backward {
 
     // minBlocks=3 budgets registers so shN Adam no longer lives across
     // the geometry backward (sweep 2..4; 3 is the measured default).
-    template <bool MIP_FILTER, int ACTIVE_SH_BASES>
+    template <bool MIP_FILTER, int ACTIVE_SH_BASES, FastGSCameraKind KIND>
     __global__ void __launch_bounds__(config::block_size_preprocess_backward, 3) preprocess_backward_cu(
         // These four alias fused_adam.{means,scaling,rotation,opacity}.param (Adam writes).
         const float3* means,
@@ -65,6 +67,8 @@ namespace fast_lfs::rasterization::kernels::backward {
         const float clip_top,
         const float clip_bottom,
         const uint sh_layout_slots,
+        const float4 fisheye_k,
+        const float theta_max,
         FusedAdamSettings fused_adam,
         const bool* __restrict__ mean_step_far_mask,
         const int mean_step_far_mask_n,
@@ -74,8 +78,14 @@ namespace fast_lfs::rasterization::kernels::backward {
         const float2* __restrict__ shN_value_bounds,
         const uint shN_value_n_cells,
         const uint shN_value_bits) {
-        (void)cx;
-        (void)cy;
+        if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+            (void)cx;
+            (void)cy;
+            (void)fisheye_k;
+            (void)theta_max;
+        } else {
+            (void)theta_max;
+        }
         auto primitive_idx = cg::this_grid().thread_rank();
         const bool in_range = primitive_idx < n_primitives;
 
@@ -180,13 +190,24 @@ namespace fast_lfs::rasterization::kernels::backward {
             const float3 mean3d = means[primitive_idx];
 
             const float4 w2c_r3 = w2c[2];
-            const float depth = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
-            const float depth_safe = fmaxf(depth, 1e-4f);
-            const float inv_depth = 1.0f / depth_safe;
-            const float4 w2c_r1 = w2c[0];
-            const float x = (w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w) * inv_depth;
-            const float4 w2c_r2 = w2c[1];
-            const float y = (w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w) * inv_depth;
+            float4 w2c_r1, w2c_r2;
+            float inv_depth, x, y, tx, ty, j11, j13, j22, j23;
+            if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+                const float depth = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
+                const float depth_safe = fmaxf(depth, 1e-4f);
+                inv_depth = 1.0f / depth_safe;
+                w2c_r1 = w2c[0];
+                x = (w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w) * inv_depth;
+                w2c_r2 = w2c[1];
+                y = (w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w) * inv_depth;
+            } else {
+                (void)clip_left;
+                (void)clip_right;
+                (void)clip_top;
+                (void)clip_bottom;
+                w2c_r1 = w2c[0];
+                w2c_r2 = w2c[1];
+            }
 
             // compute 3d covariance from raw scale and rotation
             const float3 raw_scale = raw_scales[primitive_idx];
@@ -224,21 +245,43 @@ namespace fast_lfs::rasterization::kernels::backward {
                 rotation_scaled.m31 * rotation.m31 + rotation_scaled.m32 * rotation.m32 + rotation_scaled.m33 * rotation.m33,
             };
 
-            // ewa splatting gradient helpers (clip box is grid-uniform; computed once on the host)
-            const float tx = clamp(x, clip_left, clip_right);
-            const float ty = clamp(y, clip_top, clip_bottom);
-            const float j11 = fx * inv_depth;
-            const float j13 = -j11 * tx;
-            const float j22 = fy * inv_depth;
-            const float j23 = -j22 * ty;
-            const float3 jw_r1 = make_float3(
-                j11 * w2c_r1.x + j13 * w2c_r3.x,
-                j11 * w2c_r1.y + j13 * w2c_r3.y,
-                j11 * w2c_r1.z + j13 * w2c_r3.z);
-            const float3 jw_r2 = make_float3(
-                j22 * w2c_r2.x + j23 * w2c_r3.x,
-                j22 * w2c_r2.y + j23 * w2c_r3.y,
-                j22 * w2c_r2.z + j23 * w2c_r3.z);
+            float3 jw_r1, jw_r2;
+            [[maybe_unused]] float Px, Py, Pz;
+            using KbProjT = std::conditional_t<KIND == FastGSCameraKind::FISHEYE,
+                                               fisheye_kb::KbProjection<float>, char>;
+            [[maybe_unused]] KbProjT kb_proj;
+            if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+                // ewa splatting gradient helpers (clip box is grid-uniform; computed once on the host)
+                tx = clamp(x, clip_left, clip_right);
+                ty = clamp(y, clip_top, clip_bottom);
+                j11 = fx * inv_depth;
+                j13 = -j11 * tx;
+                j22 = fy * inv_depth;
+                j23 = -j22 * ty;
+                jw_r1 = make_float3(
+                    j11 * w2c_r1.x + j13 * w2c_r3.x,
+                    j11 * w2c_r1.y + j13 * w2c_r3.y,
+                    j11 * w2c_r1.z + j13 * w2c_r3.z);
+                jw_r2 = make_float3(
+                    j22 * w2c_r2.x + j23 * w2c_r3.x,
+                    j22 * w2c_r2.y + j23 * w2c_r3.y,
+                    j22 * w2c_r2.z + j23 * w2c_r3.z);
+            } else {
+                Px = w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w;
+                Py = w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w;
+                Pz = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
+                kb_proj = fisheye_kb::kb_project(
+                    Px, Py, Pz, fx, fy, cx, cy,
+                    fisheye_k.x, fisheye_k.y, fisheye_k.z, fisheye_k.w);
+                jw_r1 = make_float3(
+                    kb_proj.J00 * w2c_r1.x + kb_proj.J01 * w2c_r2.x + kb_proj.J02 * w2c_r3.x,
+                    kb_proj.J00 * w2c_r1.y + kb_proj.J01 * w2c_r2.y + kb_proj.J02 * w2c_r3.y,
+                    kb_proj.J00 * w2c_r1.z + kb_proj.J01 * w2c_r2.z + kb_proj.J02 * w2c_r3.z);
+                jw_r2 = make_float3(
+                    kb_proj.J10 * w2c_r1.x + kb_proj.J11 * w2c_r2.x + kb_proj.J12 * w2c_r3.x,
+                    kb_proj.J10 * w2c_r1.y + kb_proj.J11 * w2c_r2.y + kb_proj.J12 * w2c_r3.y,
+                    kb_proj.J10 * w2c_r1.z + kb_proj.J11 * w2c_r2.z + kb_proj.J12 * w2c_r3.z);
+            }
             const float3 jwc_r1 = make_float3(
                 jw_r1.x * cov3d.m11 + jw_r1.y * cov3d.m12 + jw_r1.z * cov3d.m13,
                 jw_r1.x * cov3d.m12 + jw_r1.y * cov3d.m22 + jw_r1.z * cov3d.m23,
@@ -249,7 +292,7 @@ namespace fast_lfs::rasterization::kernels::backward {
                 jw_r2.x * cov3d.m13 + jw_r2.y * cov3d.m23 + jw_r2.z * cov3d.m33);
 
             // 2d covariance gradient (use same dilation as forward pass)
-            constexpr float kernel_size = MIP_FILTER ? config::dilation_mip_filter : config::dilation;
+            constexpr float kernel_size = config::dilation_for<KIND, MIP_FILTER>();
             const float raw_a = dot(jwc_r1, jw_r1);
             const float raw_b = dot(jwc_r1, jw_r2);
             const float raw_c = dot(jwc_r2, jw_r2);
@@ -270,11 +313,15 @@ namespace fast_lfs::rasterization::kernels::backward {
             const float grad_compensated_opacity = grad_opacity_helper[work_idx];
             float opacity_compensation = 1.0f;
             if constexpr (MIP_FILTER) {
-                const float det_raw = raw_a * raw_c - raw_b * raw_b;
-                if (det_raw > config::min_cov2d_determinant && determinant > config::min_cov2d_determinant) {
-                    opacity_compensation = sqrtf(det_raw * determinant_rcp);
+                if constexpr (KIND == FastGSCameraKind::FISHEYE) {
+                    opacity_compensation = 1.0f;
                 } else {
-                    opacity_compensation = 0.0f;
+                    const float det_raw = raw_a * raw_c - raw_b * raw_b;
+                    if (det_raw > config::min_cov2d_determinant && determinant > config::min_cov2d_determinant) {
+                        opacity_compensation = sqrtf(det_raw * determinant_rcp);
+                    } else {
+                        opacity_compensation = 0.0f;
+                    }
                 }
             }
 
@@ -302,16 +349,18 @@ namespace fast_lfs::rasterization::kernels::backward {
                                                 jwc_r1.y * dL_dcov2d.y + jwc_r2.y * dL_dcov2d.z,
                                                 jwc_r1.z * dL_dcov2d.y + jwc_r2.z * dL_dcov2d.z);
 
-            // gradient of non-zero entries in J
+            const float2 dL_dmean2d = grad_mean2d[work_idx];
+            const float dL_ddepth = grad_depth ? grad_depth[work_idx] : 0.0f;
+            float3 dL_dmean3d_cam;
+            if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+                // gradient of non-zero entries in J
             const float dL_dj11 = w2c_r1.x * dL_djw_r1.x + w2c_r1.y * dL_djw_r1.y + w2c_r1.z * dL_djw_r1.z;
             const float dL_dj22 = w2c_r2.x * dL_djw_r2.x + w2c_r2.y * dL_djw_r2.y + w2c_r2.z * dL_djw_r2.z;
             const float dL_dj13 = w2c_r3.x * dL_djw_r1.x + w2c_r3.y * dL_djw_r1.y + w2c_r3.z * dL_djw_r1.z;
             const float dL_dj23 = w2c_r3.x * dL_djw_r2.x + w2c_r3.y * dL_djw_r2.y + w2c_r3.z * dL_djw_r2.z;
 
             // mean3d camera space gradient from J and mean2d (accounts for tx/ty clipping)
-            const float2 dL_dmean2d = grad_mean2d[work_idx];
-            const float dL_ddepth = grad_depth ? grad_depth[work_idx] : 0.0f;
-            float3 dL_dmean3d_cam = make_float3(
+            dL_dmean3d_cam = make_float3(
                 j11 * dL_dmean2d.x,
                 j22 * dL_dmean2d.y,
                 -j11 * x * dL_dmean2d.x - j22 * y * dL_dmean2d.y + dL_ddepth);
@@ -324,6 +373,28 @@ namespace fast_lfs::rasterization::kernels::backward {
             const float factor_x = 1.0f + static_cast<float>(valid_x);
             const float factor_y = 1.0f + static_cast<float>(valid_y);
             dL_dmean3d_cam.z += (j11 * (factor_x * tx * dL_dj13 - dL_dj11) + j22 * (factor_y * ty * dL_dj23 - dL_dj22)) * inv_depth;
+            } else {
+                const float dL_dJ00 = w2c_r1.x * dL_djw_r1.x + w2c_r1.y * dL_djw_r1.y + w2c_r1.z * dL_djw_r1.z;
+                const float dL_dJ01 = w2c_r2.x * dL_djw_r1.x + w2c_r2.y * dL_djw_r1.y + w2c_r2.z * dL_djw_r1.z;
+                const float dL_dJ02 = w2c_r3.x * dL_djw_r1.x + w2c_r3.y * dL_djw_r1.y + w2c_r3.z * dL_djw_r1.z;
+                const float dL_dJ10 = w2c_r1.x * dL_djw_r2.x + w2c_r1.y * dL_djw_r2.y + w2c_r1.z * dL_djw_r2.z;
+                const float dL_dJ11 = w2c_r2.x * dL_djw_r2.x + w2c_r2.y * dL_djw_r2.y + w2c_r2.z * dL_djw_r2.z;
+                const float dL_dJ12 = w2c_r3.x * dL_djw_r2.x + w2c_r3.y * dL_djw_r2.y + w2c_r3.z * dL_djw_r2.z;
+
+                float dL_dPx = kb_proj.J00 * dL_dmean2d.x + kb_proj.J10 * dL_dmean2d.y;
+                float dL_dPy = kb_proj.J01 * dL_dmean2d.x + kb_proj.J11 * dL_dmean2d.y;
+                float dL_dPz = kb_proj.J02 * dL_dmean2d.x + kb_proj.J12 * dL_dmean2d.y;
+                fisheye_kb::kb_contract_dL_dJ(
+                    kb_proj, fx, fy,
+                    dL_dJ00, dL_dJ01, dL_dJ02, dL_dJ10, dL_dJ11, dL_dJ12,
+                    dL_dPx, dL_dPy, dL_dPz);
+                // Depth is ray length D; dD/dP = P/D.
+                const float inv_D = 1.0f / fmaxf(kb_proj.D, fisheye_kb::kMinRayLength);
+                dL_dPx += dL_ddepth * Px * inv_D;
+                dL_dPy += dL_ddepth * Py * inv_D;
+                dL_dPz += dL_ddepth * Pz * inv_D;
+                dL_dmean3d_cam = make_float3(dL_dPx, dL_dPy, dL_dPz);
+            }
 
             if (grad_w2c != nullptr) {
                 atomicAdd(&grad_w2c[0].w, dL_dmean3d_cam.x);

--- a/src/training/rasterization/fastgs/rasterization/include/kernels_backward.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernels_backward.cuh
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "buffer_utils.h"
+#include "fisheye_kb.cuh"
 #include "helper_math.h"
 #include "kernel_utils.cuh"
 #include "lfs/core/warp_reduce.cuh"
@@ -12,6 +13,7 @@
 #include "utils.h"
 #include <cooperative_groups.h>
 #include <cstdint>
+#include <type_traits>
 namespace cg = cooperative_groups;
 
 namespace fast_lfs::rasterization::kernels::backward {
@@ -33,7 +35,7 @@ namespace fast_lfs::rasterization::kernels::backward {
 
     // minBlocks=3 budgets registers so shN Adam no longer lives across
     // the geometry backward (sweep 2..4; 3 is the measured default).
-    template <bool MIP_FILTER, int ACTIVE_SH_BASES>
+    template <bool MIP_FILTER, int ACTIVE_SH_BASES, FastGSCameraKind KIND>
     __global__ void __launch_bounds__(config::block_size_preprocess_backward, 3) preprocess_backward_cu(
         // These four alias fused_adam.{means,scaling,rotation,opacity}.param (Adam writes).
         const float3* means,
@@ -64,6 +66,8 @@ namespace fast_lfs::rasterization::kernels::backward {
         const float clip_top,
         const float clip_bottom,
         const uint sh_layout_slots,
+        const float4 fisheye_k,
+        const float theta_max,
         FusedAdamSettings fused_adam,
         // model-truth shN-rest decode binds. fused_adam.shN.sh_value_*
         // is enablement-gated (null during SH warmup) and gates only the UPDATE
@@ -71,8 +75,14 @@ namespace fast_lfs::rasterization::kernels::backward {
         const float2* __restrict__ shN_value_bounds,
         const uint shN_value_n_cells,
         const uint shN_value_bits) {
-        (void)cx;
-        (void)cy;
+        if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+            (void)cx;
+            (void)cy;
+            (void)fisheye_k;
+            (void)theta_max;
+        } else {
+            (void)theta_max;
+        }
         auto primitive_idx = cg::this_grid().thread_rank();
         const bool in_range = primitive_idx < n_primitives;
 
@@ -175,13 +185,24 @@ namespace fast_lfs::rasterization::kernels::backward {
             const float3 mean3d = means[primitive_idx];
 
             const float4 w2c_r3 = w2c[2];
-            const float depth = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
-            const float depth_safe = fmaxf(depth, 1e-4f);
-            const float inv_depth = 1.0f / depth_safe;
-            const float4 w2c_r1 = w2c[0];
-            const float x = (w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w) * inv_depth;
-            const float4 w2c_r2 = w2c[1];
-            const float y = (w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w) * inv_depth;
+            float4 w2c_r1, w2c_r2;
+            float inv_depth, x, y, tx, ty, j11, j13, j22, j23;
+            if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+                const float depth = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
+                const float depth_safe = fmaxf(depth, 1e-4f);
+                inv_depth = 1.0f / depth_safe;
+                w2c_r1 = w2c[0];
+                x = (w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w) * inv_depth;
+                w2c_r2 = w2c[1];
+                y = (w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w) * inv_depth;
+            } else {
+                (void)clip_left;
+                (void)clip_right;
+                (void)clip_top;
+                (void)clip_bottom;
+                w2c_r1 = w2c[0];
+                w2c_r2 = w2c[1];
+            }
 
             // compute 3d covariance from raw scale and rotation
             const float3 raw_scale = raw_scales[primitive_idx];
@@ -219,21 +240,43 @@ namespace fast_lfs::rasterization::kernels::backward {
                 rotation_scaled.m31 * rotation.m31 + rotation_scaled.m32 * rotation.m32 + rotation_scaled.m33 * rotation.m33,
             };
 
-            // ewa splatting gradient helpers (clip box is grid-uniform; computed once on the host)
-            const float tx = clamp(x, clip_left, clip_right);
-            const float ty = clamp(y, clip_top, clip_bottom);
-            const float j11 = fx * inv_depth;
-            const float j13 = -j11 * tx;
-            const float j22 = fy * inv_depth;
-            const float j23 = -j22 * ty;
-            const float3 jw_r1 = make_float3(
-                j11 * w2c_r1.x + j13 * w2c_r3.x,
-                j11 * w2c_r1.y + j13 * w2c_r3.y,
-                j11 * w2c_r1.z + j13 * w2c_r3.z);
-            const float3 jw_r2 = make_float3(
-                j22 * w2c_r2.x + j23 * w2c_r3.x,
-                j22 * w2c_r2.y + j23 * w2c_r3.y,
-                j22 * w2c_r2.z + j23 * w2c_r3.z);
+            float3 jw_r1, jw_r2;
+            [[maybe_unused]] float Px, Py, Pz;
+            using KbProjT = std::conditional_t<KIND == FastGSCameraKind::FISHEYE,
+                                               fisheye_kb::KbProjection<float>, char>;
+            [[maybe_unused]] KbProjT kb_proj;
+            if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+                // ewa splatting gradient helpers (clip box is grid-uniform; computed once on the host)
+                tx = clamp(x, clip_left, clip_right);
+                ty = clamp(y, clip_top, clip_bottom);
+                j11 = fx * inv_depth;
+                j13 = -j11 * tx;
+                j22 = fy * inv_depth;
+                j23 = -j22 * ty;
+                jw_r1 = make_float3(
+                    j11 * w2c_r1.x + j13 * w2c_r3.x,
+                    j11 * w2c_r1.y + j13 * w2c_r3.y,
+                    j11 * w2c_r1.z + j13 * w2c_r3.z);
+                jw_r2 = make_float3(
+                    j22 * w2c_r2.x + j23 * w2c_r3.x,
+                    j22 * w2c_r2.y + j23 * w2c_r3.y,
+                    j22 * w2c_r2.z + j23 * w2c_r3.z);
+            } else {
+                Px = w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w;
+                Py = w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w;
+                Pz = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
+                kb_proj = fisheye_kb::kb_project(
+                    Px, Py, Pz, fx, fy, cx, cy,
+                    fisheye_k.x, fisheye_k.y, fisheye_k.z, fisheye_k.w);
+                jw_r1 = make_float3(
+                    kb_proj.J00 * w2c_r1.x + kb_proj.J01 * w2c_r2.x + kb_proj.J02 * w2c_r3.x,
+                    kb_proj.J00 * w2c_r1.y + kb_proj.J01 * w2c_r2.y + kb_proj.J02 * w2c_r3.y,
+                    kb_proj.J00 * w2c_r1.z + kb_proj.J01 * w2c_r2.z + kb_proj.J02 * w2c_r3.z);
+                jw_r2 = make_float3(
+                    kb_proj.J10 * w2c_r1.x + kb_proj.J11 * w2c_r2.x + kb_proj.J12 * w2c_r3.x,
+                    kb_proj.J10 * w2c_r1.y + kb_proj.J11 * w2c_r2.y + kb_proj.J12 * w2c_r3.y,
+                    kb_proj.J10 * w2c_r1.z + kb_proj.J11 * w2c_r2.z + kb_proj.J12 * w2c_r3.z);
+            }
             const float3 jwc_r1 = make_float3(
                 jw_r1.x * cov3d.m11 + jw_r1.y * cov3d.m12 + jw_r1.z * cov3d.m13,
                 jw_r1.x * cov3d.m12 + jw_r1.y * cov3d.m22 + jw_r1.z * cov3d.m23,
@@ -244,7 +287,7 @@ namespace fast_lfs::rasterization::kernels::backward {
                 jw_r2.x * cov3d.m13 + jw_r2.y * cov3d.m23 + jw_r2.z * cov3d.m33);
 
             // 2d covariance gradient (use same dilation as forward pass)
-            constexpr float kernel_size = MIP_FILTER ? config::dilation_mip_filter : config::dilation;
+            constexpr float kernel_size = config::dilation_for<KIND, MIP_FILTER>();
             const float raw_a = dot(jwc_r1, jw_r1);
             const float raw_b = dot(jwc_r1, jw_r2);
             const float raw_c = dot(jwc_r2, jw_r2);
@@ -265,11 +308,15 @@ namespace fast_lfs::rasterization::kernels::backward {
             const float grad_compensated_opacity = grad_opacity_helper[primitive_idx];
             float opacity_compensation = 1.0f;
             if constexpr (MIP_FILTER) {
-                const float det_raw = raw_a * raw_c - raw_b * raw_b;
-                if (det_raw > config::min_cov2d_determinant && determinant > config::min_cov2d_determinant) {
-                    opacity_compensation = sqrtf(det_raw * determinant_rcp);
+                if constexpr (KIND == FastGSCameraKind::FISHEYE) {
+                    opacity_compensation = 1.0f;
                 } else {
-                    opacity_compensation = 0.0f;
+                    const float det_raw = raw_a * raw_c - raw_b * raw_b;
+                    if (det_raw > config::min_cov2d_determinant && determinant > config::min_cov2d_determinant) {
+                        opacity_compensation = sqrtf(det_raw * determinant_rcp);
+                    } else {
+                        opacity_compensation = 0.0f;
+                    }
                 }
             }
 
@@ -297,28 +344,52 @@ namespace fast_lfs::rasterization::kernels::backward {
                                                 jwc_r1.y * dL_dcov2d.y + jwc_r2.y * dL_dcov2d.z,
                                                 jwc_r1.z * dL_dcov2d.y + jwc_r2.z * dL_dcov2d.z);
 
-            // gradient of non-zero entries in J
-            const float dL_dj11 = w2c_r1.x * dL_djw_r1.x + w2c_r1.y * dL_djw_r1.y + w2c_r1.z * dL_djw_r1.z;
-            const float dL_dj22 = w2c_r2.x * dL_djw_r2.x + w2c_r2.y * dL_djw_r2.y + w2c_r2.z * dL_djw_r2.z;
-            const float dL_dj13 = w2c_r3.x * dL_djw_r1.x + w2c_r3.y * dL_djw_r1.y + w2c_r3.z * dL_djw_r1.z;
-            const float dL_dj23 = w2c_r3.x * dL_djw_r2.x + w2c_r3.y * dL_djw_r2.y + w2c_r3.z * dL_djw_r2.z;
-
-            // mean3d camera space gradient from J and mean2d (accounts for tx/ty clipping)
             const float2 dL_dmean2d = grad_mean2d[primitive_idx];
             const float dL_ddepth = grad_depth ? grad_depth[primitive_idx] : 0.0f;
-            float3 dL_dmean3d_cam = make_float3(
-                j11 * dL_dmean2d.x,
-                j22 * dL_dmean2d.y,
-                -j11 * x * dL_dmean2d.x - j22 * y * dL_dmean2d.y + dL_ddepth);
-            const bool valid_x = x >= clip_left && x <= clip_right;
-            const bool valid_y = y >= clip_top && y <= clip_bottom;
-            if (valid_x)
-                dL_dmean3d_cam.x -= j11 * dL_dj13 * inv_depth;
-            if (valid_y)
-                dL_dmean3d_cam.y -= j22 * dL_dj23 * inv_depth;
-            const float factor_x = 1.0f + static_cast<float>(valid_x);
-            const float factor_y = 1.0f + static_cast<float>(valid_y);
-            dL_dmean3d_cam.z += (j11 * (factor_x * tx * dL_dj13 - dL_dj11) + j22 * (factor_y * ty * dL_dj23 - dL_dj22)) * inv_depth;
+            float3 dL_dmean3d_cam;
+            if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+                // gradient of non-zero entries in J
+                const float dL_dj11 = w2c_r1.x * dL_djw_r1.x + w2c_r1.y * dL_djw_r1.y + w2c_r1.z * dL_djw_r1.z;
+                const float dL_dj22 = w2c_r2.x * dL_djw_r2.x + w2c_r2.y * dL_djw_r2.y + w2c_r2.z * dL_djw_r2.z;
+                const float dL_dj13 = w2c_r3.x * dL_djw_r1.x + w2c_r3.y * dL_djw_r1.y + w2c_r3.z * dL_djw_r1.z;
+                const float dL_dj23 = w2c_r3.x * dL_djw_r2.x + w2c_r3.y * dL_djw_r2.y + w2c_r3.z * dL_djw_r2.z;
+
+                // mean3d camera space gradient from J and mean2d (accounts for tx/ty clipping)
+                dL_dmean3d_cam = make_float3(
+                    j11 * dL_dmean2d.x,
+                    j22 * dL_dmean2d.y,
+                    -j11 * x * dL_dmean2d.x - j22 * y * dL_dmean2d.y + dL_ddepth);
+                const bool valid_x = x >= clip_left && x <= clip_right;
+                const bool valid_y = y >= clip_top && y <= clip_bottom;
+                if (valid_x)
+                    dL_dmean3d_cam.x -= j11 * dL_dj13 * inv_depth;
+                if (valid_y)
+                    dL_dmean3d_cam.y -= j22 * dL_dj23 * inv_depth;
+                const float factor_x = 1.0f + static_cast<float>(valid_x);
+                const float factor_y = 1.0f + static_cast<float>(valid_y);
+                dL_dmean3d_cam.z += (j11 * (factor_x * tx * dL_dj13 - dL_dj11) + j22 * (factor_y * ty * dL_dj23 - dL_dj22)) * inv_depth;
+            } else {
+                const float dL_dJ00 = w2c_r1.x * dL_djw_r1.x + w2c_r1.y * dL_djw_r1.y + w2c_r1.z * dL_djw_r1.z;
+                const float dL_dJ01 = w2c_r2.x * dL_djw_r1.x + w2c_r2.y * dL_djw_r1.y + w2c_r2.z * dL_djw_r1.z;
+                const float dL_dJ02 = w2c_r3.x * dL_djw_r1.x + w2c_r3.y * dL_djw_r1.y + w2c_r3.z * dL_djw_r1.z;
+                const float dL_dJ10 = w2c_r1.x * dL_djw_r2.x + w2c_r1.y * dL_djw_r2.y + w2c_r1.z * dL_djw_r2.z;
+                const float dL_dJ11 = w2c_r2.x * dL_djw_r2.x + w2c_r2.y * dL_djw_r2.y + w2c_r2.z * dL_djw_r2.z;
+                const float dL_dJ12 = w2c_r3.x * dL_djw_r2.x + w2c_r3.y * dL_djw_r2.y + w2c_r3.z * dL_djw_r2.z;
+
+                float dL_dPx = kb_proj.J00 * dL_dmean2d.x + kb_proj.J10 * dL_dmean2d.y;
+                float dL_dPy = kb_proj.J01 * dL_dmean2d.x + kb_proj.J11 * dL_dmean2d.y;
+                float dL_dPz = kb_proj.J02 * dL_dmean2d.x + kb_proj.J12 * dL_dmean2d.y;
+                fisheye_kb::kb_contract_dL_dJ(
+                    kb_proj, fx, fy,
+                    dL_dJ00, dL_dJ01, dL_dJ02, dL_dJ10, dL_dJ11, dL_dJ12,
+                    dL_dPx, dL_dPy, dL_dPz);
+                // Depth is ray length D; dD/dP = P/D.
+                const float inv_D = 1.0f / fmaxf(kb_proj.D, fisheye_kb::kMinRayLength);
+                dL_dPx += dL_ddepth * Px * inv_D;
+                dL_dPy += dL_ddepth * Py * inv_D;
+                dL_dPz += dL_ddepth * Pz * inv_D;
+                dL_dmean3d_cam = make_float3(dL_dPx, dL_dPy, dL_dPz);
+            }
 
             if (grad_w2c != nullptr) {
                 atomicAdd(&grad_w2c[0].w, dL_dmean3d_cam.x);

--- a/src/training/rasterization/fastgs/rasterization/include/kernels_forward.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernels_forward.cuh
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "buffer_utils.h"
+#include "fisheye_kb.cuh"
 #include "helper_math.h"
 #include "kernel_utils.cuh"
 #include "lfs/training/screen_share.cuh"
@@ -54,6 +55,7 @@ namespace fast_lfs::rasterization::kernels::forward {
         return (static_cast<InstanceKey>(tile_key) << depth_bits) | static_cast<InstanceKey>(depth_key);
     }
 
+    template <FastGSCameraKind KIND>
     __global__ void preprocess_cu(
         const float3* __restrict__ means,
         const float3* __restrict__ raw_scales,
@@ -96,9 +98,20 @@ namespace fast_lfs::rasterization::kernels::forward {
         const float far_,
         const uint depth_bits,
         const bool mip_filter,
-        float* __restrict__ max_screen_share) {
-        (void)w;
-        (void)h;
+        float* __restrict__ max_screen_share,
+        const float4 fisheye_k,
+        const float theta_max) {
+        if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+            (void)w;
+            (void)h;
+            (void)fisheye_k;
+            (void)theta_max;
+        } else {
+            (void)clip_left;
+            (void)clip_right;
+            (void)clip_top;
+            (void)clip_bottom;
+        }
         auto work_idx = cg::this_grid().thread_rank();
         bool active = work_idx < n_work_items;
         if (!active) {
@@ -117,11 +130,25 @@ namespace fast_lfs::rasterization::kernels::forward {
         // load 3d mean
         const float3 mean3d = means[primitive_idx];
 
-        // z culling
         const float4 w2c_r3 = w2c[2];
-        const float depth = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
-        if (depth < near_ || depth > far_)
-            active = false;
+        float depth;
+        [[maybe_unused]] float3 fisheye_P;
+        if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+            // z culling
+            depth = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
+            if (depth < near_ || depth > far_)
+                active = false;
+        } else {
+            const float4 fisheye_w2c_r1 = w2c[0];
+            const float4 fisheye_w2c_r2 = w2c[1];
+            fisheye_P.x = fisheye_w2c_r1.x * mean3d.x + fisheye_w2c_r1.y * mean3d.y + fisheye_w2c_r1.z * mean3d.z + fisheye_w2c_r1.w;
+            fisheye_P.y = fisheye_w2c_r2.x * mean3d.x + fisheye_w2c_r2.y * mean3d.y + fisheye_w2c_r2.z * mean3d.z + fisheye_w2c_r2.w;
+            fisheye_P.z = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
+            // FISHEYE depth is ray length D = |P| (z can be <= 0 at FOV > 180).
+            depth = sqrtf(fisheye_P.x * fisheye_P.x + fisheye_P.y * fisheye_P.y + fisheye_P.z * fisheye_P.z);
+            if (depth < near_ || depth > far_ || depth < fisheye_kb::kMinRayLength)
+                active = false;
+        }
 
         // early exit if whole warp is inactive
         if (__ballot_sync(0xffffffffu, active) == 0)
@@ -173,59 +200,113 @@ namespace fast_lfs::rasterization::kernels::forward {
             rotation_scaled.m31 * rotation.m31 + rotation_scaled.m32 * rotation.m32 + rotation_scaled.m33 * rotation.m33,
         };
 
-        // compute 2d mean in normalized image coordinates
-        const float inv_depth = 1.0f / depth;
-        const float4 w2c_r1 = w2c[0];
-        const float x = (w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w) * inv_depth;
-        const float4 w2c_r2 = w2c[1];
-        const float y = (w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w) * inv_depth;
+        float3 cov2d;
+        float2 mean2d;
+        float4 w2c_r1, w2c_r2;
+        if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+            // compute 2d mean in normalized image coordinates
+            const float inv_depth = 1.0f / depth;
+            w2c_r1 = w2c[0];
+            const float x = (w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w) * inv_depth;
+            w2c_r2 = w2c[1];
+            const float y = (w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w) * inv_depth;
 
-        // ewa splatting (clip box is grid-uniform; computed once on the host)
-        const float tx = clamp(x, clip_left, clip_right);
-        const float ty = clamp(y, clip_top, clip_bottom);
-        const float j11 = fx * inv_depth;
-        const float j13 = -j11 * tx;
-        const float j22 = fy * inv_depth;
-        const float j23 = -j22 * ty;
-        const float3 jw_r1 = make_float3(
-            j11 * w2c_r1.x + j13 * w2c_r3.x,
-            j11 * w2c_r1.y + j13 * w2c_r3.y,
-            j11 * w2c_r1.z + j13 * w2c_r3.z);
-        const float3 jw_r2 = make_float3(
-            j22 * w2c_r2.x + j23 * w2c_r3.x,
-            j22 * w2c_r2.y + j23 * w2c_r3.y,
-            j22 * w2c_r2.z + j23 * w2c_r3.z);
-        const float3 jwc_r1 = make_float3(
-            jw_r1.x * cov3d.m11 + jw_r1.y * cov3d.m12 + jw_r1.z * cov3d.m13,
-            jw_r1.x * cov3d.m12 + jw_r1.y * cov3d.m22 + jw_r1.z * cov3d.m23,
-            jw_r1.x * cov3d.m13 + jw_r1.y * cov3d.m23 + jw_r1.z * cov3d.m33);
-        const float3 jwc_r2 = make_float3(
-            jw_r2.x * cov3d.m11 + jw_r2.y * cov3d.m12 + jw_r2.z * cov3d.m13,
-            jw_r2.x * cov3d.m12 + jw_r2.y * cov3d.m22 + jw_r2.z * cov3d.m23,
-            jw_r2.x * cov3d.m13 + jw_r2.y * cov3d.m23 + jw_r2.z * cov3d.m33);
-        float3 cov2d = make_float3(dot(jwc_r1, jw_r1), dot(jwc_r1, jw_r2), dot(jwc_r2, jw_r2));
+            // ewa splatting (clip box is grid-uniform; computed once on the host)
+            const float tx = clamp(x, clip_left, clip_right);
+            const float ty = clamp(y, clip_top, clip_bottom);
+            const float j11 = fx * inv_depth;
+            const float j13 = -j11 * tx;
+            const float j22 = fy * inv_depth;
+            const float j23 = -j22 * ty;
+            const float3 jw_r1 = make_float3(
+                j11 * w2c_r1.x + j13 * w2c_r3.x,
+                j11 * w2c_r1.y + j13 * w2c_r3.y,
+                j11 * w2c_r1.z + j13 * w2c_r3.z);
+            const float3 jw_r2 = make_float3(
+                j22 * w2c_r2.x + j23 * w2c_r3.x,
+                j22 * w2c_r2.y + j23 * w2c_r3.y,
+                j22 * w2c_r2.z + j23 * w2c_r3.z);
+            const float3 jwc_r1 = make_float3(
+                jw_r1.x * cov3d.m11 + jw_r1.y * cov3d.m12 + jw_r1.z * cov3d.m13,
+                jw_r1.x * cov3d.m12 + jw_r1.y * cov3d.m22 + jw_r1.z * cov3d.m23,
+                jw_r1.x * cov3d.m13 + jw_r1.y * cov3d.m23 + jw_r1.z * cov3d.m33);
+            const float3 jwc_r2 = make_float3(
+                jw_r2.x * cov3d.m11 + jw_r2.y * cov3d.m12 + jw_r2.z * cov3d.m13,
+                jw_r2.x * cov3d.m12 + jw_r2.y * cov3d.m22 + jw_r2.z * cov3d.m23,
+                jw_r2.x * cov3d.m13 + jw_r2.y * cov3d.m23 + jw_r2.z * cov3d.m33);
+            cov2d = make_float3(dot(jwc_r1, jw_r1), dot(jwc_r1, jw_r2), dot(jwc_r2, jw_r2));
+            mean2d = make_float2(x * fx + cx, y * fy + cy);
+        } else {
+            w2c_r1 = w2c[0];
+            w2c_r2 = w2c[1];
+            const auto proj = fisheye_kb::kb_project(
+                fisheye_P.x, fisheye_P.y, fisheye_P.z, fx, fy, cx, cy,
+                fisheye_k.x, fisheye_k.y, fisheye_k.z, fisheye_k.w);
+            const bool proj_ok = proj.finite && proj.theta < theta_max;
+            if (!proj_ok)
+                active = false;
+
+            if (proj_ok) {
+                mean2d = make_float2(proj.px, proj.py);
+                const float3 jw_r1 = make_float3(
+                    proj.J00 * w2c_r1.x + proj.J01 * w2c_r2.x + proj.J02 * w2c_r3.x,
+                    proj.J00 * w2c_r1.y + proj.J01 * w2c_r2.y + proj.J02 * w2c_r3.y,
+                    proj.J00 * w2c_r1.z + proj.J01 * w2c_r2.z + proj.J02 * w2c_r3.z);
+                const float3 jw_r2 = make_float3(
+                    proj.J10 * w2c_r1.x + proj.J11 * w2c_r2.x + proj.J12 * w2c_r3.x,
+                    proj.J10 * w2c_r1.y + proj.J11 * w2c_r2.y + proj.J12 * w2c_r3.y,
+                    proj.J10 * w2c_r1.z + proj.J11 * w2c_r2.z + proj.J12 * w2c_r3.z);
+                const float3 jwc_r1 = make_float3(
+                    jw_r1.x * cov3d.m11 + jw_r1.y * cov3d.m12 + jw_r1.z * cov3d.m13,
+                    jw_r1.x * cov3d.m12 + jw_r1.y * cov3d.m22 + jw_r1.z * cov3d.m23,
+                    jw_r1.x * cov3d.m13 + jw_r1.y * cov3d.m23 + jw_r1.z * cov3d.m33);
+                const float3 jwc_r2 = make_float3(
+                    jw_r2.x * cov3d.m11 + jw_r2.y * cov3d.m12 + jw_r2.z * cov3d.m13,
+                    jw_r2.x * cov3d.m12 + jw_r2.y * cov3d.m22 + jw_r2.z * cov3d.m23,
+                    jw_r2.x * cov3d.m13 + jw_r2.y * cov3d.m23 + jw_r2.z * cov3d.m33);
+                cov2d = make_float3(dot(jwc_r1, jw_r1), dot(jwc_r1, jw_r2), dot(jwc_r2, jw_r2));
+            } else {
+                // Finite dummy so culled threads cannot inject NaN into the warp.
+                mean2d = make_float2(cx, cy);
+                cov2d = make_float3(config::dilation, 0.0f, config::dilation);
+            }
+        }
 
         // Mip filter: use smaller dilation and compensate opacity
         const float det_raw = mip_filter ? fmaxf(cov2d.x * cov2d.z - cov2d.y * cov2d.y, 0.0f) : 0.0f;
-        const float kernel_size = mip_filter ? config::dilation_mip_filter : config::dilation;
+        const float kernel_size = mip_filter ? config::dilation_for<KIND, true>()
+                                             : config::dilation_for<KIND, false>();
         cov2d.x += kernel_size;
         cov2d.z += kernel_size;
         const float det = cov2d.x * cov2d.z - cov2d.y * cov2d.y;
         if (det < config::min_cov2d_determinant)
             active = false;
         const float det_rcp = 1.0f / det;
-        const float output_opacity = mip_filter ? opacity * sqrtf(det_raw * det_rcp) : opacity;
+        float output_opacity;
+        if constexpr (KIND == FastGSCameraKind::FISHEYE) {
+            output_opacity = opacity;
+            (void)det_raw;
+        } else {
+            output_opacity = mip_filter ? opacity * sqrtf(det_raw * det_rcp) : opacity;
+        }
         if (output_opacity < config::min_alpha_threshold)
             active = false;
 
         const float3 conic = make_float3(cov2d.z * det_rcp, -cov2d.y * det_rcp, cov2d.x * det_rcp);
-        const float2 mean2d = make_float2(x * fx + cx, y * fy + cy);
 
         // Compute bounds
         const float power_threshold = logf(output_opacity * config::min_alpha_threshold_rcp);
         const float power_threshold_factor = sqrtf(2.0f * power_threshold);
         float extent_x = fmaxf(power_threshold_factor * sqrtf(cov2d.x) - 0.5f, 0.0f);
         float extent_y = fmaxf(power_threshold_factor * sqrtf(cov2d.z) - 0.5f, 0.0f);
+        if constexpr (KIND == FastGSCameraKind::FISHEYE) {
+            // Cull (never clamp) when the projected pixel is outside the image by
+            // more than the splat's screen-radius margin. Pinhole clip-box is unused.
+            if (mean2d.x + extent_x < 0.0f || mean2d.x - extent_x >= w ||
+                mean2d.y + extent_y < 0.0f || mean2d.y - extent_y >= h) {
+                active = false;
+            }
+        }
         const uint4 screen_bounds = compute_screen_tile_bounds(
             mean2d, extent_x, extent_y, grid_width, grid_height);
         const uint n_touched_tiles_max = (screen_bounds.y - screen_bounds.x) * (screen_bounds.w - screen_bounds.z);
@@ -298,6 +379,11 @@ namespace fast_lfs::rasterization::kernels::forward {
         primitive_color[work_idx] = make_float4(sh_color, 0.0f);
         primitive_depth_keys[work_idx] = quantize_depth_key(depth, depth_bits);
         primitive_depths[work_idx] = depth;
+        // Sort key: PINHOLE uses camera-z; FISHEYE uses ray length D = |P|.
+        // quantize_depth_key maps d>0 through (2d+1)/(d+1) into [1,2) so D's
+        // wider range stays ordered. CUB DeviceRadixSort is stable, and
+        // create_instances writes primitives in index order, so equal-depth
+        // ties are deterministic across runs.
 
         // Camera-space unit normal: rotation column of the smallest axis, oriented toward the camera.
         if (primitive_normals != nullptr) {
@@ -849,6 +935,7 @@ namespace fast_lfs::rasterization::kernels::forward {
             image[pixel_idx + n_pixels] = color_pixel0.y + transmittance0 * bg.y;
             image[pixel_idx + n_pixels * 2] = color_pixel0.z + transmittance0 * bg.z;
             alpha_map[pixel_idx] = 1.0f - transmittance0;
+            // Accumulated primitive depth: camera-z for PINHOLE, ray length D for FISHEYE.
             depth_map[pixel_idx] = depth_pixel0;
             if constexpr (kRenderNormal) {
                 normal_map[pixel_idx] = normal_pixel0.x;

--- a/src/training/rasterization/fastgs/rasterization/include/kernels_forward.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernels_forward.cuh
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "buffer_utils.h"
+#include "fisheye_kb.cuh"
 #include "helper_math.h"
 #include "kernel_utils.cuh"
 #include "rasterization_config.h"
@@ -53,6 +54,7 @@ namespace fast_lfs::rasterization::kernels::forward {
         return (static_cast<InstanceKey>(tile_key) << depth_bits) | static_cast<InstanceKey>(depth_key);
     }
 
+    template <FastGSCameraKind KIND>
     __global__ void preprocess_cu(
         const float3* __restrict__ means,
         const float3* __restrict__ raw_scales,
@@ -91,9 +93,20 @@ namespace fast_lfs::rasterization::kernels::forward {
         const float near_, // near and far are macros in windowns
         const float far_,
         const uint depth_bits,
-        const bool mip_filter) {
-        (void)w;
-        (void)h;
+        const bool mip_filter,
+        const float4 fisheye_k,
+        const float theta_max) {
+        if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+            (void)w;
+            (void)h;
+            (void)fisheye_k;
+            (void)theta_max;
+        } else {
+            (void)clip_left;
+            (void)clip_right;
+            (void)clip_top;
+            (void)clip_bottom;
+        }
         auto primitive_idx = cg::this_grid().thread_rank();
         bool active = true;
         if (primitive_idx >= n_primitives) {
@@ -107,11 +120,25 @@ namespace fast_lfs::rasterization::kernels::forward {
         // load 3d mean
         const float3 mean3d = means[primitive_idx];
 
-        // z culling
         const float4 w2c_r3 = w2c[2];
-        const float depth = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
-        if (depth < near_ || depth > far_)
-            active = false;
+        float depth;
+        [[maybe_unused]] float3 fisheye_P;
+        if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+            // z culling
+            depth = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
+            if (depth < near_ || depth > far_)
+                active = false;
+        } else {
+            const float4 fisheye_w2c_r1 = w2c[0];
+            const float4 fisheye_w2c_r2 = w2c[1];
+            fisheye_P.x = fisheye_w2c_r1.x * mean3d.x + fisheye_w2c_r1.y * mean3d.y + fisheye_w2c_r1.z * mean3d.z + fisheye_w2c_r1.w;
+            fisheye_P.y = fisheye_w2c_r2.x * mean3d.x + fisheye_w2c_r2.y * mean3d.y + fisheye_w2c_r2.z * mean3d.z + fisheye_w2c_r2.w;
+            fisheye_P.z = w2c_r3.x * mean3d.x + w2c_r3.y * mean3d.y + w2c_r3.z * mean3d.z + w2c_r3.w;
+            // FISHEYE depth is ray length D = |P| (z can be <= 0 at FOV > 180).
+            depth = sqrtf(fisheye_P.x * fisheye_P.x + fisheye_P.y * fisheye_P.y + fisheye_P.z * fisheye_P.z);
+            if (depth < near_ || depth > far_ || depth < fisheye_kb::kMinRayLength)
+                active = false;
+        }
 
         // early exit if whole warp is inactive
         if (__ballot_sync(0xffffffffu, active) == 0)
@@ -163,59 +190,113 @@ namespace fast_lfs::rasterization::kernels::forward {
             rotation_scaled.m31 * rotation.m31 + rotation_scaled.m32 * rotation.m32 + rotation_scaled.m33 * rotation.m33,
         };
 
-        // compute 2d mean in normalized image coordinates
-        const float inv_depth = 1.0f / depth;
-        const float4 w2c_r1 = w2c[0];
-        const float x = (w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w) * inv_depth;
-        const float4 w2c_r2 = w2c[1];
-        const float y = (w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w) * inv_depth;
+        float3 cov2d;
+        float2 mean2d;
+        float4 w2c_r1, w2c_r2;
+        if constexpr (KIND == FastGSCameraKind::PINHOLE) {
+            // compute 2d mean in normalized image coordinates
+            const float inv_depth = 1.0f / depth;
+            w2c_r1 = w2c[0];
+            const float x = (w2c_r1.x * mean3d.x + w2c_r1.y * mean3d.y + w2c_r1.z * mean3d.z + w2c_r1.w) * inv_depth;
+            w2c_r2 = w2c[1];
+            const float y = (w2c_r2.x * mean3d.x + w2c_r2.y * mean3d.y + w2c_r2.z * mean3d.z + w2c_r2.w) * inv_depth;
 
-        // ewa splatting (clip box is grid-uniform; computed once on the host)
-        const float tx = clamp(x, clip_left, clip_right);
-        const float ty = clamp(y, clip_top, clip_bottom);
-        const float j11 = fx * inv_depth;
-        const float j13 = -j11 * tx;
-        const float j22 = fy * inv_depth;
-        const float j23 = -j22 * ty;
-        const float3 jw_r1 = make_float3(
-            j11 * w2c_r1.x + j13 * w2c_r3.x,
-            j11 * w2c_r1.y + j13 * w2c_r3.y,
-            j11 * w2c_r1.z + j13 * w2c_r3.z);
-        const float3 jw_r2 = make_float3(
-            j22 * w2c_r2.x + j23 * w2c_r3.x,
-            j22 * w2c_r2.y + j23 * w2c_r3.y,
-            j22 * w2c_r2.z + j23 * w2c_r3.z);
-        const float3 jwc_r1 = make_float3(
-            jw_r1.x * cov3d.m11 + jw_r1.y * cov3d.m12 + jw_r1.z * cov3d.m13,
-            jw_r1.x * cov3d.m12 + jw_r1.y * cov3d.m22 + jw_r1.z * cov3d.m23,
-            jw_r1.x * cov3d.m13 + jw_r1.y * cov3d.m23 + jw_r1.z * cov3d.m33);
-        const float3 jwc_r2 = make_float3(
-            jw_r2.x * cov3d.m11 + jw_r2.y * cov3d.m12 + jw_r2.z * cov3d.m13,
-            jw_r2.x * cov3d.m12 + jw_r2.y * cov3d.m22 + jw_r2.z * cov3d.m23,
-            jw_r2.x * cov3d.m13 + jw_r2.y * cov3d.m23 + jw_r2.z * cov3d.m33);
-        float3 cov2d = make_float3(dot(jwc_r1, jw_r1), dot(jwc_r1, jw_r2), dot(jwc_r2, jw_r2));
+            // ewa splatting (clip box is grid-uniform; computed once on the host)
+            const float tx = clamp(x, clip_left, clip_right);
+            const float ty = clamp(y, clip_top, clip_bottom);
+            const float j11 = fx * inv_depth;
+            const float j13 = -j11 * tx;
+            const float j22 = fy * inv_depth;
+            const float j23 = -j22 * ty;
+            const float3 jw_r1 = make_float3(
+                j11 * w2c_r1.x + j13 * w2c_r3.x,
+                j11 * w2c_r1.y + j13 * w2c_r3.y,
+                j11 * w2c_r1.z + j13 * w2c_r3.z);
+            const float3 jw_r2 = make_float3(
+                j22 * w2c_r2.x + j23 * w2c_r3.x,
+                j22 * w2c_r2.y + j23 * w2c_r3.y,
+                j22 * w2c_r2.z + j23 * w2c_r3.z);
+            const float3 jwc_r1 = make_float3(
+                jw_r1.x * cov3d.m11 + jw_r1.y * cov3d.m12 + jw_r1.z * cov3d.m13,
+                jw_r1.x * cov3d.m12 + jw_r1.y * cov3d.m22 + jw_r1.z * cov3d.m23,
+                jw_r1.x * cov3d.m13 + jw_r1.y * cov3d.m23 + jw_r1.z * cov3d.m33);
+            const float3 jwc_r2 = make_float3(
+                jw_r2.x * cov3d.m11 + jw_r2.y * cov3d.m12 + jw_r2.z * cov3d.m13,
+                jw_r2.x * cov3d.m12 + jw_r2.y * cov3d.m22 + jw_r2.z * cov3d.m23,
+                jw_r2.x * cov3d.m13 + jw_r2.y * cov3d.m23 + jw_r2.z * cov3d.m33);
+            cov2d = make_float3(dot(jwc_r1, jw_r1), dot(jwc_r1, jw_r2), dot(jwc_r2, jw_r2));
+            mean2d = make_float2(x * fx + cx, y * fy + cy);
+        } else {
+            w2c_r1 = w2c[0];
+            w2c_r2 = w2c[1];
+            const auto proj = fisheye_kb::kb_project(
+                fisheye_P.x, fisheye_P.y, fisheye_P.z, fx, fy, cx, cy,
+                fisheye_k.x, fisheye_k.y, fisheye_k.z, fisheye_k.w);
+            const bool proj_ok = proj.finite && proj.theta < theta_max;
+            if (!proj_ok)
+                active = false;
+
+            if (proj_ok) {
+                mean2d = make_float2(proj.px, proj.py);
+                const float3 jw_r1 = make_float3(
+                    proj.J00 * w2c_r1.x + proj.J01 * w2c_r2.x + proj.J02 * w2c_r3.x,
+                    proj.J00 * w2c_r1.y + proj.J01 * w2c_r2.y + proj.J02 * w2c_r3.y,
+                    proj.J00 * w2c_r1.z + proj.J01 * w2c_r2.z + proj.J02 * w2c_r3.z);
+                const float3 jw_r2 = make_float3(
+                    proj.J10 * w2c_r1.x + proj.J11 * w2c_r2.x + proj.J12 * w2c_r3.x,
+                    proj.J10 * w2c_r1.y + proj.J11 * w2c_r2.y + proj.J12 * w2c_r3.y,
+                    proj.J10 * w2c_r1.z + proj.J11 * w2c_r2.z + proj.J12 * w2c_r3.z);
+                const float3 jwc_r1 = make_float3(
+                    jw_r1.x * cov3d.m11 + jw_r1.y * cov3d.m12 + jw_r1.z * cov3d.m13,
+                    jw_r1.x * cov3d.m12 + jw_r1.y * cov3d.m22 + jw_r1.z * cov3d.m23,
+                    jw_r1.x * cov3d.m13 + jw_r1.y * cov3d.m23 + jw_r1.z * cov3d.m33);
+                const float3 jwc_r2 = make_float3(
+                    jw_r2.x * cov3d.m11 + jw_r2.y * cov3d.m12 + jw_r2.z * cov3d.m13,
+                    jw_r2.x * cov3d.m12 + jw_r2.y * cov3d.m22 + jw_r2.z * cov3d.m23,
+                    jw_r2.x * cov3d.m13 + jw_r2.y * cov3d.m23 + jw_r2.z * cov3d.m33);
+                cov2d = make_float3(dot(jwc_r1, jw_r1), dot(jwc_r1, jw_r2), dot(jwc_r2, jw_r2));
+            } else {
+                // Finite dummy so culled threads cannot inject NaN into the warp.
+                mean2d = make_float2(cx, cy);
+                cov2d = make_float3(config::dilation, 0.0f, config::dilation);
+            }
+        }
 
         // Mip filter: use smaller dilation and compensate opacity
         const float det_raw = mip_filter ? fmaxf(cov2d.x * cov2d.z - cov2d.y * cov2d.y, 0.0f) : 0.0f;
-        const float kernel_size = mip_filter ? config::dilation_mip_filter : config::dilation;
+        const float kernel_size = mip_filter ? config::dilation_for<KIND, true>()
+                                             : config::dilation_for<KIND, false>();
         cov2d.x += kernel_size;
         cov2d.z += kernel_size;
         const float det = cov2d.x * cov2d.z - cov2d.y * cov2d.y;
         if (det < config::min_cov2d_determinant)
             active = false;
         const float det_rcp = 1.0f / det;
-        const float output_opacity = mip_filter ? opacity * sqrtf(det_raw * det_rcp) : opacity;
+        float output_opacity;
+        if constexpr (KIND == FastGSCameraKind::FISHEYE) {
+            output_opacity = opacity;
+            (void)det_raw;
+        } else {
+            output_opacity = mip_filter ? opacity * sqrtf(det_raw * det_rcp) : opacity;
+        }
         if (output_opacity < config::min_alpha_threshold)
             active = false;
 
         const float3 conic = make_float3(cov2d.z * det_rcp, -cov2d.y * det_rcp, cov2d.x * det_rcp);
-        const float2 mean2d = make_float2(x * fx + cx, y * fy + cy);
 
         // Compute bounds
         const float power_threshold = logf(output_opacity * config::min_alpha_threshold_rcp);
         const float power_threshold_factor = sqrtf(2.0f * power_threshold);
         float extent_x = fmaxf(power_threshold_factor * sqrtf(cov2d.x) - 0.5f, 0.0f);
         float extent_y = fmaxf(power_threshold_factor * sqrtf(cov2d.z) - 0.5f, 0.0f);
+        if constexpr (KIND == FastGSCameraKind::FISHEYE) {
+            // Cull (never clamp) when the projected pixel is outside the image by
+            // more than the splat's screen-radius margin. Pinhole clip-box is unused.
+            if (mean2d.x + extent_x < 0.0f || mean2d.x - extent_x >= w ||
+                mean2d.y + extent_y < 0.0f || mean2d.y - extent_y >= h) {
+                active = false;
+            }
+        }
         const uint4 screen_bounds = compute_screen_tile_bounds(
             mean2d, extent_x, extent_y, grid_width, grid_height);
         const uint n_touched_tiles_max = (screen_bounds.y - screen_bounds.x) * (screen_bounds.w - screen_bounds.z);
@@ -269,6 +350,11 @@ namespace fast_lfs::rasterization::kernels::forward {
             primitive_idx, active_sh_bases, sh_layout_slots,
             sh_value_bounds, sh_value_n_cells, sh_value_bits);
         primitive_color[primitive_idx] = make_float4(sh_color, 0.0f);
+        // Sort key: PINHOLE uses camera-z; FISHEYE uses ray length D = |P|.
+        // quantize_depth_key maps d>0 through (2d+1)/(d+1) into [1,2) so D's
+        // wider range stays ordered. CUB DeviceRadixSort is stable, and
+        // create_instances writes primitives in index order, so equal-depth
+        // ties are deterministic across runs.
         primitive_depth_keys[primitive_idx] = quantize_depth_key(depth, depth_bits);
         primitive_depths[primitive_idx] = depth;
 
@@ -818,6 +904,7 @@ namespace fast_lfs::rasterization::kernels::forward {
             image[pixel_idx + n_pixels] = color_pixel0.y + transmittance0 * bg.y;
             image[pixel_idx + n_pixels * 2] = color_pixel0.z + transmittance0 * bg.z;
             alpha_map[pixel_idx] = 1.0f - transmittance0;
+            // Accumulated primitive depth: camera-z for PINHOLE, ray length D for FISHEYE.
             depth_map[pixel_idx] = depth_pixel0;
             if constexpr (kRenderNormal) {
                 normal_map[pixel_idx] = normal_pixel0.x;

--- a/src/training/rasterization/fastgs/rasterization/include/rasterization_api.h
+++ b/src/training/rasterization/fastgs/rasterization/include/rasterization_api.h
@@ -89,7 +89,13 @@ namespace fast_lfs::rasterization {
         cudaStream_t stream = nullptr,              // nullptr → getCurrentCUDAStream()
         const float* sh_value_bounds_ptr = nullptr, // float2 per 256; null = fp32/IEEE-f16 shN
         unsigned int sh_value_n_cells = 0,
-        unsigned int sh_value_bits = 0); // 0=fp32, 16=q16(+bounds) or IEEE f16
+        unsigned int sh_value_bits = 0, // 0=fp32, 16=q16(+bounds) or IEEE f16
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE,
+        float fisheye_k1 = 0.0f,
+        float fisheye_k2 = 0.0f,
+        float fisheye_k3 = 0.0f,
+        float fisheye_k4 = 0.0f,
+        float fisheye_theta_max = 0.0f);
 
     void release_forward_context(const ForwardContext& forward_ctx);
 
@@ -135,7 +141,13 @@ namespace fast_lfs::rasterization {
         // codes; bits==16 without bounds → IEEE f16 swizzle; bits==0 → fp32.
         const float* shN_value_bounds_ptr = nullptr,
         unsigned shN_value_n_cells = 0u,
-        unsigned shN_value_bits = 0u);
+        unsigned shN_value_bits = 0u,
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE,
+        float fisheye_k1 = 0.0f,
+        float fisheye_k2 = 0.0f,
+        float fisheye_k3 = 0.0f,
+        float fisheye_k4 = 0.0f,
+        float fisheye_theta_max = 0.0f);
 
     // Pre-compile all CUDA kernels to avoid JIT delays during rendering
     void warmup_kernels();

--- a/src/training/rasterization/fastgs/rasterization/include/rasterization_api.h
+++ b/src/training/rasterization/fastgs/rasterization/include/rasterization_api.h
@@ -101,7 +101,13 @@ namespace fast_lfs::rasterization {
         const float* sh_value_bounds_ptr = nullptr, // float2 per 256; null = fp32/IEEE-f16 shN
         unsigned int sh_value_n_cells = 0,
         unsigned int sh_value_bits = 0, // 0=fp32, 16=q16(+bounds) or IEEE f16
-        float* max_screen_share_ptr = nullptr);
+        float* max_screen_share_ptr = nullptr,
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE,
+        float fisheye_k1 = 0.0f,
+        float fisheye_k2 = 0.0f,
+        float fisheye_k3 = 0.0f,
+        float fisheye_k4 = 0.0f,
+        float fisheye_theta_max = 0.0f);
 
     void release_forward_context(const ForwardContext& forward_ctx);
 
@@ -152,7 +158,13 @@ namespace fast_lfs::rasterization {
         const bool* mean_step_far_mask = nullptr,
         int mean_step_far_mask_n = 0,
         const float* edge_weight_map = nullptr,
-        float* edge_score_out = nullptr);
+        float* edge_score_out = nullptr,
+        FastGSCameraKind camera_kind = FastGSCameraKind::PINHOLE,
+        float fisheye_k1 = 0.0f,
+        float fisheye_k2 = 0.0f,
+        float fisheye_k3 = 0.0f,
+        float fisheye_k4 = 0.0f,
+        float fisheye_theta_max = 0.0f);
 
     // Pre-compile all CUDA kernels to avoid JIT delays during rendering
     void warmup_kernels();

--- a/src/training/rasterization/fastgs/rasterization/include/rasterization_config.h
+++ b/src/training/rasterization/fastgs/rasterization/include/rasterization_config.h
@@ -12,10 +12,28 @@ enum class DensificationType : int { None = 0,
                                      MCMC = 1,
                                      MRNF = 2 };
 
+// FastGS camera model. PINHOLE is the historical path (bit-identical). FISHEYE
+// is native Kannala-Brandt (COLMAP OPENCV_FISHEYE); see fisheye_kb.cuh.
+enum class FastGSCameraKind : int { PINHOLE = 0,
+                                    FISHEYE = 1 };
+
 namespace fast_lfs::rasterization::config {
     // rendering constants
     DEF float dilation = 0.3f;            // Standard dilation when mip_filter OFF
     DEF float dilation_mip_filter = 0.1f; // Smaller dilation when mip_filter ON
+
+    // 2D kernel size added to cov2d. PINHOLE keeps the historical 0.3 / 0.1
+    // values; FISHEYE composites the EWA footprint without dilation.
+    template <FastGSCameraKind KIND, bool MIP>
+    constexpr float dilation_for() {
+        if constexpr (KIND == FastGSCameraKind::FISHEYE) {
+            return 0.0f;
+        } else if constexpr (MIP) {
+            return dilation_mip_filter;
+        } else {
+            return dilation;
+        }
+    }
     DEF float min_alpha_threshold_rcp = 255.0f;
     DEF float min_alpha_threshold = 1.0f / min_alpha_threshold_rcp; // 0.00392156862
     DEF float max_fragment_alpha = 0.999f;                          // 0.99f in original 3dgs

--- a/src/training/rasterization/fastgs/rasterization/src/backward.cu
+++ b/src/training/rasterization/fastgs/rasterization/src/backward.cu
@@ -4,6 +4,7 @@
 
 #include "backward.h"
 #include "buffer_utils.h"
+#include "fisheye_kb.cuh"
 #include "forward.h"
 #include "helper_math.h"
 #include "kernels_backward.cuh"
@@ -65,7 +66,13 @@ void fast_lfs::rasterization::backward(
     const int mean_step_far_mask_n,
     const float* edge_weight_map,
     float* edge_score_out,
-    cudaStream_t stream) {
+    cudaStream_t stream,
+    FastGSCameraKind camera_kind,
+    float fisheye_k1,
+    float fisheye_k2,
+    float fisheye_k3,
+    float fisheye_k4,
+    float fisheye_theta_max) {
     const dim3 grid(div_round_up(width, config::tile_width), div_round_up(height, config::tile_height), 1);
     const uint64_t n_tiles_u64 = static_cast<uint64_t>(grid.x) * static_cast<uint64_t>(grid.y);
     const int n_tiles = checked_to_int(n_tiles_u64, "n_tiles exceeds int range");
@@ -158,9 +165,17 @@ void fast_lfs::rasterization::backward(
     const float h_f = static_cast<float>(height);
     float clip_left, clip_right, clip_top, clip_bottom;
     ewa_clip_bounds(w_f, h_f, fx, fy, cx, cy, clip_left, clip_right, clip_top, clip_bottom);
+    const float4 fisheye_k = make_float4(fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4);
+    const float theta_max = camera_kind == FastGSCameraKind::FISHEYE
+                                ? (fisheye_theta_max > 0.0f
+                                       ? fisheye_theta_max
+                                       : fisheye_kb::kb_theta_max_from_intrinsics(
+                                             fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4,
+                                             width, height, fx, fy, cx, cy))
+                                : 0.0f;
     if (n_primitives > 0) {
-        auto launch_preprocess_backward = [&]<bool MIP_FILTER, int ACTIVE_SH_BASES>() {
-            kernels::backward::preprocess_backward_cu<MIP_FILTER, ACTIVE_SH_BASES><<<div_round_up(n_primitives, config::block_size_preprocess_backward), config::block_size_preprocess_backward, 0, stream>>>(
+        auto launch_preprocess_backward = [&]<bool MIP_FILTER, int ACTIVE_SH_BASES, FastGSCameraKind KIND>() {
+            kernels::backward::preprocess_backward_cu<MIP_FILTER, ACTIVE_SH_BASES, KIND><<<div_round_up(n_primitives, config::block_size_preprocess_backward), config::block_size_preprocess_backward, 0, stream>>>(
                 means,
                 scales_raw,
                 rotations_raw,
@@ -189,6 +204,8 @@ void fast_lfs::rasterization::backward(
                 clip_top,
                 clip_bottom,
                 sh_layout_slots,
+                fisheye_k,
+                theta_max,
                 fused_adam,
                 mean_step_far_mask,
                 mean_step_far_mask_n,
@@ -197,21 +214,28 @@ void fast_lfs::rasterization::backward(
                 shN_value_bits);
             LFS_CUDA_LAUNCH_CHECK(stream, "fastgs.backward.preprocess_backward");
         };
-        auto launch_preprocess_backward_for_mip = [&]<int ACTIVE_SH_BASES>() {
+        auto launch_preprocess_backward_for_mip = [&]<int ACTIVE_SH_BASES, FastGSCameraKind KIND>() {
             if (mip_filter) {
-                launch_preprocess_backward.template operator()<true, ACTIVE_SH_BASES>();
+                launch_preprocess_backward.template operator()<true, ACTIVE_SH_BASES, KIND>();
             } else {
-                launch_preprocess_backward.template operator()<false, ACTIVE_SH_BASES>();
+                launch_preprocess_backward.template operator()<false, ACTIVE_SH_BASES, KIND>();
+            }
+        };
+        auto launch_preprocess_backward_for_kind = [&]<int ACTIVE_SH_BASES>() {
+            if (camera_kind == FastGSCameraKind::FISHEYE) {
+                launch_preprocess_backward_for_mip.template operator()<ACTIVE_SH_BASES, FastGSCameraKind::FISHEYE>();
+            } else {
+                launch_preprocess_backward_for_mip.template operator()<ACTIVE_SH_BASES, FastGSCameraKind::PINHOLE>();
             }
         };
         if (active_sh_bases <= 1) {
-            launch_preprocess_backward_for_mip.template operator()<1>();
+            launch_preprocess_backward_for_kind.template operator()<1>();
         } else if (active_sh_bases <= 4) {
-            launch_preprocess_backward_for_mip.template operator()<4>();
+            launch_preprocess_backward_for_kind.template operator()<4>();
         } else if (active_sh_bases <= 9) {
-            launch_preprocess_backward_for_mip.template operator()<9>();
+            launch_preprocess_backward_for_kind.template operator()<9>();
         } else {
-            launch_preprocess_backward_for_mip.template operator()<16>();
+            launch_preprocess_backward_for_kind.template operator()<16>();
         }
         check_cuda_with_fastgs_status(cudaGetLastError(), "preprocess_backward", fastgs_status, "preprocess_backward", static_cast<uint64_t>(n_primitives), n_tiles_u64);
         sync_fastgs_phase_if_requested("preprocess_backward", fastgs_status, "preprocess_backward", static_cast<uint64_t>(n_primitives), n_tiles_u64);

--- a/src/training/rasterization/fastgs/rasterization/src/backward.cu
+++ b/src/training/rasterization/fastgs/rasterization/src/backward.cu
@@ -4,6 +4,7 @@
 
 #include "backward.h"
 #include "buffer_utils.h"
+#include "fisheye_kb.cuh"
 #include "forward.h"
 #include "helper_math.h"
 #include "kernels_backward.cuh"
@@ -59,7 +60,13 @@ void fast_lfs::rasterization::backward(
     const float2* shN_value_bounds,
     const uint shN_value_n_cells,
     const uint shN_value_bits,
-    cudaStream_t stream) {
+    cudaStream_t stream,
+    FastGSCameraKind camera_kind,
+    float fisheye_k1,
+    float fisheye_k2,
+    float fisheye_k3,
+    float fisheye_k4,
+    float fisheye_theta_max) {
     const dim3 grid(div_round_up(width, config::tile_width), div_round_up(height, config::tile_height), 1);
     const uint64_t n_tiles_u64 = static_cast<uint64_t>(grid.x) * static_cast<uint64_t>(grid.y);
     const int n_tiles = checked_to_int(n_tiles_u64, "n_tiles exceeds int range");
@@ -147,9 +154,17 @@ void fast_lfs::rasterization::backward(
     const float h_f = static_cast<float>(height);
     float clip_left, clip_right, clip_top, clip_bottom;
     ewa_clip_bounds(w_f, h_f, fx, fy, cx, cy, clip_left, clip_right, clip_top, clip_bottom);
+    const float4 fisheye_k = make_float4(fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4);
+    const float theta_max = camera_kind == FastGSCameraKind::FISHEYE
+                                ? (fisheye_theta_max > 0.0f
+                                       ? fisheye_theta_max
+                                       : fisheye_kb::kb_theta_max_from_intrinsics(
+                                             fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4,
+                                             width, height, fx, fy, cx, cy))
+                                : 0.0f;
     if (n_primitives > 0) {
-        auto launch_preprocess_backward = [&]<bool MIP_FILTER, int ACTIVE_SH_BASES>() {
-            kernels::backward::preprocess_backward_cu<MIP_FILTER, ACTIVE_SH_BASES><<<div_round_up(n_primitives, config::block_size_preprocess_backward), config::block_size_preprocess_backward, 0, stream>>>(
+        auto launch_preprocess_backward = [&]<bool MIP_FILTER, int ACTIVE_SH_BASES, FastGSCameraKind KIND>() {
+            kernels::backward::preprocess_backward_cu<MIP_FILTER, ACTIVE_SH_BASES, KIND><<<div_round_up(n_primitives, config::block_size_preprocess_backward), config::block_size_preprocess_backward, 0, stream>>>(
                 means,
                 scales_raw,
                 rotations_raw,
@@ -178,27 +193,36 @@ void fast_lfs::rasterization::backward(
                 clip_top,
                 clip_bottom,
                 sh_layout_slots,
+                fisheye_k,
+                theta_max,
                 fused_adam,
                 shN_value_bounds,
                 shN_value_n_cells,
                 shN_value_bits);
             LFS_CUDA_LAUNCH_CHECK(stream, "fastgs.backward.preprocess_backward");
         };
-        auto launch_preprocess_backward_for_mip = [&]<int ACTIVE_SH_BASES>() {
+        auto launch_preprocess_backward_for_mip = [&]<int ACTIVE_SH_BASES, FastGSCameraKind KIND>() {
             if (mip_filter) {
-                launch_preprocess_backward.template operator()<true, ACTIVE_SH_BASES>();
+                launch_preprocess_backward.template operator()<true, ACTIVE_SH_BASES, KIND>();
             } else {
-                launch_preprocess_backward.template operator()<false, ACTIVE_SH_BASES>();
+                launch_preprocess_backward.template operator()<false, ACTIVE_SH_BASES, KIND>();
+            }
+        };
+        auto launch_preprocess_backward_for_kind = [&]<int ACTIVE_SH_BASES>() {
+            if (camera_kind == FastGSCameraKind::FISHEYE) {
+                launch_preprocess_backward_for_mip.template operator()<ACTIVE_SH_BASES, FastGSCameraKind::FISHEYE>();
+            } else {
+                launch_preprocess_backward_for_mip.template operator()<ACTIVE_SH_BASES, FastGSCameraKind::PINHOLE>();
             }
         };
         if (active_sh_bases <= 1) {
-            launch_preprocess_backward_for_mip.template operator()<1>();
+            launch_preprocess_backward_for_kind.template operator()<1>();
         } else if (active_sh_bases <= 4) {
-            launch_preprocess_backward_for_mip.template operator()<4>();
+            launch_preprocess_backward_for_kind.template operator()<4>();
         } else if (active_sh_bases <= 9) {
-            launch_preprocess_backward_for_mip.template operator()<9>();
+            launch_preprocess_backward_for_kind.template operator()<9>();
         } else {
-            launch_preprocess_backward_for_mip.template operator()<16>();
+            launch_preprocess_backward_for_kind.template operator()<16>();
         }
         check_cuda_with_fastgs_status(cudaGetLastError(), "preprocess_backward", fastgs_status, "preprocess_backward", static_cast<uint64_t>(n_primitives), n_tiles_u64);
         sync_fastgs_phase_if_requested("preprocess_backward", fastgs_status, "preprocess_backward", static_cast<uint64_t>(n_primitives), n_tiles_u64);

--- a/src/training/rasterization/fastgs/rasterization/src/forward.cu
+++ b/src/training/rasterization/fastgs/rasterization/src/forward.cu
@@ -4,6 +4,7 @@
 
 #include "buffer_utils.h"
 #include "core/crash_handler.hpp"
+#include "fisheye_kb.cuh"
 #include "forward.h"
 #include "helper_math.h"
 #include "kernels_forward.cuh"
@@ -201,7 +202,13 @@ fast_lfs::rasterization::ForwardResult fast_lfs::rasterization::forward(
     const float far_,
     bool mip_filter,
     cudaStream_t stream,
-    float* max_screen_share) {
+    float* max_screen_share,
+    FastGSCameraKind camera_kind,
+    float fisheye_k1,
+    float fisheye_k2,
+    float fisheye_k3,
+    float fisheye_k4,
+    float fisheye_theta_max) {
 
     const dim3 grid(div_round_up(width, config::tile_width), div_round_up(height, config::tile_height), 1);
     const uint64_t n_tiles_u64 = static_cast<uint64_t>(grid.x) * static_cast<uint64_t>(grid.y);
@@ -229,13 +236,21 @@ fast_lfs::rasterization::ForwardResult fast_lfs::rasterization::forward(
     const float h_f = static_cast<float>(height);
     float clip_left, clip_right, clip_top, clip_bottom;
     ewa_clip_bounds(w_f, h_f, fx, fy, cx, cy, clip_left, clip_right, clip_top, clip_bottom);
+    const float4 fisheye_k = make_float4(fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4);
+    const float theta_max = camera_kind == FastGSCameraKind::FISHEYE
+                                ? (fisheye_theta_max > 0.0f
+                                       ? fisheye_theta_max
+                                       : fisheye_kb::kb_theta_max_from_intrinsics(
+                                             fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4,
+                                             width, height, fx, fy, cx, cy))
+                                : 0.0f;
 
     char* visibility_blob = per_primitive_buffers_func(required<VisibilityBuffers>(n_primitives));
     if (!visibility_blob)
         throw std::runtime_error("OUT_OF_MEMORY: Failed to allocate FastGS visibility buffers");
     VisibilityBuffers visibility_buffers = VisibilityBuffers::from_blob(visibility_blob, n_primitives);
 
-    auto launch_preprocess = [&](const uint* primitive_indices,
+    auto launch_preprocess = [&]<FastGSCameraKind KIND>(const uint* primitive_indices,
                                  uint* visibility_mask,
                                  uint* depth_keys,
                                  float* depths,
@@ -247,7 +262,7 @@ fast_lfs::rasterization::ForwardResult fast_lfs::rasterization::forward(
                                  float3* normals,
                                  const uint n_work_items,
                                  float* screen_share) {
-        kernels::forward::preprocess_cu<<<div_round_up(n_work_items, static_cast<uint>(config::block_size_preprocess)), config::block_size_preprocess, 0, stream>>>(
+        kernels::forward::preprocess_cu<KIND><<<div_round_up(n_work_items, static_cast<uint>(config::block_size_preprocess)), config::block_size_preprocess, 0, stream>>>(
             means,
             scales_raw,
             rotations_raw,
@@ -289,7 +304,9 @@ fast_lfs::rasterization::ForwardResult fast_lfs::rasterization::forward(
             far_,
             depth_bits,
             mip_filter,
-            screen_share);
+            screen_share,
+            fisheye_k,
+            theta_max);
         LFS_CUDA_LAUNCH_CHECK(stream, "fastgs.forward.preprocess");
     };
 
@@ -299,10 +316,17 @@ fast_lfs::rasterization::ForwardResult fast_lfs::rasterization::forward(
                                          visibility_mask_bytes, stream),
                          "cudaMemsetAsync(FastGS visibility mask)");
 
-    launch_preprocess(nullptr,
+    if (camera_kind == FastGSCameraKind::FISHEYE) {
+        launch_preprocess.template operator()<FastGSCameraKind::FISHEYE>(nullptr,
                       visibility_buffers.visibility_mask,
                       nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                       static_cast<uint>(n_primitives), max_screen_share);
+    } else {
+        launch_preprocess.template operator()<FastGSCameraKind::PINHOLE>(nullptr,
+                      visibility_buffers.visibility_mask,
+                      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                      static_cast<uint>(n_primitives), max_screen_share);
+    }
     LFS_FASTGS_PHASE_CHECK("fastgs.forward.preprocess.visibility");
 
     const uint n_visibility_blocks = static_cast<uint>(
@@ -376,7 +400,8 @@ fast_lfs::rasterization::ForwardResult fast_lfs::rasterization::forward(
                          "cudaMemsetAsync(FastGS forward status)");
 
     if (n_visible > 0) {
-        launch_preprocess(visibility_buffers.visible_indices,
+        if (camera_kind == FastGSCameraKind::FISHEYE) {
+            launch_preprocess.template operator()<FastGSCameraKind::FISHEYE>(visibility_buffers.visible_indices,
                           nullptr,
                           per_primitive_buffers.depth_keys,
                           per_primitive_buffers.depths,
@@ -387,6 +412,19 @@ fast_lfs::rasterization::ForwardResult fast_lfs::rasterization::forward(
                           per_primitive_buffers.color,
                           primitive_normals,
                           static_cast<uint>(n_visible), nullptr);
+        } else {
+            launch_preprocess.template operator()<FastGSCameraKind::PINHOLE>(visibility_buffers.visible_indices,
+                          nullptr,
+                          per_primitive_buffers.depth_keys,
+                          per_primitive_buffers.depths,
+                          per_primitive_buffers.n_touched_tiles,
+                          per_primitive_buffers.screen_bounds,
+                          per_primitive_buffers.mean2d,
+                          per_primitive_buffers.conic_opacity,
+                          per_primitive_buffers.color,
+                          primitive_normals,
+                          static_cast<uint>(n_visible), nullptr);
+        }
         check_cuda_with_fastgs_status(cudaGetLastError(), "preprocess", forward_status, "preprocess", static_cast<uint64_t>(n_primitives), n_tiles_u64);
         sync_fastgs_phase_if_requested("preprocess", forward_status, "preprocess", static_cast<uint64_t>(n_primitives), n_tiles_u64);
     }

--- a/src/training/rasterization/fastgs/rasterization/src/forward.cu
+++ b/src/training/rasterization/fastgs/rasterization/src/forward.cu
@@ -6,6 +6,7 @@
 #include "core/crash_handler.hpp"
 #include "core/memory_pressure.hpp"
 #include "core/tensor/internal/memory_pool.hpp"
+#include "fisheye_kb.cuh"
 #include "forward.h"
 #include "helper_math.h"
 #include "kernels_forward.cuh"
@@ -395,7 +396,13 @@ fast_lfs::rasterization::ForwardResult fast_lfs::rasterization::forward(
     const float near_, // near and far are macros in windows
     const float far_,
     bool mip_filter,
-    cudaStream_t stream) {
+    cudaStream_t stream,
+    FastGSCameraKind camera_kind,
+    float fisheye_k1,
+    float fisheye_k2,
+    float fisheye_k3,
+    float fisheye_k4,
+    float fisheye_theta_max) {
 
     const dim3 grid(div_round_up(width, config::tile_width), div_round_up(height, config::tile_height), 1);
     const uint64_t n_tiles_u64 = static_cast<uint64_t>(grid.x) * static_cast<uint64_t>(grid.y);
@@ -429,46 +436,63 @@ fast_lfs::rasterization::ForwardResult fast_lfs::rasterization::forward(
     const float h_f = static_cast<float>(height);
     float clip_left, clip_right, clip_top, clip_bottom;
     ewa_clip_bounds(w_f, h_f, fx, fy, cx, cy, clip_left, clip_right, clip_top, clip_bottom);
-    kernels::forward::preprocess_cu<<<div_round_up(n_primitives, config::block_size_preprocess), config::block_size_preprocess, 0, stream>>>(
-        means,
-        scales_raw,
-        rotations_raw,
-        opacities_raw,
-        sh_coefficients_0,
-        sh_coefficients_rest,
-        sh_value_bounds,
-        sh_value_n_cells,
-        sh_value_bits,
-        w2c,
-        cam_position,
-        per_primitive_buffers.depth_keys,
-        per_primitive_buffers.depths,
-        per_primitive_buffers.n_touched_tiles,
-        per_primitive_buffers.screen_bounds,
-        per_primitive_buffers.mean2d,
-        per_primitive_buffers.conic_opacity,
-        per_primitive_buffers.color,
-        normal != nullptr ? primitive_normals : nullptr,
-        n_primitives,
-        grid.x,
-        grid.y,
-        active_sh_bases,
-        sh_layout_slots,
-        w_f,
-        h_f,
-        fx,
-        fy,
-        cx,
-        cy,
-        clip_left,
-        clip_right,
-        clip_top,
-        clip_bottom,
-        near_,
-        far_,
-        depth_bits,
-        mip_filter);
-    LFS_CUDA_LAUNCH_CHECK(stream, "fastgs.forward.preprocess");
+    const float4 fisheye_k = make_float4(fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4);
+    const float theta_max = camera_kind == FastGSCameraKind::FISHEYE
+                                ? (fisheye_theta_max > 0.0f
+                                       ? fisheye_theta_max
+                                       : fisheye_kb::kb_theta_max_from_intrinsics(
+                                             fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4,
+                                             width, height, fx, fy, cx, cy))
+                                : 0.0f;
+    auto launch_preprocess = [&]<FastGSCameraKind KIND>() {
+        kernels::forward::preprocess_cu<KIND><<<div_round_up(n_primitives, config::block_size_preprocess), config::block_size_preprocess, 0, stream>>>(
+            means,
+            scales_raw,
+            rotations_raw,
+            opacities_raw,
+            sh_coefficients_0,
+            sh_coefficients_rest,
+            sh_value_bounds,
+            sh_value_n_cells,
+            sh_value_bits,
+            w2c,
+            cam_position,
+            per_primitive_buffers.depth_keys,
+            per_primitive_buffers.depths,
+            per_primitive_buffers.n_touched_tiles,
+            per_primitive_buffers.screen_bounds,
+            per_primitive_buffers.mean2d,
+            per_primitive_buffers.conic_opacity,
+            per_primitive_buffers.color,
+            normal != nullptr ? primitive_normals : nullptr,
+            n_primitives,
+            grid.x,
+            grid.y,
+            active_sh_bases,
+            sh_layout_slots,
+            w_f,
+            h_f,
+            fx,
+            fy,
+            cx,
+            cy,
+            clip_left,
+            clip_right,
+            clip_top,
+            clip_bottom,
+            near_,
+            far_,
+            depth_bits,
+            mip_filter,
+            fisheye_k,
+            theta_max);
+        LFS_CUDA_LAUNCH_CHECK(stream, "fastgs.forward.preprocess");
+    };
+    if (camera_kind == FastGSCameraKind::FISHEYE) {
+        launch_preprocess.template operator()<FastGSCameraKind::FISHEYE>();
+    } else {
+        launch_preprocess.template operator()<FastGSCameraKind::PINHOLE>();
+    }
     check_cuda_with_fastgs_status(cudaGetLastError(), "preprocess", forward_status, "preprocess", static_cast<uint64_t>(n_primitives), n_tiles_u64);
     sync_fastgs_phase_if_requested("preprocess", forward_status, "preprocess", static_cast<uint64_t>(n_primitives), n_tiles_u64);
 

--- a/src/training/rasterization/fastgs/rasterization/src/rasterization_api.cu
+++ b/src/training/rasterization/fastgs/rasterization/src/rasterization_api.cu
@@ -228,7 +228,13 @@ namespace fast_lfs::rasterization {
         const float* sh_value_bounds_ptr,
         unsigned int sh_value_n_cells,
         unsigned int sh_value_bits,
-        float* max_screen_share_ptr) {
+        float* max_screen_share_ptr,
+        FastGSCameraKind camera_kind,
+        float fisheye_k1,
+        float fisheye_k2,
+        float fisheye_k3,
+        float fisheye_k4,
+        float fisheye_theta_max) {
 
         if (stream == nullptr) {
             stream = lfs::core::getCurrentCUDAStream();
@@ -327,7 +333,7 @@ namespace fast_lfs::rasterization {
 
             // Call the actual forward implementation
             ForwardResult forward_result = forward(per_primitive_buffers_func, [phase_arena](size_t size) { phase_arena->begin_phase(
-                                                                                                                FastGSPhaseArena::Phase::Forward, size); }, phase_forward_allocator, [phase_arena](const void* source, size_t size) { return phase_arena->retain_prefix(source, size); }, per_tile_buffers_func, reinterpret_cast<const float3*>(means_ptr), reinterpret_cast<const float3*>(scales_raw_ptr), reinterpret_cast<const float4*>(rotations_raw_ptr), opacities_raw_ptr, reinterpret_cast<const float3*>(sh_coefficients_0_ptr), reinterpret_cast<const float4*>(sh_coefficients_rest_ptr), reinterpret_cast<const float2*>(sh_value_bounds_ptr), sh_value_n_cells, sh_value_bits, reinterpret_cast<const float4*>(w2c_ptr), reinterpret_cast<const float3*>(cam_position_ptr), image_ptr, alpha_ptr, depth_ptr, normal_ptr, bg_color_ptr, bg_image_ptr, n_primitives, active_sh_bases, sh_layout_bases, width, height, focal_x, focal_y, center_x, center_y, near_plane, far_plane, mip_filter, stream, max_screen_share_ptr);
+                                                                                                                FastGSPhaseArena::Phase::Forward, size); }, phase_forward_allocator, [phase_arena](const void* source, size_t size) { return phase_arena->retain_prefix(source, size); }, per_tile_buffers_func, reinterpret_cast<const float3*>(means_ptr), reinterpret_cast<const float3*>(scales_raw_ptr), reinterpret_cast<const float4*>(rotations_raw_ptr), opacities_raw_ptr, reinterpret_cast<const float3*>(sh_coefficients_0_ptr), reinterpret_cast<const float4*>(sh_coefficients_rest_ptr), reinterpret_cast<const float2*>(sh_value_bounds_ptr), sh_value_n_cells, sh_value_bits, reinterpret_cast<const float4*>(w2c_ptr), reinterpret_cast<const float3*>(cam_position_ptr), image_ptr, alpha_ptr, depth_ptr, normal_ptr, bg_color_ptr, bg_image_ptr, n_primitives, active_sh_bases, sh_layout_bases, width, height, focal_x, focal_y, center_x, center_y, near_plane, far_plane, mip_filter, stream, max_screen_share_ptr, camera_kind, fisheye_k1, fisheye_k2, fisheye_k3, fisheye_k4, fisheye_theta_max);
 
             // Verify allocations happened
             if (forward_result.n_instances > 0 && !forward_result.sorted_primitive_indices) {
@@ -476,7 +482,13 @@ namespace fast_lfs::rasterization {
         const bool* mean_step_far_mask,
         int mean_step_far_mask_n,
         const float* edge_weight_map,
-        float* edge_score_out) {
+        float* edge_score_out,
+        FastGSCameraKind camera_kind,
+        float fisheye_k1,
+        float fisheye_k2,
+        float fisheye_k3,
+        float fisheye_k4,
+        float fisheye_theta_max) {
 
         // The forward chose the stream and chained the arena frame on it; the
         // backward shares the same context/arena frame and must match.
@@ -669,7 +681,13 @@ namespace fast_lfs::rasterization {
                 mean_step_far_mask_n,
                 edge_weight_map,
                 edge_score_out,
-                stream);
+                stream,
+                camera_kind,
+                fisheye_k1,
+                fisheye_k2,
+                fisheye_k3,
+                fisheye_k4,
+                fisheye_theta_max);
 
             // Mark frame as complete
             release_forward_context(forward_ctx);

--- a/src/training/rasterization/fastgs/rasterization/src/rasterization_api.cu
+++ b/src/training/rasterization/fastgs/rasterization/src/rasterization_api.cu
@@ -226,7 +226,13 @@ namespace fast_lfs::rasterization {
         cudaStream_t stream,
         const float* sh_value_bounds_ptr,
         unsigned int sh_value_n_cells,
-        unsigned int sh_value_bits) {
+        unsigned int sh_value_bits,
+        FastGSCameraKind camera_kind,
+        float fisheye_k1,
+        float fisheye_k2,
+        float fisheye_k3,
+        float fisheye_k4,
+        float fisheye_theta_max) {
 
         if (stream == nullptr) {
             stream = lfs::core::getCurrentCUDAStream();
@@ -375,7 +381,13 @@ namespace fast_lfs::rasterization {
                                                    near_plane,
                                                    far_plane,
                                                    mip_filter,
-                                                   stream);
+                                                   stream,
+                                                   camera_kind,
+                                                   fisheye_k1,
+                                                   fisheye_k2,
+                                                   fisheye_k3,
+                                                   fisheye_k4,
+                                                   fisheye_theta_max);
 
             // Verify allocations happened
             if (forward_result.n_instances > 0 && !forward_result.sorted_primitive_indices) {
@@ -482,7 +494,13 @@ namespace fast_lfs::rasterization {
         const FusedAdamSettings* fused_adam,
         const float* shN_value_bounds_ptr,
         unsigned shN_value_n_cells,
-        unsigned shN_value_bits) {
+        unsigned shN_value_bits,
+        FastGSCameraKind camera_kind,
+        float fisheye_k1,
+        float fisheye_k2,
+        float fisheye_k3,
+        float fisheye_k4,
+        float fisheye_theta_max) {
 
         // The forward chose the stream and chained the arena frame on it; the
         // backward shares the same context/arena frame and must match.
@@ -662,7 +680,13 @@ namespace fast_lfs::rasterization {
                 reinterpret_cast<const float2*>(shN_value_bounds_ptr),
                 shN_value_n_cells,
                 shN_value_bits,
-                stream);
+                stream,
+                camera_kind,
+                fisheye_k1,
+                fisheye_k2,
+                fisheye_k3,
+                fisheye_k4,
+                fisheye_theta_max);
 
             // Mark frame as complete
             release_forward_context(forward_ctx);

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -5623,8 +5623,11 @@ namespace lfs::training {
                         });
                     }
                 } else if (!params_.optimization.undistort || !cam->is_undistort_prepared()) {
-                    if (cam->radial_distortion().numel() != 0 ||
-                        cam->tangential_distortion().numel() != 0) {
+                    const bool fastgs_fisheye =
+                        cam->camera_model_type() == core::CameraModelType::FISHEYE;
+                    if (!fastgs_fisheye &&
+                        (cam->radial_distortion().numel() != 0 ||
+                         cam->tangential_distortion().numel() != 0)) {
                         return lfs::make_error(lfs::ErrorInit{
                             .code = lfs::ErrorCode::InvalidArgument,
                             .domain = lfs::ErrorDomain::Training,
@@ -5632,7 +5635,8 @@ namespace lfs::training {
                             .detection = LFS_SOURCE_SITE_CURRENT(),
                         });
                     }
-                    if (cam->camera_model_type() != core::CameraModelType::PINHOLE) {
+                    if (!fastgs_fisheye &&
+                        cam->camera_model_type() != core::CameraModelType::PINHOLE) {
                         return lfs::make_error(lfs::ErrorInit{
                             .code = lfs::ErrorCode::InvalidArgument,
                             .domain = lfs::ErrorDomain::Training,
@@ -6614,6 +6618,9 @@ namespace lfs::training {
                                         const float* const depth_pixel_weight =
                                             roi_weight_ptr_on_stream(depth_stream);
                                         lfs::core::pin_operands({&rendered_depth, &rendered_alpha, &target_depth});
+                                        // FastGS fisheye writes ray length D=|P| into the
+                                        // depth map (pinhole still writes camera-z). Depth-prior
+                                        // supervision compares against this same quantity.
                                         lfs::training::kernels::launch_depth_loss(
                                             rendered_depth.ptr<float>(),
                                             rendered_alpha.ptr<float>(),

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -5941,8 +5941,11 @@ namespace lfs::training {
                         });
                     }
                 } else if (!params_.optimization.undistort || !cam->is_undistort_prepared()) {
-                    if (cam->radial_distortion().numel() != 0 ||
-                        cam->tangential_distortion().numel() != 0) {
+                    const bool fastgs_fisheye =
+                        cam->camera_model_type() == core::CameraModelType::FISHEYE;
+                    if (!fastgs_fisheye &&
+                        (cam->radial_distortion().numel() != 0 ||
+                         cam->tangential_distortion().numel() != 0)) {
                         return lfs::make_error(lfs::ErrorInit{
                             .code = lfs::ErrorCode::InvalidArgument,
                             .domain = lfs::ErrorDomain::Training,
@@ -5950,7 +5953,8 @@ namespace lfs::training {
                             .detection = LFS_SOURCE_SITE_CURRENT(),
                         });
                     }
-                    if (cam->camera_model_type() != core::CameraModelType::PINHOLE) {
+                    if (!fastgs_fisheye &&
+                        cam->camera_model_type() != core::CameraModelType::PINHOLE) {
                         return lfs::make_error(lfs::ErrorInit{
                             .code = lfs::ErrorCode::InvalidArgument,
                             .domain = lfs::ErrorDomain::Training,
@@ -7012,6 +7016,9 @@ namespace lfs::training {
                                         const float* const depth_pixel_weight =
                                             roi_weight_ptr_on_stream(depth_stream);
                                         lfs::core::pin_operands({&rendered_depth, &rendered_alpha, &target_depth});
+                                        // FastGS fisheye writes ray length D=|P| into the
+                                        // depth map (pinhole still writes camera-z). Depth-prior
+                                        // supervision compares against this same quantity.
                                         lfs::training::kernels::launch_depth_loss(
                                             rendered_depth.ptr<float>(),
                                             rendered_alpha.ptr<float>(),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -408,6 +408,8 @@ set(TEST_FILES
     test_fastgs_fuzz.cpp
     test_fastgs_tile_culling_boundary.cpp
     fastgs_tile_culling_boundary_cuda.cu
+    test_fastgs_fisheye.cpp
+    fastgs_fisheye_cuda.cu
     test_sh_swizzle_layout.cpp
     test_shn_bda_index_math.cpp
     test_python_io.cpp
@@ -798,6 +800,8 @@ string(CONCAT LFS_SLOW_TEST_FILTER
     "MemoryPressureTest.InjectedFailure*:"
     "PPISPControllerTest.TrainingLoopConverges:"
     "UndistortCameraTest.BicyclePinholeNoDist:"
+    "FastGSFisheyeKernelTest.T4GradcheckMeansScalesOpacitySh0:"
+    "FastGSFisheye.RimGradcheckMeansScalesRotationOpacity:"
     "VideoColorConvertTest.*FullHD*:"
     "PlyToRadLod.*:"
     "LodPageDequant.*:"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -401,6 +401,8 @@ set(TEST_FILES
     test_fastgs_fuzz.cpp
     test_fastgs_tile_culling_boundary.cpp
     fastgs_tile_culling_boundary_cuda.cu
+    test_fastgs_fisheye.cpp
+    fastgs_fisheye_cuda.cu
     test_sh_swizzle_layout.cpp
     test_python_io.cpp
     test_extended_unary_ops_vs_torch.cpp
@@ -780,6 +782,8 @@ string(CONCAT LFS_SLOW_TEST_FILTER
     "MemoryPressureTest.InjectedFailure*:"
     "PPISPControllerTest.TrainingLoopConverges:"
     "UndistortCameraTest.BicyclePinholeNoDist:"
+    "FastGSFisheyeKernelTest.T4GradcheckMeansScalesOpacitySh0:"
+    "FastGSFisheye.RimGradcheckMeansScalesRotationOpacity:"
     "VideoColorConvertTest.*FullHD*:"
     "PlyToRadLod.*:"
     "LodPageDequant.*:"

--- a/tests/fastgs_fisheye_cuda.cu
+++ b/tests/fastgs_fisheye_cuda.cu
@@ -1,0 +1,63 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "fastgs_fisheye_cuda.hpp"
+#include "fisheye_kb.cuh"
+
+#include <cuda_runtime.h>
+
+namespace fastgs_fisheye_test {
+    namespace {
+
+        __global__ void project_kernel(DeviceProjectSample* samples, const int n) {
+            const int i = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+            if (i >= n)
+                return;
+            DeviceProjectSample s = samples[i];
+            const auto proj = fast_lfs::rasterization::fisheye_kb::kb_project(
+                s.Px, s.Py, s.Pz, s.fx, s.fy, s.cx, s.cy, s.k1, s.k2, s.k3, s.k4);
+            s.px = proj.px;
+            s.py = proj.py;
+            s.J00 = proj.J00;
+            s.J01 = proj.J01;
+            s.J02 = proj.J02;
+            s.J10 = proj.J10;
+            s.J11 = proj.J11;
+            s.J12 = proj.J12;
+            s.theta = proj.theta;
+            s.D = proj.D;
+            s.finite = proj.finite ? 1 : 0;
+            samples[i] = s;
+        }
+
+    } // namespace
+
+    bool project_on_device(DeviceProjectSample* samples, std::size_t n) {
+        if (n == 0)
+            return true;
+        DeviceProjectSample* d_samples = nullptr;
+        const std::size_t bytes = n * sizeof(DeviceProjectSample);
+        if (cudaMalloc(&d_samples, bytes) != cudaSuccess)
+            return false;
+        if (cudaMemcpy(d_samples, samples, bytes, cudaMemcpyHostToDevice) != cudaSuccess) {
+            cudaFree(d_samples);
+            return false;
+        }
+        const int threads = 128;
+        const int blocks = static_cast<int>((n + threads - 1) / threads);
+        project_kernel<<<blocks, threads>>>(d_samples, static_cast<int>(n));
+        const cudaError_t launch_err = cudaGetLastError();
+        const cudaError_t sync_err = cudaDeviceSynchronize();
+        if (launch_err != cudaSuccess || sync_err != cudaSuccess) {
+            cudaFree(d_samples);
+            return false;
+        }
+        if (cudaMemcpy(samples, d_samples, bytes, cudaMemcpyDeviceToHost) != cudaSuccess) {
+            cudaFree(d_samples);
+            return false;
+        }
+        cudaFree(d_samples);
+        return true;
+    }
+
+} // namespace fastgs_fisheye_test

--- a/tests/fastgs_fisheye_cuda.hpp
+++ b/tests/fastgs_fisheye_cuda.hpp
@@ -1,0 +1,23 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include <cstddef>
+
+namespace fastgs_fisheye_test {
+
+    struct DeviceProjectSample {
+        float Px, Py, Pz;
+        float fx, fy, cx, cy;
+        float k1, k2, k3, k4;
+        float px, py;
+        float J00, J01, J02, J10, J11, J12;
+        float theta, D;
+        int finite;
+    };
+
+    // Returns false if a CUDA allocation, launch, or copy failed.
+    bool project_on_device(DeviceProjectSample* samples, std::size_t n);
+
+} // namespace fastgs_fisheye_test

--- a/tests/test_fastgs_fisheye.cpp
+++ b/tests/test_fastgs_fisheye.cpp
@@ -1,0 +1,1242 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/camera.hpp"
+#include "core/cuda/memory_arena.hpp"
+#include "core/splat_data.hpp"
+#include "core/tensor.hpp"
+#include "fastgs_fisheye_cuda.hpp"
+#include "fisheye_kb.cuh"
+#include "lfs/training/joint_adam_codec.hpp"
+#include "training/optimizer/adam_optimizer.hpp"
+#include "training/rasterization/fast_rasterizer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cuda_runtime.h>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <limits>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace lfs::training;
+using namespace lfs::core;
+namespace kb = fast_lfs::rasterization::fisheye_kb;
+
+namespace {
+
+    std::filesystem::path golden_path() {
+        return std::filesystem::path(PROJECT_ROOT_PATH) / "tests" / "data" / "fisheye_kb_golden.json";
+    }
+
+    nlohmann::json load_golden() {
+        std::ifstream in(golden_path());
+        if (!in) {
+            throw std::runtime_error("missing " + golden_path().string());
+        }
+        nlohmann::json j;
+        in >> j;
+        return j;
+    }
+
+    double rel_err(double a, double b, double eps = 1e-12) {
+        return std::abs(a - b) / (std::abs(b) + eps);
+    }
+
+    double mixed_rel(double a, double b, double floor) {
+        return std::abs(a - b) / (std::abs(b) + floor);
+    }
+
+    double float_px_tol(double px) {
+        const double ulp = static_cast<double>(std::numeric_limits<float>::epsilon()) *
+                           (1.0 + std::abs(px));
+        return std::max(1e-4, 8.0 * ulp);
+    }
+
+    const AdamParamState& adam_state(const AdamOptimizer& opt, ParamType type) {
+        const auto* state = opt.get_state(type);
+        if (!state || !state->exp_avg.is_valid()) {
+            throw std::runtime_error("Missing Adam moment state");
+        }
+        return *state;
+    }
+
+    Tensor adam_moment(const AdamOptimizer& opt, ParamType type) {
+        const auto& state = adam_state(opt, type);
+        if (state.exp_avg.dtype() == DataType::Float32) {
+            return state.exp_avg;
+        }
+        if (!state.is_joint()) {
+            throw std::runtime_error("Legacy Adam moment codec is unsupported");
+        }
+        const int bits = state.joint_bits;
+        const int bpc = joint_adam::bytes_per_cell(bits);
+        auto packed_cpu = state.exp_avg.to(Device::CPU);
+        auto bounds_cpu = state.joint_bounds.to(Device::CPU);
+        const auto* packed = packed_cpu.ptr<std::uint8_t>();
+        const auto* bounds = bounds_cpu.ptr<float>();
+        const size_t n_prim = state.exp_avg.shape()[0];
+        const size_t packed_row = state.exp_avg.ndim() >= 2 ? state.exp_avg.shape()[1] : packed_cpu.numel();
+        const size_t n_attr = state.exp_avg.ndim() >= 2 ? packed_row / static_cast<size_t>(bpc) : 1;
+        std::vector<float> dequant(n_prim * n_attr, 0.0f);
+        for (size_t p = 0; p < n_prim; ++p) {
+            const size_t bidx = p / static_cast<size_t>(joint_adam::kBlockSize);
+            const float umin = bounds[bidx * 4 + 0];
+            const float umax = bounds[bidx * 4 + 1];
+            const float smin = bounds[bidx * 4 + 2];
+            const float smax = bounds[bidx * 4 + 3];
+            for (size_t a = 0; a < n_attr; ++a) {
+                const size_t cell = p * n_attr + a;
+                float g1 = 0.0f, g2 = 0.0f;
+                if (bits == 16) {
+                    joint_adam::Codec16::decode_g1g2(packed, cell, umin, umax, smin, smax, g1, g2);
+                } else {
+                    joint_adam::Codec8::decode_g1g2(packed, cell, umin, umax, smin, smax, g1, g2);
+                }
+                dequant[cell] = g1;
+            }
+        }
+        TensorShape out_shape = n_attr == 1 ? TensorShape({n_prim}) : TensorShape({n_prim, n_attr});
+        if (type == ParamType::Sh0 && n_attr == 3) {
+            out_shape = TensorShape({n_prim, size_t{1}, size_t{3}});
+        }
+        return Tensor::from_blob(dequant.data(), out_shape, Device::CPU, DataType::Float32).clone().to(Device::CUDA);
+    }
+
+    Tensor recovered_fused_grad(const AdamOptimizer& opt, ParamType type, float beta1 = 0.9f) {
+        return adam_moment(opt, type).mul(1.0f / (1.0f - beta1));
+    }
+
+    double image_loss_f64(const Tensor& image, const Tensor& depth, bool with_depth) {
+        auto img = image.to(Device::CPU);
+        const float* p = img.ptr<float>();
+        double acc = 0.0;
+        for (size_t i = 0; i < img.numel(); ++i) {
+            const double v = static_cast<double>(p[i]);
+            acc += v * v;
+        }
+        if (with_depth) {
+            auto d = depth.to(Device::CPU);
+            const float* dp = d.ptr<float>();
+            for (size_t i = 0; i < d.numel(); ++i) {
+                const double v = static_cast<double>(dp[i]);
+                acc += v * v;
+            }
+        }
+        return acc;
+    }
+
+    float psnr_region(const std::vector<float>& a, const std::vector<float>& b, const std::vector<char>& mask) {
+        double mse = 0.0;
+        int n = 0;
+        for (size_t i = 0; i < mask.size(); ++i) {
+            if (!mask[i])
+                continue;
+            const double d0 = static_cast<double>(a[i] - b[i]);
+            mse += d0 * d0;
+            ++n;
+        }
+        if (n == 0)
+            return 0.0f;
+        mse /= static_cast<double>(n);
+        if (mse <= 1e-12)
+            return 99.0f;
+        return static_cast<float>(10.0 * std::log10(1.0 / mse));
+    }
+
+    std::unique_ptr<Camera> make_camera(
+        CameraModelType model,
+        int w,
+        int h,
+        float fx,
+        float fy,
+        float cx,
+        float cy,
+        const std::vector<float>& k = {}) {
+        auto R = Tensor::eye(3, Device::CUDA);
+        std::vector<float> t_data{0, 0, 0};
+        auto T = Tensor::from_blob(t_data.data(), {3}, Device::CPU, DataType::Float32).to(Device::CUDA);
+        Tensor radial;
+        if (!k.empty()) {
+            radial = Tensor::from_vector(k, {k.size()}, Device::CPU);
+        }
+        return std::make_unique<Camera>(
+            R, T, fx, fy, cx, cy, radial, Tensor(), model, "fisheye", "",
+            std::filesystem::path{}, w, h, 0);
+    }
+
+    int tensor_mismatch_count(const Tensor& a, const Tensor& b) {
+        auto ac = a.to(Device::CPU);
+        auto bc = b.to(Device::CPU);
+        EXPECT_EQ(ac.numel(), bc.numel());
+        const float* pa = ac.ptr<float>();
+        const float* pb = bc.ptr<float>();
+        int n_diff = 0;
+        for (size_t i = 0; i < ac.numel(); ++i) {
+            if (pa[i] != pb[i])
+                ++n_diff;
+        }
+        return n_diff;
+    }
+
+    float cosine_nonzero(const Tensor& numerical, const Tensor& analytical) {
+        auto ac = numerical.to(Device::CPU);
+        auto bc = analytical.to(Device::CPU);
+        const float* pa = ac.ptr<float>();
+        const float* pb = bc.ptr<float>();
+        double dot = 0, na = 0, nb = 0;
+        for (size_t i = 0; i < ac.numel(); ++i) {
+            if (pa[i] == 0.0f)
+                continue;
+            dot += pa[i] * pb[i];
+            na += pa[i] * pa[i];
+            nb += pb[i] * pb[i];
+        }
+        if (na < 1e-20 && nb < 1e-20)
+            return 1.0f;
+        return static_cast<float>(dot / (std::sqrt(na) * std::sqrt(nb) + 1e-12));
+    }
+
+} // namespace
+
+TEST(FastGSFisheyeT1, GoldenProjectionDoubleAndFloat) {
+    const auto recs = load_golden();
+    ASSERT_EQ(recs.size(), 16u);
+    for (const auto& r : recs) {
+        const double Px = r["P"][0], Py = r["P"][1], Pz = r["P"][2];
+        const double fx = r["f"][0], fy = r["f"][1], cx = r["f"][2], cy = r["f"][3];
+        const double k1 = r["k"][0], k2 = r["k"][1], k3 = r["k"][2], k4 = r["k"][3];
+        const auto pd = kb::kb_project(Px, Py, Pz, fx, fy, cx, cy, k1, k2, k3, k4);
+        EXPECT_NEAR(pd.theta, r["theta"].get<double>(), 1e-12);
+        EXPECT_NEAR(pd.px, r["pixel"][0].get<double>(), 1e-9);
+        EXPECT_NEAR(pd.py, r["pixel"][1].get<double>(), 1e-9);
+        const double J[2][3] = {{pd.J00, pd.J01, pd.J02}, {pd.J10, pd.J11, pd.J12}};
+        for (int i = 0; i < 2; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                EXPECT_LT(rel_err(J[i][j], r["J"][i][j].get<double>()), 1e-6);
+            }
+        }
+
+        const auto pf = kb::kb_project(
+            static_cast<float>(Px), static_cast<float>(Py), static_cast<float>(Pz),
+            static_cast<float>(fx), static_cast<float>(fy), static_cast<float>(cx), static_cast<float>(cy),
+            static_cast<float>(k1), static_cast<float>(k2), static_cast<float>(k3), static_cast<float>(k4));
+        // Float header vs the same formula in double at float-rounded inputs.
+        const auto pd_at_f = kb::kb_project(
+            static_cast<double>(static_cast<float>(Px)),
+            static_cast<double>(static_cast<float>(Py)),
+            static_cast<double>(static_cast<float>(Pz)),
+            static_cast<double>(static_cast<float>(fx)),
+            static_cast<double>(static_cast<float>(fy)),
+            static_cast<double>(static_cast<float>(cx)),
+            static_cast<double>(static_cast<float>(cy)),
+            static_cast<double>(static_cast<float>(k1)),
+            static_cast<double>(static_cast<float>(k2)),
+            static_cast<double>(static_cast<float>(k3)),
+            static_cast<double>(static_cast<float>(k4)));
+        EXPECT_LT(std::abs(static_cast<double>(pf.px) - pd_at_f.px), float_px_tol(pd_at_f.px));
+        EXPECT_LT(std::abs(static_cast<double>(pf.py) - pd_at_f.py), float_px_tol(pd_at_f.py));
+        const float Jf[2][3] = {{pf.J00, pf.J01, pf.J02}, {pf.J10, pf.J11, pf.J12}};
+        for (int i = 0; i < 2; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                EXPECT_LT(rel_err(Jf[i][j], r["J"][i][j].get<double>()), 1e-3);
+            }
+        }
+    }
+}
+
+TEST(FastGSFisheyeT1, OnAxisLimitAndAsymmetricIntrinsics) {
+    const double fx = 700, fy = 650, cx = 512, cy = 384;
+    const double k1 = 0.05, k2 = -0.01, k3 = 0.002, k4 = -0.0005;
+    const auto p = kb::kb_project(0.0, 0.0, 2.0, fx, fy, cx, cy, k1, k2, k3, k4);
+    EXPECT_TRUE(p.on_axis);
+    EXPECT_NEAR(p.px, cx, 1e-12);
+    EXPECT_NEAR(p.py, cy, 1e-12);
+    EXPECT_NEAR(p.J00, fx / 2.0, 1e-9);
+    EXPECT_NEAR(p.J11, fy / 2.0, 1e-9);
+    EXPECT_NEAR(p.J01, 0.0, 1e-12);
+    EXPECT_NEAR(p.J02, 0.0, 1e-12);
+    EXPECT_NEAR(p.J10, 0.0, 1e-12);
+    EXPECT_NEAR(p.J12, 0.0, 1e-12);
+}
+
+TEST(FastGSFisheyeT1, DeviceMatchesHostFloat) {
+    std::mt19937 rng(7);
+    std::uniform_real_distribution<float> pos(-2.5f, 2.5f);
+    std::vector<fastgs_fisheye_test::DeviceProjectSample> samples;
+    samples.reserve(272);
+    const auto recs = load_golden();
+    for (const auto& r : recs) {
+        fastgs_fisheye_test::DeviceProjectSample s{};
+        s.Px = static_cast<float>(r["P"][0].get<double>());
+        s.Py = static_cast<float>(r["P"][1].get<double>());
+        s.Pz = static_cast<float>(r["P"][2].get<double>());
+        s.fx = static_cast<float>(r["f"][0].get<double>());
+        s.fy = static_cast<float>(r["f"][1].get<double>());
+        s.cx = static_cast<float>(r["f"][2].get<double>());
+        s.cy = static_cast<float>(r["f"][3].get<double>());
+        s.k1 = static_cast<float>(r["k"][0].get<double>());
+        s.k2 = static_cast<float>(r["k"][1].get<double>());
+        s.k3 = static_cast<float>(r["k"][2].get<double>());
+        s.k4 = static_cast<float>(r["k"][3].get<double>());
+        samples.push_back(s);
+    }
+    for (int i = 0; i < 256; ++i) {
+        fastgs_fisheye_test::DeviceProjectSample s{};
+        s.Px = pos(rng);
+        s.Py = pos(rng);
+        s.Pz = pos(rng);
+        if (std::hypot(s.Px, s.Py, s.Pz) < 0.2f)
+            s.Pz = 1.2f;
+        s.fx = 700.f;
+        s.fy = 650.f;
+        s.cx = 512.f;
+        s.cy = 384.f;
+        s.k1 = 0.05f;
+        s.k2 = -0.01f;
+        s.k3 = 0.002f;
+        s.k4 = -0.0005f;
+        samples.push_back(s);
+    }
+    auto host = samples;
+    ASSERT_TRUE(fastgs_fisheye_test::project_on_device(samples.data(), samples.size()));
+    for (size_t i = 0; i < samples.size(); ++i) {
+        const auto h = kb::kb_project(
+            host[i].Px, host[i].Py, host[i].Pz, host[i].fx, host[i].fy, host[i].cx, host[i].cy,
+            host[i].k1, host[i].k2, host[i].k3, host[i].k4);
+        EXPECT_EQ(samples[i].finite, h.finite ? 1 : 0);
+        if (!h.finite)
+            continue;
+        // nvcc vs g++ FMA contraction: fp32 tolerance, never bitwise.
+        EXPECT_NEAR(samples[i].px, h.px, 5e-3f);
+        EXPECT_NEAR(samples[i].py, h.py, 5e-3f);
+        EXPECT_NEAR(samples[i].theta, h.theta, 2e-5f);
+        const float Jdev[6] = {samples[i].J00, samples[i].J01, samples[i].J02,
+                               samples[i].J10, samples[i].J11, samples[i].J12};
+        const float Jhost[6] = {h.J00, h.J01, h.J02, h.J10, h.J11, h.J12};
+        for (int j = 0; j < 6; ++j) {
+            const double scale = std::abs(static_cast<double>(Jhost[j])) + 1.0;
+            EXPECT_LT(std::abs(static_cast<double>(Jdev[j] - Jhost[j])) / scale, 5e-3)
+                << "device vs host J mismatch at sample " << i << " entry " << j;
+        }
+    }
+}
+
+TEST(FastGSFisheyeT1, RandomRaysAndNearThetaMax) {
+    std::mt19937 rng(19);
+    std::uniform_real_distribution<double> pos(-2.0, 2.0);
+    const double fx = 700, fy = 650, cx = 512, cy = 384;
+    const double k1 = 0.05, k2 = -0.01, k3 = 0.002, k4 = -0.0005;
+    const double tmax = kb::kb_theta_max(k1, k2, k3, k4, 1024.0, 768.0, fx, fy, cx, cy);
+    int n_ok = 0, n_zneg = 0, n_near_max = 0;
+    for (int i = 0; i < 800; ++i) {
+        const double P[3] = {pos(rng), pos(rng), pos(rng)};
+        const auto p = kb::kb_project(P[0], P[1], P[2], fx, fy, cx, cy, k1, k2, k3, k4);
+        if (!p.finite)
+            continue;
+        ++n_ok;
+        if (P[2] < 0)
+            ++n_zneg;
+        if (p.theta > tmax - (1.0 * kb::kPi / 180.0) && p.theta < tmax)
+            ++n_near_max;
+        const double rd = std::hypot(p.px - cx, p.py - cy);
+        if (p.d >= 1e-6) {
+            EXPECT_GT(rd, 0.0);
+        }
+    }
+    EXPECT_GT(n_ok, 400);
+    EXPECT_GT(n_zneg, 50);
+
+    const double th = std::max(1e-3, tmax - 0.01);
+    const auto rim = kb::kb_project(std::sin(th), 0.0, std::cos(th), fx, fy, cx, cy, k1, k2, k3, k4);
+    EXPECT_TRUE(rim.finite);
+    EXPECT_LT(rim.theta, tmax);
+    EXPECT_GT(n_near_max + (rim.theta > tmax - 0.02 ? 1 : 0), 0);
+}
+
+TEST(FastGSFisheyeT2, JacobianFiniteDifferences) {
+    std::mt19937 rng(11);
+    std::uniform_real_distribution<double> u01(0.0, 1.0);
+    const double fx = 700, fy = 650, cx = 512, cy = 384;
+    const double k1 = 0.05, k2 = -0.01, k3 = 0.002, k4 = -0.0005;
+    const double h = 1e-6;
+    const double tmax = kb::kb_theta_max(k1, k2, k3, k4, 1024.0, 768.0, fx, fy, cx, cy);
+    const double fold = kb::kb_theta_foldover(k1, k2, k3, k4);
+    int n_ok_mid = 0, n_ok_rim = 0, n_zneg = 0;
+    auto sample_P = [&](double theta, double phi, double D, double* P) {
+        P[0] = D * std::sin(theta) * std::cos(phi);
+        P[1] = D * std::sin(theta) * std::sin(phi);
+        P[2] = D * std::cos(theta);
+    };
+    for (int i = 0; i < 1600; ++i) {
+        const bool want_back = (i % 4 == 0);
+        const double theta = want_back
+                                 ? (0.5 * kb::kPi + u01(rng) * std::min(0.8, fold - 0.5 * kb::kPi - 0.05))
+                                 : (0.05 + u01(rng) * (std::min(tmax, fold) - 0.08));
+        const double phi = u01(rng) * 2.0 * kb::kPi;
+        const double D = 0.6 + 2.4 * u01(rng);
+        double P[3];
+        sample_P(theta, phi, D, P);
+        const double d = std::hypot(P[0], P[1]);
+        if (d < 1e-3 || std::abs(P[2]) < 8 * h)
+            continue;
+        const auto proj = kb::kb_project(P[0], P[1], P[2], fx, fy, cx, cy, k1, k2, k3, k4);
+        if (!proj.finite || proj.theta_d_prime <= 0.0)
+            continue;
+        double Jfd[2][3]{};
+        for (int k = 0; k < 3; ++k) {
+            double Pp[3] = {P[0], P[1], P[2]};
+            double Pm[3] = {P[0], P[1], P[2]};
+            Pp[k] += h;
+            Pm[k] -= h;
+            const auto rp = kb::kb_project(Pp[0], Pp[1], Pp[2], fx, fy, cx, cy, k1, k2, k3, k4);
+            const auto rm = kb::kb_project(Pm[0], Pm[1], Pm[2], fx, fy, cx, cy, k1, k2, k3, k4);
+            Jfd[0][k] = (rp.px - rm.px) / (2 * h);
+            Jfd[1][k] = (rp.py - rm.py) / (2 * h);
+        }
+        const double J[2][3] = {{proj.J00, proj.J01, proj.J02}, {proj.J10, proj.J11, proj.J12}};
+        double worst = 0.0;
+        for (int r = 0; r < 2; ++r) {
+            for (int c = 0; c < 3; ++c) {
+                worst = std::max(worst, mixed_rel(J[r][c], Jfd[r][c], 1.0));
+            }
+        }
+        const bool near_rim = std::abs(tmax - proj.theta) < (1.0 * kb::kPi / 180.0) ||
+                              (fold - proj.theta) < (1.0 * kb::kPi / 180.0);
+        if (near_rim) {
+            EXPECT_LT(worst, 1e-2);
+            ++n_ok_rim;
+        } else {
+            EXPECT_LT(worst, 1e-5);
+            ++n_ok_mid;
+        }
+        if (P[2] < 0)
+            ++n_zneg;
+    }
+    EXPECT_GT(n_ok_mid, 800);
+    EXPECT_GT(n_zneg, 50);
+}
+
+TEST(FastGSFisheyeT2, JacobianFiniteDifferencesFloat) {
+    std::mt19937 rng(13);
+    std::uniform_real_distribution<float> u01(0.0f, 1.0f);
+    const float fx = 700.f, fy = 650.f, cx = 512.f, cy = 384.f;
+    const float k1 = 0.05f, k2 = -0.01f, k3 = 0.002f, k4 = -0.0005f;
+    const float h = 1e-3f;
+    const double tmax = kb::kb_theta_max(
+        0.05, -0.01, 0.002, -0.0005, 1024.0, 768.0, 700.0, 650.0, 512.0, 384.0);
+    const double fold = kb::kb_theta_foldover(0.05, -0.01, 0.002, -0.0005);
+    int n_ok_mid = 0, n_ok_rim = 0, n_zneg = 0;
+    for (int i = 0; i < 1600; ++i) {
+        const bool want_back = (i % 4 == 0);
+        const float theta = want_back
+                                ? static_cast<float>(0.5 * kb::kPi + u01(rng) * std::min(0.8, fold - 0.5 * kb::kPi - 0.05))
+                                : static_cast<float>(0.05 + u01(rng) * (std::min(tmax, fold) - 0.08));
+        const float phi = u01(rng) * static_cast<float>(2.0 * kb::kPi);
+        const float D = 0.6f + 2.4f * u01(rng);
+        float P[3] = {D * std::sin(theta) * std::cos(phi),
+                      D * std::sin(theta) * std::sin(phi),
+                      D * std::cos(theta)};
+        const float d = std::hypot(P[0], P[1]);
+        if (d < 1e-3f || std::abs(P[2]) < 8 * h)
+            continue;
+        const auto proj = kb::kb_project(P[0], P[1], P[2], fx, fy, cx, cy, k1, k2, k3, k4);
+        if (!proj.finite || proj.theta_d_prime <= 0.0f)
+            continue;
+        float Jfd[2][3]{};
+        for (int k = 0; k < 3; ++k) {
+            float Pp[3] = {P[0], P[1], P[2]};
+            float Pm[3] = {P[0], P[1], P[2]};
+            Pp[k] += h;
+            Pm[k] -= h;
+            const auto rp = kb::kb_project(Pp[0], Pp[1], Pp[2], fx, fy, cx, cy, k1, k2, k3, k4);
+            const auto rm = kb::kb_project(Pm[0], Pm[1], Pm[2], fx, fy, cx, cy, k1, k2, k3, k4);
+            Jfd[0][k] = (rp.px - rm.px) / (2 * h);
+            Jfd[1][k] = (rp.py - rm.py) / (2 * h);
+        }
+        const float J[2][3] = {{proj.J00, proj.J01, proj.J02}, {proj.J10, proj.J11, proj.J12}};
+        double worst = 0.0;
+        for (int r = 0; r < 2; ++r) {
+            for (int c = 0; c < 3; ++c) {
+                // Float FD noise in J is ~ulp(pixel)/h; mixed floor absorbs it.
+                worst = std::max(worst, mixed_rel(J[r][c], Jfd[r][c], 80.0));
+            }
+        }
+        const bool near_rim =
+            P[2] < 0.0f ||
+            std::abs(tmax - static_cast<double>(proj.theta)) < (1.0 * kb::kPi / 180.0) ||
+            (fold - static_cast<double>(proj.theta)) < (1.0 * kb::kPi / 180.0);
+        if (near_rim) {
+            EXPECT_LT(worst, 1e-2);
+            ++n_ok_rim;
+        } else {
+            EXPECT_LT(worst, 1e-3);
+            ++n_ok_mid;
+        }
+        if (P[2] < 0)
+            ++n_zneg;
+    }
+    EXPECT_GT(n_ok_mid, 400);
+    EXPECT_GT(n_zneg, 30);
+}
+
+TEST(FastGSFisheyeDJDP, GoldenContraction) {
+    const auto recs = load_golden();
+    int n_checked = 0;
+    for (const auto& r : recs) {
+        const double Px = r["P"][0], Py = r["P"][1], Pz = r["P"][2];
+        const double fx = r["f"][0], fy = r["f"][1], cx = r["f"][2], cy = r["f"][3];
+        const double k1 = r["k"][0], k2 = r["k"][1], k3 = r["k"][2], k4 = r["k"][3];
+        const auto proj = kb::kb_project(Px, Py, Pz, fx, fy, cx, cy, k1, k2, k3, k4);
+        if (proj.on_axis || !proj.finite)
+            continue;
+        ++n_checked;
+        double dJdP[2][3][3];
+        kb::kb_dJ_dP(proj, fx, fy, dJdP);
+        for (int i = 0; i < 2; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                for (int k = 0; k < 3; ++k) {
+                    EXPECT_LT(rel_err(dJdP[i][j][k], r["dJdP_fd"][i][j][k].get<double>()), 1e-4)
+                        << "dJdP[" << i << "][" << j << "][" << k << "]";
+                }
+            }
+        }
+        // Unit dL/dJ on each of the six entries, then a mixed contraction.
+        const double dL_units[6][6] = {
+            {1, 0, 0, 0, 0, 0},
+            {0, 1, 0, 0, 0, 0},
+            {0, 0, 1, 0, 0, 0},
+            {0, 0, 0, 1, 0, 0},
+            {0, 0, 0, 0, 1, 0},
+            {0, 0, 0, 0, 0, 1},
+        };
+        const int imap[6][2] = {{0, 0}, {0, 1}, {0, 2}, {1, 0}, {1, 1}, {1, 2}};
+        for (int u = 0; u < 6; ++u) {
+            double dL_dP[3] = {0, 0, 0};
+            kb::kb_contract_dL_dJ(proj, fx, fy,
+                                  dL_units[u][0], dL_units[u][1], dL_units[u][2],
+                                  dL_units[u][3], dL_units[u][4], dL_units[u][5],
+                                  dL_dP[0], dL_dP[1], dL_dP[2]);
+            EXPECT_LT(rel_err(dL_dP[0], dJdP[imap[u][0]][imap[u][1]][0]), 1e-9);
+            EXPECT_LT(rel_err(dL_dP[1], dJdP[imap[u][0]][imap[u][1]][1]), 1e-9);
+            EXPECT_LT(rel_err(dL_dP[2], dJdP[imap[u][0]][imap[u][1]][2]), 1e-9);
+        }
+        const double mix[6] = {0.5, -0.3, 0.2, 0.1, 0.4, -0.25};
+        double dL_dP[3] = {0, 0, 0};
+        kb::kb_contract_dL_dJ(proj, fx, fy, mix[0], mix[1], mix[2], mix[3], mix[4], mix[5],
+                              dL_dP[0], dL_dP[1], dL_dP[2]);
+        double expect[3] = {0, 0, 0};
+        for (int u = 0; u < 6; ++u)
+            for (int k = 0; k < 3; ++k)
+                expect[k] += mix[u] * dJdP[imap[u][0]][imap[u][1]][k];
+        EXPECT_LT(rel_err(dL_dP[0], expect[0]), 1e-9);
+        EXPECT_LT(rel_err(dL_dP[1], expect[1]), 1e-9);
+        EXPECT_LT(rel_err(dL_dP[2], expect[2]), 1e-9);
+    }
+    EXPECT_EQ(n_checked, 16);
+}
+
+TEST(FastGSFisheyeT3, Cov2dMatchesNumericalJacobian) {
+    const double fx = 400, fy = 380, cx = 64, cy = 64;
+    const double k1 = 0.02, k2 = -0.004, k3 = 0.0, k4 = 0.0;
+    const double P[3] = {0.4, -0.25, 1.6};
+    const double Sigma[6] = {0.01, 0.001, 0.0, 0.012, 0.0, 0.008}; // triu xx,xy,xz,yy,yz,zz
+    const auto proj = kb::kb_project(P[0], P[1], P[2], fx, fy, cx, cy, k1, k2, k3, k4);
+    const double J[2][3] = {{proj.J00, proj.J01, proj.J02}, {proj.J10, proj.J11, proj.J12}};
+    auto apply_sigma = [&](const double* v, double* out) {
+        out[0] = Sigma[0] * v[0] + Sigma[1] * v[1] + Sigma[2] * v[2];
+        out[1] = Sigma[1] * v[0] + Sigma[3] * v[1] + Sigma[4] * v[2];
+        out[2] = Sigma[2] * v[0] + Sigma[4] * v[1] + Sigma[5] * v[2];
+    };
+    double JW_S[2][3]{};
+    for (int r = 0; r < 2; ++r) {
+        apply_sigma(J[r], JW_S[r]);
+    }
+    double cov[3] = {
+        JW_S[0][0] * J[0][0] + JW_S[0][1] * J[0][1] + JW_S[0][2] * J[0][2],
+        JW_S[0][0] * J[1][0] + JW_S[0][1] * J[1][1] + JW_S[0][2] * J[1][2],
+        JW_S[1][0] * J[1][0] + JW_S[1][1] * J[1][1] + JW_S[1][2] * J[1][2]};
+
+    const double h = 1e-5;
+    double Jfd[2][3]{};
+    for (int k = 0; k < 3; ++k) {
+        double Pp[3] = {P[0], P[1], P[2]};
+        double Pm[3] = {P[0], P[1], P[2]};
+        Pp[k] += h;
+        Pm[k] -= h;
+        const auto rp = kb::kb_project(Pp[0], Pp[1], Pp[2], fx, fy, cx, cy, k1, k2, k3, k4);
+        const auto rm = kb::kb_project(Pm[0], Pm[1], Pm[2], fx, fy, cx, cy, k1, k2, k3, k4);
+        Jfd[0][k] = (rp.px - rm.px) / (2 * h);
+        Jfd[1][k] = (rp.py - rm.py) / (2 * h);
+    }
+    double JW_Sfd[2][3]{};
+    for (int r = 0; r < 2; ++r)
+        apply_sigma(Jfd[r], JW_Sfd[r]);
+    double cov_fd[3] = {
+        JW_Sfd[0][0] * Jfd[0][0] + JW_Sfd[0][1] * Jfd[0][1] + JW_Sfd[0][2] * Jfd[0][2],
+        JW_Sfd[0][0] * Jfd[1][0] + JW_Sfd[0][1] * Jfd[1][1] + JW_Sfd[0][2] * Jfd[1][2],
+        JW_Sfd[1][0] * Jfd[1][0] + JW_Sfd[1][1] * Jfd[1][1] + JW_Sfd[1][2] * Jfd[1][2]};
+    EXPECT_LT(rel_err(cov[0], cov_fd[0]), 1e-4);
+    EXPECT_LT(rel_err(cov[1], cov_fd[1]), 1e-4);
+    EXPECT_LT(rel_err(cov[2], cov_fd[2]), 1e-4);
+}
+
+class FastGSFisheyeKernelTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        w_ = 64;
+        h_ = 64;
+        fx_ = 48.0f;
+        fy_ = 46.0f;
+        cx_ = 32.0f;
+        cy_ = 32.0f;
+        k_ = {0.04f, -0.008f, 0.001f, 0.0f};
+        camera_ = make_camera(CameraModelType::FISHEYE, w_, h_, fx_, fy_, cx_, cy_,
+                              {k_[0], k_[1], k_[2], k_[3]});
+        bg_ = Tensor::zeros({3}, Device::CUDA);
+        n_ = 6;
+        std::vector<float> means(n_ * 3);
+        for (size_t i = 0; i < n_; ++i) {
+            means[i * 3 + 0] = (static_cast<float>(i) - 2.5f) * 0.05f;
+            means[i * 3 + 1] = (static_cast<float>(i % 3) - 1.0f) * 0.05f;
+            means[i * 3 + 2] = 1.2f + static_cast<float>(i) * 0.15f;
+        }
+        means_ = Tensor::from_vector(means, {n_, 3}, Device::CUDA);
+        sh0_ = Tensor::full({n_, size_t{1}, size_t{3}}, 0.4f, Device::CUDA);
+        shN_ = Tensor::zeros({n_, 0, 3}, Device::CUDA);
+        std::vector<float> scales(n_ * 3);
+        for (size_t i = 0; i < n_; ++i) {
+            scales[i * 3 + 0] = -2.8f;
+            scales[i * 3 + 1] = -3.5f;
+            scales[i * 3 + 2] = -4.0f;
+        }
+        scaling_ = Tensor::from_vector(scales, {n_, 3}, Device::CUDA);
+        rotation_ = Tensor::zeros({n_, 4}, Device::CUDA);
+        rotation_.slice(1, 0, 1).fill_(1.0f);
+        opacity_ = Tensor::full({n_}, 2.0f, Device::CUDA);
+    }
+
+    void TearDown() override {
+        GlobalArenaManager::instance().get_arena().full_reset();
+    }
+
+    std::unique_ptr<SplatData> make_splat() {
+        return std::make_unique<SplatData>(0, means_.clone(), sh0_.clone(), shN_.clone(),
+                                           scaling_.clone(), rotation_.clone(), opacity_.clone(), 1.0f);
+    }
+
+    size_t n_;
+    int w_, h_;
+    float fx_, fy_, cx_, cy_;
+    std::vector<float> k_;
+    Tensor means_, sh0_, shN_, scaling_, rotation_, opacity_, bg_;
+    std::unique_ptr<Camera> camera_;
+};
+
+TEST_F(FastGSFisheyeKernelTest, T4GradcheckMeansScalesOpacitySh0) {
+    auto splat = make_splat();
+    auto fwd = fast_rasterize_forward(*camera_, *splat, bg_);
+    ASSERT_TRUE(fwd.has_value());
+    const float alpha_sum = fwd->first.alpha.sum().item<float>();
+    ASSERT_GT(alpha_sum, 1e-3f) << "forward-liveness: expected visible alpha";
+    ASSERT_GT(fwd->first.image.abs().sum().item<float>(), 1e-4f);
+    fwd->second.release_forward_context();
+
+    const double tmax = kb::kb_theta_max(
+        static_cast<double>(k_[0]), static_cast<double>(k_[1]),
+        static_cast<double>(k_[2]), static_cast<double>(k_[3]),
+        static_cast<double>(w_), static_cast<double>(h_),
+        static_cast<double>(fx_), static_cast<double>(fy_),
+        static_cast<double>(cx_), static_cast<double>(cy_));
+    auto means_cpu = means_.to(Device::CPU);
+    const float* mp = means_cpu.ptr<float>();
+    for (size_t i = 0; i < n_; ++i) {
+        const auto proj = kb::kb_project(mp[i * 3], mp[i * 3 + 1], mp[i * 3 + 2],
+                                         fx_, fy_, cx_, cy_, k_[0], k_[1], k_[2], k_[3]);
+        ASSERT_LT(proj.theta + 0.15, tmax) << "gaussian in theta_max band";
+        ASSERT_GT(proj.px, 4.0f);
+        ASSERT_LT(proj.px, w_ - 4.0f);
+        ASSERT_GT(proj.py, 4.0f);
+        ASSERT_LT(proj.py, h_ - 4.0f);
+    }
+
+    auto run_analytical = [&](ParamType param) {
+        auto s = make_splat();
+        auto r = fast_rasterize_forward(*camera_, *s, bg_);
+        AdamConfig cfg{.lr = 0.001f, .beta1 = 0.9, .beta2 = 0.999, .eps = 1e-15};
+        auto opt = std::make_unique<AdamOptimizer>(*s, cfg);
+        opt->allocate_gradients();
+        opt->zero_grad(0);
+        auto grad_out = r->first.image.mul(2.0f);
+        auto grad_depth = r->first.depth.mul(2.0f);
+        fast_rasterize_backward(r->second, grad_out, *s, *opt, {}, {}, DensificationType::None, 1, {}, grad_depth);
+        return recovered_fused_grad(*opt, param);
+    };
+
+    auto numerical = [&](ParamType param, float eps) {
+        Tensor orig;
+        switch (param) {
+        case ParamType::Means: orig = means_.clone(); break;
+        case ParamType::Scaling: orig = scaling_.clone(); break;
+        case ParamType::Rotation: orig = rotation_.clone(); break;
+        case ParamType::Opacity: orig = opacity_.clone(); break;
+        case ParamType::Sh0: orig = sh0_.clone(); break;
+        default: return Tensor();
+        }
+        auto orig_cpu = orig.to(Device::CPU);
+        auto grad_cpu = Tensor::zeros_like(orig_cpu);
+        float* g = grad_cpu.ptr<float>();
+        const float* o = orig_cpu.ptr<float>();
+        const size_t n_probe = std::min(orig.numel(), size_t{4});
+        for (size_t p = 0; p < n_probe; ++p) {
+            const size_t i = (n_probe == 1) ? 0 : p * (orig.numel() - 1) / (n_probe - 1);
+            auto plus = orig_cpu.clone();
+            auto minus = orig_cpu.clone();
+            plus.ptr<float>()[i] = o[i] + eps;
+            minus.ptr<float>()[i] = o[i] - eps;
+            auto apply = [&](const Tensor& cpu_val) {
+                switch (param) {
+                case ParamType::Means: means_ = cpu_val.to(Device::CUDA); break;
+                case ParamType::Scaling: scaling_ = cpu_val.to(Device::CUDA); break;
+                case ParamType::Rotation: rotation_ = cpu_val.to(Device::CUDA); break;
+                case ParamType::Opacity: opacity_ = cpu_val.to(Device::CUDA); break;
+                case ParamType::Sh0: sh0_ = cpu_val.to(Device::CUDA); break;
+                default: break;
+                }
+            };
+            apply(plus);
+            auto sp = make_splat();
+            auto rp = fast_rasterize_forward(*camera_, *sp, bg_);
+            const double lp = image_loss_f64(rp->first.image, rp->first.depth, true);
+            rp->second.release_forward_context();
+            apply(minus);
+            auto sm = make_splat();
+            auto rm = fast_rasterize_forward(*camera_, *sm, bg_);
+            const double lm = image_loss_f64(rm->first.image, rm->first.depth, true);
+            rm->second.release_forward_context();
+            g[i] = static_cast<float>((lp - lm) / (2.0 * static_cast<double>(eps)));
+        }
+        switch (param) {
+        case ParamType::Means: means_ = orig; break;
+        case ParamType::Scaling: scaling_ = orig; break;
+        case ParamType::Rotation: rotation_ = orig; break;
+        case ParamType::Opacity: opacity_ = orig; break;
+        case ParamType::Sh0: sh0_ = orig; break;
+        default: break;
+        }
+        return grad_cpu.to(Device::CUDA);
+    };
+
+    auto cosine = [](const Tensor& a, const Tensor& b) {
+        auto ac = a.to(Device::CPU);
+        auto bc = b.to(Device::CPU);
+        const float* pa = ac.ptr<float>();
+        const float* pb = bc.ptr<float>();
+        double dot = 0, na = 0, nb = 0;
+        for (size_t i = 0; i < ac.numel(); ++i) {
+            if (pa[i] == 0.0f)
+                continue;
+            dot += pa[i] * pb[i];
+            na += pa[i] * pa[i];
+            nb += pb[i] * pb[i];
+        }
+        if (na < 1e-20 && nb < 1e-20)
+            return 1.0f;
+        return static_cast<float>(dot / (std::sqrt(na) * std::sqrt(nb) + 1e-12));
+    };
+
+    const ParamType params[] = {ParamType::Means, ParamType::Scaling, ParamType::Rotation, ParamType::Opacity, ParamType::Sh0};
+    for (auto p : params) {
+        auto ana = run_analytical(p);
+        float best = -1.f;
+        for (float eps : {1e-3f, 5e-4f}) {
+            auto num = numerical(p, eps);
+            best = std::max(best, cosine(num, ana));
+            if (best > 0.90f)
+                break;
+        }
+        const char* name = "unknown";
+        switch (p) {
+        case ParamType::Means: name = "means"; break;
+        case ParamType::Scaling: name = "scaling"; break;
+        case ParamType::Rotation: name = "rotation"; break;
+        case ParamType::Opacity: name = "opacity"; break;
+        case ParamType::Sh0: name = "sh0"; break;
+        default: break;
+        }
+        EXPECT_GT(best, 0.75f) << "gradcheck failed for " << name;
+    }
+}
+
+TEST_F(FastGSFisheyeKernelTest, DepthIsRayLength) {
+    std::vector<float> means{0.35f, 0.2f, 1.5f};
+    means_ = Tensor::from_vector(means, {size_t{1}, size_t{3}}, Device::CUDA);
+    n_ = 1;
+    sh0_ = Tensor::full({1, 1, 3}, 1.0f, Device::CUDA);
+    shN_ = Tensor::zeros({1, 0, 3}, Device::CUDA);
+    scaling_ = Tensor::full({1, 3}, -2.5f, Device::CUDA);
+    rotation_ = Tensor::zeros({1, 4}, Device::CUDA);
+    rotation_.slice(1, 0, 1).fill_(1.0f);
+    opacity_ = Tensor::full({1}, 4.0f, Device::CUDA);
+    auto splat = make_splat();
+    auto r = fast_rasterize_forward(*camera_, *splat, bg_);
+    ASSERT_TRUE(r.has_value());
+    const float D = std::sqrt(0.35f * 0.35f + 0.2f * 0.2f + 1.5f * 1.5f);
+    auto depth = r->first.depth.to(Device::CPU);
+    auto alpha = r->first.alpha.to(Device::CPU);
+    const float* d = depth.ptr<float>();
+    const float* a = alpha.ptr<float>();
+    float max_norm = 0.f;
+    for (size_t i = 0; i < depth.numel(); ++i) {
+        if (a[i] < 0.3f)
+            continue;
+        max_norm = std::max(max_norm, d[i] / a[i]);
+    }
+    EXPECT_NEAR(max_norm, D, 0.08f);
+    EXPECT_GT(max_norm, 1.5f + 0.02f) << "fisheye depth should be ray length, not z";
+}
+
+TEST_F(FastGSFisheyeKernelTest, T7ThetaMaxCulling) {
+    const double tmax = kb::kb_theta_max(
+        static_cast<double>(k_[0]), static_cast<double>(k_[1]),
+        static_cast<double>(k_[2]), static_cast<double>(k_[3]),
+        static_cast<double>(w_), static_cast<double>(h_),
+        static_cast<double>(fx_), static_cast<double>(fy_),
+        static_cast<double>(cx_), static_cast<double>(cy_));
+    const double th_in = tmax - 0.04;
+    const double th_out = tmax + 0.04;
+    const double phi_corner = std::atan2(static_cast<double>(h_) - cy_, static_cast<double>(w_) - cx_);
+    auto ray = [](double theta, double phi) {
+        return std::vector<float>{
+            static_cast<float>(std::sin(theta) * std::cos(phi)),
+            static_cast<float>(std::sin(theta) * std::sin(phi)),
+            static_cast<float>(std::cos(theta))};
+    };
+    auto count_touched = [&](const std::vector<float>& P) {
+        means_ = Tensor::from_vector(P, {size_t{1}, size_t{3}}, Device::CUDA);
+        n_ = 1;
+        sh0_ = Tensor::full({1, 1, 3}, 0.8f, Device::CUDA);
+        shN_ = Tensor::zeros({1, 0, 3}, Device::CUDA);
+        scaling_ = Tensor::full({1, 3}, -3.5f, Device::CUDA);
+        rotation_ = Tensor::zeros({1, 4}, Device::CUDA);
+        rotation_.slice(1, 0, 1).fill_(1.0f);
+        opacity_ = Tensor::full({1}, 3.0f, Device::CUDA);
+        auto splat = make_splat();
+        auto r = fast_rasterize_forward(*camera_, *splat, bg_);
+        EXPECT_TRUE(r.has_value());
+        const int n_instances = r->second.forward_ctx.n_instances;
+        const float alpha_sum = r->first.alpha.sum().item<float>();
+        return std::pair<int, float>{n_instances, alpha_sum};
+    };
+    auto Pin = ray(th_in, phi_corner);
+    for (auto& v : Pin)
+        v *= 1.4f;
+    auto Pout = ray(th_out, phi_corner);
+    for (auto& v : Pout)
+        v *= 1.4f;
+    const auto in_c = count_touched(Pin);
+    const auto out_c = count_touched(Pout);
+    EXPECT_GT(in_c.first, 0);
+    EXPECT_EQ(out_c.first, 0);
+    EXPECT_GT(in_c.second, 0.0f);
+    EXPECT_NEAR(out_c.second, 0.0f, 1e-6f);
+}
+
+TEST(FastGSFisheyeT5, EquidistantWarpParity) {
+    GlobalArenaManager::instance().get_arena().full_reset();
+    constexpr int W = 96, H = 96;
+    const float fx = 70.f, fy = 70.f, cx = 48.f, cy = 48.f;
+    std::mt19937 rng(21);
+    constexpr size_t N = 16;
+    std::vector<float> means(N * 3), sh0(N * 3), rot(N * 4, 0.f), scale(N * 3, -2.8f), opa(N, 1.5f);
+    std::uniform_real_distribution<float> xy(-0.4f, 0.4f), z(1.2f, 2.0f), col(0.1f, 0.9f);
+    for (size_t i = 0; i < N; ++i) {
+        means[i * 3] = xy(rng);
+        means[i * 3 + 1] = xy(rng);
+        means[i * 3 + 2] = z(rng);
+        sh0[i * 3] = col(rng);
+        sh0[i * 3 + 1] = col(rng);
+        sh0[i * 3 + 2] = col(rng);
+        rot[i * 4] = 1.f;
+    }
+    auto means_t = Tensor::from_vector(means, {N, 3}, Device::CUDA);
+    auto sh0_t = Tensor::from_blob(sh0.data(), {N, 1, 3}, Device::CPU, DataType::Float32).to(Device::CUDA);
+    auto shN_t = Tensor::zeros({N, 0, 3}, Device::CUDA);
+    auto scale_t = Tensor::from_vector(scale, {N, 3}, Device::CUDA);
+    auto rot_t = Tensor::from_vector(rot, {N, 4}, Device::CUDA);
+    auto opa_t = Tensor::from_vector(opa, {N}, Device::CUDA);
+    auto splat = SplatData(0, means_t, sh0_t, shN_t, scale_t, rot_t, opa_t, 1.0f);
+    auto bg = Tensor::zeros({3}, Device::CUDA);
+
+    auto cam_p = make_camera(CameraModelType::PINHOLE, W, H, fx, fy, cx, cy);
+    auto cam_f = make_camera(CameraModelType::FISHEYE, W, H, fx, fy, cx, cy, {0, 0, 0, 0});
+    auto pin = fast_rasterize_forward(*cam_p, splat, bg);
+    ASSERT_TRUE(pin.has_value());
+    auto pin_img = pin->first.image.to(Device::CPU);
+    pin->second.release_forward_context();
+    auto fish = fast_rasterize_forward(*cam_f, splat, bg);
+    ASSERT_TRUE(fish.has_value());
+    auto fish_img = fish->first.image.to(Device::CPU);
+    fish->second.release_forward_context();
+
+    const float* p = pin_img.ptr<float>();
+    const float* fimg = fish_img.ptr<float>();
+    const int npix = W * H;
+    auto sample = [&](int c, float u, float v) {
+        const float x = std::clamp(u, 0.0f, static_cast<float>(W - 1));
+        const float y = std::clamp(v, 0.0f, static_cast<float>(H - 1));
+        const int x0 = static_cast<int>(std::floor(x));
+        const int y0 = static_cast<int>(std::floor(y));
+        const int x1 = std::min(x0 + 1, W - 1);
+        const int y1 = std::min(y0 + 1, H - 1);
+        const float ax = x - static_cast<float>(x0);
+        const float ay = y - static_cast<float>(y0);
+        auto at = [&](int xx, int yy) { return p[c * npix + yy * W + xx]; };
+        const float v0 = at(x0, y0) * (1 - ax) + at(x1, y0) * ax;
+        const float v1 = at(x0, y1) * (1 - ax) + at(x1, y1) * ax;
+        return v0 * (1 - ay) + v1 * ay;
+    };
+    std::vector<float> warped(3 * npix), fish_v(3 * npix);
+    std::vector<char> mask(npix, 0);
+    const float erode = 8.f;
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            const float u = static_cast<float>(x) + 0.5f;
+            const float v = static_cast<float>(y) + 0.5f;
+            const float mx = (u - cx) / fx;
+            const float my = (v - cy) / fy;
+            const float rd = std::hypot(mx, my);
+            if (rd < 1e-6f) {
+                if (u > erode && u < W - erode && v > erode && v < H - erode)
+                    mask[y * W + x] = 1;
+                for (int c = 0; c < 3; ++c) {
+                    warped[c * npix + y * W + x] = sample(c, u, v);
+                    fish_v[c * npix + y * W + x] = fimg[c * npix + y * W + x];
+                }
+                continue;
+            }
+            const float theta = rd;
+            if (theta >= 1.2f)
+                continue;
+            const float scale = std::tan(theta) / theta;
+            const float up = cx + fx * mx * scale;
+            const float vp = cy + fy * my * scale;
+            if (up < erode || up >= W - erode || vp < erode || vp >= H - erode)
+                continue;
+            mask[y * W + x] = 1;
+            for (int c = 0; c < 3; ++c) {
+                warped[c * npix + y * W + x] = sample(c, up, vp);
+                fish_v[c * npix + y * W + x] = fimg[c * npix + y * W + x];
+            }
+        }
+    }
+    std::vector<char> mask3(3 * npix);
+    for (int c = 0; c < 3; ++c)
+        for (int i = 0; i < npix; ++i)
+            mask3[c * npix + i] = mask[i];
+    const float psnr = psnr_region(warped, fish_v, mask3);
+    EXPECT_GT(psnr, 32.0f);
+    GlobalArenaManager::instance().get_arena().full_reset();
+
+    // Smooth synthetic: one large gaussian.
+    std::vector<float> m2{0.f, 0.f, 1.6f}, s2{3 * -1.8f, 0, 0}, r2{1, 0, 0, 0}, o2{2.0f}, c2{0.6f, 0.5f, 0.4f};
+    s2 = {-1.8f, -1.8f, -1.8f};
+    auto splat2 = SplatData(
+        0,
+        Tensor::from_vector(m2, {1, 3}, Device::CUDA),
+        Tensor::from_blob(c2.data(), {1, 1, 3}, Device::CPU, DataType::Float32).to(Device::CUDA),
+        Tensor::zeros({1, 0, 3}, Device::CUDA),
+        Tensor::from_vector(s2, {1, 3}, Device::CUDA),
+        Tensor::from_vector(r2, {1, 4}, Device::CUDA),
+        Tensor::from_vector(o2, {1}, Device::CUDA),
+        1.0f);
+    auto pin2 = fast_rasterize_forward(*cam_p, splat2, bg);
+    ASSERT_TRUE(pin2.has_value());
+    auto pin2c = pin2->first.image.to(Device::CPU);
+    pin2->second.release_forward_context();
+    auto fish2 = fast_rasterize_forward(*cam_f, splat2, bg);
+    ASSERT_TRUE(fish2.has_value());
+    auto fish2c = fish2->first.image.to(Device::CPU);
+    fish2->second.release_forward_context();
+    const float* p2 = pin2c.ptr<float>();
+    const float* f2 = fish2c.ptr<float>();
+    std::vector<float> warped2(3 * npix), fish2v(3 * npix);
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            const float u = x + 0.5f, v = y + 0.5f;
+            const float mx = (u - cx) / fx, my = (v - cy) / fy;
+            const float rd = std::hypot(mx, my);
+            const float theta = std::max(rd, 1e-6f);
+            const float scale = std::tan(theta) / theta;
+            const float up = cx + fx * mx * scale;
+            const float vp = cy + fy * my * scale;
+            if (!mask[y * W + x])
+                continue;
+            auto samp = [&](int c, float uu, float vv) {
+                const float xx = std::clamp(uu, 0.f, float(W - 1));
+                const float yy = std::clamp(vv, 0.f, float(H - 1));
+                const int x0 = int(std::floor(xx)), y0 = int(std::floor(yy));
+                const int x1 = std::min(x0 + 1, W - 1), y1 = std::min(y0 + 1, H - 1);
+                const float ax = xx - x0, ay = yy - y0;
+                auto at = [&](int xx2, int yy2) { return p2[c * npix + yy2 * W + xx2]; };
+                return (at(x0, y0) * (1 - ax) + at(x1, y0) * ax) * (1 - ay) +
+                       (at(x0, y1) * (1 - ax) + at(x1, y1) * ax) * ay;
+            };
+            for (int c = 0; c < 3; ++c) {
+                warped2[c * npix + y * W + x] = samp(c, up, vp);
+                fish2v[c * npix + y * W + x] = f2[c * npix + y * W + x];
+            }
+        }
+    }
+    EXPECT_GT(psnr_region(warped2, fish2v, mask3), 40.0f);
+    GlobalArenaManager::instance().get_arena().full_reset();
+}
+
+TEST(FastGSFisheyeT6, PinholeRenderDeterministic) {
+    GlobalArenaManager::instance().get_arena().full_reset();
+    constexpr int W = 64, H = 64;
+    auto cam = make_camera(CameraModelType::PINHOLE, W, H, 80.f, 80.f, 32.f, 32.f);
+    std::vector<float> means{0.f, 0.f, 1.5f, 0.2f, -0.1f, 1.8f};
+    auto splat = SplatData(
+        0,
+        Tensor::from_vector(means, {2, 3}, Device::CUDA),
+        Tensor::full({2, 1, 3}, 0.5f, Device::CUDA),
+        Tensor::zeros({2, 0, 3}, Device::CUDA),
+        Tensor::full({2, 3}, -3.0f, Device::CUDA),
+        Tensor::from_vector(std::vector<float>{1, 0, 0, 0, 1, 0, 0, 0}, {2, 4}, Device::CUDA),
+        Tensor::full({2}, 1.0f, Device::CUDA),
+        1.0f);
+    auto bg = Tensor::zeros({3}, Device::CUDA);
+    auto a = fast_rasterize_forward(*cam, splat, bg);
+    ASSERT_TRUE(a.has_value());
+    auto ac = a->first.image.to(Device::CPU);
+    a->second.release_forward_context();
+    auto b = fast_rasterize_forward(*cam, splat, bg);
+    ASSERT_TRUE(b.has_value());
+    auto bc = b->first.image.to(Device::CPU);
+    b->second.release_forward_context();
+    const float* pa = ac.ptr<float>();
+    const float* pb = bc.ptr<float>();
+    int n_diff = 0;
+    for (size_t i = 0; i < ac.numel(); ++i) {
+        if (pa[i] != pb[i])
+            ++n_diff;
+    }
+    EXPECT_EQ(n_diff, 0);
+    std::uint64_t checksum = 14695981039346656037ull;
+    for (size_t i = 0; i < ac.numel(); ++i) {
+        std::uint32_t bits = 0;
+        std::memcpy(&bits, pa + i, sizeof(bits));
+        checksum ^= bits;
+        checksum *= 1099511628211ull;
+    }
+    std::printf("pinhole_bitid_checksum=%llu n=%zu\n",
+                static_cast<unsigned long long>(checksum), ac.numel());
+    GlobalArenaManager::instance().get_arena().full_reset();
+}
+
+TEST(FastGSFisheye, PreprocessAddsNoDilation) {
+    GlobalArenaManager::instance().get_arena().full_reset();
+    constexpr int W = 64, H = 64;
+    const float fx = 48.f, fy = 46.f, cx = 32.f, cy = 32.f;
+    auto means = Tensor::from_vector(std::vector<float>{0.f, 0.f, 1.5f}, {1, 3}, Device::CUDA);
+    auto sh0 = Tensor::full({1, 1, 3}, 0.6f, Device::CUDA);
+    auto shN = Tensor::zeros({1, 0, 3}, Device::CUDA);
+    auto scale = Tensor::from_vector(std::vector<float>{-2.5f, -2.5f, -2.5f}, {1, 3}, Device::CUDA);
+    auto rot = Tensor::from_vector(std::vector<float>{1.f, 0.f, 0.f, 0.f}, {1, 4}, Device::CUDA);
+    auto opa = Tensor::from_vector(std::vector<float>{3.0f}, {1}, Device::CUDA);
+    auto splat = SplatData(0, means, sh0, shN, scale, rot, opa, 1.0f);
+    auto bg = Tensor::zeros({3}, Device::CUDA);
+
+    auto cam_f = make_camera(CameraModelType::FISHEYE, W, H, fx, fy, cx, cy,
+                             {0.04f, -0.008f, 0.001f, 0.0f});
+    auto fish_off = fast_rasterize_forward(*cam_f, splat, bg, 0, 0, 0, 0, false);
+    ASSERT_TRUE(fish_off.has_value());
+    ASSERT_GT(fish_off->first.alpha.sum().item<float>(), 1e-3f);
+    auto fish_off_img = fish_off->first.image.to(Device::CPU);
+    auto fish_off_alpha = fish_off->first.alpha.to(Device::CPU);
+    fish_off->second.release_forward_context();
+    auto fish_on = fast_rasterize_forward(*cam_f, splat, bg, 0, 0, 0, 0, true);
+    ASSERT_TRUE(fish_on.has_value());
+    auto fish_on_img = fish_on->first.image.to(Device::CPU);
+    auto fish_on_alpha = fish_on->first.alpha.to(Device::CPU);
+    fish_on->second.release_forward_context();
+    EXPECT_EQ(tensor_mismatch_count(fish_off_img, fish_on_img), 0);
+    EXPECT_EQ(tensor_mismatch_count(fish_off_alpha, fish_on_alpha), 0);
+
+    auto cam_p = make_camera(CameraModelType::PINHOLE, W, H, fx, fy, cx, cy);
+    auto pin_off = fast_rasterize_forward(*cam_p, splat, bg, 0, 0, 0, 0, false);
+    ASSERT_TRUE(pin_off.has_value());
+    ASSERT_GT(pin_off->first.alpha.sum().item<float>(), 1e-3f);
+    auto pin_off_img = pin_off->first.image.to(Device::CPU);
+    auto pin_off_alpha = pin_off->first.alpha.to(Device::CPU);
+    pin_off->second.release_forward_context();
+    auto pin_on = fast_rasterize_forward(*cam_p, splat, bg, 0, 0, 0, 0, true);
+    ASSERT_TRUE(pin_on.has_value());
+    auto pin_on_img = pin_on->first.image.to(Device::CPU);
+    auto pin_on_alpha = pin_on->first.alpha.to(Device::CPU);
+    pin_on->second.release_forward_context();
+    EXPECT_GT(tensor_mismatch_count(pin_off_img, pin_on_img) +
+                  tensor_mismatch_count(pin_off_alpha, pin_on_alpha),
+              0);
+
+    GlobalArenaManager::instance().get_arena().full_reset();
+}
+
+TEST(FastGSFisheye, RimGradcheckMeansScalesRotationOpacity) {
+    GlobalArenaManager::instance().get_arena().full_reset();
+    constexpr int W = 128, H = 96;
+    const float fx = 36.0f, fy = 33.4f, cx = 64.0f, cy = 48.0f;
+    const std::vector<float> k{0.05f, -0.01f, 0.002f, -0.0005f};
+    auto camera = make_camera(CameraModelType::FISHEYE, W, H, fx, fy, cx, cy, k);
+    auto bg = Tensor::zeros({3}, Device::CUDA);
+    const double tmax = kb::kb_theta_max(
+        static_cast<double>(k[0]), static_cast<double>(k[1]),
+        static_cast<double>(k[2]), static_cast<double>(k[3]),
+        static_cast<double>(W), static_cast<double>(H),
+        static_cast<double>(fx), static_cast<double>(fy),
+        static_cast<double>(cx), static_cast<double>(cy));
+    const float phi = std::atan2(static_cast<float>(H) - cy, static_cast<float>(W) - cx);
+    const float D = 1.6f;
+    const float thetas_deg[] = {80.f, 88.f, 92.f, 96.f};
+
+    auto make_splat = [](const Tensor& means, const Tensor& sh0, const Tensor& shN,
+                         const Tensor& scaling, const Tensor& rotation, const Tensor& opacity) {
+        return SplatData(0, means.clone(), sh0.clone(), shN.clone(),
+                         scaling.clone(), rotation.clone(), opacity.clone(), 1.0f);
+    };
+
+    for (float theta_deg : thetas_deg) {
+        SCOPED_TRACE(testing::Message() << "theta_deg=" << theta_deg);
+        const float th = theta_deg * static_cast<float>(kb::kPi / 180.0);
+        std::vector<float> P{
+            D * std::sin(th) * std::cos(phi),
+            D * std::sin(th) * std::sin(phi),
+            D * std::cos(th)};
+        if (theta_deg > 90.f) {
+            ASSERT_LT(P[2], 0.0f);
+        } else {
+            ASSERT_GT(P[2], 0.0f);
+        }
+        const auto proj = kb::kb_project(P[0], P[1], P[2], fx, fy, cx, cy, k[0], k[1], k[2], k[3]);
+        ASSERT_TRUE(proj.finite);
+        ASSERT_LT(static_cast<double>(proj.theta), tmax);
+        ASSERT_GT(proj.px, 2.0f);
+        ASSERT_LT(proj.px, static_cast<float>(W) - 2.0f);
+        ASSERT_GT(proj.py, 2.0f);
+        ASSERT_LT(proj.py, static_cast<float>(H) - 2.0f);
+
+        Tensor means = Tensor::from_vector(P, {size_t{1}, size_t{3}}, Device::CUDA);
+        Tensor sh0 = Tensor::full({1, 1, 3}, 0.5f, Device::CUDA);
+        Tensor shN = Tensor::zeros({1, 0, 3}, Device::CUDA);
+        Tensor scaling = Tensor::full({1, 3}, -3.6f, Device::CUDA);
+        Tensor rotation = Tensor::zeros({1, 4}, Device::CUDA);
+        rotation.slice(1, 0, 1).fill_(1.0f);
+        Tensor opacity = Tensor::full({1}, 2.5f, Device::CUDA);
+
+        {
+            auto splat = make_splat(means, sh0, shN, scaling, rotation, opacity);
+            auto fwd = fast_rasterize_forward(*camera, splat, bg);
+            ASSERT_TRUE(fwd.has_value());
+            ASSERT_GT(fwd->first.alpha.sum().item<float>(), 1e-3f)
+                << "rim gaussian at " << theta_deg << " deg produced no alpha";
+            fwd->second.release_forward_context();
+        }
+
+        auto run_analytical = [&](ParamType param) {
+            auto s = make_splat(means, sh0, shN, scaling, rotation, opacity);
+            auto r = fast_rasterize_forward(*camera, s, bg);
+            AdamConfig cfg{.lr = 0.001f, .beta1 = 0.9, .beta2 = 0.999, .eps = 1e-15};
+            auto opt = std::make_unique<AdamOptimizer>(s, cfg);
+            opt->allocate_gradients();
+            opt->zero_grad(0);
+            auto grad_out = r->first.image.mul(2.0f);
+            auto grad_depth = r->first.depth.mul(2.0f);
+            fast_rasterize_backward(r->second, grad_out, s, *opt, {}, {}, DensificationType::None, 1, {}, grad_depth);
+            return recovered_fused_grad(*opt, param);
+        };
+
+        auto numerical = [&](ParamType param, float eps) {
+            Tensor orig;
+            switch (param) {
+            case ParamType::Means: orig = means.clone(); break;
+            case ParamType::Scaling: orig = scaling.clone(); break;
+            case ParamType::Rotation: orig = rotation.clone(); break;
+            case ParamType::Opacity: orig = opacity.clone(); break;
+            default: return Tensor();
+            }
+            auto orig_cpu = orig.to(Device::CPU);
+            auto grad_cpu = Tensor::zeros_like(orig_cpu);
+            float* g = grad_cpu.ptr<float>();
+            const float* o = orig_cpu.ptr<float>();
+            const size_t n_probe = std::min(orig.numel(), size_t{4});
+            for (size_t p = 0; p < n_probe; ++p) {
+                const size_t i = (n_probe == 1) ? 0 : p * (orig.numel() - 1) / (n_probe - 1);
+                auto plus = orig_cpu.clone();
+                auto minus = orig_cpu.clone();
+                plus.ptr<float>()[i] = o[i] + eps;
+                minus.ptr<float>()[i] = o[i] - eps;
+                auto apply = [&](const Tensor& cpu_val) {
+                    switch (param) {
+                    case ParamType::Means: means = cpu_val.to(Device::CUDA); break;
+                    case ParamType::Scaling: scaling = cpu_val.to(Device::CUDA); break;
+                    case ParamType::Rotation: rotation = cpu_val.to(Device::CUDA); break;
+                    case ParamType::Opacity: opacity = cpu_val.to(Device::CUDA); break;
+                    default: break;
+                    }
+                };
+                apply(plus);
+                auto sp = make_splat(means, sh0, shN, scaling, rotation, opacity);
+                auto rp = fast_rasterize_forward(*camera, sp, bg);
+                const double lp = image_loss_f64(rp->first.image, rp->first.depth, true);
+                rp->second.release_forward_context();
+                apply(minus);
+                auto sm = make_splat(means, sh0, shN, scaling, rotation, opacity);
+                auto rm = fast_rasterize_forward(*camera, sm, bg);
+                const double lm = image_loss_f64(rm->first.image, rm->first.depth, true);
+                rm->second.release_forward_context();
+                g[i] = static_cast<float>((lp - lm) / (2.0 * static_cast<double>(eps)));
+            }
+            switch (param) {
+            case ParamType::Means: means = orig; break;
+            case ParamType::Scaling: scaling = orig; break;
+            case ParamType::Rotation: rotation = orig; break;
+            case ParamType::Opacity: opacity = orig; break;
+            default: break;
+            }
+            return grad_cpu.to(Device::CUDA);
+        };
+
+        const ParamType params[] = {ParamType::Means, ParamType::Scaling, ParamType::Rotation, ParamType::Opacity};
+        for (auto p : params) {
+            auto ana = run_analytical(p);
+            float best = -1.f;
+            for (float eps : {1e-3f, 5e-4f}) {
+                auto num = numerical(p, eps);
+                best = std::max(best, cosine_nonzero(num, ana));
+                if (best > 0.90f)
+                    break;
+            }
+            const char* name = "unknown";
+            switch (p) {
+            case ParamType::Means: name = "means"; break;
+            case ParamType::Scaling: name = "scaling"; break;
+            case ParamType::Rotation: name = "rotation"; break;
+            case ParamType::Opacity: name = "opacity"; break;
+            default: break;
+            }
+            EXPECT_GT(best, 0.75f) << "rim gradcheck failed for " << name << " at " << theta_deg << " deg";
+        }
+    }
+    GlobalArenaManager::instance().get_arena().full_reset();
+}


### PR DESCRIPTION
Fisheye (OPENCV_FISHEYE) datasets train on the fast path directly — no `--gut`, no undistorting. SH degrees 1–3 work, and the exported splats are plain 3DGS that any viewer shows as trained.

**Results** (london, 200-degree indoor fisheye, 1984 images, every 8th held out, SH 0):

| | PSNR | SSIM | time |
|---|---|---|---|
| fastgs fisheye, 7k it, 1M splats | 23.87 | 0.788 | 51 s |
| GUT, same | 24.22 | 0.782 | 113 s |
| fastgs fisheye, 30k it, 3M, images_2 | 25.07 | 0.825 | 10 min |
| GUT, same | 25.92 | 0.824 | 20 min |

Twice as fast as GUT at equal SSIM, a bit behind on PSNR. The difference is the compositing model (one 2D footprint per splat and view versus per-ray evaluation), not the projection: on 112k real splat/camera pairs the projected footprints match an exact projection through the lens to within noise. GUT remains the choice for maximum PSNR; its models render differently in standard viewers.

**How it works.** One header holds the lens projection, its Jacobian and second derivatives; forward, backward and tests share it. Depth is the ray length, so content beyond 90 degrees renders. Splats past the lens fold-over or beyond the image corner are culled. The fisheye footprint is composited without the 0.3 px dilation: +0.46 dB / +0.025 SSIM measured, with or without the mip filter.

Pinhole is bit-identical (render checksum test) with unchanged register and stack budgets. The per-camera "Undistort: ..." load-time log moves to debug level.

**Tests**: projection and Jacobian golden values, finite-difference gradient checks including the rim (80–96 degrees, behind the camera plane), tile-count and cull checks, the no-dilation guarantee, the pinhole checksum.