### PR TITLE
Fix camera spawn when opening a CLI-trained project

### DIFF
--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -280,6 +280,7 @@ target_include_directories(lfs_io
         $<INSTALL_INTERFACE:include>
         PRIVATE
         ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_SOURCE_DIR}/src/rendering/include
         ${CMAKE_SOURCE_DIR}/external/spz
 )
 target_include_directories(lfs_io SYSTEM PRIVATE

--- a/src/io/project/session_chapters.cpp
+++ b/src/io/project/session_chapters.cpp
@@ -5,6 +5,8 @@
 
 #include "io/session_chapters.hpp"
 
+#include "rendering/coordinate_conventions.hpp"
+
 #include <algorithm>
 #include <array>
 #include <bit>
@@ -98,14 +100,38 @@ namespace lfs::io::project {
             });
         }
 
+        Json rotation_matrix(const glm::mat3& rotation) {
+            return Json::array({
+                rotation[0][0],
+                rotation[0][1],
+                rotation[0][2],
+                rotation[1][0],
+                rotation[1][1],
+                rotation[1][2],
+                rotation[2][0],
+                rotation[2][1],
+                rotation[2][2],
+            });
+        }
+
+        Json default_camera_look_at_rotation() {
+            // Same look-at as Viewport::CameraMotion (from t toward origin).
+            return rotation_matrix(
+                lfs::rendering::makeVisualizerLookAtRotation(
+                    glm::vec3(-5.657f, 3.0f, -5.657f),
+                    glm::vec3(0.0f, 0.0f, 0.0f)));
+        }
+
         Json default_panel_camera(
             const std::string_view panel) {
+            const Json look_at =
+                default_camera_look_at_rotation();
             return Json{
                 {"panel", panel},
-                {"R", identity_rotation()},
+                {"R", look_at},
                 {"t", vec3(-5.657, 3.0, -5.657)},
                 {"pivot", vec3(0.0, 0.0, 0.0)},
-                {"home_R", identity_rotation()},
+                {"home_R", look_at},
                 {"home_t", vec3(-5.657, 3.0, -5.657)},
                 {"home_pivot", vec3(0.0, 0.0, 0.0)},
                 {"home_saved", true},

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,6 +132,7 @@ target_include_directories(lichtfeld_format_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/src/core/include
     ${CMAKE_SOURCE_DIR}/src/io/include
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/rendering/include
     ${CMAKE_SOURCE_DIR}/tests
     ${CMAKE_BINARY_DIR}/include
 )


### PR DESCRIPTION
A project trained on the command line opened with the camera pointing away from the scene, so the viewport looked empty. The same training done in the GUI opened correctly.

Headless runs never create a viewport, and the project file they write stored a placeholder camera rotation. It now stores the same default the GUI uses: the camera looks at the scene.

Verified by training the same dataset both ways and loading both projects — the camera now comes up identical (format tests 26/26 passing).