### PR TITLE
Fix Python test collection on Windows: register the build root as a DLL directory

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -24,6 +24,12 @@ MODULE_PATH = BUILD_DIR / "src" / "python"
 if MODULE_PATH.exists():
     sys.path.insert(1 if SOURCE_MODULE_PATH.exists() else 0, str(MODULE_PATH))
 
+# Since Python 3.8, PATH is not searched for extension-module dependencies on
+# Windows; part of lichtfeld's DLL chain lives only in the build root.
+if sys.platform == "win32" and BUILD_DIR.exists():
+    # Keep the handle alive so the registration lasts for the whole session.
+    _dll_dir = os.add_dll_directory(str(BUILD_DIR))
+
 # Ensure the C++ extension is loaded before numpy/torch so exception unwind
 # is not poisoned by their bundled native libs (see lane G nightly abort).
 try:


### PR DESCRIPTION
On Windows, `ctest -L fast` cannot run the Python suite: all six test modules fail at collection with

```
ImportError: DLL load failed while importing lichtfeld: The specified module could not be found.
```

This PR fixes that with one guarded `os.add_dll_directory()` call in `tests/python/conftest.py`.

**Cause.** The conftest puts `build/src/python` on `sys.path` so pytest can import the compiled `lichtfeld` extension. The extension's direct dependencies are applocal-deployed next to the `.pyd`, but part of its transitive DLL chain is deployed only to the build root, where the app finds it via the executable's own directory. A standalone Python interpreter has no such directory in play, and since Python 3.8 Windows ignores `PATH` for extension-module dependency resolution — only `os.add_dll_directory()` entries, the module's own directory, and system directories are searched. So `python -m pytest` can never resolve the chain, no matter how the environment is set up.

**Fix.** Register the build root via `os.add_dll_directory()`, guarded by `sys.platform == "win32"` and `BUILD_DIR.exists()`. The call sits above the conftest's module-scope `import lichtfeld` (the numpy/torch load-order guard), which would otherwise still fail. Non-Windows platforms and layouts without a `build/` directory are untouched.

**Verified** on Windows 11 (MSVC, vcpkg Python 3.12) against a clean Release build of current `master`:
- Minimal repro: `sys.path` inserts + `import lichtfeld` fails as above; after `add_dll_directory(build)` the import succeeds.
- With the fix, `python -m pytest tests/python` collects all modules and the suite runs (1301 passed); before it, collection failed outright.
