### PR TITLE
Rename the Minecraft progress bar style to Miner

### DIFF
--- a/docs/docs/development/preferences-and-user-storage.md
+++ b/docs/docs/development/preferences-and-user-storage.md
@@ -17,7 +17,7 @@ The Preferences panel currently exposes:
 - working folder (the parent of the temp project directory used for untitled
   sessions);
 - application theme and UI scale;
-- status bar progress bar style (`status_bar_progress_style`: `classic` or `minecraft`);
+- status bar progress bar style (`status_bar_progress_style`: `classic` or `miner`);
 - viewport scene reconstruction backend and backend-specific preset;
 - camera navigation mode and axis/view snap;
 - per-setting remember options;

--- a/src/python/lfs/py_ui_theme.cpp
+++ b/src/python/lfs/py_ui_theme.cpp
@@ -128,11 +128,11 @@ namespace lfs::python {
         m.def("set_scene_graph_selection_markers", &lfs::vis::saveSceneGraphSelectionMarkersPreference,
               nb::arg("enabled"), "Show or hide Scene Graph selection markers");
         m.def("get_progress_bar_style", &lfs::vis::loadProgressBarStylePreference,
-              "Return the status bar progress style (classic or minecraft)");
+              "Return the status bar progress style (classic or miner)");
         m.def(
             "set_progress_bar_style",
             [](const std::string& style) { lfs::vis::saveProgressBarStylePreference(style); },
-            nb::arg("style"), "Set the status bar progress style (classic or minecraft)");
+            nb::arg("style"), "Set the status bar progress style (classic or miner)");
     }
 
 } // namespace lfs::python

--- a/src/python/lfs_plugins/preferences_panel.py
+++ b/src/python/lfs_plugins/preferences_panel.py
@@ -43,7 +43,7 @@ class PreferencesPanel(Panel):
 
     PROGRESS_BAR_OPTIONS = (
         ("classic", "preferences.progress_bar_classic"),
-        ("minecraft", "preferences.progress_bar_minecraft"),
+        ("miner", "preferences.progress_bar_miner"),
     )
 
     EXPANDABLE_SECTIONS = (

--- a/src/python/stubs/lichtfeld/ui/__init__.pyi
+++ b/src/python/stubs/lichtfeld/ui/__init__.pyi
@@ -236,10 +236,10 @@ def set_scene_graph_selection_markers(enabled: bool) -> None:
     """Show or hide Scene Graph selection markers"""
 
 def get_progress_bar_style() -> str:
-    """Return the status bar progress style (classic or minecraft)"""
+    """Return the status bar progress style (classic or miner)"""
 
 def set_progress_bar_style(style: str) -> None:
-    """Set the status bar progress style (classic or minecraft)"""
+    """Set the status bar progress style (classic or miner)"""
 
 class PanelSpace(enum.Enum):
     SIDE_PANEL = 0

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -767,7 +767,7 @@
     "appearance": "Erscheinungsbild",
     "progress_bar_style": "Fortschrittsbalken",
     "progress_bar_classic": "Klassisch",
-    "progress_bar_minecraft": "Minecraft",
+    "progress_bar_miner": "Miner",
     "scene_rendering": "Szenen-Rendering",
     "scene_reconstruction": "Szenenrekonstruktion",
     "scene_reconstruction_off": "Aus",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -767,7 +767,7 @@
     "appearance": "Appearance",
     "progress_bar_style": "Progress bar",
     "progress_bar_classic": "Classic",
-    "progress_bar_minecraft": "Minecraft",
+    "progress_bar_miner": "Miner",
     "scene_rendering": "Scene Rendering",
     "scene_reconstruction": "Scene Reconstruction",
     "scene_reconstruction_off": "Off",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -767,7 +767,7 @@
     "appearance": "Apariencia",
     "progress_bar_style": "Barra de progreso",
     "progress_bar_classic": "Clásico",
-    "progress_bar_minecraft": "Minecraft",
+    "progress_bar_miner": "Miner",
     "scene_rendering": "Renderizado de la escena",
     "scene_reconstruction": "Reconstrucción de la escena",
     "scene_reconstruction_off": "Desactivada",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -767,7 +767,7 @@
     "appearance": "Apparence",
     "progress_bar_style": "Barre de progression",
     "progress_bar_classic": "Classique",
-    "progress_bar_minecraft": "Minecraft",
+    "progress_bar_miner": "Miner",
     "scene_rendering": "Rendu de la scène",
     "scene_reconstruction": "Reconstruction de la scène",
     "scene_reconstruction_off": "Désactivée",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -767,7 +767,7 @@
     "appearance": "Aspetto",
     "progress_bar_style": "Barra di avanzamento",
     "progress_bar_classic": "Classico",
-    "progress_bar_minecraft": "Minecraft",
+    "progress_bar_miner": "Miner",
     "scene_rendering": "Rendering della scena",
     "scene_reconstruction": "Ricostruzione della scena",
     "scene_reconstruction_off": "Disattivata",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -767,7 +767,7 @@
     "appearance": "外観",
     "progress_bar_style": "進捗バー",
     "progress_bar_classic": "クラシック",
-    "progress_bar_minecraft": "Minecraft",
+    "progress_bar_miner": "Miner",
     "scene_rendering": "シーンレンダリング",
     "scene_reconstruction": "シーン再構成",
     "scene_reconstruction_off": "オフ",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -767,7 +767,7 @@
     "appearance": "모양",
     "progress_bar_style": "진행 표시줄",
     "progress_bar_classic": "클래식",
-    "progress_bar_minecraft": "Minecraft",
+    "progress_bar_miner": "Miner",
     "scene_rendering": "장면 렌더링",
     "scene_reconstruction": "장면 재구성",
     "scene_reconstruction_off": "끄기",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -767,7 +767,7 @@
     "appearance": "Uiterlijk",
     "progress_bar_style": "Voortgangsbalk",
     "progress_bar_classic": "Klassiek",
-    "progress_bar_minecraft": "Minecraft",
+    "progress_bar_miner": "Miner",
     "scene_rendering": "Scènerendering",
     "scene_reconstruction": "Scènereconstructie",
     "scene_reconstruction_off": "Uit",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -767,7 +767,7 @@
     "appearance": "Wygląd",
     "progress_bar_style": "Pasek postępu",
     "progress_bar_classic": "Klasyczny",
-    "progress_bar_minecraft": "Minecraft",
+    "progress_bar_miner": "Miner",
     "scene_rendering": "Renderowanie sceny",
     "scene_reconstruction": "Rekonstrukcja sceny",
     "scene_reconstruction_off": "Wyłączona",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -767,7 +767,7 @@
     "appearance": "外观",
     "progress_bar_style": "进度条",
     "progress_bar_classic": "经典",
-    "progress_bar_minecraft": "Minecraft",
+    "progress_bar_miner": "Miner",
     "scene_rendering": "场景渲染",
     "scene_reconstruction": "场景重建",
     "scene_reconstruction_off": "关闭",

--- a/src/visualizer/gui/rml_status_bar.cpp
+++ b/src/visualizer/gui/rml_status_bar.cpp
@@ -184,7 +184,7 @@ namespace lfs::vis::gui {
                                      const bool past,
                                      const bool hovered,
                                      const bool preview,
-                                     const bool minecraft) {
+                                     const bool miner) {
             const float left_pct = std::clamp(
                 100.0f * static_cast<float>(step) / static_cast<float>(total_iterations),
                 0.5f,
@@ -198,7 +198,7 @@ namespace lfs::vis::gui {
             if (preview)
                 classes += " is-preview";
 
-            if (minecraft) {
+            if (miner) {
                 markers += std::format(
                     "<img class=\"{}\" src=\"../icon/mining/{}\" style=\"left:{:.3f}%;\"/>",
                     classes,
@@ -216,7 +216,7 @@ namespace lfs::vis::gui {
                                             const int total_iterations,
                                             const int current_iteration,
                                             const ProgressMarkerRenderState& state,
-                                            const bool minecraft) {
+                                            const bool miner) {
             if (total_iterations <= 0)
                 return {};
 
@@ -237,7 +237,7 @@ namespace lfs::vis::gui {
                                         save_step <= static_cast<size_t>(std::max(0, current_iteration)),
                                         !state.dragging && save_step == state.hover_step,
                                         false,
-                                        minecraft);
+                                        miner);
             }
 
             if (state.dragging && state.preview_step > 0 &&
@@ -248,7 +248,7 @@ namespace lfs::vis::gui {
                                         false,
                                         true,
                                         true,
-                                        minecraft);
+                                        miner);
             }
             return markers;
         }
@@ -393,7 +393,7 @@ namespace lfs::vis::gui {
         ctor.Bind("mode_text", &model_.mode_text);
         ctor.Bind("mode_color", &model_.mode_color);
         ctor.Bind("show_training", &model_.show_training);
-        ctor.Bind("progress_minecraft", &model_.progress_minecraft);
+        ctor.Bind("progress_miner", &model_.progress_miner);
         ctor.Bind("miner_raised", &model_.miner_raised);
         ctor.Bind("miner_step_a", &model_.miner_step_a);
         ctor.Bind("miner_strike", &model_.miner_strike);
@@ -1317,23 +1317,23 @@ namespace lfs::vis::gui {
         if (progress_style_checked_at_ == std::chrono::steady_clock::time_point{} ||
             now - progress_style_checked_at_ >= std::chrono::seconds(1)) {
             progress_style_checked_at_ = now;
-            progress_minecraft_pref_ = loadProgressBarStylePreference() == "minecraft";
+            progress_miner_pref_ = loadProgressBarStylePreference() == "miner";
         }
-        setModelBool("progress_minecraft", model_.progress_minecraft, progress_minecraft_pref_);
+        setModelBool("progress_miner", model_.progress_miner, progress_miner_pref_);
         const bool running = training_state == TrainingState::Running;
         const auto animation_ms =
             std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
         const auto swing_phase_ms = animation_ms % 550;
         const bool strike_phase = running && swing_phase_ms >= 350;
         const int walk_phase = static_cast<int>((animation_ms / 275) % 4);
-        const bool minecraft_running = progress_minecraft_pref_ && show_training && running;
+        const bool miner_running = progress_miner_pref_ && show_training && running;
         setModelBool("miner_raised", model_.miner_raised,
-                     minecraft_running && !strike_phase && walk_phase != 0 && walk_phase != 2);
+                     miner_running && !strike_phase && walk_phase != 0 && walk_phase != 2);
         setModelBool("miner_step_a", model_.miner_step_a,
-                     minecraft_running && !strike_phase && walk_phase == 0);
-        setModelBool("miner_strike", model_.miner_strike, minecraft_running && strike_phase);
+                     miner_running && !strike_phase && walk_phase == 0);
+        setModelBool("miner_strike", model_.miner_strike, miner_running && strike_phase);
         setModelBool("miner_step_b", model_.miner_step_b,
-                     minecraft_running && !strike_phase && walk_phase == 2);
+                     miner_running && !strike_phase && walk_phase == 2);
         setModelString("step_label", model_.step_label, LOC(lichtfeld::Strings::Status::STEP));
         setModelString("loss_label", model_.loss_label, LOC(lichtfeld::Strings::Status::LOSS));
         setModelString("gaussians_label", model_.gaussians_label,
@@ -1374,14 +1374,14 @@ namespace lfs::vis::gui {
                         text_width_dp = measured_width_dp;
                 }
             }
-            const float text_left_dp = progress_minecraft_pref_
+            const float text_left_dp = progress_miner_pref_
                                            ? mining::miningProgressTextLeftDp(progress * bar_dp, bar_dp,
                                                                               text_width_dp)
                                            : 0.0f;
             setModelString("progress_text_left", model_.progress_text_left,
                            std::format("{:.2f}dp", text_left_dp));
 
-            if (progress_minecraft_pref_) {
+            if (progress_miner_pref_) {
                 updateMiningScene(progress, now, training_state == TrainingState::Paused);
             } else {
                 setProgressWallRml("");
@@ -1396,7 +1396,7 @@ namespace lfs::vis::gui {
                 .hover_step = save_step_interaction_.hover_step,
             };
             setProgressMarkersRml(buildProgressMarkersRml(tm->getSaveSteps(), total, cur, marker_state,
-                                                          progress_minecraft_pref_));
+                                                          progress_miner_pref_));
             setModelString("step_value", model_.step_value, std::format("{}/{}", cur, total));
             setModelString("loss_value", model_.loss_value, std::format("{:.4f}", loss));
             setModelString("gaussians_value", model_.gaussians_value,
@@ -1434,22 +1434,22 @@ namespace lfs::vis::gui {
             setModelString("eta_value", model_.eta_value, "");
         }
 
-        const bool minecraft_smoke = progress_minecraft_pref_ && show_training &&
-                                     training_state == TrainingState::Paused &&
-                                     mining_scene_.pause_started !=
-                                         std::chrono::steady_clock::time_point{};
-        const int smoke_frame = minecraft_smoke
+        const bool miner_smoke = progress_miner_pref_ && show_training &&
+                                 training_state == TrainingState::Paused &&
+                                 mining_scene_.pause_started !=
+                                     std::chrono::steady_clock::time_point{};
+        const int smoke_frame = miner_smoke
                                     ? mining::miningSmokeSpriteIndex(static_cast<int>(
                                           std::chrono::duration_cast<std::chrono::milliseconds>(
                                               now - mining_scene_.pause_started)
                                               .count()))
                                     : 0;
-        setModelBool("miner_smoke_1", model_.miner_smoke_1, minecraft_smoke && smoke_frame == 0);
-        setModelBool("miner_smoke_2", model_.miner_smoke_2, minecraft_smoke && smoke_frame == 1);
-        setModelBool("miner_smoke_3", model_.miner_smoke_3, minecraft_smoke && smoke_frame == 2);
-        setModelBool("miner_smoke_4", model_.miner_smoke_4, minecraft_smoke && smoke_frame == 3);
-        setModelBool("miner_smoke_5", model_.miner_smoke_5, minecraft_smoke && smoke_frame == 4);
-        setModelBool("miner_smoke_6", model_.miner_smoke_6, minecraft_smoke && smoke_frame == 5);
+        setModelBool("miner_smoke_1", model_.miner_smoke_1, miner_smoke && smoke_frame == 0);
+        setModelBool("miner_smoke_2", model_.miner_smoke_2, miner_smoke && smoke_frame == 1);
+        setModelBool("miner_smoke_3", model_.miner_smoke_3, miner_smoke && smoke_frame == 2);
+        setModelBool("miner_smoke_4", model_.miner_smoke_4, miner_smoke && smoke_frame == 3);
+        setModelBool("miner_smoke_5", model_.miner_smoke_5, miner_smoke && smoke_frame == 4);
+        setModelBool("miner_smoke_6", model_.miner_smoke_6, miner_smoke && smoke_frame == 5);
 
         // Splat section (non-training)
         bool show_splats = !show_training && content_type != SceneManager::ContentType::Empty;
@@ -1626,12 +1626,12 @@ namespace lfs::vis::gui {
             (model_.show_gpu_model ? uint32_t{1} << 7 : 0) |
             (model_.account_show_tier ? uint32_t{1} << 8 : 0);
 
-        const bool minecraft_visible = progress_minecraft_pref_ && show_training;
+        const bool miner_visible = progress_miner_pref_ && show_training;
         animation_active_ = wasd_visible || zoom_visible || status_msg.visible ||
-                            minecraft_visible;
-        next_refresh_at_ = now + (minecraft_visible && training_state == TrainingState::Running
+                            miner_visible;
+        next_refresh_at_ = now + (miner_visible && training_state == TrainingState::Running
                                       ? kBusyRefreshInterval
-                                  : minecraft_visible ? kMiningRefreshInterval
+                                  : miner_visible     ? kMiningRefreshInterval
                                   : animation_active_ ? kAnimatedRefreshInterval
                                   : ctx.is_training   ? kBusyRefreshInterval
                                                       : kIdleRefreshInterval);

--- a/src/visualizer/gui/rml_status_bar.hpp
+++ b/src/visualizer/gui/rml_status_bar.hpp
@@ -190,7 +190,7 @@ namespace lfs::vis::gui {
         MiningSceneState mining_scene_;
         std::string mining_wall_rml_;
         std::string mining_debris_rml_;
-        bool progress_minecraft_pref_ = false;
+        bool progress_miner_pref_ = false;
         std::chrono::steady_clock::time_point progress_style_checked_at_{};
 
         struct ModelState {
@@ -199,7 +199,7 @@ namespace lfs::vis::gui {
             std::string mode_text;
             std::string mode_color;
             bool show_training = false;
-            bool progress_minecraft = false;
+            bool progress_miner = false;
             bool miner_raised = false;
             bool miner_step_a = false;
             bool miner_strike = false;

--- a/src/visualizer/gui/rmlui/resources/statusbar.rcss
+++ b/src/visualizer/gui/rmlui/resources/statusbar.rcss
@@ -314,7 +314,7 @@ body {
     margin-left: -4dp;
 }
 
-#progress-container.minecraft .progress-marker {
+#progress-container.miner .progress-marker {
     top: 2dp;
     width: 12dp;
     height: 12dp;
@@ -324,8 +324,8 @@ body {
     background-color: transparent;
 }
 
-#progress-container.minecraft .progress-marker.is-hovered,
-#progress-container.minecraft .progress-marker.is-preview {
+#progress-container.miner .progress-marker.is-hovered,
+#progress-container.miner .progress-marker.is-preview {
     top: 1dp;
     width: 14dp;
     height: 14dp;
@@ -344,7 +344,7 @@ body {
     z-index: 1;
 }
 
-#progress-text.progress-text--minecraft {
+#progress-text.progress-text--miner {
     width: auto;
     text-align: left;
 }

--- a/src/visualizer/gui/rmlui/resources/statusbar.rml
+++ b/src/visualizer/gui/rmlui/resources/statusbar.rml
@@ -10,7 +10,7 @@
         <div id="training-section" class="hidden" data-class-hidden="!show_training">
             <span class="separator section-sep">|</span>
             <div id="progress-group" class="status-item">
-                <div id="progress-container" data-class-minecraft="progress_minecraft">
+                <div id="progress-container" data-class-miner="progress_miner">
                     <div id="progress-wall"></div>
                     <div id="progress-fill" data-style-width="progress_width"></div>
                     <div id="progress-debris"></div>
@@ -25,7 +25,7 @@
                     <img class="progress-figure smoke" src="../icon/mining/miner-smoke-4.png" data-style-left="progress_width" data-class-hidden="!miner_smoke_4"/>
                     <img class="progress-figure smoke" src="../icon/mining/miner-smoke-5.png" data-style-left="progress_width" data-class-hidden="!miner_smoke_5"/>
                     <img class="progress-figure smoke" src="../icon/mining/miner-smoke-6.png" data-style-left="progress_width" data-class-hidden="!miner_smoke_6"/>
-                    <span id="progress-text" data-class-progress-text--minecraft="progress_minecraft" data-style-left="progress_text_left">{{ progress_text }}</span>
+                    <span id="progress-text" data-class-progress-text--miner="progress_miner" data-style-left="progress_text_left">{{ progress_text }}</span>
                 </div>
             </div>
             <div id="step-metric" class="status-item">

--- a/src/visualizer/preferences.cpp
+++ b/src/visualizer/preferences.cpp
@@ -42,7 +42,7 @@ namespace lfs::vis {
         }
 
         [[nodiscard]] bool knownProgressBarStyle(std::string_view style) {
-            return style == "classic" || style == "minecraft";
+            return style == "classic" || style == "miner";
         }
 
         [[nodiscard]] lfs::Error workingDirectoryError(

--- a/tests/test_status_bar_fit.cpp
+++ b/tests/test_status_bar_fit.cpp
@@ -94,7 +94,7 @@ namespace {
         std::string mode_text = "Training (Default/3DGS)";
         std::string mode_color = "#ffffff";
         bool show_training = true;
-        bool progress_minecraft = false;
+        bool progress_miner = false;
         bool miner_raised = false;
         bool miner_strike = false;
         std::string progress_width = "50%";
@@ -223,7 +223,7 @@ namespace {
             bound &= constructor.Bind("mode_text", &model_.mode_text);
             bound &= constructor.Bind("mode_color", &model_.mode_color);
             bound &= constructor.Bind("show_training", &model_.show_training);
-            bound &= constructor.Bind("progress_minecraft", &model_.progress_minecraft);
+            bound &= constructor.Bind("progress_miner", &model_.progress_miner);
             bound &= constructor.Bind("miner_raised", &model_.miner_raised);
             bound &= constructor.Bind("miner_strike", &model_.miner_strike);
             bound &= constructor.Bind("progress_width", &model_.progress_width);


### PR DESCRIPTION
The progress bar style is now called Miner instead of Minecraft.

The old name is gone from the whole codebase: the preference value, the picker in Preferences > Appearance, the locale keys in all ten languages, the RML classes, the data model binding, the Python API docs and stubs, the developer docs and the tests. The mining sprites and animation code already used miner names, so everything matches now.

There is no legacy mapping on purpose. A stored minecraft value falls back to Classic, so if you had the style on, pick Miner once in Preferences and you are set.
