### PR TITLE
Keep the undocked sequencer inside the viewport

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -4077,7 +4077,8 @@ namespace lfs::vis::gui {
         reg_panel("native.sequencer", "Sequencer",
                   make_panel(SequencerPanel(&sequencer_ui_, &panel_layout_)),
                   PanelSpace::BottomDock, 500,
-                  0, 8192.0f);
+                  static_cast<uint32_t>(PanelOption::FLOAT_IN_VIEWPORT),
+                  8192.0f);
 
         reg_panel("native.python_overlay", "Python Overlay",
                   make_panel(PythonOverlayPanel(this)),

--- a/src/visualizer/gui/panel_registry.cpp
+++ b/src/visualizer/gui/panel_registry.cpp
@@ -134,9 +134,21 @@ namespace lfs::vis::gui {
                                  clamped_radius, h - clamped_radius);
         }
 
-        FloatingPanelAnchor floatingAnchorRect(const PanelDrawContext& ctx) {
+        FloatingPanelAnchor floatingAnchorRect(const PanelDrawContext& ctx,
+                                               const bool in_viewport = false) {
             // Floating panels may overlap docked panels. Constraining them to
             // the viewport makes their usable area shrink with the docks.
+            // FLOAT_IN_VIEWPORT panels instead use the 3D viewport hole as their anchor.
+            if (in_viewport && ctx.viewport && ctx.viewport->size.x > 0.0f &&
+                ctx.viewport->size.y > 0.0f) {
+                return {
+                    .x = ctx.viewport->pos.x,
+                    .y = ctx.viewport->pos.y,
+                    .width = ctx.viewport->size.x,
+                    .height = ctx.viewport->size.y,
+                };
+            }
+
             if (ctx.screen_bounds && ctx.screen_bounds->valid()) {
                 const auto& screen = *ctx.screen_bounds;
                 const float screen_bottom = screen.y + screen.height;
@@ -161,6 +173,100 @@ namespace lfs::vis::gui {
             }
 
             return {};
+        }
+
+        struct LayoutContextCache {
+            ViewportLayout viewport{};
+            PanelDrawBounds screen{};
+            bool has_viewport = false;
+            bool has_screen = false;
+        };
+
+        LayoutContextCache g_layout_cache;
+
+        void rememberLayoutContext(const PanelDrawContext& ctx) {
+            if (ctx.viewport && ctx.viewport->size.x > 0.0f && ctx.viewport->size.y > 0.0f) {
+                g_layout_cache.viewport = *ctx.viewport;
+                g_layout_cache.has_viewport = true;
+            }
+            if (ctx.screen_bounds && ctx.screen_bounds->valid()) {
+                g_layout_cache.screen = *ctx.screen_bounds;
+                g_layout_cache.has_screen = true;
+            }
+        }
+
+        PanelDrawContext cachedLayoutDrawContext() {
+            PanelDrawContext ctx;
+            if (g_layout_cache.has_viewport)
+                ctx.viewport = &g_layout_cache.viewport;
+            if (g_layout_cache.has_screen)
+                ctx.screen_bounds = g_layout_cache.screen;
+            return ctx;
+        }
+
+        float clampedFloatingPanelWidth(const float initial_width, const float anchor_width,
+                                        const float dpi) {
+            const float min_panel_width = 320.0f * dpi;
+            const float max_panel_width = std::max(min_panel_width, anchor_width);
+            const float w = initial_width > 0.0f ? initial_width : 560.0f * dpi;
+            return std::clamp(w, min_panel_width, max_panel_width);
+        }
+
+        struct FloatingPanelBox {
+            float x = 0.0f;
+            float y = 0.0f;
+            float width = 0.0f;
+            float height = 0.0f;
+        };
+
+        FloatingPanelBox resolveFloatingPanelBox(const FloatingPanelAnchor& anchor,
+                                                 const float initial_width,
+                                                 const float initial_height,
+                                                 const float stored_x,
+                                                 const float stored_y,
+                                                 const bool auto_center,
+                                                 const bool park_at_bottom,
+                                                 const float dpi,
+                                                 const float override_height = 0.0f) {
+            const float w = clampedFloatingPanelWidth(initial_width, anchor.width, dpi);
+            const float h = override_height > 0.0f
+                                ? override_height
+                                : (initial_height > 0.0f ? initial_height : 400.0f * dpi);
+            float px = stored_x;
+            float py = stored_y;
+            bool center = auto_center;
+            if (center && park_at_bottom) {
+                px = anchor.x + (anchor.width - w) * 0.5f;
+                py = anchor.y + anchor.height - h;
+                center = false;
+            }
+            const auto placement = computeFloatingPanelPlacement(
+                anchor, w, h, px, py, center, 30.0f * dpi, 0.1f);
+            return {placement.x, placement.y, w, h};
+        }
+
+        void writeProvisionalFloatingBounds(const PanelInfo& panel,
+                                            FloatingPanelInteraction& interaction) {
+            const auto seed = cachedLayoutDrawContext();
+            const bool in_viewport = panel.has_option(PanelOption::FLOAT_IN_VIEWPORT);
+            const auto anchor = floatingAnchorRect(seed, in_viewport);
+            if (anchor.width <= 0.0f || anchor.height <= 0.0f)
+                return;
+
+            const auto box = resolveFloatingPanelBox(anchor,
+                                                     panel.initial_width,
+                                                     panel.initial_height,
+                                                     interaction.x,
+                                                     interaction.y,
+                                                     interaction.auto_center,
+                                                     in_viewport,
+                                                     floatingUiScale(),
+                                                     interaction.last_height);
+            interaction.last_x = box.x;
+            interaction.last_y = box.y;
+            interaction.last_width = box.width;
+            interaction.last_height = box.height;
+            interaction.last_bounds_valid = true;
         }
     } // namespace
 
@@ -586,14 +692,12 @@ apply_registered_chrome:
                 snap.has_option(PanelOption::SELF_MANAGED))
                 return;
 
-            const auto anchor = floatingAnchorRect(ctx);
+            const bool in_viewport = snap.has_option(PanelOption::FLOAT_IN_VIEWPORT);
+            const auto anchor = floatingAnchorRect(ctx, in_viewport);
             if (anchor.width <= 0.0f || anchor.height <= 0.0f)
                 return;
 
-            const float min_panel_width = 320.0f * dpi;
-            const float max_panel_width = std::max(min_panel_width, anchor.width);
-            float w = snap.initial_width > 0 ? snap.initial_width : 560.0f * dpi;
-            w = std::clamp(w, min_panel_width, max_panel_width);
+            float w = clampedFloatingPanelWidth(snap.initial_width, anchor.width, dpi);
             const float max_h = snap.initial_height > 0
                                     ? std::min(snap.initial_height, anchor.height)
                                     : anchor.height;
@@ -669,10 +773,19 @@ apply_registered_chrome:
                     }
                 }
             }
-            const auto placement =
-                computeFloatingPanelPlacement(anchor, w, h, px, py, auto_center, kTitleH, kVisibleFrac);
-            px = placement.x;
-            py = placement.y;
+            const auto box = resolveFloatingPanelBox(anchor,
+                                                     snap.initial_width,
+                                                     snap.initial_height,
+                                                     px,
+                                                     py,
+                                                     auto_center,
+                                                     in_viewport,
+                                                     dpi,
+                                                     h);
+            w = box.width;
+            h = box.height;
+            px = box.x;
+            py = box.y;
 
             layout.valid = true;
             layout.width = w;
@@ -875,7 +988,8 @@ apply_registered_chrome:
                                 }
                                 has_user_height = interaction.user_height > 0.0f;
 
-                                const auto anchor = floatingAnchorRect(ctx);
+                                const auto anchor = floatingAnchorRect(
+                                    ctx, snap.has_option(PanelOption::FLOAT_IN_VIEWPORT));
                                 const auto placement = computeFloatingPanelPlacement(
                                     anchor, w, h, px, py, false, kTitleH, kVisibleFrac);
                                 px = placement.x;
@@ -993,6 +1107,10 @@ apply_registered_chrome:
 
     float PanelRegistry::render_panels(const PanelRenderOptions& options,
                                        const PanelDrawContext& ctx) {
+        {
+            std::lock_guard lock(mutex_);
+            rememberLayoutContext(ctx);
+        }
         switch (options.mode) {
         case PanelRenderMode::Standard:
             if (options.target.kind == PanelRenderTargetKind::Space) {
@@ -1353,6 +1471,8 @@ apply_registered_chrome:
                 if (saved.float_stack_order != 0)
                     interaction.stack_order =
                         saved.float_stack_order;
+                if (found->has_option(PanelOption::FLOAT_IN_VIEWPORT))
+                    writeProvisionalFloatingBounds(*found, interaction);
                 requested_project_floating_state_.insert_or_assign(
                     saved.id, saved);
                 next_float_stack_order_ = std::max(
@@ -1778,6 +1898,7 @@ apply_registered_chrome:
                     interaction.y = NAN;
                     interaction.auto_center = true;
                     resetFloatingPanelSize(p, interaction, floatingUiScale());
+                    writeProvisionalFloatingBounds(p, interaction);
                     bring_floating_panel_to_front_locked(p);
                 } else if (was_floating && new_space != PanelSpace::Floating) {
                     p.initial_width = p.original_width;

--- a/src/visualizer/gui/panel_registry.hpp
+++ b/src/visualizer/gui/panel_registry.hpp
@@ -89,6 +89,7 @@ namespace lfs::vis::gui {
         DEFAULT_CLOSED = 1 << 0,
         HIDE_HEADER = 1 << 1,
         SELF_MANAGED = 1 << 2,
+        FLOAT_IN_VIEWPORT = 1 << 3,
     };
 
     using PollDependency = lfs::vis::op::PollDependency;

--- a/src/visualizer/gui/rml_sequencer_overlay.cpp
+++ b/src/visualizer/gui/rml_sequencer_overlay.cpp
@@ -591,8 +591,11 @@ namespace lfs::vis::gui {
         rml_context_->ProcessMouseMove(static_cast<int>(mx), static_cast<int>(my), mods);
 
         auto* hover = rml_context_->GetHoverElement();
+        const auto hover_id = hover ? hover->GetId() : Rml::String{};
+        const bool over_backdrop =
+            hover_id == "menu-backdrop" || hover_id == "popup-backdrop";
         const bool over_interactive = hover && hover->GetTagName() != "body" &&
-                                      hover->GetId() != "body";
+                                      hover_id != "body" && !over_backdrop;
 
         if (edit_overlay_visible_ && el_edit_overlay_) {
             const float h = el_edit_overlay_->GetOffsetHeight();
@@ -601,11 +604,18 @@ namespace lfs::vis::gui {
         }
 
         const bool over_edit_overlay = isMouseOverEditOverlay(mx, my);
+        wants_input_ = over_interactive || over_edit_overlay;
 
-        if (over_interactive || over_edit_overlay ||
-            context_menu_open_ || time_edit_active_ || focal_edit_active_) {
+        const bool menu_or_popup_open =
+            context_menu_open_ || time_edit_active_ || focal_edit_active_;
+        const bool consume_outside_click =
+            menu_or_popup_open && !wants_input_ &&
+            (input.mouse_clicked[0] || input.mouse_clicked[1] ||
+             input.mouse_released[0] || input.mouse_released[1]);
+        if (consume_outside_click)
             wants_input_ = true;
 
+        if (wants_input_) {
             if (skip_next_click_) {
                 skip_next_click_ = false;
             } else {

--- a/src/visualizer/gui/rmlui/resources/sequencer.rcss
+++ b/src/visualizer/gui/rmlui/resources/sequencer.rcss
@@ -840,7 +840,7 @@ body {
 #film-strip-panel {
     display: block;
     width: auto;
-    height: 56px;
+    height: 56dp;
     position: relative;
     margin-top: -1px;
     margin-left: -16dp;

--- a/src/visualizer/gui/sequencer_ui_manager.cpp
+++ b/src/visualizer/gui/sequencer_ui_manager.cpp
@@ -495,8 +495,12 @@ namespace lfs::vis::gui {
 
     float SequencerUIManager::preferredFloatingHeight() const {
         const float dp = std::max(1.0f, getThemeDpiScale());
-        const float strip_h = ui_state_.show_film_strip ? FilmStripRenderer::STRIP_HEIGHT : 0.0f;
-        return (panel_config::HEIGHT + panel_config::EASING_STRIPE_HEIGHT) * dp + strip_h;
+        // #floating-header min-height + margin-bottom + #panel.is-floating padding-top
+        const float header_h = (28.0f + 6.0f + 10.0f) * dp;
+        const float strip_h =
+            ui_state_.show_film_strip ? FilmStripRenderer::STRIP_HEIGHT * dp : 0.0f;
+        return (panel_config::HEIGHT + panel_config::EASING_STRIPE_HEIGHT) * dp + header_h +
+               strip_h;
     }
 
     void SequencerUIManager::render(const UIContext& ctx, const ViewportLayout& viewport,

--- a/tests/test_panel_layout_render_demand.cpp
+++ b/tests/test_panel_layout_render_demand.cpp
@@ -36,7 +36,9 @@ namespace {
             case PanelDirectRenderMode::Draw:
                 ++draw_count;
                 last_draw_x = request.x;
+                last_draw_y = request.y;
                 last_draw_width = request.width;
+                last_draw_height = request.height;
                 break;
             case PanelDirectRenderMode::Cached:
                 ++cached_draw_count;
@@ -51,7 +53,9 @@ namespace {
         int draw_count = 0;
         int cached_draw_count = 0;
         float last_draw_x = 0.0f;
+        float last_draw_y = 0.0f;
         float last_draw_width = 0.0f;
+        float last_draw_height = 0.0f;
         float last_cached_x = 0.0f;
         float last_cached_width = 0.0f;
 
@@ -72,12 +76,18 @@ namespace {
         static std::shared_ptr<CountingDirectPanel> registerPanel(
             std::string id,
             lfs::vis::gui::PanelSpace space,
-            float height) {
+            float height,
+            uint32_t options = 0,
+            float initial_width = 0.0f,
+            float initial_height = 0.0f) {
             auto panel = std::make_shared<CountingDirectPanel>(height);
             lfs::vis::gui::PanelInfo info;
             info.id = std::move(id);
             info.label = info.id;
             info.space = space;
+            info.options = options;
+            info.initial_width = initial_width;
+            info.initial_height = initial_height;
             info.is_native = false;
             info.panel = panel;
             EXPECT_TRUE(lfs::vis::gui::PanelRegistry::instance().register_panel(std::move(info)));
@@ -199,4 +209,83 @@ TEST_F(PanelLayoutRenderDemandTest, LeftDockReservationAppliesOnTheFramePanelBec
     const auto disabled = layout.computeBottomDockHorizontalLayout(true, false, s);
     EXPECT_FLOAT_EQ(disabled.x, closed.x);
     EXPECT_FLOAT_EQ(disabled.width, closed.width);
+}
+
+TEST_F(PanelLayoutRenderDemandTest, FloatingViewportAnchorStaysInViewportHole) {
+    using namespace lfs::vis::gui;
+
+    registerPanel("test.left.viewport_float", PanelSpace::LeftDock, 100.0f);
+    auto seq = registerPanel("test.seq.viewport_float",
+                             PanelSpace::Floating,
+                             200.0f,
+                             static_cast<uint32_t>(PanelOption::FLOAT_IN_VIEWPORT),
+                             8192.0f);
+
+    PanelLayoutManager layout;
+    UIContext ui;
+    PanelDrawContext draw_ctx;
+    draw_ctx.ui = &ui;
+    const auto s = screen();
+    const auto viewport = layout.computeViewportLayout(true, false, false, s);
+    draw_ctx.viewport = &viewport;
+    draw_ctx.screen_bounds = PanelDrawBounds{
+        .width = s.work_size.x,
+        .height = s.work_size.y,
+    };
+
+    PanelRegistry::instance().render_panels({
+                                                .target = PanelRenderTarget::for_space(PanelSpace::Floating),
+                                                .mode = PanelRenderMode::Standard,
+                                            },
+                                            draw_ctx);
+
+    EXPECT_EQ(seq->draw_count, 1);
+    EXPECT_GE(seq->last_draw_x, viewport.pos.x);
+    EXPECT_LE(seq->last_draw_x + seq->last_draw_width, viewport.pos.x + viewport.size.x);
+    const float right_edge = s.work_pos.x + s.work_size.x - layout.getRightPanelWidth();
+    EXPECT_LE(seq->last_draw_x + seq->last_draw_width, right_edge);
+    EXPECT_FLOAT_EQ(seq->last_draw_y + seq->last_draw_height,
+                    viewport.pos.y + viewport.size.y);
+}
+
+TEST_F(PanelLayoutRenderDemandTest, SetPanelSpaceFloatingMasksSameFrame) {
+    using namespace lfs::vis::gui;
+
+    registerPanel("test.left.same_frame", PanelSpace::LeftDock, 100.0f);
+    registerPanel("test.seq.same_frame",
+                  PanelSpace::BottomDock,
+                  200.0f,
+                  static_cast<uint32_t>(PanelOption::FLOAT_IN_VIEWPORT),
+                  8192.0f,
+                  200.0f);
+
+    PanelLayoutManager layout;
+    UIContext ui;
+    PanelDrawContext draw_ctx;
+    draw_ctx.ui = &ui;
+    const auto s = screen();
+    const auto viewport = layout.computeViewportLayout(true, false, false, s);
+    draw_ctx.viewport = &viewport;
+    draw_ctx.screen_bounds = PanelDrawBounds{
+        .width = s.work_size.x,
+        .height = s.work_size.y,
+    };
+
+    PanelRegistry::instance().render_panels({
+                                                .target = PanelRenderTarget::for_space(PanelSpace::Floating),
+                                                .mode = PanelRenderMode::Standard,
+                                            },
+                                            draw_ctx);
+
+    ASSERT_TRUE(PanelRegistry::instance().set_panel_space("test.seq.same_frame",
+                                                          PanelSpace::Floating));
+
+    ASSERT_GT(viewport.pos.x, 32.0f);
+
+    const float band_x = viewport.pos.x + 16.0f;
+    const float band_y = viewport.pos.y + viewport.size.y - 100.0f;
+    EXPECT_TRUE(PanelRegistry::instance().isPositionOverFloatingPanel(band_x, band_y));
+
+    const float left_x = s.work_pos.x + 8.0f;
+    EXPECT_FALSE(PanelRegistry::instance().isPositionOverFloatingPanel(left_x, band_y));
 }


### PR DESCRIPTION
## Problem

Undocking the sequencer turns it into a full-window-wide band, vertically centered, that paints over the asset manager, the left icon bar, and the right panel — and eats their mouse input. Saved projects bring the band back on restore.

| Before (master) | After |
|---|---|
| Undock = window-wide stripe over both side panels | Undock = timeline spanning the 3D view between the docks, parked at the bottom, draggable/resizable |

## Cause

The sequencer registers with width 8192, and the floating-panel anchor is the whole window, so the clamp produces a full-bleed band centered mid-screen.

## Fix

- New opt-in `PanelOption::FLOAT_IN_VIEWPORT`: floating layout, placement, and drag clamping use the 3D-viewport hole as the anchor. Only the sequencer opts in; other floating panels (video extractor) keep the full-window anchor.
- Undocking parks the timeline at the bottom of the viewport instead of the vertical center.
- Project restore clamps saved floating bounds through the same path, so old full-width layouts come back inset.
- The frame a panel starts floating now writes provisional bounds, so the left dock is input-masked immediately (same one-frame-stale class as #1878, floating side).
- The sequencer overlay claims the pointer only over its menus/popups/edit HUD; a click elsewhere while a menu is open closes the menu without also reaching the panel underneath.
- Floating height accounts for the header, and the film strip height is dp on both the C++ and stylesheet side.

## Verification

- Two new regression tests (floating layout stays inside the viewport hole; same-frame input mask): `lichtfeld_tests` panel filters 77/77.
- Verified in the running app: docked layout unchanged; undock lands in the viewport hole with the asset manager fully usable; a saved project with the floating sequencer reopens clamped.