### PR TITLE
Fix sequencer overlapping the asset manager and its own toolbar

### DIFF
--- a/src/visualizer/gui/panel_layout.cpp
+++ b/src/visualizer/gui/panel_layout.cpp
@@ -699,8 +699,7 @@ namespace lfs::vis::gui {
                                             const ScreenState& screen) {
         LOG_TIMER("gui_render.panel_layout.renderLeftDock");
         auto& reg = PanelRegistry::instance();
-        if (!show_main_panel || ui_hidden || screen.work_size.x <= 0 || screen.work_size.y <= 0 ||
-            !reg.has_panels(PanelSpace::LeftDock)) {
+        if (!willRenderLeftDock(show_main_panel, ui_hidden, screen)) {
             drawLeftDockResizeIndicator(draw_ctx, lfs::python::get_shared_dpi_scale(), false, false);
             left_dock_hovering_edge_ = false;
             left_dock_resizing_ = false;
@@ -713,15 +712,6 @@ namespace lfs::vis::gui {
         const float icon_bar_w = ICON_BAR_WIDTH * dpi;
         const float panel_h = screen.work_size.y;
         const float max_panel_w = maxLeftDockPanelWidth(show_main_panel, ui_hidden, screen);
-
-        if (max_panel_w <= 0.0f) {
-            drawLeftDockResizeIndicator(draw_ctx, dpi, false, false);
-            left_dock_hovering_edge_ = false;
-            left_dock_resizing_ = false;
-            left_dock_visible_ = false;
-            prev_mouse_x_ = input.mouse_x;
-            return;
-        }
 
         const float min_panel_w = std::min(LEFT_DOCK_MIN_WIDTH * dpi, max_panel_w);
         const float default_panel_w = LEFT_DOCK_DEFAULT_WIDTH * dpi;
@@ -827,8 +817,7 @@ namespace lfs::vis::gui {
         LOG_TIMER("gui_render.panel_layout.renderLeftDock.cached");
         drawLeftDockResizeIndicator(draw_ctx, lfs::python::get_shared_dpi_scale(), false, false);
         auto& reg = PanelRegistry::instance();
-        if (!show_main_panel || ui_hidden || screen.work_size.x <= 0 || screen.work_size.y <= 0 ||
-            !reg.has_panels(PanelSpace::LeftDock)) {
+        if (!willRenderLeftDock(show_main_panel, ui_hidden, screen)) {
             left_dock_hovering_edge_ = false;
             left_dock_resizing_ = false;
             left_dock_visible_ = false;
@@ -840,14 +829,6 @@ namespace lfs::vis::gui {
         const float icon_bar_w = ICON_BAR_WIDTH * dpi;
         const float panel_h = screen.work_size.y;
         const float max_panel_w = maxLeftDockPanelWidth(show_main_panel, ui_hidden, screen);
-
-        if (max_panel_w <= 0.0f) {
-            left_dock_hovering_edge_ = false;
-            left_dock_resizing_ = false;
-            left_dock_visible_ = false;
-            prev_mouse_x_ = input.mouse_x;
-            return;
-        }
 
         const float min_panel_w = std::min(LEFT_DOCK_MIN_WIDTH * dpi, max_panel_w);
         const float default_panel_w = LEFT_DOCK_DEFAULT_WIDTH * dpi;
@@ -969,6 +950,16 @@ namespace lfs::vis::gui {
         return PanelRegistry::instance().has_panels(PanelSpace::LeftDock);
     }
 
+    bool PanelLayoutManager::willRenderLeftDock(const bool show_main_panel,
+                                                const bool ui_hidden,
+                                                const ScreenState& screen) const {
+        if (!show_main_panel || ui_hidden || screen.work_size.x <= 0 || screen.work_size.y <= 0)
+            return false;
+        if (!shouldReserveLeftDockWidth())
+            return false;
+        return maxLeftDockPanelWidth(show_main_panel, ui_hidden, screen) > 0.0f;
+    }
+
     float PanelLayoutManager::computeViewportWidth(const bool show_main_panel,
                                                    const bool ui_hidden,
                                                    const bool python_console_visible,
@@ -1026,22 +1017,16 @@ namespace lfs::vis::gui {
     float PanelLayoutManager::computeLeftDockReservedWidth(const bool show_main_panel,
                                                            const bool ui_hidden,
                                                            const ScreenState& screen) const {
+        if (!willRenderLeftDock(show_main_panel, ui_hidden, screen))
+            return 0.0f;
+
         const float dpi = lfs::python::get_shared_dpi_scale();
         const float icon_bar_w = ICON_BAR_WIDTH * dpi;
-
-        if (!show_main_panel || ui_hidden)
-            return 0.0f;
-
-        if (!left_dock_visible_)
-            return 0.0f;
-
         const float max_panel_w = maxLeftDockPanelWidth(show_main_panel, ui_hidden, screen);
-        if (max_panel_w <= 0.0f)
-            return icon_bar_w;
-
+        const float min_panel_w = std::min(LEFT_DOCK_MIN_WIDTH * dpi, max_panel_w);
         const float default_panel_w = LEFT_DOCK_DEFAULT_WIDTH * dpi;
         const float current_w = left_dock_width_ > 0.0f ? left_dock_width_ : default_panel_w;
-        return std::clamp(current_w, 0.0f, max_panel_w) + icon_bar_w;
+        return std::clamp(current_w, min_panel_w, max_panel_w) + icon_bar_w;
     }
 
     ViewportLayout PanelLayoutManager::computeViewportLayout(bool show_main_panel, bool ui_hidden,

--- a/src/visualizer/gui/panel_layout.hpp
+++ b/src/visualizer/gui/panel_layout.hpp
@@ -176,6 +176,8 @@ namespace lfs::vis::gui {
         float computeLeftDockReservedWidth(bool show_main_panel, bool ui_hidden,
                                            const ScreenState& screen) const;
         [[nodiscard]] bool shouldReserveLeftDockWidth() const;
+        [[nodiscard]] bool willRenderLeftDock(bool show_main_panel, bool ui_hidden,
+                                              const ScreenState& screen) const;
         [[nodiscard]] float maxLeftDockPanelWidth(bool show_main_panel, bool ui_hidden,
                                                   const ScreenState& screen) const;
         [[nodiscard]] float maxRightPanelWidth(bool show_main_panel, bool ui_hidden,

--- a/src/visualizer/gui/rmlui/resources/sequencer.rcss
+++ b/src/visualizer/gui/rmlui/resources/sequencer.rcss
@@ -69,6 +69,7 @@ body {
     flex-direction: row;
     align-items: center;
     gap: 4dp;
+    flex-shrink: 0;
 }
 
 #right-controls {
@@ -76,6 +77,7 @@ body {
     flex-direction: row;
     align-items: center;
     gap: 4dp;
+    flex-shrink: 0;
 }
 
 #transport {
@@ -162,6 +164,10 @@ body {
 .transport-label {
     font-size: 12dp;
     white-space: nowrap;
+}
+
+.transport-label-short {
+    display: none;
 }
 
 .transport-info {
@@ -978,4 +984,81 @@ body {
 .timeline-tooltip-line.title {
     font-size: 12dp;
     margin-bottom: 2dp;
+}
+
+@media (max-width: 1620dp) {
+    #resolution-info,
+    .quality-group,
+    #quality-scrub,
+    .speed-text,
+    .ctx-indicator {
+        display: none;
+    }
+}
+
+@media (max-width: 1380dp) {
+    #btn-camera-path .transport-label,
+    #btn-export .transport-label,
+    #btn-clear .transport-label {
+        display: none;
+    }
+
+    #btn-camera-path .cam-path-icon,
+    #btn-export .export-icon,
+    #btn-clear .clear-icon {
+        margin-right: 0;
+    }
+}
+
+@media (max-width: 1280dp) {
+    #btn-film-strip,
+    #btn-equirect,
+    #btn-load-sequence {
+        display: none;
+    }
+}
+
+@media (max-width: 1120dp) {
+    #btn-camera-path,
+    #btn-speed,
+    #sequence-fps-field,
+    #btn-snap,
+    #btn-follow,
+    #btn-preview,
+    #btn-format,
+    #btn-clear,
+    .transport-sep {
+        display: none;
+    }
+}
+
+@media (max-width: 660dp) {
+    .transport-label-full {
+        display: none;
+    }
+
+    .transport-label-short {
+        display: block;
+    }
+}
+
+@media (max-width: 580dp) {
+    #duration-field {
+        display: none;
+    }
+
+    #time-display {
+        margin-left: 0;
+        padding-left: 4dp;
+    }
+
+    #left-controls,
+    #right-controls {
+        gap: 2dp;
+    }
+
+    #transport-row {
+        justify-content: flex-start;
+        gap: 6dp;
+    }
 }

--- a/src/visualizer/gui/rmlui/resources/sequencer.rml
+++ b/src/visualizer/gui/rmlui/resources/sequencer.rml
@@ -84,10 +84,12 @@
             </div>
             <div id="right-controls">
                 <div id="btn-save-path" class="transport-btn text" data-tooltip="tooltip.seq_save_path">
-                    <span class="transport-label">@tr:ui.save_path</span>
+                    <span class="transport-label transport-label-full">@tr:ui.save_path</span>
+                    <span class="transport-label transport-label-short">@tr:common.save</span>
                 </div>
                 <div id="btn-load-path" class="transport-btn text" data-tooltip="tooltip.seq_load_path">
-                    <span class="transport-label">@tr:ui.load_path</span>
+                    <span class="transport-label transport-label-full">@tr:ui.load_path</span>
+                    <span class="transport-label transport-label-short">@tr:common.load</span>
                 </div>
                 <div id="btn-load-sequence" class="transport-btn text" data-tooltip="tooltip.seq_load_sequence">
                     <span class="transport-label">@tr:ui.load_sequence</span>

--- a/tests/test_panel_layout_render_demand.cpp
+++ b/tests/test_panel_layout_render_demand.cpp
@@ -175,3 +175,28 @@ TEST_F(PanelLayoutRenderDemandTest, BottomDockStartsAfterVisibleLeftDock) {
     EXPECT_FLOAT_EQ(bottom->last_cached_x, viewport.pos.x);
     EXPECT_FLOAT_EQ(bottom->last_cached_width, viewport.size.x);
 }
+
+TEST_F(PanelLayoutRenderDemandTest, LeftDockReservationAppliesOnTheFramePanelBecomesVisible) {
+    using namespace lfs::vis::gui;
+
+    PanelLayoutManager layout;
+    const auto s = screen();
+
+    const auto closed = layout.computeBottomDockHorizontalLayout(true, false, s);
+    EXPECT_FLOAT_EQ(closed.x, s.work_pos.x);
+
+    registerPanel("test.left", PanelSpace::LeftDock, 100.0f);
+
+    const auto open = layout.computeBottomDockHorizontalLayout(true, false, s);
+    EXPECT_GT(open.x, closed.x);
+    EXPECT_LT(open.width, closed.width);
+
+    const auto hidden_ui = layout.computeBottomDockHorizontalLayout(true, true, s);
+    EXPECT_FLOAT_EQ(hidden_ui.x, s.work_pos.x);
+    EXPECT_FLOAT_EQ(hidden_ui.width, s.work_size.x);
+
+    PanelRegistry::instance().set_panel_enabled("test.left", false);
+    const auto disabled = layout.computeBottomDockHorizontalLayout(true, false, s);
+    EXPECT_FLOAT_EQ(disabled.x, closed.x);
+    EXPECT_FLOAT_EQ(disabled.width, closed.width);
+}


### PR DESCRIPTION
Follow-up to the asset-manager report in #1133.

Two problems, one visible cause each:

1. The bottom dock decided its left edge from last frame's asset-manager visibility. On the frame the panel opens, the sequencer was still laid out full width, so the asset manager drew on top of it (and closing left a one-frame gap). The layout now asks the same question the left dock itself answers this frame, so the sequencer always starts at the asset manager's right border.

2. The sequencer toolbar is naturally wider than the panel at common window sizes. The controls used to shrink into each other and become unreadable/unclickable. The toolbar now hides its least important pieces step by step as the panel narrows - info text first, then button labels, then optional buttons - down to a ~480px panel where transport, time, save/load, export and undock still fit and work.

Tested on a live run: asset manager open/close at 1500x860 and 1280x720, sequencer aligns to the dock border at every width, toolbar stays readable at the narrowest stage. New regression test covers the same-frame reservation; layout suite 4/4.

Before/after of the narrow case:
- before: toolbar controls drawn on top of each other, sequencer under the asset manager
- after: sequencer starts at the asset manager border, toolbar collapsed but usable