### PR TITLE
Save modified point clouds into the project, not over the source dataset

### DIFF
--- a/src/python/lfs/py_scene.cpp
+++ b/src/python/lfs/py_scene.cpp
@@ -221,8 +221,10 @@ namespace lfs::python {
         pc_->scaling = pc_->scaling.is_valid() ? pc_->scaling[mask_dev] : pc_->scaling;
         pc_->rotation = pc_->rotation.is_valid() ? pc_->rotation[mask_dev] : pc_->rotation;
 
-        if (scene_)
+        if (scene_) {
             scene_->setPointCloudModified(true);
+            scene_->notifyMutation(core::Scene::MutationType::MODEL_CHANGED);
+        }
         return old_size - pc_->size();
     }
 
@@ -243,8 +245,10 @@ namespace lfs::python {
         pc_->scaling = pc_->scaling.is_valid() ? pc_->scaling[idx_dev] : pc_->scaling;
         pc_->rotation = pc_->rotation.is_valid() ? pc_->rotation[idx_dev] : pc_->rotation;
 
-        if (scene_)
+        if (scene_) {
             scene_->setPointCloudModified(true);
+            scene_->notifyMutation(core::Scene::MutationType::MODEL_CHANGED);
+        }
         return old_size - pc_->size();
     }
 

--- a/src/python/lfs_plugins/training_panel.py
+++ b/src/python/lfs_plugins/training_panel.py
@@ -15,6 +15,7 @@ from .scrub_fields import ScrubFieldController, ScrubFieldSpec
 from .training_confirm import (
     _invoke_project_save_as,
     _project_has_path,
+    _save_titled_project,
     _schedule_once_project_bound,
     confirm_discard_work_then,
 )
@@ -2449,14 +2450,27 @@ class TrainingPanel(Panel):
             elif button == _k:
                 lf.start_training()
 
+        message = (
+            tr("training.save_pc.message_project")
+            if _project_has_path()
+            else tr("training.save_pc.message")
+        )
         lf.ui.confirm_dialog(
             tr("training.save_pc.title"),
-            tr("training.save_pc.message"),
+            message,
             [btn_save, btn_skip, btn_cancel],
             _on_result,
         )
 
     def _save_modified_pc(self):
+        if _project_has_path():
+            if _save_titled_project():
+                scene = lf.get_scene()
+                if scene:
+                    scene.is_point_cloud_modified = False
+            else:
+                lf.log.error("Failed to save the point cloud to the project")
+            return
         d = lf.dataset_params()
         if not d or not d.has_params() or not d.data_path:
             return

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -413,6 +413,7 @@
     "conflict.btn_cancel": "Abbrechen",
     "save_pc.title": "Geänderte Punktwolke",
     "save_pc.message": "Die Punktwolke wurde geändert. Für zukünftige Sitzungen im Datensatz-Ordner speichern?",
+    "save_pc.message_project": "Die Punktwolke wurde geändert. Im Projekt speichern?",
     "save_pc.btn_save_start": "Speichern & Starten",
     "save_pc.btn_start_without": "Ohne Speichern starten",
     "overwrite.title": "Vorheriges Training überschreiben?",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -413,6 +413,7 @@
     "conflict.btn_cancel": "Cancel",
     "save_pc.title": "Modified Point Cloud",
     "save_pc.message": "The point cloud has been modified. Save to the dataset folder for future sessions?",
+    "save_pc.message_project": "The point cloud has been modified. Save it to the project?",
     "save_pc.btn_save_start": "Save & Start",
     "save_pc.btn_start_without": "Start Without Saving",
     "overwrite.title": "Overwrite previous training?",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -413,6 +413,7 @@
     "conflict.btn_cancel": "Cancelar",
     "save_pc.title": "Nube de puntos modificada",
     "save_pc.message": "La nube de puntos se ha modificado. ¿Guardar en la carpeta del dataset para futuras sesiones?",
+    "save_pc.message_project": "La nube de puntos se ha modificado. ¿Guardar en el proyecto?",
     "save_pc.btn_save_start": "Guardar e iniciar",
     "save_pc.btn_start_without": "Iniciar sin guardar",
     "overwrite.title": "¿Sobrescribir el entrenamiento anterior?",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -413,6 +413,7 @@
     "conflict.btn_cancel": "Annuler",
     "save_pc.title": "Nuage de points modifié",
     "save_pc.message": "Le nuage de points a été modifié. Sauvegarder dans le dossier du dataset pour les sessions futures ?",
+    "save_pc.message_project": "Le nuage de points a été modifié. Sauvegarder dans le projet ?",
     "save_pc.btn_save_start": "Sauvegarder et démarrer",
     "save_pc.btn_start_without": "Démarrer sans sauvegarder",
     "overwrite.title": "Écraser l'entraînement précédent ?",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -413,6 +413,7 @@
     "conflict.btn_cancel": "Annulla",
     "save_pc.title": "Nuvola di punti modificata",
     "save_pc.message": "La nuvola di punti è stata modificata. Salvare nella cartella del dataset per le sessioni future?",
+    "save_pc.message_project": "La nuvola di punti è stata modificata. Salvare nel progetto?",
     "save_pc.btn_save_start": "Salva e avvia",
     "save_pc.btn_start_without": "Avvia senza salvare",
     "overwrite.title": "Sovrascrivere l'addestramento precedente?",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -413,6 +413,7 @@
     "conflict.btn_cancel": "キャンセル",
     "save_pc.title": "変更されたポイントクラウド",
     "save_pc.message": "ポイントクラウドが変更されています。今後のセッションのためにデータセットフォルダに保存しますか？",
+    "save_pc.message_project": "ポイントクラウドが変更されています。プロジェクトに保存しますか？",
     "save_pc.btn_save_start": "保存して開始",
     "save_pc.btn_start_without": "保存せずに開始",
     "overwrite.title": "以前のトレーニングを上書きしますか？",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -413,6 +413,7 @@
     "conflict.btn_cancel": "취소",
     "save_pc.title": "수정된 포인트 클라우드",
     "save_pc.message": "포인트 클라우드가 수정되었습니다. 향후 세션을 위해 데이터셋 폴더에 저장하시겠습니까?",
+    "save_pc.message_project": "포인트 클라우드가 수정되었습니다. 프로젝트에 저장하시겠습니까?",
     "save_pc.btn_save_start": "저장 후 시작",
     "save_pc.btn_start_without": "저장 없이 시작",
     "overwrite.title": "이전 학습을 덮어쓸까요?",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -413,6 +413,7 @@
     "conflict.btn_cancel": "Annuleren",
     "save_pc.title": "Gewijzigde puntenwolk",
     "save_pc.message": "De puntenwolk is gewijzigd. Opslaan in de datasetmap voor toekomstige sessies?",
+    "save_pc.message_project": "De puntenwolk is gewijzigd. Opslaan in het project?",
     "save_pc.btn_save_start": "Opslaan en starten",
     "save_pc.btn_start_without": "Starten zonder opslaan",
     "overwrite.title": "Vorige training overschrijven?",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -413,6 +413,7 @@
     "conflict.btn_cancel": "Anuluj",
     "save_pc.title": "Zmodyfikowana chmura punktów",
     "save_pc.message": "Chmura punktów została zmodyfikowana. Zapisać w folderze datasetu dla przyszłych sesji?",
+    "save_pc.message_project": "Chmura punktów została zmodyfikowana. Zapisać w projekcie?",
     "save_pc.btn_save_start": "Zapisz i rozpocznij",
     "save_pc.btn_start_without": "Rozpocznij bez zapisywania",
     "overwrite.title": "Nadpisać poprzedni trening?",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -413,6 +413,7 @@
     "conflict.btn_cancel": "取消",
     "save_pc.title": "已修改的点云",
     "save_pc.message": "点云已被修改。是否保存到数据集文件夹以供未来使用？",
+    "save_pc.message_project": "点云已被修改。是否保存到项目？",
     "save_pc.btn_save_start": "保存并开始",
     "save_pc.btn_start_without": "不保存直接开始",
     "overwrite.title": "覆盖之前的训练？",

--- a/tests/python/test_training_panel_regressions.py
+++ b/tests/python/test_training_panel_regressions.py
@@ -37,6 +37,10 @@ def _install_lf_stub(monkeypatch):
     lf_stub.loss_buffer = lambda: []
     lf_stub.push_loss_to_element = lambda _element, _data: (0.0, 0.0)
     lf_stub.get_render_settings = lambda: None
+    lf_stub.detect_dataset_info = lambda _path: None
+    lf_stub.log = SimpleNamespace(error=lambda *_a, **_k: None, info=lambda *_a, **_k: None)
+    lf_stub.io = SimpleNamespace(save_point_cloud_ply=lambda *_a, **_k: None)
+    lf_stub.scene = SimpleNamespace(NodeType=SimpleNamespace(POINTCLOUD="POINTCLOUD"))
     monkeypatch.setitem(sys.modules, "lichtfeld", lf_stub)
     return lf_stub
 
@@ -51,6 +55,7 @@ def test_bundled_locales_define_training_panel_strategy_and_color_keys():
         assert "refinement.grow_until_iter" in data["training"]
         assert "tooltip.grow_until_iter" in data["training"]
         assert data["training"]["overwrite.btn_save_as_start"]
+        assert data["training"]["save_pc.message_project"]
         assert data["training_panel"]["color_red_prefix"] == "R:"
         assert data["training_panel"]["color_green_prefix"] == "G:"
         assert data["training_panel"]["color_blue_prefix"] == "B:"
@@ -1548,3 +1553,127 @@ def test_resume_on_stored_session_restores_before_resuming(
     finally:
         runtime.has_trainer._fallback = False
         runtime.training_state._fallback = "idle"
+
+
+def test_save_modified_pc_writes_to_bound_project(training_panel_module, monkeypatch):
+    project_saves = []
+    detect_calls = []
+    ply_calls = []
+    scene = SimpleNamespace(is_point_cloud_modified=True)
+
+    def save_titled():
+        project_saves.append(True)
+        return True
+
+    monkeypatch.setattr(training_panel_module, "_project_has_path", lambda: True)
+    monkeypatch.setattr(training_panel_module, "_save_titled_project", save_titled)
+    monkeypatch.setattr(training_panel_module.lf, "get_scene", lambda: scene)
+    monkeypatch.setattr(
+        training_panel_module.lf,
+        "detect_dataset_info",
+        lambda *args, **kwargs: detect_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        training_panel_module.lf,
+        "io",
+        SimpleNamespace(
+            save_point_cloud_ply=lambda *args, **kwargs: ply_calls.append((args, kwargs))
+        ),
+    )
+
+    training_panel_module.TrainingPanel()._save_modified_pc()
+
+    assert project_saves == [True]
+    assert detect_calls == []
+    assert ply_calls == []
+    assert scene.is_point_cloud_modified is False
+
+
+def test_save_modified_pc_bound_project_failed_save_skips_dataset(
+    training_panel_module, monkeypatch
+):
+    ply_calls = []
+    scene = SimpleNamespace(is_point_cloud_modified=True)
+
+    monkeypatch.setattr(training_panel_module, "_project_has_path", lambda: True)
+    monkeypatch.setattr(training_panel_module, "_save_titled_project", lambda: False)
+    monkeypatch.setattr(training_panel_module.lf, "get_scene", lambda: scene)
+    monkeypatch.setattr(
+        training_panel_module.lf,
+        "io",
+        SimpleNamespace(
+            save_point_cloud_ply=lambda *args, **kwargs: ply_calls.append((args, kwargs))
+        ),
+    )
+
+    training_panel_module.TrainingPanel()._save_modified_pc()
+
+    assert ply_calls == []
+    assert scene.is_point_cloud_modified is True
+
+
+def test_save_modified_pc_unbound_writes_dataset_ply(training_panel_module, monkeypatch):
+    ply_calls = []
+    pc = SimpleNamespace(size=12)
+    node = SimpleNamespace(
+        type=training_panel_module.lf.scene.NodeType.POINTCLOUD,
+        point_cloud=lambda: pc,
+    )
+    scene = SimpleNamespace(
+        is_point_cloud_modified=True,
+        get_nodes=lambda: [node],
+    )
+    dataset = SimpleNamespace(data_path="/data/scene_a", has_params=lambda: True)
+    info = SimpleNamespace(sparse_path="/data/scene_a/sparse/0")
+
+    monkeypatch.setattr(training_panel_module, "_project_has_path", lambda: False)
+    monkeypatch.setattr(training_panel_module.lf, "dataset_params", lambda: dataset)
+    monkeypatch.setattr(training_panel_module.lf, "detect_dataset_info", lambda _path: info)
+    monkeypatch.setattr(training_panel_module.lf, "get_scene", lambda: scene)
+    monkeypatch.setattr(
+        training_panel_module.lf,
+        "io",
+        SimpleNamespace(
+            save_point_cloud_ply=lambda cloud, path: ply_calls.append((cloud, path))
+        ),
+    )
+
+    training_panel_module.TrainingPanel()._save_modified_pc()
+
+    assert ply_calls == [(pc, "/data/scene_a/sparse/0/points3D.ply")]
+    assert scene.is_point_cloud_modified is False
+
+
+@pytest.mark.parametrize(
+    ("bound", "expected_message"),
+    [
+        (True, "training.save_pc.message_project"),
+        (False, "training.save_pc.message"),
+    ],
+)
+def test_show_save_pc_dialog_message_depends_on_project_binding(
+    training_panel_module, monkeypatch, bound, expected_message
+):
+    dialogs = []
+
+    monkeypatch.setattr(training_panel_module, "_project_has_path", lambda: bound)
+    monkeypatch.setattr(
+        training_panel_module.lf.ui,
+        "confirm_dialog",
+        lambda title, message, buttons, callback=None: dialogs.append(
+            (title, message, list(buttons), callback)
+        ),
+        raising=False,
+    )
+
+    training_panel_module.TrainingPanel()._show_save_pc_dialog()
+
+    assert len(dialogs) == 1
+    title, message, buttons, _callback = dialogs[0]
+    assert title == "training.save_pc.title"
+    assert message == expected_message
+    assert buttons == [
+        "training.save_pc.btn_save_start",
+        "training.save_pc.btn_start_without",
+        "training.conflict.btn_cancel",
+    ]


### PR DESCRIPTION
Fixes #1854.

When a project was open and the point cloud had been modified (for example by the densification plugin), the "Save & Start" dialog wrote points3D.ply into the original dataset folder. That silently changed the source dataset for every future load, since a points3D.ply shadows the points3D.bin next to it.

Now, with a project open, the dialog saves the point cloud into the project and leaves the dataset untouched. Reopening the project brings the modified point cloud back. Without a project, the old behavior is unchanged: the dialog still asks before writing to the dataset folder.

Also fixes a gap where point clouds modified through the Python filter API were not picked up by a project save. New message string added in all languages, covered by new regression tests, and verified end to end in the app.