### PR TITLE
Fix/python callback gil lifetime

### DIFF
--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -104,6 +104,7 @@
 #include <fstream>
 #include <functional>
 #include <future>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -137,6 +138,17 @@ namespace {
     using lfs::training::SelectionKind;
     using lfs::training::TrainingPhase;
     using lfs::training::TrainingSnapshot;
+
+    using SafePyCallback = std::shared_ptr<nb::object>;
+
+    SafePyCallback make_safe_py_callback(nb::object callback) {
+        // Native hook queues copy callbacks without the GIL. Keep Python
+        // ownership behind a C++ shared pointer and acquire the GIL on deletion.
+        return {new nb::object(std::move(callback)), [](nb::object* callback) {
+                    nb::gil_scoped_acquire gil;
+                    delete callback;
+                }};
+    }
 
     void warn_deprecated_python_api(const std::string_view old_name, const std::string_view replacement) {
         const std::string message = std::format(
@@ -460,19 +472,20 @@ namespace {
 
         void add(ControlHook hook, nb::callable fn) {
             nb::object fn_obj = std::move(fn);
-            auto cb = [fn_obj](const HookContext& ctx) {
+            auto callback = make_safe_py_callback(std::move(fn_obj));
+            auto cb = [callback](const HookContext& ctx) {
                 nb::gil_scoped_acquire gil;
                 HookInvocationGuard hook_guard(ctx);
-                fn_obj(ctx.iteration, ctx.loss, ctx.num_gaussians, ctx.is_refining);
+                (*callback)(ctx.iteration, ctx.loss, ctx.num_gaussians, ctx.is_refining);
             };
 
             const auto id = ControlBoundary::instance().register_callback(hook, std::move(cb));
             registrations_.push_back({hook, id});
-            owned_callbacks_.push_back(std::move(fn_obj));
+            owned_callbacks_.push_back(std::move(callback));
         }
 
         std::vector<RegistrationHandle> registrations_;
-        std::vector<nb::object> owned_callbacks_;
+        std::vector<SafePyCallback> owned_callbacks_;
     };
 
     class PyScopedHandler {
@@ -499,15 +512,16 @@ namespace {
     private:
         void add_hook(ControlHook hook, nb::callable cb) {
             nb::object fn = nb::cast<nb::object>(cb);
-            owned_callbacks_.push_back(fn);
+            auto callback = make_safe_py_callback(std::move(fn));
+            owned_callbacks_.push_back(callback);
 
-            handler_.subscribe_hook(hook, [fn, hook](const HookContext& ctx) {
-                invoke_python_dict_hook(fn, hook, ctx);
+            handler_.subscribe_hook(hook, [callback, hook](const HookContext& ctx) {
+                invoke_python_dict_hook(*callback, hook, ctx);
             });
         }
 
         lfs::event::ScopedHandler handler_;
-        std::vector<nb::object> owned_callbacks_;
+        std::vector<SafePyCallback> owned_callbacks_;
     };
 
     class PyContextView {
@@ -700,10 +714,10 @@ namespace {
     std::size_t register_hook(ControlHook hook, nb::callable cb) {
         if (!cb)
             return 0;
-        const nb::object ocb = nb::cast<nb::object>(cb);
+        const auto callback = make_safe_py_callback(nb::cast<nb::object>(cb));
         LOG_INFO("Python hook registered for hook {}", static_cast<int>(hook));
-        return ControlBoundary::instance().register_callback(hook, [ocb, hook](const HookContext& ctx) {
-            invoke_python_dict_hook(ocb, hook, ctx);
+        return ControlBoundary::instance().register_callback(hook, [callback, hook](const HookContext& ctx) {
+            invoke_python_dict_hook(*callback, hook, ctx);
         });
     }
 

--- a/src/python/lfs/py_store.cpp
+++ b/src/python/lfs/py_store.cpp
@@ -37,6 +37,41 @@ namespace lfs::python {
         std::atomic_uint64_t g_next_subscription_id{1};
         thread_local bool g_test_drain_with_current_gil = false;
 
+        template <typename Invoke>
+        void invoke_python_subscription(
+            const std::weak_ptr<PyStoreSubscription>& weak_subscription,
+            Invoke&& invoke) {
+            const bool can_acquire = can_acquire_gil();
+            const bool use_current_gil =
+                !can_acquire && g_test_drain_with_current_gil && PyGILState_Check();
+            if (!can_acquire && !use_current_gil)
+                return;
+
+            const auto invoke_callback = [&] {
+                // Lock inside the GIL-held scope so self-unsubscription cannot
+                // release the final Python callback reference without the GIL.
+                const auto subscription = weak_subscription.lock();
+                if (!subscription)
+                    return;
+
+                try {
+                    invoke(subscription->callback);
+                } catch (nb::python_error& e) {
+                    (void)contain_python_callback(e, PyCallbackPolicy::WarnAndContinue);
+                } catch (const std::exception& e) {
+                    (void)contain_cxx_callback(e.what(), PyCallbackPolicy::WarnAndContinue);
+                }
+            };
+
+            if (can_acquire) {
+                const GilAcquire gil;
+                invoke_callback();
+            } else {
+                // Test drain already entered from Python with the GIL held.
+                invoke_callback();
+            }
+        }
+
         template <typename Observable>
         std::uint64_t subscribe_observable(Observable& observable, nb::object callback) {
             const auto id = g_next_subscription_id.fetch_add(1, std::memory_order_relaxed);
@@ -44,32 +79,9 @@ namespace lfs::python {
             subscription->callback = std::move(callback);
             const std::weak_ptr<PyStoreSubscription> weak_subscription = subscription;
             subscription->token = observable.subscribe([weak_subscription](const auto& value) {
-                const auto subscription = weak_subscription.lock();
-                if (!subscription)
-                    return;
-                const bool can_acquire = can_acquire_gil();
-                const bool use_current_gil = !can_acquire && g_test_drain_with_current_gil && PyGILState_Check();
-                if (!can_acquire && !use_current_gil)
-                    return;
-                try {
-                    if (can_acquire) {
-                        const GilAcquire gil;
-                        subscription->callback(value);
-                    } else {
-                        subscription->callback(value);
-                    }
-                } catch (nb::python_error& e) {
-                    // Containment needs the GIL to extract and report; if it is
-                    // gone the interpreter is dead or finalizing, and swallowing
-                    // here is deliberate — the pre-Phase 9 e.what() log ran
-                    // GIL-unsafe and was itself a shutdown crash class.
-                    if (can_acquire_gil()) {
-                        const GilAcquire gil;
-                        (void)contain_python_callback(e, PyCallbackPolicy::WarnAndContinue);
-                    }
-                } catch (const std::exception& e) {
-                    (void)contain_cxx_callback(e.what(), PyCallbackPolicy::WarnAndContinue);
-                }
+                invoke_python_subscription(
+                    weak_subscription,
+                    [&value](const nb::object& callback) { callback(value); });
             });
 
             {
@@ -86,32 +98,9 @@ namespace lfs::python {
             subscription->callback = std::move(callback);
             const std::weak_ptr<PyStoreSubscription> weak_subscription = subscription;
             subscription->token = observable.subscribe([weak_subscription, convert = std::move(convert)](const auto& value) {
-                const auto subscription = weak_subscription.lock();
-                if (!subscription)
-                    return;
-                const bool can_acquire = can_acquire_gil();
-                const bool use_current_gil = !can_acquire && g_test_drain_with_current_gil && PyGILState_Check();
-                if (!can_acquire && !use_current_gil)
-                    return;
-                try {
-                    if (can_acquire) {
-                        const GilAcquire gil;
-                        subscription->callback(convert(value));
-                    } else {
-                        subscription->callback(convert(value));
-                    }
-                } catch (nb::python_error& e) {
-                    // Containment needs the GIL to extract and report; if it is
-                    // gone the interpreter is dead or finalizing, and swallowing
-                    // here is deliberate — the pre-Phase 9 e.what() log ran
-                    // GIL-unsafe and was itself a shutdown crash class.
-                    if (can_acquire_gil()) {
-                        const GilAcquire gil;
-                        (void)contain_python_callback(e, PyCallbackPolicy::WarnAndContinue);
-                    }
-                } catch (const std::exception& e) {
-                    (void)contain_cxx_callback(e.what(), PyCallbackPolicy::WarnAndContinue);
-                }
+                invoke_python_subscription(
+                    weak_subscription,
+                    [&](const nb::object& callback) { callback(convert(value)); });
             });
 
             {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -912,6 +912,7 @@ set(LFS_PYTHON_FAST_TESTS
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_selection_groups_panel.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_splat_lod_hierarchy.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_store.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/test_store_subscriptions.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_tensor.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_tensor_property.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_tool_registry_activation.py

--- a/tests/python/test_store_subscriptions.py
+++ b/tests/python/test_store_subscriptions.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression tests for GIL lifetime in store subscriptions.
+Cover callbacks that unsubscribe themselves. That drops the registry's
+strong reference mid-notification, leaving the native lambda as the last
+owner of the Python callable, so it performs the final release. Before the
+fix that release happened after the GIL had been dropped, which is
+undefined behavior.
+"""
+
+import gc
+import weakref
+
+import pytest
+
+TOUCHED_FIELDS = ("iteration", "splat_simplify_state")
+
+
+@pytest.fixture
+def store(lf):
+    """The native store bridge, with every field this module writes restored."""
+    bridge = getattr(getattr(lf, "ui", None), "store", None)
+    if bridge is None or not hasattr(bridge, "_drain_for_tests"):
+        pytest.skip("native lichtfeld.ui.store bridge not available")
+
+    saved = {field: bridge.get(field) for field in TOUCHED_FIELDS}
+    yield bridge
+    for field, value in saved.items():
+        bridge.set(field, value)
+    bridge._drain_for_tests()
+
+
+def _notify_self_unsubscribing_callback(store, field, value):
+    """Fire one notification into a callback that unsubscribes itself."""
+    state = {"token": None, "calls": 0}
+
+    def on_change(_value):
+        state["calls"] += 1
+        # Unsubscribe ourselves.
+        store.unsubscribe(state["token"])
+
+    state["token"] = store.subscribe(field, on_change)
+    probe = weakref.ref(on_change)
+    del on_change
+
+    store.set(field, value)
+    assert store._drain_for_tests() is True
+    return state["calls"], probe
+
+
+def test_self_unsubscribing_subscription_releases_callback_under_gil(store):
+    calls, probe = _notify_self_unsubscribing_callback(
+        store, "iteration", store.get("iteration") + 1
+    )
+
+    assert calls == 1
+    gc.collect()
+    assert probe() is None, "callback outlived the notification; release path not exercised"
+
+
+def test_self_unsubscribing_converting_subscription_releases_callback_under_gil(store):
+    calls, probe = _notify_self_unsubscribing_callback(
+        store, "splat_simplify_state", {"active": True, "stage": "gil-lifetime-test"}
+    )
+
+    assert calls == 1
+    gc.collect()
+    assert probe() is None, "callback outlived the notification; release path not exercised"


### PR DESCRIPTION
Two independent fixes in the Python bindings, plus a regression test. Both are cases where native code owned an `nb::object` and could release it on a thread that does not hold the GIL.

`py_store.cpp`-fix:
The notification lambda's `weak_ptr::lock()` sat above the `GilAcquire` scope, so its local `shared_ptr` was released after the GIL had been dropped. This occurs when a Python callback unsubscribes itself.

`module.cpp`-fix:
Native hook registries may copy and destroy callbacks off-GIL. Callbacks are now held behind `shared_ptr<nb::object>` with a
GIL-acquiring deleter, with only the pointer captured.