### PR TITLE
Fix GIL-safe ownership of Python animation callbacks

### DIFF
--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -144,6 +144,8 @@ namespace {
     SafePyCallback make_safe_py_callback(nb::object callback) {
         // Native hook queues copy callbacks without the GIL. Keep Python
         // ownership behind a C++ shared pointer and acquire the GIL on deletion.
+        // The deleter may block on the GIL: never drop the last reference while
+        // holding a lock that a GIL-holding thread can also take.
         return {new nb::object(std::move(callback)), [](nb::object* callback) {
                     nb::gil_scoped_acquire gil;
                     delete callback;
@@ -2854,10 +2856,10 @@ NB_MODULE(lichtfeld, m) {
     // Frame callback for animations
     m.def(
         "on_frame", [](nb::callable cb) {
-            nb::object ocb = nb::cast<nb::object>(cb);
-            lfs::python::set_frame_callback([ocb](float dt) {
+            const auto callback = make_safe_py_callback(nb::cast<nb::object>(cb));
+            lfs::python::set_frame_callback([callback](float dt) {
                 try {
-                    ocb(dt);
+                    (*callback)(dt);
                 } catch (nb::python_error& e) {
                     (void)lfs::python::contain_python_callback(e, lfs::python::PyCallbackPolicy::DisableAndReport);
                     lfs::python::clear_frame_callback();
@@ -2879,10 +2881,10 @@ NB_MODULE(lichtfeld, m) {
 
     m.def(
         "on_scene_time", [](nb::callable cb) {
-            nb::object ocb = nb::cast<nb::object>(cb);
-            lfs::python::set_scene_time_callback([ocb](float clip_time) {
+            const auto callback = make_safe_py_callback(nb::cast<nb::object>(cb));
+            lfs::python::set_scene_time_callback([callback](float clip_time) {
                 try {
-                    ocb(clip_time);
+                    (*callback)(clip_time);
                 } catch (nb::python_error& e) {
                     (void)lfs::python::contain_python_callback(e, lfs::python::PyCallbackPolicy::DisableAndReport);
                     lfs::python::clear_scene_time_callback();


### PR DESCRIPTION
Follow-up to #1871: the same bug class remained in the animation callbacks.

`on_frame` and `on_scene_time` still captured the Python callable directly in the `std::function` stored by the runner. `tick_frame_callback` / `tick_scene_time_callback` copy that function on the render thread once per frame without holding the GIL, and destroy the copy after the GIL scope closes. Every copy changes the Python reference count off-GIL, and when Python replaces or clears the callback while a tick is in flight, the render thread performs the final release of the callable off-GIL.

Fix: hold the callable behind `make_safe_py_callback` (shared_ptr with a GIL-acquiring deleter), exactly as #1871 did for the training hooks. Copies now only touch the atomic C++ control block; only the final destruction touches Python, under the GIL. Also documents the lock-order constraint the deleter introduces (it may block on the GIL, so the last reference must not be dropped while holding a lock that a GIL-holding thread can also take).

Validation:
- build clean, fast-tier python tests pass (test_store_subscriptions.py, test_store.py: 15 passed)
- live GUI: loaded a PLY, registered frame + scene-time callbacks (120 ticks), replaced the frame callback 300 times while frames were ticking, then stopped/cleared; old callables verified released via weakref; no crash, no deadlock, zero error noise in the log
