### PR TITLE
Close the equirect gaps in the depth-window projection contract

### DIFF
--- a/src/rendering/selection_ops.cu
+++ b/src/rendering/selection_ops.cu
@@ -180,7 +180,7 @@ namespace lfs::rendering {
             const float pixel_focal_y,
             const float center_x,
             const float center_y,
-            const bool orthographic,
+            const std::uint32_t camera_model,
             const float ortho_scale,
             const float* __restrict__ model_transforms,
             const int* __restrict__ transform_indices,
@@ -218,14 +218,46 @@ namespace lfs::rendering {
             const float view_x = view_row0.x * dx + view_row0.y * dy + view_row0.z * dz;
             const float view_y = view_row1.x * dx + view_row1.y * dy + view_row1.z * dz;
             const float view_z = view_row2.x * dx + view_row2.y * dy + view_row2.z * dz;
-            if (!isfinite(view_x) || !isfinite(view_y) || !isfinite(view_z) || view_z >= -1.0e-6f) {
+            if (!isfinite(view_x) || !isfinite(view_y) || !isfinite(view_z)) {
+                writeInvalidScreenPosition(output, idx);
+                return;
+            }
+
+            // Equirect sees every direction, including behind the camera. The
+            // z-sign reject is pinhole/ortho only; the finite check above still
+            // applies to all three models.
+            const bool equirectangular =
+                camera_model == static_cast<std::uint32_t>(ScreenWindowCameraModel::Equirectangular);
+            if (!equirectangular && view_z >= -1.0e-6f) {
                 writeInvalidScreenPosition(output, idx);
                 return;
             }
 
             const float cx = center_x;
             const float cy = center_y;
-            if (orthographic) {
+            if (equirectangular) {
+                // Same vksplat-axis negation as filterSelectionByScreenWindowKernel's
+                // equirect branch: vis is +X right, +Y up, -Z forward; vk is +X
+                // right, +Y down, +Z forward. The resulting px/py match that kernel.
+                const float eq_x = view_x;
+                const float eq_y = -view_y;
+                const float eq_z = -view_z;
+                const float len = sqrtf(eq_x * eq_x + eq_y * eq_y + eq_z * eq_z);
+                if (len <= 1.0e-6f || !isfinite(len)) {
+                    writeInvalidScreenPosition(output, idx);
+                    return;
+                }
+                const float dir_x = eq_x / len;
+                const float dir_y = eq_y / len;
+                const float dir_z = eq_z / len;
+                constexpr float pi = 3.14159265358979323846f;
+                output[idx] = make_float2(
+                    (atan2f(dir_x, dir_z) / (2.0f * pi) + 0.5f) * static_cast<float>(width),
+                    (asinf(fminf(fmaxf(dir_y, -1.0f), 1.0f)) / pi + 0.5f) * static_cast<float>(height));
+                return;
+            }
+
+            if (camera_model == static_cast<std::uint32_t>(ScreenWindowCameraModel::Orthographic)) {
                 if (!isfinite(ortho_scale) || ortho_scale <= 0.0f) {
                     writeInvalidScreenPosition(output, idx);
                     return;
@@ -779,11 +811,13 @@ namespace lfs::rendering {
             // the splat projection uses the displayed camera's real unjittered intrinsics;
             // jitter moves the draw sample, not the containment boundary.
             // The transform/projection above is mathematically equivalent to
-            // projectScreenPositionsKernel in this file; conventions differ because
-            // that kernel keeps visualizer view Y and flips its sign at the
-            // principal point (cy - ...), negating only Z up front
-            // (depth = -view_z), while this one negates view_y and view_z up
-            // front so it can add, mirroring the slang formula verbatim.
+            // projectScreenPositionsKernel in this file (pinhole, ortho, and
+            // equirect); conventions differ because that kernel keeps visualizer
+            // view Y and flips its sign at the principal point (cy - ...),
+            // negating only Z up front (depth = -view_z), while this one negates
+            // view_y and view_z up front so it can add, mirroring the slang
+            // formula verbatim. The equirect branch in that kernel applies the
+            // same vis→vk negation used here so px/py match.
             const float half_w = 0.5f * scale * image_width;
             const float half_h = 0.5f * scale * image_height;
             const float cx = 0.5f * image_width + offset_x * (0.5f * image_width - half_w);
@@ -860,13 +894,13 @@ namespace lfs::rendering {
         const std::array<float, 3>& translation,
         const float pixel_focal_x,
         const float pixel_focal_y,
-        const bool orthographic,
+        const ScreenWindowCameraModel camera_model,
         const float ortho_scale) {
         return project_screen_positions_tensor(
             means, width, height, view_rotation_rows, translation,
             pixel_focal_x, pixel_focal_y,
             0.5f * static_cast<float>(width), 0.5f * static_cast<float>(height),
-            orthographic, ortho_scale,
+            camera_model, ortho_scale,
             nullptr, nullptr, {});
     }
 
@@ -878,14 +912,14 @@ namespace lfs::rendering {
         const std::array<float, 3>& translation,
         const float pixel_focal_x,
         const float pixel_focal_y,
-        const bool orthographic,
+        const ScreenWindowCameraModel camera_model,
         const float ortho_scale,
         const Tensor* const model_transforms) {
         return project_screen_positions_tensor(
             means, width, height, view_rotation_rows, translation,
             pixel_focal_x, pixel_focal_y,
             0.5f * static_cast<float>(width), 0.5f * static_cast<float>(height),
-            orthographic, ortho_scale,
+            camera_model, ortho_scale,
             model_transforms, nullptr, {});
     }
 
@@ -897,7 +931,7 @@ namespace lfs::rendering {
         const std::array<float, 3>& translation,
         const float pixel_focal_x,
         const float pixel_focal_y,
-        const bool orthographic,
+        const ScreenWindowCameraModel camera_model,
         const float ortho_scale,
         const Tensor* const model_transforms,
         const Tensor* const transform_indices) {
@@ -905,7 +939,7 @@ namespace lfs::rendering {
             means, width, height, view_rotation_rows, translation,
             pixel_focal_x, pixel_focal_y,
             0.5f * static_cast<float>(width), 0.5f * static_cast<float>(height),
-            orthographic, ortho_scale,
+            camera_model, ortho_scale,
             model_transforms, transform_indices, {});
     }
 
@@ -919,7 +953,7 @@ namespace lfs::rendering {
         const float pixel_focal_y,
         const float center_x,
         const float center_y,
-        const bool orthographic,
+        const ScreenWindowCameraModel camera_model,
         const float ortho_scale,
         const Tensor* const model_transforms,
         const Tensor* const transform_indices,
@@ -1003,7 +1037,7 @@ namespace lfs::rendering {
             pixel_focal_y,
             center_x,
             center_y,
-            orthographic,
+            static_cast<std::uint32_t>(camera_model),
             ortho_scale,
             prepared_transforms.ptr,
             transform_indices_ptr,

--- a/src/rendering/selection_ops.hpp
+++ b/src/rendering/selection_ops.hpp
@@ -65,7 +65,7 @@ namespace lfs::rendering {
         const std::array<float, 3>& translation,
         float pixel_focal_x,
         float pixel_focal_y,
-        bool orthographic,
+        ScreenWindowCameraModel camera_model,
         float ortho_scale);
     [[nodiscard]] Tensor project_screen_positions_tensor(
         const Tensor& means,
@@ -75,7 +75,7 @@ namespace lfs::rendering {
         const std::array<float, 3>& translation,
         float pixel_focal_x,
         float pixel_focal_y,
-        bool orthographic,
+        ScreenWindowCameraModel camera_model,
         float ortho_scale,
         const Tensor* model_transforms);
     [[nodiscard]] Tensor project_screen_positions_tensor(
@@ -86,7 +86,7 @@ namespace lfs::rendering {
         const std::array<float, 3>& translation,
         float pixel_focal_x,
         float pixel_focal_y,
-        bool orthographic,
+        ScreenWindowCameraModel camera_model,
         float ortho_scale,
         const Tensor* model_transforms,
         const Tensor* transform_indices);
@@ -100,7 +100,7 @@ namespace lfs::rendering {
         float pixel_focal_y,
         float center_x,
         float center_y,
-        bool orthographic,
+        ScreenWindowCameraModel camera_model,
         float ortho_scale,
         const Tensor* model_transforms,
         const Tensor* transform_indices,

--- a/src/visualizer/rendering/vksplat_viewport_renderer.hpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.hpp
@@ -777,7 +777,7 @@ namespace lfs::vis {
             EllipsoidExtraCount = 15,
             ParamCount = EllipsoidExtraBase + EllipsoidParamStride * EllipsoidExtraCount,
         };
-        static_assert(EllipsoidFlags + EllipsoidParamStride <= ViewFlags);
+        static_assert(EllipsoidFlags + EllipsoidParamStride <= ViewIntrinsics);
         static_assert(EllipsoidExtraBase + EllipsoidParamStride * EllipsoidExtraCount == ParamCount);
 
         // Exposed for tests (O4): pure function over the request, no device state.

--- a/src/visualizer/selection/selection_service.cpp
+++ b/src/visualizer/selection/selection_service.cpp
@@ -104,6 +104,41 @@ namespace lfs::vis {
             return render_points;
         }
 
+        // CPU inverse/forward of filterSelectionByScreenWindowKernel's equirect
+        // branch. Not a fifth KEEP-IN-SYNC copy: used by the GT path and by the
+        // CPU fallback of projectGaussianScreenPositions.
+        constexpr float kEquirectPi = 3.14159265358979323846f;
+
+        [[nodiscard]] glm::vec3 equirectVisualizerDirectionFromRenderPixel(
+            const glm::vec2& render_point, const int width, const int height) {
+            const float lon =
+                (render_point.x / static_cast<float>(width) - 0.5f) * (2.0f * kEquirectPi);
+            const float lat =
+                (render_point.y / static_cast<float>(height) - 0.5f) * kEquirectPi;
+            const glm::vec3 vk_dir{
+                std::cos(lat) * std::sin(lon),
+                std::sin(lat),
+                std::cos(lat) * std::cos(lon),
+            };
+            return {vk_dir.x, -vk_dir.y, -vk_dir.z};
+        }
+
+        [[nodiscard]] std::optional<glm::vec2> equirectRenderPixelFromVisualizerView(
+            const glm::vec3& vis_view, const int width, const int height) {
+            const glm::vec3 vk{vis_view.x, -vis_view.y, -vis_view.z};
+            const float len = glm::length(vk);
+            if (len <= 1.0e-6f || !std::isfinite(len)) {
+                return std::nullopt;
+            }
+            const glm::vec3 dir = vk / len;
+            const float px =
+                (std::atan2(dir.x, dir.z) / (2.0f * kEquirectPi) + 0.5f) * static_cast<float>(width);
+            const float py =
+                (std::asin(std::clamp(dir.y, -1.0f, 1.0f)) / kEquirectPi + 0.5f) *
+                static_cast<float>(height);
+            return glm::vec2(px, py);
+        }
+
         void hashCombine(std::size_t& seed, const std::size_t value) {
             seed ^= value + 0x9e3779b97f4a7c15ull + (seed << 6u) + (seed >> 2u);
         }
@@ -583,7 +618,7 @@ namespace lfs::vis {
             };
             if (!std::isfinite(intrinsics.focal_x) || !std::isfinite(intrinsics.focal_y) ||
                 !std::isfinite(intrinsics.center_x) || !std::isfinite(intrinsics.center_y) ||
-                intrinsics.focal_x <= 0.0f) {
+                intrinsics.focal_x <= 0.0f || intrinsics.focal_y <= 0.0f) {
                 return std::nullopt;
             }
             return intrinsics;
@@ -782,8 +817,8 @@ namespace lfs::vis {
             const bool equirectangular,
             const rendering::GaussianSceneState& scene,
             const std::optional<rendering::CameraIntrinsics>& containment) {
-            if (equirectangular || viewport.size.x <= 0 || viewport.size.y <= 0 ||
-                (viewport.orthographic && viewport.ortho_scale <= 0.0f)) {
+            if (viewport.size.x <= 0 || viewport.size.y <= 0 ||
+                (!equirectangular && viewport.orthographic && viewport.ortho_scale <= 0.0f)) {
                 return nullptr;
             }
 
@@ -858,6 +893,11 @@ namespace lfs::vis {
                             viewport.translation.y,
                             viewport.translation.z,
                         };
+                        const auto camera_model = equirectangular
+                                                      ? rendering::ScreenWindowCameraModel::Equirectangular
+                                                  : viewport.orthographic
+                                                      ? rendering::ScreenWindowCameraModel::Orthographic
+                                                      : rendering::ScreenWindowCameraModel::Pinhole;
 
                         return std::make_shared<core::Tensor>(
                             rendering::project_screen_positions_tensor(
@@ -870,7 +910,7 @@ namespace lfs::vis {
                                 fy,
                                 center_x,
                                 center_y,
-                                viewport.orthographic,
+                                camera_model,
                                 viewport.ortho_scale,
                                 model_transforms_ptr,
                                 transform_indices_ptr,
@@ -922,6 +962,19 @@ namespace lfs::vis {
                             std::clamp(transform_index, 0, static_cast<int>(transforms.size()) - 1);
                         world_point = glm::vec3(
                             transforms[static_cast<size_t>(clamped_index)] * glm::vec4(world_point, 1.0f));
+                    }
+
+                    if (equirectangular) {
+                        const glm::vec3 view =
+                            glm::transpose(viewport.rotation) * (world_point - viewport.translation);
+                        const auto projected = equirectRenderPixelFromVisualizerView(
+                            view, viewport.size.x, viewport.size.y);
+                        if (!projected || !std::isfinite(projected->x) || !std::isfinite(projected->y)) {
+                            continue;
+                        }
+                        positions[i * 2] = projected->x;
+                        positions[i * 2 + 1] = projected->y;
+                        continue;
                     }
 
                     const auto projected = rendering::projectWorldPoint(
@@ -1716,12 +1769,12 @@ namespace lfs::vis {
             if (scene_manager_) {
                 const auto cameras = scene_manager_->getScene().getAllCameras();
                 if (camera_index < static_cast<int>(cameras.size()) && cameras[camera_index]) {
-                    const auto settings = rendering_manager_->getSettings();
                     SelectionProjectionContext projection_context;
                     projection_context.viewport = viewportDataFromCamera(*cameras[camera_index]);
                     projection_context.containment_intrinsics = containmentIntrinsicsFromCamera(
                         *cameras[camera_index], projection_context.viewport.size);
-                    projection_context.equirectangular = settings.equirectangular;
+                    projection_context.equirectangular =
+                        cameras[camera_index]->camera_model_type() == core::CameraModelType::EQUIRECTANGULAR;
                     projection_context.far_plane = lfs::rendering::DEFAULT_FAR_PLANE;
                     if (projection_context.valid()) {
                         return projection_context;
@@ -3447,6 +3500,25 @@ namespace lfs::vis {
         const auto render_point = screenToRender(screen_point, info);
 
         if (const auto gt = rendering_manager_->gtComparisonSelectionContext()) {
+            // Equirect GT has empty intrinsics by construction (split_view_service.cpp:78-103).
+            // Falling through would unproject through the interactive camera — the path the
+            // STOP-3 comment below forbids. Inverse of filterSelectionByScreenWindowKernel.
+            if (gt->camera.equirectangular) {
+                projection_viewport.camera.R = gt->camera.rotation;
+                projection_viewport.camera.t = gt->camera.translation;
+
+                const float pivot_distance = glm::length(projection_viewport.camera.pivot - projection_viewport.camera.t);
+                const float fallback_distance = pivot_distance > 0.1f ? pivot_distance : 10.0f;
+                const glm::vec3 vis_dir = equirectVisualizerDirectionFromRenderPixel(
+                    render_point, info.render_width, info.render_height);
+                const glm::vec3 world =
+                    projection_viewport.camera.R * (vis_dir * fallback_distance) + projection_viewport.camera.t;
+                if (Viewport::isValidWorldPosition(world)) {
+                    return world;
+                }
+                const glm::vec3 forward = rendering::cameraForward(projection_viewport.camera.R);
+                return projection_viewport.camera.t + forward * fallback_distance;
+            }
             if (gt->camera.intrinsics) {
                 projection_viewport.camera.R = gt->camera.rotation;
                 projection_viewport.camera.t = gt->camera.translation;
@@ -3529,6 +3601,21 @@ namespace lfs::vis {
         const float ortho_scale = effectiveOrthoScale(projection_viewport, settings);
 
         if (const auto gt = rendering_manager_->gtComparisonSelectionContext()) {
+            // Forward of filterSelectionByScreenWindowKernel's equirect branch. Must
+            // not fall through to projectWorldPoint's interactive-camera pinhole.
+            if (gt->camera.equirectangular) {
+                const glm::vec3 view =
+                    glm::transpose(gt->camera.rotation) * (world_point - gt->camera.translation);
+                const auto projected = equirectRenderPixelFromVisualizerView(
+                    view, info.render_width, info.render_height);
+                if (!projected) {
+                    return std::nullopt;
+                }
+                const float scale_x = info.width / static_cast<float>(std::max(info.render_width, 1));
+                const float scale_y = info.height / static_cast<float>(std::max(info.render_height, 1));
+                return glm::vec2(info.x + projected->x * scale_x,
+                                 info.y + projected->y * scale_y);
+            }
             if (gt->camera.intrinsics) {
                 const glm::vec3 view = glm::transpose(gt->camera.rotation) * (world_point - gt->camera.translation);
                 if (!lfs::rendering::isFiniteVec3(view) || view.z >= -1e-6f) {

--- a/tests/python/test_selection_controls_panel.py
+++ b/tests/python/test_selection_controls_panel.py
@@ -304,11 +304,10 @@ def test_selection_depth_fallback_far_defaults_to_6(selection_controls_module):
 
 def test_selection_depth_toggle_and_sliders_use_selection_api(selection_controls_module):
     module, state = selection_controls_module
-    panel = module.SelectionControlsController()
-    model = _DataModelStub()
-
-    panel.bind_model(model)
-    panel.update(_DocumentStub())
+    # Start disabled so the toggle actually enables. _mounted_panel decays the
+    # echo holdoff armed by the first refresh (controller defaults (0, 6) vs
+    # stub (0.25, 7.5)) before any slider write.
+    panel, model, _doc = _mounted_panel(module, state, enabled=False)
 
     model.bound_events["selection_action"](None, None, ["toggle_depth"])
     assert state.depth_calls[-1] == (True, 0.25, 7.5, 1.35)

--- a/tests/test_rendering_refactor_services.cpp
+++ b/tests/test_rendering_refactor_services.cpp
@@ -2351,6 +2351,26 @@ namespace lfs::vis {
         EXPECT_TRUE(settings.gut);
     }
 
+    TEST_F(RenderingManagerEventsTest, EnablingDepthFilterMigratesConstructorDefaultPositiveZBox) {
+        RenderingManager manager;
+        auto settings = manager.getSettings();
+        ASSERT_FALSE(settings.depth_filter_enabled);
+        ASSERT_EQ(settings.depth_filter_min.z, 0.0f);
+        ASSERT_EQ(settings.depth_filter_max.z, 100.0f);
+
+        settings.depth_filter_enabled = true;
+        manager.updateSettings(settings);
+
+        settings = manager.getSettings();
+        EXPECT_EQ(settings.depth_filter_min.z, -100.0f);
+        EXPECT_EQ(settings.depth_filter_max.z, 0.0f);
+
+        manager.updateSettings(settings);
+        settings = manager.getSettings();
+        EXPECT_EQ(settings.depth_filter_min.z, -100.0f);
+        EXPECT_EQ(settings.depth_filter_max.z, 0.0f);
+    }
+
     TEST(OverlayParamPackingTest, GTComparisonRenderCameraReplacesDrawAndContainmentIntrinsics) {
         using lfs::core::Camera;
         using lfs::core::CameraModelType;

--- a/tests/test_selection_screen_window.cpp
+++ b/tests/test_selection_screen_window.cpp
@@ -223,6 +223,33 @@ namespace {
         return selection.cpu().to_vector_bool();
     }
 
+    std::vector<float> runShapeProjector(
+        const std::vector<float>& points,
+        const ScreenWindowConfig& config,
+        const std::array<float, 9>& view_rotation_rows,
+        const std::array<float, 3>& translation) {
+        const auto means = cudaMeans(points);
+        const auto projected = lfs::rendering::project_screen_positions_tensor(
+            means,
+            config.width,
+            config.height,
+            view_rotation_rows,
+            translation,
+            config.pixel_focal_x,
+            config.pixel_focal_y,
+            config.center_x,
+            config.center_y,
+            config.camera_model,
+            config.ortho_scale,
+            nullptr,
+            nullptr,
+            {});
+        if (!projected.is_valid()) {
+            return {};
+        }
+        return projected.cpu().to(DataType::Float32).to_vector();
+    }
+
     class SelectionScreenWindow : public ::testing::Test {
     protected:
         void SetUp() override {
@@ -622,6 +649,85 @@ namespace {
         bogus_equirect.center_y = -9999.0f;
         EXPECT_EQ(runCuda(equirect_points, bogus_equirect, identity_rows, origin), centred_equirect);
         EXPECT_EQ(centred_equirect, equirect_expected);
+    }
+
+    TEST_F(SelectionScreenWindow, EquirectShapeProjectorProjectsBehindTheCamera) {
+        // Identity visualizer pose at the origin: right=+X, up=+Y, back=+Z
+        // (forward is -Z). A splat at (0, 0, 1) is directly behind the camera.
+        constexpr std::array<float, 9> identity_rows{
+            1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+        constexpr std::array<float, 3> origin{0.0f, 0.0f, 0.0f};
+        constexpr int kImageWidth = 100;
+        constexpr int kImageHeight = 80;
+        const ScreenWindowConfig equirect{
+            .camera_model = ScreenWindowCameraModel::Equirectangular,
+            .width = kImageWidth,
+            .height = kImageHeight,
+        };
+
+        // vis = (0, 0, 1). Window-kernel axes: eq = (vis_x, -vis_y, -vis_z)
+        // = (0, 0, -1). dir = (0, 0, -1).
+        // px = (atan2(dir_x, dir_z) / (2π) + 0.5) * width
+        //    = (atan2(0, -1) / (2π) + 0.5) * width
+        //    = (π / 2π + 0.5) * width = width
+        // py = (asin(dir_y) / π + 0.5) * height = height / 2
+        constexpr float pi = 3.14159265358979323846f;
+        const float expected_px =
+            (std::atan2(0.0f, -1.0f) / (2.0f * pi) + 0.5f) * static_cast<float>(kImageWidth);
+        const float expected_py =
+            (std::asin(0.0f) / pi + 0.5f) * static_cast<float>(kImageHeight);
+
+        const auto actual = runShapeProjector({0.0f, 0.0f, 1.0f}, equirect, identity_rows, origin);
+        ASSERT_EQ(actual.size(), 2u);
+        EXPECT_NEAR(actual[0], expected_px, 1.0e-4f);
+        EXPECT_NEAR(actual[1], expected_py, 1.0e-4f);
+
+        // Control: the same splat is behind the camera in pinhole, so the shape
+        // projector must still write an invalid screen position.
+        ScreenWindowConfig pinhole = equirect;
+        pinhole.camera_model = ScreenWindowCameraModel::Pinhole;
+        const auto pinhole_actual =
+            runShapeProjector({0.0f, 0.0f, 1.0f}, pinhole, identity_rows, origin);
+        ASSERT_EQ(pinhole_actual.size(), 2u);
+        EXPECT_LT(pinhole_actual[0], -1000.0f);
+        EXPECT_LT(pinhole_actual[1], -1000.0f);
+    }
+
+    TEST_F(SelectionScreenWindow, EquirectShapeProjectorMatchesWindowCpuReference) {
+        std::mt19937 rng(0xE01EC7u);
+        std::uniform_real_distribution<float> coordinate(-25.0f, 25.0f);
+        std::vector<float> points(kRandomPointCount * 3);
+        std::vector<std::array<float, 3>> point_arrays(kRandomPointCount);
+        for (std::size_t i = 0; i < kRandomPointCount; ++i) {
+            point_arrays[i] = {coordinate(rng), coordinate(rng), coordinate(rng)};
+            points[i * 3] = point_arrays[i][0];
+            points[i * 3 + 1] = point_arrays[i][1];
+            points[i * 3 + 2] = point_arrays[i][2];
+        }
+
+        const ScreenWindowConfig config{
+            .camera_model = ScreenWindowCameraModel::Equirectangular,
+            .width = 1024,
+            .height = 512,
+        };
+        const auto actual = runShapeProjector(points, config, kViewRotationRows, kTranslation);
+        ASSERT_EQ(actual.size(), kRandomPointCount * 2);
+
+        std::size_t compared = 0;
+        for (std::size_t i = 0; i < kRandomPointCount; ++i) {
+            const auto projected = projectCpu(point_arrays[i], config, kViewRotationRows, kTranslation);
+            if (projected.depth <= 0.0f || !std::isfinite(projected.px) || !std::isfinite(projected.py)) {
+                // Degenerate (at the camera). The shape kernel writes invalid;
+                // the window CPU reference leaves px/py at 0 with depth = -1.
+                EXPECT_LT(actual[i * 2], -1000.0f) << "point=" << i;
+                EXPECT_LT(actual[i * 2 + 1], -1000.0f) << "point=" << i;
+                continue;
+            }
+            ++compared;
+            EXPECT_NEAR(actual[i * 2], projected.px, 1.0e-3f) << "point=" << i;
+            EXPECT_NEAR(actual[i * 2 + 1], projected.py, 1.0e-3f) << "point=" << i;
+        }
+        EXPECT_GT(compared, kRandomPointCount / 2);
     }
 
 } // namespace

--- a/tests/test_selection_service_interactions.cpp
+++ b/tests/test_selection_service_interactions.cpp
@@ -549,7 +549,9 @@ TEST_F(SelectionServiceInteractionsTest, CommandRingSelectionUsesHoveredGaussian
 // Neither test can pass vacuously.
 namespace {
 
-    std::shared_ptr<lfs::core::Camera> make_x_axis_dataset_camera() {
+    std::shared_ptr<lfs::core::Camera> make_x_axis_dataset_camera(
+        lfs::core::CameraModelType model = lfs::core::CameraModelType::PINHOLE,
+        const std::string& image_name = "dataset.png") {
         // world->camera rotation: R * (1,0,0) = (0,0,1), det = +1.
         auto rotation = Tensor::from_vector(
             std::vector<float>{
@@ -563,8 +565,8 @@ namespace {
             std::move(translation),
             100.0f, 100.0f, 50.0f, 50.0f,
             Tensor{}, Tensor{},
-            lfs::core::CameraModelType::PINHOLE,
-            "dataset.png", std::filesystem::path{}, std::filesystem::path{},
+            model,
+            image_name, std::filesystem::path{}, std::filesystem::path{},
             100, 100, 0);
     }
 
@@ -693,26 +695,72 @@ namespace {
                              0.0f, 5.0f, 0.0f}));
     }
 
+    // Same x-axis camera as install_m44_axis_depth_pair_fixture, but splat1 is
+    // off-axis so a hover pick at the optical-axis principal point cannot
+    // resolve it. splat0 origin: depth 10, px = 50, py = 50. splat1 (1.5, 5, 0):
+    // depth 11.5 (band-rejected), px = 50 + 100*(5/11.5) ≈ 93.5 — well outside
+    // HOVER_PICK_RADIUS_PX of (50, 50).
+    void install_m44_color_seed_fixture(lfs::vis::SceneManager& scene_manager) {
+        scene_manager.changeContentType(lfs::vis::SceneManager::ContentType::SplatFiles);
+        scene_manager.getScene().removeNode("test");
+        scene_manager.getScene().addSplat(
+            "m44_color_seed",
+            make_test_splat({0.0f, 0.0f, 0.0f,
+                             1.5f, 5.0f, 0.0f}));
+    }
+
+    // x-axis camera at cam_pos=(-10,0,0) looking +X. splat0 (-20,0,0) sits
+    // directly behind the camera (visualizer view_z = +10): pinhole rejects
+    // (vksplat depth = -view_z < 0), equirect maps it to the image edge with
+    // depth = 10. splat1 (1000,0,0) is in front at depth 1010, outside a
+    // (0, 100] band under both models.
+    void install_equirect_behind_camera_fixture(lfs::vis::SceneManager& scene_manager) {
+        scene_manager.changeContentType(lfs::vis::SceneManager::ContentType::SplatFiles);
+        scene_manager.getScene().removeNode("test");
+        scene_manager.getScene().addSplat(
+            "equirect_behind",
+            make_test_splat({-20.0f, 0.0f, 0.0f,
+                             1000.0f, 0.0f, 0.0f}));
+    }
+
+    void arm_wide_full_frame_depth_window(lfs::vis::RenderingManager& rendering_manager) {
+        auto settings = rendering_manager.getSettings();
+        settings.depth_filter_enabled = true;
+        settings.depth_filter_min = {-0.5f, -0.5f, -100.0f};
+        settings.depth_filter_max = {0.5f, 0.5f, 0.0f};
+        settings.depth_filter_scale = 1.0f;
+        settings.depth_filter_offset_x = 0.0f;
+        settings.depth_filter_offset_y = 0.0f;
+        rendering_manager.updateSettings(settings);
+    }
+
+    void starve_testing_viewport(lfs::vis::SelectionService& service) {
+        service.setTestingViewport({
+            .x = 0.0f,
+            .y = 0.0f,
+            .width = 0.0f,
+            .height = 0.0f,
+            .render_width = 0,
+            .render_height = 0,
+        });
+    }
+
 } // namespace
 
 TEST_F(SelectionServiceInteractionsTest, ExplicitCameraRectFiltersWithTheCommandCameraNotTheViewer) {
+    install_m44_axis_depth_pair_fixture(*scene_manager_);
     const auto cameras_group = scene_manager_->getScene().addGroup("Cameras");
     scene_manager_->getScene().addCamera("dataset.png", cameras_group, make_x_axis_dataset_camera());
     ASSERT_EQ(scene_manager_->getScene().getAllCameras().size(), 1u);
 
     arm_dataset_camera_depth_band(*rendering_manager_);
 
-    // Mask side: both splats inside the rect, bound to camera 0 so the mask is
-    // unambiguously the command camera's.
-    service_->setTestingScreenPositionsForCamera(0, make_screen_positions({
-                                                        10.0f,
-                                                        10.0f,
-                                                        20.0f,
-                                                        20.0f,
-                                                    }));
-
-    const auto result = service_->selectRect(0.0f, 0.0f, 50.0f, 50.0f, lfs::vis::SelectionMode::Replace, 0);
-    ASSERT_TRUE(result.success);
+    // Real projector, no screen-position stub. Both splats sit on the optical
+    // axis so they share px = center_x = 50, py = 50 and fall inside this rect;
+    // only the depth band can discriminate. splat0 origin: depth 10 (inside
+    // [9.5, 10.5]). splat1 (1.5, 0, 0): depth 11.5 — band-rejected.
+    const auto result = service_->selectRect(40.0f, 35.0f, 60.0f, 65.0f, lfs::vis::SelectionMode::Replace, 0);
+    ASSERT_TRUE(result.success) << "error: " << result.error;
 
     // Depth filtering must use camera 0 (band keeps splat0 only), NOT the
     // viewer camera (which rejects both and yields {}).
@@ -720,6 +768,7 @@ TEST_F(SelectionServiceInteractionsTest, ExplicitCameraRectFiltersWithTheCommand
 }
 
 TEST_F(SelectionServiceInteractionsTest, ExplicitCameraColorSeedFiltersWithTheCommandCamera) {
+    install_m44_color_seed_fixture(*scene_manager_);
     const auto cameras_group = scene_manager_->getScene().addGroup("Cameras");
     scene_manager_->getScene().addCamera("dataset.png", cameras_group, make_x_axis_dataset_camera());
     ASSERT_EQ(scene_manager_->getScene().getAllCameras().size(), 1u);
@@ -728,22 +777,11 @@ TEST_F(SelectionServiceInteractionsTest, ExplicitCameraColorSeedFiltersWithTheCo
 
     // Deliberately NOT setTestingHoveredGaussianId: the override short-circuits
     // resolveCommandHoveredGaussianId and would bypass the seed-camera identity
-    // this test exists to prove.
-    service_->setTestingScreenPositionsForCamera(0, make_screen_positions({
-                                                        10.0f,
-                                                        10.0f,
-                                                        20.0f,
-                                                        20.0f,
-                                                    }));
-    // Viewer-side positions too, so the seed pick can resolve a candidate at
-    // all. Without these the failure is merely "no positions", which would not
-    // distinguish a wrong-camera filter from an unseeded fixture.
-    service_->setTestingScreenPositions(make_screen_positions({
-        10.0f,
-        10.0f,
-        20.0f,
-        20.0f,
-    }));
+    // this test exists to prove. No command-camera screen-position stub either:
+    // the seed is picked from the real projector. splat0 origin projects to the
+    // principal point (50, 50); splat1 is off-axis so it cannot steal the pick.
+    // camera_index >= 0 never consults the viewer-side testing_screen_positions_
+    // hook, so that stub is omitted too.
 
     // CONTROL: with filtering off, the seed resolves and the colour selection
     // succeeds. This is what makes the assertion below non-vacuous - it proves
@@ -751,7 +789,7 @@ TEST_F(SelectionServiceInteractionsTest, ExplicitCameraColorSeedFiltersWithTheCo
     {
         lfs::vis::SelectionFilterState unfiltered;
         const auto control =
-            service_->selectByColorAt(10.0f, 10.0f, lfs::vis::SelectionMode::Replace, unfiltered, 0);
+            service_->selectByColorAt(50.0f, 50.0f, lfs::vis::SelectionMode::Replace, unfiltered, 0);
         ASSERT_TRUE(control.success) << "fixture cannot seed at all: " << control.error;
         ASSERT_FALSE(selection_values(*scene_manager_).empty());
     }
@@ -763,7 +801,7 @@ TEST_F(SelectionServiceInteractionsTest, ExplicitCameraColorSeedFiltersWithTheCo
     // pickHoveredGaussianIdFromScreenPositions), BEFORE commitSelection — which
     // is why a rect-only repair would leave this path wrong.
     // Under the command camera the band accepts splat0, so the seed must survive.
-    const auto result = service_->selectByColorAt(10.0f, 10.0f, lfs::vis::SelectionMode::Replace, filters, 0);
+    const auto result = service_->selectByColorAt(50.0f, 50.0f, lfs::vis::SelectionMode::Replace, filters, 0);
     ASSERT_TRUE(result.success) << "seed rejected by a filter using the wrong camera: " << result.error;
 
     EXPECT_EQ(selection_values(*scene_manager_), (std::vector<uint8_t>{1, 0}));
@@ -918,4 +956,72 @@ TEST_F(SelectionServiceInteractionsTest, ScreenPositionCacheIsNotSharedAcrossCon
     ASSERT_TRUE(second.success) << "error: " << second.error;
     EXPECT_TRUE(nothing_selected(*scene_manager_));
     service_->setTestingContainmentIntrinsics(std::nullopt);
+}
+
+TEST_F(SelectionServiceInteractionsTest, ExplicitCameraEquirectangularKeepsSplatBehindTheCamera) {
+    install_equirect_behind_camera_fixture(*scene_manager_);
+    const auto cameras_group = scene_manager_->getScene().addGroup("Cameras");
+    scene_manager_->getScene().addCamera(
+        "equirect.png", cameras_group,
+        make_x_axis_dataset_camera(lfs::core::CameraModelType::EQUIRECTANGULAR, "equirect.png"));
+    ASSERT_EQ(scene_manager_->getScene().getAllCameras().size(), 1u);
+
+    // Viewer stays pinhole: leaking settings.equirectangular into the explicit-
+    // camera snapshot would classify this as pinhole and drop splat0.
+    ASSERT_FALSE(rendering_manager_->getSettings().equirectangular);
+    arm_wide_full_frame_depth_window(*rendering_manager_);
+
+    // Real projector, no screen-position stub. Splat0 is directly behind the
+    // camera: vis = (0, 0, +10), vk = (0, 0, -10),
+    // px = (atan2(0, -1)/(2π) + 0.5)*100 = 100, py = 50 — the image edge.
+    // Splat1 is in front on-axis at px = 50, py = 50, depth 1010. A full-frame
+    // rect includes both so only the depth band can discriminate:
+    // {1, 0} equirect kept the behind-camera splat and band-rejected the far one
+    // {}     leaked the viewer's pinhole (behind-camera z-reject)
+    // {1, 1} depth filter did not run
+    const auto result = service_->selectRect(0.0f, 0.0f, 100.0f, 100.0f, lfs::vis::SelectionMode::Replace, 0);
+    ASSERT_TRUE(result.success) << "error: " << result.error;
+    EXPECT_EQ(selection_values(*scene_manager_), (std::vector<uint8_t>{1, 0}));
+}
+
+TEST_F(SelectionServiceInteractionsTest, FilteredSelectAllAndInvertRequireProjectionOnlyWhenDepthFilterOn) {
+    starve_testing_viewport(*service_);
+
+    ASSERT_FALSE(rendering_manager_->getSettings().depth_filter_enabled);
+
+    const auto copy_id = scene_manager_->getScene().addSplat(
+        "copy",
+        make_test_splat({
+            2.0f,
+            0.0f,
+            0.0f,
+            3.0f,
+            0.0f,
+            0.0f,
+        }));
+    ASSERT_NE(copy_id, lfs::core::NULL_NODE);
+    scene_manager_->selectNodes({"copy"});
+    EXPECT_EQ(scene_manager_->getSelectedNodeMask(), (std::vector<bool>{false, true}));
+
+    const auto all = service_->selectAllFiltered();
+    ASSERT_TRUE(all.success) << "error: " << all.error;
+    EXPECT_EQ(selection_values(*scene_manager_), (std::vector<uint8_t>{0, 0, 1, 1}));
+
+    set_initial_selection({0, 0, 1, 0});
+    const auto inverted = service_->invertFiltered();
+    ASSERT_TRUE(inverted.success) << "error: " << inverted.error;
+    EXPECT_EQ(selection_values(*scene_manager_), (std::vector<uint8_t>{0, 0, 0, 1}));
+
+    auto settings = rendering_manager_->getSettings();
+    settings.depth_filter_enabled = true;
+    rendering_manager_->updateSettings(settings);
+
+    const auto all_fail = service_->selectAllFiltered();
+    EXPECT_FALSE(all_fail.success);
+    EXPECT_EQ(all_fail.error, "Invalid projection context");
+
+    const auto invert_fail = service_->invertFiltered();
+    EXPECT_FALSE(invert_fail.success);
+    EXPECT_EQ(invert_fail.error, "Invalid projection context");
+    EXPECT_EQ(selection_values(*scene_manager_), (std::vector<uint8_t>{0, 0, 0, 1}));
 }


### PR DESCRIPTION
Follow-up to #1860, covering what the round-2 review flagged.

The projection contract from #1860 — selection classifies with the real camera of the image you are looking at — had equirect holes. A selection command naming an equirect dataset camera classified as a centred pinhole because the snapshot copied the viewer's projection toggle instead of the camera's model. Equirect GT compare, whose pinhole intrinsics are empty by design, sent the solid tools down the interactive-camera depth path the GT lane forbids. And the 2D shape-mask projector had no equirect branch at all, so even with the model flag right, the rectangle mask was pinhole math and everything behind the camera was rejected outright.

All three now use the same spherical mapping as the depth-window kernel, derived from it and noted as such at each site. Two small hardening items from the review ride along: the intrinsics validator rejects a non-positive fy like it already did fx, and the overlay packing static_assert guards the containment-intrinsics slot.

Also repairs the test debt the review found: `test_selection_depth_toggle_and_sliders_use_selection_api` was failing at head (it wrote through a slider binding while the echo holdoff was armed) and is migrated to the mounted-panel pattern; the two explicit-camera tests that stubbed the shape projector now drive the real one; and the constructor-default box migration plus the filter-off guard predicate are pinned by new tests.

Verified: python panel suite 85/85 (was 84 + 1 failing), targeted C++ sweep 172/172, new shape-vs-window equirect parity on 10k random points, new end-to-end explicit equirect camera case with no stubs.