### PR TITLE
Make undo work for pasted splats (#1776)

### DIFF
--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -4706,6 +4706,9 @@ namespace lfs::vis {
         if (!hasGaussianClipboard() || gaussian_clipboard_->size() == 0)
             return {};
 
+        const auto history_options = sceneGraphCaptureOptions(false, false);
+        auto history_before = op::SceneGraphPatchEntry::captureState(*this, {}, history_options);
+
         const auto& src = *gaussian_clipboard_;
         auto data = std::make_unique<lfs::core::SplatData>(
             src.get_max_sh_degree(),
@@ -4763,6 +4766,7 @@ namespace lfs::vis {
         }
 
         LOG_INFO("Pasted {} Gaussians as '{}'", count, name);
+        pushSceneGraphHistoryEntry(*this, "Paste", std::move(history_before), {name}, history_options);
         return {name};
     }
 
@@ -4833,6 +4837,9 @@ namespace lfs::vis {
         if (!hasClipboard()) {
             return pasted_names;
         }
+
+        const auto history_options = sceneGraphCaptureOptions(false, false);
+        auto history_before = op::SceneGraphPatchEntry::captureState(*this, {}, history_options);
 
         pasted_names.reserve(clipboard_.size());
         core::Scene::Transaction txn(scene_);
@@ -4948,6 +4955,9 @@ namespace lfs::vis {
         }
 
         LOG_DEBUG("Pasted {} nodes", pasted_names.size());
+        if (!pasted_names.empty()) {
+            pushSceneGraphHistoryEntry(*this, "Paste", std::move(history_before), pasted_names, history_options);
+        }
         return pasted_names;
     }
 

--- a/tests/test_undo_history.cpp
+++ b/tests/test_undo_history.cpp
@@ -1639,6 +1639,49 @@ TEST_F(UndoHistoryTest, NodeCopyPasteWithoutDeletionsKeepsAllRows) {
     EXPECT_FALSE(pasted_node->model->has_deleted_mask());
 }
 
+TEST_F(UndoHistoryTest, PasteNodesCreatesUndoableSceneGraphEntry) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    scene_manager->getScene().addSplat("model", make_linear_test_splat(3));
+    scene_manager->selectNode("model");
+    EXPECT_TRUE(scene_manager->copySelectedNodes());
+
+    const auto pasted = scene_manager->pasteNodes();
+    ASSERT_EQ(pasted.size(), 1u);
+    EXPECT_NE(scene_manager->getScene().getNode(pasted.front()), nullptr);
+
+    auto undo_result = lfs::vis::op::undoHistory().undo();
+    ASSERT_TRUE(undo_result.success) << undo_result.error;
+    EXPECT_EQ(scene_manager->getScene().getNode(pasted.front()), nullptr);
+
+    auto redo_result = lfs::vis::op::undoHistory().redo();
+    ASSERT_TRUE(redo_result.success) << redo_result.error;
+    EXPECT_NE(scene_manager->getScene().getNode(pasted.front()), nullptr);
+}
+
+TEST_F(UndoHistoryTest, PasteGaussiansCreatesUndoableSceneGraphEntry) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    scene_manager->getScene().addSplat("model", make_linear_test_splat(3));
+    scene_manager->getScene().setSelectionMask(
+        std::make_shared<Tensor>(make_uint8_mask({1, 1, 0})));
+
+    EXPECT_TRUE(scene_manager->copySelectedGaussians());
+    const auto pasted = scene_manager->pasteGaussians();
+    ASSERT_EQ(pasted.size(), 1u);
+    EXPECT_NE(scene_manager->getScene().getNode(pasted.front()), nullptr);
+
+    auto undo_result = lfs::vis::op::undoHistory().undo();
+    ASSERT_TRUE(undo_result.success) << undo_result.error;
+    EXPECT_EQ(scene_manager->getScene().getNode(pasted.front()), nullptr);
+}
+
 TEST_F(UndoHistoryTest, NodeCopyWithAllRowsDeletedProducesNoClipboard) {
     auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
     auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();


### PR DESCRIPTION
Fixes #1776.

Cutting splats could be undone, but pasting them could not — Ctrl-Z after a paste left the pasted node in the scene. Paste never recorded an undo entry.

Both paste paths now record history the same way node duplication already does, so Ctrl-Z removes the pasted node and Ctrl-Shift-Z brings it back.

Covered by two new undo-history tests (94/94 passing) and verified in the app with the exact reproduction steps from the issue.