### PR TITLE
Export of very large models no longer runs out of GPU memory

### DIFF
--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -3653,10 +3653,11 @@ namespace lfs::core {
             splats.begin(), splats.end(),
             [](const auto& entry) { return entry.second == IDENTITY; });
 
-        // q16 (Float16 codes + bounds) and IEEE-f16 shN cannot be read via
-        // ptr<float>() / float4-swizzle gather kernels. Materialise float
-        // canonical SH, filter, and rebuild with Canonical layout so the
-        // constructor re-swizzles to Float32 for ephemeral export/merge copies.
+        // q16 (Float16 codes + bounds) and IEEE-f16 shN cannot be gathered via
+        // ptr<float>() / float4-swizzle kernels. Borrow/clone identity paths keep
+        // the compact resident SH (codes + bounds) so export does not allocate a
+        // float swizzle. Deleted-mask filtering still materialises float canonical
+        // SH, then rebuilds with Canonical layout.
         const auto shN_requires_float_materialize = [](const lfs::core::SplatData& src) {
             return src.shN_raw().is_valid() && src.shN_raw().numel() > 0 &&
                    (src.shN_raw().dtype() != lfs::core::DataType::Float32 ||
@@ -3667,22 +3668,6 @@ namespace lfs::core {
             -> std::unique_ptr<lfs::core::SplatData> {
             if (!src.has_deleted_mask()) {
                 const int active_sh = src.get_active_sh_degree();
-                if (shN_requires_float_materialize(src)) {
-                    // Materialise float SH so the clone is export-safe without
-                    // requiring a transferred q16 bounds tensor.
-                    auto result = std::make_unique<lfs::core::SplatData>(
-                        src.get_max_sh_degree(),
-                        src.means_raw().clone(),
-                        src.sh0_raw().clone(),
-                        src.shN_canonical(),
-                        src.scaling_raw().clone(),
-                        src.rotation_raw().clone(),
-                        src.opacity_raw().clone(),
-                        src.get_scene_scale(),
-                        lfs::core::SplatData::ShNLayout::Canonical);
-                    result->set_active_sh_degree(active_sh);
-                    return result;
-                }
                 auto result = std::make_unique<lfs::core::SplatData>(
                     src.get_max_sh_degree(),
                     src.means_raw().clone(),
@@ -3772,22 +3757,6 @@ namespace lfs::core {
 
                 if (storage_mode == MergeStorageMode::BorrowSingleIdentity && !src->has_deleted_mask()) {
                     const int active_sh = src->get_active_sh_degree();
-                    // q16/ieee-f16: materialise float SH for export/merge so
-                    // save_ply does not need bounds on the ephemeral SplatData.
-                    if (shN_requires_float_materialize(*src)) {
-                        auto result = std::make_unique<lfs::core::SplatData>(
-                            src->get_max_sh_degree(),
-                            src->means_raw(),
-                            src->sh0_raw(),
-                            src->shN_canonical(),
-                            src->scaling_raw(),
-                            src->rotation_raw(),
-                            src->opacity_raw(),
-                            src->get_scene_scale(),
-                            lfs::core::SplatData::ShNLayout::Canonical);
-                        result->set_active_sh_degree(active_sh);
-                        return result;
-                    }
                     auto result = std::make_unique<lfs::core::SplatData>(
                         src->get_max_sh_degree(),
                         src->means_raw(),

--- a/src/core/splat_data.cpp
+++ b/src/core/splat_data.cpp
@@ -640,6 +640,105 @@ namespace {
         shN = std::move(resized);
     }
 
+    // Host deswizzle of a 1D float4-packed buffer into canonical [N, K, 3].
+    // Shared by the fp32 shN_canonical_cpu path and IEEE-f16 host decode.
+    [[nodiscard]] lfs::core::Tensor unpack_swizzled_floats_to_canonical_cpu(
+        const float* src,
+        const size_t src_floats,
+        const size_t n,
+        const size_t k) {
+        using namespace lfs::core;
+        Tensor out = Tensor::empty({n, k, SH_CHANNELS}, Device::CPU, DataType::Float32);
+        auto* const dst = out.ptr<float>();
+        const size_t active_floats = k * SH_CHANNELS;
+        tbb::parallel_for(
+            tbb::blocked_range<size_t>(0, n),
+            [&](const tbb::blocked_range<size_t>& range) {
+                for (size_t p = range.begin(); p != range.end(); ++p) {
+                    float* const dst_row = dst + p * active_floats;
+                    for (size_t offset = 0; offset < active_floats; ++offset) {
+                        const auto slot = static_cast<std::uint32_t>(offset / 4u);
+                        const auto component = static_cast<std::uint32_t>(offset % 4u);
+                        const size_t src_offset =
+                            static_cast<size_t>(sh_swizzled_index(
+                                static_cast<std::uint32_t>(p), slot, static_cast<uint32_t>(k))) *
+                                4u +
+                            component;
+                        dst_row[offset] = src_offset < src_floats ? src[src_offset] : 0.0f;
+                    }
+                }
+            });
+        return out;
+    }
+
+    // Host q16 dequant into canonical [N, K, 3]. Math matches the previous
+    // single-threaded loop in shN_canonical() (lo/hi/kInvQ + cell-linear index).
+    [[nodiscard]] lfs::core::Tensor dequant_q16_to_canonical_cpu(
+        const std::uint16_t* codes,
+        const float* bounds,
+        const size_t n,
+        const size_t k) {
+        using namespace lfs::core;
+        Tensor out = Tensor::zeros({n, k, SH_CHANNELS}, Device::CPU, DataType::Float32);
+        auto* const dst = out.ptr<float>();
+        const std::uint32_t n_cells =
+            sh_value_quant::n_value_cells_per_prim(static_cast<std::uint32_t>(k));
+        constexpr float kInvQ = 1.0f / 65535.0f;
+        tbb::parallel_for(
+            tbb::blocked_range<size_t>(0, n),
+            [&](const tbb::blocked_range<size_t>& range) {
+                for (size_t p = range.begin(); p != range.end(); ++p) {
+                    const size_t bidx = p / 256u;
+                    const float lo = bounds[bidx * 2 + 0];
+                    const float hi = bounds[bidx * 2 + 1];
+                    float* row = dst + p * k * SH_CHANNELS;
+                    for (std::uint32_t c = 0; c < n_cells && c < k * SH_CHANNELS; ++c) {
+                        // cell-linear swizzle: block * (n_cells * R) + c * R + lane
+                        const std::uint32_t block = static_cast<std::uint32_t>(p) / kShReorderSize;
+                        const std::uint32_t lane = static_cast<std::uint32_t>(p) % kShReorderSize;
+                        const size_t idx = static_cast<size_t>(block) * n_cells * kShReorderSize +
+                                           static_cast<size_t>(c) * kShReorderSize + lane;
+                        const auto q = codes[idx];
+                        row[c] = lo + (hi - lo) * (static_cast<float>(q) * kInvQ);
+                    }
+                }
+            });
+        return out;
+    }
+
+    // Host-only Float16 → canonical [N, K, 3]. D2H of the compact codes is the
+    // only device traffic; no CUDA destination is allocated here.
+    [[nodiscard]] lfs::core::Tensor canonical_shN_from_f16_cpu(
+        const lfs::core::Tensor& shN,
+        const lfs::core::Tensor& bounds,
+        const size_t n,
+        const size_t k) {
+        using namespace lfs::core;
+        if (n == 0 || k == 0) {
+            return Tensor::zeros({n, k, SH_CHANNELS}, Device::CPU);
+        }
+        const Tensor codes_cpu = shN.cpu().contiguous();
+        if (bounds.is_valid() && bounds.numel() > 0) {
+            const Tensor bounds_cpu = bounds.cpu().contiguous();
+            return dequant_q16_to_canonical_cpu(
+                reinterpret_cast<const std::uint16_t*>(codes_cpu.data_ptr()),
+                bounds_cpu.ptr<float>(),
+                n,
+                k);
+        }
+        const Tensor fp32_swizzled = codes_cpu.to(DataType::Float32);
+        if (!fp32_swizzled.is_valid() || fp32_swizzled.numel() == 0) {
+            Tensor out = Tensor::empty({n, k, SH_CHANNELS}, Device::CPU, DataType::Float32);
+            out.zero_();
+            return out;
+        }
+        return unpack_swizzled_floats_to_canonical_cpu(
+            fp32_swizzled.ptr<float>(),
+            static_cast<size_t>(fp32_swizzled.numel()),
+            n,
+            k);
+    }
+
 } // anonymous namespace
 
 namespace lfs::core {
@@ -935,51 +1034,16 @@ namespace lfs::core {
         if (n == 0 || k == 0) {
             return Tensor::zeros({n, k, SH_CHANNELS}, dst_device);
         }
-        // Quantized path: materialise float4-swizzled temp via host/device dequant helper.
-        // Full GPU dequant is in training::sh_value::decode_shN_u16_to_float4; for core we
-        // fall back to a float temporary when the resident tensor is Float16 — callers that
-        // zero float swizzled buffer then leave dequant to higher layers when quant is on
-        // without bounds (bounds required for correct decode).
+        // Float16 resident SH (q16 codes + bounds, or IEEE-f16 swizzle) decodes on the
+        // host. Device cost is only the returned canonical tensor when dst is CUDA.
         if (_shN.dtype() == DataType::Float16) {
-            // IEEE f16 float4-swizzle (exportable): cast half→float then deswizzle.
-            if (!_shN_value_bounds.is_valid() || _shN_value_bounds.numel() == 0) {
-                Tensor fp32 = _shN.to(DataType::Float32);
-                if (fp32.device() != Device::CUDA)
-                    fp32 = fp32.cuda();
-                Tensor out = Tensor::empty({n, k, SH_CHANNELS}, Device::CUDA);
-                undo_reorder_sh_from_swizzled(fp32.ptr<float>(),
-                                              out.ptr<float>(),
-                                              n,
-                                              static_cast<uint32_t>(k),
-                                              static_cast<uint32_t>(k));
-                return dst_device == Device::CUDA ? out : out.cpu();
+            // q16 and IEEE-f16 decode on the host (parallel), then upload the
+            // canonical tensor once when the resident buffer lives on CUDA.
+            Tensor out = canonical_shN_from_f16_cpu(_shN, _shN_value_bounds, n, k);
+            if (dst_device == Device::CUDA) {
+                return out.to(Device::CUDA);
             }
-            // Host-side q16 dequant (avoids core→training link). Fine for export/I/O paths.
-            Tensor out = Tensor::zeros({n, k, SH_CHANNELS}, Device::CPU, DataType::Float32);
-            const Tensor codes_cpu = _shN.cpu().contiguous();
-            const Tensor bounds_cpu = _shN_value_bounds.cpu().contiguous();
-            const auto* codes = reinterpret_cast<const std::uint16_t*>(codes_cpu.data_ptr());
-            const auto* bounds = bounds_cpu.ptr<float>();
-            auto* dst = out.ptr<float>();
-            const std::uint32_t n_cells =
-                sh_value_quant::n_value_cells_per_prim(static_cast<std::uint32_t>(k));
-            constexpr float kInvQ = 1.0f / 65535.0f;
-            for (size_t p = 0; p < n; ++p) {
-                const size_t bidx = p / 256u;
-                const float lo = bounds[bidx * 2 + 0];
-                const float hi = bounds[bidx * 2 + 1];
-                float* row = dst + p * k * SH_CHANNELS;
-                for (std::uint32_t c = 0; c < n_cells && c < k * SH_CHANNELS; ++c) {
-                    // cell-linear swizzle: block * (n_cells * R) + c * R + lane
-                    const std::uint32_t block = static_cast<std::uint32_t>(p) / kShReorderSize;
-                    const std::uint32_t lane = static_cast<std::uint32_t>(p) % kShReorderSize;
-                    const size_t idx = static_cast<size_t>(block) * n_cells * kShReorderSize +
-                                       static_cast<size_t>(c) * kShReorderSize + lane;
-                    const auto q = codes[idx];
-                    row[c] = lo + (hi - lo) * (static_cast<float>(q) * kInvQ);
-                }
-            }
-            return out.to(dst_device);
+            return out;
         }
         Tensor out = Tensor::empty({n, k, SH_CHANNELS}, dst_device);
         undo_reorder_sh_from_swizzled(_shN.ptr<float>(),
@@ -1008,41 +1072,24 @@ namespace lfs::core {
             return Tensor::zeros({n, k, SH_CHANNELS}, Device::CPU);
         }
 
-        // Quantized path: host dequant to [N,K,3] on CPU (export/checkpoint bit-compat).
+        // Quantized / IEEE-f16 path: host dequant to [N,K,3] on CPU (export/checkpoint
+        // bit-compat). Must not allocate a CUDA destination.
         if (_shN.is_valid() && _shN.dtype() == DataType::Float16) {
-            Tensor t = shN_canonical();
-            return t.device() == Device::CPU ? t : t.cpu();
+            return canonical_shN_from_f16_cpu(_shN, _shN_value_bounds, n, k);
         }
 
-        Tensor out = Tensor::empty({n, k, SH_CHANNELS}, Device::CPU, DataType::Float32);
         if (!_shN.is_valid() || _shN.numel() == 0) {
+            Tensor out = Tensor::empty({n, k, SH_CHANNELS}, Device::CPU, DataType::Float32);
             out.zero_();
             return out;
         }
 
         const Tensor shN_cpu = _shN.cpu().contiguous();
-        const auto* const src = shN_cpu.ptr<float>();
-        auto* const dst = out.ptr<float>();
-        const size_t src_floats = shN_cpu.numel();
-        const size_t active_floats = k * SH_CHANNELS;
-
-        tbb::parallel_for(
-            tbb::blocked_range<size_t>(0, n),
-            [&](const tbb::blocked_range<size_t>& range) {
-                for (size_t p = range.begin(); p != range.end(); ++p) {
-                    float* const dst_row = dst + p * active_floats;
-                    for (size_t offset = 0; offset < active_floats; ++offset) {
-                        const auto slot = static_cast<std::uint32_t>(offset / 4u);
-                        const auto component = static_cast<std::uint32_t>(offset % 4u);
-                        const size_t src_offset =
-                            static_cast<size_t>(sh_swizzled_index(static_cast<std::uint32_t>(p), slot, static_cast<uint32_t>(k))) * 4u +
-                            component;
-                        dst_row[offset] = src_offset < src_floats ? src[src_offset] : 0.0f;
-                    }
-                }
-            });
-
-        return out;
+        return unpack_swizzled_floats_to_canonical_cpu(
+            shN_cpu.ptr<float>(),
+            static_cast<size_t>(shN_cpu.numel()),
+            n,
+            k);
     }
 
     void SplatData::shN_set_from_canonical(const Tensor& canonical, size_t capacity) {

--- a/src/io/formats/ply.cpp
+++ b/src/io/formats/ply.cpp
@@ -458,7 +458,7 @@ namespace lfs::io {
                 return false;
             }
 
-            struct stat st {};
+            struct stat st{};
             if (fstat(fd, &st) < 0) {
                 return false;
             }
@@ -2909,18 +2909,24 @@ namespace lfs::io {
                 attr_off += cols;
             };
 
-            append_builtin_block(pc.means.cpu().contiguous(), {"x", "y", "z"});
+            auto as_cpu_contiguous = [](const Tensor& tensor) -> Tensor {
+                if (tensor.device() == Device::CPU && tensor.is_contiguous())
+                    return tensor;
+                return tensor.cpu().contiguous();
+            };
+
+            append_builtin_block(as_cpu_contiguous(pc.means), {"x", "y", "z"});
 
             if (pc.normals.is_valid()) {
-                append_builtin_block(pc.normals.cpu().contiguous(), {"nx", "ny", "nz"});
+                append_builtin_block(as_cpu_contiguous(pc.normals), {"nx", "ny", "nz"});
             }
 
-            auto process_sh = [](const Tensor& sh) -> Tensor {
+            auto process_sh = [&](const Tensor& sh) -> Tensor {
                 if (sh.ndim() == 3) {
                     auto transposed = sh.transpose(1, 2).contiguous();
-                    return transposed.flatten(1).cpu().contiguous();
+                    return as_cpu_contiguous(transposed.flatten(1));
                 }
-                return sh.cpu().contiguous();
+                return as_cpu_contiguous(sh);
             };
 
             if (pc.sh0.is_valid()) {
@@ -2934,14 +2940,14 @@ namespace lfs::io {
                 append_builtin_block(std::move(t), make_indexed_names("f_rest_", cols));
             }
             if (pc.opacity.is_valid())
-                append_builtin_block(pc.opacity.cpu().contiguous(), {"opacity"});
+                append_builtin_block(as_cpu_contiguous(pc.opacity), {"opacity"});
             if (pc.scaling.is_valid()) {
-                auto t = pc.scaling.cpu().contiguous();
+                auto t = as_cpu_contiguous(pc.scaling);
                 const auto cols = static_cast<size_t>(t.size(1));
                 append_builtin_block(std::move(t), make_indexed_names("scale_", cols));
             }
             if (pc.rotation.is_valid()) {
-                auto t = pc.rotation.cpu().contiguous();
+                auto t = as_cpu_contiguous(pc.rotation);
                 const auto cols = static_cast<size_t>(t.size(1));
                 append_builtin_block(std::move(t), make_indexed_names("rot_", cols));
             }

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -1352,6 +1352,12 @@ namespace lfs::vis::gui {
                         model_lock.emplace(*model_mutex);
                     }
 
+                    if (!cancelled &&
+                        !update_progress(0.0f, LOC(lichtfeld::Strings::Runtime::EXPORT_PREPARING_DATA))) {
+                        cancelled = true;
+                        error_msg = LOC(lichtfeld::Strings::Runtime::EXPORT_CANCELLED);
+                    }
+
                     if (!cancelled) {
                         std::vector<std::pair<const lfs::core::SplatData*, glm::mat4>> merge_inputs;
                         merge_inputs.reserve(splats.size());

--- a/tests/test_sh_value_storage.cpp
+++ b/tests/test_sh_value_storage.cpp
@@ -5,11 +5,11 @@
 #include "core/cuda/sh_layout.cuh"
 #include "core/scene.hpp"
 #include "core/sh_value_quant.hpp"
-#include "core/sh_value_quant_kernels.hpp"
 #include "core/splat_data.hpp"
 #include "core/splat_exportable_storage.hpp"
 #include "core/tensor.hpp"
 #include "io/exporter.hpp"
+#include "io/formats/ply.hpp"
 #include "io/loader.hpp"
 #include "lfs/training/live_model_mutation_guard.hpp"
 #include "lfs/training/sh_value_codec.hpp"
@@ -21,6 +21,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <cuda_runtime.h>
 #include <filesystem>
 #include <glm/mat4x4.hpp>
@@ -77,6 +78,16 @@ namespace {
             mse += e * e;
         }
         return mse / static_cast<double>(a.numel());
+    }
+
+    void expect_tensors_bitwise_equal(const Tensor& a, const Tensor& b, const char* name) {
+        auto ac = a.cpu().contiguous();
+        auto bc = b.cpu().contiguous();
+        ASSERT_EQ(ac.dtype(), bc.dtype()) << name;
+        ASSERT_EQ(ac.ndim(), bc.ndim()) << name;
+        ASSERT_EQ(ac.numel(), bc.numel()) << name;
+        ASSERT_EQ(ac.shape().str(), bc.shape().str()) << name;
+        ASSERT_EQ(std::memcmp(ac.data_ptr(), bc.data_ptr(), ac.bytes()), 0) << name;
     }
 
     [[nodiscard]] double psnr_from_mse(double mse) {
@@ -175,6 +186,34 @@ TEST(ShValueStorageTest, CanonicalExportIsFp32BitCompat) {
     EXPECT_GT(psnr_from_mse(mse), 55.0);
 
     sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+}
+
+TEST(ShValueStorageTest, Q16CanonicalCpuMatchesDevicePath) {
+    sh_value::set_sh_value_quant_enabled_for_testing(true);
+    auto splat = make_random_sh3(kN);
+    ASSERT_TRUE(sh_value::apply_shN_value_quant(splat));
+    ASSERT_TRUE(splat.shN_value_quantized());
+
+    const auto cpu = splat.shN_canonical_cpu();
+    const auto device_cpu = splat.shN_canonical().cpu();
+    EXPECT_EQ(cpu.device(), Device::CPU);
+    EXPECT_EQ(cpu.dtype(), DataType::Float32);
+    expect_tensors_bitwise_equal(cpu, device_cpu, "q16 canonical cpu vs device");
+
+    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+}
+
+TEST(ShValueStorageTest, IeeeF16CanonicalCpuMatchesDevicePath) {
+    auto splat = make_random_sh3(64);
+    splat.shN() = splat.shN().to(DataType::Float16);
+    ASSERT_TRUE(splat.shN_ieee_f16());
+    ASSERT_FALSE(splat.shN_value_quantized());
+
+    const auto cpu = splat.shN_canonical_cpu();
+    const auto device_cpu = splat.shN_canonical().cpu();
+    EXPECT_EQ(cpu.device(), Device::CPU);
+    EXPECT_EQ(cpu.dtype(), DataType::Float32);
+    expect_tensors_bitwise_equal(cpu, device_cpu, "ieee-f16 canonical cpu vs device");
 }
 
 TEST(ShValueStorageTest, Q16CloneCarriesBoundsAndDecodesIdentically) {
@@ -294,6 +333,57 @@ TEST(ShValueStorageTest, Q16DeletedMaskSceneMergeAndPlyExport) {
     EXPECT_GT(std::filesystem::file_size(output_path), 0u);
     std::filesystem::remove(output_path);
 
+    sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
+}
+
+TEST(ShValueStorageTest, Q16BorrowSingleIdentityMergePreservesQuantAndPly) {
+    sh_value::set_sh_value_quant_enabled_for_testing(true);
+    auto splat = make_random_sh3(64);
+    ASSERT_TRUE(sh_value::apply_shN_value_quant(splat));
+    ASSERT_TRUE(splat.shN_value_quantized());
+    ASSERT_EQ(splat.shN_raw().dtype(), DataType::Float16);
+
+    auto merged = Scene::mergeSplatsWithTransforms(
+        {{&splat, glm::mat4{1.0f}}}, Scene::MergeStorageMode::BorrowSingleIdentity);
+    ASSERT_NE(merged, nullptr);
+    EXPECT_EQ(merged->shN_raw().dtype(), DataType::Float16);
+    EXPECT_TRUE(merged->shN_value_quantized());
+    EXPECT_TRUE(merged->shN_value_bounds().is_valid());
+    EXPECT_GT(merged->shN_value_bounds().numel(), 0u);
+    expect_tensors_bitwise_equal(splat.shN_canonical_cpu(), merged->shN_canonical_cpu(),
+                                 "borrow ephemeral shN");
+
+    const auto source_path =
+        std::filesystem::temp_directory_path() / "lfs_q16_borrow_source.ply";
+    const auto merged_path =
+        std::filesystem::temp_directory_path() / "lfs_q16_borrow_merged.ply";
+    std::filesystem::remove(source_path);
+    std::filesystem::remove(merged_path);
+
+    const auto save_source = lfs::io::save_ply(
+        splat, {.output_path = source_path, .binary = true, .async = false});
+    ASSERT_TRUE(save_source.has_value()) << save_source.error().message;
+    const auto save_merged = lfs::io::save_ply(
+        *merged, {.output_path = merged_path, .binary = true, .async = false});
+    ASSERT_TRUE(save_merged.has_value()) << save_merged.error().message;
+
+    auto loaded_source = lfs::io::load_ply(source_path);
+    auto loaded_merged = lfs::io::load_ply(merged_path);
+    ASSERT_TRUE(loaded_source.has_value()) << lfs::format_for_developer(loaded_source.error());
+    ASSERT_TRUE(loaded_merged.has_value()) << lfs::format_for_developer(loaded_merged.error());
+
+    const SplatData& src_pc = loaded_source->value;
+    const SplatData& merged_pc = loaded_merged->value;
+    expect_tensors_bitwise_equal(src_pc.means_raw(), merged_pc.means_raw(), "ply means");
+    expect_tensors_bitwise_equal(src_pc.sh0_raw(), merged_pc.sh0_raw(), "ply sh0");
+    expect_tensors_bitwise_equal(src_pc.shN_canonical_cpu(), merged_pc.shN_canonical_cpu(),
+                                 "ply shN");
+    expect_tensors_bitwise_equal(src_pc.opacity_raw(), merged_pc.opacity_raw(), "ply opacity");
+    expect_tensors_bitwise_equal(src_pc.scaling_raw(), merged_pc.scaling_raw(), "ply scaling");
+    expect_tensors_bitwise_equal(src_pc.rotation_raw(), merged_pc.rotation_raw(), "ply rotation");
+
+    std::filesystem::remove(source_path);
+    std::filesystem::remove(merged_path);
     sh_value::set_sh_value_quant_enabled_for_testing(std::nullopt);
 }
 


### PR DESCRIPTION
Fixes #1862.

Exporting a big model right after training could freeze the app. The export built several full copies of the model's color data on the GPU, even though the file is written from normal RAM. With the GPU already full from training, that ran out of memory and the export dialog hung at 0% with Cancel doing nothing.

The export now reads the model without claiming extra GPU memory, the slow decode step runs on all CPU cores instead of one, and Cancel works during preparation.

Verified with a 10M-splat model: export used to need about 3.5 GB of free GPU memory and failed below that. It now completes with under 400 MB free, writes a byte-identical file, and is about 35% faster. The fix covers all export formats. SOG still needs GPU memory for its compression math and now reports a clear error instead of hanging.

About the second point in the issue: the automatic PLY at the end of training was replaced by project saves when the .licht format landed — save steps now save the project instead. An optional final PLY can come back in a follow-up if wanted.