### PR TITLE
Faster tensor-core kernels and new NN ops

### DIFF
--- a/src/core/include/core/nn/ops.hpp
+++ b/src/core/include/core/nn/ops.hpp
@@ -73,10 +73,13 @@ namespace lfs::core::nn {
                                            const Tensor* residual = nullptr,
                                            const Tensor* scale = nullptr);
 
-    // y = x @ Wᵀ [+ bias] [+ activation]. x is [..., K], W is [N, K], bias [N].
+    // y = x @ Wᵀ [+ bias] [+ activation] [+ residual]. x is [..., K], W is [N, K],
+    // bias [N]. residual, if given, matches the output and is added after the
+    // activation (same epilogue order as gemm).
     [[nodiscard]] LFS_CORE_API Tensor linear(const Tensor& input, const Tensor& weight,
                                              const Tensor* bias = nullptr,
-                                             Activation activation = Activation::None);
+                                             Activation activation = Activation::None,
+                                             const Tensor* residual = nullptr);
 
     // Batched GEMM. a is [B, M, K], b is [B, N, K] if trans_b else [B, K, N].
     // A rank-2 b is broadcast across the batch.
@@ -111,6 +114,21 @@ namespace lfs::core::nn {
     // Inverse of window_partition. original_n is the unpadded sequence length.
     [[nodiscard]] LFS_CORE_API Tensor window_unpartition(const Tensor& windows, int window_size,
                                                          int original_n);
+
+    // 2D window partition for Hiera: [B, H, W, C] -> [B * nH * nW, ws, ws, C],
+    // padding H/W up to a multiple of window_size with zeros (bottom/right).
+    struct Window2d {
+        Tensor windows;
+        int pad_h = 0;
+        int pad_w = 0;
+    };
+
+    [[nodiscard]] LFS_CORE_API Window2d window_partition_2d(const Tensor& input, int window_size);
+
+    // Inverse of window_partition_2d. Crops back to orig_h x orig_w.
+    [[nodiscard]] LFS_CORE_API Tensor window_unpartition_2d(const Tensor& windows, int window_size,
+                                                            int pad_h, int pad_w, int orig_h,
+                                                            int orig_w);
 
     [[nodiscard]] LFS_CORE_API std::pair<int, int> conv2d_output_hw(
         int height, int width, int kernel_h, int kernel_w, const Conv2dParams& params);
@@ -156,14 +174,46 @@ namespace lfs::core::nn {
                                            GELUApprox approx = GELUApprox::Erf);
     [[nodiscard]] LFS_CORE_API Tensor silu(const Tensor& input);
     [[nodiscard]] LFS_CORE_API Tensor relu(const Tensor& input);
+    [[nodiscard]] LFS_CORE_API Tensor sigmoid(const Tensor& input);
+
+    // Channel-wise LayerNorm on NCHW (SAM LayerNorm2d): permute + layer_norm.
+    [[nodiscard]] LFS_CORE_API Tensor layer_norm_2d(const Tensor& input, const Tensor& weight,
+                                                    const Tensor& bias, float eps = 1e-6f);
+
+    // Random-Fourier PE: coords [..., 2] in [0, 1], gaussian [2, F], out [..., 2F].
+    [[nodiscard]] LFS_CORE_API Tensor fourier_pe(const Tensor& coords, const Tensor& gaussian);
+
+    // Dense grid PE as NCHW [1, 2F, H, W], matching PositionEmbeddingRandom.forward.
+    [[nodiscard]] LFS_CORE_API Tensor fourier_pe_grid(int height, int width, const Tensor& gaussian,
+                                                      DataType dtype, Device device,
+                                                      cudaStream_t stream);
 
     [[nodiscard]] LFS_CORE_API Tensor cast(const Tensor& input, DataType dtype);
 
     // qkv is [B, S, 3*H*D] or [B, S, 3, H, D]. Returns Q,K,V each [B, H, S, D].
     [[nodiscard]] LFS_CORE_API std::array<Tensor, 3> split_qkv(const Tensor& qkv, int heads);
 
+    // qkv is BHWC [B, H, W, 3*heads*d] packed as [3, heads, d] on the last dim.
+    // Returns Q,K,V each [B*nH*nW, heads, window*window, d], with bottom/right
+    // pad zeros (same padding as window_partition_2d).
+    [[nodiscard]] LFS_CORE_API std::array<Tensor, 3>
+    split_qkv_window_2d(const Tensor& qkv, int heads, int window, const Tensor* bias = nullptr);
+
     // context [B, H, S, D] -> [B, S, H*D].
     [[nodiscard]] LFS_CORE_API Tensor merge_heads(const Tensor& context);
+
+    // context [B*nH*nW, heads, window*window, d] -> [B, orig_h, orig_w, heads*d].
+    // orig_h/orig_w are the unpadded spatial size (pad is cropped).
+    [[nodiscard]] LFS_CORE_API Tensor merge_heads_unwindow_2d(const Tensor& context, int window,
+                                                              int orig_h, int orig_w);
+
+    // Max-pool 2x2 stride-2 over the spatial sequence of [B, heads, H*W, D].
+    // height*width must equal S. Output is [B, heads, (H/2)*(W/2), D].
+    [[nodiscard]] LFS_CORE_API Tensor max_pool_heads_2d(const Tensor& input, int height,
+                                                        int width);
+
+    // Max-pool 2x2 stride-2 on BHWC [B, H, W, C] -> [B, H/2, W/2, C].
+    [[nodiscard]] LFS_CORE_API Tensor max_pool2d_bhwc(const Tensor& input);
 
     // MoGe-2 unit-circle UV encoding as NCHW [1, 2, H, W].
     [[nodiscard]] LFS_CORE_API Tensor uv_grid(int height, int width, float aspect, DataType dtype,

--- a/src/core/nn/attention.cu
+++ b/src/core/nn/attention.cu
@@ -466,11 +466,26 @@ namespace lfs::core::nn::kernels {
         constexpr int kFlashD = 64;
         constexpr int kFlashLd = 72;
 
+        __device__ __forceinline__ uint4 scale_half8(uint4 packed, float scale) {
+            uint4 out;
+            const auto* src = reinterpret_cast<const __half2*>(&packed);
+            auto* dst = reinterpret_cast<__half2*>(&out);
+#pragma unroll
+            for (int c = 0; c < 4; ++c) {
+                const float2 f = __half22float2(src[c]);
+                dst[c] = __float22half2_rn(make_float2(f.x * scale, f.y * scale));
+            }
+            return out;
+        }
+
         // K/V tiles live at leading-dimension 72 (64 useful + 8 pad). The pad
         // is the load_matrix_sync-compatible form of an 8-half xor swizzle:
         // 8 consecutive rows at a fixed column hit distinct smem banks.
+        // Global K/V are [n_k, d] with d <= 64; columns d..63 are a uint4 zero.
+        // kPad=false is the d==64 path and must stay byte-identical.
+        template <bool kPad>
         __device__ __forceinline__ void load_kv_tile(__half* Ks, __half* Vs, const __half* K,
-                                                     const __half* V, int k0, int n_k,
+                                                     const __half* V, int k0, int n_k, int d,
                                                      long long kv_head, int tid) {
 #pragma unroll
             for (int i = 0; i < 4; ++i) {
@@ -479,24 +494,98 @@ namespace lfs::core::nn::kernels {
                 const int col = off % kFlashD;
                 const int k_idx = k0 + row;
                 const int sm = row * kFlashLd + col;
-                if (k_idx < n_k) {
-                    const long long base = kv_head + static_cast<long long>(k_idx) * kFlashD + col;
-                    device::cp_async16(Ks + sm, K + base);
-                    device::cp_async16(Vs + sm, V + base);
+                if constexpr (!kPad) {
+                    if (k_idx < n_k) {
+                        const long long base =
+                            kv_head + static_cast<long long>(k_idx) * kFlashD + col;
+                        device::cp_async16(Ks + sm, K + base);
+                        device::cp_async16(Vs + sm, V + base);
+                    } else {
+                        *reinterpret_cast<uint4*>(Ks + sm) = uint4{0, 0, 0, 0};
+                        *reinterpret_cast<uint4*>(Vs + sm) = uint4{0, 0, 0, 0};
+                    }
                 } else {
-                    *reinterpret_cast<uint4*>(Ks + sm) = uint4{0, 0, 0, 0};
-                    *reinterpret_cast<uint4*>(Vs + sm) = uint4{0, 0, 0, 0};
+                    const long long base =
+                        kv_head + static_cast<long long>(k_idx) * d + col;
+                    if (k_idx < n_k && col + 8 <= d) {
+                        device::cp_async16(Ks + sm, K + base);
+                        device::cp_async16(Vs + sm, V + base);
+                    } else if (k_idx < n_k && col < d) {
+#pragma unroll
+                        for (int c = 0; c < 8; ++c) {
+                            __half kv = __float2half(0.0f);
+                            __half vv = __float2half(0.0f);
+                            if ((col + c) < d) {
+                                kv = K[base + c];
+                                vv = V[base + c];
+                            }
+                            Ks[sm + c] = kv;
+                            Vs[sm + c] = vv;
+                        }
+                    } else {
+                        *reinterpret_cast<uint4*>(Ks + sm) = uint4{0, 0, 0, 0};
+                        *reinterpret_cast<uint4*>(Vs + sm) = uint4{0, 0, 0, 0};
+                    }
                 }
             }
         }
 
-        // Flash attention for d=64: two 64-row Q tiles per block (Br=128),
-        // Q/O fragment-resident, K/V cp.async double-buffered with xor-swizzle,
-        // P kept in A fragments for the PV mma (no BrxBc overlay on the inner ds loop).
+        template <bool kPad>
+        __device__ __forceinline__ void load_q_tile(__half* Qs, const __half* Q, int q_base,
+                                                    int n_q, int d, long long q_head, float scale,
+                                                    int tid) {
+            if constexpr (!kPad) {
+                for (int i = tid; i < kFlashTile * kFlashD; i += 128) {
+                    const int r = i / kFlashD;
+                    const int c = i % kFlashD;
+                    const int q_row = q_base + r;
+                    float val = 0.0f;
+                    if (q_row < n_q) {
+                        val = __half2float(
+                            Q[q_head + static_cast<long long>(q_row) * kFlashD + c]);
+                    }
+                    Qs[i] = __float2half_rn(val * scale);
+                }
+            } else {
+#pragma unroll
+                for (int i = 0; i < 4; ++i) {
+                    const int off = (tid + i * 128) * 8;
+                    const int row = off / kFlashD;
+                    const int col = off % kFlashD;
+                    const int q_row = q_base + row;
+                    uint4 packed = uint4{0, 0, 0, 0};
+                    if (q_row < n_q && col + 8 <= d) {
+                        const long long base =
+                            q_head + static_cast<long long>(q_row) * d + col;
+                        packed = scale_half8(*reinterpret_cast<const uint4*>(Q + base), scale);
+                    } else if (q_row < n_q && col < d) {
+                        const long long base =
+                            q_head + static_cast<long long>(q_row) * d + col;
+                        auto* h = reinterpret_cast<__half*>(&packed);
+#pragma unroll
+                        for (int c = 0; c < 8; ++c) {
+                            if (col + c < d) {
+                                h[c] = __float2half_rn(__half2float(Q[base + c]) * scale);
+                            }
+                        }
+                    }
+                    *reinterpret_cast<uint4*>(Qs + row * kFlashD + col) = packed;
+                }
+            }
+        }
+
+        // Flash attention for d<=64 (head dim padded to 64 in smem/fragments;
+        // tail columns are zero on load and skipped on store). Two 64-row Q
+        // tiles per block (Br=128), Q/O fragment-resident, K/V cp.async
+        // double-buffered with xor-swizzle, P kept in A fragments for the PV
+        // mma (no BrxBc overlay on the inner ds loop).
+        // kPad=false is compiled separately so the d==64 fast path stays
+        // byte-identical (MoGe-2).
+        template <bool kPad>
         __global__ void __launch_bounds__(128, 2)
             flash_attn_d64_kernel(const __half* __restrict__ q_ptr, const __half* __restrict__ k_ptr,
                                   const __half* __restrict__ v_ptr, __half* __restrict__ o_ptr,
-                                  int batch, int heads, int n_q, int n_k, float scale) {
+                                  int batch, int heads, int n_q, int n_k, int d, float scale) {
             const int tid = static_cast<int>(threadIdx.x);
             const int q0 = static_cast<int>(blockIdx.x) * kFlashBr;
             const int bh = static_cast<int>(blockIdx.y);
@@ -514,10 +603,11 @@ namespace lfs::core::nn::kernels {
             auto* Vs1 = Ks1 + kFlashBc * kFlashLd;
             auto* Ps = Qs;
 
+            const int head_d = kPad ? d : kFlashD;
             const long long q_head =
-                (static_cast<long long>(b) * heads + h) * static_cast<long long>(n_q) * kFlashD;
+                (static_cast<long long>(b) * heads + h) * static_cast<long long>(n_q) * head_d;
             const long long kv_head =
-                (static_cast<long long>(b) * heads + h) * static_cast<long long>(n_k) * kFlashD;
+                (static_cast<long long>(b) * heads + h) * static_cast<long long>(n_k) * head_d;
 
 #if __CUDA_ARCH__ >= 700
             using namespace nvcuda::wmma;
@@ -534,17 +624,7 @@ namespace lfs::core::nn::kernels {
 #pragma unroll
             for (int tile = 0; tile < 2; ++tile) {
                 const int q_base = q0 + tile * kFlashTile;
-                for (int i = tid; i < kFlashTile * kFlashD; i += 128) {
-                    const int r = i / kFlashD;
-                    const int c = i % kFlashD;
-                    const int q_row = q_base + r;
-                    float val = 0.0f;
-                    if (q_row < n_q) {
-                        val = __half2float(
-                            q_ptr[q_head + static_cast<long long>(q_row) * kFlashD + c]);
-                    }
-                    Qs[i] = __float2half_rn(val * scale);
-                }
+                load_q_tile<kPad>(Qs, q_ptr, q_base, n_q, d, q_head, scale, tid);
                 __syncthreads();
 #pragma unroll
                 for (int ds = 0; ds < 4; ++ds) {
@@ -556,7 +636,7 @@ namespace lfs::core::nn::kernels {
 
             auto* Kcur = Ks0;
             auto* Vcur = Vs0;
-            load_kv_tile(Kcur, Vcur, k_ptr, v_ptr, 0, n_k, kv_head, tid);
+            load_kv_tile<kPad>(Kcur, Vcur, k_ptr, v_ptr, 0, n_k, d, kv_head, tid);
             device::cp_async_commit();
             device::cp_async_wait0();
             __syncthreads();
@@ -566,7 +646,7 @@ namespace lfs::core::nn::kernels {
                 auto* Koth = (Kcur == Ks0) ? Ks1 : Ks0;
                 auto* Voth = (Vcur == Vs0) ? Vs1 : Vs0;
                 if (next < n_k) {
-                    load_kv_tile(Koth, Voth, k_ptr, v_ptr, next, n_k, kv_head, tid);
+                    load_kv_tile<kPad>(Koth, Voth, k_ptr, v_ptr, next, n_k, d, kv_head, tid);
                     device::cp_async_commit();
                 }
 
@@ -684,21 +764,63 @@ namespace lfs::core::nn::kernels {
 #pragma unroll
             for (int tile = 0; tile < 2; ++tile) {
                 const int q_base = q0 + tile * kFlashTile;
+                if constexpr (!kPad) {
 #pragma unroll
-                for (int ds = 0; ds < 4; ++ds) {
+                    for (int ds = 0; ds < 4; ++ds) {
 #pragma unroll
-                    for (int i = 0; i < 8; ++i) {
-                        const int row_off = (i >> 1) & 1;
-                        const int row = warp_row + base_row + row_off * 8;
-                        const int col = base_col + (i & 1) + ((i & 4) ? 8 : 0) + ds * 16;
-                        const int q_row = q_base + row;
-                        if (q_row < n_q && col < kFlashD) {
-                            const float inv =
-                                (l_i[tile][row_off] == 0.0f) ? 0.0f : 1.0f / l_i[tile][row_off];
-                            o_ptr[q_head + static_cast<long long>(q_row) * kFlashD + col] =
-                                __float2half_rn(o_frag[tile][ds].x[i] * inv);
+                        for (int i = 0; i < 8; ++i) {
+                            const int row_off = (i >> 1) & 1;
+                            const int row = warp_row + base_row + row_off * 8;
+                            const int col = base_col + (i & 1) + ((i & 4) ? 8 : 0) + ds * 16;
+                            const int q_row = q_base + row;
+                            if (q_row < n_q && col < kFlashD) {
+                                const float inv =
+                                    (l_i[tile][row_off] == 0.0f) ? 0.0f : 1.0f / l_i[tile][row_off];
+                                o_ptr[q_head + static_cast<long long>(q_row) * kFlashD + col] =
+                                    __float2half_rn(o_frag[tile][ds].x[i] * inv);
+                            }
                         }
                     }
+                } else {
+#pragma unroll
+                    for (int ds = 0; ds < 4; ++ds) {
+#pragma unroll
+                        for (int i = 0; i < 8; ++i) {
+                            const int row_off = (i >> 1) & 1;
+                            const int row = warp_row + base_row + row_off * 8;
+                            const int col = base_col + (i & 1) + ((i & 4) ? 8 : 0) + ds * 16;
+                            if (row < kFlashTile) {
+                                const float inv =
+                                    (l_i[tile][row_off] == 0.0f) ? 0.0f : 1.0f / l_i[tile][row_off];
+                                Qs[row * kFlashD + col] =
+                                    __float2half_rn(o_frag[tile][ds].x[i] * inv);
+                            }
+                        }
+                    }
+                    __syncthreads();
+#pragma unroll
+                    for (int i = 0; i < 4; ++i) {
+                        const int off = (tid + i * 128) * 8;
+                        const int row = off / kFlashD;
+                        const int col = off % kFlashD;
+                        const int q_row = q_base + row;
+                        if (q_row < n_q && col + 8 <= d) {
+                            const long long dst =
+                                q_head + static_cast<long long>(q_row) * d + col;
+                            *reinterpret_cast<uint4*>(o_ptr + dst) =
+                                *reinterpret_cast<const uint4*>(Qs + row * kFlashD + col);
+                        } else if (q_row < n_q && col < d) {
+                            const long long dst =
+                                q_head + static_cast<long long>(q_row) * d + col;
+#pragma unroll
+                            for (int c = 0; c < 8; ++c) {
+                                if (col + c < d) {
+                                    o_ptr[dst + c] = Qs[row * kFlashD + col + c];
+                                }
+                            }
+                        }
+                    }
+                    __syncthreads();
                 }
             }
 #else
@@ -715,6 +837,7 @@ namespace lfs::core::nn::kernels {
             (void)o_ptr;
             (void)n_q;
             (void)n_k;
+            (void)d;
             (void)q_head;
             (void)kv_head;
             (void)tid;
@@ -738,24 +861,35 @@ namespace lfs::core::nn::kernels {
         }
         const bool is_half = dtype == DataType::Float16;
 
-        if (is_half && d == 64 && !has_mask && n_k > 0) {
+        if (is_half && d <= kFlashD && !has_mask && n_k > 0) {
             dim3 grid((n_q + kFlashBr - 1) / kFlashBr, batch * heads);
             const int smem = flash_d64_smem_bytes();
-            auto* fn = flash_attn_d64_kernel;
-            LFS_CUDA_CHECK(cudaFuncSetAttribute(reinterpret_cast<const void*>(fn),
-                                                cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                                smem));
-            fn<<<grid, 128, smem, stream>>>(
-                static_cast<const __half*>(q), static_cast<const __half*>(k),
-                static_cast<const __half*>(v), static_cast<__half*>(o), batch, heads, n_q, n_k,
-                scale);
-            LFS_CUDA_LAUNCH_CHECK(stream, "nn.attention.flash_d64");
+            auto launch = [&](auto* fn, bool& smem_ready) {
+                if (!smem_ready) {
+                    LFS_CUDA_CHECK(cudaFuncSetAttribute(reinterpret_cast<const void*>(fn),
+                                                        cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                                        smem));
+                    smem_ready = true;
+                }
+                fn<<<grid, 128, smem, stream>>>(
+                    static_cast<const __half*>(q), static_cast<const __half*>(k),
+                    static_cast<const __half*>(v), static_cast<__half*>(o), batch, heads, n_q,
+                    n_k, d, scale);
+                LFS_CUDA_LAUNCH_CHECK(stream, "nn.attention.flash_d64");
+            };
+            if (d == kFlashD) {
+                static bool smem_d64 = false;
+                launch(flash_attn_d64_kernel<false>, smem_d64);
+            } else {
+                static bool smem_pad = false;
+                launch(flash_attn_d64_kernel<true>, smem_pad);
+            }
             return;
         }
 
         dim3 grid((n_q + kBr - 1) / kBr, batch * heads);
 
-        if (is_half && (d % 16) == 0 && d <= 64 && n_k > 0) {
+        if (is_half && d <= kFlashD && n_k > 0) {
             constexpr int Br = 64;
             constexpr int Bc = 64;
             constexpr int D = 64;

--- a/src/core/nn/elementwise.cu
+++ b/src/core/nn/elementwise.cu
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#include <float.h>
 
 namespace lfs::core::nn::kernels {
     namespace {
@@ -137,6 +138,9 @@ namespace lfs::core::nn::kernels {
                     break;
                 case 3:
                     o = fmaxf(v, 0.0f);
+                    break;
+                case 6:
+                    o = 1.0f / (1.0f + expf(-v));
                     break;
                 default:
                     break;
@@ -453,6 +457,339 @@ namespace lfs::core::nn::kernels {
         LFS_CUDA_LAUNCH_CHECK(stream, "nn.merge_heads");
     }
 
+    static int layout_grid(long long n) {
+        const int block = 256;
+        const int max_blocks = 2048;
+        if (n <= 0) {
+            return 1;
+        }
+        const long long blocks = (n + block - 1) / block;
+        return static_cast<int>(std::min(static_cast<long long>(max_blocks), std::max(blocks, 1LL)));
+    }
+
+    __device__ __forceinline__ void copy_half8(void* dst, const void* src) {
+        *reinterpret_cast<uint4*>(dst) = *reinterpret_cast<const uint4*>(src);
+    }
+
+    __device__ __forceinline__ void zero_half8(void* dst) {
+        *reinterpret_cast<uint4*>(dst) = uint4{0, 0, 0, 0};
+    }
+
+    __global__ void split_qkv_window_2d_kernel(const void* __restrict__ qkv, void* __restrict__ q,
+                                               void* __restrict__ k, void* __restrict__ v,
+                                               const void* __restrict__ bias, int batch, int height,
+                                               int width, int heads, int d, int window, int n_h,
+                                               int n_w, int vec, bool is_half) {
+        const int nwin = n_h * n_w;
+        const int seq = window * window;
+        const int packed = 3 * heads * d;
+        const int d_step = vec ? 8 : 1;
+        const long long total =
+            static_cast<long long>(batch) * nwin * heads * seq * (d / d_step);
+        for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+             idx < total; idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+            long long t = idx;
+            const int dd0 = static_cast<int>(t % (d / d_step)) * d_step;
+            t /= (d / d_step);
+            const int s = static_cast<int>(t % seq);
+            t /= seq;
+            const int h = static_cast<int>(t % heads);
+            t /= heads;
+            const int win = static_cast<int>(t % nwin);
+            t /= nwin;
+            const int b = static_cast<int>(t);
+            const int nh = win / n_w;
+            const int nw = win % n_w;
+            const int wy = s / window;
+            const int wx = s % window;
+            const int y = nh * window + wy;
+            const int x = nw * window + wx;
+            const int bw = b * nwin + win;
+            const long long dst =
+                ((((static_cast<long long>(bw) * heads + h) * seq + s) * d) + dd0);
+            if (y >= height || x >= width) {
+                if (bias != nullptr) {
+                    const long long bq = static_cast<long long>((0 * heads + h) * d + dd0);
+                    const long long bk = static_cast<long long>((1 * heads + h) * d + dd0);
+                    const long long bv = static_cast<long long>((2 * heads + h) * d + dd0);
+                    if (vec) {
+                        const auto* bp = static_cast<const __half*>(bias);
+                        copy_half8(static_cast<__half*>(q) + dst, bp + bq);
+                        copy_half8(static_cast<__half*>(k) + dst, bp + bk);
+                        copy_half8(static_cast<__half*>(v) + dst, bp + bv);
+                    } else {
+                        device::st_strided(q, dst, device::ld_strided(bias, bq, is_half), is_half);
+                        device::st_strided(k, dst, device::ld_strided(bias, bk, is_half), is_half);
+                        device::st_strided(v, dst, device::ld_strided(bias, bv, is_half), is_half);
+                    }
+                } else if (vec) {
+                    zero_half8(static_cast<__half*>(q) + dst);
+                    zero_half8(static_cast<__half*>(k) + dst);
+                    zero_half8(static_cast<__half*>(v) + dst);
+                } else {
+                    device::st_strided(q, dst, 0.0f, is_half);
+                    device::st_strided(k, dst, 0.0f, is_half);
+                    device::st_strided(v, dst, 0.0f, is_half);
+                }
+                continue;
+            }
+            const long long pix =
+                ((static_cast<long long>(b) * height + y) * width + x) * packed;
+            const long long src_q = pix + static_cast<long long>((0 * heads + h) * d + dd0);
+            const long long src_k = pix + static_cast<long long>((1 * heads + h) * d + dd0);
+            const long long src_v = pix + static_cast<long long>((2 * heads + h) * d + dd0);
+            if (vec) {
+                const auto* in = static_cast<const __half*>(qkv);
+                copy_half8(static_cast<__half*>(q) + dst, in + src_q);
+                copy_half8(static_cast<__half*>(k) + dst, in + src_k);
+                copy_half8(static_cast<__half*>(v) + dst, in + src_v);
+            } else {
+                device::st_strided(q, dst, device::ld_strided(qkv, src_q, is_half), is_half);
+                device::st_strided(k, dst, device::ld_strided(qkv, src_k, is_half), is_half);
+                device::st_strided(v, dst, device::ld_strided(qkv, src_v, is_half), is_half);
+            }
+        }
+    }
+
+    void split_qkv_window_2d(const void* qkv, void* q, void* k, void* v, int batch, int height,
+                             int width, int heads, int d, int window, int n_h, int n_w,
+                             const void* bias, DataType dtype, cudaStream_t stream) {
+        NvtxRange nvtx("nn.op/split_qkv_window_2d");
+        const bool is_half = dtype == DataType::Float16;
+        const bool vec = is_half && d > 0 && (d % 8) == 0;
+        const int d_step = vec ? 8 : 1;
+        const long long total = static_cast<long long>(batch) * n_h * n_w * heads * window *
+                                window * (d / d_step);
+        if (total <= 0) {
+            return;
+        }
+        split_qkv_window_2d_kernel<<<layout_grid(total), 256, 0, stream>>>(
+            qkv, q, k, v, bias, batch, height, width, heads, d, window, n_h, n_w, vec ? 1 : 0,
+            is_half);
+        LFS_CUDA_LAUNCH_CHECK(stream, "nn.split_qkv_window_2d");
+    }
+
+    __global__ void merge_heads_unwindow_2d_kernel(const void* __restrict__ context,
+                                                   void* __restrict__ packed, int batch, int orig_h,
+                                                   int orig_w, int heads, int d, int window,
+                                                   int n_h, int n_w, int vec, bool is_half) {
+        const int nwin = n_h * n_w;
+        const int seq = window * window;
+        const int c_out = heads * d;
+        const int d_step = vec ? 8 : 1;
+        const long long total =
+            static_cast<long long>(batch) * orig_h * orig_w * (c_out / d_step);
+        for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+             idx < total; idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+            long long t = idx;
+            const int c0 = static_cast<int>(t % (c_out / d_step)) * d_step;
+            t /= (c_out / d_step);
+            const int x = static_cast<int>(t % orig_w);
+            t /= orig_w;
+            const int y = static_cast<int>(t % orig_h);
+            t /= orig_h;
+            const int b = static_cast<int>(t);
+            const int h = c0 / d;
+            const int dd0 = c0 % d;
+            const int nh = y / window;
+            const int wy = y % window;
+            const int nw = x / window;
+            const int wx = x % window;
+            const int win = nh * n_w + nw;
+            const int s = wy * window + wx;
+            const int bw = b * nwin + win;
+            const long long src =
+                ((((static_cast<long long>(bw) * heads + h) * seq + s) * d) + dd0);
+            const long long dst =
+                (((static_cast<long long>(b) * orig_h + y) * orig_w + x) * c_out) + c0;
+            if (vec) {
+                copy_half8(static_cast<__half*>(packed) + dst,
+                           static_cast<const __half*>(context) + src);
+            } else {
+                device::st_strided(packed, dst, device::ld_strided(context, src, is_half),
+                                   is_half);
+            }
+        }
+    }
+
+    void merge_heads_unwindow_2d(const void* context, void* packed, int batch, int orig_h,
+                                 int orig_w, int heads, int d, int window, int n_h, int n_w,
+                                 DataType dtype, cudaStream_t stream) {
+        NvtxRange nvtx("nn.op/merge_heads_unwindow_2d");
+        const bool is_half = dtype == DataType::Float16;
+        const bool vec = is_half && d > 0 && (d % 8) == 0;
+        const int d_step = vec ? 8 : 1;
+        const long long total =
+            static_cast<long long>(batch) * orig_h * orig_w * heads * (d / d_step);
+        if (total <= 0) {
+            return;
+        }
+        merge_heads_unwindow_2d_kernel<<<layout_grid(total), 256, 0, stream>>>(
+            context, packed, batch, orig_h, orig_w, heads, d, window, n_h, n_w, vec ? 1 : 0,
+            is_half);
+        LFS_CUDA_LAUNCH_CHECK(stream, "nn.merge_heads_unwindow_2d");
+    }
+
+    __global__ void max_pool_heads_2d_kernel(const void* __restrict__ input, void* __restrict__ output,
+                                             int batch, int heads, int height, int width, int d,
+                                             int vec, bool is_half) {
+        const int out_h = height / 2;
+        const int out_w = width / 2;
+        const int out_s = out_h * out_w;
+        const int in_s = height * width;
+        const int d_step = vec ? 8 : 1;
+        const long long total =
+            static_cast<long long>(batch) * heads * out_s * (d / d_step);
+        for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+             idx < total; idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+            long long t = idx;
+            const int dd0 = static_cast<int>(t % (d / d_step)) * d_step;
+            t /= (d / d_step);
+            const int os = static_cast<int>(t % out_s);
+            t /= out_s;
+            const int h = static_cast<int>(t % heads);
+            t /= heads;
+            const int b = static_cast<int>(t);
+            const int oy = os / out_w;
+            const int ox = os % out_w;
+            const int y0 = oy * 2;
+            const int x0 = ox * 2;
+            const long long bh = (static_cast<long long>(b) * heads + h);
+            const long long dst = ((bh * out_s + os) * d) + dd0;
+            if (vec) {
+                uint4 packed = uint4{0, 0, 0, 0};
+                auto* out_h8 = reinterpret_cast<__half*>(&packed);
+#pragma unroll
+                for (int c = 0; c < 8; ++c) {
+                    float best = -FLT_MAX;
+#pragma unroll
+                    for (int dy = 0; dy < 2; ++dy) {
+#pragma unroll
+                        for (int dx = 0; dx < 2; ++dx) {
+                            const int s = (y0 + dy) * width + (x0 + dx);
+                            const long long src = ((bh * in_s + s) * d) + dd0 + c;
+                            best = fmaxf(best, __half2float(static_cast<const __half*>(input)[src]));
+                        }
+                    }
+                    out_h8[c] = __float2half_rn(best);
+                }
+                *reinterpret_cast<uint4*>(static_cast<__half*>(output) + dst) = packed;
+            } else {
+#pragma unroll
+                for (int c = 0; c < d_step; ++c) {
+                    float best = -FLT_MAX;
+#pragma unroll
+                    for (int dy = 0; dy < 2; ++dy) {
+#pragma unroll
+                        for (int dx = 0; dx < 2; ++dx) {
+                            const int s = (y0 + dy) * width + (x0 + dx);
+                            const long long src = ((bh * in_s + s) * d) + dd0 + c;
+                            best = fmaxf(best, device::ld_strided(input, src, is_half));
+                        }
+                    }
+                    device::st_strided(output, dst + c, best, is_half);
+                }
+            }
+        }
+    }
+
+    void max_pool_heads_2d(const void* input, void* output, int batch, int heads, int height,
+                           int width, int d, DataType dtype, cudaStream_t stream) {
+        NvtxRange nvtx("nn.op/max_pool_heads_2d");
+        const bool is_half = dtype == DataType::Float16;
+        const bool vec = is_half && d > 0 && (d % 8) == 0;
+        const int d_step = vec ? 8 : 1;
+        const long long total = static_cast<long long>(batch) * heads * (height / 2) * (width / 2) *
+                                (d / d_step);
+        if (total <= 0) {
+            return;
+        }
+        max_pool_heads_2d_kernel<<<layout_grid(total), 256, 0, stream>>>(
+            input, output, batch, heads, height, width, d, vec ? 1 : 0, is_half);
+        LFS_CUDA_LAUNCH_CHECK(stream, "nn.max_pool_heads_2d");
+    }
+
+    __global__ void max_pool2d_bhwc_kernel(const void* __restrict__ input, void* __restrict__ output,
+                                           int batch, int height, int width, int channels, int vec,
+                                           bool is_half) {
+        const int out_h = height / 2;
+        const int out_w = width / 2;
+        const int d_step = vec ? 8 : 1;
+        const long long total =
+            static_cast<long long>(batch) * out_h * out_w * (channels / d_step);
+        for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+             idx < total; idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+            long long t = idx;
+            const int c0 = static_cast<int>(t % (channels / d_step)) * d_step;
+            t /= (channels / d_step);
+            const int ox = static_cast<int>(t % out_w);
+            t /= out_w;
+            const int oy = static_cast<int>(t % out_h);
+            t /= out_h;
+            const int b = static_cast<int>(t);
+            const int y0 = oy * 2;
+            const int x0 = ox * 2;
+            const long long dst =
+                (((static_cast<long long>(b) * out_h + oy) * out_w + ox) * channels) + c0;
+            if (vec) {
+                uint4 packed = uint4{0, 0, 0, 0};
+                auto* out_h8 = reinterpret_cast<__half*>(&packed);
+#pragma unroll
+                for (int c = 0; c < 8; ++c) {
+                    float best = -FLT_MAX;
+#pragma unroll
+                    for (int dy = 0; dy < 2; ++dy) {
+#pragma unroll
+                        for (int dx = 0; dx < 2; ++dx) {
+                            const long long src =
+                                (((static_cast<long long>(b) * height + (y0 + dy)) * width +
+                                  (x0 + dx)) *
+                                 channels) +
+                                c0 + c;
+                            best = fmaxf(best, __half2float(static_cast<const __half*>(input)[src]));
+                        }
+                    }
+                    out_h8[c] = __float2half_rn(best);
+                }
+                *reinterpret_cast<uint4*>(static_cast<__half*>(output) + dst) = packed;
+            } else {
+#pragma unroll
+                for (int c = 0; c < d_step; ++c) {
+                    float best = -FLT_MAX;
+#pragma unroll
+                    for (int dy = 0; dy < 2; ++dy) {
+#pragma unroll
+                        for (int dx = 0; dx < 2; ++dx) {
+                            const long long src =
+                                (((static_cast<long long>(b) * height + (y0 + dy)) * width +
+                                  (x0 + dx)) *
+                                 channels) +
+                                c0 + c;
+                            best = fmaxf(best, device::ld_strided(input, src, is_half));
+                        }
+                    }
+                    device::st_strided(output, dst + c, best, is_half);
+                }
+            }
+        }
+    }
+
+    void max_pool2d_bhwc(const void* input, void* output, int batch, int height, int width,
+                         int channels, DataType dtype, cudaStream_t stream) {
+        NvtxRange nvtx("nn.op/max_pool2d_bhwc");
+        const bool is_half = dtype == DataType::Float16;
+        const bool vec = is_half && channels > 0 && (channels % 8) == 0;
+        const int d_step = vec ? 8 : 1;
+        const long long total =
+            static_cast<long long>(batch) * (height / 2) * (width / 2) * (channels / d_step);
+        if (total <= 0) {
+            return;
+        }
+        max_pool2d_bhwc_kernel<<<layout_grid(total), 256, 0, stream>>>(
+            input, output, batch, height, width, channels, vec ? 1 : 0, is_half);
+        LFS_CUDA_LAUNCH_CHECK(stream, "nn.max_pool2d_bhwc");
+    }
+
     void uv_grid(void* output, int height, int width, float u0, float u1, float v0, float v1,
                  DataType dtype, cudaStream_t stream) {
         NvtxRange nvtx("nn.op/uv_grid");
@@ -479,6 +816,181 @@ namespace lfs::core::nn::kernels {
         residual_scale_kernel<<<grid, block, 0, stream>>>(x, hidden, gamma, y, rows, cols,
                                                           dtype == DataType::Float16);
         LFS_CUDA_LAUNCH_CHECK(stream, "nn.residual_scale");
+    }
+
+    void sigmoid(const void* x, void* y, std::size_t n, DataType dtype, cudaStream_t stream) {
+        NvtxRange nvtx("nn.op/sigmoid");
+        if (n == 0) {
+            return;
+        }
+        unary_kernel<<<unary_grid(n), 256, 0, stream>>>(x, y, n, 6, dtype == DataType::Float16);
+        LFS_CUDA_LAUNCH_CHECK(stream, "nn.act.sigmoid");
+    }
+
+    __global__ void window_partition_2d_kernel(const void* __restrict__ input, void* __restrict__ output,
+                                               int batch, int height, int width, int channels,
+                                               int window, int n_h, int n_w, bool is_half) {
+        const int nwin = n_h * n_w;
+        const long long total = static_cast<long long>(batch) * nwin * window * window * channels;
+        for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+             idx < total; idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+            long long t = idx;
+            const int c = static_cast<int>(t % channels);
+            t /= channels;
+            const int wx = static_cast<int>(t % window);
+            t /= window;
+            const int wy = static_cast<int>(t % window);
+            t /= window;
+            const int win = static_cast<int>(t % nwin);
+            t /= nwin;
+            const int b = static_cast<int>(t);
+            const int nh = win / n_w;
+            const int nw = win % n_w;
+            const int y = nh * window + wy;
+            const int x = nw * window + wx;
+            float v = 0.0f;
+            if (y < height && x < width) {
+                const long long si =
+                    (((static_cast<long long>(b) * height + y) * width + x) * channels) + c;
+                v = device::ld_strided(input, si, is_half);
+            }
+            device::st_strided(output, idx, v, is_half);
+        }
+    }
+
+    void window_partition_2d(const void* input, void* output, int batch, int height, int width,
+                             int channels, int window, int n_h, int n_w, DataType dtype,
+                             cudaStream_t stream) {
+        NvtxRange nvtx("nn.op/window_partition_2d");
+        const long long total =
+            static_cast<long long>(batch) * n_h * n_w * window * window * channels;
+        if (total <= 0) {
+            return;
+        }
+        const int block = 256;
+        const int grid = std::min(2048, static_cast<int>((total + block - 1) / block));
+        window_partition_2d_kernel<<<grid, block, 0, stream>>>(
+            input, output, batch, height, width, channels, window, n_h, n_w,
+            dtype == DataType::Float16);
+        LFS_CUDA_LAUNCH_CHECK(stream, "nn.window_partition_2d");
+    }
+
+    __global__ void window_unpartition_2d_kernel(const void* __restrict__ windows,
+                                                 void* __restrict__ output, int batch, int height,
+                                                 int width, int channels, int window, int n_h,
+                                                 int n_w, bool is_half) {
+        const int nwin = n_h * n_w;
+        const long long total =
+            static_cast<long long>(batch) * height * width * channels;
+        for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+             idx < total; idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+            long long t = idx;
+            const int c = static_cast<int>(t % channels);
+            t /= channels;
+            const int x = static_cast<int>(t % width);
+            t /= width;
+            const int y = static_cast<int>(t % height);
+            t /= height;
+            const int b = static_cast<int>(t);
+            const int nh = y / window;
+            const int wy = y % window;
+            const int nw = x / window;
+            const int wx = x % window;
+            const int win = nh * n_w + nw;
+            const int bw = b * nwin + win;
+            const long long si =
+                (((((static_cast<long long>(bw) * window + wy) * window) + wx) * channels) + c);
+            device::st_strided(output, idx, device::ld_strided(windows, si, is_half), is_half);
+        }
+    }
+
+    void window_unpartition_2d(const void* windows, void* output, int batch, int height, int width,
+                               int channels, int window, int n_h, int n_w, DataType dtype,
+                               cudaStream_t stream) {
+        NvtxRange nvtx("nn.op/window_unpartition_2d");
+        const long long total = static_cast<long long>(batch) * height * width * channels;
+        if (total <= 0) {
+            return;
+        }
+        const int block = 256;
+        const int grid = std::min(2048, static_cast<int>((total + block - 1) / block));
+        window_unpartition_2d_kernel<<<grid, block, 0, stream>>>(
+            windows, output, batch, height, width, channels, window, n_h, n_w,
+            dtype == DataType::Float16);
+        LFS_CUDA_LAUNCH_CHECK(stream, "nn.window_unpartition_2d");
+    }
+
+    __global__ void fourier_pe_coords_kernel(const void* __restrict__ coords,
+                                             const void* __restrict__ gaussian,
+                                             void* __restrict__ output, int count, int feats,
+                                             bool is_half) {
+        const long long total = static_cast<long long>(count) * (feats * 2);
+        for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+             idx < total; idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+            const int two_c = static_cast<int>(idx % (feats * 2));
+            const int n = static_cast<int>(idx / (feats * 2));
+            const int f = two_c % feats;
+            const float x =
+                2.0f * device::ld_strided(coords, static_cast<long long>(n) * 2 + 0, is_half) - 1.0f;
+            const float y =
+                2.0f * device::ld_strided(coords, static_cast<long long>(n) * 2 + 1, is_half) - 1.0f;
+            const float g0 = device::ld_strided(gaussian, f, is_half);
+            const float g1 = device::ld_strided(gaussian, static_cast<long long>(feats) + f, is_half);
+            const float ang = 6.283185307179586f * (x * g0 + y * g1);
+            const float o = two_c < feats ? sinf(ang) : cosf(ang);
+            device::st_strided(output, idx, o, is_half);
+        }
+    }
+
+    void fourier_pe_coords(const void* coords, const void* gaussian, void* output, int count,
+                           int feats, DataType dtype, cudaStream_t stream) {
+        NvtxRange nvtx("nn.op/fourier_pe");
+        const long long total = static_cast<long long>(count) * feats * 2;
+        if (total <= 0) {
+            return;
+        }
+        const int block = 256;
+        const int grid = std::min(2048, static_cast<int>((total + block - 1) / block));
+        fourier_pe_coords_kernel<<<grid, block, 0, stream>>>(coords, gaussian, output, count, feats,
+                                                             dtype == DataType::Float16);
+        LFS_CUDA_LAUNCH_CHECK(stream, "nn.fourier_pe");
+    }
+
+    __global__ void fourier_pe_grid_kernel(const void* __restrict__ gaussian,
+                                           void* __restrict__ output, int height, int width,
+                                           int feats, bool is_half) {
+        const int channels = feats * 2;
+        const long long spatial = static_cast<long long>(height) * width;
+        const long long total = spatial * channels;
+        for (long long idx = static_cast<long long>(blockIdx.x) * blockDim.x + threadIdx.x;
+             idx < total; idx += static_cast<long long>(blockDim.x) * gridDim.x) {
+            const int x = static_cast<int>(idx % width);
+            const int y = static_cast<int>((idx / width) % height);
+            const int ch = static_cast<int>(idx / spatial);
+            const int f = ch % feats;
+            const float xn = 2.0f * ((static_cast<float>(x) + 0.5f) / static_cast<float>(width)) - 1.0f;
+            const float yn = 2.0f * ((static_cast<float>(y) + 0.5f) / static_cast<float>(height)) - 1.0f;
+            const float g0 = device::ld_strided(gaussian, f, is_half);
+            const float g1 = device::ld_strided(gaussian, static_cast<long long>(feats) + f, is_half);
+            const float ang = 6.283185307179586f * (xn * g0 + yn * g1);
+            const float o = ch < feats ? sinf(ang) : cosf(ang);
+            device::st_strided(output, static_cast<long long>(ch) * spatial + static_cast<long long>(y) * width + x,
+                               o, is_half);
+        }
+    }
+
+    void fourier_pe_grid(const void* gaussian, void* output, int height, int width, int feats,
+                         DataType dtype, cudaStream_t stream) {
+        NvtxRange nvtx("nn.op/fourier_pe_grid");
+        const long long total = static_cast<long long>(height) * width * feats * 2;
+        if (total <= 0) {
+            return;
+        }
+        const int block = 256;
+        const int grid = std::min(2048, static_cast<int>((total + block - 1) / block));
+        fourier_pe_grid_kernel<<<grid, block, 0, stream>>>(gaussian, output, height, width, feats,
+                                                           dtype == DataType::Float16);
+        LFS_CUDA_LAUNCH_CHECK(stream, "nn.fourier_pe_grid");
     }
 
 } // namespace lfs::core::nn::kernels

--- a/src/core/nn/gemm.cu
+++ b/src/core/nn/gemm.cu
@@ -549,13 +549,284 @@ namespace lfs::core::nn::kernels {
 #endif
         }
 
+        __device__ __forceinline__ void store_nt_pair(__half* C, int gr, int gc, int m, int n,
+                                                      float v0, float v1, const __half* bias,
+                                                      int activation, const __half* residual,
+                                                      const __half* scale) {
+            const bool r_ok = gr < m;
+            const bool c0 = r_ok && gc < n;
+            const bool c1 = r_ok && (gc + 1) < n;
+            if (!c0 && !c1) {
+                return;
+            }
+            if (bias) {
+                if (c0) {
+                    v0 += __half2float(__ldg(bias + gc));
+                }
+                if (c1) {
+                    v1 += __half2float(__ldg(bias + gc + 1));
+                }
+            }
+            v0 = device::apply_activation(v0, activation);
+            v1 = device::apply_activation(v1, activation);
+            if (scale) {
+                if (c0) {
+                    v0 *= __half2float(__ldg(scale + gc));
+                }
+                if (c1) {
+                    v1 *= __half2float(__ldg(scale + gc + 1));
+                }
+            }
+            const long long base = static_cast<long long>(gr) * n + gc;
+            if (residual) {
+                if (c0) {
+                    v0 += __half2float(residual[base]);
+                }
+                if (c1) {
+                    v1 += __half2float(residual[base + 1]);
+                }
+            }
+            if (c0 && c1 && (reinterpret_cast<uintptr_t>(C + base) & 3u) == 0) {
+                *reinterpret_cast<__half2*>(C + base) = __floats2half2_rn(v0, v1);
+            } else if (c0) {
+                C[base] = __float2half_rn(v0);
+                if (c1) {
+                    C[base + 1] = __float2half_rn(v1);
+                }
+            } else {
+                C[base + 1] = __float2half_rn(v1);
+            }
+        }
+
+        // NT (C = A @ Bᵀ) double-buffered WMMA. A is [M,K] row-major, B is [N,K].
+        // Requires K%8==0 so every 16-byte vector is in-bounds or fully OOB
+        // (predicated cp.async, no scalar K-tail). 8 warps: 4×2 for BN=64
+        // (32×32/warp) or 2×4 for BN=128 (64×32/warp).
+        template <int BM, int BN, int BK>
+        __global__ void __launch_bounds__(256, (BN <= 64 && BK <= 32) ? 3 : 2)
+            hgemm_nt_aligned_kernel(const __half* __restrict__ A, const __half* __restrict__ B,
+                                    __half* __restrict__ C, const __half* __restrict__ bias,
+                                    int m, int n, int k, long long stride_a, long long stride_b,
+                                    long long stride_c, int activation,
+                                    const __half* __restrict__ residual,
+                                    const __half* __restrict__ scale) {
+            const int batch = static_cast<int>(blockIdx.z);
+            A += batch * stride_a;
+            B += batch * stride_b;
+            C += batch * stride_c;
+            if (residual) {
+                residual += batch * stride_c;
+            }
+
+            const int tid = static_cast<int>(threadIdx.x);
+            const int block_row = static_cast<int>(blockIdx.y) * BM;
+            const int block_col = static_cast<int>(blockIdx.x) * BN;
+
+#if __CUDA_ARCH__ >= 700
+            using namespace nvcuda::wmma;
+            constexpr int WM = 16;
+            constexpr int WN = 16;
+            constexpr int WK = 16;
+            constexpr int kWarpM = (BN == 64) ? 4 : 2;
+            constexpr int kWarpN = (BN == 64) ? 2 : 4;
+            constexpr int kFragM = (BM / kWarpM) / WM;
+            constexpr int kFragN = (BN / kWarpN) / WN;
+            constexpr int kAVecs = (BM * BK) / (256 * 8);
+            constexpr int kBVecs = (BN * BK) / (256 * 8);
+
+            const int warp_id = tid / 32;
+            const int warp_m = warp_id / kWarpN;
+            const int warp_n = warp_id % kWarpN;
+            const int lane = tid % 32;
+
+            __shared__ __align__(16) __half As[2][BM][BK];
+            __shared__ __align__(16) __half Bs[2][BN][BK];
+
+            fragment<matrix_a, WM, WN, WK, __half, row_major> a_frag[kFragM];
+            fragment<matrix_b, WM, WN, WK, __half, col_major> b_frag[kFragN];
+            fragment<accumulator, WM, WN, WK, float> c_frag[kFragM][kFragN];
+#pragma unroll
+            for (int i = 0; i < kFragM; ++i) {
+#pragma unroll
+                for (int j = 0; j < kFragN; ++j) {
+                    fill_fragment(c_frag[i][j], 0.0f);
+                }
+            }
+
+            auto load_ab = [&](int stage, int k0) {
+#pragma unroll
+                for (int v = 0; v < kAVecs; ++v) {
+                    const int vec = tid + v * 256;
+                    const int elem = vec * 8;
+                    const int r = elem / BK;
+                    const int c = elem % BK;
+                    const int gr = block_row + r;
+                    const int gc = k0 + c;
+                    const bool pred = gr < m && gc + 7 < k;
+                    const __half* src = A + static_cast<long long>(pred ? gr : 0) * k +
+                                        (pred ? gc : 0);
+                    device::cp_async16_pred<true>(&As[stage][r][c], src, pred);
+                }
+                if constexpr (kBVecs == 0) {
+                    if (tid < (BN * BK) / 8) {
+                        const int elem = tid * 8;
+                        const int r = elem / BK;
+                        const int c = elem % BK;
+                        const int gc = block_col + r;
+                        const int kk = k0 + c;
+                        const bool pred = gc < n && kk + 7 < k;
+                        const __half* src = B + static_cast<long long>(pred ? gc : 0) * k +
+                                            (pred ? kk : 0);
+                        device::cp_async16_pred<false>(&Bs[stage][r][c], src, pred);
+                    }
+                } else {
+#pragma unroll
+                    for (int v = 0; v < kBVecs; ++v) {
+                        const int vec = tid + v * 256;
+                        const int elem = vec * 8;
+                        const int r = elem / BK;
+                        const int c = elem % BK;
+                        const int gc = block_col + r;
+                        const int kk = k0 + c;
+                        const bool pred = gc < n && kk + 7 < k;
+                        const __half* src = B + static_cast<long long>(pred ? gc : 0) * k +
+                                            (pred ? kk : 0);
+                        device::cp_async16_pred<false>(&Bs[stage][r][c], src, pred);
+                    }
+                }
+                device::cp_async_commit();
+            };
+
+            auto mma_stage = [&](int stage) {
+                const int am = warp_m * (kFragM * WM);
+                const int bn = warp_n * (kFragN * WN);
+#pragma unroll
+                for (int kk = 0; kk < BK; kk += WK) {
+#pragma unroll
+                    for (int fi = 0; fi < kFragM; ++fi) {
+                        load_matrix_sync(a_frag[fi], &As[stage][am + fi * WM][kk], BK);
+                    }
+#pragma unroll
+                    for (int fj = 0; fj < kFragN; ++fj) {
+                        load_matrix_sync(b_frag[fj], &Bs[stage][bn + fj * WN][kk], BK);
+                    }
+#pragma unroll
+                    for (int fi = 0; fi < kFragM; ++fi) {
+#pragma unroll
+                        for (int fj = 0; fj < kFragN; ++fj) {
+                            mma_sync(c_frag[fi][fj], a_frag[fi], b_frag[fj], c_frag[fi][fj]);
+                        }
+                    }
+                }
+            };
+
+            load_ab(0, 0);
+            device::cp_async_wait0();
+            __syncthreads();
+
+            int stage = 0;
+            for (int k0 = 0; k0 < k; k0 += BK) {
+                const int next = k0 + BK;
+                const int other = stage ^ 1;
+                if (next < k) {
+                    load_ab(other, next);
+                }
+                mma_stage(stage);
+                if (next < k) {
+                    device::cp_async_wait0();
+                }
+                __syncthreads();
+                stage = other;
+            }
+
+            const int am = warp_m * (kFragM * WM);
+            const int bn = warp_n * (kFragN * WN);
+            const int base_row = lane / 4;
+            const int base_col = (lane % 4) * 2;
+#pragma unroll
+            for (int fi = 0; fi < kFragM; ++fi) {
+#pragma unroll
+                for (int fj = 0; fj < kFragN; ++fj) {
+#pragma unroll
+                    for (int i = 0; i < 8; i += 2) {
+                        const int r = am + fi * WM + base_row + ((i >> 1) & 1) * 8;
+                        const int c = bn + fj * WN + base_col + ((i & 4) ? 8 : 0);
+                        store_nt_pair(C, block_row + r, block_col + c, m, n, c_frag[fi][fj].x[i],
+                                      c_frag[fi][fj].x[i + 1], bias, activation, residual, scale);
+                    }
+                }
+            }
+#else
+            for (int i = tid; i < BM * BN; i += 256) {
+                const int r = i / BN;
+                const int c = i % BN;
+                const int gr = block_row + r;
+                const int gc = block_col + c;
+                if (gr >= m || gc >= n) {
+                    continue;
+                }
+                float acc = 0.0f;
+                for (int kk = 0; kk < k; ++kk) {
+                    acc += __half2float(A[static_cast<long long>(gr) * k + kk]) *
+                           __half2float(B[static_cast<long long>(gc) * k + kk]);
+                }
+                store_c_f16(C, gr, gc, m, n, acc, bias, activation, false, residual, scale, 0, 0);
+            }
+#endif
+        }
+
         void launch_hgemm_wmma(const __half* a, const __half* b, __half* c, const __half* bias,
                                int m, int n, int k, long long stride_a, long long stride_b,
                                long long stride_c, int batch, bool trans_a, bool trans_b,
                                int activation, bool trans_c, cudaStream_t stream,
                                const __half* residual, const __half* scale, int scatter_h,
                                int scatter_w) {
-            const bool large = (m >= 96 && n >= 64 && k >= 32) || scatter_h > 0;
+            // Linear / NT encoder GEMMs (SAM2 Hiera, MoGe ViT): K is a multiple of
+            // 8 so every 16-byte vector is fully in-bounds or fully OOB. Keep the
+            // generic 128×64 kernel for trans_a (1×1 NCHW), scatter (conv-transpose),
+            // and odd-K shapes used by the parity tests.
+            const bool aligned_nt = !trans_a && trans_b && !trans_c && scatter_h == 0 && k >= 8 &&
+                                    (k % 8 == 0);
+            if (aligned_nt && m >= 96 && n >= 64) {
+                dim3 block(256);
+                // 128-wide N reuses A across more columns; worth it when N fits
+                // one tile, N is a multiple of 128, or K is short (Hiera stage-0
+                // K=112 is memory-bound and A traffic dominates).
+                const bool tile_128 = n >= 96 && (n <= 128 || n % 128 == 0 || k <= 128);
+                const bool k32 = (k % 32 == 0) && k >= 32;
+                if (tile_128) {
+                    constexpr int BM = 128, BN = 128;
+                    dim3 grid((n + BN - 1) / BN, (m + BM - 1) / BM, batch);
+                    if (k32) {
+                        hgemm_nt_aligned_kernel<BM, BN, 32><<<grid, block, 0, stream>>>(
+                            a, b, c, bias, m, n, k, stride_a, stride_b, stride_c, activation,
+                            residual, scale);
+                        LFS_CUDA_LAUNCH_CHECK(stream, "nn.gemm.hgemm_nt_128x128x32");
+                    } else {
+                        hgemm_nt_aligned_kernel<BM, BN, 16><<<grid, block, 0, stream>>>(
+                            a, b, c, bias, m, n, k, stride_a, stride_b, stride_c, activation,
+                            residual, scale);
+                        LFS_CUDA_LAUNCH_CHECK(stream, "nn.gemm.hgemm_nt_128x128x16");
+                    }
+                } else {
+                    constexpr int BM = 128, BN = 64;
+                    dim3 grid((n + BN - 1) / BN, (m + BM - 1) / BM, batch);
+                    if (k32) {
+                        hgemm_nt_aligned_kernel<BM, BN, 32><<<grid, block, 0, stream>>>(
+                            a, b, c, bias, m, n, k, stride_a, stride_b, stride_c, activation,
+                            residual, scale);
+                        LFS_CUDA_LAUNCH_CHECK(stream, "nn.gemm.hgemm_nt_128x64x32");
+                    } else {
+                        hgemm_nt_aligned_kernel<BM, BN, 16><<<grid, block, 0, stream>>>(
+                            a, b, c, bias, m, n, k, stride_a, stride_b, stride_c, activation,
+                            residual, scale);
+                        LFS_CUDA_LAUNCH_CHECK(stream, "nn.gemm.hgemm_nt_128x64x16");
+                    }
+                }
+                return;
+            }
+            const bool large = (m >= 96 && n >= 64 && k >= 32) || scatter_h > 0 || residual ||
+                               scale;
             if (large) {
                 constexpr int BM = 128, BN = 64;
                 dim3 block(256);

--- a/src/core/nn/nn_device.cuh
+++ b/src/core/nn/nn_device.cuh
@@ -96,6 +96,30 @@ namespace lfs::core::nn::device {
 #endif
     }
 
+    // src_bytes is 0 or 16. 0 writes zeros to smem and does not touch gmem, so
+    // K/N/M tails stay on the cp.async path instead of a scalar fallback.
+    template <bool kCacheGlobal>
+    __device__ __forceinline__ void cp_async16_pred(void* smem_addr, const void* glob_addr,
+                                                    const bool pred) {
+#if __CUDA_ARCH__ >= 800
+        const unsigned smem = __cvta_generic_to_shared(smem_addr);
+        const unsigned sz = pred ? 16u : 0u;
+        if constexpr (kCacheGlobal) {
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16, %2;\n" ::"r"(smem),
+                         "l"(glob_addr), "r"(sz));
+        } else {
+            asm volatile("cp.async.ca.shared.global [%0], [%1], 16, %2;\n" ::"r"(smem),
+                         "l"(glob_addr), "r"(sz));
+        }
+#else
+        if (pred) {
+            *reinterpret_cast<uint4*>(smem_addr) = *reinterpret_cast<const uint4*>(glob_addr);
+        } else {
+            *reinterpret_cast<uint4*>(smem_addr) = uint4{0, 0, 0, 0};
+        }
+#endif
+    }
+
     __device__ __forceinline__ void cp_async_commit() {
 #if __CUDA_ARCH__ >= 800
         asm volatile("cp.async.commit_group;\n");

--- a/src/core/nn/nn_kernels.hpp
+++ b/src/core/nn/nn_kernels.hpp
@@ -77,6 +77,22 @@ namespace lfs::core::nn::kernels {
 
     void relu(const void* x, void* y, std::size_t n, DataType dtype, cudaStream_t stream);
 
+    void sigmoid(const void* x, void* y, std::size_t n, DataType dtype, cudaStream_t stream);
+
+    void window_partition_2d(const void* input, void* output, int batch, int height, int width,
+                             int channels, int window, int n_h, int n_w, DataType dtype,
+                             cudaStream_t stream);
+
+    void window_unpartition_2d(const void* windows, void* output, int batch, int height, int width,
+                               int channels, int window, int n_h, int n_w, DataType dtype,
+                               cudaStream_t stream);
+
+    void fourier_pe_coords(const void* coords, const void* gaussian, void* output, int count,
+                           int feats, DataType dtype, cudaStream_t stream);
+
+    void fourier_pe_grid(const void* gaussian, void* output, int height, int width, int feats,
+                         DataType dtype, cudaStream_t stream);
+
     void channel_bias(void* nchw, const void* bias, int n, int c, int spatial, DataType dtype,
                       cudaStream_t stream);
 
@@ -84,9 +100,30 @@ namespace lfs::core::nn::kernels {
     void split_qkv(const void* qkv, void* q, void* k, void* v, int batch, int seq, int heads,
                    int d, DataType dtype, cudaStream_t stream);
 
+    // qkv is [B, H, W, 3*heads*d] packed as [3, heads, d] on the last dim.
+    // Writes Q/K/V as windowed [B*nH*nW, heads, window*window, d], zero-filling
+    // the bottom/right pad so H/W need not be multiples of `window`.
+    void split_qkv_window_2d(const void* qkv, void* q, void* k, void* v, int batch, int height,
+                             int width, int heads, int d, int window, int n_h, int n_w,
+                             const void* bias, DataType dtype, cudaStream_t stream);
+
     // context [B, H, S, D] -> packed [B, S, H, D].
     void merge_heads(const void* context, void* packed, int batch, int heads, int seq, int d,
                      DataType dtype, cudaStream_t stream);
+
+    // Inverse of split_qkv_window_2d on the Q layout: [B*nH*nW, heads, ws*ws, d]
+    // -> [B, orig_h, orig_w, heads*d], cropping pad.
+    void merge_heads_unwindow_2d(const void* context, void* packed, int batch, int orig_h,
+                                 int orig_w, int heads, int d, int window, int n_h, int n_w,
+                                 DataType dtype, cudaStream_t stream);
+
+    // 2x2 stride-2 max-pool over the spatial sequence of [B, heads, H*W, D].
+    void max_pool_heads_2d(const void* input, void* output, int batch, int heads, int height,
+                           int width, int d, DataType dtype, cudaStream_t stream);
+
+    // 2x2 stride-2 max-pool on BHWC [B, H, W, C] -> [B, H/2, W/2, C].
+    void max_pool2d_bhwc(const void* input, void* output, int batch, int height, int width,
+                         int channels, DataType dtype, cudaStream_t stream);
 
     void uv_grid(void* output, int height, int width, float u0, float u1, float v0, float v1,
                  DataType dtype, cudaStream_t stream);

--- a/src/core/nn/nn_nvtx.hpp
+++ b/src/core/nn/nn_nvtx.hpp
@@ -80,7 +80,7 @@ namespace lfs::core::nn {
                 float ms = 0.0f;
                 LFS_CUDA_CHECK(cudaEventElapsedTime(&ms, events_[i], events_[i + 1]));
                 total += ms;
-                std::fprintf(stderr, "  %7.3f  %s\n", static_cast<double>(ms), names_[i + 1].c_str());
+                std::fprintf(stderr, "  %7.3f  %s\n", static_cast<double>(ms), names_[i].c_str());
             }
             std::fprintf(stderr, "  %7.3f  TOTAL\n", static_cast<double>(total));
         }

--- a/src/core/nn/ops.cpp
+++ b/src/core/nn/ops.cpp
@@ -176,7 +176,7 @@ namespace lfs::core::nn {
     }
 
     Tensor linear(const Tensor& input, const Tensor& weight, const Tensor* bias,
-                  Activation activation) {
+                  Activation activation, const Tensor* residual) {
         require_nn_tensor(input, "linear", "input");
         require_nn_tensor(weight, "linear", "weight");
         require_same_dtype_device(input, weight, "linear", "input", "weight");
@@ -201,13 +201,23 @@ namespace lfs::core::nn {
             bias_c = &bias_store;
         }
 
+        Tensor residual_store;
+        const Tensor* residual_c = nullptr;
+        if (residual != nullptr && residual->is_valid()) {
+            require_nn_tensor(*residual, "linear", "residual");
+            require_same_dtype_device(in_c, *residual, "linear", "input", "residual");
+            LFS_ASSERT_MSG(residual->numel() == m * n, "linear residual must match the output");
+            residual_store = residual->contiguous();
+            residual_c = &residual_store;
+        }
+
         std::vector<std::size_t> out_dims;
         for (std::size_t i = 0; i + 1 < input.ndim(); ++i) {
             out_dims.push_back(input.shape()[i]);
         }
         out_dims.push_back(n);
         auto out = empty_like_shape(in_c, TensorShape(out_dims));
-        pin_operands({&in_2d, &w_c});
+        pin_operands({&in_2d, &w_c, residual_c});
         const cudaStream_t stream = prepare_inputs_for_stream({&in_2d, &w_c}, out.stream());
         out.set_stream(stream);
         kernels::gemm(raw(in_2d), raw(w_c), raw_mut(out), static_cast<int>(m), static_cast<int>(n),
@@ -215,7 +225,7 @@ namespace lfs::core::nn {
                       static_cast<long long>(n) * static_cast<long long>(k),
                       static_cast<long long>(m) * static_cast<long long>(n), 1, false, true,
                       bias_c ? raw(*bias_c) : nullptr, static_cast<int>(activation), in_c.dtype(),
-                      stream);
+                      stream, false, residual_c ? raw(*residual_c) : nullptr);
         return out;
     }
 
@@ -422,6 +432,66 @@ namespace lfs::core::nn {
             return folded;
         }
         return folded.slice(2, 0, static_cast<std::size_t>(original_n)).contiguous();
+    }
+
+    Window2d window_partition_2d(const Tensor& input, int window_size) {
+        require_nn_tensor(input, "window_partition_2d", "input");
+        LFS_ASSERT_MSG(input.ndim() == 4, "window_partition_2d expects [B, H, W, C]");
+        LFS_ASSERT_MSG(window_size > 0, "window_size must be positive");
+        const Tensor in_c = input.contiguous();
+        const int b = static_cast<int>(in_c.shape()[0]);
+        const int h = static_cast<int>(in_c.shape()[1]);
+        const int w = static_cast<int>(in_c.shape()[2]);
+        const int c = static_cast<int>(in_c.shape()[3]);
+        const int pad_h = (window_size - h % window_size) % window_size;
+        const int pad_w = (window_size - w % window_size) % window_size;
+        const int n_h = (h + pad_h) / window_size;
+        const int n_w = (w + pad_w) / window_size;
+        auto out = empty_like_shape(
+            in_c, TensorShape{std::vector<std::size_t>{
+                      static_cast<std::size_t>(b) * static_cast<std::size_t>(n_h) *
+                          static_cast<std::size_t>(n_w),
+                      static_cast<std::size_t>(window_size), static_cast<std::size_t>(window_size),
+                      static_cast<std::size_t>(c)}});
+        pin_operands({&in_c});
+        const cudaStream_t stream = prepare_inputs_for_stream({&in_c}, out.stream());
+        out.set_stream(stream);
+        kernels::window_partition_2d(raw(in_c), raw_mut(out), b, h, w, c, window_size, n_h, n_w,
+                                     in_c.dtype(), stream);
+        return Window2d{std::move(out), pad_h, pad_w};
+    }
+
+    Tensor window_unpartition_2d(const Tensor& windows, int window_size, int pad_h, int pad_w,
+                                 int orig_h, int orig_w) {
+        require_nn_tensor(windows, "window_unpartition_2d", "windows");
+        LFS_ASSERT_MSG(windows.ndim() == 4, "window_unpartition_2d expects [B*nwin, ws, ws, C]");
+        LFS_ASSERT_MSG(window_size > 0 && orig_h > 0 && orig_w > 0, "window_unpartition_2d sizes invalid");
+        LFS_ASSERT_MSG(pad_h >= 0 && pad_w >= 0, "window_unpartition_2d pad must be non-negative");
+        const Tensor w_c = windows.contiguous();
+        const int hp = orig_h + pad_h;
+        const int wp = orig_w + pad_w;
+        LFS_ASSERT_MSG(hp % window_size == 0 && wp % window_size == 0,
+                       "window_unpartition_2d padded size is not divisible by window");
+        const int n_h = hp / window_size;
+        const int n_w = wp / window_size;
+        const int nwin = n_h * n_w;
+        LFS_ASSERT_MSG(nwin > 0 && w_c.shape()[0] % static_cast<std::size_t>(nwin) == 0,
+                       "window_unpartition_2d batch is not divisible by n_windows");
+        LFS_ASSERT_MSG(static_cast<int>(w_c.shape()[1]) == window_size &&
+                           static_cast<int>(w_c.shape()[2]) == window_size,
+                       "window_unpartition_2d window spatial mismatch");
+        const int b = static_cast<int>(w_c.shape()[0] / static_cast<std::size_t>(nwin));
+        const int c = static_cast<int>(w_c.shape()[3]);
+        auto out = empty_like_shape(
+            w_c, TensorShape{std::vector<std::size_t>{
+                     static_cast<std::size_t>(b), static_cast<std::size_t>(orig_h),
+                     static_cast<std::size_t>(orig_w), static_cast<std::size_t>(c)}});
+        pin_operands({&w_c});
+        const cudaStream_t stream = prepare_inputs_for_stream({&w_c}, out.stream());
+        out.set_stream(stream);
+        kernels::window_unpartition_2d(raw(w_c), raw_mut(out), b, orig_h, orig_w, c, window_size, n_h,
+                                       n_w, w_c.dtype(), stream);
+        return out;
     }
 
     std::pair<int, int> conv2d_output_hw(int height, int width, int kernel_h, int kernel_w,
@@ -830,6 +900,76 @@ namespace lfs::core::nn {
         return out;
     }
 
+    Tensor sigmoid(const Tensor& input) {
+        require_nn_tensor(input, "sigmoid", "input");
+        const Tensor in_c = input.contiguous();
+        auto out = empty_like_shape(in_c, in_c.shape());
+        pin_operands({&in_c});
+        const cudaStream_t stream = prepare_inputs_for_stream({&in_c}, out.stream());
+        out.set_stream(stream);
+        kernels::sigmoid(raw(in_c), raw_mut(out), in_c.numel(), in_c.dtype(), stream);
+        return out;
+    }
+
+    Tensor layer_norm_2d(const Tensor& input, const Tensor& weight, const Tensor& bias, float eps) {
+        require_nn_tensor(input, "layer_norm_2d", "input");
+        LFS_ASSERT_MSG(input.ndim() == 4, "layer_norm_2d expects NCHW");
+        auto nhwc = input.permute({0, 2, 3, 1}).contiguous();
+        auto y = layer_norm(nhwc, weight, bias, eps);
+        return y.permute({0, 3, 1, 2}).contiguous();
+    }
+
+    Tensor fourier_pe(const Tensor& coords, const Tensor& gaussian) {
+        require_nn_tensor(coords, "fourier_pe", "coords");
+        require_nn_tensor(gaussian, "fourier_pe", "gaussian");
+        require_same_dtype_device(coords, gaussian, "fourier_pe", "coords", "gaussian");
+        LFS_ASSERT_MSG(coords.ndim() >= 1 && coords.shape()[coords.ndim() - 1] == 2,
+                       "fourier_pe coords last dim must be 2");
+        LFS_ASSERT_MSG(gaussian.ndim() == 2 && gaussian.shape()[0] == 2,
+                       "fourier_pe gaussian must be [2, F]");
+        const Tensor c_c = coords.contiguous();
+        const Tensor g_c = gaussian.contiguous();
+        const int feats = static_cast<int>(g_c.shape()[1]);
+        const int count = static_cast<int>(c_c.numel() / 2);
+        std::vector<std::size_t> out_dims;
+        for (std::size_t i = 0; i + 1 < c_c.ndim(); ++i) {
+            out_dims.push_back(c_c.shape()[i]);
+        }
+        out_dims.push_back(static_cast<std::size_t>(feats) * 2);
+        auto out = empty_like_shape(c_c, TensorShape(out_dims));
+        pin_operands({&c_c, &g_c});
+        const cudaStream_t stream = prepare_inputs_for_stream({&c_c, &g_c}, out.stream());
+        out.set_stream(stream);
+        kernels::fourier_pe_coords(raw(c_c), raw(g_c), raw_mut(out), count, feats, c_c.dtype(),
+                                   stream);
+        return out;
+    }
+
+    Tensor fourier_pe_grid(int height, int width, const Tensor& gaussian, DataType dtype,
+                           Device device, cudaStream_t stream) {
+        require_nn_tensor(gaussian, "fourier_pe_grid", "gaussian");
+        LFS_ASSERT_MSG(height > 0 && width > 0, "fourier_pe_grid size must be positive");
+        LFS_ASSERT_MSG(device == Device::CUDA, "fourier_pe_grid requires CUDA");
+        LFS_ASSERT_MSG(dtype == DataType::Float16 || dtype == DataType::Float32,
+                       "fourier_pe_grid dtype must be float16 or float32");
+        LFS_ASSERT_MSG(gaussian.ndim() == 2 && gaussian.shape()[0] == 2,
+                       "fourier_pe_grid gaussian must be [2, F]");
+        LFS_ASSERT_MSG(gaussian.dtype() == dtype, "fourier_pe_grid gaussian dtype mismatch");
+        const Tensor g_c = gaussian.contiguous();
+        const int feats = static_cast<int>(g_c.shape()[1]);
+        auto out = Tensor::empty(
+            TensorShape{std::vector<std::size_t>{1, static_cast<std::size_t>(feats) * 2,
+                                                 static_cast<std::size_t>(height),
+                                                 static_cast<std::size_t>(width)}},
+            device, dtype);
+        out.set_stream(stream);
+        pin_operands({&g_c});
+        const cudaStream_t used = prepare_inputs_for_stream({&g_c}, stream);
+        out.set_stream(used);
+        kernels::fourier_pe_grid(raw(g_c), raw_mut(out), height, width, feats, dtype, used);
+        return out;
+    }
+
     Tensor cast(const Tensor& input, DataType dtype) {
         tensor_contract::require_valid(input, "cast", "input", LFS_SOURCE_SITE_CURRENT());
         return input.to(dtype);
@@ -867,6 +1007,52 @@ namespace lfs::core::nn {
         return {std::move(q), std::move(k), std::move(v)};
     }
 
+    std::array<Tensor, 3> split_qkv_window_2d(const Tensor& qkv, int heads, int window,
+                                              const Tensor* bias) {
+        require_nn_tensor(qkv, "split_qkv_window_2d", "qkv");
+        LFS_ASSERT_MSG(heads > 0 && window > 0, "split_qkv_window_2d heads/window must be positive");
+        LFS_ASSERT_MSG(qkv.ndim() == 4, "split_qkv_window_2d expects [B, H, W, 3HD]");
+        const Tensor in_c = qkv.contiguous();
+        const int b = static_cast<int>(in_c.shape()[0]);
+        const int height = static_cast<int>(in_c.shape()[1]);
+        const int width = static_cast<int>(in_c.shape()[2]);
+        const int packed = static_cast<int>(in_c.shape()[3]);
+        LFS_ASSERT_MSG(packed % (3 * heads) == 0, "split_qkv_window_2d packed width is not 3*H*D");
+        const int d = packed / (3 * heads);
+        Tensor bias_store;
+        const Tensor* bias_c = nullptr;
+        if (bias != nullptr && bias->is_valid()) {
+            require_nn_tensor(*bias, "split_qkv_window_2d", "bias");
+            require_same_dtype_device(in_c, *bias, "split_qkv_window_2d", "qkv", "bias");
+            LFS_ASSERT_MSG(bias->numel() == static_cast<std::size_t>(packed),
+                           "split_qkv_window_2d bias must have 3*H*D elements");
+            bias_store = bias->contiguous();
+            bias_c = &bias_store;
+        }
+        const int pad_h = (window - height % window) % window;
+        const int pad_w = (window - width % window) % window;
+        const int n_h = (height + pad_h) / window;
+        const int n_w = (width + pad_w) / window;
+        const int seq = window * window;
+        const auto shape = TensorShape{std::vector<std::size_t>{
+            static_cast<std::size_t>(b) * static_cast<std::size_t>(n_h) *
+                static_cast<std::size_t>(n_w),
+            static_cast<std::size_t>(heads), static_cast<std::size_t>(seq),
+            static_cast<std::size_t>(d)}};
+        auto q = empty_like_shape(in_c, shape);
+        auto k = empty_like_shape(in_c, shape);
+        auto v = empty_like_shape(in_c, shape);
+        pin_operands({&in_c});
+        const cudaStream_t stream = prepare_inputs_for_stream({&in_c}, q.stream());
+        q.set_stream(stream);
+        k.set_stream(stream);
+        v.set_stream(stream);
+        kernels::split_qkv_window_2d(raw(in_c), raw_mut(q), raw_mut(k), raw_mut(v), b, height,
+                                     width, heads, d, window, n_h, n_w,
+                                     bias_c ? raw(*bias_c) : nullptr, in_c.dtype(), stream);
+        return {std::move(q), std::move(k), std::move(v)};
+    }
+
     Tensor merge_heads(const Tensor& context) {
         require_nn_tensor(context, "merge_heads", "context");
         LFS_ASSERT_MSG(context.ndim() == 4, "merge_heads expects [B, H, S, D]");
@@ -883,6 +1069,83 @@ namespace lfs::core::nn {
         const cudaStream_t stream = prepare_inputs_for_stream({&in_c}, out.stream());
         out.set_stream(stream);
         kernels::merge_heads(raw(in_c), raw_mut(out), b, heads, seq, d, in_c.dtype(), stream);
+        return out;
+    }
+
+    Tensor merge_heads_unwindow_2d(const Tensor& context, int window, int orig_h, int orig_w) {
+        require_nn_tensor(context, "merge_heads_unwindow_2d", "context");
+        LFS_ASSERT_MSG(context.ndim() == 4, "merge_heads_unwindow_2d expects [Bwin, heads, S, D]");
+        LFS_ASSERT_MSG(window > 0 && orig_h > 0 && orig_w > 0,
+                       "merge_heads_unwindow_2d sizes must be positive");
+        const Tensor in_c = context.contiguous();
+        const int heads = static_cast<int>(in_c.shape()[1]);
+        const int seq = static_cast<int>(in_c.shape()[2]);
+        const int d = static_cast<int>(in_c.shape()[3]);
+        LFS_ASSERT_MSG(seq == window * window, "merge_heads_unwindow_2d S must be window*window");
+        const int pad_h = (window - orig_h % window) % window;
+        const int pad_w = (window - orig_w % window) % window;
+        const int n_h = (orig_h + pad_h) / window;
+        const int n_w = (orig_w + pad_w) / window;
+        const int nwin = n_h * n_w;
+        LFS_ASSERT_MSG(nwin > 0 && in_c.shape()[0] % static_cast<std::size_t>(nwin) == 0,
+                       "merge_heads_unwindow_2d batch is not divisible by n_windows");
+        const int b = static_cast<int>(in_c.shape()[0] / static_cast<std::size_t>(nwin));
+        auto out = empty_like_shape(
+            in_c, TensorShape{std::vector<std::size_t>{
+                      static_cast<std::size_t>(b), static_cast<std::size_t>(orig_h),
+                      static_cast<std::size_t>(orig_w),
+                      static_cast<std::size_t>(heads) * static_cast<std::size_t>(d)}});
+        pin_operands({&in_c});
+        const cudaStream_t stream = prepare_inputs_for_stream({&in_c}, out.stream());
+        out.set_stream(stream);
+        kernels::merge_heads_unwindow_2d(raw(in_c), raw_mut(out), b, orig_h, orig_w, heads, d,
+                                         window, n_h, n_w, in_c.dtype(), stream);
+        return out;
+    }
+
+    Tensor max_pool_heads_2d(const Tensor& input, int height, int width) {
+        require_nn_tensor(input, "max_pool_heads_2d", "input");
+        LFS_ASSERT_MSG(input.ndim() == 4, "max_pool_heads_2d expects [B, heads, H*W, D]");
+        LFS_ASSERT_MSG(height > 0 && width > 0 && (height % 2) == 0 && (width % 2) == 0,
+                       "max_pool_heads_2d requires even positive H and W");
+        const Tensor in_c = input.contiguous();
+        const int b = static_cast<int>(in_c.shape()[0]);
+        const int heads = static_cast<int>(in_c.shape()[1]);
+        const int seq = static_cast<int>(in_c.shape()[2]);
+        const int d = static_cast<int>(in_c.shape()[3]);
+        LFS_ASSERT_MSG(seq == height * width, "max_pool_heads_2d S must equal H*W");
+        const int out_s = (height / 2) * (width / 2);
+        auto out = empty_like_shape(
+            in_c, TensorShape{std::vector<std::size_t>{
+                      static_cast<std::size_t>(b), static_cast<std::size_t>(heads),
+                      static_cast<std::size_t>(out_s), static_cast<std::size_t>(d)}});
+        pin_operands({&in_c});
+        const cudaStream_t stream = prepare_inputs_for_stream({&in_c}, out.stream());
+        out.set_stream(stream);
+        kernels::max_pool_heads_2d(raw(in_c), raw_mut(out), b, heads, height, width, d,
+                                   in_c.dtype(), stream);
+        return out;
+    }
+
+    Tensor max_pool2d_bhwc(const Tensor& input) {
+        require_nn_tensor(input, "max_pool2d_bhwc", "input");
+        LFS_ASSERT_MSG(input.ndim() == 4, "max_pool2d_bhwc expects [B, H, W, C]");
+        const Tensor in_c = input.contiguous();
+        const int b = static_cast<int>(in_c.shape()[0]);
+        const int height = static_cast<int>(in_c.shape()[1]);
+        const int width = static_cast<int>(in_c.shape()[2]);
+        const int channels = static_cast<int>(in_c.shape()[3]);
+        LFS_ASSERT_MSG(height > 0 && width > 0 && (height % 2) == 0 && (width % 2) == 0,
+                       "max_pool2d_bhwc requires even positive H and W");
+        auto out = empty_like_shape(
+            in_c, TensorShape{std::vector<std::size_t>{
+                      static_cast<std::size_t>(b), static_cast<std::size_t>(height / 2),
+                      static_cast<std::size_t>(width / 2), static_cast<std::size_t>(channels)}});
+        pin_operands({&in_c});
+        const cudaStream_t stream = prepare_inputs_for_stream({&in_c}, out.stream());
+        out.set_stream(stream);
+        kernels::max_pool2d_bhwc(raw(in_c), raw_mut(out), b, height, width, channels, in_c.dtype(),
+                                 stream);
         return out;
     }
 

--- a/tests/bench_nn_ops.cpp
+++ b/tests/bench_nn_ops.cpp
@@ -105,6 +105,18 @@ TEST(NnBench, DISABLED_ReportTable) {
                kPeakFp16);
     bench_gemm("gemm M1370 K768 N768", 1370, 768, 768, true, lfs::core::DataType::Float32, kPeakFp32);
     bench_gemm("gemm M1370 K768 N768", 1370, 768, 768, true, lfs::core::DataType::Float16, kPeakFp16);
+    bench_gemm("hiera M65536 K112 N112", 65536, 112, 112, true, lfs::core::DataType::Float16,
+               kPeakFp16);
+    bench_gemm("hiera M65536 K112 N336", 65536, 336, 112, true, lfs::core::DataType::Float16,
+               kPeakFp16);
+    bench_gemm("hiera M65536 K112 N448", 65536, 448, 112, true, lfs::core::DataType::Float16,
+               kPeakFp16);
+    bench_gemm("hiera M4096 K448 N448", 4096, 448, 448, true, lfs::core::DataType::Float16,
+               kPeakFp16);
+    bench_gemm("hiera M4096 K448 N1792", 4096, 1792, 448, true, lfs::core::DataType::Float16,
+               kPeakFp16);
+    bench_gemm("hiera M4096 K1792 N448", 4096, 448, 1792, true, lfs::core::DataType::Float16,
+               kPeakFp16);
 
     auto bench_bmm = [&](lfs::core::DataType dtype, double peak) {
         auto a = randn({12, 1370, 64}, dtype);

--- a/tests/test_nn_ops.cpp
+++ b/tests/test_nn_ops.cpp
@@ -135,36 +135,42 @@ namespace {
     }
 
     std::vector<float> cpu_attention(const std::vector<float>& q, const std::vector<float>& k,
-                                     const std::vector<float>& v, int b, int h, int n, int d) {
+                                     const std::vector<float>& v, int b, int h, int n_q, int n_k,
+                                     int d) {
         const float scale = 1.0f / std::sqrt(static_cast<float>(d));
-        std::vector<float> o(q.size(), 0.0f);
-        std::vector<float> scores(static_cast<std::size_t>(n) * n);
+        std::vector<float> o(static_cast<std::size_t>(b) * h * n_q * d, 0.0f);
+        std::vector<float> scores(static_cast<std::size_t>(n_q) * n_k);
         for (int bh = 0; bh < b * h; ++bh) {
-            const float* qh = q.data() + static_cast<std::size_t>(bh) * n * d;
-            const float* kh = k.data() + static_cast<std::size_t>(bh) * n * d;
-            const float* vh = v.data() + static_cast<std::size_t>(bh) * n * d;
-            float* oh = o.data() + static_cast<std::size_t>(bh) * n * d;
-            for (int i = 0; i < n; ++i) {
-                for (int j = 0; j < n; ++j) {
+            const float* qh = q.data() + static_cast<std::size_t>(bh) * n_q * d;
+            const float* kh = k.data() + static_cast<std::size_t>(bh) * n_k * d;
+            const float* vh = v.data() + static_cast<std::size_t>(bh) * n_k * d;
+            float* oh = o.data() + static_cast<std::size_t>(bh) * n_q * d;
+            for (int i = 0; i < n_q; ++i) {
+                for (int j = 0; j < n_k; ++j) {
                     float dot = 0.0f;
                     for (int t = 0; t < d; ++t) {
                         dot += qh[i * d + t] * kh[j * d + t];
                     }
-                    scores[i * n + j] = dot * scale;
+                    scores[i * n_k + j] = dot * scale;
                 }
             }
-            auto p = cpu_softmax(scores, n, n);
-            for (int i = 0; i < n; ++i) {
+            auto p = cpu_softmax(scores, n_q, n_k);
+            for (int i = 0; i < n_q; ++i) {
                 for (int t = 0; t < d; ++t) {
                     float sum = 0.0f;
-                    for (int j = 0; j < n; ++j) {
-                        sum += p[i * n + j] * vh[j * d + t];
+                    for (int j = 0; j < n_k; ++j) {
+                        sum += p[i * n_k + j] * vh[j * d + t];
                     }
                     oh[i * d + t] = sum;
                 }
             }
         }
         return o;
+    }
+
+    std::vector<float> cpu_attention(const std::vector<float>& q, const std::vector<float>& k,
+                                     const std::vector<float>& v, int b, int h, int n, int d) {
+        return cpu_attention(q, k, v, b, h, n, n, d);
     }
 
     std::vector<float> cpu_conv2d(const std::vector<float>& in, const std::vector<float>& w,
@@ -288,6 +294,94 @@ TEST_F(NnOpsTest, LinearMatchesGemmNT) {
     EXPECT_TRUE(all_close(host_f32(y), ref, kF32Rtol, kF32Atol));
 }
 
+TEST_F(NnOpsTest, GemmAlignedNtResidualScaleGelu) {
+    const int shapes[][3] = {
+        {128, 112, 112},
+        {256, 336, 112},
+        {192, 128, 64},
+        {1370, 768, 768},
+        {160, 80, 48}};
+    std::mt19937 rng(2);
+    std::uniform_real_distribution<float> dist(-0.4f, 0.4f);
+    for (const auto& mnk : shapes) {
+        const int m = mnk[0], n = mnk[1], k = mnk[2];
+        std::vector<float> a(static_cast<std::size_t>(m) * k);
+        std::vector<float> b(static_cast<std::size_t>(n) * k);
+        std::vector<float> bias(static_cast<std::size_t>(n));
+        std::vector<float> scale(static_cast<std::size_t>(n));
+        std::vector<float> residual(static_cast<std::size_t>(m) * n);
+        for (auto& v : a) {
+            v = dist(rng);
+        }
+        for (auto& v : b) {
+            v = dist(rng);
+        }
+        for (auto& v : bias) {
+            v = dist(rng);
+        }
+        for (auto& v : scale) {
+            v = 0.75f + dist(rng);
+        }
+        for (auto& v : residual) {
+            v = dist(rng);
+        }
+        auto ref = cpu_gemm(a, b, m, n, k, true, bias.data(), 3);
+        for (int i = 0; i < m; ++i) {
+            for (int j = 0; j < n; ++j) {
+                const int idx = i * n + j;
+                ref[static_cast<std::size_t>(idx)] =
+                    ref[static_cast<std::size_t>(idx)] * scale[static_cast<std::size_t>(j)] +
+                    residual[static_cast<std::size_t>(idx)];
+            }
+        }
+        auto A = upload(a, {static_cast<std::size_t>(m), static_cast<std::size_t>(k)},
+                        lfs::core::DataType::Float16);
+        auto B = upload(b, {static_cast<std::size_t>(n), static_cast<std::size_t>(k)},
+                        lfs::core::DataType::Float16);
+        auto Bs = upload(bias, {static_cast<std::size_t>(n)}, lfs::core::DataType::Float16);
+        auto Sc = upload(scale, {static_cast<std::size_t>(n)}, lfs::core::DataType::Float16);
+        auto R = upload(residual, {static_cast<std::size_t>(m), static_cast<std::size_t>(n)},
+                        lfs::core::DataType::Float16);
+        auto C = lfs::core::nn::gemm(A, B, false, true, &Bs, lfs::core::nn::Activation::GeluErf, &R,
+                                     &Sc);
+        EXPECT_TRUE(all_close(host_f32(C), ref, kF16Rtol, kF16Atol))
+            << "m=" << m << " n=" << n << " k=" << k;
+    }
+}
+
+TEST_F(NnOpsTest, LinearResidualMatchesAdd) {
+    const int m = 192, n = 112, k = 112;
+    std::mt19937 rng(3);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+    std::vector<float> x(static_cast<std::size_t>(m) * k);
+    std::vector<float> w(static_cast<std::size_t>(n) * k);
+    std::vector<float> bias(static_cast<std::size_t>(n));
+    std::vector<float> residual(static_cast<std::size_t>(m) * n);
+    for (auto& v : x) {
+        v = dist(rng);
+    }
+    for (auto& v : w) {
+        v = dist(rng);
+    }
+    for (auto& v : bias) {
+        v = dist(rng);
+    }
+    for (auto& v : residual) {
+        v = dist(rng);
+    }
+    for (const auto dtype : {lfs::core::DataType::Float32, lfs::core::DataType::Float16}) {
+        auto X = upload(x, {2, 96, static_cast<std::size_t>(k)}, dtype);
+        auto W = upload(w, {static_cast<std::size_t>(n), static_cast<std::size_t>(k)}, dtype);
+        auto B = upload(bias, {static_cast<std::size_t>(n)}, dtype);
+        auto R = upload(residual, {2, 96, static_cast<std::size_t>(n)}, dtype);
+        auto fused = lfs::core::nn::linear(X, W, &B, lfs::core::nn::Activation::None, &R);
+        auto composed = lfs::core::nn::linear(X, W, &B, lfs::core::nn::Activation::None).add(R);
+        const float rtol = dtype == lfs::core::DataType::Float16 ? kF16Rtol : kF32Rtol;
+        const float atol = dtype == lfs::core::DataType::Float16 ? kF16Atol : kF32Atol;
+        EXPECT_TRUE(all_close(host_f32(fused), host_f32(composed), rtol, atol));
+    }
+}
+
 TEST_F(NnOpsTest, LayerNormAndRmsNorm) {
     const int rows = 6, cols = 17;
     std::vector<float> x(rows * cols), w(cols, 1.2f), b(cols, -0.3f);
@@ -345,6 +439,45 @@ TEST_F(NnOpsTest, AttentionWmmaTileParity) {
     auto V = upload(v, shape, lfs::core::DataType::Float16);
     auto O = lfs::core::nn::attention(Q, K, V);
     EXPECT_TRUE(all_close(host_f32(O), ref, kF16Rtol, kF16Atol));
+}
+
+TEST_F(NnOpsTest, AttentionD56RectangularParity) {
+    std::mt19937 rng(23);
+    std::uniform_real_distribution<float> dist(-0.6f, 0.6f);
+    const auto run = [&](int b, int h, int n_q, int n_k, int d) {
+        std::vector<float> q(static_cast<std::size_t>(b) * h * n_q * d);
+        std::vector<float> k(static_cast<std::size_t>(b) * h * n_k * d);
+        std::vector<float> v(k.size());
+        for (auto& val : q) {
+            val = dist(rng);
+        }
+        for (auto& val : k) {
+            val = dist(rng);
+        }
+        for (auto& val : v) {
+            val = dist(rng);
+        }
+        const auto ref = cpu_attention(q, k, v, b, h, n_q, n_k, d);
+        auto q_shape = std::vector<std::size_t>{static_cast<std::size_t>(b),
+                                                static_cast<std::size_t>(h),
+                                                static_cast<std::size_t>(n_q),
+                                                static_cast<std::size_t>(d)};
+        auto kv_shape = std::vector<std::size_t>{static_cast<std::size_t>(b),
+                                                 static_cast<std::size_t>(h),
+                                                 static_cast<std::size_t>(n_k),
+                                                 static_cast<std::size_t>(d)};
+        auto Q = upload(q, q_shape, lfs::core::DataType::Float16);
+        auto K = upload(k, kv_shape, lfs::core::DataType::Float16);
+        auto V = upload(v, kv_shape, lfs::core::DataType::Float16);
+        auto O = lfs::core::nn::attention(Q, K, V);
+        EXPECT_TRUE(all_close(host_f32(O), ref, kF16Rtol, kF16Atol))
+            << "b=" << b << " h=" << h << " n_q=" << n_q << " n_k=" << n_k << " d=" << d;
+    };
+    run(1, 1, 17, 17, 56);
+    run(1, 2, 49, 196, 56);
+    run(2, 8, 12, 40, 56);
+    run(1, 8, 128, 128, 56);
+    run(1, 1, 64, 64, 32);
 }
 
 TEST_F(NnOpsTest, AttentionVsExplicitSoftmax) {
@@ -515,6 +648,116 @@ TEST_F(NnOpsTest, Conv2dFp16Large3x3MatchesRef) {
     const auto refr = cpu_conv2d(in, wt, &bias, n, cin, h, w, cout, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1);
     auto OutR = lfs::core::nn::conv2d(In, W, &B, p);
     EXPECT_TRUE(all_close(host_f32(OutR), refr, kF16Rtol, kF16Atol)) << "3x3 replicate";
+}
+
+TEST_F(NnOpsTest, SplitQkvWindow2dMatchesComposed) {
+    const int b = 1, h = 16, w = 16, heads = 2, d = 8, ws = 8;
+    std::vector<float> qkv(static_cast<std::size_t>(b) * h * w * 3 * heads * d);
+    for (int i = 0; i < static_cast<int>(qkv.size()); ++i) {
+        qkv[static_cast<std::size_t>(i)] = 0.01f * (i - 40);
+    }
+    for (const auto dtype : {lfs::core::DataType::Float32, lfs::core::DataType::Float16}) {
+        auto QKV = upload(qkv,
+                          {static_cast<std::size_t>(b), static_cast<std::size_t>(h),
+                           static_cast<std::size_t>(w), static_cast<std::size_t>(3 * heads * d)},
+                          dtype);
+        auto part = lfs::core::nn::window_partition_2d(QKV, ws);
+        auto packed = part.windows.reshape(lfs::core::TensorShape(std::vector<std::size_t>{
+            part.windows.shape()[0],
+            part.windows.shape()[1] * part.windows.shape()[2],
+            part.windows.shape()[3]}));
+        auto ref = lfs::core::nn::split_qkv(packed, heads);
+        auto got = lfs::core::nn::split_qkv_window_2d(QKV, heads, ws);
+        const float rtol = dtype == lfs::core::DataType::Float16 ? kF16Rtol : kF32Rtol;
+        const float atol = dtype == lfs::core::DataType::Float16 ? kF16Atol : kF32Atol;
+        EXPECT_TRUE(all_close(host_f32(got[0]), host_f32(ref[0]), rtol, atol)) << "Q";
+        EXPECT_TRUE(all_close(host_f32(got[1]), host_f32(ref[1]), rtol, atol)) << "K";
+        EXPECT_TRUE(all_close(host_f32(got[2]), host_f32(ref[2]), rtol, atol)) << "V";
+    }
+
+    const int hp = 14, wp = 14;
+    std::vector<float> qkvp(static_cast<std::size_t>(b) * hp * wp * 3 * heads * d);
+    for (int i = 0; i < static_cast<int>(qkvp.size()); ++i) {
+        qkvp[static_cast<std::size_t>(i)] = 0.02f * (i - 9);
+    }
+    auto QKVp = upload(qkvp,
+                       {1, static_cast<std::size_t>(hp), static_cast<std::size_t>(wp),
+                        static_cast<std::size_t>(3 * heads * d)},
+                       lfs::core::DataType::Float16);
+    auto partp = lfs::core::nn::window_partition_2d(QKVp, ws);
+    auto packedp = partp.windows.reshape(lfs::core::TensorShape(std::vector<std::size_t>{
+        partp.windows.shape()[0], partp.windows.shape()[1] * partp.windows.shape()[2],
+        partp.windows.shape()[3]}));
+    auto refp = lfs::core::nn::split_qkv(packedp, heads);
+    auto gotp = lfs::core::nn::split_qkv_window_2d(QKVp, heads, ws);
+    EXPECT_TRUE(all_close(host_f32(gotp[0]), host_f32(refp[0]), kF16Rtol, kF16Atol)) << "Q pad";
+}
+
+TEST_F(NnOpsTest, MergeHeadsUnwindow2dMatchesComposed) {
+    const int b = 1, h = 16, w = 16, heads = 2, d = 8, ws = 8;
+    const int nwin = (h / ws) * (w / ws);
+    const int seq = ws * ws;
+    std::vector<float> ctx(static_cast<std::size_t>(b) * nwin * heads * seq * d);
+    for (int i = 0; i < static_cast<int>(ctx.size()); ++i) {
+        ctx[static_cast<std::size_t>(i)] = 0.015f * (i - 11);
+    }
+    auto Ctx = upload(ctx,
+                      {static_cast<std::size_t>(b * nwin), static_cast<std::size_t>(heads),
+                       static_cast<std::size_t>(seq), static_cast<std::size_t>(d)},
+                      lfs::core::DataType::Float16);
+    auto merged = lfs::core::nn::merge_heads(Ctx);
+    auto spatial = merged.reshape(lfs::core::TensorShape(std::vector<std::size_t>{
+        static_cast<std::size_t>(b * nwin), static_cast<std::size_t>(ws),
+        static_cast<std::size_t>(ws), static_cast<std::size_t>(heads * d)}));
+    auto ref = lfs::core::nn::window_unpartition_2d(spatial, ws, 0, 0, h, w);
+    auto got = lfs::core::nn::merge_heads_unwindow_2d(Ctx, ws, h, w);
+    EXPECT_TRUE(all_close(host_f32(got), host_f32(ref), kF16Rtol, kF16Atol));
+}
+
+TEST_F(NnOpsTest, MaxPoolHeads2dMatchesComposed) {
+    const int b = 2, heads = 4, hh = 8, ww = 8, d = 8;
+    std::vector<float> q(static_cast<std::size_t>(b) * heads * hh * ww * d);
+    for (int i = 0; i < static_cast<int>(q.size()); ++i) {
+        q[static_cast<std::size_t>(i)] = std::sin(0.03f * i);
+    }
+    auto Q = upload(q,
+                    {static_cast<std::size_t>(b), static_cast<std::size_t>(heads),
+                     static_cast<std::size_t>(hh * ww), static_cast<std::size_t>(d)},
+                    lfs::core::DataType::Float16);
+    auto qmap = Q.permute({0, 2, 1, 3})
+                    .contiguous()
+                    .reshape(lfs::core::TensorShape(std::vector<std::size_t>{
+                        static_cast<std::size_t>(b), static_cast<std::size_t>(hh),
+                        static_cast<std::size_t>(ww),
+                        static_cast<std::size_t>(heads * d)}));
+    auto nchw = qmap.permute({0, 3, 1, 2}).contiguous();
+    auto pooled = lfs::core::nn::max_pool2d(nchw, 2, 2, 2, 2, 0, 0);
+    auto bhwc = pooled.permute({0, 2, 3, 1}).contiguous();
+    auto ref = bhwc
+                   .reshape(lfs::core::TensorShape(std::vector<std::size_t>{
+                       static_cast<std::size_t>(b), static_cast<std::size_t>((hh / 2) * (ww / 2)),
+                       static_cast<std::size_t>(heads), static_cast<std::size_t>(d)}))
+                   .permute({0, 2, 1, 3})
+                   .contiguous();
+    auto got = lfs::core::nn::max_pool_heads_2d(Q, hh, ww);
+    EXPECT_TRUE(all_close(host_f32(got), host_f32(ref), kF16Rtol, kF16Atol));
+}
+
+TEST_F(NnOpsTest, MaxPool2dBhwcMatchesComposed) {
+    const int b = 1, h = 8, w = 8, c = 16;
+    std::vector<float> x(static_cast<std::size_t>(b) * h * w * c);
+    for (int i = 0; i < static_cast<int>(x.size()); ++i) {
+        x[static_cast<std::size_t>(i)] = std::cos(0.02f * i);
+    }
+    auto X = upload(x,
+                    {static_cast<std::size_t>(b), static_cast<std::size_t>(h),
+                     static_cast<std::size_t>(w), static_cast<std::size_t>(c)},
+                    lfs::core::DataType::Float16);
+    auto nchw = X.permute({0, 3, 1, 2}).contiguous();
+    auto pooled = lfs::core::nn::max_pool2d(nchw, 2, 2, 2, 2, 0, 0);
+    auto ref = pooled.permute({0, 2, 3, 1}).contiguous();
+    auto got = lfs::core::nn::max_pool2d_bhwc(X);
+    EXPECT_TRUE(all_close(host_f32(got), host_f32(ref), kF16Rtol, kF16Atol));
 }
 
 TEST_F(NnOpsTest, SplitQkvMergeHeadsAndResidual) {
@@ -715,4 +958,137 @@ TEST_F(NnOpsTest, MogeFixtureIsOptionalAndSmall) {
     std::string body((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     EXPECT_LT(body.size(), 2u * 1024u * 1024u);
     EXPECT_NE(body.find("\"normal\""), std::string::npos);
+}
+
+TEST_F(NnOpsTest, WindowPartition2dRoundTripAndPad) {
+    const int b = 2, h = 5, w = 6, c = 3, ws = 4;
+    std::vector<float> x(static_cast<std::size_t>(b) * h * w * c);
+    for (int i = 0; i < static_cast<int>(x.size()); ++i) {
+        x[static_cast<std::size_t>(i)] = 0.1f * (i - 17);
+    }
+    auto X = upload(x, {static_cast<std::size_t>(b), static_cast<std::size_t>(h), static_cast<std::size_t>(w), static_cast<std::size_t>(c)},
+                    lfs::core::DataType::Float32);
+    auto part = lfs::core::nn::window_partition_2d(X, ws);
+    EXPECT_EQ(part.pad_h, 3);
+    EXPECT_EQ(part.pad_w, 2);
+    EXPECT_EQ(part.windows.shape()[0], static_cast<std::size_t>(b * 2 * 2));
+    EXPECT_EQ(part.windows.shape()[1], static_cast<std::size_t>(ws));
+    auto back = lfs::core::nn::window_unpartition_2d(part.windows, ws, part.pad_h, part.pad_w, h, w);
+    EXPECT_TRUE(all_close(host_f32(back), x, kF32Rtol, kF32Atol));
+
+    const auto got_w = host_f32(part.windows);
+    const int n_h = 2, n_w = 2;
+    for (int bi = 0; bi < b; ++bi) {
+        for (int nh = 0; nh < n_h; ++nh) {
+            for (int nw = 0; nw < n_w; ++nw) {
+                const int win = ((bi * n_h + nh) * n_w) + nw;
+                for (int wy = 0; wy < ws; ++wy) {
+                    for (int wx = 0; wx < ws; ++wx) {
+                        const int y = nh * ws + wy;
+                        const int xj = nw * ws + wx;
+                        for (int ch = 0; ch < c; ++ch) {
+                            const std::size_t oi =
+                                ((((static_cast<std::size_t>(win) * ws + wy) * ws + wx) *
+                                  static_cast<std::size_t>(c)) +
+                                 static_cast<std::size_t>(ch));
+                            float expect = 0.0f;
+                            if (y < h && xj < w) {
+                                expect = x[(((static_cast<std::size_t>(bi) * h + y) * w + xj) *
+                                            static_cast<std::size_t>(c)) +
+                                           static_cast<std::size_t>(ch)];
+                            }
+                            EXPECT_NEAR(got_w[oi], expect, 1e-6f);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    auto X16 = upload(x, {static_cast<std::size_t>(b), static_cast<std::size_t>(h), static_cast<std::size_t>(w), static_cast<std::size_t>(c)},
+                      lfs::core::DataType::Float16);
+    auto part16 = lfs::core::nn::window_partition_2d(X16, ws);
+    auto back16 = lfs::core::nn::window_unpartition_2d(part16.windows, ws, part16.pad_h,
+                                                       part16.pad_w, h, w);
+    EXPECT_TRUE(all_close(host_f32(back16), x, kF16Rtol, kF16Atol));
+}
+
+TEST_F(NnOpsTest, FourierPe) {
+    std::vector<float> coords = {0.25f, 0.75f, 0.0f, 1.0f};
+    std::vector<float> gauss = {0.2f, -0.1f, 0.5f, 0.3f, -0.4f, 0.15f};
+    auto Co = upload(coords, {2, 2}, lfs::core::DataType::Float32);
+    auto G = upload(gauss, {2, 3}, lfs::core::DataType::Float32);
+    auto pe = lfs::core::nn::fourier_pe(Co, G);
+    std::vector<float> peref(12);
+    const float twopi = 6.283185307179586f;
+    for (int n = 0; n < 2; ++n) {
+        const float xn = 2.0f * coords[static_cast<std::size_t>(n) * 2] - 1.0f;
+        const float yn = 2.0f * coords[static_cast<std::size_t>(n) * 2 + 1] - 1.0f;
+        for (int f = 0; f < 3; ++f) {
+            const float ang = twopi * (xn * gauss[static_cast<std::size_t>(f)] +
+                                       yn * gauss[3 + f]);
+            peref[static_cast<std::size_t>(n) * 6 + f] = std::sin(ang);
+            peref[static_cast<std::size_t>(n) * 6 + 3 + f] = std::cos(ang);
+        }
+    }
+    EXPECT_TRUE(all_close(host_f32(pe), peref, 1e-5f, 1e-5f));
+
+    auto grid = lfs::core::nn::fourier_pe_grid(2, 3, G, lfs::core::DataType::Float32,
+                                               lfs::core::Device::CUDA, 0);
+    EXPECT_EQ(grid.shape()[1], 6u);
+    EXPECT_EQ(grid.shape()[2], 2u);
+    EXPECT_EQ(grid.shape()[3], 3u);
+    const auto ggot = host_f32(grid);
+    for (int y = 0; y < 2; ++y) {
+        for (int xj = 0; xj < 3; ++xj) {
+            const float xn = 2.0f * ((static_cast<float>(xj) + 0.5f) / 3.0f) - 1.0f;
+            const float yn = 2.0f * ((static_cast<float>(y) + 0.5f) / 2.0f) - 1.0f;
+            for (int f = 0; f < 3; ++f) {
+                const float ang = twopi * (xn * gauss[static_cast<std::size_t>(f)] +
+                                           yn * gauss[3 + f]);
+                const int spatial = 2 * 3;
+                EXPECT_NEAR(ggot[f * spatial + y * 3 + xj], std::sin(ang), 1e-5f);
+                EXPECT_NEAR(ggot[(3 + f) * spatial + y * 3 + xj], std::cos(ang), 1e-5f);
+            }
+        }
+    }
+}
+
+TEST_F(NnOpsTest, LayerNorm2dMatchesChannelNorm) {
+    const int n = 1, c = 4, h = 3, w = 2;
+    std::vector<float> x(static_cast<std::size_t>(n) * c * h * w);
+    std::vector<float> wt(c), bs(c);
+    for (int i = 0; i < static_cast<int>(x.size()); ++i) {
+        x[static_cast<std::size_t>(i)] = 0.2f * (i - 5);
+    }
+    for (int i = 0; i < c; ++i) {
+        wt[static_cast<std::size_t>(i)] = 0.5f + 0.1f * i;
+        bs[static_cast<std::size_t>(i)] = -0.05f * i;
+    }
+    auto X = upload(x, {1, 4, 3, 2}, lfs::core::DataType::Float32);
+    auto W = upload(wt, {4}, lfs::core::DataType::Float32);
+    auto B = upload(bs, {4}, lfs::core::DataType::Float32);
+    auto Y = lfs::core::nn::layer_norm_2d(X, W, B, 1e-6f);
+    std::vector<float> yref(x.size());
+    const int spatial = h * w;
+    for (int s = 0; s < spatial; ++s) {
+        float mean = 0.0f;
+        for (int ch = 0; ch < c; ++ch) {
+            mean += x[static_cast<std::size_t>(ch) * spatial + s];
+        }
+        mean /= static_cast<float>(c);
+        float var = 0.0f;
+        for (int ch = 0; ch < c; ++ch) {
+            const float d = x[static_cast<std::size_t>(ch) * spatial + s] - mean;
+            var += d * d;
+        }
+        var /= static_cast<float>(c);
+        const float inv = 1.0f / std::sqrt(var + 1e-6f);
+        for (int ch = 0; ch < c; ++ch) {
+            const float nrm = (x[static_cast<std::size_t>(ch) * spatial + s] - mean) * inv;
+            yref[static_cast<std::size_t>(ch) * spatial + s] =
+                nrm * wt[static_cast<std::size_t>(ch)] + bs[static_cast<std::size_t>(ch)];
+        }
+    }
+    EXPECT_TRUE(all_close(host_f32(Y), yref, 1e-5f, 1e-5f));
 }


### PR DESCRIPTION
Kernel upgrades in the in-tree NN engine, measured on an RTX 4080:

- Attention now runs on tensor cores for any head dim up to 64 (before: only 64). Models like SAM2 (head dim 56) used to fall back to a path ~15x slower.
- Matrix multiplies get a new aligned kernel: 46-79% of the GPU's peak, up from ~35%. MoGe-2's encoder matmul improves from 60% to 72% of peak on the same shape.
- New building-block ops for windowed vision transformers (2D windowing, fused QKV/windowing, token pooling, Fourier position encodings), each with parity tests.

No behavior change for existing models: MoGe-2 full parity stays green with unchanged gates (34/34 tests). No new dependencies.

This is the kernel groundwork for native SAM2 image masking, which follows as a separate PR against dev.