### PR TITLE
Save the final project into -o and run --export in the GUI flow

### DIFF
--- a/docs/building_and_distribution.md
+++ b/docs/building_and_distribution.md
@@ -63,7 +63,7 @@ cmake -B build
 cmake --build build -j 16
 ./build/LichtFeld-Studio --help
 
-# Example training run
+# Example training run (writes /path/to/output/project.licht; add --headless and --export ply for a CLI-only splat export)
 ./build/LichtFeld-Studio -d /path/to/data -o /path/to/output
 ```
 
@@ -78,7 +78,7 @@ cmake --install build --prefix ./dist
 
 ./dist/bin/run_lichtfeld.sh --help
 
-# Example training run
+# Example training run (writes /path/to/output/project.licht)
 ./dist/bin/run_lichtfeld.sh -d /path/to/data -o /path/to/output
 ```
 

--- a/docs/docs/development/preferences-and-user-storage.md
+++ b/docs/docs/development/preferences-and-user-storage.md
@@ -135,7 +135,9 @@ projects, and removing a mapping never deletes the directory or project files.
 
 Untitled crash files and untitled training snapshots live in
 `<working folder>/tmp/<session-uuid>.licht`, not under `dataset.output_path`.
-The temp directory is created lazily on first scratch write. Changing the
+An explicit CLI `-o` / `--output-path` is different: training binds a titled
+`<output_path>/project.licht` instead of the untitled temp file. The temp
+directory is created lazily on first scratch write. Changing the
 working folder applies to the next untitled session (New Project or restart);
 a live session keeps the temp file it already bound. Cache, logs, plugins,
 the venv, and ONNX models stay on the unified root and do not follow the

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -36,7 +36,6 @@
 #include "visualizer/visualizer.hpp"
 
 #include "app/mcp_gui_tools.hpp"
-#include "io/exporter.hpp"
 #include "io/loader.hpp"
 #include "io/video/video_encoder.hpp"
 #include "mcp/mcp_http_server.hpp"
@@ -73,75 +72,6 @@
 namespace lfs::app {
 
     namespace {
-
-        const char* final_export_extension(const core::param::OutputFormat format) {
-            using core::param::OutputFormat;
-            switch (format) {
-            case OutputFormat::PLY: return ".ply";
-            case OutputFormat::SOG: return ".sog";
-            case OutputFormat::SPZ: return ".spz";
-            case OutputFormat::HTML: return ".html";
-            case OutputFormat::USD: return ".usd";
-            case OutputFormat::USDA: return ".usda";
-            case OutputFormat::USDC: return ".usdc";
-            case OutputFormat::RAD: return ".rad";
-            }
-            return ".ply";
-        }
-
-        io::Result<void> save_final_splat(const core::SplatData& splat,
-                                          const std::filesystem::path& output,
-                                          const core::param::OutputFormat format,
-                                          const core::ProvenanceStamp& provenance) {
-            using core::param::OutputFormat;
-            switch (format) {
-            case OutputFormat::PLY:
-                return io::save_ply(splat, {.output_path = output, .binary = true, .provenance = provenance});
-            case OutputFormat::SOG:
-                return io::save_sog(splat, {.output_path = output, .kmeans_iterations = 10, .provenance = provenance});
-            case OutputFormat::SPZ:
-                return io::save_spz(splat, {.output_path = output, .version = 4, .provenance = provenance});
-            case OutputFormat::HTML:
-                return io::export_html(splat, {.output_path = output, .kmeans_iterations = 10, .provenance = provenance});
-            case OutputFormat::USD:
-            case OutputFormat::USDA:
-            case OutputFormat::USDC:
-                return io::save_usd(splat, {.output_path = output, .provenance = provenance});
-            case OutputFormat::RAD:
-                return io::save_rad(splat, {.output_path = output, .provenance = provenance});
-            }
-            return io::save_ply(splat, {.output_path = output, .binary = true, .provenance = provenance});
-        }
-
-        void export_final_splats(const training::Trainer& trainer,
-                                 const core::param::TrainingParameters& params) {
-            if (params.export_formats.empty()) {
-                return;
-            }
-            const auto& model = trainer.get_strategy().get_model();
-            const std::filesystem::path out_dir = params.dataset.output_path;
-            const std::string stem = params.dataset.output_name.empty()
-                                         ? std::format("splat_{}", trainer.get_current_iteration())
-                                         : params.dataset.output_name;
-
-            core::ProvenanceStamp stamp = params.include_provenance
-                                              ? core::make_provenance_stamp()
-                                              : core::make_minimal_provenance_stamp();
-            if (params.include_provenance) {
-                stamp.iteration = trainer.get_current_iteration();
-                stamp.strategy = params.optimization.strategy;
-            }
-
-            for (const auto format : params.export_formats) {
-                const std::filesystem::path path = out_dir / (stem + final_export_extension(format));
-                if (const auto result = save_final_splat(model, path, format, stamp); !result) {
-                    LOG_ERROR("Failed to export final splat to {}: {}",
-                              core::path_to_utf8(path), result.error().message);
-                } else {
-                    LOG_INFO("Exported final splat: {}", core::path_to_utf8(path));
-                }
-            }
-        }
 
         struct HeadlessPluginSignalGuard {
             HeadlessPluginSignalGuard() {
@@ -823,7 +753,7 @@ namespace lfs::app {
                                 rebound.error()));
                         return 1;
                     }
-                    export_final_splats(*trainer, *params);
+                    training::export_final_splats(*trainer, *params);
                     trainer->shutdown();
                     static_cast<void>(
                         trainer.release());
@@ -871,7 +801,7 @@ namespace lfs::app {
                         }
                         return 1;
                     }
-                    export_final_splats(*trainer, *params);
+                    training::export_final_splats(*trainer, *params);
                     trainer->shutdown();
                     static_cast<void>(trainer.release());
                 } else {
@@ -917,7 +847,7 @@ namespace lfs::app {
                         }
                         return 1;
                     }
-                    export_final_splats(*trainer, *params);
+                    training::export_final_splats(*trainer, *params);
                     trainer->shutdown();
                     static_cast<void>(trainer.release());
                 }

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -454,6 +454,7 @@ namespace {
                 "\n"
                 "EXAMPLES:\n"
                 "lichtfeld-studio -d ./data -o ./output\n"
+                "lichtfeld-studio --headless -d ./data -o ./output --export ply\n"
                 "lichtfeld-studio -v session.licht\n"
                 "lichtfeld-studio --headless --resume session.licht\n"
                 "lichtfeld-studio -d ./data -o ./output --save-project-at-iter 7000\n"
@@ -486,7 +487,7 @@ namespace {
             ::args::Group paths_sep(parser, " ");
             ::args::Group paths_group(parser, "TRAINING PATHS:");
             ::args::ValueFlag<std::string> data_path(paths_group, "data_path", "Path to training data", {'d', "data-path"});
-            ::args::ValueFlag<std::string> output_path(paths_group, "output_path", "Path to output", {'o', "output-path"});
+            ::args::ValueFlag<std::string> output_path(paths_group, "output_path", "Directory for project.licht and --export files", {'o', "output-path"});
             ::args::ValueFlag<std::string> output_name(paths_group, "output_name", "Output filename (replaces default splat_ITER.ply stem)", {"output-name"});
             ::args::ValueFlag<std::string> config_file(paths_group, "config_file", "LichtFeldStudio config file (json)", {"config"});
             ::args::ValueFlag<std::string> init_path(paths_group, "path", "Initialize from splat file (.ply, .sog, .spz, .usd, .usda, .usdc, .usdz, .resume)", {"init"});
@@ -1260,6 +1261,7 @@ namespace {
                                             cli_option_present({"--save-project-path"})
                                                 ? std::optional<std::string>(::args::get(save_project_path))
                                                 : std::optional<std::string>(),
+                                        output_path_explicit_val = cli_option_present({"-o", "--output-path"}),
                                         output_name_val = cli_option_present({"--output-name"}) ? std::optional<std::string>(::args::get(output_name)) : std::optional<std::string>()]() {
                 auto& opt = params.optimization;
                 auto& svs = params.server;
@@ -1322,6 +1324,7 @@ namespace {
                 setVal(timelapse_images_val, ds.timelapse_images);
                 setVal(timelapse_every_val, ds.timelapse_every);
                 setVal(output_name_val, ds.output_name);
+                ds.output_path_explicit = output_path_explicit_val;
                 if (save_project_at_iteration_val) {
                     params.save_project_at_iteration =
                         static_cast<size_t>(*save_project_at_iteration_val);

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -332,6 +332,9 @@ namespace lfs::core {
         struct LFS_CORE_API DatasetConfig {
             std::filesystem::path data_path = "";
             std::filesystem::path output_path = "";
+            // True when -o/--output-path was given on this process's command line.
+            // Runtime-only: to_json, from_json, and PRMS dataset_json omit it.
+            bool output_path_explicit = false;
             std::string output_name = "";
             std::string images = "images";
             int resize_factor = -1;
@@ -452,7 +455,7 @@ namespace lfs::core {
             std::vector<std::filesystem::path> python_scripts;
 
             // Additional final-splat exports written next to project.licht after
-            // headless training completes. Empty = only the .licht project is written.
+            // training completes. Empty = only the .licht project is written.
             std::vector<OutputFormat> export_formats;
 
             // True when --bg-color was provided on the command line.

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -8511,6 +8511,11 @@ namespace lfs::training {
                                               terminal_iteration, save_result.error()),
                         .detection = LFS_SOURCE_SITE_CURRENT(),
                     }));
+                } else {
+                    const auto params = getParams();
+                    if (!params.optimization.headless) {
+                        export_final_splats(*this, params);
+                    }
                 }
             } catch (const std::exception& e) {
                 append_terminal_error(lfs::make_error(lfs::ErrorInit{

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -10,6 +10,7 @@
 #include "core/mesh_data.hpp"
 #include "core/path_utils.hpp"
 #include "core/point_cloud.hpp"
+#include "core/provenance.hpp"
 #include "core/scene.hpp"
 #include "core/sh_value_quant.hpp"
 #include "core/shareable_allocation_limit.hpp"
@@ -17,6 +18,7 @@
 #include "core/splat_data.hpp"
 #include "core/splat_data_transform.hpp"
 #include "dataset.hpp"
+#include "io/exporter.hpp"
 #include "io/loader.hpp"
 #include "io/project_document.hpp"
 #include "lfs/training/sh_value_storage.hpp"
@@ -1304,6 +1306,77 @@ namespace lfs::training {
             .on_stop_or_error = true,
             .at_step_boundaries = true,
         });
+    }
+
+    namespace {
+        const char* final_export_extension(const lfs::core::param::OutputFormat format) {
+            using lfs::core::param::OutputFormat;
+            switch (format) {
+            case OutputFormat::PLY: return ".ply";
+            case OutputFormat::SOG: return ".sog";
+            case OutputFormat::SPZ: return ".spz";
+            case OutputFormat::HTML: return ".html";
+            case OutputFormat::USD: return ".usd";
+            case OutputFormat::USDA: return ".usda";
+            case OutputFormat::USDC: return ".usdc";
+            case OutputFormat::RAD: return ".rad";
+            }
+            return ".ply";
+        }
+
+        lfs::io::Result<void> save_final_splat(const lfs::core::SplatData& splat,
+                                               const std::filesystem::path& output,
+                                               const lfs::core::param::OutputFormat format,
+                                               const lfs::core::ProvenanceStamp& provenance) {
+            using lfs::core::param::OutputFormat;
+            switch (format) {
+            case OutputFormat::PLY:
+                return lfs::io::save_ply(splat, {.output_path = output, .binary = true, .provenance = provenance});
+            case OutputFormat::SOG:
+                return lfs::io::save_sog(splat, {.output_path = output, .kmeans_iterations = 10, .provenance = provenance});
+            case OutputFormat::SPZ:
+                return lfs::io::save_spz(splat, {.output_path = output, .version = 4, .provenance = provenance});
+            case OutputFormat::HTML:
+                return lfs::io::export_html(splat, {.output_path = output, .kmeans_iterations = 10, .provenance = provenance});
+            case OutputFormat::USD:
+            case OutputFormat::USDA:
+            case OutputFormat::USDC:
+                return lfs::io::save_usd(splat, {.output_path = output, .provenance = provenance});
+            case OutputFormat::RAD:
+                return lfs::io::save_rad(splat, {.output_path = output, .provenance = provenance});
+            }
+            return lfs::io::save_ply(splat, {.output_path = output, .binary = true, .provenance = provenance});
+        }
+    } // namespace
+
+    void export_final_splats(const Trainer& trainer,
+                             const lfs::core::param::TrainingParameters& params) {
+        if (params.export_formats.empty()) {
+            return;
+        }
+        const auto& model = trainer.get_strategy().get_model();
+        const std::filesystem::path out_dir = params.dataset.output_path;
+        const std::string stem = params.dataset.output_name.empty()
+                                     ? std::format("splat_{}", trainer.get_current_iteration())
+                                     : params.dataset.output_name;
+
+        lfs::core::ProvenanceStamp stamp = params.include_provenance
+                                               ? lfs::core::make_provenance_stamp()
+                                               : lfs::core::make_minimal_provenance_stamp();
+        if (params.include_provenance) {
+            stamp.iteration = trainer.get_current_iteration();
+            stamp.strategy = params.optimization.strategy;
+        }
+
+        for (const auto format : params.export_formats) {
+            const std::filesystem::path path = out_dir / (stem + final_export_extension(format));
+            if (const auto result = save_final_splat(model, path, format, stamp); !result) {
+                LOG_ERROR("Failed to export final splat to {}: {}",
+                          lfs::core::path_to_utf8(path), result.error().message);
+            } else {
+                LOG_INFO("Exported final splat: {}", lfs::core::path_to_utf8(path));
+            }
+        }
     }
 
 } // namespace lfs::training

--- a/src/training/training_setup.hpp
+++ b/src/training/training_setup.hpp
@@ -42,6 +42,12 @@ namespace lfs::training {
         const lfs::core::param::TrainingParameters& params,
         const std::filesystem::path& destination = {});
 
+    /// Write `--export` formats next to project.licht after a terminal project
+    /// save. No-op when `params.export_formats` is empty.
+    void export_final_splats(
+        const Trainer& trainer,
+        const lfs::core::param::TrainingParameters& params);
+
     /// Construct + initialize Trainer on the live scene, then stream the
     /// document's CKPT payload via load_checkpoint(istream). Does not clear
     /// the scene and does not install into TrainerManager.

--- a/src/visualizer/core/parameter_manager.cpp
+++ b/src/visualizer/core/parameter_manager.cpp
@@ -254,6 +254,7 @@ namespace lfs::vis {
         dataset_config_ = lfs::core::param::DatasetConfig{};
         dataset_config_.centralize_dataset = "off";
         dataset_config_.loading_params = lfs::core::param::LoadingParams{};
+        export_formats_.clear();
         dirty_.store(false, std::memory_order_release);
     }
 
@@ -308,6 +309,11 @@ namespace lfs::vis {
         dataset_config_.timelapse_every = ds.timelapse_every;
         dataset_config_.invert_masks = ds.invert_masks;
         dataset_config_.mask_threshold = ds.mask_threshold;
+        dataset_config_.output_path_explicit = ds.output_path_explicit;
+        if (ds.output_path_explicit) {
+            dataset_config_.output_path = ds.output_path;
+        }
+        export_formats_ = params.export_formats;
 
         LOG_INFO("Session: strategy={}, iter={}, resize={}", opt.strategy, opt.iterations, dataset_config_.resize_factor);
     }
@@ -365,6 +371,7 @@ namespace lfs::vis {
         }
 
         dataset_config_ = params.dataset;
+        export_formats_ = params.export_formats;
         dirty_.store(false, std::memory_order_release);
 
         LOG_INFO("Imported training params: strategy={}, iter={}, images={}, resize={}",
@@ -413,6 +420,7 @@ namespace lfs::vis {
         params.dataset = dataset_config_;
         params.dataset.data_path = data_path;
         params.dataset.output_path = output_path;
+        params.export_formats = export_formats_;
         return params;
     }
 

--- a/src/visualizer/core/parameter_manager.hpp
+++ b/src/visualizer/core/parameter_manager.hpp
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace lfs::vis {
 
@@ -133,6 +134,7 @@ namespace lfs::vis {
 
         // Dataset config (CLI overrides JSON defaults)
         lfs::core::param::DatasetConfig dataset_config_;
+        std::vector<lfs::core::param::OutputFormat> export_formats_;
 
         mutable std::mutex params_mutex_;
         std::atomic<bool> dirty_{false};

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -3461,7 +3461,52 @@ namespace lfs::vis::project {
                 "project.training");
         }
 
-        if (!hasSourcePath()) {
+        const auto dataset = trainer->getParams().dataset;
+        if (dataset.output_path_explicit &&
+            !dataset.output_path.empty()) {
+            std::error_code create_error;
+            std::filesystem::create_directories(
+                dataset.output_path, create_error);
+            if (create_error) {
+                return fail<void>(
+                    lfs::ErrorCode::PermissionDenied,
+                    "The training output folder could not be created.",
+                    create_error.message(),
+                    "project.training");
+            }
+            const auto destination =
+                dataset.output_path / "project.licht";
+            std::error_code abs_error;
+            const auto absolute_destination =
+                std::filesystem::absolute(
+                    destination, abs_error);
+            const bool already_bound_there =
+                !abs_error && hasSourcePath() &&
+                document_ && document_->source_path() &&
+                document_->source_path()
+                        ->lexically_normal() ==
+                    absolute_destination.lexically_normal();
+            if (!already_bound_there) {
+                if (auto saved = saveAs(
+                        destination, false, true);
+                    !saved) {
+                    return saved;
+                }
+                if (project_write_thread_.joinable()) {
+                    project_write_thread_.join();
+                    settleProjectWrite();
+                }
+                if (!hasSourcePath()) {
+                    return fail<void>(
+                        lfs::ErrorCode::Unavailable,
+                        "The training project could not be created.",
+                        last_project_write_error_.empty()
+                            ? "CLI output path first bind did not set a source path"
+                            : last_project_write_error_,
+                        "project.training");
+                }
+            }
+        } else if (!hasSourcePath()) {
             if (auto waited =
                     waitOutBackgroundAutosaveForExplicitSave();
                 !waited) {

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -51,6 +51,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_CloseSaveRoutesTrainingSnapshotToLiveDocument_Test;
     class VisualizerImplResetTest_TrainerOwnedSaveTargetsLiveDocumentPath_Test;
     class VisualizerImplResetTest_StartTrainingUntitledBindsTempProjectAndStaysUntitled_Test;
+    class VisualizerImplResetTest_StartTrainingWithCliOutputPathBindsProjectThere_Test;
     class VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionKeepsSessionUntitledAndOutOfMru_Test;
     class VisualizerImplResetTest_SaveAsAfterUntitledTrainingMigratesTempIncludingCheckpoint_Test;
     class VisualizerImplResetTest_UntitledStartConflictNeverReportsExistingOutputProject_Test;
@@ -305,6 +306,7 @@ namespace lfs::vis::project {
         friend class lfs::vis::VisualizerImplResetTest_CloseSaveRoutesTrainingSnapshotToLiveDocument_Test;
         friend class lfs::vis::VisualizerImplResetTest_TrainerOwnedSaveTargetsLiveDocumentPath_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartTrainingUntitledBindsTempProjectAndStaysUntitled_Test;
+        friend class lfs::vis::VisualizerImplResetTest_StartTrainingWithCliOutputPathBindsProjectThere_Test;
         friend class lfs::vis::VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionKeepsSessionUntitledAndOutOfMru_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsAfterUntitledTrainingMigratesTempIncludingCheckpoint_Test;
         friend class lfs::vis::VisualizerImplResetTest_UntitledStartConflictNeverReportsExistingOutputProject_Test;

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -302,6 +302,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_TrainerOwnedSaveTargetsLiveDocumentPath_Test;
         friend class VisualizerImplResetTest_StartTrainingUntitledBindsTempProjectAndStaysUntitled_Test;
         friend class VisualizerImplResetTest_PrepareTrainingStartProjectSucceedsAfterInitPlyLoad_Test;
+        friend class VisualizerImplResetTest_StartTrainingWithCliOutputPathBindsProjectThere_Test;
         friend class VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionKeepsSessionUntitledAndOutOfMru_Test;
         friend class VisualizerImplResetTest_SaveAsAfterUntitledTrainingMigratesTempIncludingCheckpoint_Test;
         friend class VisualizerImplResetTest_UntitledStartConflictNeverReportsExistingOutputProject_Test;

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -6,6 +6,7 @@
 
 #include "core/argument_parser.hpp"
 #include "core/optimization_properties.hpp"
+#include "core/parameter_manager.hpp"
 #include "core/parameters.hpp"
 #include "core/property_registry.hpp"
 #include "io/project_path.hpp"
@@ -349,6 +350,39 @@ TEST(ArgumentParserMetadataTest, BuiltHelpContainsRegistryDescriptionsAndDefault
         EXPECT_NE(help.find(meta->description), std::string::npos);
         EXPECT_NE(help.find("(default: "), std::string::npos);
     }
+}
+
+TEST(ArgumentParserTest, CliOutputPathSetsExplicitAndSurvivesCreateForDataset) {
+    const auto data_path = make_test_path("lfs_arg_parser_cli_output_data");
+    const auto output_path = make_test_path("lfs_arg_parser_cli_output_out");
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "-d",
+        data_path.c_str(),
+        "-o",
+        output_path.c_str(),
+        "--export",
+        "ply",
+    };
+    auto parsed = lfs::core::args::parse_args_and_params(
+        static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+    EXPECT_TRUE((*parsed)->dataset.output_path_explicit);
+    EXPECT_EQ((*parsed)->dataset.output_path, std::filesystem::path(output_path));
+    ASSERT_EQ((*parsed)->export_formats.size(), 1u);
+    EXPECT_EQ((*parsed)->export_formats.front(), lfs::core::param::OutputFormat::PLY);
+
+    lfs::vis::ParameterManager manager;
+    const auto load_result = manager.ensureLoaded();
+    ASSERT_TRUE(load_result.has_value()) << load_result.error();
+    manager.setSessionDefaults(**parsed);
+    const auto recreated = manager.createForDataset(
+        "/tmp/override_dataset", "/tmp/override_output");
+    EXPECT_TRUE(recreated.dataset.output_path_explicit);
+    EXPECT_EQ(recreated.dataset.output_path, std::filesystem::path("/tmp/override_output"));
+    ASSERT_EQ(recreated.export_formats.size(), 1u);
+    EXPECT_EQ(recreated.export_formats.front(), lfs::core::param::OutputFormat::PLY);
 }
 
 TEST(ArgumentParserTest, TrainingDefaultsApplyMaxWidthCap) {

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -8128,6 +8128,7 @@ namespace lfs::vis {
             ASSERT_NE(trainer, nullptr);
             auto params = trainer->getParams();
             params.dataset.output_path = output_path;
+            params.dataset.output_path_explicit = false;
             trainer->setParams(params);
 
             auto prepared =
@@ -8237,6 +8238,74 @@ namespace lfs::vis {
             ASSERT_TRUE(prepared)
                 << lfs::format_for_developer(
                        prepared.error());
+        }
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           StartTrainingWithCliOutputPathBindsProjectThere) {
+        const auto& temporary = temporary_.path;
+        const auto output_path =
+            temporary / "train-cli-out";
+        std::filesystem::create_directories(output_path);
+        auto options = projectOptions();
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()
+                            ->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr,
+                    viewer.getViewport());
+            auto* const lifecycle =
+                viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            ASSERT_FALSE(lifecycle->hasSourcePath());
+
+            auto& scene = viewer.getScene();
+            const auto cameras =
+                scene.addGroup("Train cameras");
+            scene.addCamera(
+                "camera.png", cameras,
+                make_project_request_test_camera());
+            viewer.getTrainerManager()->setTrainer(
+                std::make_unique<
+                    lfs::training::Trainer>(scene));
+            auto* const trainer = viewer.getTrainer();
+            ASSERT_NE(trainer, nullptr);
+            auto params = trainer->getParams();
+            params.dataset.output_path = output_path;
+            params.dataset.output_path_explicit = true;
+            trainer->setParams(params);
+
+            auto prepared =
+                lifecycle->prepareTrainingStartProject();
+            ASSERT_TRUE(prepared)
+                << lfs::format_for_developer(
+                       prepared.error());
+            EXPECT_TRUE(lifecycle->hasSourcePath());
+            EXPECT_FALSE(lifecycle->isTempProject());
+            const auto expected =
+                std::filesystem::absolute(
+                    output_path / "project.licht")
+                    .lexically_normal();
+            const auto bound =
+                trainer->bound_project_path();
+            ASSERT_TRUE(bound.has_value());
+            EXPECT_EQ(
+                bound->lexically_normal(), expected);
+            ASSERT_TRUE(
+                lifecycle->document_->source_path());
+            EXPECT_EQ(
+                lifecycle->document_->source_path()
+                    ->lexically_normal(),
+                expected);
+            EXPECT_TRUE(std::filesystem::exists(
+                output_path / "project.licht"));
+            const auto policy =
+                trainer->trainer_project_save_policy();
+            EXPECT_TRUE(policy.on_completion);
+            EXPECT_TRUE(policy.at_step_boundaries);
+            EXPECT_FALSE(policy.on_stop_or_error);
         }
     }
 


### PR DESCRIPTION
Running `-d data -o out ... --export ply` without `--headless` opens the GUI path. There the training project stayed in the untitled temp file, so `out/` was empty when training finished and the project could be lost when the app closed. `--export` only worked in the headless path.

Now an explicit `-o` on the command line binds the project to `out/project.licht` from the start, using the same routine as Save As. The final export runs after the last project save in both flows, so `--export ply` writes `splat_<iter>.ply` next to `project.licht` in the GUI flow too. Loading a dataset from the GUI without `-o` keeps the untitled temp project as before.

Checked with `-d data/bicycle -o out --strategy mrnf --train -i 300 --export ply` in the GUI: `out/project.licht` and `out/splat_300.ply` are written, nothing is left in the temp folder. Tests added for the parser and the project binding.

Fixes #1900
