### PR TITLE
Per-launch MCP port override (#1786)

### DIFF
--- a/docs/docs/development/mcp/connecting-clients.md
+++ b/docs/docs/development/mcp/connecting-clients.md
@@ -101,6 +101,19 @@ because another process already owns the port. The displayed endpoint list
 contains client-ready URLs; `0.0.0.0` is only the listener bind address and is
 not presented as a client endpoint.
 
+## Running Two Instances
+
+The MCP port is a saved preference (default `45677`) shared by every launch of
+the same install. A second instance fails to bind and shows "MCP Error" in the
+status bar. To isolate a second instance for this launch only, start it with
+`--mcp-port=45678`. The saved preference is not changed.
+
+Before mutating anything, check `serverInfo.version` from the `initialize`
+response. It is the build's git-describe string (for example
+`v0.5.3-361-g59682b11`) and identifies the binary that answered. Two instances
+of the same binary return the same value, so when in doubt use a distinct
+`--mcp-port` per instance instead of sharing the default port.
+
 ## Runtime Controls and Diagnostics
 
 The MCP section in Preferences controls:

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1154,6 +1154,7 @@ namespace lfs::app {
             constexpr auto graphics_backend = lfs::vis::GraphicsBackend::Vulkan;
             mcp::McpHttpServer mcp_http({.enable_resources = true});
             const auto mcp_preferences = vis::loadMcpPreferences();
+            const auto mcp_port_override = params->mcp_port;
             const auto startup_project =
                 params->project_path
                     ? params->project_path
@@ -1252,14 +1253,15 @@ namespace lfs::app {
 
             mcp::setActiveMcpHttpServer(&mcp_http);
             vis::setRuntimeServiceControls({
-                .toggle_mcp_enabled = [safe_mode] {
+                .toggle_mcp_enabled = [safe_mode, mcp_port_override] {
                     if (safe_mode)
                         return false;
                     const auto status = mcp::activeMcpHttpStatus();
+                    const auto mcp_preferences = vis::loadMcpPreferences();
                     const mcp::McpHttpConfig config{
                         .enabled = !status.enabled,
                         .expose_network = status.expose_network,
-                        .port = status.port,
+                        .port = mcp_port_override.value_or(mcp_preferences.port),
                         .request_logging = status.request_logging,
                     };
                     if (!mcp::applyActiveMcpHttpConfig(config))
@@ -1267,18 +1269,19 @@ namespace lfs::app {
                     vis::saveMcpPreferences({
                         .enabled = config.enabled,
                         .expose_network = config.expose_network,
-                        .port = config.port,
+                        .port = mcp_preferences.port,
                         .request_logging = config.request_logging,
                     });
                     return true; },
-                .toggle_mcp_binding = [safe_mode] {
+                .toggle_mcp_binding = [safe_mode, mcp_port_override] {
                     if (safe_mode)
                         return false;
                     const auto status = mcp::activeMcpHttpStatus();
+                    const auto mcp_preferences = vis::loadMcpPreferences();
                     const mcp::McpHttpConfig config{
                         .enabled = status.enabled,
                         .expose_network = !status.expose_network,
-                        .port = status.port,
+                        .port = mcp_port_override.value_or(mcp_preferences.port),
                         .request_logging = status.request_logging,
                     };
                     if (!mcp::applyActiveMcpHttpConfig(config))
@@ -1286,7 +1289,7 @@ namespace lfs::app {
                     vis::saveMcpPreferences({
                         .enabled = config.enabled,
                         .expose_network = config.expose_network,
-                        .port = config.port,
+                        .port = mcp_preferences.port,
                         .request_logging = config.request_logging,
                     });
                     return true; },
@@ -1299,7 +1302,7 @@ namespace lfs::app {
             if (!mcp_http.start({
                     .enabled = mcp_preferences.enabled,
                     .expose_network = mcp_preferences.expose_network,
-                    .port = mcp_preferences.port,
+                    .port = mcp_port_override.value_or(mcp_preferences.port),
                     .request_logging = mcp_preferences.request_logging,
                 }))
                 LOG_ERROR("Failed to start MCP HTTP server");

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -568,6 +568,7 @@ namespace {
 #endif
             ::args::Flag debug_python(ui_group, "debug_python", "Start debugpy listener on port 5678 for plugin debugging", {"debug-python"});
             ::args::ValueFlag<int> debug_python_port(ui_group, "port", "Port for debugpy listener (default: 5678)", {"debug-python-port"});
+            ::args::ValueFlag<int> mcp_port(ui_group, "port", "Override the MCP server port for this launch (does not change the saved preference)", {"mcp-port"});
 
             // =============================================================================
             // PERF / PROFILING
@@ -923,6 +924,12 @@ namespace {
                     return std::unexpected("ERROR: --min-track-length must be 0 or greater");
                 }
             }
+            if (mcp_port) {
+                const int port = ::args::get(mcp_port);
+                if (port < 1 || port > 65535) {
+                    return std::unexpected("ERROR: --mcp-port must be between 1 and 65535");
+                }
+            }
 
             // Validate sh_degree (0-3)
             if (sh_degree) {
@@ -1074,6 +1081,7 @@ namespace {
 #endif
                                         debug_python_flag = bool(debug_python),
                                         debug_python_port_val = cli_option_present({"--debug-python-port"}) ? std::optional<int>(::args::get(debug_python_port)) : std::optional<int>(),
+                                        mcp_port_val = cli_option_present({"--mcp-port"}) ? std::optional<int>(::args::get(mcp_port)) : std::optional<int>(),
                                         no_save_eval_images_flag = bool(no_save_eval_images),
                                         bg_mode_val = parsed_bg_mode,
                                         bg_color_val = parsed_bg_color,
@@ -1190,6 +1198,7 @@ namespace {
                 setFlag(no_splash_flag, opt.no_splash);
                 setFlag(debug_python_flag, opt.debug_python);
                 setVal(debug_python_port_val, opt.debug_python_port);
+                setVal(mcp_port_val, params.mcp_port);
                 if (no_save_eval_images_flag)
                     opt.enable_save_eval_images = false;
                 if (bg_mode_val) {

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -338,6 +338,7 @@ namespace lfs::core {
             bool reset_preferences = false;
             bool reset_layout = false;
             bool reset_all_settings = false;
+            std::optional<int> mcp_port = std::nullopt;
 
             // Viewer mode: splat files to load (.ply, .sog, .spz, .usd, .usda, .usdc, .usdz, .resume)
             std::vector<std::filesystem::path> view_paths;

--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -392,6 +392,8 @@ namespace lfs::core {
             if (!valid_port(server.tcp_broadcast_connection_port))
                 return std::format("tcp_broadcast_connection_port must be -1 or within [1, 65535] (got {})",
                                    server.tcp_broadcast_connection_port);
+            if (mcp_port && (*mcp_port < 1 || *mcp_port > 65535))
+                return std::format("mcp_port must be within [1, 65535] (got {})", *mcp_port);
             if (render_path) {
                 if (render_path->width <= 0 || render_path->height <= 0 ||
                     (render_path->width % 2) != 0 || (render_path->height % 2) != 0)


### PR DESCRIPTION
Addresses the remaining gaps of #1786.

The MCP port is a saved preference shared by every launch of the same install, so a second instance could not get its own port without editing that shared setting. A new `--mcp-port` flag binds just that launch; the saved preference is untouched.

Also documents how a client verifies which instance it reached (`serverInfo.version` from `initialize`).

The issue's other ask — making a failed bind visible in the UI — already works: the second instance shows a red "MCP Error" chip in the status bar (shipped with #1658/#1669, verified with two instances).

Verified: two instances on 45677 and 45678, each reachable and provably distinct; the preference file stays unchanged.