### PR TITLE
Add Orthographic Mode toggle to the web viewer

### DIFF
--- a/src/visualizer/gui/resources/viewer/index.css
+++ b/src/visualizer/gui/resources/viewer/index.css
@@ -199,6 +199,9 @@ button {
 #controlsWrap > #buttonsContainer #measure.active {
   color: #F60;
 }
+#controlsWrap > #buttonsContainer #orthoCamera.active {
+  color: #F60;
+}
 
 /* Measurement tool overlay */
 #measureToolSvg,

--- a/src/visualizer/gui/resources/viewer/index.js
+++ b/src/visualizer/gui/resources/viewer/index.js
@@ -99843,7 +99843,7 @@ const initUI = (global) => {
         'buttonContainer',
         'play', 'pause',
         'settings', 'settingsPanel',
-        'orbitCamera', 'flyCamera',
+        'orbitCamera', 'flyCamera', 'orthoCamera',
         'hqCheck', 'hqOption', 'lqCheck', 'lqOption',
         'reset', 'frame',
         'loadingText', 'loadingBar',
@@ -100076,6 +100076,13 @@ const initUI = (global) => {
     dom.flyCamera.addEventListener('click', () => {
         state.cameraMode = 'fly';
     });
+    dom.orthoCamera.addEventListener('click', () => {
+        const cameraComponent = global.camera.camera;
+        cameraComponent.projection = cameraComponent.projection === PROJECTION_ORTHOGRAPHIC
+            ? PROJECTION_PERSPECTIVE
+            : PROJECTION_ORTHOGRAPHIC;
+        dom.orthoCamera.classList[cameraComponent.projection === PROJECTION_ORTHOGRAPHIC ? 'add' : 'remove']('active');
+    });
     dom.reset.addEventListener('click', (event) => {
         events.fire('inputEvent', 'reset', event);
     });
@@ -100110,6 +100117,7 @@ const initUI = (global) => {
     tooltip.register(dom.pause, 'Pause', 'top');
     tooltip.register(dom.orbitCamera, 'Orbit Camera', 'top');
     tooltip.register(dom.flyCamera, 'Fly Camera', 'top');
+    tooltip.register(dom.orthoCamera, 'Orthographic Mode', 'top');
     tooltip.register(dom.reset, 'Reset Camera', 'bottom');
     tooltip.register(dom.frame, 'Frame Scene', 'bottom');
     tooltip.register(dom.settings, 'Settings', 'top');
@@ -101650,6 +101658,15 @@ class Viewer {
             cameraEntity.setPosition(camera.position);
             cameraEntity.setEulerAngles(camera.angles);
             cameraEntity.camera.fov = camera.fov;
+            if (cameraEntity.camera.projection === PROJECTION_ORTHOGRAPHIC) {
+                // match the orthographic frustum size to the current view distance so
+                // wheel zoom and orbiting keep working in orthographic mode
+                let orthoHeight = camera.distance * Math.tan(0.5 * camera.fov * Math.PI / 180);
+                if (cameraEntity.camera.horizontalFov) {
+                    orthoHeight /= cameraEntity.camera.aspectRatio;
+                }
+                cameraEntity.camera.orthoHeight = orthoHeight;
+            }
             // fit clipping planes to bounding box
             const boundRadius = sceneBound.halfExtents.length();
             // calculate the forward distance between the camera to the bound center

--- a/src/visualizer/gui/resources/viewer/viewer_template.html
+++ b/src/visualizer/gui/resources/viewer/viewer_template.html
@@ -110,6 +110,13 @@
                         </svg>
                     </button>
 
+                    <button id="orthoCamera" class="controlButton" title="Orthographic Mode">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
+                            <g class='stroke'><use href="#orthoIcon"/></g>
+                            <g class='fill'><use href="#orthoIcon"/></g>
+                        </svg>
+                    </button>
+
                     <button id="arMode" class="controlButton hidden">
                         <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28">
                             <g class='stroke'><use href="#arIcon"/></g>
@@ -321,6 +328,9 @@
                     <rect x="14" y="8" width="2" height="4"/>
                     <rect x="19" y="8" width="2" height="4"/>
                 </g>
+            </symbol>
+            <symbol id="orthoIcon" viewBox="0 0 24 24">
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M5 2C3.34315 2 2 3.34315 2 5V19C2 20.6569 3.34315 22 5 22H19C20.6569 22 22 20.6569 22 19V5C22 3.34315 20.6569 2 19 2H5ZM5 7V17H17V7H5Z"/>
             </symbol>
             <symbol id="exitFullscreenIcon" viewBox="0 0 24 24">
                 <path d="M8 15.0996C8.49706 15.0996 8.90039 15.5029 8.90039 16V21C8.90039 21.4971 8.49706 21.9004 8 21.9004C7.50294 21.9004 7.09961 21.4971 7.09961 21V16.9004H3C2.50294 16.9004 2.09961 16.4971 2.09961 16C2.09961 15.5029 2.50294 15.0996 3 15.0996H8Z" />


### PR DESCRIPTION
Adds a toggle button to the HTML-export viewer's control bar that switches the model between perspective and orthographic projection.

## Changes

- iewer_template.html: new #orthoCamera button (with a frame icon) in the bottom control bar, next to Measure.
- index.js:
  - The button toggles the camera component's projection between PROJECTION_PERSPECTIVE (0) and PROJECTION_ORTHOGRAPHIC (1) and mirrors its state on the button.
  - pplyCamera now keeps orthoHeight in sync with the current view distance (distance * tan(fov/2), aspect-adjusted for horizontal FOV), so the ortho view matches the perspective view at the moment of toggling, and wheel zoom, orbiting and panning all keep working in orthographic mode.
- index.css: active-state styling for the new button (same orange accent as the Measure button).

The bundled engine (PlayCanvas fork) already supported orthographic projection end-to-end: the projection matrix evaluation, the renderer's camera_params uniform, and the gsplat vertex shader (which switches its corner-projection math when camera_params.w == 1). This change only wires the UI toggle into it.

## Testing

- Exported an HTML viewer and verified the button toggles the model between perspective and orthographic views; zoom/orbit/pan behave correctly in both modes.
- 
Node --check passes on the modified index.js.