### PR TITLE
Seed PPISP exposure from EXIF and apply PPISP in evaluation

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -55,6 +55,7 @@ set(CORE_SOURCES
         device_fault.cpp
         error.cpp
         error_bus.cpp
+        exif.cpp
         error_envelope.cpp
         error_latch.cpp
         error_reporter.cpp

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -73,6 +73,7 @@ namespace lfs::core::args {
             OptimizationCliBinding{"--enable-mip", "mip_filter", Bool},
             OptimizationCliBinding{"--bilateral-grid", "use_bilateral_grid", Bool},
             OptimizationCliBinding{"--ppisp", "ppisp", Bool},
+            OptimizationCliBinding{"--no-ppisp-exif-exposure", "ppisp_exposure_from_exif", Bool, true},
             OptimizationCliBinding{"--ppisp-controller", "ppisp_use_controller", Bool},
             OptimizationCliBinding{"--ppisp-freeze", "ppisp_freeze_from_sidecar", Bool},
             OptimizationCliBinding{"--gut", "gut", Bool},
@@ -521,6 +522,7 @@ namespace {
             ::args::Flag enable_mip(rendering_group, "enable_mip", lfs::core::args::optimization_cli_help("--enable-mip"), {"enable-mip"});
             ::args::Flag use_bilateral_grid(rendering_group, "bilateral_grid", lfs::core::args::optimization_cli_help("--bilateral-grid"), {"bilateral-grid"});
             ::args::Flag use_ppisp(rendering_group, "ppisp", lfs::core::args::optimization_cli_help("--ppisp"), {"ppisp"});
+            ::args::Flag no_ppisp_exif_exposure(rendering_group, "no_ppisp_exif_exposure", lfs::core::args::optimization_cli_help("--no-ppisp-exif-exposure"), {"no-ppisp-exif-exposure"});
             ::args::Flag ppisp_controller(rendering_group, "ppisp_controller", lfs::core::args::optimization_cli_help("--ppisp-controller"), {"ppisp-controller"});
             ::args::Flag ppisp_freeze_from_sidecar(rendering_group, "ppisp_freeze", lfs::core::args::optimization_cli_help("--ppisp-freeze"), {"ppisp-freeze"});
             ::args::ValueFlag<std::string> ppisp_sidecar_path(rendering_group, "path", "Path to PPISP sidecar (.ppisp) used for frozen PPISP training", {"ppisp-sidecar"});
@@ -1046,6 +1048,7 @@ namespace {
                                         enable_mip_flag = bool(enable_mip),
                                         use_bilateral_grid_flag = bool(use_bilateral_grid),
                                         use_ppisp_flag = bool(use_ppisp),
+                                        no_ppisp_exif_exposure_flag = bool(no_ppisp_exif_exposure),
                                         ppisp_controller_flag = bool(ppisp_controller),
                                         ppisp_freeze_from_sidecar_flag = bool(ppisp_freeze_from_sidecar),
                                         ppisp_sidecar_path_val = cli_option_present({"--ppisp-sidecar"}) ? std::optional<std::string>(::args::get(ppisp_sidecar_path)) : std::optional<std::string>(),
@@ -1157,6 +1160,8 @@ namespace {
                 setFlag(enable_mip_flag, opt.mip_filter);
                 setFlag(use_bilateral_grid_flag, opt.use_bilateral_grid);
                 setFlag(use_ppisp_flag, opt.use_ppisp);
+                if (no_ppisp_exif_exposure_flag)
+                    opt.ppisp_exposure_from_exif = false;
                 setFlag(ppisp_controller_flag, opt.ppisp_use_controller);
                 setFlag(ppisp_freeze_from_sidecar_flag, opt.ppisp_freeze_from_sidecar);
                 if (ppisp_sidecar_path_val) {

--- a/src/core/exif.cpp
+++ b/src/core/exif.cpp
@@ -1,0 +1,425 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/exif.hpp"
+#include "core/path_utils.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <span>
+#include <vector>
+
+namespace lfs::core {
+    namespace {
+
+        constexpr std::size_t kMaxScanBytes = 64 * 1024;
+        constexpr std::uint16_t kTagExifIfd = 0x8769;
+        constexpr std::uint16_t kTagExposureTime = 0x829A;
+        constexpr std::uint16_t kTagFNumber = 0x829D;
+        constexpr std::uint16_t kTagIso = 0x8827;
+        constexpr std::uint16_t kTagStandardOutputSensitivity = 0x8831;
+        constexpr std::uint16_t kTagRecommendedExposureIndex = 0x8832;
+        constexpr std::uint16_t kTagIsoSpeed = 0x8833;
+        constexpr std::uint16_t kTagShutterSpeedValue = 0x9201;
+        constexpr std::uint16_t kTagApertureValue = 0x9202;
+
+        constexpr std::uint16_t kTypeShort = 3;
+        constexpr std::uint16_t kTypeLong = 4;
+        constexpr std::uint16_t kTypeRational = 5;
+        constexpr std::uint16_t kTypeSLong = 9;
+        constexpr std::uint16_t kTypeSRational = 10;
+
+        constexpr int kMaxIfdEntries = 256;
+
+        [[nodiscard]] bool fits(const std::span<const std::uint8_t> data, const std::size_t offset,
+                                const std::size_t nbytes) {
+            return nbytes <= data.size() && offset <= data.size() - nbytes;
+        }
+
+        [[nodiscard]] std::optional<std::uint16_t> read_u16(const std::span<const std::uint8_t> data,
+                                                            const std::size_t offset, const bool little) {
+            if (!fits(data, offset, 2)) {
+                return std::nullopt;
+            }
+            const std::uint16_t lo = data[offset];
+            const std::uint16_t hi = data[offset + 1];
+            return little ? static_cast<std::uint16_t>(lo | (hi << 8))
+                          : static_cast<std::uint16_t>(hi | (lo << 8));
+        }
+
+        [[nodiscard]] std::optional<std::uint32_t> read_u32(const std::span<const std::uint8_t> data,
+                                                            const std::size_t offset, const bool little) {
+            if (!fits(data, offset, 4)) {
+                return std::nullopt;
+            }
+            if (little) {
+                return static_cast<std::uint32_t>(data[offset]) |
+                       (static_cast<std::uint32_t>(data[offset + 1]) << 8) |
+                       (static_cast<std::uint32_t>(data[offset + 2]) << 16) |
+                       (static_cast<std::uint32_t>(data[offset + 3]) << 24);
+            }
+            return (static_cast<std::uint32_t>(data[offset]) << 24) |
+                   (static_cast<std::uint32_t>(data[offset + 1]) << 16) |
+                   (static_cast<std::uint32_t>(data[offset + 2]) << 8) |
+                   static_cast<std::uint32_t>(data[offset + 3]);
+        }
+
+        [[nodiscard]] std::optional<std::int32_t> read_i32(const std::span<const std::uint8_t> data,
+                                                           const std::size_t offset, const bool little) {
+            const auto raw = read_u32(data, offset, little);
+            if (!raw) {
+                return std::nullopt;
+            }
+            return static_cast<std::int32_t>(*raw);
+        }
+
+        [[nodiscard]] std::size_t tiff_type_size(const std::uint16_t type) {
+            switch (type) {
+            case 1:
+            case 2:
+            case 7:
+                return 1;
+            case kTypeShort:
+            case 8:
+                return 2;
+            case kTypeLong:
+            case kTypeSLong:
+            case 11:
+                return 4;
+            case kTypeRational:
+            case kTypeSRational:
+            case 12:
+                return 8;
+            default:
+                return 0;
+            }
+        }
+
+        struct IfdEntry {
+            std::uint16_t tag = 0;
+            std::uint16_t type = 0;
+            std::uint32_t count = 0;
+            std::uint32_t value_or_offset = 0;
+        };
+
+        [[nodiscard]] std::optional<IfdEntry> read_ifd_entry(const std::span<const std::uint8_t> tiff,
+                                                             const std::size_t offset, const bool little) {
+            const auto tag = read_u16(tiff, offset, little);
+            const auto type = read_u16(tiff, offset + 2, little);
+            const auto count = read_u32(tiff, offset + 4, little);
+            const auto value = read_u32(tiff, offset + 8, little);
+            if (!tag || !type || !count || !value) {
+                return std::nullopt;
+            }
+            return IfdEntry{*tag, *type, *count, *value};
+        }
+
+        [[nodiscard]] std::optional<std::size_t> entry_value_offset(const IfdEntry& entry,
+                                                                    const std::size_t entry_offset) {
+            const std::size_t elem = tiff_type_size(entry.type);
+            if (elem == 0 || entry.count == 0) {
+                return std::nullopt;
+            }
+            if (entry.count > (std::numeric_limits<std::size_t>::max() / elem)) {
+                return std::nullopt;
+            }
+            const std::size_t nbytes = elem * static_cast<std::size_t>(entry.count);
+            if (nbytes <= 4) {
+                return entry_offset + 8;
+            }
+            return static_cast<std::size_t>(entry.value_or_offset);
+        }
+
+        [[nodiscard]] bool usable_positive(const double value) {
+            return std::isfinite(value) && value > 0.0;
+        }
+
+        [[nodiscard]] std::optional<double> read_unsigned_number(const std::span<const std::uint8_t> tiff,
+                                                                 const IfdEntry& entry,
+                                                                 const std::size_t entry_offset,
+                                                                 const bool little) {
+            const auto data_off = entry_value_offset(entry, entry_offset);
+            if (!data_off) {
+                return std::nullopt;
+            }
+            switch (entry.type) {
+            case kTypeShort: {
+                const auto v = read_u16(tiff, *data_off, little);
+                return v ? std::optional<double>{static_cast<double>(*v)} : std::nullopt;
+            }
+            case kTypeLong: {
+                const auto v = read_u32(tiff, *data_off, little);
+                return v ? std::optional<double>{static_cast<double>(*v)} : std::nullopt;
+            }
+            case kTypeRational: {
+                const auto num = read_u32(tiff, *data_off, little);
+                const auto den = read_u32(tiff, *data_off + 4, little);
+                if (!num || !den || *den == 0) {
+                    return std::nullopt;
+                }
+                return static_cast<double>(*num) / static_cast<double>(*den);
+            }
+            default:
+                return std::nullopt;
+            }
+        }
+
+        [[nodiscard]] std::optional<double> read_signed_number(const std::span<const std::uint8_t> tiff,
+                                                               const IfdEntry& entry,
+                                                               const std::size_t entry_offset,
+                                                               const bool little) {
+            const auto data_off = entry_value_offset(entry, entry_offset);
+            if (!data_off) {
+                return std::nullopt;
+            }
+            switch (entry.type) {
+            case kTypeSLong: {
+                const auto v = read_i32(tiff, *data_off, little);
+                return v ? std::optional<double>{static_cast<double>(*v)} : std::nullopt;
+            }
+            case kTypeSRational: {
+                const auto num = read_i32(tiff, *data_off, little);
+                const auto den = read_i32(tiff, *data_off + 4, little);
+                if (!num || !den || *den == 0) {
+                    return std::nullopt;
+                }
+                return static_cast<double>(*num) / static_cast<double>(*den);
+            }
+            case kTypeRational:
+            case kTypeShort:
+            case kTypeLong:
+                return read_unsigned_number(tiff, entry, entry_offset, little);
+            default:
+                return std::nullopt;
+            }
+        }
+
+        struct ExposureTags {
+            std::optional<double> exposure_time;
+            std::optional<double> f_number;
+            std::optional<double> iso;
+            std::optional<double> iso_sos;
+            std::optional<double> iso_rei;
+            std::optional<double> iso_speed;
+            std::optional<double> shutter_speed_apex;
+            std::optional<double> aperture_apex;
+            std::optional<std::uint32_t> exif_ifd_offset;
+        };
+
+        void ingest_entry(ExposureTags& tags, const std::span<const std::uint8_t> tiff, const IfdEntry& entry,
+                          const std::size_t entry_offset, const bool little) {
+            switch (entry.tag) {
+            case kTagExifIfd: {
+                if (entry.type == kTypeLong || entry.type == kTypeShort) {
+                    const auto off = read_unsigned_number(tiff, entry, entry_offset, little);
+                    if (off && *off <= static_cast<double>(std::numeric_limits<std::uint32_t>::max()) &&
+                        *off >= 0.0) {
+                        tags.exif_ifd_offset = static_cast<std::uint32_t>(*off);
+                    }
+                }
+                break;
+            }
+            case kTagExposureTime:
+                tags.exposure_time = read_unsigned_number(tiff, entry, entry_offset, little);
+                break;
+            case kTagFNumber:
+                tags.f_number = read_unsigned_number(tiff, entry, entry_offset, little);
+                break;
+            case kTagIso:
+                tags.iso = read_unsigned_number(tiff, entry, entry_offset, little);
+                break;
+            case kTagStandardOutputSensitivity:
+                tags.iso_sos = read_unsigned_number(tiff, entry, entry_offset, little);
+                break;
+            case kTagRecommendedExposureIndex:
+                tags.iso_rei = read_unsigned_number(tiff, entry, entry_offset, little);
+                break;
+            case kTagIsoSpeed:
+                tags.iso_speed = read_unsigned_number(tiff, entry, entry_offset, little);
+                break;
+            case kTagShutterSpeedValue:
+                tags.shutter_speed_apex = read_signed_number(tiff, entry, entry_offset, little);
+                break;
+            case kTagApertureValue:
+                tags.aperture_apex = read_unsigned_number(tiff, entry, entry_offset, little);
+                break;
+            default:
+                break;
+            }
+        }
+
+        bool parse_ifd(const std::span<const std::uint8_t> tiff, const std::uint32_t ifd_offset, const bool little,
+                       ExposureTags& tags) {
+            const auto count = read_u16(tiff, static_cast<std::size_t>(ifd_offset), little);
+            if (!count || *count > kMaxIfdEntries) {
+                return false;
+            }
+            if (*count == 0) {
+                return true;
+            }
+            const std::size_t entries_off = static_cast<std::size_t>(ifd_offset) + 2;
+            if (!fits(tiff, entries_off, static_cast<std::size_t>(*count) * 12)) {
+                return false;
+            }
+            for (std::uint16_t i = 0; i < *count; ++i) {
+                const std::size_t entry_off = entries_off + static_cast<std::size_t>(i) * 12;
+                const auto entry = read_ifd_entry(tiff, entry_off, little);
+                if (!entry) {
+                    return false;
+                }
+                ingest_entry(tags, tiff, *entry, entry_off, little);
+            }
+            return true;
+        }
+
+        [[nodiscard]] std::optional<double> ev_from_tags(const ExposureTags& tags) {
+            std::optional<double> t;
+            if (usable_positive(tags.exposure_time.value_or(0.0))) {
+                t = tags.exposure_time;
+            } else if (tags.shutter_speed_apex && std::isfinite(*tags.shutter_speed_apex)) {
+                const double time = std::exp2(-*tags.shutter_speed_apex);
+                if (usable_positive(time)) {
+                    t = time;
+                }
+            }
+
+            std::optional<double> n;
+            if (usable_positive(tags.f_number.value_or(0.0))) {
+                n = tags.f_number;
+            } else if (tags.aperture_apex && std::isfinite(*tags.aperture_apex)) {
+                const double fno = std::exp2(*tags.aperture_apex / 2.0);
+                if (usable_positive(fno)) {
+                    n = fno;
+                }
+            }
+
+            std::optional<double> iso;
+            for (const auto& candidate : {tags.iso, tags.iso_sos, tags.iso_rei, tags.iso_speed}) {
+                if (usable_positive(candidate.value_or(0.0))) {
+                    iso = candidate;
+                    break;
+                }
+            }
+
+            if (!t && !n && !iso) {
+                return std::nullopt;
+            }
+            const double time = t.value_or(1.0);
+            const double fno = n.value_or(1.0);
+            const double speed = iso.value_or(1.0);
+            const double ev = std::log2(time / (fno * fno) * speed);
+            if (!std::isfinite(ev)) {
+                return std::nullopt;
+            }
+            return ev;
+        }
+
+        [[nodiscard]] std::optional<double> parse_tiff_ev(const std::span<const std::uint8_t> tiff) {
+            if (tiff.size() < 8) {
+                return std::nullopt;
+            }
+            const bool little = tiff[0] == 'I' && tiff[1] == 'I';
+            const bool big = tiff[0] == 'M' && tiff[1] == 'M';
+            if (!little && !big) {
+                return std::nullopt;
+            }
+            const auto magic = read_u16(tiff, 2, little);
+            if (!magic || *magic != 42) {
+                return std::nullopt;
+            }
+            const auto ifd0 = read_u32(tiff, 4, little);
+            if (!ifd0) {
+                return std::nullopt;
+            }
+
+            ExposureTags tags;
+            if (!parse_ifd(tiff, *ifd0, little, tags)) {
+                return std::nullopt;
+            }
+            if (tags.exif_ifd_offset) {
+                if (!parse_ifd(tiff, *tags.exif_ifd_offset, little, tags)) {
+                    return std::nullopt;
+                }
+            }
+            return ev_from_tags(tags);
+        }
+
+        [[nodiscard]] std::optional<double> parse_jpeg_ev(const std::span<const std::uint8_t> jpeg) {
+            if (jpeg.size() < 4 || jpeg[0] != 0xFF || jpeg[1] != 0xD8) {
+                return std::nullopt;
+            }
+
+            std::size_t i = 2;
+            while (i < jpeg.size()) {
+                if (jpeg[i] != 0xFF) {
+                    return std::nullopt;
+                }
+                while (i < jpeg.size() && jpeg[i] == 0xFF) {
+                    ++i;
+                }
+                if (i >= jpeg.size()) {
+                    return std::nullopt;
+                }
+                const std::uint8_t marker = jpeg[i++];
+                if (marker == 0xD9 || marker == 0xDA) {
+                    return std::nullopt;
+                }
+                if (marker == 0x01 || (marker >= 0xD0 && marker <= 0xD7)) {
+                    continue;
+                }
+                const auto length = read_u16(jpeg, i, false);
+                if (!length || *length < 2) {
+                    return std::nullopt;
+                }
+                const std::size_t payload_off = i + 2;
+                const std::size_t payload_len = static_cast<std::size_t>(*length) - 2;
+                if (!fits(jpeg, payload_off, payload_len)) {
+                    return std::nullopt;
+                }
+                if (marker == 0xE1 && payload_len >= 8) {
+                    const auto payload = jpeg.subspan(payload_off, payload_len);
+                    if (payload[0] == 'E' && payload[1] == 'x' && payload[2] == 'i' && payload[3] == 'f' &&
+                        payload[4] == 0 && payload[5] == 0) {
+                        return parse_tiff_ev(payload.subspan(6));
+                    }
+                }
+                i = payload_off + payload_len;
+            }
+            return std::nullopt;
+        }
+
+    } // namespace
+
+    std::optional<double> exif_exposure_ev(const std::filesystem::path& image) {
+        std::ifstream file;
+        if (!open_file_for_read(image, std::ios::in | std::ios::binary, file)) {
+            return std::nullopt;
+        }
+        std::vector<std::uint8_t> buffer(kMaxScanBytes);
+        file.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
+        const auto nread = static_cast<std::size_t>(file.gcount());
+        if (nread < 2) {
+            return std::nullopt;
+        }
+        buffer.resize(nread);
+        return parse_jpeg_ev(buffer);
+    }
+
+    std::optional<double> exif_exposure_ev_for_training_image(const std::filesystem::path& image_path,
+                                                              const std::filesystem::path& dataset_root) {
+        if (auto ev = exif_exposure_ev(image_path)) {
+            return ev;
+        }
+        if (image_path.empty() || image_path.filename().empty()) {
+            return std::nullopt;
+        }
+        const auto fallback = dataset_root / "images" / image_path.filename();
+        if (fallback == image_path) {
+            return std::nullopt;
+        }
+        return exif_exposure_ev(fallback);
+    }
+
+} // namespace lfs::core

--- a/src/core/include/core/exif.hpp
+++ b/src/core/include/core/exif.hpp
@@ -1,0 +1,23 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include "core/export.hpp"
+
+#include <filesystem>
+#include <optional>
+
+namespace lfs::core {
+
+    /// Photographic EV = log2(t / N^2 * ISO) from JPEG APP1 Exif, or nullopt.
+    [[nodiscard]] LFS_CORE_API std::optional<double>
+    exif_exposure_ev(const std::filesystem::path& image);
+
+    /// Like exif_exposure_ev, then the same filename under dataset_root/images/.
+    /// COLMAP images_N/ copies strip APP1; the full-resolution images/ folder keeps it.
+    [[nodiscard]] LFS_CORE_API std::optional<double>
+    exif_exposure_ev_for_training_image(const std::filesystem::path& image_path,
+                                        const std::filesystem::path& dataset_root);
+
+} // namespace lfs::core

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -198,6 +198,7 @@ namespace lfs::core {
 
             // PPISP (Physically-Plausible ISP) parameters
             bool use_ppisp = false;
+            bool ppisp_exposure_from_exif = true;
             float ppisp_lr = 2e-3f;
             float ppisp_reg_weight = 0.001f;
             int ppisp_warmup_steps = 500;

--- a/src/core/optimization_properties.cpp
+++ b/src/core/optimization_properties.cpp
@@ -513,6 +513,12 @@ namespace lfs::core::param {
             .locale("training_params.ppisp")
             .tooltip("training.tooltip.ppisp")
             .all_strategies()
+            .bool_prop(&OptimizationParameters::ppisp_exposure_from_exif,
+                       "ppisp_exposure_from_exif", "EXIF Exposure", d.ppisp_exposure_from_exif,
+                       "Seed per-frame PPISP exposure from image EXIF")
+            .locale("training_params.ppisp_exposure_from_exif")
+            .tooltip("training.tooltip.ppisp_exposure_from_exif")
+            .all_strategies()
             .float_prop(&OptimizationParameters::ppisp_lr,
                         "ppisp_lr", "PPISP Learning Rate", d.ppisp_lr, 0.0f, 0.1f,
                         "Learning rate for PPISP parameters")

--- a/src/python/lfs/py_params.cpp
+++ b/src/python/lfs/py_params.cpp
@@ -957,6 +957,11 @@ namespace lfs::python {
                 [](PyOptimizationParams&, bool v) { modify_params([v](auto& p) { p.use_ppisp = v; }); },
                 "Enable per-pixel image signal processing")
             .def_prop_rw(
+                "ppisp_exposure_from_exif",
+                [](PyOptimizationParams& self) { return self.params().ppisp_exposure_from_exif; },
+                [](PyOptimizationParams& self, bool v) { self.params().ppisp_exposure_from_exif = v; },
+                "Seed per-frame PPISP exposure from image EXIF")
+            .def_prop_rw(
                 "ppisp_use_controller",
                 [](PyOptimizationParams& self) { return self.params().ppisp_use_controller; },
                 [](PyOptimizationParams& self, bool v) { self.params().ppisp_use_controller = v; },

--- a/src/python/lfs_plugins/property_view.py
+++ b/src/python/lfs_plugins/property_view.py
@@ -78,6 +78,7 @@ BOOL_PROPS = (
     "undistort",
     "mip_filter",
     "ppisp",
+    "ppisp_exposure_from_exif",
     "ppisp_use_controller",
     "ppisp_freeze_from_sidecar",
     "ppisp_freeze_gaussians",
@@ -164,6 +165,7 @@ BASIC_RUNS = (
     _run("basic_after_gut", "undistort", "mip_filter", "ppisp"),
     _run(
         "ppisp_freeze",
+        "ppisp_exposure_from_exif",
         "ppisp_freeze_from_sidecar",
         visibility_condition_id="dep_ppisp",
     ),

--- a/src/training/components/ppisp.cpp
+++ b/src/training/components/ppisp.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace lfs::training {
@@ -197,6 +198,41 @@ namespace lfs::training {
         LOG_DEBUG("PPISP: {} cameras, {} frames, lr={:.2e}", num_cameras_, num_frames_, config_.lr);
     }
 
+    void PPISP::seed_exposure(const std::vector<std::pair<int, float>>& uid_ev) {
+        assert(finalized_ && "Must call finalize() before seed_exposure()");
+        if (uid_ev.empty() || num_frames_ <= 0) {
+            return;
+        }
+
+        double sum = 0.0;
+        int n = 0;
+        for (const auto& [uid, ev] : uid_ev) {
+            if (!std::isfinite(ev) || !is_known_frame(uid)) {
+                continue;
+            }
+            sum += static_cast<double>(ev);
+            ++n;
+        }
+        if (n == 0) {
+            return;
+        }
+        const float mean = static_cast<float>(sum / static_cast<double>(n));
+
+        auto host = exposure_params_.cpu();
+        float* const ptr = host.ptr<float>();
+        for (const auto& [uid, ev] : uid_ev) {
+            if (!std::isfinite(ev)) {
+                continue;
+            }
+            const auto it = uid_to_frame_idx_.find(uid);
+            if (it == uid_to_frame_idx_.end()) {
+                continue;
+            }
+            ptr[it->second] = std::clamp(0.5f * (ev - mean), -16.0f, 16.0f); // PPISP_MIN/MAX_EXPOSURE_EV
+        }
+        exposure_params_.copy_from(host);
+    }
+
     bool PPISP::is_known_frame(int uid) const { return uid_to_frame_idx_.find(uid) != uid_to_frame_idx_.end(); }
 
     bool PPISP::is_known_camera(int camera_id) const {
@@ -254,6 +290,9 @@ namespace lfs::training {
         crf_exp_avg_sq_ = lfs::core::Tensor::zeros({crf_size}, lfs::core::Device::CUDA);
         crf_grad_ = lfs::core::Tensor::zeros({crf_size}, lfs::core::Device::CUDA);
 
+        override_exposure_ = lfs::core::Tensor::zeros({1}, lfs::core::Device::CUDA);
+        override_color_ = lfs::core::Tensor::zeros({8}, lfs::core::Device::CUDA);
+
         // Scratch buffers for backward_with_controller_params
         ctrl_bwd_exposure_ = lfs::core::Tensor::zeros({1}, lfs::core::Device::CUDA);
         ctrl_bwd_color_ = lfs::core::Tensor::zeros({8}, lfs::core::Device::CUDA);
@@ -290,11 +329,9 @@ namespace lfs::training {
         // clang-format on
     }
 
-    lfs::core::Tensor PPISP::apply(const lfs::core::Tensor& rgb, int camera_id, int uid, const PPISPRegion& region) {
-        assert(finalized_ && "Must call finalize() before apply()");
-        const int camera_idx = translate_camera(camera_id);
-        const int frame_idx = translate_frame(uid);
-
+    lfs::core::Tensor PPISP::apply_forward(const lfs::core::Tensor& rgb, int camera_idx, int frame_idx,
+                                           const float* exposure, const float* color, int num_frames,
+                                           const PPISPRegion& region) {
         const auto& shape = rgb.shape();
         assert(shape.rank() == 3 && shape[0] == 3 && "Expected CHW layout with 3 channels");
 
@@ -305,12 +342,30 @@ namespace lfs::training {
 
         auto output = lfs::core::Tensor::empty({3, shape[1], shape[2]}, lfs::core::Device::CUDA);
 
-        kernels::launch_ppisp_forward_chw_region(exposure_params_.ptr<float>(), vignetting_params_.ptr<float>(),
-                                                 color_params_.ptr<float>(), crf_params_.ptr<float>(),
-                                                 rgb.ptr<float>(), output.ptr<float>(), h, w, region.y_offset, full_h,
-                                                 num_cameras_, num_frames_, camera_idx, frame_idx, nullptr);
+        kernels::launch_ppisp_forward_chw_region(exposure, vignetting_params_.ptr<float>(), color,
+                                                 crf_params_.ptr<float>(), rgb.ptr<float>(), output.ptr<float>(), h, w,
+                                                 region.y_offset, full_h, num_cameras_, num_frames, camera_idx,
+                                                 frame_idx, nullptr);
 
         return output;
+    }
+
+    lfs::core::Tensor PPISP::apply(const lfs::core::Tensor& rgb, int camera_id, int uid, const PPISPRegion& region) {
+        assert(finalized_ && "Must call finalize() before apply()");
+        const int camera_idx = translate_camera(camera_id);
+        const int frame_idx = translate_frame(uid);
+        return apply_forward(rgb, camera_idx, frame_idx, exposure_params_.ptr<float>(), color_params_.ptr<float>(),
+                             num_frames_, region);
+    }
+
+    lfs::core::Tensor PPISP::apply_with_exposure(const lfs::core::Tensor& rgb, int camera_id, float exposure_ev,
+                                                 const PPISPRegion& region) {
+        assert(finalized_ && "Must call finalize() before apply_with_exposure()");
+        const int camera_idx = translate_camera(camera_id);
+        const float clamped = std::clamp(exposure_ev, -16.0f, 16.0f); // PPISP_MIN/MAX_EXPOSURE_EV
+        override_exposure_.fill_(clamped);
+        return apply_forward(rgb, camera_idx, 0, override_exposure_.ptr<float>(), override_color_.ptr<float>(), 1,
+                             region);
     }
 
     lfs::core::Tensor PPISP::apply_with_controller_params(const lfs::core::Tensor& rgb,

--- a/src/training/components/ppisp.hpp
+++ b/src/training/components/ppisp.hpp
@@ -10,6 +10,7 @@
 #include <istream>
 #include <ostream>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace lfs::training {
@@ -83,6 +84,12 @@ namespace lfs::training {
         /// Finalize registration and allocate tensors (must call after all register_frame calls)
         void finalize();
 
+        /// Write 0.5 * (ev - mean) into exposure_params_ for known UIDs. Moments unchanged.
+        void seed_exposure(const std::vector<std::pair<int, float>>& uid_ev);
+
+        /// Per-frame exposure in EV (same units as the optimiser).
+        [[nodiscard]] const lfs::core::Tensor& exposure_params() const { return exposure_params_; }
+
         /// Check if a frame UID is registered
         bool is_known_frame(int uid) const;
 
@@ -100,6 +107,12 @@ namespace lfs::training {
         /// @param uid Original frame UID (translated internally)
         lfs::core::Tensor apply(const lfs::core::Tensor& rgb, int camera_id, int uid,
                                 const PPISPRegion& region = {});
+
+        /// Same as apply(), but exposure comes from the argument instead of
+        /// exposure_params_[frame]. Camera-level vignetting/CRF come from camera_id;
+        /// per-frame colour is identity (held-out frames have no colour latent).
+        lfs::core::Tensor apply_with_exposure(const lfs::core::Tensor& rgb, int camera_id,
+                                              float exposure_ev, const PPISPRegion& region = {});
 
         /// Apply ISP with controller-predicted params (for novel view synthesis)
         /// @param rgb input image [C,H,W]
@@ -208,6 +221,10 @@ namespace lfs::training {
         int translate_camera(int camera_id) const;
         int translate_frame(int uid) const;
 
+        lfs::core::Tensor apply_forward(const lfs::core::Tensor& rgb, int camera_idx, int frame_idx,
+                                        const float* exposure, const float* color, int num_frames,
+                                        const PPISPRegion& region);
+
         void allocate_tensors();
         void init_color_pinv_block_diag();
 
@@ -238,6 +255,10 @@ namespace lfs::training {
         lfs::core::Tensor crf_exp_avg_;
         lfs::core::Tensor crf_exp_avg_sq_;
         lfs::core::Tensor crf_grad_;
+
+        // Scratch for apply_with_exposure: 1-element exposure + identity colour.
+        lfs::core::Tensor override_exposure_;
+        lfs::core::Tensor override_color_;
 
         // Scratch buffers for backward_with_controller_params (preallocated)
         lfs::core::Tensor ctrl_bwd_exposure_;

--- a/src/training/metrics/metrics.cpp
+++ b/src/training/metrics/metrics.cpp
@@ -490,6 +490,9 @@ namespace lfs::training {
             } else {
                 r_output = fast_rasterize(*cam, splatData_mutable, background, _params.optimization.mip_filter);
             }
+            if (appearance_ && r_output.image.is_valid()) {
+                r_output.image = appearance_(r_output.image, *cam);
+            }
             r_output.image = r_output.image.clamp(0.0f, 1.0f);
 
             float psnr = 0.0f;
@@ -545,12 +548,10 @@ namespace lfs::training {
             }
         }
 
-        // Wait for all images to be saved before computing final timing
+        // Wait for queued eval PNGs before returning so callers can read them
+        // without racing the BatchImageSaver workers.
         if (_params.optimization.enable_save_eval_images) {
-            const auto pending = lfs::core::image_io::BatchImageSaver::pending_count_if_initialized();
-            if (pending > 0) {
-                lfs::core::image_io::wait_for_pending_saves();
-            }
+            lfs::core::image_io::wait_for_pending_saves();
         }
 
         const auto end_time = std::chrono::steady_clock::now();

--- a/src/training/metrics/metrics.hpp
+++ b/src/training/metrics/metrics.hpp
@@ -10,6 +10,7 @@
 #include "core/tensor.hpp"
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -103,6 +104,12 @@ namespace lfs::training {
     public:
         explicit MetricsEvaluator(const lfs::core::param::TrainingParameters& params);
 
+        using AppearanceFn =
+            std::function<lfs::core::Tensor(const lfs::core::Tensor& rgb_chw, const lfs::core::Camera& cam)>;
+
+        void set_appearance(AppearanceFn fn) { appearance_ = std::move(fn); }
+        [[nodiscard]] bool has_appearance() const { return static_cast<bool>(appearance_); }
+
         // Check if evaluation is enabled
         bool is_enabled() const { return _params.optimization.enable_eval; }
 
@@ -135,6 +142,7 @@ namespace lfs::training {
         std::unique_ptr<PSNR> _psnr_metric;
         std::unique_ptr<SSIM> _ssim_metric;
         std::unique_ptr<MetricsReporter> _reporter;
+        AppearanceFn appearance_;
 
         // Helper functions
         lfs::core::Tensor load_eval_mask(lfs::core::Camera* cam, lfs::core::Tensor& gt_image,

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -20,6 +20,7 @@
 #include "core/cuda_error_typed.hpp"
 #include "core/environment.hpp"
 #include "core/events.hpp"
+#include "core/exif.hpp"
 #include "core/image_io.hpp"
 #include "core/logger.hpp"
 #include "core/path_utils.hpp"
@@ -73,6 +74,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <utility>
 
 #include <algorithm>
 #include <atomic>
@@ -1199,6 +1201,9 @@ namespace lfs::training {
         bilateral_grid_.reset();
         ppisp_.reset();
         ppisp_controller_pool_.reset();
+        ppisp_exif_exposure_mean_.reset();
+        eval_ppisp_applied_.store(0);
+        eval_ppisp_exif_.store(0);
         sparsity_optimizer_.reset();
         evaluator_.reset();
 
@@ -1322,6 +1327,36 @@ namespace lfs::training {
             LOG_INFO("PPISP initialized: {} cameras (physical), {} frames, lr={:.2e}, warmup={}, reg_weight={:.2e}",
                      ppisp_->num_cameras(), ppisp_->num_frames(), params_.optimization.ppisp_lr,
                      config.warmup_steps, reg_weight);
+
+            const bool resume = params_.resume_checkpoint.has_value() || params_.resume_project.has_value();
+            if (params_.optimization.ppisp_exposure_from_exif && !resume) {
+                std::vector<std::pair<int, float>> uid_ev;
+                for (const auto& cam : train_dataset_->get_cameras()) {
+                    if (!cam || !ppisp_->is_known_frame(cam->uid())) {
+                        continue;
+                    }
+                    const auto ev = lfs::core::exif_exposure_ev_for_training_image(
+                        cam->image_path(), params_.dataset.data_path);
+                    if (ev) {
+                        uid_ev.emplace_back(cam->uid(), static_cast<float>(*ev));
+                    }
+                }
+                const int n = static_cast<int>(uid_ev.size());
+                const int m = ppisp_->num_frames();
+                if (n == 0) {
+                    LOG_DEBUG("PPISP exposure EXIF seed skipped: no tags in {} frames", m);
+                } else {
+                    double sum = 0.0;
+                    for (const auto& item : uid_ev) {
+                        sum += static_cast<double>(item.second);
+                    }
+                    const double mean = sum / static_cast<double>(n);
+                    ppisp_exif_exposure_mean_ = static_cast<float>(mean);
+                    ppisp_->seed_exposure(uid_ev);
+                    LOG_INFO("PPISP exposure seeded from EXIF for {} of {} frames (mean {:.2f} EV)",
+                             n, m, mean);
+                }
+            }
 
             if (auto result = apply_ppisp_sidecar_if_configured(); !result) {
                 return result;
@@ -3027,6 +3062,11 @@ namespace lfs::training {
 
             // Initialize the evaluator - it handles all metrics internally
             evaluator_ = std::make_unique<lfs::training::MetricsEvaluator>(params_);
+            if (params_.optimization.use_ppisp && ppisp_ && ppisp_->isFinalized()) {
+                evaluator_->set_appearance([this](const lfs::core::Tensor& rgb, const lfs::core::Camera& cam) {
+                    return applyPPISPForEval(rgb, cam);
+                });
+            }
             LOG_DEBUG("Metrics evaluator initialized");
 
             // Resume from checkpoint if provided
@@ -3399,6 +3439,9 @@ namespace lfs::training {
         bilateral_grid_.reset();
         ppisp_.reset();
         ppisp_controller_pool_.reset();
+        ppisp_exif_exposure_mean_.reset();
+        eval_ppisp_applied_.store(0);
+        eval_ppisp_exif_.store(0);
         sparsity_optimizer_.reset();
         evaluator_.reset();
         progress_.reset();
@@ -7486,10 +7529,18 @@ namespace lfs::training {
                     // Clean evaluation - let the evaluator handle everything
                     if (evaluator_->is_enabled() && evaluator_->should_evaluate(iter)) {
                         evaluator_->print_evaluation_header(iter);
+                        eval_ppisp_applied_.store(0);
+                        eval_ppisp_exif_.store(0);
                         auto metrics = evaluator_->evaluate(iter,
                                                             strategy_->get_model(),
                                                             val_dataset_,
                                                             background_);
+                        if (evaluator_->has_appearance()) {
+                            const int n = eval_ppisp_applied_.load();
+                            const int k = eval_ppisp_exif_.load();
+                            LOG_INFO("Eval: PPISP applied to {} held-out frames ({} with EXIF exposure, {} at mean exposure)",
+                                     n, k, n - k);
+                        }
                         LOG_INFO("{}", metrics.to_string());
                         // B2: retain only the current active shape after evaluation.
                         photometric_loss_.arena().shrink_to_required();
@@ -8524,6 +8575,58 @@ namespace lfs::training {
                 "Project snapshot did not publish the requested destination");
         }
         return path;
+    }
+
+    lfs::core::Tensor Trainer::applyPPISPForEval(const lfs::core::Tensor& rgb,
+                                                 const lfs::core::Camera& cam) const {
+        eval_ppisp_applied_.fetch_add(1, std::memory_order_relaxed);
+
+        const auto params = getParams();
+        if (!ppisp_ || !params.optimization.use_ppisp || !ppisp_->isFinalized() ||
+            rgb.shape().rank() != 3) {
+            return rgb;
+        }
+
+        auto rgb_chw = rgb.device() == lfs::core::Device::CUDA ? rgb : rgb.cuda();
+        if (rgb_chw.shape()[0] != 3 && rgb_chw.shape()[2] == 3) {
+            rgb_chw = rgb_chw.permute({2, 0, 1}).contiguous();
+        } else if (!rgb_chw.is_contiguous()) {
+            rgb_chw = rgb_chw.contiguous();
+        }
+
+        auto* const pool = controller_pool_for_save(get_current_iteration());
+        if (pool && params.optimization.ppisp_use_controller) {
+            const bool is_training_camera = ppisp_->is_known_frame(cam.uid());
+            const int camera_idx =
+                is_training_camera ? ppisp_->camera_index(ppisp_->camera_for_frame(cam.uid())) : 0;
+            const int controller_idx =
+                (camera_idx >= 0 && camera_idx < pool->num_cameras()) ? camera_idx : 0;
+            std::lock_guard<std::mutex> controller_lock(pool->predict_mutex());
+            const auto controller_params = pool->predict(controller_idx, rgb_chw.unsqueeze(0), 1.0f);
+            return ppisp_->apply_with_controller_params(rgb_chw, controller_params, controller_idx);
+        }
+
+        int camera_id = cam.camera_id();
+        if (!ppisp_->is_known_camera(camera_id)) {
+            camera_id = ppisp_->any_camera_id();
+        }
+
+        if (ppisp_->is_known_frame(cam.uid())) {
+            return ppisp_->apply(rgb_chw, camera_id, cam.uid());
+        }
+
+        float exposure = 0.0f;
+        if (ppisp_exif_exposure_mean_) {
+            const auto ev = lfs::core::exif_exposure_ev_for_training_image(
+                cam.image_path(), params.dataset.data_path);
+            if (ev) {
+                exposure = std::clamp(0.5f * (static_cast<float>(*ev) - *ppisp_exif_exposure_mean_),
+                                      -16.0f, 16.0f);
+                eval_ppisp_exif_.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+
+        return ppisp_->apply_with_exposure(rgb_chw, camera_id, exposure);
     }
 
     lfs::core::Tensor Trainer::applyPPISPForViewport(const lfs::core::Tensor& rgb, const int camera_uid,

--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -343,6 +343,11 @@ namespace lfs::training {
             return ppisp_ != nullptr && params.optimization.use_ppisp && ppisp_->isFinalized();
         }
 
+        /// Held-out eval appearance hook is installed iff PPISP was enabled and finalized.
+        [[nodiscard]] bool hasEvalAppearance() const {
+            return evaluator_ && evaluator_->has_appearance();
+        }
+
         /// Check if PPISP controller is enabled and ready for novel views
         bool hasPPISPController() const {
             const auto params = getParams();
@@ -594,6 +599,7 @@ namespace lfs::training {
                    !params.optimization.ppisp_sidecar_path.empty();
         }
         [[nodiscard]] PPISPControllerPool* controller_pool_for_save(int iteration) const;
+        lfs::core::Tensor applyPPISPForEval(const lfs::core::Tensor& rgb, const lfs::core::Camera& cam) const;
         [[nodiscard]] lfs::core::param::TrainingParameters params_for_project_snapshot() const;
         [[nodiscard]] TrainingProgress::Phase get_progress_phase(
             int iter,
@@ -711,6 +717,11 @@ namespace lfs::training {
 
         // PPISP for physically-plausible ISP appearance modeling (optional)
         std::unique_ptr<PPISP> ppisp_;
+        // Train-set EXIF EV mean used by seed_exposure (0.5 * (ev - mean)). Unset
+        // when the seed was skipped or disabled; eval then uses exposure 0.
+        std::optional<float> ppisp_exif_exposure_mean_;
+        mutable std::atomic<int> eval_ppisp_applied_{0};
+        mutable std::atomic<int> eval_ppisp_exif_{0};
 
         // PPISP controller pool for novel-view distillation.
         // Shared CNN and per-camera FC weights for memory efficiency

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -530,6 +530,7 @@
     "button.switch_edit_mode": "Bearbeitungsmodus",
     "tooltip": {
       "btn_switch_edit": "In Bearbeitungsmodus für die trainierte Szene wechseln",
+      "ppisp_exposure_from_exif": "Pro-Frame-PPISP-Belichtung aus EXIF der Fotos setzen, relativ zum Datensatzmittel",
       "ppisp_freeze_from_sidecar": "PPISP-Gewichte aus Sidecar-Datei laden",
       "ppisp_sidecar_path": "Pfad zur PPISP-Sidecar-Datei",
       "ppisp_sidecar_browse": "Nach PPISP-Sidecar-Datei suchen",
@@ -1506,6 +1507,7 @@
     "init_rho": "Init Rho:",
     "prune_ratio": "Prune Verhältnis:",
     "ppisp": "PPISP:",
+    "ppisp_exposure_from_exif": "EXIF-Belichtung:",
     "ppisp_controller": "  Controller:",
     "ppisp_lr": "Lernrate:",
     "ppisp_reg": "Regularisierung:",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -530,6 +530,7 @@
     "button.switch_edit_mode": "Edit Mode",
     "tooltip": {
       "btn_switch_edit": "Switch to edit mode for the trained scene",
+      "ppisp_exposure_from_exif": "Seed per-frame PPISP exposure from photo EXIF, relative to the dataset mean",
       "ppisp_freeze_from_sidecar": "Load PPISP weights from a sidecar file",
       "ppisp_sidecar_path": "Path to the PPISP sidecar file",
       "ppisp_sidecar_browse": "Browse for a PPISP sidecar file",
@@ -1506,6 +1507,7 @@
     "init_rho": "Init Rho:",
     "prune_ratio": "Prune Ratio:",
     "ppisp": "PPISP:",
+    "ppisp_exposure_from_exif": "EXIF Exposure:",
     "ppisp_controller": "  Controller:",
     "ppisp_lr": "Learning Rate:",
     "ppisp_reg": "Regularization:",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -530,6 +530,7 @@
     "button.switch_edit_mode": "Modo Edición",
     "tooltip": {
       "btn_switch_edit": "Cambiar al modo de edición para la escena entrenada",
+      "ppisp_exposure_from_exif": "Inicializar la exposición PPISP por fotograma desde EXIF, relativa a la media del conjunto",
       "ppisp_freeze_from_sidecar": "Cargar los pesos PPISP desde un archivo sidecar",
       "ppisp_sidecar_path": "Ruta al archivo sidecar PPISP",
       "ppisp_sidecar_browse": "Buscar un archivo sidecar PPISP",
@@ -1506,6 +1507,7 @@
     "init_rho": "Rho inicial:",
     "prune_ratio": "Proporción de poda:",
     "ppisp": "PPISP:",
+    "ppisp_exposure_from_exif": "Exposición EXIF:",
     "ppisp_controller": "  Controlador:",
     "ppisp_lr": "Tasa de Aprendizaje:",
     "ppisp_reg": "Regularización:",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -531,6 +531,7 @@
     "button.switch_edit_mode": "Mode Édition",
     "tooltip": {
       "btn_switch_edit": "Passer en mode édition pour la scène entraînée",
+      "ppisp_exposure_from_exif": "Initialiser l'exposition PPISP par image depuis EXIF, relative à la moyenne du jeu",
       "ppisp_freeze_from_sidecar": "Charger les poids PPISP depuis un fichier sidecar",
       "ppisp_sidecar_path": "Chemin vers le fichier sidecar PPISP",
       "ppisp_sidecar_browse": "Rechercher un fichier sidecar PPISP",
@@ -1507,6 +1508,7 @@
     "init_rho": "Rho initial :",
     "prune_ratio": "Ratio d'élagage :",
     "ppisp": "PPISP:",
+    "ppisp_exposure_from_exif": "Exposition EXIF :",
     "ppisp_controller": "  Contrôleur:",
     "ppisp_lr": "Taux d'apprentissage:",
     "ppisp_reg": "Régularisation:",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -530,6 +530,7 @@
     "button.switch_edit_mode": "Modalità Modifica",
     "tooltip": {
       "btn_switch_edit": "Passa alla modalità modifica per la scena addestrata",
+      "ppisp_exposure_from_exif": "Inizializza l'esposizione PPISP per fotogramma da EXIF, relativa alla media del dataset",
       "ppisp_freeze_from_sidecar": "Carica i pesi PPISP da un file sidecar",
       "ppisp_sidecar_path": "Percorso del file sidecar PPISP",
       "ppisp_sidecar_browse": "Sfoglia per un file sidecar PPISP",
@@ -1506,6 +1507,7 @@
     "init_rho": "Rho iniziale:",
     "prune_ratio": "Rapporto pruning:",
     "ppisp": "PPISP:",
+    "ppisp_exposure_from_exif": "Esposizione EXIF:",
     "ppisp_controller": "  Controller:",
     "ppisp_lr": "Tasso di apprendimento:",
     "ppisp_reg": "Regolarizzazione:",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -530,6 +530,7 @@
     "button.switch_edit_mode": "編集モード",
     "tooltip": {
       "btn_switch_edit": "トレーニング済みシーンの編集モードに切り替え",
+      "ppisp_exposure_from_exif": "各フレームの PPISP 露出を写真の EXIF からデータセット平均との相対値で初期化",
       "ppisp_freeze_from_sidecar": "サイドカーファイルから PPISP の重みを読み込み",
       "ppisp_sidecar_path": "PPISP サイドカーファイルのパス",
       "ppisp_sidecar_browse": "PPISP サイドカーファイルを参照",
@@ -1506,6 +1507,7 @@
     "init_rho": "初期 rho:",
     "prune_ratio": "プルーニング比率:",
     "ppisp": "PPISP:",
+    "ppisp_exposure_from_exif": "EXIF 露出:",
     "ppisp_controller": "  コントローラー:",
     "ppisp_lr": "学習率:",
     "ppisp_reg": "正則化:",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -530,6 +530,7 @@
     "button.switch_edit_mode": "편집 모드",
     "tooltip": {
       "btn_switch_edit": "훈련된 장면의 편집 모드로 전환",
+      "ppisp_exposure_from_exif": "사진 EXIF에서 프레임별 PPISP 노출을 데이터세트 평균 기준으로 초기화",
       "ppisp_freeze_from_sidecar": "사이드카 파일에서 PPISP 가중치 로드",
       "ppisp_sidecar_path": "PPISP 사이드카 파일 경로",
       "ppisp_sidecar_browse": "PPISP 사이드카 파일 찾아보기",
@@ -1506,6 +1507,7 @@
     "init_rho": "초기 rho:",
     "prune_ratio": "가지치기 비율:",
     "ppisp": "PPISP:",
+    "ppisp_exposure_from_exif": "EXIF 노출:",
     "ppisp_controller": "  컨트롤러:",
     "ppisp_lr": "학습률:",
     "ppisp_reg": "정규화:",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -530,6 +530,7 @@
     "button.switch_edit_mode": "Bewerkingsmodus",
     "tooltip": {
       "btn_switch_edit": "Schakel naar bewerkmodus voor de getrainde scène",
+      "ppisp_exposure_from_exif": "Per-frame PPISP-belichting uit EXIF van foto's, relatief t.o.v. het datasetgemiddelde",
       "ppisp_freeze_from_sidecar": "PPISP-gewichten laden uit een sidecar-bestand",
       "ppisp_sidecar_path": "Pad naar het PPISP-sidecar-bestand",
       "ppisp_sidecar_browse": "Bladeren naar een PPISP-sidecar-bestand",
@@ -1506,6 +1507,7 @@
     "init_rho": "Initiële rho:",
     "prune_ratio": "Snoeiverhouding:",
     "ppisp": "PPISP:",
+    "ppisp_exposure_from_exif": "EXIF-belichting:",
     "ppisp_controller": "  Controller:",
     "ppisp_lr": "Leersnelheid:",
     "ppisp_reg": "Regularisatie:",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -530,6 +530,7 @@
     "button.switch_edit_mode": "Tryb Edycji",
     "tooltip": {
       "btn_switch_edit": "Przełącz na tryb edycji wytrenowanej sceny",
+      "ppisp_exposure_from_exif": "Inicjuj ekspozycję PPISP każdej klatki z EXIF, względem średniej zbioru",
       "ppisp_freeze_from_sidecar": "Załaduj wagi PPISP z pliku sidecar",
       "ppisp_sidecar_path": "Ścieżka do pliku sidecar PPISP",
       "ppisp_sidecar_browse": "Przeglądaj plik sidecar PPISP",
@@ -1506,6 +1507,7 @@
     "init_rho": "Początkowe rho:",
     "prune_ratio": "Współczynnik przycinania:",
     "ppisp": "PPISP:",
+    "ppisp_exposure_from_exif": "Ekspozycja EXIF:",
     "ppisp_controller": "  Kontroler:",
     "ppisp_lr": "Tempo uczenia:",
     "ppisp_reg": "Regularyzacja:",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -530,6 +530,7 @@
     "button.switch_edit_mode": "编辑模式",
     "tooltip": {
       "btn_switch_edit": "切换到已训练场景的编辑模式",
+      "ppisp_exposure_from_exif": "从照片 EXIF 按数据集均值初始化每帧 PPISP 曝光",
       "ppisp_freeze_from_sidecar": "从 sidecar 文件加载 PPISP 权重",
       "ppisp_sidecar_path": "PPISP sidecar 文件路径",
       "ppisp_sidecar_browse": "浏览 PPISP sidecar 文件",
@@ -1506,6 +1507,7 @@
     "init_rho": "初始 rho:",
     "prune_ratio": "修剪比例:",
     "ppisp": "PPISP:",
+    "ppisp_exposure_from_exif": "EXIF 曝光：",
     "ppisp_controller": "  控制器:",
     "ppisp_lr": "学习率:",
     "ppisp_reg": "正则化:",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -354,6 +354,7 @@ set(TEST_FILES
     test_crash_handler.cpp
     test_gpu_teardown_order.cpp
     test_logger.cpp
+    test_exif.cpp
     test_system_info.cpp
     test_parameter_manager.cpp
     test_mcp_protocol.cpp
@@ -442,6 +443,8 @@ set(TEST_FILES
     test_ppisp_checkpoint_roundtrip.cpp
     test_ppisp_cuda_vs_torch.cpp
     test_ppisp_banded_region.cpp
+    test_ppisp_exposure_seed.cpp
+    test_metrics_evaluator_appearance.cpp
     test_export_env_composite.cpp
     test_undistort.cpp
     test_viewport_region_utils.cpp

--- a/tests/data/param_json_golden/igs_plus.json
+++ b/tests/data/param_json_golden/igs_plus.json
@@ -55,6 +55,7 @@
   "opacity_reg": 0.0,
   "ppisp_controller_activation_step": -1,
   "ppisp_controller_lr": 0.0020000000949949026,
+  "ppisp_exposure_from_exif": true,
   "ppisp_freeze_from_sidecar": false,
   "ppisp_freeze_gaussians_on_distill": true,
   "ppisp_lr": 0.0020000000949949026,

--- a/tests/data/param_json_golden/mcmc.json
+++ b/tests/data/param_json_golden/mcmc.json
@@ -55,6 +55,7 @@
   "opacity_reg": 0.009999999776482582,
   "ppisp_controller_activation_step": -1,
   "ppisp_controller_lr": 0.0020000000949949026,
+  "ppisp_exposure_from_exif": true,
   "ppisp_freeze_from_sidecar": false,
   "ppisp_freeze_gaussians_on_distill": true,
   "ppisp_lr": 0.0020000000949949026,

--- a/tests/data/param_json_golden/mrnf.json
+++ b/tests/data/param_json_golden/mrnf.json
@@ -55,6 +55,7 @@
   "opacity_reg": 0.0,
   "ppisp_controller_activation_step": -1,
   "ppisp_controller_lr": 0.0020000000949949026,
+  "ppisp_exposure_from_exif": true,
   "ppisp_freeze_from_sidecar": false,
   "ppisp_freeze_gaussians_on_distill": true,
   "ppisp_lr": 0.0020000000949949026,

--- a/tests/licht_matrix_test_data.hpp
+++ b/tests/licht_matrix_test_data.hpp
@@ -36,7 +36,7 @@ namespace lfs::test::licht {
         "init_opacity init_scaling max_cap eval_steps save_steps enable_eval "
         "enable_save_eval_images strategy mip_filter use_bilateral_grid bilateral_grid_X "
         "bilateral_grid_Y bilateral_grid_W bilateral_grid_lr tv_loss_weight use_ppisp ppisp_lr "
-        "ppisp_reg_weight ppisp_warmup_steps ppisp_freeze_from_sidecar ppisp_reference_uuid "
+        "ppisp_reg_weight ppisp_warmup_steps ppisp_exposure_from_exif ppisp_freeze_from_sidecar ppisp_reference_uuid "
         "ppisp_use_controller ppisp_freeze_gaussians_on_distill ppisp_controller_activation_step "
         "ppisp_controller_lr prune_opacity reset_every gut undistort steps_scaler "
         "sh_degree_interval random init_num_pts init_extent enable_sparsity sparsify_steps init_rho "

--- a/tests/python/test_property_view.py
+++ b/tests/python/test_property_view.py
@@ -383,6 +383,10 @@ EXPECTED_CHECKBOX_ROWS = {
     "undistort": ("training_params.undistort", "training.tooltip.undistort"),
     "mip_filter": ("training_params.mip_filter", "training.tooltip.mip_filter"),
     "ppisp": ("training_params.ppisp", "training.tooltip.ppisp"),
+    "ppisp_exposure_from_exif": (
+        "training_params.ppisp_exposure_from_exif",
+        "training.tooltip.ppisp_exposure_from_exif",
+    ),
     "ppisp_use_controller": (
         "training_params.ppisp_controller",
         "training.tooltip.ppisp_controller",
@@ -478,13 +482,13 @@ def test_full_migration_inventory_and_schema_are_exact(lf):
     assert property_view.NUMBER_PROPS == tuple(EXPECTED_NUMBER_ROWS)
     assert property_view.BOOL_PROPS == tuple(EXPECTED_CHECKBOX_ROWS)
     assert property_view.SELECT_PROPS == tuple(EXPECTED_SELECT_ROWS)
-    assert len(property_view.MIGRATED_PROP_IDS) == 54
-    assert len(set(property_view.MIGRATED_PROP_IDS)) == 54
+    assert len(property_view.MIGRATED_PROP_IDS) == 55
+    assert len(set(property_view.MIGRATED_PROP_IDS)) == 55
 
     group_info = lf.ui.property_group_info("optimization")
     resolved_runs = property_view.resolve_runs(group_info)
     rendered = tuple(prop for run in resolved_runs for prop in run.prop_ids)
-    assert len(rendered) == len(set(rendered)) == 68
+    assert len(rendered) == len(set(rendered)) == 69
     assert set(rendered) == (
         set(property_view.MIGRATED_PROP_IDS) | set(EXPECTED_ADVANCED_IDS)
     ) - set(property_view.BESPOKE_OR_HIDDEN)

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -373,6 +373,35 @@ TEST(ArgumentParserTest, TrainingDefaultsApplyMaxWidthCap) {
     EXPECT_EQ((*parsed)->optimization.morton_reorder_interval, 5000u);
 }
 
+TEST(ArgumentParserTest, NoPpispExifExposureDisablesSeed) {
+    const auto data_path = make_test_path("lfs_arg_parser_ppisp_exif_data");
+    const auto output_path = make_test_path("lfs_arg_parser_ppisp_exif_output");
+
+    const char* default_argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str()};
+    auto default_parsed =
+        lfs::core::args::parse_args_and_params(static_cast<int>(std::size(default_argv)), default_argv);
+    ASSERT_TRUE(default_parsed.has_value()) << default_parsed.error();
+    EXPECT_TRUE((*default_parsed)->optimization.ppisp_exposure_from_exif);
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "--data-path",
+        data_path.c_str(),
+        "--output-path",
+        output_path.c_str(),
+        "--no-ppisp-exif-exposure"};
+    auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+    EXPECT_FALSE((*parsed)->optimization.ppisp_exposure_from_exif);
+}
+
 TEST(ArgumentParserTest, MortonReorderIntervalFlag) {
     const auto data_path = make_test_path("lfs_arg_parser_morton_data");
     const auto output_path = make_test_path("lfs_arg_parser_morton_output");

--- a/tests/test_exif.cpp
+++ b/tests/test_exif.cpp
@@ -1,0 +1,251 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/exif.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+namespace {
+
+    enum class Endian { Little,
+                        Big };
+
+    constexpr std::uint16_t kTypeShort = 3;
+    constexpr std::uint16_t kTypeLong = 4;
+    constexpr std::uint16_t kTypeRational = 5;
+    constexpr std::uint16_t kTypeSRational = 10;
+    constexpr std::uint16_t kTagExifIfd = 0x8769;
+    constexpr std::uint16_t kTagExposureTime = 0x829A;
+    constexpr std::uint16_t kTagFNumber = 0x829D;
+    constexpr std::uint16_t kTagIso = 0x8827;
+    constexpr std::uint16_t kTagShutterSpeedValue = 0x9201;
+    constexpr std::uint16_t kTagApertureValue = 0x9202;
+    constexpr std::uint16_t kTagIsoSpeed = 0x8833;
+
+    void put_u16(std::vector<std::uint8_t>& out, const std::uint16_t value, const Endian endian) {
+        if (endian == Endian::Little) {
+            out.push_back(static_cast<std::uint8_t>(value));
+            out.push_back(static_cast<std::uint8_t>(value >> 8));
+        } else {
+            out.push_back(static_cast<std::uint8_t>(value >> 8));
+            out.push_back(static_cast<std::uint8_t>(value));
+        }
+    }
+
+    void put_u32(std::vector<std::uint8_t>& out, const std::uint32_t value, const Endian endian) {
+        if (endian == Endian::Little) {
+            out.push_back(static_cast<std::uint8_t>(value));
+            out.push_back(static_cast<std::uint8_t>(value >> 8));
+            out.push_back(static_cast<std::uint8_t>(value >> 16));
+            out.push_back(static_cast<std::uint8_t>(value >> 24));
+        } else {
+            out.push_back(static_cast<std::uint8_t>(value >> 24));
+            out.push_back(static_cast<std::uint8_t>(value >> 16));
+            out.push_back(static_cast<std::uint8_t>(value >> 8));
+            out.push_back(static_cast<std::uint8_t>(value));
+        }
+    }
+
+    struct ExifTag {
+        std::uint16_t tag = 0;
+        std::uint16_t type = 0;
+        std::uint32_t a = 0;
+        std::uint32_t b = 0;
+    };
+
+    [[nodiscard]] bool is_rational(const std::uint16_t type) {
+        return type == kTypeRational || type == kTypeSRational;
+    }
+
+    std::vector<std::uint8_t> build_tiff(const Endian endian, const std::vector<ExifTag>& tags) {
+        const std::uint32_t ifd0_offset = 8;
+        const std::uint32_t exif_ifd_offset = 26;
+        const std::uint32_t extra_offset =
+            exif_ifd_offset + 2 + 12 * static_cast<std::uint32_t>(tags.size()) + 4;
+
+        std::vector<std::uint8_t> tiff;
+        if (endian == Endian::Little) {
+            tiff.push_back('I');
+            tiff.push_back('I');
+        } else {
+            tiff.push_back('M');
+            tiff.push_back('M');
+        }
+        put_u16(tiff, 42, endian);
+        put_u32(tiff, ifd0_offset, endian);
+
+        put_u16(tiff, 1, endian);
+        put_u16(tiff, kTagExifIfd, endian);
+        put_u16(tiff, kTypeLong, endian);
+        put_u32(tiff, 1, endian);
+        put_u32(tiff, exif_ifd_offset, endian);
+        put_u32(tiff, 0, endian);
+
+        put_u16(tiff, static_cast<std::uint16_t>(tags.size()), endian);
+        std::uint32_t extra_cursor = extra_offset;
+        std::vector<std::uint8_t> extra;
+        for (const auto& tag : tags) {
+            put_u16(tiff, tag.tag, endian);
+            put_u16(tiff, tag.type, endian);
+            put_u32(tiff, 1, endian);
+            if (is_rational(tag.type)) {
+                put_u32(tiff, extra_cursor, endian);
+                put_u32(extra, tag.a, endian);
+                put_u32(extra, tag.b, endian);
+                extra_cursor += 8;
+            } else if (tag.type == kTypeShort) {
+                put_u16(tiff, static_cast<std::uint16_t>(tag.a), endian);
+                put_u16(tiff, 0, endian);
+            } else {
+                put_u32(tiff, tag.a, endian);
+            }
+        }
+        put_u32(tiff, 0, endian);
+        tiff.insert(tiff.end(), extra.begin(), extra.end());
+        return tiff;
+    }
+
+    std::vector<std::uint8_t> wrap_jpeg(const std::vector<std::uint8_t>& tiff) {
+        std::vector<std::uint8_t> jpeg;
+        jpeg.reserve(12 + tiff.size());
+        jpeg.push_back(0xFF);
+        jpeg.push_back(0xD8);
+        jpeg.push_back(0xFF);
+        jpeg.push_back(0xE1);
+        const std::uint16_t length = static_cast<std::uint16_t>(2 + 6 + tiff.size());
+        jpeg.push_back(static_cast<std::uint8_t>(length >> 8));
+        jpeg.push_back(static_cast<std::uint8_t>(length));
+        jpeg.push_back('E');
+        jpeg.push_back('x');
+        jpeg.push_back('i');
+        jpeg.push_back('f');
+        jpeg.push_back(0);
+        jpeg.push_back(0);
+        jpeg.insert(jpeg.end(), tiff.begin(), tiff.end());
+        jpeg.push_back(0xFF);
+        jpeg.push_back(0xD9);
+        return jpeg;
+    }
+
+    std::filesystem::path write_temp(const std::string& name, const std::vector<std::uint8_t>& bytes) {
+        const auto dir = std::filesystem::temp_directory_path() / "lfs_exif_test";
+        std::filesystem::create_directories(dir);
+        const auto path = dir / name;
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+        return path;
+    }
+
+    const std::vector<ExifTag> kDirectTags{
+        {kTagExposureTime, kTypeRational, 1, 1},
+        {kTagFNumber, kTypeRational, 2, 1},
+        {kTagIso, kTypeShort, 16, 0},
+    };
+
+    const std::vector<ExifTag> kApexTags{
+        {kTagShutterSpeedValue, kTypeSRational, 0, 1},
+        {kTagApertureValue, kTypeRational, 2, 1},
+        {kTagIso, kTypeShort, 16, 0},
+    };
+
+} // namespace
+
+TEST(ExifExposureTest, DirectTagsLittleEndian) {
+    const auto path = write_temp("direct_le.jpg", wrap_jpeg(build_tiff(Endian::Little, kDirectTags)));
+    const auto ev = lfs::core::exif_exposure_ev(path);
+    ASSERT_TRUE(ev.has_value());
+    EXPECT_DOUBLE_EQ(*ev, 2.0);
+}
+
+TEST(ExifExposureTest, DirectTagsBigEndian) {
+    const auto path = write_temp("direct_be.jpg", wrap_jpeg(build_tiff(Endian::Big, kDirectTags)));
+    const auto ev = lfs::core::exif_exposure_ev(path);
+    ASSERT_TRUE(ev.has_value());
+    EXPECT_DOUBLE_EQ(*ev, 2.0);
+}
+
+TEST(ExifExposureTest, ApexOnlyMatchesDirect) {
+    const auto path = write_temp("apex_le.jpg", wrap_jpeg(build_tiff(Endian::Little, kApexTags)));
+    const auto ev = lfs::core::exif_exposure_ev(path);
+    ASSERT_TRUE(ev.has_value());
+    EXPECT_DOUBLE_EQ(*ev, 2.0);
+}
+
+TEST(ExifExposureTest, ZeroFNumberTreatedAsMissing) {
+    const std::vector<ExifTag> tags{
+        {kTagExposureTime, kTypeRational, 1, 1},
+        {kTagFNumber, kTypeRational, 0, 1},
+        {kTagIso, kTypeShort, 16, 0},
+    };
+    const auto path = write_temp("fnumber0.jpg", wrap_jpeg(build_tiff(Endian::Little, tags)));
+    const auto ev = lfs::core::exif_exposure_ev(path);
+    ASSERT_TRUE(ev.has_value());
+    EXPECT_DOUBLE_EQ(*ev, 4.0);
+}
+
+TEST(ExifExposureTest, NoExposureTagsReturnsNullopt) {
+    const auto path = write_temp("empty_exif.jpg", wrap_jpeg(build_tiff(Endian::Little, {})));
+    EXPECT_EQ(lfs::core::exif_exposure_ev(path), std::nullopt);
+}
+
+TEST(ExifExposureTest, TruncatedAndGarbageOffsetsReturnNullopt) {
+    const std::vector<std::uint8_t> truncated{0xFF, 0xD8, 0xFF, 0xE1, 0x00, 0x40, 'E', 'x', 'i', 'f', 0, 0, 'I', 'I'};
+    const auto truncated_path = write_temp("truncated.jpg", truncated);
+    EXPECT_EQ(lfs::core::exif_exposure_ev(truncated_path), std::nullopt);
+
+    std::vector<std::uint8_t> garbage_tiff{'I', 'I', 42, 0, 0xFF, 0xFF, 0x00, 0x00};
+    const auto garbage_path = write_temp("garbage_ifd.jpg", wrap_jpeg(garbage_tiff));
+    EXPECT_EQ(lfs::core::exif_exposure_ev(garbage_path), std::nullopt);
+}
+
+TEST(ExifExposureTest, PngPathReturnsNullopt) {
+    const std::vector<std::uint8_t> png{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0};
+    const auto path = write_temp("not_a_jpeg.png", png);
+    EXPECT_EQ(lfs::core::exif_exposure_ev(path), std::nullopt);
+}
+
+TEST(ExifExposureTest, ImagesDirectoryFallback) {
+    const auto root = std::filesystem::temp_directory_path() / "lfs_exif_fallback";
+    const auto resized_dir = root / "images_8";
+    const auto full_dir = root / "images";
+    std::filesystem::create_directories(resized_dir);
+    std::filesystem::create_directories(full_dir);
+
+    const auto stripped = wrap_jpeg(build_tiff(Endian::Little, {}));
+    const auto tagged = wrap_jpeg(build_tiff(Endian::Little, kDirectTags));
+    const auto resized = resized_dir / "frame.jpg";
+    const auto full = full_dir / "frame.jpg";
+    {
+        std::ofstream out(resized, std::ios::binary | std::ios::trunc);
+        out.write(reinterpret_cast<const char*>(stripped.data()),
+                  static_cast<std::streamsize>(stripped.size()));
+    }
+    {
+        std::ofstream out(full, std::ios::binary | std::ios::trunc);
+        out.write(reinterpret_cast<const char*>(tagged.data()),
+                  static_cast<std::streamsize>(tagged.size()));
+    }
+
+    EXPECT_EQ(lfs::core::exif_exposure_ev(resized), std::nullopt);
+    const auto ev = lfs::core::exif_exposure_ev_for_training_image(resized, root);
+    ASSERT_TRUE(ev.has_value());
+    EXPECT_DOUBLE_EQ(*ev, 2.0);
+}
+
+TEST(ExifExposureTest, IsoSpeedFallbackWithoutIsoTag) {
+    const std::vector<ExifTag> tags{
+        {kTagExposureTime, kTypeRational, 1, 1},
+        {kTagFNumber, kTypeRational, 2, 1},
+        {kTagIsoSpeed, kTypeLong, 16, 0},
+    };
+    const auto path = write_temp("iso_speed.jpg", wrap_jpeg(build_tiff(Endian::Little, tags)));
+    const auto ev = lfs::core::exif_exposure_ev(path);
+    ASSERT_TRUE(ev.has_value());
+    EXPECT_DOUBLE_EQ(*ev, 2.0);
+}

--- a/tests/test_metrics_evaluator_appearance.cpp
+++ b/tests/test_metrics_evaluator_appearance.cpp
@@ -1,0 +1,190 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/camera.hpp"
+#include "core/event_bridge/event_bridge.hpp"
+#include "core/image_io.hpp"
+#include "core/parameters.hpp"
+#include "core/splat_data.hpp"
+#include "core/tensor.hpp"
+#include "training/dataset.hpp"
+#include "training/metrics/metrics.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <format>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+    using lfs::core::Camera;
+    using lfs::core::Device;
+    using lfs::core::SplatData;
+    using lfs::core::Tensor;
+    using lfs::training::CameraDataset;
+    using lfs::training::MetricsEvaluator;
+
+    constexpr int kImageSize = 32;
+    constexpr int kSeparator = 4;
+
+    // Unique per call so parallel/repeated runs do not share /tmp/lfs_eval_appearance_*.
+    class UniqueTempDir {
+    public:
+        explicit UniqueTempDir(const std::string_view prefix) {
+            static std::atomic<uint64_t> seq{0};
+            path_ = std::filesystem::temp_directory_path() /
+                    std::format("{}_{}_{}", prefix,
+                                std::chrono::steady_clock::now().time_since_epoch().count(),
+                                seq.fetch_add(1, std::memory_order_relaxed));
+            std::filesystem::create_directories(path_);
+        }
+
+        ~UniqueTempDir() {
+            std::error_code ec;
+            std::filesystem::remove_all(path_, ec);
+        }
+
+        UniqueTempDir(const UniqueTempDir&) = delete;
+        UniqueTempDir& operator=(const UniqueTempDir&) = delete;
+
+        const std::filesystem::path& path() const { return path_; }
+
+    private:
+        std::filesystem::path path_;
+    };
+
+    void write_constant_png(const std::filesystem::path& path, const float value) {
+        auto image = Tensor::full({3, static_cast<size_t>(kImageSize), static_cast<size_t>(kImageSize)},
+                                  value, Device::CPU);
+        lfs::core::save_image(path, image);
+    }
+
+    std::shared_ptr<Camera> make_eval_camera(const std::filesystem::path& image_path, const int uid) {
+        auto R = Tensor::eye(3, Device::CPU);
+        auto T = Tensor::from_vector({0.0f, 0.0f, 3.0f}, {3}, Device::CPU);
+        return std::make_shared<Camera>(
+            R, T,
+            40.0f, 40.0f,
+            kImageSize * 0.5f, kImageSize * 0.5f,
+            Tensor(), Tensor(),
+            lfs::core::CameraModelType::PINHOLE,
+            image_path.filename().string(),
+            image_path,
+            std::filesystem::path{},
+            kImageSize, kImageSize,
+            uid);
+    }
+
+    std::unique_ptr<SplatData> make_eval_splat() {
+        const size_t n = 1;
+        auto means = Tensor::zeros({n, 3}, Device::CUDA);
+        auto sh0 = Tensor::full({n, 1, 3}, 0.5f, Device::CUDA);
+        auto shN = Tensor::zeros({n, 0, 3}, Device::CUDA);
+        auto scaling = Tensor::full({n, 3}, -2.0f, Device::CUDA);
+        auto rotation = Tensor::from_vector({1.0f, 0.0f, 0.0f, 0.0f}, {n, 4}, Device::CUDA);
+        auto opacity = Tensor::full({n, 1}, 2.0f, Device::CUDA);
+        return std::make_unique<SplatData>(0, means, sh0, shN, scaling, rotation, opacity, 1.0f);
+    }
+
+    lfs::core::param::TrainingParameters make_eval_params(const std::filesystem::path& output) {
+        lfs::core::param::TrainingParameters params;
+        params.dataset.output_path = output;
+        params.optimization.enable_eval = true;
+        params.optimization.enable_save_eval_images = true;
+        params.optimization.headless = true;
+        params.optimization.gut = false;
+        params.optimization.mask_mode = lfs::core::param::MaskMode::None;
+        params.optimization.use_alpha_as_mask = false;
+        return params;
+    }
+
+} // namespace
+
+class MetricsEvaluatorAppearanceTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Drop leftover EvaluationCompleted handlers (TrainerManager never unsubscribes).
+        lfs::event::EventBridge::instance().clear_all();
+    }
+
+    void TearDown() override {
+        lfs::event::EventBridge::instance().clear_all();
+    }
+};
+
+TEST_F(MetricsEvaluatorAppearanceTest, HookNotConsultedWhenUnset) {
+    const UniqueTempDir root("lfs_eval_appearance_unset");
+    write_constant_png(root.path() / "gt.png", 0.5f);
+
+    auto cam = make_eval_camera(root.path() / "gt.png", 1);
+    CameraDataset dataset({cam}, {}, CameraDataset::Split::ALL);
+    auto splat = make_eval_splat();
+    auto background = Tensor::zeros({3}, Device::CUDA);
+
+    auto params = make_eval_params(root.path());
+    MetricsEvaluator evaluator(params);
+
+    int calls = 0;
+    auto metrics = evaluator.evaluate(1, *splat, std::make_shared<CameraDataset>(dataset), background);
+    EXPECT_TRUE(metrics.valid);
+    EXPECT_EQ(calls, 0);
+
+    evaluator.set_appearance([&](const Tensor& rgb, const Camera&) {
+        ++calls;
+        return rgb;
+    });
+    metrics = evaluator.evaluate(1, *splat, std::make_shared<CameraDataset>(dataset), background);
+    EXPECT_TRUE(metrics.valid);
+    EXPECT_EQ(calls, 1);
+}
+
+TEST_F(MetricsEvaluatorAppearanceTest, HookRunsOncePerFrameBeforeClampAndSavesCorrectedRender) {
+    const UniqueTempDir root("lfs_eval_appearance_hook");
+    write_constant_png(root.path() / "a.png", 1.0f);
+    write_constant_png(root.path() / "b.png", 1.0f);
+
+    auto cam_a = make_eval_camera(root.path() / "a.png", 1);
+    auto cam_b = make_eval_camera(root.path() / "b.png", 2);
+    auto splat = make_eval_splat();
+    auto background = Tensor::zeros({3}, Device::CUDA);
+
+    auto params = make_eval_params(root.path());
+    MetricsEvaluator evaluator(params);
+
+    int calls = 0;
+    evaluator.set_appearance([&](const Tensor& rgb, const Camera&) {
+        ++calls;
+        return Tensor::full(rgb.shape(), 2.0f, rgb.device());
+    });
+
+    auto val_dataset = std::make_shared<CameraDataset>(
+        std::vector<std::shared_ptr<Camera>>{cam_a, cam_b}, lfs::training::DatasetConfig{},
+        CameraDataset::Split::ALL);
+    auto metrics = evaluator.evaluate(7, *splat, val_dataset, background);
+    ASSERT_TRUE(metrics.valid);
+    EXPECT_EQ(calls, 2);
+
+    // Hook returns 2; clamp after the hook yields 1, matching the white GT.
+    // Without the post-hook clamp, PSNR against 1 would be 0 dB.
+    EXPECT_NEAR(metrics.psnr, 100.0f, 0.5f);
+
+    const auto saved = root.path() / "eval_step_7" / "0.png";
+    ASSERT_TRUE(std::filesystem::exists(saved));
+    auto [data, width, height, channels] = lfs::core::load_image(saved);
+    ASSERT_NE(data, nullptr);
+    ASSERT_EQ(height, kImageSize);
+    ASSERT_EQ(width, kImageSize + kSeparator + kImageSize);
+    ASSERT_GE(channels, 3);
+    const int render_x = kImageSize + kSeparator;
+    const int idx = (0 * width + render_x) * channels;
+    EXPECT_EQ(data[idx], 255);
+    EXPECT_EQ(data[idx + 1], 255);
+    EXPECT_EQ(data[idx + 2], 255);
+    lfs::core::free_image(data);
+}

--- a/tests/test_ppisp_exposure_seed.cpp
+++ b/tests/test_ppisp_exposure_seed.cpp
@@ -1,0 +1,116 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "components/ppisp.hpp"
+#include "core/tensor.hpp"
+
+#include <cmath>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <utility>
+#include <vector>
+
+namespace {
+
+    using lfs::core::Device;
+    using lfs::training::PPISP;
+    using lfs::training::PPISPConfig;
+
+    std::vector<float> exposure_host(const PPISP& ppisp) {
+        return ppisp.exposure_params().cpu().contiguous().to_vector();
+    }
+
+} // namespace
+
+TEST(PPISPExposureSeedTest, CentersAndScalesKnownFrames) {
+    PPISP ppisp(100);
+    ppisp.register_frame(10, 0);
+    ppisp.register_frame(20, 0);
+    ppisp.register_frame(30, 0);
+    ppisp.register_frame(40, 0);
+    ppisp.finalize();
+
+    const std::vector<std::pair<int, float>> uid_ev{{10, 0.0f}, {20, 2.0f}, {40, 4.0f}};
+    ppisp.seed_exposure(uid_ev);
+
+    const auto values = exposure_host(ppisp);
+    ASSERT_EQ(values.size(), 4u);
+    const float mean = (0.0f + 2.0f + 4.0f) / 3.0f;
+    EXPECT_NEAR(values[0], 0.5f * (0.0f - mean), 1e-6f);
+    EXPECT_NEAR(values[1], 0.5f * (2.0f - mean), 1e-6f);
+    EXPECT_NEAR(values[2], 0.0f, 1e-6f);
+    EXPECT_NEAR(values[3], 0.5f * (4.0f - mean), 1e-6f);
+}
+
+TEST(PPISPExposureSeedTest, CopyInferenceWeightsOverwritesSeed) {
+    PPISPConfig config;
+    config.warmup_steps = 0;
+
+    PPISP seeded(100, config);
+    seeded.register_frame(1, 0);
+    seeded.register_frame(2, 0);
+    seeded.register_frame(3, 0);
+    seeded.register_frame(4, 0);
+    seeded.finalize();
+    seeded.seed_exposure({{1, -2.0f}, {2, 0.0f}, {3, 2.0f}});
+
+    PPISP blank(100, config);
+    blank.register_frame(1, 0);
+    blank.register_frame(2, 0);
+    blank.register_frame(3, 0);
+    blank.register_frame(4, 0);
+    blank.finalize();
+
+    const auto import = seeded.copy_inference_weights_from(blank, {0, 1, 2, 3}, {0});
+    ASSERT_TRUE(import) << import.error();
+
+    const auto values = exposure_host(seeded);
+    ASSERT_EQ(values.size(), 4u);
+    for (float value : values) {
+        EXPECT_NEAR(value, 0.0f, 1e-6f);
+    }
+}
+
+TEST(PPISPApplyWithExposureTest, MatchesApplyForRegisteredFrame) {
+    PPISP ppisp(100);
+    ppisp.register_frame(10, 7);
+    ppisp.register_frame(20, 7);
+    ppisp.register_frame(30, 7);
+    ppisp.finalize();
+    ppisp.seed_exposure({{10, 0.0f}, {20, 2.0f}, {30, 4.0f}});
+
+    const auto values = exposure_host(ppisp);
+    ASSERT_EQ(values.size(), 3u);
+    const float e = values[0];
+    ASSERT_NE(e, 0.0f);
+
+    std::vector<float> pixels(3 * 4 * 4);
+    for (size_t i = 0; i < pixels.size(); ++i) {
+        pixels[i] = 0.2f + 0.01f * static_cast<float>(i);
+    }
+    const auto rgb = lfs::core::Tensor::from_vector(pixels, {3, 4, 4}, Device::CUDA);
+
+    const auto from_apply = ppisp.apply(rgb, 7, 10).cpu().contiguous().to_vector();
+    const auto from_explicit = ppisp.apply_with_exposure(rgb, 7, e).cpu().contiguous().to_vector();
+    ASSERT_EQ(from_apply.size(), from_explicit.size());
+    EXPECT_EQ(std::memcmp(from_apply.data(), from_explicit.data(), from_apply.size() * sizeof(float)), 0);
+
+    const auto other = ppisp.apply_with_exposure(rgb, 7, e + 1.0f).cpu().contiguous().to_vector();
+    EXPECT_NE(std::memcmp(from_apply.data(), other.data(), from_apply.size() * sizeof(float)), 0);
+}
+
+TEST(PPISPExposureSeedTest, ClampsToExposureRange) {
+    PPISP ppisp(100);
+    ppisp.register_frame(1, 0);
+    ppisp.register_frame(2, 0);
+    ppisp.finalize();
+    ppisp.seed_exposure({{1, 0.0f}, {2, 100.0f}});
+
+    const auto values = exposure_host(ppisp);
+    ASSERT_EQ(values.size(), 2u);
+    EXPECT_GE(values[0], -16.0f);
+    EXPECT_LE(values[0], 16.0f);
+    EXPECT_GE(values[1], -16.0f);
+    EXPECT_LE(values[1], 16.0f);
+    EXPECT_FLOAT_EQ(values[1], 16.0f);
+}

--- a/tests/test_scene_validity.cpp
+++ b/tests/test_scene_validity.cpp
@@ -26,6 +26,7 @@
 #include "core/pinned_memory_allocator.hpp"
 #include "core/point_cloud.hpp"
 #include "core/scene.hpp"
+#include "core/splat_data.hpp"
 #include "core/tensor.hpp"
 #include "io/exporter.hpp"
 #include "ppisp_fixture.hpp"
@@ -165,6 +166,73 @@ namespace lfs::python {
             EXPECT_TRUE(std::isfinite(value));
         for (const float value : grad_input)
             EXPECT_TRUE(std::isfinite(value));
+    }
+
+    std::unique_ptr<core::SplatData> make_construction_splat() {
+        const size_t n = 1;
+        std::vector<float> rotation{1.0f, 0.0f, 0.0f, 0.0f};
+        return std::make_unique<core::SplatData>(
+            0,
+            core::Tensor::zeros({n, 3}, core::Device::CUDA),
+            core::Tensor::zeros({n, 1, 3}, core::Device::CUDA),
+            core::Tensor::zeros({n, 0, 3}, core::Device::CUDA),
+            core::Tensor::zeros({n, 3}, core::Device::CUDA),
+            core::Tensor::from_vector(rotation, {n, 4}, core::Device::CUDA),
+            core::Tensor::zeros({n, 1}, core::Device::CUDA),
+            1.0f);
+    }
+
+    core::param::TrainingParameters make_construction_params(const bool use_ppisp,
+                                                             const std::filesystem::path& output) {
+        core::param::TrainingParameters params;
+        params.dataset.output_path = output;
+        params.optimization.strategy = "mcmc";
+        params.optimization.iterations = 8;
+        params.optimization.sh_degree = 0;
+        params.optimization.max_cap = 16;
+        params.optimization.headless = true;
+        params.optimization.enable_eval = false;
+        params.optimization.use_ppisp = use_ppisp;
+        return params;
+    }
+
+    TEST(TrainerConstructionTest, EvalAppearanceHookPresentIffUsePpisp) {
+        const auto output_on = std::filesystem::temp_directory_path() / "lfs_trainer_eval_hook_on";
+        const auto output_off = std::filesystem::temp_directory_path() / "lfs_trainer_eval_hook_off";
+        std::error_code ec;
+        std::filesystem::create_directories(output_on, ec);
+        std::filesystem::create_directories(output_off, ec);
+
+        {
+            core::Scene scene;
+            const core::NodeId cameras = scene.addGroup("Cameras");
+            scene.addCamera("camera.png", cameras, make_test_camera());
+            scene.addSplat("Model", make_construction_splat());
+            scene.setTrainingModelNode("Model");
+            training::Trainer trainer(scene);
+            const auto result = trainer.initialize(make_construction_params(true, output_on));
+            ASSERT_TRUE(result) << result.error();
+            EXPECT_TRUE(trainer.hasPPISP());
+            EXPECT_TRUE(trainer.hasEvalAppearance());
+            trainer.shutdown();
+        }
+
+        {
+            core::Scene scene;
+            const core::NodeId cameras = scene.addGroup("Cameras");
+            scene.addCamera("camera.png", cameras, make_test_camera());
+            scene.addSplat("Model", make_construction_splat());
+            scene.setTrainingModelNode("Model");
+            training::Trainer trainer(scene);
+            const auto result = trainer.initialize(make_construction_params(false, output_off));
+            ASSERT_TRUE(result) << result.error();
+            EXPECT_FALSE(trainer.hasPPISP());
+            EXPECT_FALSE(trainer.hasEvalAppearance());
+            trainer.shutdown();
+        }
+
+        std::filesystem::remove_all(output_on, ec);
+        std::filesystem::remove_all(output_off, ec);
     }
 
     TEST(TrainerConstructionTest, RejectsInvalidSceneBeforeAllocatingCudaResources) {

--- a/tests/test_training_parameters.cpp
+++ b/tests/test_training_parameters.cpp
@@ -304,6 +304,17 @@ namespace {
         EXPECT_THROW((void)OptimizationParameters::from_json(json), nlohmann::json::out_of_range);
     }
 
+    TEST_F(TrainingParametersTest, PpispExposureFromExifRoundTripsThroughJson) {
+        auto params = OptimizationParameters::mrnf_defaults();
+        EXPECT_TRUE(params.ppisp_exposure_from_exif);
+        EXPECT_TRUE(params.to_json().at("ppisp_exposure_from_exif").get<bool>());
+
+        params.ppisp_exposure_from_exif = false;
+        const auto json = params.to_json();
+        EXPECT_FALSE(json.at("ppisp_exposure_from_exif").get<bool>());
+        EXPECT_FALSE(OptimizationParameters::from_json(json).ppisp_exposure_from_exif);
+    }
+
     TEST_F(TrainingParametersTest, MissingOptionalJsonValuesUseStrategyDefaults) {
         auto mrnf_json = OptimizationParameters::mrnf_defaults().to_json();
         mrnf_json.erase("max_cap");


### PR DESCRIPTION
Photos taken with auto-exposure differ by whole stops from one frame to the next. PPISP learns a per-frame exposure, but it started every frame at zero and had to discover those differences during training, and the evaluator compared raw renders with photos at arbitrary exposures.

**What changes**
- Each frame's exposure starts from its photo's EXIF (shutter, aperture, ISO), relative to the dataset mean. No new dependency; the reader also looks at the full-resolution `images/` file because COLMAP's resized copies carry no tags.
- With PPISP enabled, evaluation applies the camera's learned correction to held-out frames using their own EXIF exposure. Without PPISP nothing changes.
- Switch: `ppisp_exposure_from_exif` (on by default, only active with PPISP), CLI `--no-ppisp-exif-exposure`, checkbox next to the other PPISP options.

**Result** (alameda, exposure varies by 1.6 stops, PPISP on, 7k iterations): **20.37 → 22.43 dB**. Scenes shot at a fixed exposure (london, berlin) are unaffected; scenes without EXIF (garden) behave exactly as before.

The seeding idea follows spirulae-splat.

Tests: EXIF parser (both byte orders, APEX fallbacks, missing tags, truncated data, the `images/` fallback), seeding into the right frames, `apply_with_exposure` parity, evaluator hook applied once per frame before the clamp, hook present only with PPISP, parameter/CLI round-trips, locales.