### PR TITLE
Derive sequencer preview freshness from state instead of scattered dirty flags

### DIFF
--- a/src/visualizer/gui/sequencer_ui_manager.cpp
+++ b/src/visualizer/gui/sequencer_ui_manager.cpp
@@ -308,6 +308,8 @@ namespace lfs::vis::gui {
             overlay_->destroyGraphicsResources();
         pip_texture_.reset();
         pip_initialized_ = false;
+        pip_last_key_.reset();
+        pip_needs_update_ = true;
         line_renderer_.destroyResources();
         film_strip_.destroyGraphicsResources();
     }
@@ -332,7 +334,7 @@ namespace lfs::vis::gui {
 
         viewport_edit_mode_ = SequencerViewportEditMode::None;
         keyframe_gizmo_active_ = false;
-        pip_last_keyframe_ = std::nullopt;
+        pip_last_key_.reset();
         pip_needs_update_ = true;
         last_panel_frame_time_ = std::chrono::steady_clock::now();
         endViewportKeyframeEdit();
@@ -510,16 +512,7 @@ namespace lfs::vis::gui {
 
         if (ui_state_.equirectangular != last_equirectangular_) {
             last_equirectangular_ = ui_state_.equirectangular;
-            pip_needs_update_ = true;
             film_strip_.invalidateAll();
-        }
-
-        const int output_width = ui_state_.outputWidth();
-        const int output_height = ui_state_.outputHeight();
-        if (output_width != last_pip_output_width_ || output_height != last_pip_output_height_) {
-            last_pip_output_width_ = output_width;
-            last_pip_output_height_ = output_height;
-            pip_needs_update_ = true;
         }
 
         const auto& sdl_buf = viewer_->getWindowManager()->frameInput();
@@ -590,7 +583,8 @@ namespace lfs::vis::gui {
                plySequenceStreamHasWork() ||
                keyframe_gizmo_active_ ||
                viewport_keyframe_edit_snapshot_.has_value() ||
-               (ui_state_.show_pip_preview && pip_needs_update_) ||
+               (ui_state_.show_pip_preview &&
+                (pip_needs_update_ || !pip_last_key_ || currentPipPreviewKey() != *pip_last_key_)) ||
                (overlay_ && (overlay_->wantsInput() ||
                              overlay_->isContextMenuOpen() ||
                              overlay_->isPopupOpen()));
@@ -1325,7 +1319,6 @@ namespace lfs::vis::gui {
                     lfs::core::events::state::KeyframeListChanged{
                         .count = controller_.timeline().realKeyframeCount()}
                         .emit();
-                    pip_needs_update_ = true;
                 } else {
                     LOG_ERROR("Failed to load camera path from {}", path_utf8);
                 }
@@ -2022,7 +2015,6 @@ namespace lfs::vis::gui {
                     new_pos,
                     new_rot,
                     kf->focal_length_mm)) {
-                pip_needs_update_ = true;
                 rendering_manager->markDirty(DirtyFlag::OVERLAY);
             }
         }
@@ -2247,7 +2239,6 @@ namespace lfs::vis::gui {
                 controller_.addKeyframeAtTime(kf, time);
                 controller_.seek(time);
                 state::KeyframeListChanged{.count = controller_.timeline().realKeyframeCount()}.emit();
-                pip_needs_update_ = true;
             } break;
             case Action::UPDATE_KEYFRAME:
                 viewport_edit_mode_ = SequencerViewportEditMode::None;
@@ -2317,7 +2308,6 @@ namespace lfs::vis::gui {
                             view_state.rotation,
                             view_state.focal_length_mm)) {
                         state::KeyframeListChanged{.count = controller_.timeline().realKeyframeCount()}.emit();
-                        pip_needs_update_ = true;
                     }
                     if (const auto* const keyframe =
                             controller_.timeline().getKeyframeById(
@@ -2340,16 +2330,44 @@ namespace lfs::vis::gui {
         if (auto time_result = overlay_->consumeTimeEdit()) {
             if (controller_.setKeyframeTime(time_result->index, time_result->value)) {
                 state::KeyframeListChanged{.count = controller_.timeline().realKeyframeCount()}.emit();
-                pip_needs_update_ = true;
             }
         }
 
         if (auto focal_result = overlay_->consumeFocalEdit()) {
             if (controller_.setKeyframeFocalLength(focal_result->index, focal_result->value)) {
                 state::KeyframeListChanged{.count = controller_.timeline().realKeyframeCount()}.emit();
-                pip_needs_update_ = true;
             }
         }
+    }
+
+    SequencerUIManager::PipPreviewKey SequencerUIManager::currentPipPreviewKey() const {
+        const auto preview = pipPreviewSize(ui_state_.outputWidth(), ui_state_.outputHeight());
+        const auto selected = controller_.selectedKeyframe();
+        const bool follow_playhead = !controller_.isStopped() || !selected.has_value();
+
+        PipPreviewKey key;
+        key.equirectangular = ui_state_.equirectangular;
+        key.width = preview.width;
+        key.height = preview.height;
+
+        if (follow_playhead) {
+            const auto state = controller_.currentCameraState();
+            key.timeline_revision = controller_.timelineRevision();
+            key.playhead = controller_.playhead();
+            key.position = state.position;
+            key.rotation = state.rotation;
+            key.focal_length_mm = state.focal_length_mm;
+            return key;
+        }
+
+        const auto* const kf = controller_.timeline().getKeyframe(*selected);
+        if (kf) {
+            key.selected_id = kf->id;
+            key.position = kf->position;
+            key.rotation = kf->rotation;
+            key.focal_length_mm = kf->focal_length_mm;
+        }
+        return key;
     }
 
     void SequencerUIManager::initPipPreview() {
@@ -2360,78 +2378,36 @@ namespace lfs::vis::gui {
         if (!ui_state_.show_pip_preview)
             return;
 
-        const bool is_playing = !controller_.isStopped();
-        const auto selected = controller_.selectedKeyframe();
-
-        const auto now = std::chrono::steady_clock::now();
-        if (is_playing) {
-            const float elapsed = std::chrono::duration<float>(now - pip_last_render_time_).count();
-            if (elapsed < 1.0f / PREVIEW_TARGET_FPS)
-                return;
-        }
-
         auto* const rm = ctx.viewer->getRenderingManager();
         auto* const sm = ctx.viewer->getSceneManager();
         if (!rm || !sm)
             return;
 
+        const auto key = currentPipPreviewKey();
+        if (!pip_needs_update_ && pip_last_key_ == key)
+            return;
+
+        const auto now = std::chrono::steady_clock::now();
+        if (!key.selected_id.has_value() && !pip_needs_update_) {
+            const float elapsed = std::chrono::duration<float>(now - pip_last_render_time_).count();
+            if (elapsed < 1.0f / PREVIEW_TARGET_FPS)
+                return;
+        }
+
         if (!pip_initialized_)
             initPipPreview();
 
-        glm::mat3 cam_rot;
-        glm::vec3 cam_pos;
-        float cam_focal_length_mm;
-        auto& vp = ctx.viewer->getViewport();
-
-        if (is_playing) {
-            const auto state = controller_.currentCameraState();
-            cam_rot = glm::mat3_cast(state.rotation);
-            cam_pos = state.position;
-            cam_focal_length_mm = state.focal_length_mm;
-        } else {
-            if (selected.has_value()) {
-                if (pip_last_keyframe_ == selected && !pip_needs_update_)
-                    return;
-
-                const auto& timeline = controller_.timeline();
-                if (*selected >= timeline.size())
-                    return;
-
-                const auto* const kf = timeline.getKeyframe(*selected);
-                if (!kf)
-                    return;
-
-                cam_rot = glm::mat3_cast(kf->rotation);
-                cam_pos = kf->position;
-                cam_focal_length_mm = kf->focal_length_mm;
-            } else {
-                if (pip_last_keyframe_.has_value()) {
-                    pip_needs_update_ = true;
-                    pip_last_keyframe_ = std::nullopt;
-                }
-                if (!pip_needs_update_)
-                    return;
-
-                cam_rot = vp.camera.R;
-                cam_pos = vp.camera.t;
-                cam_focal_length_mm = rm ? rm->getFocalLengthMm()
-                                         : lfs::rendering::DEFAULT_FOCAL_LENGTH_MM;
-            }
-        }
-
-        const auto preview = pipPreviewSize(ui_state_.outputWidth(), ui_state_.outputHeight());
-        const auto image = rm->renderPreviewImage(sm, cam_rot, cam_pos, cam_focal_length_mm,
-                                                  preview.width, preview.height);
+        const glm::mat3 cam_rot = glm::mat3_cast(key.rotation);
+        const auto image = rm->renderPreviewImage(sm, cam_rot, key.position, key.focal_length_mm,
+                                                  key.width, key.height);
         // Vulkan preview readback is already in the orientation RmlUi samples.
         // upload() recreates the VkImage when width/height change.
-        if (image && pip_texture_.upload(*image, preview.width, preview.height, /*flip_y=*/false)) {
-            pip_render_width_ = preview.width;
-            pip_render_height_ = preview.height;
+        if (image && pip_texture_.upload(*image, key.width, key.height, /*flip_y=*/false)) {
+            pip_render_width_ = key.width;
+            pip_render_height_ = key.height;
             pip_last_render_time_ = now;
-            if (!is_playing) {
-                pip_last_keyframe_ = selected;
-                pip_needs_update_ = false;
-            }
+            pip_last_key_ = key;
+            pip_needs_update_ = false;
         }
     }
 

--- a/src/visualizer/gui/sequencer_ui_manager.hpp
+++ b/src/visualizer/gui/sequencer_ui_manager.hpp
@@ -106,6 +106,22 @@ namespace lfs::vis {
             void initPipPreview();
             void renderKeyframePreview(const UIContext& ctx);
             void syncPipPreviewWindow(const ViewportLayout& viewport);
+
+            struct PipPreviewKey {
+                std::optional<sequencer::KeyframeId> selected_id;
+                uint64_t timeline_revision = 0;
+                float playhead = 0.0f;
+                glm::vec3 position{0.0f};
+                glm::quat rotation{1.0f, 0.0f, 0.0f, 0.0f};
+                float focal_length_mm = 0.0f;
+                bool equirectangular = false;
+                int width = 0;
+                int height = 0;
+
+                bool operator==(const PipPreviewKey&) const = default;
+            };
+
+            [[nodiscard]] PipPreviewKey currentPipPreviewKey() const;
             void beginViewportKeyframeEdit(size_t keyframe_index);
             void endViewportKeyframeEdit();
             [[nodiscard]] sequencer::CameraState currentViewportCameraState() const;
@@ -134,10 +150,9 @@ namespace lfs::vis {
             static constexpr float PREVIEW_TARGET_FPS = 30.0f;
             VulkanUiTexture pip_texture_;
             bool pip_initialized_ = false;
-            std::optional<size_t> pip_last_keyframe_;
+            std::optional<PipPreviewKey> pip_last_key_;
+            // Rml reload / GPU reset are not encoded in model state.
             bool pip_needs_update_ = true;
-            int last_pip_output_width_ = -1;
-            int last_pip_output_height_ = -1;
             int pip_render_width_ = 320;
             int pip_render_height_ = 180;
             bool last_equirectangular_ = false;


### PR DESCRIPTION
Part of #1133, stacked on #1883.

Fixes "preview window does not always update (cannot pinpoint yet when it stops working)". The cause was structural: the preview only re-rendered when one of nine scattered call sites remembered to poke a dirty flag, and several paths - update keyframe to current view, keyframe add/delete/drag, scrubbing with nothing selected - never did. Which path you hit determined whether the preview froze, hence "cannot pinpoint".

The preview now derives freshness from what the image actually depends on (selected keyframe and its camera, or the playhead camera while following, plus focal length, panorama flag and preview size) and re-renders exactly when any of that changes. The nine hand-written invalidations are deleted rather than patched. With no keyframe selected the preview follows the playhead, so scrubbing shows up in it.

Verified live: updating a keyframe to the current view now flips the preview immediately (this exact step reproduced the freeze on the previous build - pixel-identical before/after); moving the camera without updating leaves the keyframe preview correctly unchanged; the preview appears on first enable without needing a selection. Sequencer suite 38/38.