### PR TITLE
Add overview video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ LichtFeld Studio lets you train new scenes from COLMAP datasets, resume checkpoi
 
 <img src="docs/viewer_demo.gif" alt="LichtFeld Studio viewer" width="85%"/>
 
+[**See It in Action**](#see-it-in-action) •
 [**Why LichtFeld**](#why-lichtfeld-studio) •
 [**Who It Is For**](#who-it-is-for) •
 [**Capabilities**](#capabilities) •
@@ -37,6 +38,18 @@ LichtFeld Studio lets you train new scenes from COLMAP datasets, resume checkpoi
 [**Community**](#community) •
 [**Contributing**](#contributing) •
 [**License**](#license)
+
+</div>
+
+## See It in Action
+
+<div align="center">
+
+<a href="https://www.youtube.com/watch?v=i-04z4_eqiU">
+  <img src="https://img.youtube.com/vi/i-04z4_eqiU/maxresdefault.jpg" alt="LichtFeld Studio — Everything it can do today" width="85%">
+</a>
+
+[**▶ Watch on YouTube — Everything LichtFeld Studio can do today**](https://www.youtube.com/watch?v=i-04z4_eqiU)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ LichtFeld Studio lets you train new scenes from COLMAP datasets, resume checkpoi
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord&logoColor=white)](https://discord.gg/TbxJST2BbC)
 [![Website](https://img.shields.io/badge/Website-LichtFeld%20Studio-blue)](https://lichtfeld.io)
 [![X](https://img.shields.io/badge/X-Follow-111111?logo=x&logoColor=white)](https://twitter.com/janusch_patas)
+[![YouTube](https://img.shields.io/badge/YouTube-Subscribe-FF0000?logo=youtube&logoColor=white)](https://www.youtube.com/@lichtfeldstudio)
 [![Papers](https://img.shields.io/badge/Papers-Awesome%203DGS-orange)](https://mrnerf.github.io/awesome-3D-gaussian-splatting/)
 
 [![GitHub Sponsors](https://img.shields.io/badge/GitHub%20Sponsors-Support-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/MrNeRF)
@@ -123,6 +124,7 @@ Current project notes:
 - [Discord](https://discord.gg/TbxJST2BbC) for support, discussion, and showcase posts
 - [Website](https://mrnerf.com) for project updates and related work
 - [Twitter / X](https://twitter.com/janusch_patas) for announcements
+- [YouTube](https://www.youtube.com/@lichtfeldstudio) for video tours and feature demos
 
 ## Contributing
 


### PR DESCRIPTION
Adds the "Everything it can do today" YouTube video to the README as a new **See It in Action** section right below the hero — centered full-res thumbnail linked to the video, plus a nav entry. GitHub does not allow embedded players in READMEs, so a clickable thumbnail is the standard approach.