### PR TITLE
Fix training-time autosave failing after a training restart

### DIFF
--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -62,6 +62,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_InfoSurvivesFailedTerminalSnapshotAftermath_Test;
     class VisualizerImplResetTest_AdoptCompletedTrainingSnapshotSkipsOpenWhenCountersEqual_Test;
     class VisualizerImplResetTest_AdoptedStepBoundaryPublishRebasesAutosaveBase_Test;
+    class VisualizerImplResetTest_LightAutosaveRebasesWhenSnapshotCountersMissNewMaster_Test;
     class VisualizerImplResetTest_ExplicitSaveAfterUnadoptedTrainerAppendUsesCurrentHead_Test;
     class VisualizerImplResetTest_ExplicitSaveAfterTrainerRewriteUsesCurrentHead_Test;
     class VisualizerImplResetTest_UntitledTrainerRewriteAdoptThenSaveAsUsesCurrentHead_Test;
@@ -425,6 +426,7 @@ namespace lfs::training {
         friend class lfs::vis::VisualizerImplResetTest_InfoSurvivesFailedTerminalSnapshotAftermath_Test;
         friend class lfs::vis::VisualizerImplResetTest_AdoptCompletedTrainingSnapshotSkipsOpenWhenCountersEqual_Test;
         friend class lfs::vis::VisualizerImplResetTest_AdoptedStepBoundaryPublishRebasesAutosaveBase_Test;
+        friend class lfs::vis::VisualizerImplResetTest_LightAutosaveRebasesWhenSnapshotCountersMissNewMaster_Test;
         friend class lfs::vis::VisualizerImplResetTest_ExplicitSaveAfterUnadoptedTrainerAppendUsesCurrentHead_Test;
         friend class lfs::vis::VisualizerImplResetTest_ExplicitSaveAfterTrainerRewriteUsesCurrentHead_Test;
         friend class lfs::vis::VisualizerImplResetTest_UntitledTrainerRewriteAdoptThenSaveAsUsesCurrentHead_Test;

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -2028,6 +2028,13 @@ namespace lfs::vis::project {
     }
 
     namespace {
+        [[nodiscard]] bool isStaleAutosaveBasePublicationError(
+            const std::string& formatted) {
+            return formatted.find(
+                       "The autosave base changed before publication.") !=
+                   std::string::npos;
+        }
+
         [[nodiscard]] bool documentMatchesOpenedHead(
             const lfs::io::project::ProjectDocument& current,
             const lfs::io::project::ProjectDocument& opened) {
@@ -3729,6 +3736,14 @@ namespace lfs::vis::project {
             !adopted) {
             return adopted;
         }
+        // Sidecar publication re-opens the master and
+        // rejects a stale base commit. Explicit save
+        // already rebases; light autosave must too.
+        if (auto rebased =
+                ensureDocumentMatchesBoundMaster();
+            !rebased) {
+            return rebased;
+        }
         const auto hydration = hydration_.load(
             std::memory_order_acquire);
         if (hydration != Hydration::Empty &&
@@ -4406,6 +4421,16 @@ namespace lfs::vis::project {
                 LOG_INFO(
                     "Project background write canceled: {}",
                     error);
+            } else if (
+                was_autosave &&
+                isStaleAutosaveBasePublicationError(
+                    error)) {
+                // Trainer step-boundary publish can advance
+                // the on-disk master after this sidecar was
+                // bound. The next autosave rebases and retries.
+                LOG_INFO(
+                    "Autosave skipped because the master moved: {}",
+                    error);
             } else {
                 LOG_ERROR(
                     "Project background write failed: {}",
@@ -4417,7 +4442,9 @@ namespace lfs::vis::project {
                     error,
                     gui::error_op::kSave);
             }
-            if (was_autosave) {
+            if (was_autosave &&
+                !isStaleAutosaveBasePublicationError(
+                    error)) {
                 scheduleAutosaveFailureBackoff();
             }
         }
@@ -4674,6 +4701,8 @@ namespace lfs::vis::project {
         }
         const auto metrics =
             trainer->get_project_snapshot_metrics();
+        resetAdoptedSnapshotCountOnServiceRestart(
+            metrics.capture.completed_snapshots);
         if (metrics.writer_in_flight ||
             metrics.last_path.empty()) {
             return {};
@@ -4762,6 +4791,18 @@ namespace lfs::vis::project {
         return {};
     }
 
+    void ProjectLifecycle::
+        resetAdoptedSnapshotCountOnServiceRestart(
+            const std::uint64_t completed_snapshots) {
+        // A new trainer / snapshot service starts this
+        // counter at 0. Comparing it with a previous
+        // run's adopted count skips the new head.
+        if (completed_snapshots <
+            adopted_training_snapshot_count_) {
+            adopted_training_snapshot_count_ = 0;
+        }
+    }
+
     lfs::Result<void>
     ProjectLifecycle::
         adoptSettledTrainerPublishOntoCurrentMaster() {
@@ -4776,6 +4817,8 @@ namespace lfs::vis::project {
         }
         const auto metrics =
             trainer->get_project_snapshot_metrics();
+        resetAdoptedSnapshotCountOnServiceRestart(
+            metrics.capture.completed_snapshots);
         if (metrics.writer_in_flight ||
             metrics.last_path.empty() ||
             !metrics.last_writer_error.empty()) {

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -70,6 +70,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_InfoSurvivesFailedTerminalSnapshotAftermath_Test;
     class VisualizerImplResetTest_AdoptCompletedTrainingSnapshotSkipsOpenWhenCountersEqual_Test;
     class VisualizerImplResetTest_AdoptedStepBoundaryPublishRebasesAutosaveBase_Test;
+    class VisualizerImplResetTest_LightAutosaveRebasesWhenSnapshotCountersMissNewMaster_Test;
     class VisualizerImplResetTest_ExplicitSaveAfterUnadoptedTrainerAppendUsesCurrentHead_Test;
     class VisualizerImplResetTest_ExplicitSaveAfterTrainerRewriteUsesCurrentHead_Test;
     class VisualizerImplResetTest_UntitledTrainerRewriteAdoptThenSaveAsUsesCurrentHead_Test;
@@ -323,6 +324,7 @@ namespace lfs::vis::project {
         friend class lfs::vis::VisualizerImplResetTest_InfoSurvivesFailedTerminalSnapshotAftermath_Test;
         friend class lfs::vis::VisualizerImplResetTest_AdoptCompletedTrainingSnapshotSkipsOpenWhenCountersEqual_Test;
         friend class lfs::vis::VisualizerImplResetTest_AdoptedStepBoundaryPublishRebasesAutosaveBase_Test;
+        friend class lfs::vis::VisualizerImplResetTest_LightAutosaveRebasesWhenSnapshotCountersMissNewMaster_Test;
         friend class lfs::vis::VisualizerImplResetTest_ExplicitSaveAfterUnadoptedTrainerAppendUsesCurrentHead_Test;
         friend class lfs::vis::VisualizerImplResetTest_ExplicitSaveAfterTrainerRewriteUsesCurrentHead_Test;
         friend class lfs::vis::VisualizerImplResetTest_UntitledTrainerRewriteAdoptThenSaveAsUsesCurrentHead_Test;
@@ -516,6 +518,8 @@ namespace lfs::vis::project {
         [[nodiscard]] lfs::Result<void>
         adoptCompletedTrainingSnapshot(
             bool allow_during_application_close = false);
+        void resetAdoptedSnapshotCountOnServiceRestart(
+            std::uint64_t completed_snapshots);
         [[nodiscard]] lfs::Result<void>
         adoptSettledTrainerPublishOntoCurrentMaster();
         [[nodiscard]] lfs::Result<std::vector<std::byte>>

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -322,6 +322,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_InfoSurvivesFailedTerminalSnapshotAftermath_Test;
         friend class VisualizerImplResetTest_AdoptCompletedTrainingSnapshotSkipsOpenWhenCountersEqual_Test;
         friend class VisualizerImplResetTest_AdoptedStepBoundaryPublishRebasesAutosaveBase_Test;
+        friend class VisualizerImplResetTest_LightAutosaveRebasesWhenSnapshotCountersMissNewMaster_Test;
         friend class VisualizerImplResetTest_ExplicitSaveAfterUnadoptedTrainerAppendUsesCurrentHead_Test;
         friend class VisualizerImplResetTest_ExplicitSaveAfterTrainerRewriteUsesCurrentHead_Test;
         friend class VisualizerImplResetTest_UntitledTrainerRewriteAdoptThenSaveAsUsesCurrentHead_Test;

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -10240,6 +10240,159 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
+           LightAutosaveRebasesWhenSnapshotCountersMissNewMaster) {
+        // Training restart creates a new snapshot service
+        // whose completed_snapshots can match the previous
+        // run's adopted count, so adoptSettled skips. Disk
+        // already has the new master commit. Light autosave
+        // must rebase before binding the sidecar.
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        const auto& temporary = temporary_.path;
+        const auto project_path =
+            temporary / "restart-autosave-base.licht";
+        const auto sidecar =
+            lfs::io::project::autosave_sidecar_path(
+                project_path);
+        write_empty_project(project_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()
+                            ->ensureLoaded());
+            ASSERT_TRUE(viewer.projectOpen(
+                project_path,
+                ProjectSwitchDisposition::
+                    DiscardChanges));
+            ASSERT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    const auto info =
+                        viewer.projectGetInfo();
+                    return info &&
+                           info->hydration_state ==
+                               "complete";
+                }));
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            ASSERT_NE(lifecycle->document_, nullptr);
+            const auto stale_commit =
+                lifecycle->document_
+                    ->source_commit_uuid();
+            ASSERT_TRUE(stale_commit.has_value());
+
+            auto& scene = viewer.getScene();
+            const auto cameras =
+                scene.addGroup("Train cameras");
+            scene.addCamera(
+                "camera.png", cameras,
+                make_project_request_test_camera());
+            viewer.getTrainerManager()->setTrainer(
+                std::make_unique<
+                    lfs::training::Trainer>(scene));
+            auto* const trainer = viewer.getTrainer();
+            ASSERT_NE(trainer, nullptr);
+            auto& state_machine =
+                const_cast<TrainingStateMachine&>(
+                    viewer.getTrainerManager()
+                        ->getStateMachine());
+            if (state_machine.getState() ==
+                TrainingState::Idle) {
+                ASSERT_TRUE(state_machine.transitionTo(
+                    TrainingState::Ready));
+            }
+            ASSERT_TRUE(state_machine.transitionTo(
+                TrainingState::Running));
+
+            append_view_marker_generation(
+                project_path, "generation-3");
+            auto disk =
+                lfs::io::project::ProjectReader::open(
+                    project_path);
+            ASSERT_TRUE(disk)
+                << lfs::format_for_developer(
+                       disk.error());
+            const auto published_commit =
+                disk->commit().commit_uuid;
+            EXPECT_NE(
+                published_commit, *stale_commit);
+            EXPECT_EQ(
+                *lifecycle->document_
+                     ->source_commit_uuid(),
+                *stale_commit);
+
+            ASSERT_NE(
+                trainer->project_snapshot_service_,
+                nullptr);
+            trainer->last_project_snapshot_path_ =
+                project_path;
+            trainer->last_project_writer_error_
+                .clear();
+            trainer->project_snapshot_service_
+                ->testing_advance_completed_snapshots(
+                    1);
+            lifecycle->adopted_training_snapshot_count_ =
+                trainer->get_project_snapshot_metrics()
+                    .capture.completed_snapshots;
+            ASSERT_EQ(
+                lifecycle
+                    ->adopted_training_snapshot_count_,
+                trainer->get_project_snapshot_metrics()
+                    .capture.completed_snapshots);
+            EXPECT_GT(
+                lifecycle
+                    ->adopted_training_snapshot_count_,
+                0u);
+
+            ASSERT_NE(
+                viewer.getScene().addGroup(
+                    "Light dirty after unadopted publish"),
+                lfs::core::NULL_NODE);
+            auto started = lifecycle->startAutosave();
+            ASSERT_TRUE(started)
+                << lfs::format_for_developer(
+                       started.error());
+            EXPECT_TRUE(pumpUntil(
+                viewer.work_queue_mutex_,
+                viewer.work_queue_,
+                [&] {
+                    return !viewer.jobs().anyRunning(
+                        JobType::ProjectWrite);
+                }));
+            EXPECT_FALSE(viewer.jobs().anyRunning(
+                JobType::ProjectWrite));
+            EXPECT_TRUE(
+                lifecycle->last_project_write_error_
+                    .empty())
+                << lifecycle->last_project_write_error_;
+            EXPECT_TRUE(
+                std::filesystem::is_regular_file(
+                    sidecar));
+            ASSERT_NE(lifecycle->document_, nullptr);
+            ASSERT_TRUE(
+                lifecycle->document_
+                    ->source_commit_uuid());
+            EXPECT_EQ(
+                *lifecycle->document_
+                     ->source_commit_uuid(),
+                published_commit);
+            auto overlay =
+                lfs::io::project::ProjectReader::open(
+                    sidecar);
+            ASSERT_TRUE(overlay)
+                << lfs::format_for_developer(
+                       overlay.error());
+            EXPECT_EQ(
+                overlay->superblock()
+                    .base_explicit_commit_uuid,
+                published_commit);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
            ExplicitSaveAfterUnadoptedTrainerAppendUsesCurrentHead) {
         // Ctrl+S after a trainer-like append that the
         // lifecycle has not adopted. Idle explicit save


### PR DESCRIPTION
After stopping and restarting training in the same session, the five-minute background autosave started failing every time with "The autosave base changed before publication." and kept showing an error toast.

Cause: the restart creates a new snapshot service whose counter starts at zero, but the lifecycle kept the previous run's adopted-snapshot count. Adoption of the new run's snapshots was skipped, the in-memory document stayed bound to the old master generation, and every light autosave failed the sidecar binding check. The check itself is correct and is unchanged.

Fix, all in ProjectLifecycle:
- reset the adopted-snapshot counter when a new snapshot service appears
- rebase the document onto the current master before a light autosave binds, same as explicit save already does
- the one remaining benign case (trainer publishes between capture and write) now logs at info and retries on the next tick instead of toasting and backing off

Regression test reproduces the stop/restart/autosave sequence. 236 project tests green.