### PR TITLE
Fix --save-project-at-iter when the target is the last iteration

### DIFF
--- a/src/training/checkpoint.cpp
+++ b/src/training/checkpoint.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -292,8 +293,13 @@ namespace lfs::training {
             };
         } catch (const std::exception& error) {
             // LFS-CENSUS-OK(empty-catch): normalize the exception into a typed checkpoint error.
+            const bool layout_changed =
+                std::string_view(error.what()).find("layout changed") !=
+                std::string_view::npos;
             return checkpoint_stream_error(
-                lfs::ErrorCode::Internal,
+                layout_changed
+                    ? lfs::ErrorCode::FailedPrecondition
+                    : lfs::ErrorCode::Internal,
                 std::string("Serialize checkpoint failed: ") +
                     error.what(),
                 LFS_SOURCE_SITE_CURRENT());

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -8292,6 +8292,20 @@ namespace lfs::training {
             : user_stopped
                 ? lfs::io::project::TrainingFinishReason::UserStopped
                 : lfs::io::project::TrainingFinishReason::Completed;
+        // A save-project-at-iter capture that needed replan is re-queued for
+        // the next post-step. When the target is the final iteration there is
+        // no next post-step; drain here (layout is stable) before the terminal save.
+        {
+            bool drain_requested_project_snapshot = false;
+            {
+                std::lock_guard lock(project_snapshot_mutex_);
+                drain_requested_project_snapshot = requested_project_path_.has_value();
+            }
+            if (drain_requested_project_snapshot) {
+                consume_requested_project_snapshot(terminal_iteration);
+                finish_project_writer();
+            }
+        }
         TrainerProjectSavePolicy terminal_save_policy;
         std::optional<std::filesystem::path> terminal_project_path;
         {

--- a/src/training/training_snapshot_service.cpp
+++ b/src/training/training_snapshot_service.cpp
@@ -2189,9 +2189,22 @@ namespace lfs::training {
                         request
                             .sparsity_optimizer);
                 if (!serialized) {
+                    const auto& error =
+                        serialized.error();
+                    // serialize_checkpoint() maps layout-change
+                    // exceptions to a Result; restore the type.
+                    if (error.code() ==
+                            lfs::ErrorCode::
+                                FailedPrecondition ||
+                        error.detail().find(
+                            "layout changed") !=
+                            std::string_view::npos) {
+                        throw SnapshotReplanRequired(
+                            std::string(error.detail()));
+                    }
                     throw std::runtime_error(
                         lfs::format_for_developer(
-                            serialized.error()));
+                            error));
                 }
                 if (serialized->bytes !=
                         prepared.impl_


### PR DESCRIPTION
Asking the trainer to save a project at the final iteration silently failed: the save was scheduled a step ahead, the last training step changed the model underneath it, and the retry it queued had no later step to run on. The file was never written and the log showed a hard error.

The retry now runs once right after training ends, when nothing can change anymore, so the file is written. The transient condition is also logged as the intended "replanning" notice instead of an error.

Verified: final-iteration save now writes a loadable project; mid-training saves unchanged.