### PR TITLE
Add loss visualization to GT Compare mode

### DIFF
--- a/src/python/lfs/py_rendering.cpp
+++ b/src/python/lfs/py_rendering.cpp
@@ -809,7 +809,7 @@ namespace lfs::python {
                      {{"Color", "palette", 0}, {"Gray", "gray", 1}}, 0);
         add_int_enum(&Proxy::gt_comparison_mode, "gt_comparison_mode", "GT Compare",
                      "Ground-truth comparison payload",
-                     {{"RGB", "rgb", 0}, {"Normal", "normal", 1}, {"Depth", "depth", 2}}, 0);
+                     {{"RGB", "rgb", 0}, {"Normal", "normal", 1}, {"Depth", "depth", 2}, {"Loss", "loss", 3}}, 0);
         add_int_enum(&Proxy::camera_metrics_mode, "camera_metrics_mode", "Camera Metrics",
                      "Compute metrics when jumping to a source camera",
                      {{"Off", "OFF", 0}, {"PSNR", "PSNR", 1}, {"PSNR + SSIM", "PSNR_SSIM", 2}}, 0);

--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -4128,11 +4128,12 @@ namespace lfs::python {
                 switch (rm->getSettings().gt_comparison_mode) {
                 case vis::GTComparisonMode::Normal: return "normal";
                 case vis::GTComparisonMode::Depth: return "depth";
+                case vis::GTComparisonMode::Loss: return "loss";
                 case vis::GTComparisonMode::RGB:
                 default: return "rgb";
                 }
             },
-            "Get ground-truth comparison mode: rgb, normal, or depth.");
+            "Get ground-truth comparison mode: rgb, normal, depth, or loss.");
 
         m.def(
             "set_gt_comparison_mode",
@@ -4147,8 +4148,10 @@ namespace lfs::python {
                     settings.gt_comparison_mode = vis::GTComparisonMode::Normal;
                 } else if (mode == "depth") {
                     settings.gt_comparison_mode = vis::GTComparisonMode::Depth;
+                } else if (mode == "loss") {
+                    settings.gt_comparison_mode = vis::GTComparisonMode::Loss;
                 } else {
-                    throw nb::value_error("GT comparison mode must be 'rgb', 'normal', or 'depth'");
+                    throw nb::value_error("GT comparison mode must be 'rgb', 'normal', 'depth', or 'loss'");
                 }
                 rm->updateSettings(settings, vis::DirtyFlag::ALL);
             },
@@ -4169,6 +4172,9 @@ namespace lfs::python {
                     settings.gt_comparison_mode = vis::GTComparisonMode::Depth;
                     break;
                 case vis::GTComparisonMode::Depth:
+                    settings.gt_comparison_mode = vis::GTComparisonMode::Loss;
+                    break;
+                case vis::GTComparisonMode::Loss:
                 default:
                     settings.gt_comparison_mode = vis::GTComparisonMode::RGB;
                     break;
@@ -4177,11 +4183,12 @@ namespace lfs::python {
                 switch (settings.gt_comparison_mode) {
                 case vis::GTComparisonMode::Normal: return "normal";
                 case vis::GTComparisonMode::Depth: return "depth";
+                case vis::GTComparisonMode::Loss: return "loss";
                 case vis::GTComparisonMode::RGB:
                 default: return "rgb";
                 }
             },
-            "Cycle ground-truth comparison mode: rgb -> normal -> depth -> rgb.");
+            "Cycle ground-truth comparison mode: rgb -> normal -> depth -> loss -> rgb.");
 
         m.def(
             "reveal_in_file_manager",

--- a/src/python/lfs_plugins/gt_compare_controls.py
+++ b/src/python/lfs_plugins/gt_compare_controls.py
@@ -8,6 +8,7 @@ from .ui import RuntimeState
 
 
 _DEFAULT_MODE = "rgb"
+_DEFAULT_DEPTH_MODE = "palette"
 
 
 def _ui_label(key: str, fallback: str) -> str:
@@ -34,16 +35,23 @@ def _normalize_mode(value):
     return _DEFAULT_MODE
 
 
+def _normalize_depth_mode(value):
+    value = str(value or "").strip().lower()
+    return "gray" if value in {"gray", "grayscale"} else _DEFAULT_DEPTH_MODE
+
+
 class GTCompareControlsController:
     _DIRTY_FIELDS = (
         "gt_compare_tool_label",
         "gt_compare_mode_value",
+        "gt_compare_depth_mode_value",
     )
 
     def __init__(self):
         self._handle = None
         self._visible = False
         self._mode = _DEFAULT_MODE
+        self._depth_mode = _DEFAULT_DEPTH_MODE
         self._last_state_key = None
 
     @property
@@ -57,6 +65,7 @@ class GTCompareControlsController:
             lambda: self._mode,
             self._set_mode,
         )
+        model.bind_func("gt_compare_depth_mode_value", lambda: self._depth_mode)
         self._handle = model.get_handle()
 
     def mount(self, doc):
@@ -84,7 +93,8 @@ class GTCompareControlsController:
             return ",".join(dirty_reasons) if dirty else None
 
         self._mode = self._read_mode()
-        state_key = (RuntimeState.language_generation.value, self._mode)
+        self._depth_mode = self._read_depth_mode()
+        state_key = (RuntimeState.language_generation.value, self._mode, self._depth_mode)
         if state_key != self._last_state_key:
             self._last_state_key = state_key
             self._dirty_all()
@@ -127,6 +137,15 @@ class GTCompareControlsController:
         else:
             self._mode = _DEFAULT_MODE
         self._dirty_all()
+
+    def _read_depth_mode(self):
+        getter = getattr(lf, "get_depth_view_mode", None)
+        if not callable(getter):
+            return _DEFAULT_DEPTH_MODE
+        try:
+            return _normalize_depth_mode(getter())
+        except Exception:
+            return _DEFAULT_DEPTH_MODE
 
     def _dirty_all(self):
         if not self._handle:

--- a/src/python/lfs_plugins/gt_compare_controls.py
+++ b/src/python/lfs_plugins/gt_compare_controls.py
@@ -29,6 +29,8 @@ def _normalize_mode(value):
         return "normal"
     if value == "depth":
         return "depth"
+    if value == "loss":
+        return "loss"
     return _DEFAULT_MODE
 
 

--- a/src/python/stubs/lichtfeld/ui/__init__.pyi
+++ b/src/python/stubs/lichtfeld/ui/__init__.pyi
@@ -2192,13 +2192,15 @@ def is_gt_comparison_active() -> bool:
     """
 
 def get_gt_comparison_mode() -> str:
-    """Get ground-truth comparison mode: rgb, normal, or depth."""
+    """Get ground-truth comparison mode: rgb, normal, depth, or loss."""
 
 def set_gt_comparison_mode(mode: str) -> None:
     """Set ground-truth comparison mode."""
 
 def cycle_gt_comparison_mode() -> str:
-    """Cycle ground-truth comparison mode: rgb -> normal -> depth -> rgb."""
+    """
+    Cycle ground-truth comparison mode: rgb -> normal -> depth -> loss -> rgb.
+    """
 
 def reveal_in_file_manager(path: str) -> bool:
     """

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1109,7 +1109,7 @@
     "depth_view_tool": "Aktive Tiefenkartenansicht",
     "depth_view_mode": "Farbmodus der Tiefenkarte wählen",
     "gt_compare_mode": "RGB-, Normalen-, Tiefen- oder Verlustvisualisierung auswählen",
-    "gt_loss_match": "Übereinstimmung (0)",
+    "gt_loss_lower_error": "Niedrigerer Fehler",
     "gt_loss_higher_error": "Höherer Fehler",
     "depth_view_range": "Visualisierungsbereich der Tiefenkarte",
     "depth_view_near": "Nahe Grenze des Tiefenkartenbereichs",

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1108,7 +1108,7 @@
     "depth_view_panel": "Tiefenkarten-Steuerung",
     "depth_view_tool": "Aktive Tiefenkartenansicht",
     "depth_view_mode": "Farbmodus der Tiefenkarte wählen",
-    "gt_compare_mode": "RGB-, Normalen- oder Tiefen-Referenzvergleich auswählen",
+    "gt_compare_mode": "RGB-, Normalen-, Tiefen- oder Verlustvisualisierung auswählen",
     "depth_view_range": "Visualisierungsbereich der Tiefenkarte",
     "depth_view_near": "Nahe Grenze des Tiefenkartenbereichs",
     "depth_view_far": "Ferne Grenze des Tiefenkartenbereichs",

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -1109,6 +1109,8 @@
     "depth_view_tool": "Aktive Tiefenkartenansicht",
     "depth_view_mode": "Farbmodus der Tiefenkarte wählen",
     "gt_compare_mode": "RGB-, Normalen-, Tiefen- oder Verlustvisualisierung auswählen",
+    "gt_loss_match": "Übereinstimmung (0)",
+    "gt_loss_higher_error": "Höherer Fehler",
     "depth_view_range": "Visualisierungsbereich der Tiefenkarte",
     "depth_view_near": "Nahe Grenze des Tiefenkartenbereichs",
     "depth_view_far": "Ferne Grenze des Tiefenkartenbereichs",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1109,7 +1109,7 @@
     "depth_view_tool": "Active depth-map view",
     "depth_view_mode": "Choose depth-map color mode",
     "gt_compare_mode": "Choose RGB, normal, depth, or loss ground-truth visualization",
-    "gt_loss_match": "Match (0)",
+    "gt_loss_lower_error": "Lower error",
     "gt_loss_higher_error": "Higher error",
     "depth_view_range": "Depth-map visualization range",
     "depth_view_near": "Near edge of the depth-map range",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1108,7 +1108,7 @@
     "depth_view_panel": "Depth-map controls",
     "depth_view_tool": "Active depth-map view",
     "depth_view_mode": "Choose depth-map color mode",
-    "gt_compare_mode": "Choose RGB, normal, or depth ground-truth comparison",
+    "gt_compare_mode": "Choose RGB, normal, depth, or loss ground-truth visualization",
     "depth_view_range": "Depth-map visualization range",
     "depth_view_near": "Near edge of the depth-map range",
     "depth_view_far": "Far edge of the depth-map range",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -1109,6 +1109,8 @@
     "depth_view_tool": "Active depth-map view",
     "depth_view_mode": "Choose depth-map color mode",
     "gt_compare_mode": "Choose RGB, normal, depth, or loss ground-truth visualization",
+    "gt_loss_match": "Match (0)",
+    "gt_loss_higher_error": "Higher error",
     "depth_view_range": "Depth-map visualization range",
     "depth_view_near": "Near edge of the depth-map range",
     "depth_view_far": "Far edge of the depth-map range",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -1110,7 +1110,7 @@
     "depth_view_tool": "Vista de mapa de profundidad activa",
     "depth_view_mode": "Elegir el modo de color de profundidad",
     "gt_compare_mode": "Elige la visualización de referencia RGB, normales, profundidad o pérdida",
-    "gt_loss_match": "Coincidencia (0)",
+    "gt_loss_lower_error": "Menor error",
     "gt_loss_higher_error": "Mayor error",
     "depth_view_range": "Rango de visualización de profundidad",
     "depth_view_near": "Límite cercano del rango de profundidad",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -1109,7 +1109,7 @@
     "depth_view_panel": "Controles del mapa de profundidad",
     "depth_view_tool": "Vista de mapa de profundidad activa",
     "depth_view_mode": "Elegir el modo de color de profundidad",
-    "gt_compare_mode": "Elige la comparación con datos de referencia RGB, normales o profundidad",
+    "gt_compare_mode": "Elige la visualización de referencia RGB, normales, profundidad o pérdida",
     "depth_view_range": "Rango de visualización de profundidad",
     "depth_view_near": "Límite cercano del rango de profundidad",
     "depth_view_far": "Límite lejano del rango de profundidad",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -1110,6 +1110,8 @@
     "depth_view_tool": "Vista de mapa de profundidad activa",
     "depth_view_mode": "Elegir el modo de color de profundidad",
     "gt_compare_mode": "Elige la visualización de referencia RGB, normales, profundidad o pérdida",
+    "gt_loss_match": "Coincidencia (0)",
+    "gt_loss_higher_error": "Mayor error",
     "depth_view_range": "Rango de visualización de profundidad",
     "depth_view_near": "Límite cercano del rango de profundidad",
     "depth_view_far": "Límite lejano del rango de profundidad",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1109,7 +1109,7 @@
     "depth_view_panel": "Contrôles de la carte de profondeur",
     "depth_view_tool": "Vue de carte de profondeur active",
     "depth_view_mode": "Choisir le mode couleur de profondeur",
-    "gt_compare_mode": "Choisir la comparaison de référence RGB, normales ou profondeur",
+    "gt_compare_mode": "Choisir la visualisation de référence RGB, normales, profondeur ou perte",
     "depth_view_range": "Plage de visualisation de profondeur",
     "depth_view_near": "Limite proche de la plage de profondeur",
     "depth_view_far": "Limite éloignée de la plage de profondeur",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1110,7 +1110,7 @@
     "depth_view_tool": "Vue de carte de profondeur active",
     "depth_view_mode": "Choisir le mode couleur de profondeur",
     "gt_compare_mode": "Choisir la visualisation de référence RGB, normales, profondeur ou perte",
-    "gt_loss_match": "Correspondance (0)",
+    "gt_loss_lower_error": "Erreur plus faible",
     "gt_loss_higher_error": "Erreur plus élevée",
     "depth_view_range": "Plage de visualisation de profondeur",
     "depth_view_near": "Limite proche de la plage de profondeur",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -1110,6 +1110,8 @@
     "depth_view_tool": "Vue de carte de profondeur active",
     "depth_view_mode": "Choisir le mode couleur de profondeur",
     "gt_compare_mode": "Choisir la visualisation de référence RGB, normales, profondeur ou perte",
+    "gt_loss_match": "Correspondance (0)",
+    "gt_loss_higher_error": "Erreur plus élevée",
     "depth_view_range": "Plage de visualisation de profondeur",
     "depth_view_near": "Limite proche de la plage de profondeur",
     "depth_view_far": "Limite éloignée de la plage de profondeur",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1110,6 +1110,8 @@
     "depth_view_tool": "Vista mappa di profondità attiva",
     "depth_view_mode": "Scegli il modo colore della profondità",
     "gt_compare_mode": "Scegli la visualizzazione della ground truth RGB, delle normali, della profondità o della perdita",
+    "gt_loss_match": "Corrispondenza (0)",
+    "gt_loss_higher_error": "Errore maggiore",
     "depth_view_range": "Intervallo di visualizzazione della profondità",
     "depth_view_near": "Limite vicino dell'intervallo di profondità",
     "depth_view_far": "Limite lontano dell'intervallo di profondità",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1109,7 +1109,7 @@
     "depth_view_panel": "Controlli della mappa di profondità",
     "depth_view_tool": "Vista mappa di profondità attiva",
     "depth_view_mode": "Scegli il modo colore della profondità",
-    "gt_compare_mode": "Scegli il confronto con la ground truth RGB, delle normali o della profondità",
+    "gt_compare_mode": "Scegli la visualizzazione della ground truth RGB, delle normali, della profondità o della perdita",
     "depth_view_range": "Intervallo di visualizzazione della profondità",
     "depth_view_near": "Limite vicino dell'intervallo di profondità",
     "depth_view_far": "Limite lontano dell'intervallo di profondità",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -1110,7 +1110,7 @@
     "depth_view_tool": "Vista mappa di profondità attiva",
     "depth_view_mode": "Scegli il modo colore della profondità",
     "gt_compare_mode": "Scegli la visualizzazione della ground truth RGB, delle normali, della profondità o della perdita",
-    "gt_loss_match": "Corrispondenza (0)",
+    "gt_loss_lower_error": "Errore minore",
     "gt_loss_higher_error": "Errore maggiore",
     "depth_view_range": "Intervallo di visualizzazione della profondità",
     "depth_view_near": "Limite vicino dell'intervallo di profondità",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1110,7 +1110,7 @@
     "depth_view_tool": "有効な深度マップ表示",
     "depth_view_mode": "深度マップのカラーモードを選択",
     "gt_compare_mode": "RGB、法線、深度、または損失のグラウンドトゥルース表示を選択",
-    "gt_loss_match": "一致 (0)",
+    "gt_loss_lower_error": "誤差小",
     "gt_loss_higher_error": "誤差大",
     "depth_view_range": "深度マップの表示範囲",
     "depth_view_near": "深度範囲の近端",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1110,6 +1110,8 @@
     "depth_view_tool": "有効な深度マップ表示",
     "depth_view_mode": "深度マップのカラーモードを選択",
     "gt_compare_mode": "RGB、法線、深度、または損失のグラウンドトゥルース表示を選択",
+    "gt_loss_match": "一致 (0)",
+    "gt_loss_higher_error": "誤差大",
     "depth_view_range": "深度マップの表示範囲",
     "depth_view_near": "深度範囲の近端",
     "depth_view_far": "深度範囲の遠端",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -1109,7 +1109,7 @@
     "depth_view_panel": "深度マップコントロール",
     "depth_view_tool": "有効な深度マップ表示",
     "depth_view_mode": "深度マップのカラーモードを選択",
-    "gt_compare_mode": "RGB、法線、または深度のグラウンドトゥルース比較を選択",
+    "gt_compare_mode": "RGB、法線、深度、または損失のグラウンドトゥルース表示を選択",
     "depth_view_range": "深度マップの表示範囲",
     "depth_view_near": "深度範囲の近端",
     "depth_view_far": "深度範囲の遠端",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1110,6 +1110,8 @@
     "depth_view_tool": "활성 깊이 맵 보기",
     "depth_view_mode": "깊이 맵 색상 모드 선택",
     "gt_compare_mode": "RGB, 법선, 깊이 또는 손실 정답 시각화 선택",
+    "gt_loss_match": "일치 (0)",
+    "gt_loss_higher_error": "높은 오차",
     "depth_view_range": "깊이 맵 시각화 범위",
     "depth_view_near": "깊이 범위의 가까운 경계",
     "depth_view_far": "깊이 범위의 먼 경계",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1110,7 +1110,7 @@
     "depth_view_tool": "활성 깊이 맵 보기",
     "depth_view_mode": "깊이 맵 색상 모드 선택",
     "gt_compare_mode": "RGB, 법선, 깊이 또는 손실 정답 시각화 선택",
-    "gt_loss_match": "일치 (0)",
+    "gt_loss_lower_error": "낮은 오차",
     "gt_loss_higher_error": "높은 오차",
     "depth_view_range": "깊이 맵 시각화 범위",
     "depth_view_near": "깊이 범위의 가까운 경계",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -1109,7 +1109,7 @@
     "depth_view_panel": "깊이 맵 컨트롤",
     "depth_view_tool": "활성 깊이 맵 보기",
     "depth_view_mode": "깊이 맵 색상 모드 선택",
-    "gt_compare_mode": "RGB, 법선 또는 깊이 정답 비교 선택",
+    "gt_compare_mode": "RGB, 법선, 깊이 또는 손실 정답 시각화 선택",
     "depth_view_range": "깊이 맵 시각화 범위",
     "depth_view_near": "깊이 범위의 가까운 경계",
     "depth_view_far": "깊이 범위의 먼 경계",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1109,7 +1109,7 @@
     "depth_view_panel": "Bediening voor dieptekaart",
     "depth_view_tool": "Actieve dieptekaartweergave",
     "depth_view_mode": "Kleurmodus voor dieptekaart kiezen",
-    "gt_compare_mode": "Kies RGB-, normaal- of diepte-ground-truthvergelijking",
+    "gt_compare_mode": "Kies RGB-, normaal-, diepte- of verliesvisualisatie voor ground truth",
     "depth_view_range": "Visualisatiebereik van dieptekaart",
     "depth_view_near": "Dichtbijgrens van het dieptebereik",
     "depth_view_far": "Verre grens van het dieptebereik",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1110,6 +1110,8 @@
     "depth_view_tool": "Actieve dieptekaartweergave",
     "depth_view_mode": "Kleurmodus voor dieptekaart kiezen",
     "gt_compare_mode": "Kies RGB-, normaal-, diepte- of verliesvisualisatie voor ground truth",
+    "gt_loss_match": "Overeenkomst (0)",
+    "gt_loss_higher_error": "Hogere fout",
     "depth_view_range": "Visualisatiebereik van dieptekaart",
     "depth_view_near": "Dichtbijgrens van het dieptebereik",
     "depth_view_far": "Verre grens van het dieptebereik",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -1110,7 +1110,7 @@
     "depth_view_tool": "Actieve dieptekaartweergave",
     "depth_view_mode": "Kleurmodus voor dieptekaart kiezen",
     "gt_compare_mode": "Kies RGB-, normaal-, diepte- of verliesvisualisatie voor ground truth",
-    "gt_loss_match": "Overeenkomst (0)",
+    "gt_loss_lower_error": "Lagere fout",
     "gt_loss_higher_error": "Hogere fout",
     "depth_view_range": "Visualisatiebereik van dieptekaart",
     "depth_view_near": "Dichtbijgrens van het dieptebereik",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1110,7 +1110,7 @@
     "depth_view_tool": "Aktywny widok mapy głębi",
     "depth_view_mode": "Wybierz tryb koloru głębi",
     "gt_compare_mode": "Wybierz wizualizację referencji RGB, normalnych, głębi lub straty",
-    "gt_loss_match": "Zgodność (0)",
+    "gt_loss_lower_error": "Mniejszy błąd",
     "gt_loss_higher_error": "Większy błąd",
     "depth_view_range": "Zakres wizualizacji głębi",
     "depth_view_near": "Bliska granica zakresu głębi",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1109,7 +1109,7 @@
     "depth_view_panel": "Sterowanie mapą głębi",
     "depth_view_tool": "Aktywny widok mapy głębi",
     "depth_view_mode": "Wybierz tryb koloru głębi",
-    "gt_compare_mode": "Wybierz porównanie z referencją RGB, normalnych lub głębi",
+    "gt_compare_mode": "Wybierz wizualizację referencji RGB, normalnych, głębi lub straty",
     "depth_view_range": "Zakres wizualizacji głębi",
     "depth_view_near": "Bliska granica zakresu głębi",
     "depth_view_far": "Daleka granica zakresu głębi",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -1110,6 +1110,8 @@
     "depth_view_tool": "Aktywny widok mapy głębi",
     "depth_view_mode": "Wybierz tryb koloru głębi",
     "gt_compare_mode": "Wybierz wizualizację referencji RGB, normalnych, głębi lub straty",
+    "gt_loss_match": "Zgodność (0)",
+    "gt_loss_higher_error": "Większy błąd",
     "depth_view_range": "Zakres wizualizacji głębi",
     "depth_view_near": "Bliska granica zakresu głębi",
     "depth_view_far": "Daleka granica zakresu głębi",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -1110,7 +1110,7 @@
     "depth_view_tool": "活动深度图视图",
     "depth_view_mode": "选择深度图颜色模式",
     "gt_compare_mode": "选择 RGB、法线、深度或损失真值可视化",
-    "gt_loss_match": "匹配 (0)",
+    "gt_loss_lower_error": "更低误差",
     "gt_loss_higher_error": "更高误差",
     "depth_view_range": "深度图可视化范围",
     "depth_view_near": "深度范围近端",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -1110,6 +1110,8 @@
     "depth_view_tool": "活动深度图视图",
     "depth_view_mode": "选择深度图颜色模式",
     "gt_compare_mode": "选择 RGB、法线、深度或损失真值可视化",
+    "gt_loss_match": "匹配 (0)",
+    "gt_loss_higher_error": "更高误差",
     "depth_view_range": "深度图可视化范围",
     "depth_view_near": "深度范围近端",
     "depth_view_far": "深度范围远端",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -1109,7 +1109,7 @@
     "depth_view_panel": "深度图控件",
     "depth_view_tool": "活动深度图视图",
     "depth_view_mode": "选择深度图颜色模式",
-    "gt_compare_mode": "选择 RGB、法线或深度真值比较",
+    "gt_compare_mode": "选择 RGB、法线、深度或损失真值可视化",
     "depth_view_range": "深度图可视化范围",
     "depth_view_near": "深度范围近端",
     "depth_view_far": "深度范围远端",

--- a/src/visualizer/gui/rmlui/resources/viewport_overlay.rcss
+++ b/src/visualizer/gui/rmlui/resources/viewport_overlay.rcss
@@ -572,6 +572,57 @@ body {
     line-height: 20dp;
 }
 
+.viewport-gt-loss-legend {
+    width: 240dp;
+    min-width: 240dp;
+    margin-top: 4dp;
+}
+
+.viewport-gt-loss-scale {
+    width: 240dp;
+    height: 10dp;
+    box-sizing: border-box;
+    display: flex;
+    overflow: hidden;
+    border-width: 1dp;
+    border-color: #585b70;
+    border-radius: 3dp;
+}
+
+.viewport-gt-loss-scale__segment {
+    display: block;
+    width: 0;
+    height: 8dp;
+    flex-grow: 1;
+    flex-shrink: 0;
+}
+
+.viewport-gt-loss-scale__segment--match {
+    decorator: horizontal-gradient(#000000 #380578);
+}
+
+.viewport-gt-loss-scale__segment--low {
+    decorator: horizontal-gradient(#380578 #b81f4a);
+}
+
+.viewport-gt-loss-scale__segment--medium {
+    decorator: horizontal-gradient(#b81f4a #fca60a);
+}
+
+.viewport-gt-loss-scale__segment--high {
+    decorator: horizontal-gradient(#fca60a #ffffbf);
+}
+
+.viewport-gt-loss-labels {
+    width: 240dp;
+    margin-top: 2dp;
+    display: flex;
+    justify-content: space-between;
+    color: #a6adc8;
+    font-size: 10dp;
+    line-height: 12dp;
+}
+
 .viewport-transform-panel.viewport-export-panel {
     width: 470dp;
     min-width: 470dp;

--- a/src/visualizer/gui/rmlui/resources/viewport_overlay.rcss
+++ b/src/visualizer/gui/rmlui/resources/viewport_overlay.rcss
@@ -572,13 +572,13 @@ body {
     line-height: 20dp;
 }
 
-.viewport-gt-loss-legend {
+.viewport-gt-color-legend {
     width: 240dp;
     min-width: 240dp;
     margin-top: 4dp;
 }
 
-.viewport-gt-loss-scale {
+.viewport-gt-color-scale {
     width: 240dp;
     height: 10dp;
     box-sizing: border-box;
@@ -589,7 +589,7 @@ body {
     border-radius: 3dp;
 }
 
-.viewport-gt-loss-scale__segment {
+.viewport-gt-color-scale__segment {
     display: block;
     width: 0;
     height: 8dp;
@@ -597,23 +597,52 @@ body {
     flex-shrink: 0;
 }
 
-.viewport-gt-loss-scale__segment--match {
+.viewport-gt-color-scale__segment--loss-lowest {
     decorator: horizontal-gradient(#000000 #380578);
 }
 
-.viewport-gt-loss-scale__segment--low {
+.viewport-gt-color-scale__segment--loss-low {
     decorator: horizontal-gradient(#380578 #b81f4a);
 }
 
-.viewport-gt-loss-scale__segment--medium {
+.viewport-gt-color-scale__segment--loss-medium {
     decorator: horizontal-gradient(#b81f4a #fca60a);
 }
 
-.viewport-gt-loss-scale__segment--high {
+.viewport-gt-color-scale__segment--loss-high {
     decorator: horizontal-gradient(#fca60a #ffffbf);
 }
 
-.viewport-gt-loss-labels {
+.viewport-gt-color-scale__segment--depth-far {
+    flex-grow: 20;
+    decorator: horizontal-gradient(#0d0a26 #0f3280);
+}
+
+.viewport-gt-color-scale__segment--depth-far-mid {
+    flex-grow: 23;
+    decorator: horizontal-gradient(#0f3280 #0080a6);
+}
+
+.viewport-gt-color-scale__segment--depth-mid {
+    flex-grow: 24;
+    decorator: horizontal-gradient(#0080a6 #5cbb69);
+}
+
+.viewport-gt-color-scale__segment--depth-near-mid {
+    flex-grow: 19;
+    decorator: horizontal-gradient(#5cbb69 #f6d14d);
+}
+
+.viewport-gt-color-scale__segment--depth-near {
+    flex-grow: 14;
+    decorator: horizontal-gradient(#f6d14d #fb6e20);
+}
+
+.viewport-gt-color-scale__segment--depth-gray {
+    decorator: horizontal-gradient(#000000 #ffffff);
+}
+
+.viewport-gt-color-labels {
     width: 240dp;
     margin-top: 2dp;
     display: flex;

--- a/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
+++ b/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
@@ -778,6 +778,7 @@
                         <option value="rgb">RGB</option>
                         <option value="normal">@tr:ui.normal</option>
                         <option value="depth">@tr:ui.depth</option>
+                        <option value="loss">@tr:status.loss</option>
                     </select>
                 </div>
             </div>

--- a/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
+++ b/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
@@ -782,16 +782,35 @@
                     </select>
                 </div>
             </div>
-            <div class="viewport-gt-loss-legend"
-                 data-if="gt_compare_mode_value == 'loss'">
-                <div class="viewport-gt-loss-scale">
-                    <span class="viewport-gt-loss-scale__segment viewport-gt-loss-scale__segment--match"></span>
-                    <span class="viewport-gt-loss-scale__segment viewport-gt-loss-scale__segment--low"></span>
-                    <span class="viewport-gt-loss-scale__segment viewport-gt-loss-scale__segment--medium"></span>
-                    <span class="viewport-gt-loss-scale__segment viewport-gt-loss-scale__segment--high"></span>
+            <div class="viewport-gt-color-legend"
+                 data-if="gt_compare_mode_value == 'depth'">
+                <div class="viewport-gt-color-scale"
+                     data-if="gt_compare_depth_mode_value == 'palette'">
+                    <span class="viewport-gt-color-scale__segment viewport-gt-color-scale__segment--depth-far"></span>
+                    <span class="viewport-gt-color-scale__segment viewport-gt-color-scale__segment--depth-far-mid"></span>
+                    <span class="viewport-gt-color-scale__segment viewport-gt-color-scale__segment--depth-mid"></span>
+                    <span class="viewport-gt-color-scale__segment viewport-gt-color-scale__segment--depth-near-mid"></span>
+                    <span class="viewport-gt-color-scale__segment viewport-gt-color-scale__segment--depth-near"></span>
                 </div>
-                <div class="viewport-gt-loss-labels">
-                    <span>@tr:tooltip.gt_loss_match</span>
+                <div class="viewport-gt-color-scale"
+                     data-if="gt_compare_depth_mode_value == 'gray'">
+                    <span class="viewport-gt-color-scale__segment viewport-gt-color-scale__segment--depth-gray"></span>
+                </div>
+                <div class="viewport-gt-color-labels">
+                    <span>@tr:ui.far</span>
+                    <span>@tr:ui.near</span>
+                </div>
+            </div>
+            <div class="viewport-gt-color-legend"
+                 data-if="gt_compare_mode_value == 'loss'">
+                <div class="viewport-gt-color-scale">
+                    <span class="viewport-gt-color-scale__segment viewport-gt-color-scale__segment--loss-lowest"></span>
+                    <span class="viewport-gt-color-scale__segment viewport-gt-color-scale__segment--loss-low"></span>
+                    <span class="viewport-gt-color-scale__segment viewport-gt-color-scale__segment--loss-medium"></span>
+                    <span class="viewport-gt-color-scale__segment viewport-gt-color-scale__segment--loss-high"></span>
+                </div>
+                <div class="viewport-gt-color-labels">
+                    <span>@tr:tooltip.gt_loss_lower_error</span>
                     <span>@tr:tooltip.gt_loss_higher_error</span>
                 </div>
             </div>

--- a/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
+++ b/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
@@ -782,6 +782,19 @@
                     </select>
                 </div>
             </div>
+            <div class="viewport-gt-loss-legend"
+                 data-if="gt_compare_mode_value == 'loss'">
+                <div class="viewport-gt-loss-scale">
+                    <span class="viewport-gt-loss-scale__segment viewport-gt-loss-scale__segment--match"></span>
+                    <span class="viewport-gt-loss-scale__segment viewport-gt-loss-scale__segment--low"></span>
+                    <span class="viewport-gt-loss-scale__segment viewport-gt-loss-scale__segment--medium"></span>
+                    <span class="viewport-gt-loss-scale__segment viewport-gt-loss-scale__segment--high"></span>
+                </div>
+                <div class="viewport-gt-loss-labels">
+                    <span>@tr:tooltip.gt_loss_match</span>
+                    <span>@tr:tooltip.gt_loss_higher_error</span>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/src/visualizer/rendering/passes/vulkan_split_view_pass.cpp
+++ b/src/visualizer/rendering/passes/vulkan_split_view_pass.cpp
@@ -52,7 +52,7 @@ namespace lfs::vis {
         }
 
         struct SplitPush {
-            float split[4];               // x = position, y = left_flip_y, z = right_flip_y, w = pad
+            float split[4];               // x = position, y/z = flip_y, w = loss visualization
             float rect[4];                // x, y, w, h
             float panel_norm[4];          // left_start, left_end, right_start, right_end
             float panel_flags[4];         // left_normalize, right_normalize, left_filter, right_filter
@@ -1166,6 +1166,7 @@ namespace lfs::vis {
             push.split[0] = std::clamp(params.split_position, 0.0f, 1.0f);
             push.split[1] = params.left.flip_y ? 1.0f : 0.0f;
             push.split[2] = params.right.flip_y ? 1.0f : 0.0f;
+            push.split[3] = params.loss_visualization ? 1.0f : 0.0f;
 
             const float rect_x = static_cast<float>(params.content_rect.x);
             const float rect_y = static_cast<float>(params.content_rect.y);

--- a/src/visualizer/rendering/passes/vulkan_split_view_pass.hpp
+++ b/src/visualizer/rendering/passes/vulkan_split_view_pass.hpp
@@ -37,6 +37,7 @@ namespace lfs::vis {
 
     struct VulkanSplitViewParams {
         bool enabled = false;
+        bool loss_visualization = false;
         VulkanSplitViewPanel left;
         VulkanSplitViewPanel right;
         float split_position = 0.5f;

--- a/src/visualizer/rendering/rendering_manager.cpp
+++ b/src/visualizer/rendering/rendering_manager.cpp
@@ -816,7 +816,9 @@ namespace lfs::vis {
     std::optional<float> RenderingManager::getSplitDividerScreenX(const glm::vec2& viewport_pos,
                                                                   const glm::vec2& viewport_size) const {
         std::lock_guard<std::mutex> lock(settings_mutex_);
-        if (!split_view_service_.isActive(settings_)) {
+        if (!split_view_service_.isActive(settings_) ||
+            (splitViewUsesGTComparison(settings_.split_view_mode) &&
+             gtComparisonShowsLoss(settings_.gt_comparison_mode))) {
             return std::nullopt;
         }
 

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -760,6 +760,50 @@ namespace lfs::vis {
                 output[pixel_count + idx] = c.g;
                 output[2 * pixel_count + idx] = c.b;
             };
+            const auto sample_panel_color = [&](const VulkanSplitViewPanel& panel,
+                                                const auto& data,
+                                                const float u,
+                                                const float v) {
+                float panel_u = u;
+                if (panel.normalize_x_to_panel) {
+                    const float span = std::max(panel.end_position - panel.start_position, 1e-6f);
+                    panel_u = (u - panel.start_position) / span;
+                }
+                const float panel_v = panel.flip_y ? 1.0f - v : v;
+                const glm::vec2 clamp_max = glm::clamp(panel.uv_clamp_max,
+                                                       glm::vec2(0.0f), glm::vec2(1.0f));
+                const glm::vec2 texture_uv = glm::min(glm::vec2(panel_u, panel_v) * panel.uv_scale,
+                                                      clamp_max);
+                const auto sample_color = [&](const glm::vec2 sample_uv) {
+                    return glm::vec3{
+                        sample(std::get<0>(data), std::get<1>(data), std::get<2>(data),
+                               sample_uv.x, sample_uv.y, 0),
+                        sample(std::get<0>(data), std::get<1>(data), std::get<2>(data),
+                               sample_uv.x, sample_uv.y, 1),
+                        sample(std::get<0>(data), std::get<1>(data), std::get<2>(data),
+                               sample_uv.x, sample_uv.y, 2)};
+                };
+
+                glm::vec3 color = sample_color(texture_uv);
+                if (panel.spatial_filter) {
+                    constexpr float kSpatialSharpenStrength = 0.18f;
+                    const float texel_x = 1.0f / static_cast<float>(std::max(std::get<1>(data), 1));
+                    const float texel_y = 1.0f / static_cast<float>(std::max(std::get<2>(data), 1));
+                    const auto clamp_uv = [&clamp_max](const glm::vec2 uv) {
+                        return glm::clamp(uv, glm::vec2(0.0f), clamp_max);
+                    };
+                    const glm::vec3 left = sample_color(clamp_uv(texture_uv - glm::vec2(texel_x, 0.0f)));
+                    const glm::vec3 right = sample_color(clamp_uv(texture_uv + glm::vec2(texel_x, 0.0f)));
+                    const glm::vec3 up = sample_color(clamp_uv(texture_uv - glm::vec2(0.0f, texel_y)));
+                    const glm::vec3 down = sample_color(clamp_uv(texture_uv + glm::vec2(0.0f, texel_y)));
+                    const glm::vec3 sharpened = color * (1.0f + 4.0f * kSpatialSharpenStrength) -
+                                                (left + right + up + down) * kSpatialSharpenStrength;
+                    color = glm::clamp(sharpened,
+                                       glm::min(color, glm::min(glm::min(left, right), glm::min(up, down))),
+                                       glm::max(color, glm::max(glm::max(left, right), glm::max(up, down))));
+                }
+                return color;
+            };
 
             for (int y = rect_y; y < rect_y + rect_h; ++y) {
                 const float v = rect_h > 1
@@ -771,51 +815,21 @@ namespace lfs::vis {
                                         ? (static_cast<float>(x) + 0.5f - static_cast<float>(rect_x)) /
                                               static_cast<float>(rect_w - 1)
                                         : 0.0f;
-                    const bool use_left = x < divider;
-                    const auto& panel = use_left ? left_panel : right_panel;
-                    const auto& data = use_left ? *left_data : *right_data;
-                    float panel_u = u;
-                    if (panel.normalize_x_to_panel) {
-                        const float span = std::max(panel.end_position - panel.start_position, 1e-6f);
-                        panel_u = (u - panel.start_position) / span;
-                    }
-                    const float panel_v = panel.flip_y ? 1.0f - v : v;
-                    const glm::vec2 clamp_max = glm::clamp(panel.uv_clamp_max,
-                                                           glm::vec2(0.0f), glm::vec2(1.0f));
-                    const glm::vec2 texture_uv = glm::min(glm::vec2(panel_u, panel_v) * panel.uv_scale,
-                                                          clamp_max);
                     const std::size_t idx = static_cast<std::size_t>(y) * width + x;
-                    const auto sample_color = [&](const glm::vec2 sample_uv) {
-                        return glm::vec3{
-                            sample(std::get<0>(data), std::get<1>(data), std::get<2>(data),
-                                   sample_uv.x, sample_uv.y, 0),
-                            sample(std::get<0>(data), std::get<1>(data), std::get<2>(data),
-                                   sample_uv.x, sample_uv.y, 1),
-                            sample(std::get<0>(data), std::get<1>(data), std::get<2>(data),
-                                   sample_uv.x, sample_uv.y, 2)};
-                    };
-                    glm::vec3 color = sample_color(texture_uv);
-                    if (panel.spatial_filter) {
-                        constexpr float kSpatialSharpenStrength = 0.18f;
-                        const float texel_x = 1.0f / static_cast<float>(std::max(std::get<1>(data), 1));
-                        const float texel_y = 1.0f / static_cast<float>(std::max(std::get<2>(data), 1));
-                        const auto clamp_uv = [&clamp_max](const glm::vec2 uv) {
-                            return glm::clamp(uv, glm::vec2(0.0f), clamp_max);
-                        };
-                        const glm::vec3 left = sample_color(clamp_uv(texture_uv - glm::vec2(texel_x, 0.0f)));
-                        const glm::vec3 right = sample_color(clamp_uv(texture_uv + glm::vec2(texel_x, 0.0f)));
-                        const glm::vec3 up = sample_color(clamp_uv(texture_uv - glm::vec2(0.0f, texel_y)));
-                        const glm::vec3 down = sample_color(clamp_uv(texture_uv + glm::vec2(0.0f, texel_y)));
-                        const glm::vec3 sharpened = color * (1.0f + 4.0f * kSpatialSharpenStrength) -
-                                                    (left + right + up + down) * kSpatialSharpenStrength;
-                        color = glm::clamp(sharpened,
-                                           glm::min(color, glm::min(glm::min(left, right), glm::min(up, down))),
-                                           glm::max(color, glm::max(glm::max(left, right), glm::max(up, down))));
+                    glm::vec3 color;
+                    if (params.loss_visualization) {
+                        color = gtLossHeatmapColor(
+                            sample_panel_color(left_panel, *left_data, u, v),
+                            sample_panel_color(right_panel, *right_data, u, v));
+                    } else if (x < divider) {
+                        color = sample_panel_color(left_panel, *left_data, u, v);
+                    } else {
+                        color = sample_panel_color(right_panel, *right_data, u, v);
                     }
                     write(idx, color);
 
                     const float dist_from_split = std::abs(static_cast<float>(x) + 0.5f - split_x);
-                    if (dist_from_split < kMinBarWidthPx * 0.5f) {
+                    if (!params.loss_visualization && dist_from_split < kMinBarWidthPx * 0.5f) {
                         glm::vec3 color = kDividerColor;
                         const float dist_from_center =
                             std::abs(static_cast<float>(y) + 0.5f - center_y);
@@ -2488,7 +2502,7 @@ namespace lfs::vis {
                     std::string gt_error;
                     bool gt_loading = false;
 
-                    if (gt_mode == GTComparisonMode::RGB) {
+                    if (gtComparisonUsesRGBReference(gt_mode)) {
                         if (camera->image_path().empty() || !camera->has_image()) {
                             gt_error = "RGB GT comparison requires a source image";
                         } else {
@@ -2677,7 +2691,7 @@ namespace lfs::vis {
                             RenderedPanel compare_panel{};
                             std::string compare_error;
 
-                            if (gt_mode != GTComparisonMode::RGB) {
+                            if (!gtComparisonUsesRGBReference(gt_mode)) {
                                 // #1574 hold-then-swap: never host-wait the GT depth ticket on the
                                 // render thread. Poll any outstanding ticket; swap into the held
                                 // display when Ready; submit at most one new ticket when free. The
@@ -2940,14 +2954,14 @@ namespace lfs::vis {
 
                             if (!compare_panel.image && compare_panel.external_image_view == VK_NULL_HANDLE &&
                                 !compare_error.empty() &&
-                                !(gt_mode == GTComparisonMode::RGB &&
+                                !(gtComparisonUsesRGBReference(gt_mode) &&
                                   isRetryableSharedScratchUnavailable(compare_error))) {
                                 LOG_WARN("GT comparison using placeholder rendered panel: {}", compare_error);
                                 compare_panel = make_placeholder_panel(gt_size, glm::vec3(0.035f, 0.045f, 0.070f));
                             }
 
                             if (compare_panel.image || compare_panel.external_image_view != VK_NULL_HANDLE) {
-                                if (gt_mode == GTComparisonMode::RGB) {
+                                if (gtComparisonUsesRGBReference(gt_mode)) {
                                     bool compare_panel_ppisp_applied = false;
                                     if (!compare_panel.image &&
                                         compare_panel.external_image_view != VK_NULL_HANDLE &&
@@ -3010,6 +3024,7 @@ namespace lfs::vis {
                                 const SplitCompositeContentRect rect =
                                     resolveSplitCompositeContentRect(render_size, true, gt_size);
                                 pending_split_view.enabled = true;
+                                pending_split_view.loss_visualization = gtComparisonShowsLoss(gt_mode);
                                 pending_split_view.split_position = frame_settings.split_position;
                                 pending_split_view.background = frame_settings.background_color;
                                 pending_split_view.content_rect = {rect.x, rect.y, rect.width, rect.height};
@@ -3030,6 +3045,10 @@ namespace lfs::vis {
                                     mode_label = "GT Normal Compare";
                                     left_name = "GT Normal";
                                     right_name = "Rendered Normal";
+                                } else if (gt_mode == GTComparisonMode::Loss) {
+                                    mode_label = "GT Loss";
+                                    left_name = "Loss";
+                                    right_name = "";
                                 }
                                 rendered_split_info = SplitViewInfo{
                                     .enabled = true,

--- a/src/visualizer/rendering/rendering_types.hpp
+++ b/src/visualizer/rendering/rendering_types.hpp
@@ -43,7 +43,61 @@ namespace lfs::vis {
         RGB = 0,
         Normal = 1,
         Depth = 2,
+        Loss = 3,
     };
+
+    [[nodiscard]] inline bool gtComparisonUsesRGBReference(
+        const GTComparisonMode mode) noexcept {
+        return mode == GTComparisonMode::RGB ||
+               mode == GTComparisonMode::Loss;
+    }
+
+    [[nodiscard]] inline bool gtComparisonShowsLoss(
+        const GTComparisonMode mode) noexcept {
+        return mode == GTComparisonMode::Loss;
+    }
+
+    [[nodiscard]] inline glm::vec3 gtLossHeatmapColor(
+        const glm::vec3& ground_truth,
+        const glm::vec3& rendered) noexcept {
+        const glm::vec3 difference =
+            glm::abs(ground_truth - rendered);
+        const float mean_absolute_error =
+            (difference.r + difference.g + difference.b) /
+            3.0f;
+        const float intensity =
+            std::isfinite(mean_absolute_error)
+                ? std::clamp(
+                      1.0f - std::exp(
+                                 -8.0f *
+                                 std::max(
+                                     mean_absolute_error,
+                                     0.0f)),
+                      0.0f, 1.0f)
+                : 1.0f;
+
+        constexpr glm::vec3 black{0.0f, 0.0f, 0.0f};
+        constexpr glm::vec3 purple{0.22f, 0.02f, 0.47f};
+        constexpr glm::vec3 red{0.72f, 0.12f, 0.29f};
+        constexpr glm::vec3 yellow{0.99f, 0.65f, 0.04f};
+        constexpr glm::vec3 white{1.0f, 1.0f, 0.75f};
+        if (intensity < 0.25f) {
+            return glm::mix(black, purple, intensity * 4.0f);
+        }
+        if (intensity < 0.5f) {
+            return glm::mix(
+                purple, red,
+                (intensity - 0.25f) * 4.0f);
+        }
+        if (intensity < 0.75f) {
+            return glm::mix(
+                red, yellow,
+                (intensity - 0.5f) * 4.0f);
+        }
+        return glm::mix(
+            yellow, white,
+            (intensity - 0.75f) * 4.0f);
+    }
 
     enum class SplitViewPanelId : uint8_t {
         Left = 0,
@@ -342,6 +396,7 @@ namespace lfs::vis {
         case GTComparisonMode::RGB:
         case GTComparisonMode::Normal:
         case GTComparisonMode::Depth:
+        case GTComparisonMode::Loss:
             break;
         default:
             settings.gt_comparison_mode = GTComparisonMode::RGB;

--- a/src/visualizer/rendering/resources/viewport/split_view.frag
+++ b/src/visualizer/rendering/resources/viewport/split_view.frag
@@ -13,7 +13,7 @@ layout(push_constant) uniform Push {
     // x = split_position (0..1 in viewport space)
     // y = left_flip_y (0/1)
     // z = right_flip_y (0/1)
-    // w = padding
+    // w = loss visualization (0/1)
     vec4 split;
 
     // Viewport pixel rect (x, y, width, height) — letterboxed content extent.
@@ -66,6 +66,31 @@ vec3 sample_panel(sampler2D tex, vec2 uv, float start, float end, float normaliz
     return clamp(sharpened, neighborhood_min, neighborhood_max);
 }
 
+vec3 loss_heatmap(vec3 ground_truth, vec3 rendered) {
+    vec3 difference = abs(ground_truth - rendered);
+    float mean_absolute_error =
+        (difference.r + difference.g + difference.b) / 3.0;
+    float intensity = clamp(
+        1.0 - exp(-8.0 * max(mean_absolute_error, 0.0)),
+        0.0, 1.0);
+
+    const vec3 black = vec3(0.0, 0.0, 0.0);
+    const vec3 purple = vec3(0.22, 0.02, 0.47);
+    const vec3 red = vec3(0.72, 0.12, 0.29);
+    const vec3 yellow = vec3(0.99, 0.65, 0.04);
+    const vec3 white = vec3(1.0, 1.0, 0.75);
+    if (intensity < 0.25) {
+        return mix(black, purple, intensity * 4.0);
+    }
+    if (intensity < 0.5) {
+        return mix(purple, red, (intensity - 0.25) * 4.0);
+    }
+    if (intensity < 0.75) {
+        return mix(red, yellow, (intensity - 0.5) * 4.0);
+    }
+    return mix(yellow, white, (intensity - 0.75) * 4.0);
+}
+
 void main() {
     // Pixel-space coordinate (gl_FragCoord origin top-left in Vulkan).
     vec2 px = gl_FragCoord.xy;
@@ -81,6 +106,19 @@ void main() {
     vec2 content_uv = vec2(
         pc.rect.z > 1.0 ? (px.x - pc.rect.x) / (pc.rect.z - 1.0) : 0.0,
         pc.rect.w > 1.0 ? (px.y - pc.rect.y) / (pc.rect.w - 1.0) : 0.0);
+
+    if (pc.split.w > 0.5) {
+        vec3 ground_truth = sample_panel(
+            u_left, content_uv, pc.panel_norm.x, pc.panel_norm.y,
+            pc.panel_flags.x, pc.split.y, pc.panel_flags.z,
+            pc.left_uv_scale_clamp.xy, pc.left_uv_scale_clamp.zw);
+        vec3 rendered = sample_panel(
+            u_right, content_uv, pc.panel_norm.z, pc.panel_norm.w,
+            pc.panel_flags.y, pc.split.z, pc.panel_flags.w,
+            pc.right_uv_scale_clamp.xy, pc.right_uv_scale_clamp.zw);
+        frag_color = vec4(loss_heatmap(ground_truth, rendered), 1.0);
+        return;
+    }
 
     float split_x = pc.rect.x + clamp(pc.split.x, 0.0, 1.0) * pc.rect.z;
     float divider_pixel = pc.rect.x + floor(pc.split.x * pc.rect.z + 0.5);

--- a/tests/python/test_toolbar_hooks.py
+++ b/tests/python/test_toolbar_hooks.py
@@ -1515,6 +1515,20 @@ def test_viewport_overlay_template_moves_tools_left_and_transform_numbers_center
     assert "viewport-export-status" not in rml[panel_start:panel_end]
 
 
+def test_gt_loss_mode_shows_matching_heatmap_legend():
+    project_root = Path(__file__).parent.parent.parent
+    resources = project_root / "src/visualizer/gui/rmlui/resources"
+    rml = (resources / "viewport_overlay.rml").read_text(encoding="utf-8")
+    rcss = (resources / "viewport_overlay.rcss").read_text(encoding="utf-8")
+
+    assert 'data-if="gt_compare_mode_value == \'loss\'"' in rml
+    assert rml.count("viewport-gt-loss-scale__segment--") == 4
+    assert "@tr:tooltip.gt_loss_match" in rml
+    assert "@tr:tooltip.gt_loss_higher_error" in rml
+    assert "horizontal-gradient(#000000 #380578)" in rcss
+    assert "horizontal-gradient(#fca60a #ffffbf)" in rcss
+
+
 def test_viewport_toolbar_update_syncs_utility_records(toolbar_module, monkeypatch):
     module, _hook_calls, _remove_calls = toolbar_module
     model = _DataModelStub()

--- a/tests/python/test_toolbar_hooks.py
+++ b/tests/python/test_toolbar_hooks.py
@@ -180,6 +180,7 @@ class _DocumentStub:
                 "overlay-body",
                 "dm-root",
                 "depth-view-block",
+                "gt-compare-mode-block",
                 "viewport-export-block",
                 "viewport-export-status",
                 "selection-block",
@@ -289,6 +290,8 @@ def test_toolbar_binds_overlay_model_fields(toolbar_module):
     assert "selection_depth_far_slider_min" in model.bound_funcs
     assert "selection_depth_far_slider_max" in model.bound_funcs
     assert "selection_action" in model.bound_events
+    assert "gt_compare_mode_value" in model.bound_binds
+    assert "gt_compare_depth_mode_value" in model.bound_funcs
     assert "transform_show_translate" in model.bound_funcs
     assert "transform_show_rotate" in model.bound_funcs
     assert "transform_show_scale" in model.bound_funcs
@@ -314,6 +317,25 @@ def test_toolbar_attach_handle_marks_model_dirty(toolbar_module):
     module.attach_overlay_model_handle(handle)
 
     assert handle.dirty_all_calls == 1
+
+
+def test_gt_compare_controls_track_depth_visualization_mode(toolbar_module, monkeypatch):
+    module, _hook_calls, _remove_calls = toolbar_module
+    lf_stub = sys.modules["lichtfeld"]
+    monkeypatch.setattr(lf_stub.ui, "get_split_view_mode", lambda: "gt_comparison", raising=False)
+    monkeypatch.setattr(lf_stub.ui, "get_gt_comparison_mode", lambda: "depth", raising=False)
+    monkeypatch.setattr(lf_stub, "get_depth_view_mode", lambda: "gray", raising=False)
+
+    model = _DataModelStub()
+    doc = _DocumentStub()
+    controller = module.GTCompareControlsController()
+    controller.bind_model(model)
+    controller.mount(doc)
+
+    assert controller.update(doc) == "visibility,mode"
+    assert model.bound_funcs["gt_compare_depth_mode_value"]() == "gray"
+    assert "gt_compare_depth_mode_value" in model.handle.dirty_calls
+    assert "hidden" not in doc.elements["gt-compare-mode-block"].classes
 
 
 def test_button_record_resolves_toolbar_tooltip(toolbar_module, monkeypatch):
@@ -1515,15 +1537,23 @@ def test_viewport_overlay_template_moves_tools_left_and_transform_numbers_center
     assert "viewport-export-status" not in rml[panel_start:panel_end]
 
 
-def test_gt_loss_mode_shows_matching_heatmap_legend():
+def test_gt_compare_modes_show_matching_color_legends():
     project_root = Path(__file__).parent.parent.parent
     resources = project_root / "src/visualizer/gui/rmlui/resources"
     rml = (resources / "viewport_overlay.rml").read_text(encoding="utf-8")
     rcss = (resources / "viewport_overlay.rcss").read_text(encoding="utf-8")
 
+    assert 'data-if="gt_compare_mode_value == \'depth\'"' in rml
+    assert 'data-if="gt_compare_depth_mode_value == \'palette\'"' in rml
+    assert 'data-if="gt_compare_depth_mode_value == \'gray\'"' in rml
+    assert "@tr:ui.far" in rml
+    assert "@tr:ui.near" in rml
+    assert "horizontal-gradient(#0d0a26 #0f3280)" in rcss
+    assert "horizontal-gradient(#f6d14d #fb6e20)" in rcss
+    assert "horizontal-gradient(#000000 #ffffff)" in rcss
+
     assert 'data-if="gt_compare_mode_value == \'loss\'"' in rml
-    assert rml.count("viewport-gt-loss-scale__segment--") == 4
-    assert "@tr:tooltip.gt_loss_match" in rml
+    assert "@tr:tooltip.gt_loss_lower_error" in rml
     assert "@tr:tooltip.gt_loss_higher_error" in rml
     assert "horizontal-gradient(#000000 #380578)" in rcss
     assert "horizontal-gradient(#fca60a #ffffbf)" in rcss

--- a/tests/test_rendering_refactor_services.cpp
+++ b/tests/test_rendering_refactor_services.cpp
@@ -212,6 +212,43 @@ namespace lfs::vis {
         EXPECT_TRUE(idle_info.right_name.empty());
     }
 
+    TEST(GTComparisonTest, LossHeatmapIsBlackForMatchingPixelsAndHighlightsLargerErrors) {
+        const glm::vec3 ground_truth(0.4f, 0.5f, 0.6f);
+        const glm::vec3 matching = gtLossHeatmapColor(ground_truth, ground_truth);
+        const glm::vec3 small_error = gtLossHeatmapColor(
+            ground_truth, ground_truth + glm::vec3(0.01f));
+        const glm::vec3 large_error = gtLossHeatmapColor(
+            ground_truth, ground_truth + glm::vec3(0.5f));
+
+        EXPECT_EQ(matching, glm::vec3(0.0f));
+        EXPECT_GT(small_error.r + small_error.g + small_error.b, 0.0f);
+        EXPECT_GT(large_error.r + large_error.g + large_error.b,
+                  small_error.r + small_error.g + small_error.b);
+    }
+
+    TEST(GTComparisonTest, LossModeSurvivesSettingsSanitization) {
+        RenderSettings settings;
+        settings.gt_comparison_mode = GTComparisonMode::Loss;
+
+        sanitizeGTComparisonSettings(settings);
+
+        EXPECT_EQ(settings.gt_comparison_mode, GTComparisonMode::Loss);
+    }
+
+    TEST_F(RenderingManagerEventsTest, LossModeDoesNotExposeDraggableDivider) {
+        RenderingManager manager;
+        auto settings = manager.getSettings();
+        settings.split_view_mode = SplitViewMode::GTComparison;
+        settings.gt_comparison_mode = GTComparisonMode::RGB;
+        manager.updateSettings(settings);
+        ASSERT_TRUE(manager.getSplitDividerScreenX({10.0f, 20.0f}, {800.0f, 600.0f}).has_value());
+
+        settings.gt_comparison_mode = GTComparisonMode::Loss;
+        manager.updateSettings(settings);
+
+        EXPECT_FALSE(manager.getSplitDividerScreenX({10.0f, 20.0f}, {800.0f, 600.0f}).has_value());
+    }
+
     TEST(SplitViewServiceTest, SceneClearedDisablesSplitViewAndResetsOffset) {
         SplitViewService service;
         RenderSettings settings;


### PR DESCRIPTION
## Features

- Adds a Loss view to GT Compare mode, showing the difference between the rendered and ground-truth images.
- Adds clear color legends for both the Loss and Depth views.

## How to test

- Load a dataset.
- Start training.
- Open GT Compare mode.
- Select Depth and verify that the depth color legend appears.
- Select Loss and verify that the loss visualization and its color legend appear.

Closes #1850