### PR TITLE
Honor --mcp-port and --no-splash in view mode

### DIFF
--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -363,6 +363,27 @@ namespace {
         return {};
     }
 
+    std::expected<void, std::string> apply_per_launch_ui_flags(
+        lfs::core::param::TrainingParameters& params,
+        const bool no_splash_flag,
+        const std::optional<int> mcp_port_val) {
+        if (mcp_port_val) {
+            const int port = *mcp_port_val;
+            if (port < 1 || port > 65535) {
+                return std::unexpected("ERROR: --mcp-port must be between 1 and 65535");
+            }
+            params.mcp_port = port;
+        }
+#ifndef LFS_BUILD_PORTABLE
+        if (no_splash_flag) {
+            params.optimization.no_splash = true;
+        }
+#else
+        (void)no_splash_flag;
+#endif
+        return {};
+    }
+
     std::optional<lfs::core::param::OutputFormat> parseFormat(const std::string& str) {
         using lfs::core::param::OutputFormat;
         if (str == "ply" || str == ".ply")
@@ -785,6 +806,14 @@ namespace {
                 return std::make_tuple(ParseResult::Success, std::function<void()>{});
             }
 
+#ifdef LFS_BUILD_PORTABLE
+            const bool per_launch_no_splash = false;
+#else
+            const bool per_launch_no_splash = bool(no_splash);
+#endif
+            const std::optional<int> per_launch_mcp_port =
+                mcp_port ? std::optional<int>(::args::get(mcp_port)) : std::nullopt;
+
             // Viewer mode: file or directory. Bare positional paths are rewritten to
             // -v in parse_args_and_params so they share this branch.
             if (view_ply) {
@@ -798,7 +827,20 @@ namespace {
                 if (gut) {
                     params.optimization.gut = true;
                 }
-                return std::make_tuple(ParseResult::Success, std::function<void()>{});
+                if (const auto applied = apply_per_launch_ui_flags(
+                        params, per_launch_no_splash, per_launch_mcp_port);
+                    !applied) {
+                    return std::unexpected(applied.error());
+                }
+                // parse_args_and_params replaces optimization with defaults
+                // after this return; re-apply so --no-splash survives.
+                return std::make_tuple(
+                    ParseResult::Success,
+                    std::function<void()>([&params, per_launch_no_splash,
+                                           per_launch_mcp_port]() {
+                        (void)apply_per_launch_ui_flags(
+                            params, per_launch_no_splash, per_launch_mcp_port);
+                    }));
             }
 
             // Headless camera-path -> video render mode: no training, no window.
@@ -1018,11 +1060,10 @@ namespace {
                     return std::unexpected("ERROR: --min-track-length must be 0 or greater");
                 }
             }
-            if (mcp_port) {
-                const int port = ::args::get(mcp_port);
-                if (port < 1 || port > 65535) {
-                    return std::unexpected("ERROR: --mcp-port must be between 1 and 65535");
-                }
+            if (const auto applied = apply_per_launch_ui_flags(
+                    params, per_launch_no_splash, per_launch_mcp_port);
+                !applied) {
+                return std::unexpected(applied.error());
             }
 
             // Validate sh_degree (0-3)
@@ -1171,14 +1212,10 @@ namespace {
                                         reset_preferences_flag = bool(reset_preferences),
                                         reset_layout_flag = bool(reset_layout),
                                         reset_all_settings_flag = bool(reset_all_settings),
-#ifdef LFS_BUILD_PORTABLE
-                                        no_splash_flag = false,
-#else
-                                        no_splash_flag = bool(no_splash),
-#endif
+                                        no_splash_flag = per_launch_no_splash,
                                         debug_python_flag = bool(debug_python),
                                         debug_python_port_val = cli_option_present({"--debug-python-port"}) ? std::optional<int>(::args::get(debug_python_port)) : std::optional<int>(),
-                                        mcp_port_val = cli_option_present({"--mcp-port"}) ? std::optional<int>(::args::get(mcp_port)) : std::optional<int>(),
+                                        mcp_port_val = per_launch_mcp_port,
                                         no_save_eval_images_flag = bool(no_save_eval_images),
                                         bg_mode_val = parsed_bg_mode,
                                         bg_color_val = parsed_bg_color,
@@ -1328,10 +1365,9 @@ namespace {
                 setFlag(reset_preferences_flag, params.reset_preferences);
                 setFlag(reset_layout_flag, params.reset_layout);
                 setFlag(reset_all_settings_flag, params.reset_all_settings);
-                setFlag(no_splash_flag, opt.no_splash);
+                (void)apply_per_launch_ui_flags(params, no_splash_flag, mcp_port_val);
                 setFlag(debug_python_flag, opt.debug_python);
                 setVal(debug_python_port_val, opt.debug_python_port);
-                setVal(mcp_port_val, params.mcp_port);
                 if (no_save_eval_images_flag)
                     opt.enable_save_eval_images = false;
                 if (bg_mode_val) {

--- a/src/mcp/mcp_http_server.cpp
+++ b/src/mcp/mcp_http_server.cpp
@@ -574,11 +574,10 @@ namespace lfs::mcp {
 
         const auto listener_url = std::format("http://{}:{}/mcp", bind_address, config.port);
         const bool announce_listener = listener_url != last_announced_listener_url_;
-        listener_thread_ = std::jthread([this, listener_url, announce_listener,
-                                         listener_generation](
+        if (announce_listener)
+            LOG_INFO("MCP HTTP server listening on {}", listener_url);
+        listener_thread_ = std::jthread([this, listener_generation](
                                             std::stop_token /*st*/) {
-            if (announce_listener)
-                LOG_INFO("MCP HTTP server listening on {}", listener_url);
             bool listener_completed_normally = false;
             lfs::core::run_guarded<void>(
                 lfs::core::TaskContext{

--- a/src/visualizer/gui/rml_status_bar.cpp
+++ b/src/visualizer/gui/rml_status_bar.cpp
@@ -1050,8 +1050,10 @@ namespace lfs::vis::gui {
                 tooltip = details;
                 color = colorToRml(p.error);
             } else {
-                summary = status.network_exposed ? LOC("status_bar.mcp_network")
-                                                 : LOC("status_bar.mcp_local");
+                summary = std::format("{} ({})",
+                                      status.network_exposed ? LOC("status_bar.mcp_network")
+                                                             : LOC("status_bar.mcp_local"),
+                                      status.port);
                 for (const auto& endpoint : status.endpoints) {
                     if (!details.empty())
                         details += '\n';

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -1460,3 +1460,62 @@ TEST(ArgumentParserTest, ResumeConfigKeysPopulateExplicitOverrides) {
     EXPECT_EQ(restored.optimization.save_steps, std::vector<size_t>({30100}));
     EXPECT_EQ(restored.dataset.test_every, 64);
 }
+
+TEST(ArgumentParserTest, ViewModeHonorsMcpPortOverride) {
+    const auto directory = make_test_path("lfs_arg_parser_view_mcp_port");
+    const auto ply = std::filesystem::path(directory) / "some.ply";
+    std::ofstream(ply).put('\n');
+    const auto ply_text = ply.string();
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "-v",
+        ply_text.c_str(),
+        "--mcp-port",
+        "45690",
+    };
+    auto parsed = lfs::core::args::parse_args_and_params(
+        static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+    EXPECT_EQ((*parsed)->mcp_port, std::optional<int>(45690));
+}
+
+#ifndef LFS_BUILD_PORTABLE
+TEST(ArgumentParserTest, ViewModeHonorsNoSplash) {
+    const auto directory = make_test_path("lfs_arg_parser_view_no_splash");
+    const auto ply = std::filesystem::path(directory) / "some.ply";
+    std::ofstream(ply).put('\n');
+    const auto ply_text = ply.string();
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "-v",
+        ply_text.c_str(),
+        "--no-splash",
+    };
+    auto parsed = lfs::core::args::parse_args_and_params(
+        static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+    EXPECT_TRUE((*parsed)->optimization.no_splash);
+}
+#endif
+
+TEST(ArgumentParserTest, ViewModeRejectsOutOfRangeMcpPort) {
+    const auto directory = make_test_path("lfs_arg_parser_view_mcp_port_invalid");
+    const auto ply = std::filesystem::path(directory) / "some.ply";
+    std::ofstream(ply).put('\n');
+    const auto ply_text = ply.string();
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "-v",
+        ply_text.c_str(),
+        "--mcp-port",
+        "70000",
+    };
+    auto parsed = lfs::core::args::parse_args_and_params(
+        static_cast<int>(std::size(argv)), argv);
+    ASSERT_FALSE(parsed.has_value());
+    EXPECT_NE(parsed.error().find("must be between 1 and 65535"),
+              std::string::npos);
+}


### PR DESCRIPTION
In view mode the argument parser returned early, before the per-launch UI flags were applied. So `--view file --mcp-port 8766` still started the MCP server on the saved port, and `--no-splash` was ignored too. Both flags now go through one helper that is used by the view path and the normal path.

Two smaller things from the same issue: the status bar chip now shows the port it serves on, for example "MCP Local (45690)", and the "listening on" log line is only printed after the bind succeeded. I could not reproduce the red "MCP Error" chip while the server was running; every state that shows it is a real failure (bad port, bind failure, listener exit), so that logic is unchanged.

Checked with `-v gd.ply --mcp-port 45690 --no-splash`: the server listens on 45690 only, the chip shows the port, no splash. Parser tests added.

Fixes #1899
