### PR TITLE
Fix selection depth filter collapsing to a 1 cm slab (#1785)

### DIFF
--- a/src/python/lfs_plugins/selection_controls.py
+++ b/src/python/lfs_plugins/selection_controls.py
@@ -362,7 +362,7 @@ class SelectionControlsController:
             return False
 
     def _set_depth_near(self, value):
-        if not self._visible:
+        if not self._visible or self._last_state_key is None:
             return
         self._refresh_depth_state()
         near = _clamp(_parse_float(value, self._depth_near), _DEPTH_MIN, _DEPTH_MAX - _DEPTH_GAP)
@@ -370,7 +370,7 @@ class SelectionControlsController:
         self._apply_depth_range(self._depth_enabled, near, far)
 
     def _set_depth_far(self, value):
-        if not self._visible:
+        if not self._visible or self._last_state_key is None:
             return
         self._refresh_depth_state()
         far = _clamp(_parse_float(value, self._depth_far), self._depth_near + _DEPTH_GAP, _DEPTH_MAX)

--- a/src/python/lfs_plugins/selection_controls.py
+++ b/src/python/lfs_plugins/selection_controls.py
@@ -362,12 +362,16 @@ class SelectionControlsController:
             return False
 
     def _set_depth_near(self, value):
+        if not self._visible:
+            return
         self._refresh_depth_state()
         near = _clamp(_parse_float(value, self._depth_near), _DEPTH_MIN, _DEPTH_MAX - _DEPTH_GAP)
         far = max(self._depth_far, near + _DEPTH_GAP)
         self._apply_depth_range(self._depth_enabled, near, far)
 
     def _set_depth_far(self, value):
+        if not self._visible:
+            return
         self._refresh_depth_state()
         far = _clamp(_parse_float(value, self._depth_far), self._depth_near + _DEPTH_GAP, _DEPTH_MAX)
         self._apply_depth_range(self._depth_enabled, self._depth_near, far)

--- a/src/visualizer/project/session_state.cpp
+++ b/src/visualizer/project/session_state.cpp
@@ -314,7 +314,7 @@ namespace lfs::vis::project {
         template <typename Owner, typename Member>
         JsonField<Owner> required_field(
             const std::string_view name,
-            Member Owner::*member) {
+            Member Owner::* member) {
             return {
                 .name = name,
                 .write = [member](const Owner& source) { return Json(source.*member); },
@@ -333,7 +333,7 @@ namespace lfs::vis::project {
         template <typename Owner, typename Member>
         JsonField<Owner> optional_field(
             const std::string_view name,
-            Member Owner::*member) {
+            Member Owner::* member) {
             return {
                 .name = name,
                 .write = [member](const Owner& source) { return Json(source.*member); },
@@ -351,7 +351,7 @@ namespace lfs::vis::project {
         template <typename Owner>
         JsonField<Owner> vec3_field(
             const std::string_view name,
-            glm::vec3 Owner::*member) {
+            glm::vec3 Owner::* member) {
             return {
                 .name = name,
                 .write = [member](const Owner& source) { return vec3_json(source.*member); },
@@ -375,7 +375,7 @@ namespace lfs::vis::project {
                   typename AfterAssign = std::nullptr_t>
         JsonField<Owner> enum_field(
             const std::string_view name,
-            Enum Owner::*member,
+            Enum Owner::* member,
             const int minimum,
             const int maximum,
             const std::string_view invalid_detail,
@@ -467,7 +467,7 @@ namespace lfs::vis::project {
         template <typename Owner, std::size_t Size>
         JsonField<Owner> array_field(
             const std::string_view name,
-            std::array<float, Size> Owner::*member) {
+            std::array<float, Size> Owner::* member) {
             return custom_field<Owner>(
                 name,
                 [member](const Owner& source) {
@@ -503,7 +503,7 @@ namespace lfs::vis::project {
         template <typename Owner>
         JsonField<Owner> nullable_positive_float_field(
             const std::string_view name,
-            std::optional<float> Owner::*member) {
+            std::optional<float> Owner::* member) {
             return custom_field<Owner>(
                 name,
                 [member](const Owner& source) {
@@ -1588,7 +1588,7 @@ namespace lfs::vis::project {
             using Panel = gui::PanelProjectState;
             const auto nullable_float = [](
                                             const std::string_view name,
-                                            float Panel::*member) {
+                                            float Panel::* member) {
                 return custom_field<Panel>(
                     name,
                     [member](const Panel& panel) {
@@ -3530,26 +3530,30 @@ namespace lfs::vis::project {
                                 renderSettingsFromProjectJson(
                                     *render_json,
                                     rendering->getSettings())) {
-                            const float near_plane =
-                                std::max(0.0f,
-                                         -settings
-                                              ->depth_filter_max.z);
-                            const float far_plane =
-                                std::max(near_plane + 0.01f,
-                                         -settings
-                                              ->depth_filter_min.z);
-                            const float half_width =
-                                std::max(
-                                    std::abs(settings
-                                                 ->depth_filter_min.x),
-                                    std::abs(settings
-                                                 ->depth_filter_max.x));
-                            selection_tool
-                                ->setDepthFilterRange(
-                                    settings
-                                        ->depth_filter_enabled,
-                                    near_plane, far_plane,
-                                    half_width);
+                            // Disabled constructor-default boxes are not in near/far encoding.
+                            if (settings
+                                    ->depth_filter_enabled) {
+                                const float near_plane =
+                                    std::max(0.0f,
+                                             -settings
+                                                  ->depth_filter_max.z);
+                                const float far_plane =
+                                    std::max(near_plane + 0.01f,
+                                             -settings
+                                                  ->depth_filter_min.z);
+                                const float half_width =
+                                    std::max(
+                                        std::abs(settings
+                                                     ->depth_filter_min.x),
+                                        std::abs(settings
+                                                     ->depth_filter_max.x));
+                                selection_tool
+                                    ->setDepthFilterRange(
+                                        settings
+                                            ->depth_filter_enabled,
+                                        near_plane, far_plane,
+                                        half_width);
+                            }
                             auto restored =
                                 rendering->getSettings();
                             restored.crop_filter_for_selection =


### PR DESCRIPTION
Fixes #1785.

Opening a .licht that never had the depth filter enabled set the filter range to 1 cm, so enabling it selected nothing and could black out the viewport.

Two causes, two small fixes:
- Project restore no longer decodes the depth box when the saved filter was disabled — the tool keeps its 6 m default.
- The selection panel no longer applies slider events fired during UI startup, which overwrote the tool with a collapsed range before the panel was even visible.

Verified end to end: fresh start, save, reopen — the filter now comes up with its correct default range in every case.

Note: a smaller pre-existing quirk remains for projects saved with the filter *enabled* — the far value can be reset to default on reopen by a late slider echo. Reproduced on master too; separate issue.