### PR TITLE
Encode shN of viewer-built models into exportable q16 storage

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -96,6 +96,7 @@ set(CORE_SOURCES
         splat_data_mirror.cpp
         splat_data_transform.cpp
         splat_exportable_storage.cpp
+        sh_value_quant.cpp
         shareable_allocation_limit.cpp
         tensor_debug.cpp
         training_snapshot.cpp

--- a/src/core/include/core/sh_value_quant.hpp
+++ b/src/core/include/core/sh_value_quant.hpp
@@ -10,8 +10,8 @@
  */
 
 #include "core/cuda/sh_layout.cuh"
+#include "core/export.hpp"
 
-#include <atomic>
 #include <cstdint>
 #include <optional>
 
@@ -44,24 +44,8 @@ namespace lfs::core::sh_value_quant {
 
     // Production: SH value quantization permanently ON.
     // Tests may force off via set_enabled_for_testing (footprint tables, etc.).
-    inline std::atomic<int>& override_flag() {
-        static std::atomic<int> g{-1};
-        return g;
-    }
-
-    inline void set_enabled_for_testing(std::optional<bool> enabled) {
-        if (!enabled.has_value()) {
-            override_flag().store(-1, std::memory_order_relaxed);
-            return;
-        }
-        override_flag().store(*enabled ? 1 : 0, std::memory_order_relaxed);
-    }
-
-    [[nodiscard]] inline bool enabled() {
-        const int o = override_flag().load(std::memory_order_relaxed);
-        if (o >= 0)
-            return o != 0;
-        return true; // production default: always ON
-    }
+    // Implemented in lfs_core so the flag is process-wide across DSOs.
+    LFS_CORE_API void set_enabled_for_testing(std::optional<bool> enabled);
+    [[nodiscard]] LFS_CORE_API bool enabled();
 
 } // namespace lfs::core::sh_value_quant

--- a/src/core/include/core/splat_data.hpp
+++ b/src/core/include/core/splat_data.hpp
@@ -426,6 +426,10 @@ namespace lfs::core {
             DataType dtype,
             std::string_view name);
 
+        // Encode float/ieee-f16 shN into allocator-backed pad-dropped q16.
+        // No-op when already quantized, flag off, or shN empty.
+        [[nodiscard]] bool apply_shN_value_quant();
+
         // Optional hook for exportable / external storage growth.
         // When densification needs more rows than the committed exportable block,
         // AdamOptimizer calls this before falling back to Tensor::cat (which would

--- a/src/core/include/core/splat_exportable_storage.hpp
+++ b/src/core/include/core/splat_exportable_storage.hpp
@@ -93,7 +93,8 @@ namespace lfs::core {
         // Captures a shared control block so post-grow offset updates are visible
         // to *new* tensors from this allocator; existing tensors must be rebuilt
         // (see rebindSplatDataToStorage).
-        // ShN is always Float16 (q16 codes); ShNBounds is Float32 float2s.
+        // ShN is Float16 q16 codes when value-quant is on; Float32 float4-swizzle
+        // when off. ShNBounds is Float32 float2s (empty region when q16 is off).
         [[nodiscard]] LFS_CORE_API SplatTensorAllocator make_allocator() const;
 
         // Rebuild SplatData parameter tensors as views into this storage at the

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -9,6 +9,7 @@
 #include "core/events.hpp"
 #include "core/logger.hpp"
 #include "core/path_utils.hpp"
+#include "core/sh_value_quant.hpp"
 #include "core/splat_data_transform.hpp"
 
 #include <algorithm>
@@ -63,7 +64,19 @@ namespace lfs::core {
                    tensor_uses_vulkan_external_storage(model.scaling_raw()) &&
                    tensor_uses_vulkan_external_storage(model.rotation_raw()) &&
                    tensor_uses_vulkan_external_storage(model.opacity_raw()) &&
-                   tensor_uses_vulkan_external_storage(model.shN_raw());
+                   tensor_uses_vulkan_external_storage(model.shN_raw()) &&
+                   (!model.shN_value_quantized() ||
+                    tensor_uses_vulkan_external_storage(model.shN_value_bounds()));
+        }
+
+        void commit_combined_model_q16(SplatData& model, const SplatTensorAllocator& alloc) {
+            model.set_tensor_allocator(alloc);
+            if (!alloc || !sh_value_quant::enabled()) {
+                return;
+            }
+            if (model.apply_shN_value_quant()) {
+                Tensor::trim_memory_pool();
+            }
         }
     } // namespace
 
@@ -856,7 +869,9 @@ namespace lfs::core {
             shN_layout = lfs::core::SplatData::ShNLayout::Canonical;
         } else if (layout_rest > 0 && source->shN_raw().is_valid() && source->shN_raw().numel() > 0) {
             const size_t shN_floats = lfs::core::sh_swizzled_float_count(new_size, layout_rest);
-            if (alloc) {
+            const bool q16_float_workspace =
+                static_cast<bool>(alloc) && sh_value_quant::enabled();
+            if (alloc && !q16_float_workspace) {
                 shN = alloc(TensorShape({shN_floats}), shN_floats, DataType::Float32, "SplatData.shN");
                 shN.zero_();
             } else {
@@ -888,7 +903,7 @@ namespace lfs::core {
             source->get_scene_scale(),
             shN_layout);
         compacted->set_active_sh_degree(source->get_active_sh_degree());
-        compacted->set_tensor_allocator(snapshot.allocator);
+        commit_combined_model_q16(*compacted, snapshot.allocator);
 
         if (deleted.is_valid()) {
             compacted->deleted() = std::move(deleted);
@@ -1685,7 +1700,9 @@ namespace lfs::core {
         // shN needs zeroing: copy_contiguous leaves the swizzled block-padding lanes untouched.
         Tensor shN;
         if (shN_swizzled_floats > 0) {
-            if (alloc) {
+            const bool q16_float_workspace =
+                static_cast<bool>(alloc) && sh_value_quant::enabled();
+            if (alloc && !q16_float_workspace) {
                 shN = alloc(TensorShape({shN_swizzled_floats}),
                             shN_swizzled_floats,
                             lfs::core::DataType::Float32,
@@ -1802,7 +1819,7 @@ namespace lfs::core {
             stats.total_scene_scale / visible_nodes.size(),
             lfs::core::SplatData::ShNLayout::Swizzled);
         cached_combined_->set_active_sh_degree(stats.max_active_sh_degree);
-        cached_combined_->set_tensor_allocator(combined_model_allocator_);
+        commit_combined_model_q16(*cached_combined_, combined_model_allocator_);
 
         if (has_any_deleted) {
             cached_combined_->deleted() = std::move(deleted);

--- a/src/core/sh_value_quant.cpp
+++ b/src/core/sh_value_quant.cpp
@@ -1,0 +1,30 @@
+/* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/sh_value_quant.hpp"
+
+#include <atomic>
+
+namespace lfs::core::sh_value_quant {
+    namespace {
+        std::atomic<int>& override_flag() {
+            static std::atomic<int> g{-1};
+            return g;
+        }
+    } // namespace
+
+    void set_enabled_for_testing(const std::optional<bool> enabled) {
+        if (!enabled.has_value()) {
+            override_flag().store(-1, std::memory_order_relaxed);
+            return;
+        }
+        override_flag().store(*enabled ? 1 : 0, std::memory_order_relaxed);
+    }
+
+    bool enabled() {
+        const int o = override_flag().load(std::memory_order_relaxed);
+        if (o >= 0)
+            return o != 0;
+        return true; // production default: always ON
+    }
+} // namespace lfs::core::sh_value_quant

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cuda_runtime.h>
+#include <exception>
 #include <expected>
 #include <format>
 #include <tbb/blocked_range.h>
@@ -305,6 +306,28 @@ namespace {
         return tensor;
     }
 
+    lfs::core::Tensor home_param_tensor(const lfs::core::Tensor& gathered,
+                                        const lfs::core::Tensor& capacity_src,
+                                        const lfs::core::SplatTensorAllocator& allocator,
+                                        std::string_view name) {
+        using namespace lfs::core;
+        if (!gathered.is_valid()) {
+            return {};
+        }
+        if (!allocator) {
+            Tensor out = gathered;
+            out.set_name(std::string{name});
+            return out;
+        }
+        const size_t n = gathered.shape().rank() > 0
+                             ? static_cast<size_t>(gathered.shape()[0])
+                             : static_cast<size_t>(gathered.numel());
+        const size_t cap = std::max(n, capacity_src.is_valid() ? capacity_src.capacity() : n);
+        Tensor dest = allocate_param_tensor(gathered.shape(), cap, allocator, name);
+        dest.copy_from(gathered);
+        return dest;
+    }
+
     [[nodiscard]] uint32_t infer_swizzled_rest_coefficients(size_t n, size_t numel) {
         using namespace lfs::core;
         const size_t blocks = sh_swizzled_block_count(n);
@@ -380,7 +403,7 @@ namespace {
                           error.what());
             }
             if (t.is_valid() && t.dtype() == DataType::Float32 &&
-                t.capacity() >= capacity_floats) {
+                t.capacity() >= logical_floats) {
                 return t;
             }
         }
@@ -389,6 +412,27 @@ namespace {
                                              Device::CUDA);
         tensor.set_name(std::string{name});
         return tensor;
+    }
+
+    lfs::core::Tensor home_swizzled_shN(const lfs::core::Tensor& gathered,
+                                        size_t n,
+                                        size_t primitive_capacity,
+                                        uint32_t layout_rest,
+                                        const lfs::core::SplatTensorAllocator& allocator,
+                                        std::string_view name) {
+        using namespace lfs::core;
+        if (!gathered.is_valid()) {
+            return {};
+        }
+        if (!allocator) {
+            Tensor out = gathered;
+            out.set_name(std::string{name});
+            return out;
+        }
+        const size_t cap = std::max(n, primitive_capacity);
+        Tensor dest = allocate_swizzled_shN(n, cap, layout_rest, allocator, name);
+        dest.copy_from(gathered);
+        return dest;
     }
 
     [[nodiscard]] uint32_t canonical_rest_coefficients(const lfs::core::Tensor& canonical) {
@@ -1470,80 +1514,115 @@ namespace lfs::core {
                                            ? std::vector<int>{}
                                            : kept_indices.to_vector_int();
 
-        // Gather kept rows for each parameter directly into a destination allocated
-        // from the model's backing storage (Vulkan-external interop when set, the
-        // default device allocator otherwise). Gathering into the destination avoids
-        // the transient copy of an index_select() + re-home, and keeps the tensors in
-        // the storage the viewport renderer requires.
-        const auto gather_param = [&](const Tensor& src, std::string_view name) {
-            auto dims = src.shape().dims();
-            dims[0] = new_size;
-            Tensor out = allocate_param_tensor(TensorShape(dims), new_size,
-                                               _tensor_allocator, name);
-            src.index_select_into(out, 0, kept_indices, BoundaryMode::Assert);
-            return out;
-        };
-        auto new_means = gather_param(_means, "SplatData.means");
-        auto new_sh0 = gather_param(_sh0, "SplatData.sh0");
-        auto new_scaling = gather_param(_scaling, "SplatData.scaling");
-        auto new_rotation = gather_param(_rotation, "SplatData.rotation");
-        auto new_opacity = gather_param(_opacity, "SplatData.opacity");
+        Tensor saved_means = _means;
+        Tensor saved_sh0 = _sh0;
+        Tensor saved_scaling = _scaling;
+        Tensor saved_rotation = _rotation;
+        Tensor saved_opacity = _opacity;
+        Tensor saved_shN = _shN;
+        Tensor saved_bounds = _shN_value_bounds;
+        Tensor saved_deleted = _deleted;
+        Tensor saved_densify = _densification_info;
+        auto saved_frozen = _frozen_ranges;
 
-        // Verify new sizes are correct before committing
-        if (new_means.size(0) != new_size || new_sh0.size(0) != new_size ||
-            new_scaling.size(0) != new_size || new_rotation.size(0) != new_size ||
-            new_opacity.size(0) != new_size) {
-            LOG_ERROR("apply_deleted: post-filter size mismatch - means:{} sh0:{} scaling:{} rotation:{} opacity:{} expected:{}",
-                      new_means.size(0), new_sh0.size(0), new_scaling.size(0),
-                      new_rotation.size(0), new_opacity.size(0), new_size);
+        auto restore = [&]() {
+            _means = saved_means;
+            _sh0 = saved_sh0;
+            _scaling = saved_scaling;
+            _rotation = saved_rotation;
+            _opacity = saved_opacity;
+            _shN = saved_shN;
+            _shN_value_bounds = saved_bounds;
+            _deleted = saved_deleted;
+            _densification_info = saved_densify;
+            _frozen_ranges = saved_frozen;
+        };
+
+        try {
+            // Gather params and shN into pooled tensors first. Homing is the first
+            // overwrite of exportable regions; a throw during gather restores by
+            // handles alone.
+            const auto gather_rows = [&](const Tensor& src) {
+                return src.index_select(0, kept_indices).contiguous();
+            };
+            Tensor gathered_means = gather_rows(_means);
+            Tensor gathered_sh0 = gather_rows(_sh0);
+            Tensor gathered_scaling = gather_rows(_scaling);
+            Tensor gathered_rotation = gather_rows(_rotation);
+            Tensor gathered_opacity = gather_rows(_opacity);
+
+            if (gathered_means.size(0) != new_size || gathered_sh0.size(0) != new_size ||
+                gathered_scaling.size(0) != new_size || gathered_rotation.size(0) != new_size ||
+                gathered_opacity.size(0) != new_size) {
+                LOG_ERROR("apply_deleted: post-filter size mismatch - means:{} sh0:{} scaling:{} rotation:{} opacity:{} expected:{}",
+                          gathered_means.size(0), gathered_sh0.size(0), gathered_scaling.size(0),
+                          gathered_rotation.size(0), gathered_opacity.size(0), new_size);
+                return 0;
+            }
+
+            Tensor gathered_shN;
+            const auto layout_rest = static_cast<uint32_t>(max_sh_coeffs_rest());
+            if (_shN.is_valid() && _shN.numel() > 0 && layout_rest > 0) {
+                if (_shN.dtype() != DataType::Float32 || shN_value_quantized() || shN_ieee_f16()) {
+                    Tensor canon = shN_canonical();
+                    if (canon.device() != _means.device()) {
+                        canon = canon.to(_means.device());
+                    }
+                    Tensor kept_canon = canon.index_select(0, kept_indices).contiguous();
+                    gathered_shN = allocate_swizzled_shN(new_size, new_size, layout_rest);
+                    reorder_canonical_into_swizzled(kept_canon, gathered_shN, new_size,
+                                                    layout_rest, layout_rest);
+                } else {
+                    gathered_shN = allocate_swizzled_shN(new_size, new_size, layout_rest);
+                    shN_swizzled_gather_self(_shN.ptr<float>(), gathered_shN.ptr<float>(),
+                                             kept_indices.ptr<int>(), new_size, 0, layout_rest);
+                }
+            }
+
+            Tensor new_means = home_param_tensor(gathered_means, _means, _tensor_allocator,
+                                                 "SplatData.means");
+            Tensor new_sh0 = home_param_tensor(gathered_sh0, _sh0, _tensor_allocator,
+                                               "SplatData.sh0");
+            Tensor new_scaling = home_param_tensor(gathered_scaling, _scaling, _tensor_allocator,
+                                                   "SplatData.scaling");
+            Tensor new_rotation = home_param_tensor(gathered_rotation, _rotation, _tensor_allocator,
+                                                    "SplatData.rotation");
+            Tensor new_opacity = home_param_tensor(gathered_opacity, _opacity, _tensor_allocator,
+                                                   "SplatData.opacity");
+            if (gathered_shN.is_valid() && !sh_value_quant::enabled() && _tensor_allocator) {
+                gathered_shN = home_swizzled_shN(gathered_shN, new_size,
+                                                 _means.is_valid() ? _means.capacity() : new_size,
+                                                 layout_rest, _tensor_allocator, "SplatData.shN");
+            }
+
+            _means = std::move(new_means);
+            _sh0 = std::move(new_sh0);
+            _scaling = std::move(new_scaling);
+            _rotation = std::move(new_rotation);
+            _opacity = std::move(new_opacity);
+
+            if (gathered_shN.is_valid()) {
+                _shN_value_bounds = Tensor{};
+                _shN = std::move(gathered_shN);
+                if (sh_value_quant::enabled()) {
+                    (void)apply_shN_value_quant();
+                }
+            }
+
+            _densification_info = Tensor();
+            if (!_frozen_ranges.empty()) {
+                remap_frozen_ranges_after_keep(old_size, kept_indices_host);
+            }
+            clear_deleted();
+
+            const size_t removed = old_size - new_size;
+            LOG_INFO("apply_deleted: removed {} gaussians ({} -> {})", removed, old_size, new_size);
+            return removed;
+        } catch (const std::exception& e) {
+            restore();
+            LOG_ERROR("apply_deleted: aborted ({}); model restored", e.what());
             return 0;
         }
-
-        // Commit the changes
-        _means = std::move(new_means);
-        _sh0 = std::move(new_sh0);
-        _scaling = std::move(new_scaling);
-        _rotation = std::move(new_rotation);
-        _opacity = std::move(new_opacity);
-
-        // shN is in swizzled layout — block-aware gather of kept primitives.
-        // q16 / IEEE-f16 cannot use ptr<float>() gather; filter via canonical float.
-        const auto layout_rest = static_cast<uint32_t>(max_sh_coeffs_rest());
-        if (_shN.is_valid() && _shN.numel() > 0 && layout_rest > 0) {
-            if (_shN.dtype() != DataType::Float32 || shN_value_quantized() || shN_ieee_f16()) {
-                Tensor canon = shN_canonical();
-                if (canon.device() != _means.device()) {
-                    canon = canon.to(_means.device());
-                }
-                Tensor kept_canon = canon.index_select(0, kept_indices).contiguous();
-                // Drop q16 bounds: storage is rebuilt as float4-swizzle.
-                _shN_value_bounds = Tensor{};
-                _shN = allocate_swizzled_shN(new_size, new_size, layout_rest,
-                                             _tensor_allocator, "SplatData.shN");
-                reorder_canonical_into_swizzled(kept_canon, _shN, new_size,
-                                                layout_rest, layout_rest);
-            } else {
-                auto new_shN = allocate_swizzled_shN(new_size, new_size, layout_rest,
-                                                     _tensor_allocator, "SplatData.shN");
-                shN_swizzled_gather_self(_shN.ptr<float>(), new_shN.ptr<float>(),
-                                         kept_indices.ptr<int>(), new_size, 0, layout_rest);
-                _shN = std::move(new_shN);
-            }
-        }
-
-        // Clear densification info
-        _densification_info = Tensor();
-        if (!_frozen_ranges.empty()) {
-            remap_frozen_ranges_after_keep(old_size, kept_indices_host);
-        }
-
-        // Clear deletion mask (bumps deleted_mask_version so the viewport
-        // drops any soft-delete opacity bake for the old N).
-        clear_deleted();
-
-        const size_t removed = old_size - new_size;
-        LOG_INFO("apply_deleted: removed {} gaussians ({} -> {})", removed, old_size, new_size);
-        return removed;
     }
 
     // ========== SERIALIZATION ==========

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -4,11 +4,15 @@
 
 #include "core/splat_data.hpp"
 #include "core/cuda/sh_layout.cuh"
+#include "core/cuda_error.hpp"
 #include "core/logger.hpp"
 #include "core/parameters.hpp"
 #include "core/point_cloud.hpp"
 #include "core/sh_value_quant.hpp"
+#include "core/sh_value_quant_kernels.hpp"
 #include "core/shareable_allocation_limit.hpp"
+#include "core/splat_exportable_storage.hpp"
+#include "core/tensor/internal/cuda_stream_context.hpp"
 #include "core/tensor/internal/tensor_serialization.hpp"
 #include "core/tensor_serialization_sink.hpp"
 #include "nanoflann.hpp"
@@ -16,6 +20,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cuda_runtime.h>
 #include <expected>
 #include <format>
@@ -2481,6 +2486,83 @@ namespace lfs::core {
             return std::unexpected(
                 std::format("Failed to initialize SplatData: {}", e.what()));
         }
+    }
+
+    bool SplatData::apply_shN_value_quant() {
+        if (!sh_value_quant::enabled()) {
+            return false;
+        }
+        Tensor& shN = this->shN();
+        if (!shN.is_valid() || shN.numel() == 0) {
+            return false;
+        }
+        if (shN.dtype() == DataType::Float16 && shN_value_quantized()) {
+            return false;
+        }
+
+        const auto n = static_cast<size_t>(size());
+        const auto rest = static_cast<std::uint32_t>(max_sh_coeffs_rest());
+        if (n == 0 || rest == 0) {
+            return false;
+        }
+
+        const auto cap = means().is_valid()
+                             ? std::max(means().capacity() > 0 ? means().capacity() : n, n)
+                             : n;
+        const auto n_cells = sh_value_quant::sh_value_u16_count(n, rest);
+        const auto capacity_cells = sh_value_quant::sh_value_u16_count(cap, rest);
+        const auto n_bounds = sh_value_quant::n_bounds_for_prims(n);
+        const auto n_bounds_cap = sh_value_quant::n_bounds_for_prims(cap);
+
+        Tensor u16 = allocate_named_param(
+            TensorShape({n_cells}),
+            std::max(n_cells, capacity_cells),
+            DataType::Float16,
+            "SplatData.shN");
+        Tensor bounds = allocate_named_param(
+            TensorShape({n_bounds * 2}),
+            std::max(n_bounds, n_bounds_cap) * 2,
+            DataType::Float32,
+            "SplatData.shN_value_bounds");
+        u16.set_name("splat.shN");
+        bounds.set_name("splat.shN_value_bounds");
+
+        Tensor float_src = shN;
+        if (float_src.dtype() == DataType::Float16) {
+            float_src = float_src.to(DataType::Float32);
+        }
+        if (float_src.device() != Device::CUDA) {
+            float_src = float_src.cuda();
+        }
+        if (!float_src.is_contiguous()) {
+            float_src = float_src.contiguous();
+        }
+
+        const cudaStream_t stream = getCurrentCUDAStream();
+        if (u16.stream() != stream) {
+            u16.set_stream(stream);
+        }
+        if (bounds.stream() != stream) {
+            bounds.set_stream(stream);
+        }
+        if (float_src.stream() != stream) {
+            float_src.set_stream(stream);
+        }
+
+        sh_value_quant::encode_shN_float4_to_u16(
+            float_src.ptr<float>(),
+            reinterpret_cast<std::uint16_t*>(resolve_exportable_device_ptr(u16)),
+            static_cast<float*>(resolve_exportable_device_ptr(bounds)),
+            n,
+            rest,
+            stream);
+        LFS_CUDA_CHECK_MSG(cudaDeviceSynchronize(), "sh_value quant codec device barrier");
+
+        shN = std::move(u16);
+        shN_value_bounds() = std::move(bounds);
+        LOG_DEBUG("SH value quant applied: N={} cap={} rest={} cells={} bounds={}",
+                  n, cap, rest, n_cells, n_bounds);
+        return true;
     }
 
 } // namespace lfs::core

--- a/src/core/splat_data_mirror.cpp
+++ b/src/core/splat_data_mirror.cpp
@@ -6,6 +6,7 @@
 #include "core/crash_handler.hpp"
 #include "core/cuda/sh_layout.cuh"
 #include "core/logger.hpp"
+#include "core/sh_value_quant.hpp"
 #include "core/splat_data.hpp"
 #include <mutex>
 
@@ -168,6 +169,23 @@ namespace lfs::core {
                     shN_canon.index_select(0, indices) * g_cache.sh_mult[a][degree - 1];
                 shN_canon.index_copy_(0, indices, selected);
                 splat_data.shN_set_from_canonical(shN_canon, splat_data.means().capacity());
+                if (sh_value_quant::enabled()) {
+                    (void)splat_data.apply_shN_value_quant();
+                } else if (splat_data.has_tensor_allocator()) {
+                    auto& shN = splat_data.shN();
+                    if (shN.is_valid() && shN.dtype() == DataType::Float32) {
+                        const size_t n = splat_data.size();
+                        const size_t cap = std::max(n, splat_data.means().capacity());
+                        const auto rest = static_cast<uint32_t>(splat_data.max_sh_coeffs_rest());
+                        Tensor dest = splat_data.allocate_named_param(
+                            shN.shape(),
+                            sh_swizzled_float_count(cap, rest),
+                            DataType::Float32,
+                            "SplatData.shN");
+                        dest.copy_from(shN);
+                        shN = std::move(dest);
+                    }
+                }
             }
         }
     }

--- a/src/core/splat_data_transform.cpp
+++ b/src/core/splat_data_transform.cpp
@@ -7,6 +7,7 @@
 #include "core/cuda/sh_layout.cuh"
 #include "core/logger.hpp"
 #include "core/point_cloud.hpp"
+#include "core/sh_value_quant.hpp"
 #include "core/splat_data.hpp"
 #include "geometry/bounding_box.hpp"
 
@@ -499,6 +500,8 @@ namespace lfs::core {
                 splat_data._densification_info.index_select(0, indices).contiguous();
         }
 
+        (void)cropped_splat.apply_shN_value_quant();
+
         LOG_DEBUG("Cropped SplatData: {} -> {} points (inverse={})", num_points, points_selected, inverse);
         return cropped_splat;
     }
@@ -590,6 +593,9 @@ namespace lfs::core {
 
         LOG_DEBUG("Randomly selecting {} points from {} total points (seed: {})",
                   num_required_splat, num_points, seed);
+        const size_t old_capacity = splat_data._means.is_valid()
+                                        ? splat_data._means.capacity()
+                                        : static_cast<size_t>(num_points);
 
         std::vector<int> all_indices(num_points);
         std::iota(all_indices.begin(), all_indices.end(), 0);
@@ -687,9 +693,38 @@ namespace lfs::core {
         } else if (shN_selected_swizzled.is_valid() && shN_selected_swizzled.numel() > 0) {
             splat_data._shN = std::move(shN_selected_swizzled);
         }
+        (void)splat_data.apply_shN_value_quant();
         splat_data._scaling = splat_data._scaling.index_select(0, indices_tensor).contiguous();
         splat_data._rotation = splat_data._rotation.index_select(0, indices_tensor).contiguous();
         splat_data._opacity = splat_data._opacity.index_select(0, indices_tensor).contiguous();
+        if (splat_data._tensor_allocator) {
+            const size_t dest_cap = std::max(static_cast<size_t>(num_required_splat), old_capacity);
+            const auto home = [&](Tensor& tensor, std::string_view name) {
+                if (!tensor.is_valid()) {
+                    return;
+                }
+                Tensor dest = splat_data.allocate_named_param(
+                    tensor.shape(), dest_cap, tensor.dtype(), name);
+                dest.copy_from(tensor);
+                tensor = std::move(dest);
+            };
+            home(splat_data._means, "SplatData.means");
+            home(splat_data._sh0, "SplatData.sh0");
+            home(splat_data._scaling, "SplatData.scaling");
+            home(splat_data._rotation, "SplatData.rotation");
+            home(splat_data._opacity, "SplatData.opacity");
+            if (!sh_value_quant::enabled() && splat_data._shN.is_valid() &&
+                splat_data._shN.dtype() == DataType::Float32) {
+                const auto rest = static_cast<uint32_t>(splat_data.max_sh_coeffs_rest());
+                Tensor dest = splat_data.allocate_named_param(
+                    splat_data._shN.shape(),
+                    sh_swizzled_float_count(dest_cap, rest),
+                    DataType::Float32,
+                    "SplatData.shN");
+                dest.copy_from(splat_data._shN);
+                splat_data._shN = std::move(dest);
+            }
+        }
         if (!splat_data._frozen_ranges.empty()) {
             splat_data.remap_frozen_ranges_after_keep(
                 static_cast<size_t>(num_points),
@@ -896,6 +931,7 @@ namespace lfs::core {
             result.lod_tree = std::make_unique<lfs::core::SplatLodTree>(*splat_data.lod_tree);
         }
 
+        (void)result.apply_shN_value_quant();
         return result;
     }
 

--- a/src/core/splat_exportable_storage.cpp
+++ b/src/core/splat_exportable_storage.cpp
@@ -76,18 +76,28 @@ namespace lfs::core {
             using R = SplatExportableStorage;
             const auto rest_coeffs =
                 static_cast<std::uint32_t>(sh_rest_coefficients_for_degree(sh_degree));
-            const std::size_t shN_u16_cells =
-                sh_value_quant::sh_value_u16_count(capacity, rest_coeffs);
-            const std::size_t bounds_float2s = sh_value_quant::n_bounds_for_prims(capacity);
-            const std::size_t bounds_bytes = bounds_float2s * 2u * kFloatBytes;
+            std::size_t shN_bytes = 0;
+            std::size_t bounds_bytes = 0;
+            if (sh_value_quant::enabled()) {
+                const std::size_t shN_u16_cells =
+                    sh_value_quant::sh_value_u16_count(capacity, rest_coeffs);
+                shN_bytes = checked_product(
+                    shN_u16_cells, kShNElementBytes, "exportable q16 shN byte count");
+                const std::size_t bounds_float2s = sh_value_quant::n_bounds_for_prims(capacity);
+                bounds_bytes = bounds_float2s * 2u * kFloatBytes;
+            } else {
+                const std::size_t shN_floats = sh_swizzled_float_count(capacity, rest_coeffs);
+                shN_bytes = checked_product(
+                    shN_floats, kFloatBytes, "exportable float shN byte count");
+            }
             return {
-                region_bytes_for(capacity, 3),    // Means {N,3}
-                region_bytes_for(capacity, 3),    // Scaling {N,3}
-                region_bytes_for(capacity, 4),    // Rotation {N,4}
-                region_bytes_for(capacity, 1),    // Opacity {N,1}
-                region_bytes_for(capacity, 3),    // Sh0 {N,1,3}
-                shN_u16_cells * kShNElementBytes, // ShN (pad-dropped q16)
-                bounds_bytes,                     // ShNBounds (float2 / 256)
+                region_bytes_for(capacity, 3), // Means {N,3}
+                region_bytes_for(capacity, 3), // Scaling {N,3}
+                region_bytes_for(capacity, 4), // Rotation {N,4}
+                region_bytes_for(capacity, 1), // Opacity {N,1}
+                region_bytes_for(capacity, 3), // Sh0 {N,1,3}
+                shN_bytes,                     // ShN (q16 codes or float4-swizzle)
+                bounds_bytes,                  // ShNBounds (float2 / 256); empty if q16 off
             };
         }
 
@@ -423,9 +433,15 @@ namespace lfs::core {
 
             std::size_t clamped = capacity;
             if (region == SplatExportableStorage::ShN) {
-                dtype = DataType::Float16;
-                const std::size_t max_cells = region_bytes / kShNElementBytes;
-                clamped = std::min(capacity, max_cells);
+                if (sh_value_quant::enabled()) {
+                    dtype = DataType::Float16;
+                    const std::size_t max_cells = region_bytes / kShNElementBytes;
+                    clamped = std::min(capacity, max_cells);
+                } else {
+                    dtype = DataType::Float32;
+                    const std::size_t max_floats = region_bytes / kFloatBytes;
+                    clamped = std::min(capacity, max_floats);
+                }
             } else if (region == SplatExportableStorage::ShNBounds) {
                 dtype = DataType::Float32;
                 const std::size_t max_floats = region_bytes / kFloatBytes;

--- a/src/io/loader_service.cpp
+++ b/src/io/loader_service.cpp
@@ -5,6 +5,7 @@
 #include "io/loader_service.hpp"
 #include "core/logger.hpp"
 #include "core/path_utils.hpp"
+#include "core/sh_value_quant.hpp"
 #include "core/splat_data.hpp"
 #include "io/error.hpp"
 #include "io/formats/rad.hpp"
@@ -102,13 +103,21 @@ namespace lfs::io {
             const int active_sh = model.get_active_sh_degree();
             const float scene_scale = model.get_scene_scale();
             const bool shN_q16 = model.shN_value_quantized();
+            const bool encode_q16 = lfs::core::sh_value_quant::enabled() && !shN_q16;
             lfs::core::Tensor deleted = model.has_deleted_mask() ? model.deleted() : lfs::core::Tensor{};
 
             lfs::core::Tensor shN;
             lfs::core::Tensor shN_bounds;
             const auto& shN_src = model.shN_raw();
             if (shN_src.is_valid() && shN_src.numel() > 0) {
-                shN = copy_to_allocator(shN_src, "SplatData.shN");
+                if (encode_q16) {
+                    // Keep the source float/f16 workspace; encode into allocator
+                    // q16 after the migrate so we do not import a full-size float
+                    // rest buffer just to throw it away.
+                    shN = shN_src;
+                } else {
+                    shN = copy_to_allocator(shN_src, "SplatData.shN");
+                }
             }
             if (shN_q16) {
                 shN_bounds = copy_to_allocator(
@@ -131,6 +140,9 @@ namespace lfs::io {
             model = std::move(migrated);
             model.lod_tree = std::move(lod_tree);
             model.set_tensor_allocator(allocator);
+            if (encode_q16) {
+                (void)model.apply_shN_value_quant();
+            }
             lfs::core::Tensor::trim_memory_pool();
         } catch (const std::exception& e) {
             return make_error(ErrorCode::CORRUPTED_DATA,

--- a/src/training/sh_value_storage.cpp
+++ b/src/training/sh_value_storage.cpp
@@ -47,79 +47,7 @@ namespace lfs::training::sh_value {
     } // namespace
 
     bool apply_shN_value_quant(core::SplatData& splat) {
-        if (!sh_value_quant_enabled())
-            return false;
-        auto& shN = splat.shN();
-        if (!shN.is_valid() || shN.numel() == 0)
-            return false;
-        // Already pad-dropped q16 (codes + bounds). IEEE f16 float4-swizzle is also
-        // Float16 but has no bounds — that path expands to float then re-encodes.
-        if (shN.dtype() == DataType::Float16 && splat.shN_value_quantized())
-            return false;
-
-        const auto n = static_cast<std::size_t>(splat.size());
-        const auto rest = layout_rest(splat);
-        if (n == 0 || rest == 0)
-            return false;
-
-        // Capacity must track means capacity (max_cap), not exact-N.
-        const auto cap = prim_capacity(splat);
-        const auto n_cells = core::sh_value_quant::sh_value_u16_count(n, rest);
-        const auto capacity_cells = core::sh_value_quant::sh_value_u16_count(cap, rest);
-        const auto n_bounds = core::sh_value_quant::n_bounds_for_prims(n);
-        const auto n_bounds_cap = core::sh_value_quant::n_bounds_for_prims(cap);
-
-        // Prefer the model's backing allocator (exportable / Vulkan-external) so
-        // codes + bounds land in the shared block the viewer zero-copies.
-        Tensor u16 = splat.allocate_named_param(
-            TensorShape({n_cells}),
-            std::max(n_cells, capacity_cells),
-            DataType::Float16,
-            "SplatData.shN");
-        Tensor bounds = splat.allocate_named_param(
-            TensorShape({n_bounds * 2}),
-            std::max(n_bounds, n_bounds_cap) * 2,
-            DataType::Float32,
-            "SplatData.shN_value_bounds");
-        u16.set_name("splat.shN");
-        bounds.set_name("splat.shN_value_bounds");
-
-        // Source may be fp32 or IEEE f16 float4-swizzle. Stage to float for the
-        // encode kernel.
-        Tensor float_src = shN;
-        if (float_src.dtype() == DataType::Float16) {
-            float_src = float_src.to(DataType::Float32);
-        }
-        if (float_src.device() != Device::CUDA)
-            float_src = float_src.cuda();
-        if (!float_src.is_contiguous())
-            float_src = float_src.contiguous();
-
-        // Encode on the current training stream, then sync before releasing the
-        // float source to prevent a use-after-free before the next FastGS preprocess.
-        const cudaStream_t stream = core::getCurrentCUDAStream();
-        if (u16.stream() != stream)
-            u16.set_stream(stream);
-        if (bounds.stream() != stream)
-            bounds.set_stream(stream);
-        if (float_src.stream() != stream)
-            float_src.set_stream(stream);
-
-        lfs::core::sh_value_quant::encode_shN_float4_to_u16(
-            float_src.ptr<float>(),
-            reinterpret_cast<std::uint16_t*>(
-                lfs::core::resolve_exportable_device_ptr(u16)),
-            static_cast<float*>(lfs::core::resolve_exportable_device_ptr(bounds)),
-            n,
-            rest,
-            stream);
-        sync_codec_stream(stream);
-
-        shN = std::move(u16);
-        splat.shN_value_bounds() = std::move(bounds);
-        LOG_DEBUG("SH value quant applied: N={} cap={} rest={} cells={} bounds={}",
-                  n, cap, rest, n_cells, n_bounds);
-        return true;
+        return splat.apply_shN_value_quant();
     }
 
     bool ensure_shN_fp32_for_mutation(core::SplatData& splat) {
@@ -225,7 +153,7 @@ namespace lfs::training::sh_value {
         // Single-buffer: rebuild codes+bounds into the live exportable q16 region
         // (allocate_named_param). The caller must already own the mutation guard or
         // trainer render exclusive; this helper's marker only covers nested work.
-        return apply_shN_value_quant(splat);
+        return splat.apply_shN_value_quant();
     }
 
     ShNCommitGuard::~ShNCommitGuard() noexcept {

--- a/src/visualizer/rendering/vulkan_external_tensor.cpp
+++ b/src/visualizer/rendering/vulkan_external_tensor.cpp
@@ -381,10 +381,18 @@ namespace lfs::vis {
             std::shared_ptr<void> owner = sub_views[region];
             std::size_t clamped = capacity;
             if (region == R::ShN) {
-                dtype = lfs::core::DataType::Float16;
-                const std::size_t max_cells = region_bytes / sizeof(std::uint16_t);
-                if (max_cells > 0) {
-                    clamped = std::min(capacity, max_cells);
+                if (lfs::core::sh_value_quant::enabled()) {
+                    dtype = lfs::core::DataType::Float16;
+                    const std::size_t max_cells = region_bytes / sizeof(std::uint16_t);
+                    if (max_cells > 0) {
+                        clamped = std::min(capacity, max_cells);
+                    }
+                } else {
+                    dtype = lfs::core::DataType::Float32;
+                    const std::size_t max_floats = region_bytes / sizeof(float);
+                    if (max_floats > 0) {
+                        clamped = std::min(capacity, max_floats);
+                    }
                 }
             } else if (region == R::ShNBounds) {
                 dtype = lfs::core::DataType::Float32;

--- a/tests/test_exportable_storage.cpp
+++ b/tests/test_exportable_storage.cpp
@@ -1847,6 +1847,20 @@ namespace {
         EXPECT_TRUE(model.means_raw().has_exportable_provenance());
     }
 
+    void expect_exportable_float_shN(const SplatData& model, const size_t expected_n) {
+        EXPECT_EQ(static_cast<size_t>(model.size()), expected_n);
+        ASSERT_TRUE(model.shN_raw().is_valid());
+        EXPECT_GT(model.shN_raw().numel(), 0u);
+        EXPECT_EQ(model.shN_raw().dtype(), DataType::Float32);
+        EXPECT_FALSE(model.shN_value_quantized());
+        EXPECT_TRUE(model.shN_raw().has_exportable_provenance());
+        EXPECT_EQ(model.shN_raw().external_storage_kind(), "splat.exportable");
+        EXPECT_EQ(model.means_raw().external_storage_kind(), "splat.exportable");
+        EXPECT_TRUE(model.means_raw().has_exportable_provenance());
+        ASSERT_TRUE(model.shN_canonical().is_valid());
+        EXPECT_EQ(static_cast<size_t>(model.shN_canonical().size(0)), expected_n);
+    }
+
 } // namespace
 
 TEST(SplatExportableStorageTest, ConsolidateTwoModelsKeepsExportableQ16ShN) {
@@ -1952,4 +1966,153 @@ TEST(SplatExportableStorageTest, MigrateMergedModelsEncodesExportableQ16ShN) {
     expect_exportable_q16(*merged, kTotal);
 
     sh_value_quant::set_enabled_for_testing(std::nullopt);
+}
+
+TEST(SplatExportableStorageTest, ApplyDeletedKeepsExportableQ16ModelConsistent) {
+    require_cuda();
+    sh_value_quant::set_enabled_for_testing(true);
+
+    constexpr size_t kN = 96;
+    constexpr int kShDegree = 1;
+
+    auto model = make_cuda_sh_splat(kN, kShDegree, 0.25f);
+    auto storage_result = SplatExportableStorage::create(kN, kShDegree, 0, kN * 2);
+    if (!storage_result) {
+        sh_value_quant::set_enabled_for_testing(std::nullopt);
+        FAIL() << storage_result.error();
+    }
+    auto storage = std::make_shared<SplatExportableStorage>(std::move(*storage_result));
+    const auto migrated = lfs::io::migrateSplatTensorsToAllocator(*model, storage->make_allocator());
+    ASSERT_TRUE(migrated.has_value()) << migrated.error().format();
+    expect_exportable_q16(*model, kN);
+
+    std::vector<uint8_t> host_mask(kN, 0);
+    for (size_t i = 0; i < kN; i += 2) {
+        host_mask[i] = 1;
+    }
+    Tensor mask = Tensor::from_blob(host_mask.data(), {kN}, Device::CPU, DataType::Bool).to(Device::CUDA);
+    model->soft_delete(mask);
+    ASSERT_TRUE(model->has_deleted_mask());
+
+    const size_t removed = model->apply_deleted();
+    EXPECT_EQ(removed, kN / 2);
+    EXPECT_EQ(static_cast<size_t>(model->size()), kN / 2);
+    EXPECT_FALSE(model->has_deleted_mask());
+    EXPECT_EQ(model->sh0_raw().size(0), kN / 2);
+    EXPECT_EQ(model->scaling_raw().size(0), kN / 2);
+    EXPECT_EQ(model->rotation_raw().size(0), kN / 2);
+    EXPECT_EQ(model->opacity_raw().size(0), kN / 2);
+    expect_exportable_q16(*model, kN / 2);
+
+    const auto means_host = model->means_raw().to_vector();
+    ASSERT_EQ(means_host.size(), (kN / 2) * 3);
+    for (size_t i = 0; i < kN / 2; ++i) {
+        EXPECT_FLOAT_EQ(means_host[i * 3], static_cast<float>(2 * i + 1)) << "row " << i;
+    }
+
+    sh_value_quant::set_enabled_for_testing(std::nullopt);
+}
+
+TEST(SplatExportableStorageTest, ApplyDeletedThenMergeKeepsMaskLengthConsistent) {
+    require_cuda();
+    sh_value_quant::set_enabled_for_testing(true);
+
+    constexpr size_t kN = 64;
+    constexpr int kShDegree = 1;
+
+    auto model = make_cuda_sh_splat(kN, kShDegree, 0.25f);
+    auto storage_result = SplatExportableStorage::create(kN, kShDegree, 0, kN * 2);
+    if (!storage_result) {
+        sh_value_quant::set_enabled_for_testing(std::nullopt);
+        FAIL() << storage_result.error();
+    }
+    auto storage = std::make_shared<SplatExportableStorage>(std::move(*storage_result));
+    const auto migrated = lfs::io::migrateSplatTensorsToAllocator(*model, storage->make_allocator());
+    ASSERT_TRUE(migrated.has_value()) << migrated.error().format();
+    expect_exportable_q16(*model, kN);
+
+    std::vector<uint8_t> host_mask(kN, 0);
+    for (size_t i = 0; i < kN / 2; ++i) {
+        host_mask[i] = 1;
+    }
+    Tensor mask = Tensor::from_blob(host_mask.data(), {kN}, Device::CPU, DataType::Bool).to(Device::CUDA);
+    model->soft_delete(mask);
+    ASSERT_TRUE(model->has_deleted_mask());
+
+    const size_t removed = model->apply_deleted();
+    EXPECT_EQ(removed, kN / 2);
+    EXPECT_EQ(static_cast<size_t>(model->size()), kN / 2);
+    EXPECT_FALSE(model->has_deleted_mask());
+    EXPECT_EQ(static_cast<size_t>(model->means_raw().size(0)), kN / 2);
+    EXPECT_EQ(static_cast<size_t>(model->sh0_raw().size(0)), kN / 2);
+    EXPECT_EQ(static_cast<size_t>(model->scaling_raw().size(0)), kN / 2);
+    EXPECT_EQ(static_cast<size_t>(model->rotation_raw().size(0)), kN / 2);
+    EXPECT_EQ(static_cast<size_t>(model->opacity_raw().size(0)), kN / 2);
+    expect_exportable_q16(*model, kN / 2);
+
+    const auto means_host = model->means_raw().to_vector();
+    ASSERT_EQ(means_host.size(), (kN / 2) * 3);
+    for (size_t i = 0; i < kN / 2; ++i) {
+        EXPECT_FLOAT_EQ(means_host[i * 3], static_cast<float>(kN / 2 + i)) << "row " << i;
+    }
+
+    auto merged = Scene::mergeSplatsWithTransforms({{model.get(), glm::mat4{1.0f}}});
+    ASSERT_NE(merged, nullptr);
+    EXPECT_EQ(static_cast<size_t>(merged->size()), kN / 2);
+    EXPECT_FALSE(merged->has_deleted_mask());
+
+    sh_value_quant::set_enabled_for_testing(std::nullopt);
+}
+
+TEST(SplatExportableStorageTest, ApplyDeletedKeepsExportableFloatShNWhenQ16Disabled) {
+    require_cuda();
+    sh_value_quant::set_enabled_for_testing(false);
+    struct QuantFlagRestorer {
+        ~QuantFlagRestorer() { sh_value_quant::set_enabled_for_testing(std::nullopt); }
+    } restore_flag;
+
+    constexpr size_t kN = 96;
+    constexpr int kShDegree = 1;
+    constexpr float kShNFill = 0.25f;
+
+    auto model = make_cuda_sh_splat(kN, kShDegree, kShNFill);
+    auto storage_result = SplatExportableStorage::create(kN, kShDegree, 0, kN * 2);
+    if (!storage_result) {
+        FAIL() << storage_result.error();
+    }
+    auto storage = std::make_shared<SplatExportableStorage>(std::move(*storage_result));
+    const auto migrated = lfs::io::migrateSplatTensorsToAllocator(*model, storage->make_allocator());
+    ASSERT_TRUE(migrated.has_value()) << migrated.error().format();
+    expect_exportable_float_shN(*model, kN);
+
+    std::vector<uint8_t> host_mask(kN, 0);
+    for (size_t i = 0; i < kN; i += 2) {
+        host_mask[i] = 1;
+    }
+    Tensor mask = Tensor::from_blob(host_mask.data(), {kN}, Device::CPU, DataType::Bool).to(Device::CUDA);
+    model->soft_delete(mask);
+    ASSERT_TRUE(model->has_deleted_mask());
+
+    const size_t removed = model->apply_deleted();
+    EXPECT_EQ(removed, kN / 2);
+    EXPECT_EQ(static_cast<size_t>(model->size()), kN / 2);
+    EXPECT_FALSE(model->has_deleted_mask());
+    EXPECT_EQ(model->sh0_raw().size(0), kN / 2);
+    EXPECT_EQ(model->scaling_raw().size(0), kN / 2);
+    EXPECT_EQ(model->rotation_raw().size(0), kN / 2);
+    EXPECT_EQ(model->opacity_raw().size(0), kN / 2);
+    expect_exportable_float_shN(*model, kN / 2);
+
+    const auto means_host = model->means_raw().to_vector();
+    ASSERT_EQ(means_host.size(), (kN / 2) * 3);
+    for (size_t i = 0; i < kN / 2; ++i) {
+        EXPECT_FLOAT_EQ(means_host[i * 3], static_cast<float>(2 * i + 1)) << "row " << i;
+    }
+
+    const auto shN_host = model->shN_canonical().to_vector();
+    const auto rest = static_cast<size_t>(sh_rest_coefficients_for_degree(kShDegree));
+    ASSERT_EQ(shN_host.size(), (kN / 2) * rest * 3);
+    for (size_t i = 0; i < shN_host.size(); ++i) {
+        EXPECT_FLOAT_EQ(shN_host[i], kShNFill) << "shN canonical element " << i;
+    }
 }

--- a/tests/test_exportable_storage.cpp
+++ b/tests/test_exportable_storage.cpp
@@ -6,16 +6,19 @@
 #include "core/exportable_storage.hpp"
 #include "core/parameters.hpp"
 #include "core/point_cloud.hpp"
+#include "core/scene.hpp"
 #include "core/sh_value_quant.hpp"
 #include "core/shareable_allocation_limit.hpp"
 #include "core/splat_data.hpp"
 #include "core/splat_exportable_storage.hpp"
 #include "core/tensor.hpp"
 #include "diagnostics/vram_profiler.hpp"
+#include "io/loader.hpp"
 #include "training/optimizer/adam_optimizer.hpp"
 #include "training/training_setup.hpp"
 
 #include <cuda_runtime.h>
+#include <glm/mat4x4.hpp>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -24,6 +27,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -1788,4 +1792,164 @@ TEST(ExportableStorageTest, MakeVulkanExternalTensorShapedBlockSplitsChunksAndIs
     EXPECT_EQ(back[boundary - 1], pattern[boundary - 1]);
     EXPECT_EQ(back[boundary], pattern[boundary]);
     EXPECT_EQ(back[boundary + 1], pattern[boundary + 1]);
+}
+
+namespace {
+
+    std::unique_ptr<SplatData> make_cuda_sh_splat(const size_t n,
+                                                  const int sh_degree,
+                                                  const float shN_fill) {
+        const auto rest = static_cast<size_t>(sh_rest_coefficients_for_degree(sh_degree));
+        Tensor means = Tensor::zeros({n, size_t{3}}, Device::CUDA);
+        Tensor sh0 = Tensor::zeros({n, size_t{1}, size_t{3}}, Device::CUDA);
+        Tensor shN = rest > 0 ? Tensor::zeros({n, rest, size_t{3}}, Device::CUDA)
+                              : Tensor::zeros({0}, Device::CUDA);
+        Tensor scaling = Tensor::zeros({n, size_t{3}}, Device::CUDA);
+        Tensor rotation = Tensor::zeros({n, size_t{4}}, Device::CUDA);
+        Tensor opacity = Tensor::zeros({n, size_t{1}}, Device::CUDA);
+
+        std::vector<float> host_means(n * 3, 0.0f);
+        std::vector<float> host_rot(n * 4, 0.0f);
+        for (size_t i = 0; i < n; ++i) {
+            host_means[i * 3] = static_cast<float>(i);
+            host_rot[i * 4] = 1.0f;
+        }
+        EXPECT_EQ(cudaMemcpy(means.ptr<float>(), host_means.data(),
+                             host_means.size() * sizeof(float), cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        EXPECT_EQ(cudaMemcpy(rotation.ptr<float>(), host_rot.data(),
+                             host_rot.size() * sizeof(float), cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        if (rest > 0 && shN.is_valid()) {
+            shN.fill_(shN_fill);
+        }
+
+        return std::make_unique<SplatData>(sh_degree,
+                                           std::move(means),
+                                           std::move(sh0),
+                                           std::move(shN),
+                                           std::move(scaling),
+                                           std::move(rotation),
+                                           std::move(opacity),
+                                           1.0f);
+    }
+
+    void expect_exportable_q16(const SplatData& model, const size_t expected_n) {
+        EXPECT_EQ(static_cast<size_t>(model.size()), expected_n);
+        ASSERT_TRUE(model.shN_raw().is_valid());
+        EXPECT_GT(model.shN_raw().numel(), 0u);
+        EXPECT_TRUE(model.shN_value_quantized());
+        EXPECT_TRUE(model.shN_raw().has_exportable_provenance());
+        EXPECT_TRUE(model.shN_value_bounds().has_exportable_provenance());
+        EXPECT_EQ(model.shN_raw().external_storage_kind(), "splat.exportable");
+        EXPECT_EQ(model.shN_value_bounds().external_storage_kind(), "splat.exportable");
+        EXPECT_EQ(model.means_raw().external_storage_kind(), "splat.exportable");
+        EXPECT_TRUE(model.means_raw().has_exportable_provenance());
+    }
+
+} // namespace
+
+TEST(SplatExportableStorageTest, ConsolidateTwoModelsKeepsExportableQ16ShN) {
+    require_cuda();
+    sh_value_quant::set_enabled_for_testing(true);
+
+    constexpr size_t kN0 = 32;
+    constexpr size_t kN1 = 48;
+    constexpr size_t kTotal = kN0 + kN1;
+    constexpr int kShDegree = 1;
+
+    Scene scene;
+    scene.addSplat("A", make_cuda_sh_splat(kN0, kShDegree, 0.25f));
+    scene.addSplat("B", make_cuda_sh_splat(kN1, kShDegree, 0.50f));
+
+    auto storage_result = SplatExportableStorage::create(kTotal, kShDegree, 0, kTotal);
+    if (!storage_result) {
+        sh_value_quant::set_enabled_for_testing(std::nullopt);
+        FAIL() << storage_result.error();
+    }
+    auto storage = std::make_shared<SplatExportableStorage>(std::move(*storage_result));
+    scene.setCombinedModelAllocator(storage->make_allocator());
+
+    ASSERT_EQ(scene.consolidateNodeModels(), 2u);
+    ASSERT_TRUE(scene.isConsolidated());
+
+    const auto* combined = scene.getCombinedModel();
+    ASSERT_NE(combined, nullptr);
+    expect_exportable_q16(*combined, kTotal);
+
+    sh_value_quant::set_enabled_for_testing(std::nullopt);
+}
+
+TEST(SplatExportableStorageTest, CompactConsolidatedSnapshotKeepsExportableQ16ShN) {
+    require_cuda();
+    sh_value_quant::set_enabled_for_testing(true);
+
+    constexpr size_t kN0 = 32;
+    constexpr size_t kN1 = 48;
+    constexpr size_t kTotal = kN0 + kN1;
+    constexpr int kShDegree = 1;
+
+    Scene scene;
+    scene.addSplat("A", make_cuda_sh_splat(kN0, kShDegree, 0.25f));
+    scene.addSplat("B", make_cuda_sh_splat(kN1, kShDegree, 0.50f));
+
+    auto storage_result = SplatExportableStorage::create(kTotal, kShDegree, 0, kTotal);
+    if (!storage_result) {
+        sh_value_quant::set_enabled_for_testing(std::nullopt);
+        FAIL() << storage_result.error();
+    }
+    auto storage = std::make_shared<SplatExportableStorage>(std::move(*storage_result));
+    scene.setCombinedModelAllocator(storage->make_allocator());
+    ASSERT_EQ(scene.consolidateNodeModels(), 2u);
+
+    scene.removeNode("A");
+    auto snapshot = scene.captureConsolidatedCompaction();
+    ASSERT_TRUE(snapshot.has_value());
+
+    auto compact_storage_result = SplatExportableStorage::create(kN1, kShDegree, 0, kN1);
+    if (!compact_storage_result) {
+        sh_value_quant::set_enabled_for_testing(std::nullopt);
+        FAIL() << compact_storage_result.error();
+    }
+    auto compact_storage =
+        std::make_shared<SplatExportableStorage>(std::move(*compact_storage_result));
+    snapshot->allocator = compact_storage->make_allocator();
+
+    std::vector<Scene::ConsolidatedNodeSlot> compacted_slots;
+    auto compacted = Scene::compactConsolidatedSnapshot(*snapshot, compacted_slots);
+    ASSERT_NE(compacted, nullptr);
+    expect_exportable_q16(*compacted, kN1);
+    ASSERT_EQ(compacted_slots.size(), 1u);
+
+    sh_value_quant::set_enabled_for_testing(std::nullopt);
+}
+
+TEST(SplatExportableStorageTest, MigrateMergedModelsEncodesExportableQ16ShN) {
+    require_cuda();
+    sh_value_quant::set_enabled_for_testing(true);
+
+    constexpr size_t kN0 = 32;
+    constexpr size_t kN1 = 48;
+    constexpr size_t kTotal = kN0 + kN1;
+    constexpr int kShDegree = 1;
+
+    auto a = make_cuda_sh_splat(kN0, kShDegree, 0.25f);
+    auto b = make_cuda_sh_splat(kN1, kShDegree, 0.50f);
+    auto merged = Scene::mergeSplatsWithTransforms(
+        {{a.get(), glm::mat4{1.0f}}, {b.get(), glm::mat4{1.0f}}});
+    ASSERT_NE(merged, nullptr);
+    ASSERT_EQ(static_cast<size_t>(merged->size()), kTotal);
+    EXPECT_FALSE(merged->shN_value_quantized());
+
+    auto storage_result = SplatExportableStorage::create(kTotal, kShDegree, 0, kTotal);
+    if (!storage_result) {
+        sh_value_quant::set_enabled_for_testing(std::nullopt);
+        FAIL() << storage_result.error();
+    }
+    auto storage = std::make_shared<SplatExportableStorage>(std::move(*storage_result));
+    const auto migrated = lfs::io::migrateSplatTensorsToAllocator(*merged, storage->make_allocator());
+    ASSERT_TRUE(migrated.has_value()) << migrated.error().format();
+    expect_exportable_q16(*merged, kTotal);
+
+    sh_value_quant::set_enabled_for_testing(std::nullopt);
 }

--- a/tests/test_shareable_allocation_limit.cpp
+++ b/tests/test_shareable_allocation_limit.cpp
@@ -105,6 +105,12 @@ namespace {
         });
     }
 
+    [[nodiscard]] bool called_for_q16_shN(const std::vector<AllocCall>& calls) {
+        return std::any_of(calls.begin(), calls.end(), [](const AllocCall& call) {
+            return call.name == "SplatData.shN" && call.dtype == DataType::Float16;
+        });
+    }
+
     [[nodiscard]] bool called_for(const std::vector<AllocCall>& calls, const std::string_view name) {
         return std::any_of(calls.begin(), calls.end(), [&](const AllocCall& call) {
             return call.name == name;
@@ -196,7 +202,7 @@ TEST(ShareableAllocationLimitTest, ViolationMessageIncludesNumbers) {
     EXPECT_TRUE(is_shareable_allocation_limit_message(*message));
 }
 
-TEST(ShareableAllocationLimitTest, MigrateRequestsFloatShNRegardlessOfLimit) {
+TEST(ShareableAllocationLimitTest, MigrateEncodesQ16ShNUnderShareableLimit) {
     require_cuda();
     const auto ply_path = std::filesystem::path(PROJECT_ROOT_PATH) / "gd.ply";
     if (!std::filesystem::exists(ply_path)) {
@@ -219,11 +225,14 @@ TEST(ShareableAllocationLimitTest, MigrateRequestsFloatShNRegardlessOfLimit) {
     EXPECT_TRUE(called_for(calls, "SplatData.scaling"));
     EXPECT_TRUE(called_for(calls, "SplatData.rotation"));
     EXPECT_TRUE(called_for(calls, "SplatData.opacity"));
-    EXPECT_TRUE(called_for_float_shN(calls));
+    EXPECT_FALSE(called_for_float_shN(calls));
+    EXPECT_TRUE(called_for_q16_shN(calls));
+    EXPECT_TRUE(called_for(calls, "SplatData.shN_value_bounds"));
+    EXPECT_TRUE(model.shN_value_quantized());
     EXPECT_TRUE(lfs::io::splatTensorsRendererReady(model));
 }
 
-TEST(ShareableAllocationLimitTest, MigrateRequestsFloatShNWithoutLimit) {
+TEST(ShareableAllocationLimitTest, MigrateEncodesQ16ShNWithoutLimit) {
     require_cuda();
     const auto ply_path = std::filesystem::path(PROJECT_ROOT_PATH) / "gd.ply";
     if (!std::filesystem::exists(ply_path)) {
@@ -239,6 +248,9 @@ TEST(ShareableAllocationLimitTest, MigrateRequestsFloatShNWithoutLimit) {
     std::vector<AllocCall> calls;
     const auto result = lfs::io::migrateSplatTensorsToAllocator(model, recording_allocator(calls));
     ASSERT_TRUE(result.has_value()) << result.error().format();
-    EXPECT_TRUE(called_for_float_shN(calls));
+    EXPECT_FALSE(called_for_float_shN(calls));
+    EXPECT_TRUE(called_for_q16_shN(calls));
+    EXPECT_TRUE(called_for(calls, "SplatData.shN_value_bounds"));
+    EXPECT_TRUE(model.shN_value_quantized());
     EXPECT_TRUE(lfs::io::splatTensorsRendererReady(model));
 }


### PR DESCRIPTION
Two fixes for models the viewer builds or rewrites itself.

**Folder load (`-v <dir>`).** Consolidating the nodes into one combined model gave it the exportable allocator but kept shN as a float workspace outside Vulkan-external storage, so VkSplat refused to bind it (`refusing full input-copy fallback ... missing_shN+non_external_float_shN_workspace`) and the viewport froze on the last good image. Any folder with 2+ PLYs reproduced it. The q16 encode that loaded PLYs and training commits already used now lives on `SplatData::apply_shN_value_quant()` and runs for the consolidated model, the compacted consolidation snapshot and the loader migration.

**Delete/crop compaction (`apply_deleted`).** On any loaded model it faulted on the device: the compacted means were committed before the rest-SH gather, so `shN_canonical()` sized itself from the new count and the kept row ids were out of range, leaving the model half compacted (a following duplicate then failed a mask-length contract). The gathers also wrote into allocator views aliasing the live exportable regions, and the rebuilt shN left Vulkan-external storage. Now every attribute is gathered into pooled tensors first, then homed into the allocator with shN re-encoded as q16 (or kept as exportable float when quantization is off); handles are restored if anything throws. Mirror, `random_choose` and the crop/extract copies get the same shN treatment. The quantization test flag moved into `lfs_core` so it is process-wide across DSOs.

Tests: consolidation, compacted snapshot, merge+migrate, `apply_deleted` on exportable q16 and on q16-off models, compaction followed by merge; memcheck clean on the new tests. GUI: 3-file and 10 x 1M-splat folders load and render; compaction of 137k and 3M models succeeds and the result duplicates; an MCP matrix over writes/undo/duplicate/merge/mirror/bake/.licht open/training-time attribute edits shows zero degraded-mode lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tQT3mHi3L9QBzWMbXnJpa
