### PR TITLE
Fix .licht resume anomalies: q16 pre-allocation, explicit -o, quiet shutdown

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -88,6 +88,18 @@ namespace lfs::app {
                 const HeadlessPluginSignalGuard&) = delete;
         };
 
+        [[nodiscard]] std::filesystem::path headless_project_save_destination(
+            const core::param::TrainingParameters& cli_params,
+            const std::filesystem::path& source) {
+            if (!cli_params.dataset.output_path_explicit)
+                return source;
+
+            const auto destination = cli_params.dataset.output_path / "project.licht";
+            LOG_INFO("Headless resume project destination: {}",
+                     core::path_to_utf8(destination));
+            return destination;
+        }
+
         [[nodiscard]] lfs::Error training_project_error(
             const lfs::ErrorCode code,
             std::string detail,
@@ -509,7 +521,8 @@ namespace lfs::app {
                         training::grant_headless_project_saves(
                             *installed->trainer,
                             effective_params,
-                            *params->resume_project);
+                            headless_project_save_destination(
+                                *params, *params->resume_project));
                         manager->setTrainer(
                             std::move(installed->trainer));
                     } else {
@@ -725,7 +738,8 @@ namespace lfs::app {
                         std::move(installed->trainer);
                     training::grant_headless_project_saves(
                         *trainer, project->params,
-                        *params->resume_project);
+                        headless_project_save_destination(
+                            *params, *params->resume_project));
                     LOG_INFO(
                         "Project display hydration complete; full "
                         "trainer state restored at iteration {}",

--- a/src/io/pipelined_image_loader.cpp
+++ b/src/io/pipelined_image_loader.cpp
@@ -124,6 +124,10 @@ namespace lfs::io {
 
         void cancel() { cv_.notify_all(); }
 
+        [[nodiscard]] bool cancelled() const noexcept {
+            return !running_ || !running_->load(std::memory_order_acquire);
+        }
+
         void reclaim_idle() {
             std::lock_guard<std::mutex> lock(mutex_);
             for (auto& slot : slots_) {
@@ -2324,8 +2328,13 @@ namespace lfs::io {
                 }
                 if (!rgb_batch_indices.empty()) {
                     auto leases = decoded_frame_ring_->acquire_batch(rgb_batch_indices.size());
-                    if (leases.empty())
+                    if (leases.empty()) {
+                        if (decoded_frame_ring_->cancelled()) {
+                            LOG_DEBUG("[PipelinedImageLoader] GPU batch decode cancelled during shutdown");
+                            return;
+                        }
                         throw std::runtime_error("decoded frame ring cancelled");
+                    }
                     rgb_batch_indices.resize(leases.size());
                     std::vector<std::pair<const uint8_t*, size_t>> spans;
                     spans.reserve(rgb_batch_indices.size());

--- a/src/training/strategies/mcmc.cpp
+++ b/src/training/strategies/mcmc.cpp
@@ -6,6 +6,7 @@
 #include "core/cuda/sh_layout.cuh"
 #include "core/cuda_error.hpp"
 #include "core/logger.hpp"
+#include "core/sh_value_quant.hpp"
 #include "diagnostics/vram_profiler.hpp"
 #include "kernels/densification_kernels.hpp"
 #include "kernels/mcmc_kernels.hpp"
@@ -938,6 +939,8 @@ namespace lfs::training {
                 // releases the freed chunk — so only replace if the param's capacity is actually
                 // below the target.
                 auto ensure_capacity_direct = [capacity](Tensor& param) {
+                    LFS_ASSERT_MSG(param.dtype() == DataType::Float32,
+                                   "MCMC training parameter must be Float32");
                     if (param.capacity() >= capacity)
                         return;
                     // GUI exportable tensors grow with live N.
@@ -949,17 +952,25 @@ namespace lfs::training {
                     param = std::move(new_param);
                 };
 
-                // shN is 1D swizzled — its capacity must be in FLOATS, not row count.
                 const auto layout_rest = static_cast<uint32_t>(_splat_data->max_sh_coeffs_rest());
-                auto ensure_shN_capacity_direct = [capacity, layout_rest](Tensor& param) {
-                    const size_t cap_floats = lfs::core::sh_swizzled_float_count(capacity, layout_rest);
-                    if (param.capacity() >= cap_floats)
+                const bool shN_quantized = _splat_data->shN_value_quantized();
+                auto ensure_shN_capacity_direct = [capacity, layout_rest, shN_quantized](Tensor& param) {
+                    const auto expected_dtype = shN_quantized ? DataType::Float16 : DataType::Float32;
+                    LFS_ASSERT_MSG(param.dtype() == expected_dtype,
+                                   "MCMC shN dtype does not match its storage representation");
+                    const size_t required_capacity =
+                        shN_quantized
+                            ? lfs::core::sh_value_quant::sh_value_u16_count(capacity, layout_rest)
+                            : lfs::core::sh_swizzled_float_count(capacity, layout_rest);
+                    if (param.capacity() >= required_capacity)
                         return;
                     if (param.is_external_storage())
                         return;
-                    auto new_param = Tensor::zeros_direct(param.shape(), cap_floats);
-                    cudaMemcpy(new_param.ptr<float>(), param.ptr<float>(),
-                               param.numel() * sizeof(float), cudaMemcpyDeviceToDevice);
+                    auto new_param = Tensor::zeros_direct(
+                        param.shape(), required_capacity, Device::CUDA, param.dtype());
+                    cudaMemcpy(new_param.data_ptr(), param.data_ptr(),
+                               param.numel() * dtype_size(param.dtype()),
+                               cudaMemcpyDeviceToDevice);
                     param = std::move(new_param);
                 };
 

--- a/tests/test_dual_rep_optimizer.cpp
+++ b/tests/test_dual_rep_optimizer.cpp
@@ -487,6 +487,9 @@ TEST(DualRepOptimizer, MRNF_PerSplatMeanStepWithQuantizedAdamIsFinite) {
     opt_params.iterations = 200;
     opt_params.max_cap = 32;
     opt_params.sh_degree_interval = 10000;
+    // The per-splat mean step ships behind the opt-in Background Improvements
+    // switch; the test exercises that path, so it must opt in.
+    opt_params.background_improvements = true;
     ASSERT_NO_THROW(strategy.initialize(opt_params));
 
     std::vector<float> log_s(8 * 3);

--- a/tests/test_dual_rep_optimizer.cpp
+++ b/tests/test_dual_rep_optimizer.cpp
@@ -454,6 +454,28 @@ TEST(DualRepOptimizer, MCMC_InitializeWithBothCodecsOn) {
                                       layout_rest));
 }
 
+TEST(DualRepOptimizer, MCMC_InitializeWithPrequantizedShN) {
+    CodecsOnGuard guard;
+    constexpr size_t n = 20;
+    constexpr size_t max_cap = 40;
+    auto splat = make_sh_splat(n, 3);
+    ASSERT_TRUE(sh_value::apply_shN_value_quant(splat));
+    ASSERT_TRUE(splat.shN_value_quantized());
+
+    MCMC strategy(splat);
+    param::OptimizationParameters opt_params;
+    opt_params.iterations = 100;
+    opt_params.max_cap = static_cast<int>(max_cap);
+    ASSERT_NO_THROW(strategy.initialize(opt_params));
+
+    const auto layout_rest = static_cast<uint32_t>(strategy.get_model().max_sh_coeffs_rest());
+    EXPECT_GE(strategy.get_model().shN_raw().capacity(),
+              sh_value_quant::sh_value_u16_count(max_cap, layout_rest));
+    EXPECT_GE(strategy.get_model().scaling_raw().capacity(), max_cap);
+    EXPECT_GE(strategy.get_model().rotation_raw().capacity(), max_cap);
+    EXPECT_GE(strategy.get_model().opacity_raw().capacity(), max_cap);
+}
+
 TEST(DualRepOptimizer, MRNF_PerSplatMeanStepWithQuantizedAdamIsFinite) {
     CodecsOnGuard guard;
     auto splat = make_sh_splat(8, 3);


### PR DESCRIPTION
Three defects found while verifying #1909 (resume from .licht works on master, headless and GUI; the verification itself passed), plus one test repair.

**MCMC capacity pre-allocation fails on project restore** (091229cd9)
`MCMC::initialize` runs twice when a trainer is installed from a .licht checkpoint. The first pass quantizes shN to u16; the second pass computed capacity with the float helper and called `ptr<float>()` on the quantized tensor, tripping the tensor dtype contract. The catch then skipped pre-allocation of scaling/rotation/opacity, so restored sessions grew those tensors incrementally (VRAM churn) and logged an LFS FAILURE REPORT on every GUI restore. The shN lambda is now representation-aware: q16 capacity via `sh_value_quant::sh_value_u16_count`, allocation in the resident dtype, byte-correct copy. Regression test added (`DualRepOptimizer.MCMC_InitializeWithPrequantizedShN`).

**`--resume X.licht -o B` silently ignored `-o`** (d8302328b)
Both headless resume branches passed the source project as the save destination, so the final project appended into the source and the requested output directory stayed empty. With an explicit `-o` the final project is now written to `<output>/project.licht` (the source stays untouched, resume-as-fork); without `-o` the in-place append is unchanged. Detection uses the existing `output_path_explicit` CLI presence flag, so a restored project's serialized output path cannot trigger it.

**Deliberate shutdown logged as a decode error** (61df9abb2)
A no-op resume (target already reached) tore down the image loader through the batch-decode catch-all: error-level "Batch decode error: decoded frame ring cancelled" plus a pointless per-item CPU fallback walk. Ring cancellation is now detected before the throw and exits the batch quietly at debug level; real decode errors keep the existing path.

**Born-failing gtest** (d194a5de3)
`DualRepOptimizer.MRNF_PerSplatMeanStepWithQuantizedAdamIsFinite` was written while `mrnf_defaults()` still had `background_improvements = true` and landed together with the default-off flip, so it asserted a path that defaults disable. The test now opts into the switch it exercises. Suite is 14/14.

Verification: build clean, `DualRepOptimizer.*` green, `compute-sanitizer memcheck` clean on the resume repro, GUI project restore shows zero failure reports and both initialize passes pre-allocate, headless proofs for the `-o` fork (source sha256 unchanged, output project loads and continues) and for the quiet no-op shutdown (zero error lines, exit 0).
