### PR TITLE
Fix rendering of Python-added splats

### DIFF
--- a/src/python/lfs/py_scene.cpp
+++ b/src/python/lfs/py_scene.cpp
@@ -9,6 +9,7 @@
 #include "core/path_utils.hpp"
 #include "core/property_registry.hpp"
 #include "io/loader.hpp"
+#include "lfs/training/sh_value_storage.hpp"
 #include "python/python_runtime.hpp"
 #include "visualizer/gui_capabilities.hpp"
 #include "visualizer/operation/undo_entry.hpp"
@@ -411,6 +412,15 @@ namespace lfs::python {
                 throw std::runtime_error("Failed to prepare splat tensors for rendering: " +
                                          migrated.error().format());
             }
+
+            // Migration moves the base splat tensors into Vulkan-external storage but,
+            // when SH quantization is enabled, deliberately leaves float32 SH-rest in a
+            // temporary CUDA workspace. VkSplat cannot bind that workspace, so we need to
+            // convert SH-rest into Vulkan-visible q16 codes and bounds before rendering.
+            // This conversion is a no-op when quantization is disabled or already applied
+            // (checked in lfs::training::sh_value::apply_shN_value_quant)
+            (void)lfs::training::sh_value::apply_shN_value_quant(*splat);
+
             scene_->setCombinedModelAllocator(std::move(allocator));
         }
 


### PR DESCRIPTION
**Summary**
Splats added through the Python `add_splat()` API don't render when SH value quantization is enabled because shN is parked in memory no accessible by the Vulkan renderer.

**Details**
`add_splat` migrates the new model into the viewer allocator, but `keepFloatShNInPooledCuda` deliberately parks float32 `SplatData.shN` in pooled CUDA as a q16 workspace rather than importing a float rest buffer into Vulkan. VkSplat can't bind that workspace.

**Fix**
Call `apply_shN_value_quant` after migration and before `addSplat`, so shN becomes Vulkan-visible q16 codes plus bounds.