### PR TITLE
Stop sequencer UI state reads from reverting GUI changes

### DIFF
--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -708,19 +708,33 @@ namespace lfs::vis {
             auto& state = gm->getSequencerUIState();
             auto& s = *sequencer_ui_state_;
 
-            if (sequencer_ui_initialized_) {
-                state.show_camera_path = s.show_camera_path;
-                state.snap_to_grid = s.snap_to_grid;
-                state.snap_interval = s.snap_interval;
-                state.playback_speed = s.playback_speed;
-                gm->sequencer().setPlaybackSpeed(state.playback_speed);
-                state.playback_speed = gm->sequencer().playbackSpeed();
-                state.follow_playback = s.follow_playback;
-                state.show_pip_preview = s.show_pip_preview;
-                state.pip_preview_scale = s.pip_preview_scale;
-                state.show_film_strip = s.show_film_strip;
-                state.equirectangular = s.equirectangular;
-                state.sequence_fps = s.sequence_fps;
+            // Python writes land on this pointer; apply only fields it changed
+            // since the last hand-out so a pure read cannot clobber GUI state.
+            if (sequencer_ui_last_handed_out_) {
+                const auto& last = *sequencer_ui_last_handed_out_;
+                if (s.show_camera_path != last.show_camera_path)
+                    state.show_camera_path = s.show_camera_path;
+                if (s.snap_to_grid != last.snap_to_grid)
+                    state.snap_to_grid = s.snap_to_grid;
+                if (s.snap_interval != last.snap_interval)
+                    state.snap_interval = s.snap_interval;
+                if (s.playback_speed != last.playback_speed) {
+                    state.playback_speed = s.playback_speed;
+                    gm->sequencer().setPlaybackSpeed(state.playback_speed);
+                    state.playback_speed = gm->sequencer().playbackSpeed();
+                }
+                if (s.follow_playback != last.follow_playback)
+                    state.follow_playback = s.follow_playback;
+                if (s.show_pip_preview != last.show_pip_preview)
+                    state.show_pip_preview = s.show_pip_preview;
+                if (s.pip_preview_scale != last.pip_preview_scale)
+                    state.pip_preview_scale = s.pip_preview_scale;
+                if (s.show_film_strip != last.show_film_strip)
+                    state.show_film_strip = s.show_film_strip;
+                if (s.equirectangular != last.equirectangular)
+                    state.equirectangular = s.equirectangular;
+                if (s.sequence_fps != last.sequence_fps)
+                    state.sequence_fps = s.sequence_fps;
             }
 
             s.show_camera_path = state.show_camera_path;
@@ -735,7 +749,9 @@ namespace lfs::vis {
             s.sequence_fps = state.sequence_fps;
             const auto sel = gm->sequencer().selectedKeyframe();
             s.selected_keyframe = sel.has_value() ? static_cast<int>(*sel) : -1;
-            sequencer_ui_initialized_ = true;
+            if (!sequencer_ui_last_handed_out_)
+                sequencer_ui_last_handed_out_ = std::make_unique<python::SequencerUIStateData>();
+            *sequencer_ui_last_handed_out_ = s;
             return &s;
         });
         callback_cleanup_.add([] { python::set_sequencer_ui_state_callback({}); });

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -629,8 +629,8 @@ namespace lfs::vis {
         bool update_work_processed_ = false;
         std::chrono::high_resolution_clock::time_point last_frame_time_ = std::chrono::high_resolution_clock::now();
         float live_scene_clip_time_ = 0.0f;
-        bool sequencer_ui_initialized_ = false;
         std::unique_ptr<python::SequencerUIStateData> sequencer_ui_state_;
+        std::unique_ptr<python::SequencerUIStateData> sequencer_ui_last_handed_out_;
         std::vector<std::filesystem::path> pending_view_paths_;
         std::filesystem::path pending_dataset_path_;
         project::GuiSessionRestoreCoordinator


### PR DESCRIPTION
Part of the #1133 series, stacked on #1884. Found while verifying the other fixes.

Reading the sequencer UI state from Python or MCP was destructive: the accessor pushed its stale mirror back over the live GUI state on every call. The film-strip overlay polls it every frame while the sequencer is open, so toolbar toggles (follow, path, snap, preview...) could silently snap back to their previous values - reproduced live: toggle follow in the GUI, poll the state, watch the toggle revert.

The accessor now remembers what it handed to Python last time and writes back only fields Python actually changed. Reads are side-effect free; plugin writes still work.

Verified live on both sides: a GUI toggle now survives a storm of MCP state polls (button pixel-identical before/after), and a Python script assigning follow_playback = False through the returned struct still lands. Sequencer suite 38/38.