### PR TITLE
Keep the focal length when leaving orthographic mode

### DIFF
--- a/src/visualizer/rendering/rendering_manager.cpp
+++ b/src/visualizer/rendering/rendering_manager.cpp
@@ -567,13 +567,6 @@ namespace lfs::vis {
             settings_.ortho_scale = std::clamp(
                 viewport_height / (2.0f * distance_to_pivot * half_tan_fov),
                 MIN_SCALE, MAX_SCALE);
-        } else if (!enabled && settings_.orthographic) {
-            const float half_tan_fov = viewport_height / (2.0f * distance_to_pivot * settings_.ortho_scale);
-            const float vfov = glm::degrees(2.0f * std::atan(half_tan_fov));
-            settings_.focal_length_mm = std::clamp(
-                lfs::rendering::vFovToFocalLength(vfov),
-                lfs::rendering::MIN_FOCAL_LENGTH_MM,
-                lfs::rendering::MAX_FOCAL_LENGTH_MM);
         }
 
         settings_.orthographic = enabled;

--- a/src/visualizer/rendering/rendering_manager.hpp
+++ b/src/visualizer/rendering/rendering_manager.hpp
@@ -263,7 +263,8 @@ namespace lfs::vis {
         void reportSceneUpscalerRuntimeSelection(SceneUpscalerSelection selection);
         [[nodiscard]] SceneUpscalerSelection sceneUpscalerRuntimeSelection() const;
 
-        // Toggle orthographic mode, calculating ortho_scale to preserve size at pivot
+        // Entering computes ortho_scale so the view at the pivot matches the current
+        // lens. Leaving ortho keeps the focal length the user set.
         void setOrthographic(bool enabled, float viewport_height, float distance_to_pivot);
 
         float getFovDegrees() const;

--- a/tests/test_rendering_refactor_services.cpp
+++ b/tests/test_rendering_refactor_services.cpp
@@ -377,7 +377,7 @@ namespace lfs::vis {
         EXPECT_EQ(pose.translation, glm::vec3(1.0f, 2.0f, 3.0f));
     }
 
-    TEST_F(RenderingManagerEventsTest, OrthographicTogglePreservesApparentZoomAtPivotInBothDirections) {
+    TEST_F(RenderingManagerEventsTest, OrthographicEnterSetsScaleFromCurrentFocal) {
         RenderingManager manager;
         auto settings = manager.getSettings();
         settings.focal_length_mm = 50.0f;
@@ -394,19 +394,33 @@ namespace lfs::vis {
                                      (2.0f * distance_to_pivot *
                                       std::tan(glm::radians(lfs::rendering::focalLengthToVFov(50.0f)) * 0.5f));
         EXPECT_NEAR(ortho_settings.ortho_scale, expected_scale, 1e-4f);
+    }
 
-        settings = ortho_settings;
-        settings.ortho_scale *= 1.75f;
+    TEST_F(RenderingManagerEventsTest, OrthographicLeaveKeepsFocalLength) {
+        RenderingManager manager;
+        auto settings = manager.getSettings();
+        settings.focal_length_mm = 35.0f;
+        manager.updateSettings(settings);
+
+        constexpr float viewport_height = 900.0f;
+        constexpr float distance_to_pivot = 7.5f;
+
+        manager.setOrthographic(true, viewport_height, distance_to_pivot);
+        manager.setOrthographic(false, viewport_height, distance_to_pivot);
+        const auto after_round_trip = manager.getSettings();
+        ASSERT_FALSE(after_round_trip.orthographic);
+        EXPECT_FLOAT_EQ(after_round_trip.focal_length_mm, 35.0f);
+
+        manager.setOrthographic(true, viewport_height, distance_to_pivot);
+        settings = manager.getSettings();
+        ASSERT_TRUE(settings.orthographic);
+        settings.ortho_scale *= std::pow(1.1f, 20.0f);
         manager.updateSettings(settings);
 
         manager.setOrthographic(false, viewport_height, distance_to_pivot);
-        const auto perspective_settings = manager.getSettings();
-        ASSERT_FALSE(perspective_settings.orthographic);
-
-        const float expected_vfov = glm::degrees(2.0f * std::atan(
-                                                            viewport_height / (2.0f * distance_to_pivot * settings.ortho_scale)));
-        const float expected_focal = lfs::rendering::vFovToFocalLength(expected_vfov);
-        EXPECT_NEAR(perspective_settings.focal_length_mm, expected_focal, 1e-4f);
+        const auto after_zoom = manager.getSettings();
+        ASSERT_FALSE(after_zoom.orthographic);
+        EXPECT_FLOAT_EQ(after_zoom.focal_length_mm, 35.0f);
     }
 
     TEST(SplitViewServiceTest, GtComparisonPlanPreservesGtTextureOrigin) {


### PR DESCRIPTION
Reported on Discord: after playing with orthographic mode and switching back to perspective, the focal length in the Rendering tab could jump to 200 or some other big number.

Leaving ortho mode used to recompute the focal length from the ortho zoom and the camera distance. Zooming in ortho mode made that value large, and the slider clamped it at 200. Now leaving ortho keeps the lens the user set. Entering ortho still matches the view at the pivot to the current lens.

Checked in the viewer: enter ortho, zoom in 20 wheel ticks, leave ortho, focal length stays at 35 mm. Before the fix the same steps gave 200. Unit tests updated.
