### PR TITLE
Training started over MCP now uses the real default settings

### DIFF
--- a/src/mcp/shared_scene_tools.cpp
+++ b/src/mcp/shared_scene_tools.cpp
@@ -45,6 +45,22 @@ namespace lfs::mcp {
         std::expected<void, std::string> apply_dataset_load_arguments(
             const json& args,
             core::param::TrainingParameters& params) {
+            std::string resolved_strategy = params.optimization.strategy;
+            if (args.contains("strategy")) {
+                const auto requested = args["strategy"].get<std::string>();
+                if (requested != kDefaultStrategyAlias) {
+                    if (const auto canonical = core::param::canonical_strategy_name(requested); !canonical.empty()) {
+                        resolved_strategy = std::string(canonical);
+                    } else {
+                        return std::unexpected(std::format(
+                            "Invalid strategy '{}'. Use one of: default, mcmc, mrnf, igs+",
+                            requested));
+                    }
+                }
+            }
+
+            params.optimization = core::param::OptimizationParameters::defaults_for_strategy(resolved_strategy);
+
             if (args.contains("images_folder"))
                 params.dataset.images = args["images_folder"].get<std::string>();
             if (args.contains("max_iterations"))
@@ -60,22 +76,7 @@ namespace lfs::mcp {
             if (params.dataset.output_path.empty())
                 params.dataset.output_path = core::param::default_dataset_output_path(params.dataset.data_path);
 
-            if (!args.contains("strategy"))
-                return {};
-
-            const auto requested = args["strategy"].get<std::string>();
-            if (requested == kDefaultStrategyAlias) {
-                return {};
-            }
-
-            if (const auto canonical = core::param::canonical_strategy_name(requested); !canonical.empty()) {
-                params.optimization.strategy = std::string(canonical);
-                return {};
-            }
-
-            return std::unexpected(std::format(
-                "Invalid strategy '{}'. Use one of: default, mcmc, mrnf, igs+",
-                requested));
+            return {};
         }
 
     } // namespace

--- a/src/training/include/lfs/core/warp_reduce.cuh
+++ b/src/training/include/lfs/core/warp_reduce.cuh
@@ -186,8 +186,9 @@ namespace lfs::core {
                 val.w = fminf(val.w, o.w);
             }
 
-            // Non-static shared: exclusive to this call (avoids static-shared races
-            // when min/max alternated through block_reduce_min/max).
+            // __shared__ has static storage duration: one allocation for ALL inlined
+            // call sites of this function. Consecutive calls to the same block-reduce
+            // need an intervening __syncthreads() (or use a distinct function).
             __shared__ float4 shared[32];
             const int lane = static_cast<int>(threadIdx.x) % 32;
             const int warp_id = static_cast<int>(threadIdx.x) / 32;
@@ -212,6 +213,48 @@ namespace lfs::core {
                     val.y = fminf(val.y, o.y);
                     val.z = fminf(val.z, o.z);
                     val.w = fminf(val.w, o.w);
+                }
+            }
+            return val; // valid in warp 0
+        }
+
+        /**
+         * @brief Fused block min of float2 via __shfl_xor butterfly + one shared round.
+         *
+         * Distinct function from block_reduce_min4 so its __shared__ float2[32] is a
+         * separate allocation. Safe to call adjacent to min4 without an extra barrier.
+         * Result valid in warp 0.
+         */
+        __device__ inline float2 block_reduce_min2(float2 val) {
+#pragma unroll
+            for (int offset = 16; offset > 0; offset /= 2) {
+                const float2 o = make_float2(
+                    __shfl_xor_sync(0xffffffff, val.x, offset),
+                    __shfl_xor_sync(0xffffffff, val.y, offset));
+                val.x = fminf(val.x, o.x);
+                val.y = fminf(val.y, o.y);
+            }
+
+            __shared__ float2 shared[32];
+            const int lane = static_cast<int>(threadIdx.x) % 32;
+            const int warp_id = static_cast<int>(threadIdx.x) / 32;
+            if (lane == 0) {
+                shared[warp_id] = val;
+            }
+            __syncthreads();
+
+            if (warp_id == 0) {
+                constexpr float kInf = 1e30f;
+                val = (threadIdx.x < (blockDim.x + 31u) / 32u)
+                          ? shared[lane]
+                          : make_float2(kInf, kInf);
+#pragma unroll
+                for (int offset = 16; offset > 0; offset /= 2) {
+                    const float2 o = make_float2(
+                        __shfl_xor_sync(0xffffffff, val.x, offset),
+                        __shfl_xor_sync(0xffffffff, val.y, offset));
+                    val.x = fminf(val.x, o.x);
+                    val.y = fminf(val.y, o.y);
                 }
             }
             return val; // valid in warp 0

--- a/src/training/rasterization/fastgs/rasterization/include/kernel_utils.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernel_utils.cuh
@@ -925,9 +925,15 @@ namespace fast_lfs::rasterization::kernels {
         const float u_max = -red.y;
         const float s_min = red.z;
         const float s_max = -red.w;
-        // value bounds (separate from moment bounds).
-        const float v_min = value_q16 ? lfs::core::warp_ops::block_reduce_min(local_v_min) : 0.0f;
-        const float v_max = value_q16 ? lfs::core::warp_ops::block_reduce_max(local_v_max) : 0.0f;
+        // value bounds: block-uniform fused min2 (own shared alloc, distinct from min4).
+        float v_min = 0.0f;
+        float v_max = 0.0f;
+        if (value_q16) {
+            const float2 r = lfs::core::warp_ops::block_reduce_min2(
+                make_float2(local_v_min, -local_v_max));
+            v_min = r.x;
+            v_max = -r.y;
+        }
 
         __shared__ float4 sm_bounds;
         __shared__ float2 sm_vbounds;

--- a/tests/test_mcp_shared_scene_tools.cpp
+++ b/tests/test_mcp_shared_scene_tools.cpp
@@ -127,6 +127,64 @@ TEST(McpSharedSceneToolsTest, LoadDatasetHonorsExplicitOutputPathAndCanonicalStr
     EXPECT_EQ(result["strategy"].get<std::string>(), std::string(lfs::core::param::kStrategyIGSPlus));
 }
 
+TEST(McpSharedSceneToolsTest, LoadDatasetAppliesMrnfDefaultsWhenStrategyOmitted) {
+    ScopedSharedSceneToolRegistration cleanup;
+    FakeSharedSceneBackend backend;
+    lfs::mcp::register_shared_scene_tools(backend.backend());
+
+    const std::filesystem::path dataset_path = "/tmp/mcp_dataset";
+    const auto result = lfs::mcp::ToolRegistry::instance().call_tool(
+        "scene.load_dataset",
+        json{{"path", dataset_path.string()}});
+
+    ASSERT_TRUE(result["success"].get<bool>());
+    ASSERT_TRUE(backend.load_dataset_called);
+    const auto expected = lfs::core::param::OptimizationParameters::mrnf_defaults();
+    EXPECT_EQ(backend.loaded_params.optimization.max_cap, expected.max_cap);
+    EXPECT_FLOAT_EQ(backend.loaded_params.optimization.opacity_reg, expected.opacity_reg);
+    EXPECT_EQ(backend.loaded_params.optimization.refine_every, expected.refine_every);
+}
+
+TEST(McpSharedSceneToolsTest, LoadDatasetAppliesIgsPlusStrategyDefaults) {
+    ScopedSharedSceneToolRegistration cleanup;
+    FakeSharedSceneBackend backend;
+    lfs::mcp::register_shared_scene_tools(backend.backend());
+
+    const std::filesystem::path dataset_path = "/tmp/mcp_dataset";
+    const auto result = lfs::mcp::ToolRegistry::instance().call_tool(
+        "scene.load_dataset",
+        json{{"path", dataset_path.string()}, {"strategy", "igs+"}});
+
+    ASSERT_TRUE(result["success"].get<bool>());
+    ASSERT_TRUE(backend.load_dataset_called);
+    const auto expected = lfs::core::param::OptimizationParameters::igs_plus_defaults();
+    EXPECT_EQ(backend.loaded_params.optimization.max_cap, expected.max_cap);
+    EXPECT_EQ(backend.loaded_params.optimization.refine_every, expected.refine_every);
+}
+
+TEST(McpSharedSceneToolsTest, LoadDatasetPreservesMaxIterationsWithMcmcDefaults) {
+    ScopedSharedSceneToolRegistration cleanup;
+    FakeSharedSceneBackend backend;
+    lfs::mcp::register_shared_scene_tools(backend.backend());
+
+    const std::filesystem::path dataset_path = "/tmp/mcp_dataset";
+    const auto result = lfs::mcp::ToolRegistry::instance().call_tool(
+        "scene.load_dataset",
+        json{
+            {"path", dataset_path.string()},
+            {"strategy", "mcmc"},
+            {"max_iterations", 12345},
+        });
+
+    ASSERT_TRUE(result["success"].get<bool>());
+    ASSERT_TRUE(backend.load_dataset_called);
+    EXPECT_EQ(backend.loaded_params.optimization.iterations, 12345u);
+    const auto expected = lfs::core::param::OptimizationParameters::mcmc_defaults();
+    EXPECT_EQ(backend.loaded_params.optimization.max_cap, expected.max_cap);
+    EXPECT_EQ(backend.loaded_params.optimization.refine_every, expected.refine_every);
+    EXPECT_FLOAT_EQ(backend.loaded_params.optimization.opacity_reg, expected.opacity_reg);
+}
+
 TEST(McpSharedSceneToolsTest, GetLastErrorReturnsEnvelopeWhenLatched) {
     ScopedSharedSceneToolRegistration cleanup;
     FakeSharedSceneBackend fake;


### PR DESCRIPTION
Loading a dataset over MCP trained with old leftover settings instead of the real defaults. Most visibly, the model was capped at 1 million splats while the panel promised 5 million, so quality silently stopped improving. Now MCP runs get exactly the same settings as the CLI and the GUI panel. Verified live: the model grows past the old ceiling and every value matches the defaults. Three new tests cover it.

Second commit: while investigating #1864, one spot in the training optimizer still used a shared-memory pattern that caused a race once before. It now uses a dedicated race-safe reduction, slightly faster, with identical results. All 135 kernel tests pass.