### PR TITLE
Let training start again after loading with an init PLY

### DIFF
--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -20,6 +20,9 @@
 #include "lfs/training/sh_value_storage.hpp"
 #include "trainer.hpp"
 #include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <exception>
 #include <filesystem>
 #include <format>
 #include <memory>
@@ -147,6 +150,184 @@ namespace lfs::training {
                      lfs::core::path_to_utf8(init_file.filename()),
                      previous_scale,
                      *scene_scale);
+        }
+
+        constexpr float kShC0 = 0.28209479177387814f;
+
+        bool isPlainPointCloudPly(const std::filesystem::path& path) {
+            return path.extension().string() == ".ply" && !lfs::io::is_gaussian_splat_ply(path);
+        }
+
+        std::optional<std::filesystem::path> gaussianSplatInitPath(
+            const lfs::core::param::TrainingParameters& params) {
+            if (!params.init_path.has_value() || params.init_path->empty()) {
+                return std::nullopt;
+            }
+            const std::filesystem::path init_file = lfs::core::utf8_to_path(*params.init_path);
+            if (isPlainPointCloudPly(init_file)) {
+                return std::nullopt;
+            }
+            return init_file;
+        }
+
+        std::shared_ptr<lfs::core::PointCloud> pointCloudPreviewFromSplat(
+            const lfs::core::SplatData& splat) {
+            const auto n = static_cast<size_t>(splat.size());
+            auto means = splat.means_raw().is_valid()
+                             ? splat.means_raw().cpu().contiguous()
+                             : lfs::core::Tensor::zeros({n, 3}, lfs::core::Device::CPU);
+            auto colors = lfs::core::Tensor::zeros({n, 3}, lfs::core::Device::CPU, lfs::core::DataType::UInt8);
+            if (n > 0 && colors.data_ptr() != nullptr) {
+                std::memset(colors.data_ptr(), 255, n * 3);
+            }
+
+            const auto& sh0 = splat.sh0_raw();
+            if (n > 0 && sh0.is_valid() && sh0.numel() > 0) {
+                try {
+                    auto rgb = (sh0.cpu().slice(1, 0, 1).squeeze(1) * kShC0 + 0.5f)
+                                   .clamp(0.0f, 1.0f)
+                                   .contiguous();
+                    if (rgb.is_valid() && rgb.ndim() == 2 &&
+                        static_cast<size_t>(rgb.size(0)) == n && rgb.size(1) == 3 &&
+                        rgb.dtype() == lfs::core::DataType::Float32 && rgb.ptr<float>() != nullptr) {
+                        const float* src = rgb.ptr<float>();
+                        auto* dst = static_cast<uint8_t*>(colors.data_ptr());
+                        for (size_t i = 0; i < n * 3; ++i) {
+                            const float scaled = src[i] * 255.0f;
+                            dst[i] = static_cast<uint8_t>(
+                                scaled < 0.0f ? 0.0f : (scaled > 255.0f ? 255.0f : scaled + 0.5f));
+                        }
+                    }
+                } catch (const std::exception& e) {
+                    LOG_WARN("Could not derive PointCloud colors from SH0: {}", e.what());
+                }
+            }
+
+            return std::make_shared<lfs::core::PointCloud>(std::move(means), std::move(colors));
+        }
+
+        std::expected<std::shared_ptr<lfs::core::PointCloud>, std::string>
+        loadInitReplacementPointCloud(const std::filesystem::path& init_file) {
+            const auto filename = lfs::core::path_to_utf8(init_file.filename());
+            const auto path_utf8 = lfs::core::path_to_utf8(init_file);
+
+            if (isPlainPointCloudPly(init_file)) {
+                auto pc_result = lfs::io::load_ply_point_cloud(init_file);
+                if (!pc_result) {
+                    return std::unexpected(std::format("Failed to load '{}': {}", path_utf8, pc_result.error()));
+                }
+                if (pc_result->size() <= 0) {
+                    return std::unexpected(std::format("'{}' contains no points", path_utf8));
+                }
+                LOG_INFO("Init {} points from {} (replaces points3D)", pc_result->size(), filename);
+                return std::make_shared<lfs::core::PointCloud>(std::move(*pc_result));
+            }
+
+            auto loader = lfs::io::Loader::create();
+            auto init_result = loader->load(init_file);
+            if (!init_result) {
+                return std::unexpected(std::format("Failed to load '{}': {}",
+                                                   path_utf8, init_result.error().format()));
+            }
+
+            auto* splat_ptr = std::get_if<std::shared_ptr<lfs::core::SplatData>>(&init_result->data);
+            if (!splat_ptr || !*splat_ptr) {
+                return std::unexpected(std::format("'{}': invalid SplatData", path_utf8));
+            }
+
+            auto preview = pointCloudPreviewFromSplat(**splat_ptr);
+            if (!preview || preview->size() <= 0) {
+                return std::unexpected(std::format("'{}' contains no points", path_utf8));
+            }
+            LOG_INFO("Init {} points from splat {} (preview)", preview->size(), filename);
+            return preview;
+        }
+
+        std::expected<void, std::string> attachDatasetPointCloud(
+            const lfs::core::param::TrainingParameters& params,
+            lfs::core::Scene& scene,
+            const lfs::core::NodeId dataset_id,
+            const lfs::io::LoadedScene& data,
+            const bool verbose) {
+            std::shared_ptr<lfs::core::PointCloud> point_cloud;
+            if (params.init_path.has_value() && !params.init_path->empty()) {
+                auto loaded = loadInitReplacementPointCloud(lfs::core::utf8_to_path(*params.init_path));
+                if (!loaded) {
+                    return std::unexpected(std::move(loaded.error()));
+                }
+                point_cloud = std::move(*loaded);
+            } else if (data.point_cloud && data.point_cloud->size() > 0) {
+                point_cloud = data.point_cloud;
+                if (verbose) {
+                    LOG_INFO("Adding {} points to scene", point_cloud->size());
+                }
+            } else {
+                if (verbose) {
+                    LOG_INFO("No point cloud, using random initialization");
+                }
+                point_cloud = createRandomPointCloud();
+                if (verbose) {
+                    LOG_INFO("Adding {} random points to scene", point_cloud->size());
+                }
+            }
+
+            scene.setInitialPointCloud(point_cloud);
+            scene.addPointCloud("PointCloud", point_cloud, dataset_id);
+            return {};
+        }
+
+        std::expected<void, std::string> installGaussianInitAsTrainingModel(
+            const lfs::core::param::TrainingParameters& params,
+            lfs::core::Scene& scene,
+            const std::filesystem::path& init_file) {
+            auto loader = lfs::io::Loader::create();
+            auto init_result = loader->load(init_file);
+            if (!init_result) {
+                return std::unexpected(std::format("Failed to load '{}': {}",
+                                                   lfs::core::path_to_utf8(init_file),
+                                                   init_result.error().format()));
+            }
+
+            auto* splat_ptr = std::get_if<std::shared_ptr<lfs::core::SplatData>>(&init_result->data);
+            if (!splat_ptr || !*splat_ptr) {
+                return std::unexpected(std::format("'{}': invalid SplatData",
+                                                   lfs::core::path_to_utf8(init_file)));
+            }
+
+            auto model = std::make_unique<lfs::core::SplatData>(std::move(**splat_ptr));
+            recomputeInitSplatSceneScale(*model, scene.getSceneCenter(), init_file);
+            applyTrainingSHDegree(*model, params.optimization.sh_degree);
+            LOG_INFO("Loaded {} gaussians from {} (sh={})",
+                     model->size(),
+                     lfs::core::path_to_utf8(init_file.filename()),
+                     model->get_max_sh_degree());
+
+            lfs::core::NodeId parent_id = lfs::core::NULL_NODE;
+            lfs::core::NodeId point_cloud_node_id = lfs::core::NULL_NODE;
+            glm::mat4 node_transform{1.0f};
+            for (const auto* node : scene.getNodes()) {
+                if (node->type == lfs::core::NodeType::POINTCLOUD && node->point_cloud) {
+                    point_cloud_node_id = node->id;
+                    parent_id = node->parent_id;
+                    node_transform = node->transform();
+                    break;
+                }
+            }
+            if (point_cloud_node_id != lfs::core::NULL_NODE) {
+                if (const auto* pc_node = scene.getNodeById(point_cloud_node_id)) {
+                    scene.removeNode(pc_node->name, false);
+                }
+            }
+
+            const auto model_id = scene.addSplat("Model", std::move(model), parent_id);
+            if (model_id == lfs::core::NULL_NODE) {
+                return std::unexpected("Failed to add loaded training model to scene");
+            }
+            if (node_transform != glm::mat4{1.0f}) {
+                scene.setNodeTransform(model_id, node_transform);
+            }
+            scene.setTrainingModelNode(model_id);
+            return {};
         }
 
         std::expected<std::unique_ptr<lfs::core::SplatData>, std::string> loadAddedSplat(
@@ -575,7 +756,6 @@ namespace lfs::training {
                 return {};
 
             } else if constexpr (std::is_same_v<T, lfs::io::LoadedScene>) {
-                scene.setInitialPointCloud(data.point_cloud);
                 scene.setSceneCenter(load_result->scene_center);
                 scene.setImagesHaveAlpha(load_result->images_have_alpha);
 
@@ -590,69 +770,9 @@ namespace lfs::training {
 
                 const auto dataset_id = scene.addDataset(dataset_name);
 
-                if (params.init_path.has_value()) {
-                    const std::filesystem::path init_file = lfs::core::utf8_to_path(params.init_path.value());
-                    const auto ext = init_file.extension().string();
-
-                    if (ext == ".ply" && !lfs::io::is_gaussian_splat_ply(init_file)) {
-                        auto pc_result = lfs::io::load_ply_point_cloud(init_file);
-                        if (!pc_result) {
-                            return std::unexpected(std::format("Failed to load '{}': {}",
-                                                               lfs::core::path_to_utf8(init_file), pc_result.error()));
-                        }
-
-                        auto splat_result = lfs::core::init_model_from_pointcloud(
-                            params, load_result->scene_center, *pc_result, static_cast<int>(pc_result->size()));
-
-                        if (!splat_result) {
-                            return std::unexpected(std::format("Init failed: {}", splat_result.error()));
-                        }
-
-                        auto model = std::make_unique<lfs::core::SplatData>(std::move(*splat_result));
-                        LOG_INFO("Initialized {} Gaussians from {} (sh={})",
-                                 model->size(), lfs::core::path_to_utf8(init_file.filename()), model->get_max_sh_degree());
-                        const auto model_id = scene.addSplat("Model", std::move(model), dataset_id);
-                        if (model_id == lfs::core::NULL_NODE) {
-                            return std::unexpected("Failed to add initialized training model to scene");
-                        }
-                        scene.setTrainingModelNode(model_id);
-                    } else {
-                        auto loader = lfs::io::Loader::create();
-                        auto init_result = loader->load(init_file);
-
-                        if (!init_result) {
-                            return std::unexpected(std::format("Failed to load '{}': {}",
-                                                               lfs::core::path_to_utf8(init_file), init_result.error().format()));
-                        }
-
-                        try {
-                            auto splat_data = std::move(*std::get<std::shared_ptr<lfs::core::SplatData>>(init_result->data));
-                            auto model = std::make_unique<lfs::core::SplatData>(std::move(splat_data));
-
-                            recomputeInitSplatSceneScale(*model, load_result->scene_center, init_file);
-                            applyTrainingSHDegree(*model, params.optimization.sh_degree);
-
-                            LOG_INFO("Loaded {} Gaussians from {} (sh={})",
-                                     model->size(), lfs::core::path_to_utf8(init_file.filename()), model->get_max_sh_degree());
-                            const auto model_id = scene.addSplat("Model", std::move(model), dataset_id);
-                            if (model_id == lfs::core::NULL_NODE) {
-                                return std::unexpected("Failed to add loaded training model to scene");
-                            }
-                            scene.setTrainingModelNode(model_id);
-                        } catch (const std::bad_variant_access&) {
-                            return std::unexpected(std::format("'{}': invalid SplatData", lfs::core::path_to_utf8(init_file)));
-                        }
-                    }
-                } else {
-                    if (data.point_cloud && data.point_cloud->size() > 0) {
-                        LOG_INFO("Adding {} points to scene", data.point_cloud->size());
-                        scene.addPointCloud("PointCloud", data.point_cloud, dataset_id);
-                    } else {
-                        LOG_INFO("No point cloud, using random initialization");
-                        auto pc = createRandomPointCloud();
-                        LOG_INFO("Adding {} random points to scene", pc->size());
-                        scene.addPointCloud("PointCloud", pc, dataset_id);
-                    }
+                if (auto attached = attachDatasetPointCloud(params, scene, dataset_id, data, true);
+                    !attached) {
+                    return attached;
                 }
 
                 const auto& cameras = data.cameras;
@@ -727,6 +847,15 @@ namespace lfs::training {
         const lfs::core::param::TrainingParameters& params,
         lfs::core::Scene& scene,
         lfs::core::SplatTensorAllocator tensor_allocator) {
+
+        if (!scene.getTrainingModel()) {
+            if (const auto init_file = gaussianSplatInitPath(params)) {
+                if (auto installed = installGaussianInitAsTrainingModel(params, scene, *init_file);
+                    !installed) {
+                    return installed;
+                }
+            }
+        }
 
         if (auto* model = scene.getTrainingModel()) {
             applyTrainingSHDegree(*model, params.optimization.sh_degree);
@@ -907,7 +1036,14 @@ namespace lfs::training {
         if (auto result = migrateTrainingModelToAllocator(params, *model, tensor_allocator); !result) {
             return result;
         }
-        LOG_INFO("Created training model with {} gaussians", model->size());
+        if (params.init_path.has_value() && !params.init_path->empty()) {
+            LOG_INFO("Init {} gaussians from {} (sh={})",
+                     model->size(),
+                     lfs::core::path_to_utf8(lfs::core::utf8_to_path(*params.init_path).filename()),
+                     model->get_max_sh_degree());
+        } else {
+            LOG_INFO("Created training model with {} gaussians", model->size());
+        }
         const lfs::core::NodeId model_id = scene.addSplat("Model", std::move(model), parent_id);
         if (model_id == lfs::core::NULL_NODE) {
             return std::unexpected("Failed to add training model to scene");
@@ -971,7 +1107,6 @@ namespace lfs::training {
                 return {};
 
             } else if constexpr (std::is_same_v<T, lfs::io::LoadedScene>) {
-                scene.setInitialPointCloud(data.point_cloud);
                 scene.setSceneCenter(load_result.scene_center);
                 scene.setImagesHaveAlpha(load_result.images_have_alpha);
 
@@ -985,61 +1120,9 @@ namespace lfs::training {
 
                 const auto dataset_id = scene.addDataset(dataset_name);
 
-                if (params.init_path.has_value()) {
-                    const std::filesystem::path init_file = lfs::core::utf8_to_path(params.init_path.value());
-                    const auto ext = init_file.extension().string();
-
-                    if (ext == ".ply" && !lfs::io::is_gaussian_splat_ply(init_file)) {
-                        auto pc_result = lfs::io::load_ply_point_cloud(init_file);
-                        if (!pc_result) {
-                            return std::unexpected(std::format("Failed to load '{}': {}",
-                                                               lfs::core::path_to_utf8(init_file), pc_result.error()));
-                        }
-
-                        auto splat_result = lfs::core::init_model_from_pointcloud(
-                            params, load_result.scene_center, *pc_result, static_cast<int>(pc_result->size()));
-                        if (!splat_result) {
-                            return std::unexpected(std::format("Init failed: {}", splat_result.error()));
-                        }
-
-                        auto model = std::make_unique<lfs::core::SplatData>(std::move(*splat_result));
-                        LOG_INFO("Init {} gaussians from {} (sh={})",
-                                 model->size(), lfs::core::path_to_utf8(init_file.filename()), model->get_max_sh_degree());
-                        const auto model_id = scene.addSplat("Model", std::move(model), dataset_id);
-                        if (model_id == lfs::core::NULL_NODE) {
-                            return std::unexpected("Failed to add initialized training model to scene");
-                        }
-                        scene.setTrainingModelNode(model_id);
-                    } else {
-                        auto loader = lfs::io::Loader::create();
-                        auto init_result = loader->load(init_file);
-                        if (!init_result) {
-                            return std::unexpected(std::format("Failed to load '{}': {}",
-                                                               lfs::core::path_to_utf8(init_file), init_result.error().format()));
-                        }
-
-                        try {
-                            auto splat_data = std::move(*std::get<std::shared_ptr<lfs::core::SplatData>>(init_result->data));
-                            auto model = std::make_unique<lfs::core::SplatData>(std::move(splat_data));
-
-                            recomputeInitSplatSceneScale(*model, load_result.scene_center, init_file);
-                            applyTrainingSHDegree(*model, params.optimization.sh_degree);
-
-                            LOG_INFO("Loaded {} gaussians from {} (sh={})",
-                                     model->size(), lfs::core::path_to_utf8(init_file.filename()), model->get_max_sh_degree());
-                            const auto model_id = scene.addSplat("Model", std::move(model), dataset_id);
-                            if (model_id == lfs::core::NULL_NODE) {
-                                return std::unexpected("Failed to add loaded training model to scene");
-                            }
-                            scene.setTrainingModelNode(model_id);
-                        } catch (const std::bad_variant_access&) {
-                            return std::unexpected(std::format("'{}': invalid SplatData", lfs::core::path_to_utf8(init_file)));
-                        }
-                    }
-                } else if (data.point_cloud && data.point_cloud->size() > 0) {
-                    scene.addPointCloud("PointCloud", data.point_cloud, dataset_id);
-                } else {
-                    scene.addPointCloud("PointCloud", createRandomPointCloud(), dataset_id);
+                if (auto attached = attachDatasetPointCloud(params, scene, dataset_id, data, false);
+                    !attached) {
+                    return attached;
                 }
 
                 const auto& cameras = data.cameras;

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -4,6 +4,7 @@
 
 #include "training_setup.hpp"
 #include "core/cuda/sh_layout.cuh"
+#include "core/error.hpp"
 #include "core/events.hpp"
 #include "core/logger.hpp"
 #include "core/mesh_data.hpp"
@@ -12,6 +13,7 @@
 #include "core/scene.hpp"
 #include "core/sh_value_quant.hpp"
 #include "core/shareable_allocation_limit.hpp"
+#include "core/source_site.hpp"
 #include "core/splat_data.hpp"
 #include "core/splat_data_transform.hpp"
 #include "dataset.hpp"
@@ -154,6 +156,15 @@ namespace lfs::training {
 
         constexpr float kShC0 = 0.28209479177387814f;
 
+        lfs::Error initFileError(std::string message) {
+            return lfs::make_error(lfs::ErrorInit{
+                .code = lfs::ErrorCode::InvalidArgument,
+                .domain = lfs::ErrorDomain::Training,
+                .user_message = std::move(message),
+                .detection = LFS_SOURCE_SITE_CURRENT(),
+            });
+        }
+
         bool isPlainPointCloudPly(const std::filesystem::path& path) {
             return path.extension().string() == ".ply" && !lfs::io::is_gaussian_splat_ply(path);
         }
@@ -206,7 +217,7 @@ namespace lfs::training {
             return std::make_shared<lfs::core::PointCloud>(std::move(means), std::move(colors));
         }
 
-        std::expected<std::shared_ptr<lfs::core::PointCloud>, std::string>
+        lfs::Result<std::shared_ptr<lfs::core::PointCloud>>
         loadInitReplacementPointCloud(const std::filesystem::path& init_file) {
             const auto filename = lfs::core::path_to_utf8(init_file.filename());
             const auto path_utf8 = lfs::core::path_to_utf8(init_file);
@@ -214,10 +225,11 @@ namespace lfs::training {
             if (isPlainPointCloudPly(init_file)) {
                 auto pc_result = lfs::io::load_ply_point_cloud(init_file);
                 if (!pc_result) {
-                    return std::unexpected(std::format("Failed to load '{}': {}", path_utf8, pc_result.error()));
+                    return initFileError(
+                        std::format("Failed to load '{}': {}", path_utf8, pc_result.error()));
                 }
                 if (pc_result->size() <= 0) {
-                    return std::unexpected(std::format("'{}' contains no points", path_utf8));
+                    return initFileError(std::format("'{}' contains no points", path_utf8));
                 }
                 LOG_INFO("Init {} points from {} (replaces points3D)", pc_result->size(), filename);
                 return std::make_shared<lfs::core::PointCloud>(std::move(*pc_result));
@@ -226,24 +238,24 @@ namespace lfs::training {
             auto loader = lfs::io::Loader::create();
             auto init_result = loader->load(init_file);
             if (!init_result) {
-                return std::unexpected(std::format("Failed to load '{}': {}",
-                                                   path_utf8, init_result.error().format()));
+                return initFileError(std::format(
+                    "Failed to load '{}': {}", path_utf8, init_result.error().format()));
             }
 
             auto* splat_ptr = std::get_if<std::shared_ptr<lfs::core::SplatData>>(&init_result->data);
             if (!splat_ptr || !*splat_ptr) {
-                return std::unexpected(std::format("'{}': invalid SplatData", path_utf8));
+                return initFileError(std::format("'{}': invalid SplatData", path_utf8));
             }
 
             auto preview = pointCloudPreviewFromSplat(**splat_ptr);
             if (!preview || preview->size() <= 0) {
-                return std::unexpected(std::format("'{}' contains no points", path_utf8));
+                return initFileError(std::format("'{}' contains no points", path_utf8));
             }
             LOG_INFO("Init {} points from splat {} (preview)", preview->size(), filename);
             return preview;
         }
 
-        std::expected<void, std::string> attachDatasetPointCloud(
+        lfs::Result<void> attachDatasetPointCloud(
             const lfs::core::param::TrainingParameters& params,
             lfs::core::Scene& scene,
             const lfs::core::NodeId dataset_id,
@@ -253,7 +265,7 @@ namespace lfs::training {
             if (params.init_path.has_value() && !params.init_path->empty()) {
                 auto loaded = loadInitReplacementPointCloud(lfs::core::utf8_to_path(*params.init_path));
                 if (!loaded) {
-                    return std::unexpected(std::move(loaded.error()));
+                    return lfs::Status::failure(loaded.error());
                 }
                 point_cloud = std::move(*loaded);
             } else if (data.point_cloud && data.point_cloud->size() > 0) {
@@ -276,22 +288,22 @@ namespace lfs::training {
             return {};
         }
 
-        std::expected<void, std::string> installGaussianInitAsTrainingModel(
+        lfs::Result<void> installGaussianInitAsTrainingModel(
             const lfs::core::param::TrainingParameters& params,
             lfs::core::Scene& scene,
             const std::filesystem::path& init_file) {
             auto loader = lfs::io::Loader::create();
             auto init_result = loader->load(init_file);
             if (!init_result) {
-                return std::unexpected(std::format("Failed to load '{}': {}",
-                                                   lfs::core::path_to_utf8(init_file),
-                                                   init_result.error().format()));
+                return lfs::Status::failure(initFileError(std::format("Failed to load '{}': {}",
+                                                                      lfs::core::path_to_utf8(init_file),
+                                                                      init_result.error().format())));
             }
 
             auto* splat_ptr = std::get_if<std::shared_ptr<lfs::core::SplatData>>(&init_result->data);
             if (!splat_ptr || !*splat_ptr) {
-                return std::unexpected(std::format("'{}': invalid SplatData",
-                                                   lfs::core::path_to_utf8(init_file)));
+                return lfs::Status::failure(initFileError(std::format("'{}': invalid SplatData",
+                                                                      lfs::core::path_to_utf8(init_file))));
             }
 
             auto model = std::make_unique<lfs::core::SplatData>(std::move(**splat_ptr));
@@ -321,7 +333,7 @@ namespace lfs::training {
 
             const auto model_id = scene.addSplat("Model", std::move(model), parent_id);
             if (model_id == lfs::core::NULL_NODE) {
-                return std::unexpected("Failed to add loaded training model to scene");
+                return lfs::Status::failure(initFileError("Failed to add loaded training model to scene"));
             }
             if (node_transform != glm::mat4{1.0f}) {
                 scene.setNodeTransform(model_id, node_transform);
@@ -772,7 +784,7 @@ namespace lfs::training {
 
                 if (auto attached = attachDatasetPointCloud(params, scene, dataset_id, data, true);
                     !attached) {
-                    return attached;
+                    return std::unexpected(std::string(attached.error().user_message()));
                 }
 
                 const auto& cameras = data.cameras;
@@ -852,7 +864,7 @@ namespace lfs::training {
             if (const auto init_file = gaussianSplatInitPath(params)) {
                 if (auto installed = installGaussianInitAsTrainingModel(params, scene, *init_file);
                     !installed) {
-                    return installed;
+                    return std::unexpected(std::string(installed.error().user_message()));
                 }
             }
         }
@@ -1122,7 +1134,7 @@ namespace lfs::training {
 
                 if (auto attached = attachDatasetPointCloud(params, scene, dataset_id, data, false);
                     !attached) {
-                    return attached;
+                    return std::unexpected(std::string(attached.error().user_message()));
                 }
 
                 const auto& cameras = data.cameras;

--- a/src/training/training_setup.hpp
+++ b/src/training/training_setup.hpp
@@ -81,8 +81,9 @@ namespace lfs::training {
     /**
      * @brief Initialize training model from point cloud
      *
-     * Called when training starts. Creates SplatData from the POINTCLOUD node,
-     * optionally filtering by any CropBox attached to the point cloud.
+     * Called when training starts. If a Gaussian-splat init file is set, that
+     * file is loaded as the training model. Otherwise creates SplatData from the
+     * POINTCLOUD node, optionally filtering by any CropBox attached to the point cloud.
      *
      * The POINTCLOUD node is replaced with a SPLAT node containing the initialized model.
      *

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -301,6 +301,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_CloseSaveRoutesTrainingSnapshotToLiveDocument_Test;
         friend class VisualizerImplResetTest_TrainerOwnedSaveTargetsLiveDocumentPath_Test;
         friend class VisualizerImplResetTest_StartTrainingUntitledBindsTempProjectAndStaysUntitled_Test;
+        friend class VisualizerImplResetTest_PrepareTrainingStartProjectSucceedsAfterInitPlyLoad_Test;
         friend class VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionKeepsSessionUntitledAndOutOfMru_Test;
         friend class VisualizerImplResetTest_SaveAsAfterUntitledTrainingMigratesTempIncludingCheckpoint_Test;
         friend class VisualizerImplResetTest_UntitledStartConflictNeverReportsExistingOutputProject_Test;

--- a/tests/test_checkpoint_resume.cpp
+++ b/tests/test_checkpoint_resume.cpp
@@ -34,6 +34,7 @@
 #include "core/splat_data.hpp"
 #include "core/tensor.hpp"
 #include "core/uuid.hpp"
+#include "io/exporter.hpp"
 #include "io/loader.hpp"
 #include "io/loaders/checkpoint_loader.hpp"
 #include "io/project_document.hpp"
@@ -297,6 +298,64 @@ namespace {
         scene.addCamera("camera.png", cameras, std::move(camera));
     }
 
+    std::shared_ptr<lfs::core::Camera> make_init_load_test_camera() {
+        return std::make_shared<lfs::core::Camera>(
+            lfs::core::Tensor::eye(3, lfs::core::Device::CPU),
+            lfs::core::Tensor::zeros({3}, lfs::core::Device::CPU),
+            100.0f, 100.0f, 32.0f, 32.0f,
+            lfs::core::Tensor(), lfs::core::Tensor(),
+            lfs::core::CameraModelType::PINHOLE,
+            "test.png", std::filesystem::path{}, std::filesystem::path{},
+            64, 64, 0);
+    }
+
+    lfs::io::LoadResult make_init_load_test_result() {
+        lfs::io::LoadedScene loaded_scene;
+        loaded_scene.cameras.push_back(make_init_load_test_camera());
+        lfs::io::LoadResult load_result;
+        load_result.data = std::move(loaded_scene);
+        load_result.scene_center = lfs::core::Tensor::from_vector(
+            std::vector<float>{0.0f, 0.0f, 0.0f},
+            {size_t{3}},
+            lfs::core::Device::CPU);
+        load_result.loader_used = "test";
+        return load_result;
+    }
+
+    size_t first_point_cloud_count(const lfs::core::Scene& scene) {
+        for (const auto* node : scene.getNodes()) {
+            if (node && node->type == lfs::core::NodeType::POINTCLOUD && node->point_cloud) {
+                return static_cast<size_t>(node->point_cloud->size());
+            }
+        }
+        return 0;
+    }
+
+    void write_ascii_xyz_rgb_ply(const std::filesystem::path& path, const size_t count) {
+        std::ofstream ply(path);
+        ASSERT_TRUE(ply.is_open());
+        ply << "ply\n"
+               "format ascii 1.0\n"
+               "element vertex "
+            << count
+            << "\n"
+               "property float x\n"
+               "property float y\n"
+               "property float z\n"
+               "property uchar red\n"
+               "property uchar green\n"
+               "property uchar blue\n"
+               "end_header\n";
+        for (size_t i = 0; i < count; ++i) {
+            ply << static_cast<float>(i) << ' '
+                << static_cast<float>(i % 3) << ' '
+                << static_cast<float>(i % 5) << ' '
+                << static_cast<int>(10 + i) << ' '
+                << static_cast<int>(20 + i) << ' '
+                << static_cast<int>(30 + i) << '\n';
+        }
+    }
+
     std::streamoff first_model_tensor_header_offset(const std::filesystem::path& checkpoint) {
         std::ifstream file(checkpoint, std::ios::binary);
         if (!file)
@@ -400,7 +459,6 @@ namespace {
     }
     TEST(TrainingSetupRegressionTest, ApplyLoadedDatasetKeepsFullInitPointCloudUntilTrainingStarts) {
         constexpr size_t initial_points = 12;
-        constexpr int target_splats = 5;
 
         const auto temp_dir = std::filesystem::temp_directory_path() / "lfs_training_setup_full_init_regression";
         std::error_code ec;
@@ -408,71 +466,75 @@ namespace {
         std::filesystem::create_directories(temp_dir);
 
         const auto init_path = temp_dir / "init_points.ply";
-        {
-            std::ofstream ply(init_path);
-            ASSERT_TRUE(ply.is_open());
-            ply << "ply\n"
-                   "format ascii 1.0\n"
-                   "element vertex "
-                << initial_points
-                << "\n"
-                   "property float x\n"
-                   "property float y\n"
-                   "property float z\n"
-                   "property uchar red\n"
-                   "property uchar green\n"
-                   "property uchar blue\n"
-                   "end_header\n";
-            for (size_t i = 0; i < initial_points; ++i) {
-                ply << static_cast<float>(i) << ' '
-                    << static_cast<float>(i % 3) << ' '
-                    << static_cast<float>(i % 5) << ' '
-                    << static_cast<int>(10 + i) << ' '
-                    << static_cast<int>(20 + i) << ' '
-                    << static_cast<int>(30 + i) << '\n';
-            }
-        }
+        write_ascii_xyz_rgb_ply(init_path, initial_points);
 
         lfs::core::param::TrainingParameters params;
         params.dataset.data_path = temp_dir / "dataset";
         params.init_path = lfs::core::path_to_utf8(init_path);
-        params.optimization.max_cap = target_splats;
-
-        lfs::io::LoadedScene loaded_scene;
-        loaded_scene.cameras.push_back(std::make_shared<lfs::core::Camera>(
-            lfs::core::Tensor::eye(3, lfs::core::Device::CPU),
-            lfs::core::Tensor::zeros({3}, lfs::core::Device::CPU),
-            100.0f, 100.0f, 32.0f, 32.0f,
-            lfs::core::Tensor(), lfs::core::Tensor(),
-            lfs::core::CameraModelType::PINHOLE,
-            "test.png", std::filesystem::path{}, std::filesystem::path{},
-            64, 64, 0));
-
-        lfs::io::LoadResult load_result;
-        load_result.data = std::move(loaded_scene);
-        load_result.scene_center = lfs::core::Tensor::from_vector(
-            std::vector<float>{0.0f, 0.0f, 0.0f},
-            {size_t{3}},
-            lfs::core::Device::CPU);
-        load_result.loader_used = "test";
 
         lfs::core::Scene scene;
-        auto apply_result = lfs::training::applyLoadResultToScene(params, scene, std::move(load_result));
+        auto apply_result = lfs::training::applyLoadResultToScene(
+            params, scene, make_init_load_test_result());
         ASSERT_TRUE(apply_result.has_value()) << apply_result.error();
+
+        EXPECT_EQ(scene.getTrainingModel(), nullptr);
+        EXPECT_EQ(scene.getTrainingModelGaussianCount(), 0u);
+        EXPECT_EQ(first_point_cloud_count(scene), initial_points);
+
+        auto init_result = lfs::training::initializeTrainingModel(params, scene);
+        ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
         const auto* model = scene.getTrainingModel();
         ASSERT_NE(model, nullptr);
         EXPECT_EQ(static_cast<size_t>(model->size()), initial_points);
         EXPECT_EQ(scene.getTrainingModelGaussianCount(), initial_points);
 
-        auto trainer = std::make_unique<lfs::training::Trainer>(scene);
-        auto init_result = trainer->initialize(params);
+        std::filesystem::remove_all(temp_dir, ec);
+    }
+
+    TEST(TrainingSetupRegressionTest, ApplyLoadedDatasetKeepsGaussianInitAsPointCloudUntilTrainingStarts) {
+        constexpr size_t initial_splats = 8;
+
+        const auto temp_dir =
+            std::filesystem::temp_directory_path() / "lfs_training_setup_gaussian_init_regression";
+        std::error_code ec;
+        std::filesystem::remove_all(temp_dir, ec);
+        std::filesystem::create_directories(temp_dir);
+
+        const auto init_path = temp_dir / "init_gaussians.ply";
+        auto seed = make_checkpoint_test_splat(initial_splats);
+        ASSERT_NE(seed, nullptr);
+        const auto saved = lfs::io::save_ply(*seed, {
+                                                        .output_path = init_path,
+                                                        .binary = true,
+                                                        .async = false,
+                                                    });
+        ASSERT_TRUE(saved.has_value()) << saved.error().format();
+        seed.reset();
+
+        lfs::core::param::TrainingParameters params;
+        params.dataset.data_path = temp_dir / "dataset";
+        params.init_path = lfs::core::path_to_utf8(init_path);
+
+        lfs::core::Scene scene;
+        auto apply_result = lfs::training::applyLoadResultToScene(
+            params, scene, make_init_load_test_result());
+        ASSERT_TRUE(apply_result.has_value()) << apply_result.error();
+
+        EXPECT_EQ(scene.getTrainingModel(), nullptr);
+        EXPECT_EQ(scene.getTrainingModelGaussianCount(), 0u);
+        EXPECT_EQ(first_point_cloud_count(scene), initial_splats);
+
+        auto init_result = lfs::training::initializeTrainingModel(params, scene);
         ASSERT_TRUE(init_result.has_value()) << init_result.error();
 
-        EXPECT_EQ(static_cast<size_t>(trainer->get_strategy().get_model().size()), static_cast<size_t>(target_splats));
-        EXPECT_EQ(scene.getTrainingModelGaussianCount(), static_cast<size_t>(target_splats));
+        const auto* model = scene.getTrainingModel();
+        ASSERT_NE(model, nullptr);
+        EXPECT_EQ(static_cast<size_t>(model->size()), initial_splats);
+        EXPECT_EQ(scene.getTrainingModelGaussianCount(), initial_splats);
+        ASSERT_TRUE(model->scaling_raw().is_valid());
+        EXPECT_NEAR(model->scaling_raw().cpu().ptr<float>()[0], 0.0f, 1e-3f);
 
-        trainer->shutdown();
         std::filesystem::remove_all(temp_dir, ec);
     }
 

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -19,6 +19,7 @@
 #include "gui/scene_tree_session.hpp"
 #include "gui/string_keys.hpp"
 #include "input/input_controller.hpp"
+#include "io/loader.hpp"
 #include "io/project_chapters.hpp"
 #include "io/project_container.hpp"
 #include "io/project_document.hpp"
@@ -37,6 +38,7 @@
 #include "training/dataset.hpp"
 #include "training/strategies/mcmc.hpp"
 #include "training/trainer.hpp"
+#include "training/training_setup.hpp"
 #include "training/training_state.hpp"
 #include "visualizer/core/data_loading_service.hpp"
 #include "visualizer/include/visualizer/visualizer.hpp"
@@ -8155,6 +8157,86 @@ namespace lfs::vis {
             EXPECT_TRUE(policy.on_completion);
             EXPECT_TRUE(policy.at_step_boundaries);
             EXPECT_FALSE(policy.on_stop_or_error);
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           PrepareTrainingStartProjectSucceedsAfterInitPlyLoad) {
+        const auto& temporary = temporary_.path;
+        const auto output_path =
+            temporary / "init-ply-train-out";
+        std::filesystem::create_directories(output_path);
+        const auto init_path = temporary / "init_points.ply";
+        {
+            std::ofstream ply(init_path);
+            ASSERT_TRUE(ply.is_open());
+            ply << "ply\n"
+                   "format ascii 1.0\n"
+                   "element vertex 12\n"
+                   "property float x\n"
+                   "property float y\n"
+                   "property float z\n"
+                   "property uchar red\n"
+                   "property uchar green\n"
+                   "property uchar blue\n"
+                   "end_header\n";
+            for (int i = 0; i < 12; ++i) {
+                ply << i << " 0 0 10 20 30\n";
+            }
+        }
+
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()
+                            ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr, viewer.getViewport());
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+
+            lfs::core::param::TrainingParameters params;
+            params.dataset.data_path = temporary / "dataset";
+            params.init_path = lfs::core::path_to_utf8(init_path);
+
+            lfs::io::LoadedScene loaded_scene;
+            loaded_scene.cameras.push_back(
+                make_project_request_test_camera());
+            lfs::io::LoadResult load_result;
+            load_result.data = std::move(loaded_scene);
+            load_result.scene_center =
+                lfs::core::Tensor::from_vector(
+                    std::vector<float>{0.0f, 0.0f, 0.0f},
+                    {size_t{3}},
+                    lfs::core::Device::CPU);
+            load_result.loader_used = "test";
+
+            auto apply_result =
+                lfs::training::applyLoadResultToScene(
+                    params, viewer.getScene(),
+                    std::move(load_result));
+            ASSERT_TRUE(apply_result.has_value())
+                << apply_result.error();
+            EXPECT_EQ(
+                viewer.getScene().getTrainingModel(),
+                nullptr);
+
+            viewer.getTrainerManager()->setTrainer(
+                std::make_unique<lfs::training::Trainer>(
+                    viewer.getScene()));
+            auto* const trainer = viewer.getTrainer();
+            ASSERT_NE(trainer, nullptr);
+            auto trainer_params = trainer->getParams();
+            trainer_params.dataset.output_path = output_path;
+            trainer->setParams(trainer_params);
+
+            auto prepared =
+                lifecycle->prepareTrainingStartProject();
+            ASSERT_TRUE(prepared)
+                << lfs::format_for_developer(
+                       prepared.error());
         }
     }
 


### PR DESCRIPTION
Loading a dataset with an init PLY (`--init`, or the "Init file, replaces points3D" field in the Load Dataset dialog) made training impossible: Start Training and Save As both failed with "new training node has no CKPT binding".

The init file was turned into the training model right at load time. The project file needs a trainer checkpoint for a training model, and Start Training writes the project before the trainer exists, so it could never pass. Normal datasets never hit this because their points stay a point cloud until training starts.

Now the init points replace the dataset point cloud at load, and the trainer builds its model from them at Start Training, the same path every normal dataset uses. A Gaussian splat given as init shows up as a point cloud before training and is loaded as the model when training starts. This is how `--init` worked in 0.5.3.

Checked with a LiDAR-style PLY and with a Gaussian PLY, in the GUI flow and headless. Tests updated and added.

Fixes #1898
