### PR TITLE
Fix lichtfeld_tests not compiling on Windows

### DIFF
--- a/src/visualizer/scene/viewer_splat_quantize.hpp
+++ b/src/visualizer/scene/viewer_splat_quantize.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "core/export.hpp"
+
 #include <filesystem>
 
 namespace lfs::core {
@@ -15,7 +17,7 @@ namespace lfs::vis {
     // Same Vulkan-external storage check VkSplat uses before it will bind a model
     // without the input-copy fallback (means/sh0/rotation/scaling/opacity/shN, and
     // shN bounds when the rest buffer is q16).
-    [[nodiscard]] bool viewerSplatTensorsRendererReady(const lfs::core::SplatData& model);
+    [[nodiscard]] LFS_VIS_API bool viewerSplatTensorsRendererReady(const lfs::core::SplatData& model);
 
     // Encode rest SH into exportable q16 Vulkan-external storage when the current
     // buffer cannot be bound. Reuses SplatData::apply_shN_value_quant. Does not


### PR DESCRIPTION
Add export macro to fix lichtfeld_tests compilation on Windows