### PR TITLE
Create a new project UUID when using Save As

### DIFF
--- a/src/io/include/io/project_container.hpp
+++ b/src/io/include/io/project_container.hpp
@@ -523,6 +523,10 @@ namespace lfs::io::project {
     struct CompactionOptions {
         ReaderOptions compatibility;
         lfs::core::Uuid new_file_uuid;
+        // Save As staging may replace the project identity before rewriting
+        // the project-keyed singleton chapters. Ordinary compaction leaves
+        // this null and preserves the source project UUID.
+        lfs::core::Uuid new_project_uuid = {};
         lfs::core::Uuid commit_uuid;
         lfs::core::Uuid snapshot_uuid;
         std::uint64_t creation_time_unix_ns = 0;

--- a/src/io/include/io/project_document.hpp
+++ b/src/io/include/io/project_document.hpp
@@ -86,6 +86,9 @@ namespace lfs::io::project {
     struct ProjectDocumentSaveOptions {
         CommitOptions commit;
         lfs::core::Uuid file_uuid;
+        // A titled-project Save As uses a new catalog identity. Leave null
+        // for ordinary saves, recovery publication, and first save.
+        lfs::core::Uuid save_as_project_uuid = {};
         IndexCompression index_compression = IndexCompression::Zstd;
         std::uint64_t disk_reserve_bytes = 64ull * 1024 * 1024;
         // Only a file-dialog-confirmed Save As may replace a first-save destination.
@@ -313,9 +316,10 @@ namespace lfs::io::project {
         [[nodiscard]] lfs::Result<ProjectDocumentSaveReport>
         save(const std::filesystem::path& path,
              const ProjectDocumentSaveOptions& options = {});
-        // Publishes a compacted sibling with a new file UUID, preserving the
-        // project UUID and all clean/unloaded payloads. An existing
-        // destination is atomically replaced only after staged verification.
+        // Publishes a compacted sibling with a new file UUID and all
+        // clean/unloaded payloads. save_as_project_uuid optionally assigns a
+        // new project identity. An existing destination is atomically
+        // replaced only after staged verification.
         [[nodiscard]] lfs::Result<ProjectDocumentSaveReport>
         save_as(const std::filesystem::path& path,
                 const ProjectDocumentSaveOptions& options = {});

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -3526,6 +3526,13 @@ namespace lfs::io::project {
             return save(*normalized, options);
         }
 
+        const auto original_project_uuid =
+            impl_->project_uuid;
+        const auto save_as_project_uuid =
+            options.save_as_project_uuid.is_nil()
+                ? original_project_uuid
+                : options.save_as_project_uuid;
+
         std::optional<detail::WriterLock>
             destination_lock;
         if (options.writer_lock_lease) {
@@ -3608,6 +3615,8 @@ namespace lfs::io::project {
                               ->reader_options()
                         : ReaderOptions{},
                 .new_file_uuid = file_uuid,
+                .new_project_uuid =
+                    save_as_project_uuid,
                 .commit_uuid =
                     options.save_as_compaction_commit_uuid.is_nil()
                         ? lfs::core::generate_uuid_v4()
@@ -3625,24 +3634,33 @@ namespace lfs::io::project {
         }
 
         const auto rebind_preserving_dirty_lazy =
-            [this, &original_dirty,
-             &original_normalized_source_keys](
-                const std::filesystem::path& source)
+            [this](
+                const std::filesystem::path& source,
+                const lfs::core::Uuid& project_uuid,
+                const auto& preserved_dirty,
+                const auto& preserved_normalized_source_keys)
             -> lfs::Result<void> {
+            auto rebound_project = impl_->project;
+            if (auto updated =
+                    rebound_project.set_project_uuid(
+                        project_uuid);
+                !updated) {
+                return updated;
+            }
             std::unordered_map<lfs::core::Uuid, LazyChunkValue>
                 dirty_checkpoints;
             std::unordered_map<lfs::core::Uuid, LazyChunkValue>
                 dirty_ppisp;
             const auto extract_dirty =
-                [&original_dirty](auto& from, auto& to,
-                                  const Fourcc fourcc) {
+                [&preserved_dirty](auto& from, auto& to,
+                                   const Fourcc fourcc) {
                     for (auto iterator = from.begin();
                          iterator != from.end();) {
                         const ChunkKey key{
                             .fourcc = fourcc,
                             .instance_uuid = iterator->first,
                         };
-                        if (!original_dirty.contains(key)) {
+                        if (!preserved_dirty.contains(key)) {
                             ++iterator;
                             continue;
                         }
@@ -3679,9 +3697,9 @@ namespace lfs::io::project {
                     impl_->ppisp_payloads.insert_or_assign(
                         uuid, std::move(payload));
                 }
-                impl_->dirty = original_dirty;
+                impl_->dirty = preserved_dirty;
                 impl_->normalized_source_keys =
-                    original_normalized_source_keys;
+                    preserved_normalized_source_keys;
                 return refreshed;
             }
             for (auto& [uuid, payload] : dirty_checkpoints) {
@@ -3693,10 +3711,10 @@ namespace lfs::io::project {
                     uuid, std::move(payload));
             }
             const auto erase_recorded_removals =
-                [&original_dirty](auto& payloads,
-                                  const auto& preserved,
-                                  const Fourcc fourcc) {
-                    for (const auto& key : original_dirty) {
+                [&preserved_dirty](auto& payloads,
+                                   const auto& preserved,
+                                   const Fourcc fourcc) {
+                    for (const auto& key : preserved_dirty) {
                         if (key.fourcc == fourcc &&
                             !preserved.contains(
                                 key.instance_uuid)) {
@@ -3710,14 +3728,28 @@ namespace lfs::io::project {
             erase_recorded_removals(
                 impl_->ppisp_payloads, dirty_ppisp,
                 FOURCC_PPIS);
-            impl_->dirty = original_dirty;
+            impl_->project = std::move(rebound_project);
+            impl_->project_uuid = project_uuid;
+            impl_->dirty = preserved_dirty;
             impl_->normalized_source_keys =
-                original_normalized_source_keys;
+                preserved_normalized_source_keys;
             return {};
+        };
+        const auto restore_original_document =
+            [&]() -> lfs::Result<void> {
+            return rebind_preserving_dirty_lazy(
+                original_path,
+                original_project_uuid,
+                original_dirty,
+                original_normalized_source_keys);
         };
 
         if (auto rebound =
-                rebind_preserving_dirty_lazy(temporary);
+                rebind_preserving_dirty_lazy(
+                    temporary,
+                    save_as_project_uuid,
+                    original_dirty,
+                    original_normalized_source_keys);
             !rebound) {
             remove_temporary();
             return std::move(rebound).error();
@@ -3729,7 +3761,7 @@ namespace lfs::io::project {
         if (!saved) {
             auto save_error = std::move(saved).error();
             auto restored =
-                rebind_preserving_dirty_lazy(original_path);
+                restore_original_document();
             remove_temporary();
             if (!restored) {
                 return std::move(save_error).with_suppressed(std::move(restored).error());
@@ -3759,8 +3791,7 @@ namespace lfs::io::project {
         }
         if (staged_failure) {
             auto restored =
-                rebind_preserving_dirty_lazy(
-                    original_path);
+                restore_original_document();
             remove_temporary();
             if (!restored) {
                 return std::move(*staged_failure)
@@ -3773,7 +3804,7 @@ namespace lfs::io::project {
         auto post_save_dirty = impl_->dirty;
         auto post_save_keys = impl_->normalized_source_keys;
         if (auto rebound =
-                rebind_preserving_dirty_lazy(original_path);
+                restore_original_document();
             !rebound) {
             remove_temporary();
             return std::move(rebound).error();
@@ -3826,13 +3857,25 @@ namespace lfs::io::project {
             }
             return cause;
         }
-        if (auto refreshed =
-                impl_->refresh_source_rows(*normalized);
-            !refreshed) {
-            return std::move(refreshed).error();
+        if (auto rebound =
+                rebind_preserving_dirty_lazy(
+                    *normalized,
+                    save_as_project_uuid,
+                    post_save_dirty,
+                    post_save_keys);
+            !rebound) {
+            auto cause = std::move(rebound).error();
+            auto rollback =
+                detail::rollback_atomic_replace(
+                    *replacement, *normalized);
+            if (!rollback) {
+                cause = std::move(cause)
+                            .with_suppressed(
+                                std::move(rollback)
+                                    .error());
+            }
+            return cause;
         }
-        impl_->dirty = std::move(post_save_dirty);
-        impl_->normalized_source_keys = std::move(post_save_keys);
         if (auto finished =
                 detail::finish_atomic_replace(
                     *replacement, *normalized);

--- a/src/io/project/project_writer.cpp
+++ b/src/io/project/project_writer.cpp
@@ -3152,7 +3152,10 @@ namespace lfs::io::project {
         impl->superblock = SuperblockInfo{
             .format = CURRENT_CONTAINER_VERSION,
             .role = ContainerRole::Master,
-            .project_uuid = source_result->superblock().project_uuid,
+            .project_uuid =
+                options.new_project_uuid.is_nil()
+                    ? source_result->superblock().project_uuid
+                    : options.new_project_uuid,
             .file_uuid = *file_uuid,
             .creation_time_unix_ns =
                 options.creation_time_unix_ns != 0

--- a/src/training/project_snapshot_chapters.hpp
+++ b/src/training/project_snapshot_chapters.hpp
@@ -36,6 +36,7 @@ namespace lfs::training {
     // inheriting an unrelated destination project's identity.
     struct ProjectSnapshotDocumentContext {
         lfs::core::Uuid project_uuid;
+        lfs::core::Uuid save_as_project_uuid = {};
         std::optional<std::filesystem::path>
             source_path;
         lfs::io::project::ProjectChapter project;

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -5002,6 +5002,11 @@ namespace lfs::training {
                                     .file_uuid =
                                         lfs::core::
                                             generate_uuid_v4(),
+                                    .save_as_project_uuid =
+                                        document_context
+                                            ? document_context
+                                                  ->save_as_project_uuid
+                                            : lfs::core::Uuid{},
                                     .allow_existing_destination_replacement =
                                         document_context &&
                                         document_context

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -5796,6 +5796,19 @@ namespace lfs::vis::project {
             return lfs::Status::failure(
                 std::move(normalized).error());
         }
+        lfs::core::Uuid save_as_project_uuid;
+        const auto current_project_path =
+            recovered_master_path_
+                ? recovered_master_path_
+                : document_->source_path();
+        if (hasSourcePath() &&
+            current_project_path &&
+            current_project_path
+                    ->lexically_normal() !=
+                normalized->lexically_normal()) {
+            save_as_project_uuid =
+                lfs::core::generate_uuid_v4();
+        }
         if (auto* trainer = viewer_.getTrainer();
             trainer &&
             viewer_.getTrainerManager() &&
@@ -5834,6 +5847,8 @@ namespace lfs::vis::project {
             }
             context->allow_existing_destination_replacement =
                 allow_existing_destination_replacement;
+            context->save_as_project_uuid =
+                save_as_project_uuid;
             std::vector<std::byte> preview;
             if (regenerate_preview) {
                 auto captured =
@@ -5906,6 +5921,8 @@ namespace lfs::vis::project {
                     },
                 .file_uuid =
                     lfs::core::generate_uuid_v4(),
+                .save_as_project_uuid =
+                    save_as_project_uuid,
                 .index_compression =
                     lfs::io::project::
                         IndexCompression::Zstd,

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -396,6 +396,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_PostTrainingProjectSaveRestoresCameraEnabledAndHidden_Test;
         friend class VisualizerImplResetTest_CaptureOmitsPlySequenceClipAndCollapsedUuid_Test;
         friend class VisualizerImplResetTest_AssetManagerProjectRestorePreservesLeftDockWidth_Test;
+        friend class VisualizerImplResetTest_SaveAsAssignsNewProjectIdentity_Test;
 
         // Allow ToolContext to access GUI manager for logging
         friend class ToolContext;

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -2349,6 +2349,99 @@ namespace {
     }
 
     TEST(ProjectDocumentTest,
+         SaveAsCanAssignNewProjectIdentityAndRekeySingletons) {
+        TemporaryDirectory temporary;
+        const auto source =
+            temporary.path / "identity-source.licht";
+        const auto destination =
+            temporary.path / "identity-destination.licht";
+        write_phase_a_fixture(source);
+
+        auto document = require_result_ptr(ProjectDocument::open(
+            source,
+            ProjectDocumentOpenOptions{
+                .defer_geometry_payloads = true,
+            }));
+        const auto original_project_uuid =
+            document->project_uuid();
+        const auto new_project_uuid =
+            fixed_uuid(1011);
+        ASSERT_NE(
+            original_project_uuid,
+            new_project_uuid);
+        auto options = save_options(1010, 600);
+        options.save_as_project_uuid =
+            new_project_uuid;
+
+        auto saved = document->save_as(
+            destination, options);
+        ASSERT_TRUE(saved)
+            << lfs::format_for_developer(
+                   saved.error());
+        EXPECT_EQ(
+            document->project_uuid(),
+            new_project_uuid);
+
+        auto source_reader = require_result(
+            ProjectReader::open(source));
+        auto destination_reader = require_result(
+            ProjectReader::open(destination));
+        EXPECT_EQ(
+            source_reader.superblock().project_uuid,
+            original_project_uuid);
+        EXPECT_EQ(
+            destination_reader.superblock().project_uuid,
+            new_project_uuid);
+
+        const std::array singleton_fourccs{
+            FOURCC_PROJ,
+            FOURCC_REFS,
+            FOURCC_SCNG,
+            FOURCC_SELM,
+            FOURCC_PRMS,
+            FOURCC_GUIL,
+            FOURCC_VIEW,
+            FOURCC_EDTR,
+            FOURCC_SEQR,
+            FOURCC_METR,
+        };
+        for (const auto fourcc : singleton_fourccs) {
+            EXPECT_NE(
+                destination_reader.find(
+                    fourcc, new_project_uuid),
+                nullptr)
+                << fourcc.to_string();
+            EXPECT_EQ(
+                destination_reader.find(
+                    fourcc, original_project_uuid),
+                nullptr)
+                << fourcc.to_string();
+        }
+        EXPECT_NE(
+            destination_reader.find(
+                FOURCC_SPLT, fixed_uuid(952)),
+            nullptr);
+        EXPECT_NE(
+            destination_reader.find(
+                FOURCC_PCLD, fixed_uuid(953)),
+            nullptr);
+        EXPECT_NE(
+            destination_reader.find(
+                FOURCC_MESH, fixed_uuid(954)),
+            nullptr);
+
+        auto reopened = require_result_ptr(
+            ProjectDocument::open(destination));
+        EXPECT_EQ(
+            reopened->project_uuid(),
+            new_project_uuid);
+        auto chapter_uuid =
+            reopened->project().project_uuid();
+        ASSERT_TRUE(chapter_uuid);
+        EXPECT_EQ(*chapter_uuid, new_project_uuid);
+    }
+
+    TEST(ProjectDocumentTest,
          FirstSaveExplicitlyReplacesForeignDestinationAtomically) {
         TemporaryDirectory temporary;
         const auto destination = temporary.path / "destination.licht";
@@ -4017,10 +4110,20 @@ namespace {
         auto document =
             require_result_ptr(ProjectDocument::open(source));
         auto options = save_options(9970, 500);
+        options.save_as_project_uuid =
+            fixed_uuid(9971);
         options.disk_reserve_bytes =
             std::numeric_limits<std::uint64_t>::max() / 2;
         auto saved = document->save_as(destination, options);
         ASSERT_FALSE(saved);
+        EXPECT_EQ(
+            document->project_uuid(),
+            fixed_uuid(950));
+        ASSERT_TRUE(document->source_path());
+        EXPECT_EQ(
+            *document->source_path(),
+            std::filesystem::absolute(source)
+                .lexically_normal());
         EXPECT_FALSE(fs::exists(destination));
         auto destination_lock = destination;
         destination_lock += ".lock";

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -2406,15 +2406,13 @@ namespace {
             FOURCC_METR,
         };
         for (const auto fourcc : singleton_fourccs) {
-            EXPECT_NE(
-                destination_reader.find(
-                    fourcc, new_project_uuid),
-                nullptr)
-                << fourcc.to_string();
-            EXPECT_EQ(
-                destination_reader.find(
-                    fourcc, original_project_uuid),
-                nullptr)
+            const auto* rekeyed = destination_reader.find(
+                fourcc, new_project_uuid);
+            ASSERT_NE(rekeyed, nullptr) << fourcc.to_string();
+            EXPECT_TRUE(rekeyed->is_live()) << fourcc.to_string();
+            const auto* stale = destination_reader.find(
+                fourcc, original_project_uuid);
+            EXPECT_TRUE(!stale || !stale->is_live())
                 << fourcc.to_string();
         }
         EXPECT_NE(

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -6374,6 +6374,71 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
+           SaveAsAssignsNewProjectIdentity) {
+        const auto source_path =
+            temporary_.path / "identity-source.licht";
+        const auto destination =
+            temporary_.path / "identity-save-as.licht";
+        write_empty_project(source_path);
+        auto source_before =
+            lfs::test::licht::require_result(
+                lfs::io::project::ProjectReader::open(
+                    source_path));
+        const auto original_project_uuid =
+            source_before.superblock().project_uuid;
+
+        VisualizerImpl viewer(projectOptions());
+        ASSERT_TRUE(
+            viewer.getParameterManager()
+                ->ensureLoaded());
+        viewer.input_controller_ =
+            std::make_unique<InputController>(
+                nullptr, viewer.getViewport());
+        ASSERT_TRUE(viewer.projectOpen(
+            source_path,
+            ProjectSwitchDisposition::DiscardChanges));
+        ASSERT_TRUE(waitForHydrationComplete(
+            viewer, viewer.work_queue_mutex_,
+            viewer.work_queue_));
+
+        ASSERT_TRUE(viewer.projectSaveAs(
+            destination, false));
+        ASSERT_TRUE(pumpUntil(
+            viewer.work_queue_mutex_,
+            viewer.work_queue_, [&] {
+                return !viewer.jobs().anyRunning(
+                    JobType::ProjectWrite);
+            }));
+
+        const auto info = viewer.projectGetInfo();
+        ASSERT_TRUE(info)
+            << lfs::format_for_developer(
+                   info.error());
+        ASSERT_TRUE(info->path);
+        EXPECT_EQ(
+            info->path->lexically_normal(),
+            destination.lexically_normal());
+        EXPECT_NE(
+            info->project_uuid,
+            original_project_uuid.to_string());
+
+        auto source_after =
+            lfs::test::licht::require_result(
+                lfs::io::project::ProjectReader::open(
+                    source_path));
+        auto saved_as =
+            lfs::test::licht::require_result_ptr(
+                lfs::io::project::ProjectDocument::open(
+                    destination));
+        EXPECT_EQ(
+            source_after.superblock().project_uuid,
+            original_project_uuid);
+        EXPECT_EQ(
+            saved_as->project_uuid().to_string(),
+            info->project_uuid);
+    }
+
+    TEST_F(VisualizerImplResetTest,
            SaveAsAndExitClearsParameterDirtyBaseline) {
         const auto source_path = temporary_.path / "parameter-source.licht";
         const auto destination = temporary_.path / "parameter-save-as.licht";


### PR DESCRIPTION
## Summary

- assign a new project UUID when a titled project is saved to a different path, allowing Asset Manager to catalog both files
- rekey project singleton chapters while preserving UUIDs for first saves, same-path saves, and recovery publication
- carry the new identity through live-training snapshot saves and keep document rebinding transactional
- add document-level and visualizer regression coverage

## Testing

- CMAKE_BUILD_PARALLEL_LEVEL=22 cmake -B cmake-build-release -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF -DLFS_VCPKG_MAX_CONCURRENCY=22 -DLFS_CUDA_COMPILER_CACHE=OFF
- cmake --build cmake-build-release -j22
- manual Asset Manager Save As workflow

Fixes #1852
