### PR TITLE
Fix unstable spherical harmonics updates during training

### DIFF
--- a/src/training/optimizer/adam_optimizer.cpp
+++ b/src/training/optimizer/adam_optimizer.cpp
@@ -31,6 +31,7 @@ namespace lfs::training {
 
     namespace {
         constexpr int SH_WARMUP_ITERATIONS = 1000;
+        constexpr int SH_BAND_COUNT = 3;
         constexpr float DEFAULT_GROWTH_MULTIPLIER = 1.5f;
 
         std::atomic<uint64_t> g_adam_slow_path_grow_count{0};
@@ -55,6 +56,44 @@ namespace lfs::training {
                 return 0;
             }
             return (tensor.capacity() > 0 ? tensor.capacity() : tensor.shape()[0]) * row_size;
+        }
+
+        [[nodiscard]] int active_sh_band_count(const lfs::core::SplatData& splat_data) {
+            return std::clamp(splat_data.get_active_sh_degree(), 0, SH_BAND_COUNT);
+        }
+
+        void advance_sh_band_steps(AdamParamState& state, const int active_bands) {
+            for (int band = 0; band < active_bands; ++band) {
+                ++state.sh_band_step_count[static_cast<size_t>(band)];
+            }
+        }
+
+        void prepare_sh_band_corrections(
+            const AdamConfig& config,
+            const AdamParamState& state,
+            const int active_bands,
+            const bool next_step,
+            const float learning_rate,
+            float (&step_size)[SH_BAND_COUNT],
+            float (&bias_correction2_sqrt_rcp)[SH_BAND_COUNT]) {
+            for (int band = 0; band < SH_BAND_COUNT; ++band) {
+                const auto index = static_cast<size_t>(band);
+                const int64_t step = state.sh_band_step_count[index] +
+                                     ((next_step && band < active_bands) ? 1 : 0);
+                if (step <= 0) {
+                    step_size[index] = 0.0f;
+                    bias_correction2_sqrt_rcp[index] = 1.0f;
+                    continue;
+                }
+                const double bias_correction1_rcp =
+                    1.0 / (1.0 - std::pow(config.beta1, step));
+                const double correction2_sqrt_rcp =
+                    1.0 / std::sqrt(1.0 - std::pow(config.beta2, step));
+                step_size[index] =
+                    learning_rate * static_cast<float>(bias_correction1_rcp);
+                bias_correction2_sqrt_rcp[index] =
+                    static_cast<float>(correction2_sqrt_rcp);
+            }
         }
 
     } // namespace
@@ -399,6 +438,7 @@ namespace lfs::training {
             state.capacity = alloc_cap;
             state.size = logical_size;
             state.step_count = 0;
+            state.sh_band_step_count.fill(0);
             LOG_DEBUG("allocate_gradients({}): cap={}", name, state.capacity);
         }
         LOG_DEBUG("Allocated gradients for {} parameter groups", states_.size());
@@ -587,6 +627,7 @@ namespace lfs::training {
         state.capacity = std::max(initial_cap, logical_size);
         state.size = logical_size;
         state.step_count = 0;
+        state.sh_band_step_count.fill(0);
         if (type == ParamType::ShN) {
             const double mib = (2.0 * static_cast<double>(state.capacity) * sizeof(uint8_t) +
                                 2.0 * static_cast<double>(prim_capacity) * sizeof(float)) /
@@ -663,12 +704,24 @@ namespace lfs::training {
         }
 
         state.step_count++;
+        const int active_sh_bands =
+            type == ParamType::ShN ? active_sh_band_count(splat_data_) : 0;
+        if (type == ParamType::ShN) {
+            advance_sh_band_steps(state, active_sh_bands);
+        }
 
         auto& param_live = get_param(type);
 
         const double bias_correction1_rcp = 1.0 / (1.0 - std::pow(config_.beta1, state.step_count));
         const double bias_correction2_sqrt_rcp = 1.0 / std::sqrt(1.0 - std::pow(config_.beta2, state.step_count));
         const float param_lr = static_cast<float>(get_param_lr(type));
+        float sh_band_step_size[SH_BAND_COUNT] = {};
+        float sh_band_bias_correction2_sqrt_rcp[SH_BAND_COUNT] = {1.0f, 1.0f, 1.0f};
+        if (type == ParamType::ShN) {
+            prepare_sh_band_corrections(
+                config_, state, active_sh_bands, /*next_step=*/false, param_lr,
+                sh_band_step_size, sh_band_bias_correction2_sqrt_rcp);
+        }
 
         cudaStream_t execution_stream = state.grad.stream();
         if (execution_stream == nullptr) {
@@ -748,10 +801,12 @@ namespace lfs::training {
                     sh_value_bits,
                     sh_value_n_cells,
                     param_lr * static_cast<float>(bias_correction1_rcp),
+                    sh_band_step_size,
                     static_cast<float>(config_.beta1),
                     static_cast<float>(config_.beta2),
                     static_cast<float>(config_.eps),
                     static_cast<float>(bias_correction2_sqrt_rcp),
+                    sh_band_bias_correction2_sqrt_rcp,
                     execution_stream);
                 param_live.set_stream(execution_stream);
                 state.exp_avg.set_stream(execution_stream);
@@ -1022,6 +1077,15 @@ namespace lfs::training {
         fused.shN = prepare_param(ParamType::ShN,
                                   static_cast<int>(lfs::core::sh_float4_slots_for_rest(layout_rest) * 4u),
                                   active_rest > 0 && iteration > SH_WARMUP_ITERATIONS);
+        if (fused.shN.enabled) {
+            auto& sh_state = states_.at(param_name(ParamType::ShN));
+            prepare_sh_band_corrections(
+                config_, sh_state, active_sh_band_count(splat_data_),
+                /*next_step=*/true, static_cast<float>(get_param_lr(ParamType::ShN)),
+                fused.shN.sh_band_step_size,
+                fused.shN.sh_band_bias_correction2_sqrt_rcp);
+            fused.shN.use_sh_band_corrections = true;
+        }
         // Generation-checked q16 fetch — never bake a pre-grow exportable pointer.
         if (fused.shN.enabled && splat_data_.shN_value_quantized() &&
             splat_data_.shN_value_bounds().is_valid()) {
@@ -1079,6 +1143,9 @@ namespace lfs::training {
             auto& state = states_[name];
             if (state.exp_avg.is_valid() && state.is_joint()) {
                 state.step_count++;
+                if (type == ParamType::ShN) {
+                    advance_sh_band_steps(state, active_sh_band_count(splat_data_));
+                }
             }
         }
         fused_step_iteration_ = iteration;
@@ -1777,7 +1844,8 @@ namespace lfs::training {
         // v1: fp32 moments (no scales).
         // v2: uint8 quantised moments + per-primitive fp32 scales (legacy codec only).
         // v3: per-state joint_bits marker; joint packs (exp_avg + joint_bounds), legacy keeps v2 tensors.
-        constexpr uint32_t ADAM_STATE_VERSION = 3;
+        // v4: three SH-rest band step counters for degree-local Adam bias correction.
+        constexpr uint32_t ADAM_STATE_VERSION = 4;
     } // namespace
 
     void AdamOptimizer::serialize(std::ostream& os) const {
@@ -1819,6 +1887,9 @@ namespace lfs::training {
             os.write(reinterpret_cast<const char*>(&name_len), sizeof(name_len));
             os.write(name.data(), name_len);
             os.write(reinterpret_cast<const char*>(&state.step_count), sizeof(state.step_count));
+            os.write(
+                reinterpret_cast<const char*>(state.sh_band_step_count.data()),
+                sizeof(state.sh_band_step_count));
             os.write(reinterpret_cast<const char*>(&state.capacity), sizeof(state.capacity));
             os.write(reinterpret_cast<const char*>(&state.size), sizeof(state.size));
             // v3: joint_bits discriminates packed joint moments from legacy u8+scales.
@@ -1916,9 +1987,28 @@ namespace lfs::training {
 
             AdamParamState state;
             lfs::core::serialization_detail::read_exact(is, &state.step_count, sizeof(state.step_count), "Adam step count");
+            if (version >= 4) {
+                lfs::core::serialization_detail::read_exact(
+                    is,
+                    state.sh_band_step_count.data(),
+                    sizeof(state.sh_band_step_count),
+                    "Adam SH band step counts");
+            } else if (name == "shN") {
+                // Legacy checkpoints used the tensor-wide step for every active SH
+                // coefficient. Preserve that age for already-active bands while leaving
+                // future bands fresh when they are enabled after resume.
+                const int active_bands = active_sh_band_count(splat_data_);
+                for (int band = 0; band < active_bands; ++band) {
+                    state.sh_band_step_count[static_cast<size_t>(band)] =
+                        state.step_count;
+                }
+            }
             lfs::core::serialization_detail::read_exact(is, &state.capacity, sizeof(state.capacity), "Adam state capacity");
             lfs::core::serialization_detail::read_exact(is, &state.size, sizeof(state.size), "Adam state size");
-            if (state.step_count < 0 || state.size > state.capacity)
+            const bool invalid_band_step = std::any_of(
+                state.sh_band_step_count.begin(), state.sh_band_step_count.end(),
+                [](const int64_t step) { return step < 0; });
+            if (state.step_count < 0 || invalid_band_step || state.size > state.capacity)
                 throw std::runtime_error("Invalid AdamOptimizer checkpoint: inconsistent state bounds");
 
             // v3 introduces per-state joint_bits; v1/v2 are always legacy (joint_bits=0).
@@ -2136,6 +2226,7 @@ namespace lfs::training {
         if (state->joint_bounds.is_valid())
             state->joint_bounds.zero_();
         state->step_count = 0;
+        state->sh_band_step_count.fill(0);
     }
 
 } // namespace lfs::training

--- a/src/training/optimizer/adam_optimizer.hpp
+++ b/src/training/optimizer/adam_optimizer.hpp
@@ -51,6 +51,10 @@ namespace lfs::training {
         lfs::core::Tensor joint_bounds; // [n_bounds, 4] fp32; joint codec only
         int joint_bits = 0;             // 0=legacy, 8=SH, 16=non-SH
         int64_t step_count = 0;
+        // SH-rest bands are activated progressively. Their Adam bias-correction ages
+        // must start when each band becomes trainable instead of inheriting the age of
+        // the whole shN tensor. Unused for non-ShN parameter states.
+        std::array<int64_t, 3> sh_band_step_count{};
         size_t capacity = 0; // Allocated capacity (moment rows / float cells)
         size_t size = 0;     // Used size
         [[nodiscard]] bool is_joint() const noexcept { return joint_bits != 0; }
@@ -94,6 +98,11 @@ namespace lfs::training {
         int n_attributes = 0;
         float step_size = 0.0f;
         float bias_correction2_sqrt_rcp = 1.0f;
+        // shN-only bias corrections for degree bands l=1, l=2, l=3. The
+        // scalar fields above remain the fallback for non-SH and legacy callers.
+        float sh_band_step_size[3] = {0.0f, 0.0f, 0.0f};
+        float sh_band_bias_correction2_sqrt_rcp[3] = {1.0f, 1.0f, 1.0f};
+        bool use_sh_band_corrections = false;
         bool enabled = false;
         const float* screen_share_max = nullptr;
         int screen_share_n = 0;

--- a/src/training/rasterization/fast_rasterizer.cpp
+++ b/src/training/rasterization/fast_rasterizer.cpp
@@ -751,6 +751,12 @@ namespace lfs::training {
             dst.n_attributes = src.n_attributes;
             dst.step_size = src.step_size;
             dst.bias_correction2_sqrt_rcp = src.bias_correction2_sqrt_rcp;
+            for (int band = 0; band < 3; ++band) {
+                dst.sh_band_step_size[band] = src.sh_band_step_size[band];
+                dst.sh_band_bias_correction2_sqrt_rcp[band] =
+                    src.sh_band_bias_correction2_sqrt_rcp[band];
+            }
+            dst.use_sh_band_corrections = src.use_sh_band_corrections;
             dst.enabled = src.enabled;
             dst.screen_share_max = src.screen_share_max;
             dst.screen_share_n = src.screen_share_n;

--- a/src/training/rasterization/fastgs/optimizer/include/adam_api.h
+++ b/src/training/rasterization/fastgs/optimizer/include/adam_api.h
@@ -113,10 +113,12 @@ namespace fast_lfs::optimizer {
         int sh_value_bits,
         int sh_value_n_cells,
         float step_size,
+        const float* sh_band_step_size,
         float beta1,
         float beta2,
         float eps,
         float bias_correction2_sqrt_rcp,
+        const float* sh_band_bias_correction2_sqrt_rcp,
         cudaStream_t stream = nullptr);
 
     // Joint (u,log_s) densify reset: encode true (m,v)=(0,0). Widens block

--- a/src/training/rasterization/fastgs/optimizer/src/adam_shN_joint.cu
+++ b/src/training/rasterization/fastgs/optimizer/src/adam_shN_joint.cu
@@ -48,10 +48,12 @@ namespace fast_lfs::optimizer {
         const int sh_value_bits,
         const int sh_value_n_cells,
         const float step_size,
+        const float* sh_band_step_size,
         const float beta1,
         const float beta2,
         const float eps,
         const float bias_correction2_sqrt_rcp,
+        const float* sh_band_bias_correction2_sqrt_rcp,
         cudaStream_t stream) {
         LFS_VALIDATE_CUDA_DEVICE_POINTER(param, "param");
         LFS_VALIDATE_CUDA_DEVICE_POINTER(packed, "joint_packed");
@@ -67,6 +69,11 @@ namespace fast_lfs::optimizer {
         if (sh_value_bits != 0 && sh_value_bits != 16) {
             throw std::runtime_error(
                 "adam_step_shN_joint_from_grad: sh_value_bits must be 0 or 16");
+        }
+        if (sh_band_step_size == nullptr ||
+            sh_band_bias_correction2_sqrt_rcp == nullptr) {
+            throw std::runtime_error(
+                "adam_step_shN_joint_from_grad: missing SH band corrections");
         }
 
         fast_lfs::rasterization::FusedAdamSettings fused{};
@@ -90,6 +97,12 @@ namespace fast_lfs::optimizer {
         fused.shN.cropbox_lr_scale = cropbox_lr_scale;
         fused.shN.step_size = step_size;
         fused.shN.bias_correction2_sqrt_rcp = bias_correction2_sqrt_rcp;
+        for (int band = 0; band < 3; ++band) {
+            fused.shN.sh_band_step_size[band] = sh_band_step_size[band];
+            fused.shN.sh_band_bias_correction2_sqrt_rcp[band] =
+                sh_band_bias_correction2_sqrt_rcp[band];
+        }
+        fused.shN.use_sh_band_corrections = true;
         fused.shN.enabled = true;
 
         constexpr int kBS = 256;

--- a/src/training/rasterization/fastgs/rasterization/include/fused_adam_types.h
+++ b/src/training/rasterization/fastgs/rasterization/include/fused_adam_types.h
@@ -33,6 +33,11 @@ namespace fast_lfs::rasterization {
         int n_attributes = 0;
         float step_size = 0.0f;
         float bias_correction2_sqrt_rcp = 1.0f;
+        // shN-only per-band corrections. Logical scalar cells [0,9), [9,24),
+        // and [24,45) select l=1, l=2, and l=3 respectively.
+        float sh_band_step_size[3] = {0.0f, 0.0f, 0.0f};
+        float sh_band_bias_correction2_sqrt_rcp[3] = {1.0f, 1.0f, 1.0f};
+        bool use_sh_band_corrections = false;
         bool enabled = false;
         const float* screen_share_max = nullptr;
         int screen_share_n = 0;

--- a/src/training/rasterization/fastgs/rasterization/include/kernel_utils.cuh
+++ b/src/training/rasterization/fastgs/rasterization/include/kernel_utils.cuh
@@ -826,7 +826,7 @@ namespace fast_lfs::rasterization::kernels {
         const bool value_f16 = p.sh_value_bits == 16 && !value_q16;
         const uint n_value_cells = value_q16 ? static_cast<uint>(p.sh_value_n_cells) : 0u;
 
-        float row_step_size = p.step_size;
+        float row_step_scale = 1.0f;
         bool apply_step = true;
         bool touch = p.enabled && sh_layout_slots > 0u &&
                      p.joint_packed != nullptr && p.joint_bounds != nullptr;
@@ -842,7 +842,7 @@ namespace fast_lfs::rasterization::kernels {
             if (p.frozen_lr_scale == 0.0f)
                 apply_step = false;
             else
-                row_step_size *= p.frozen_lr_scale;
+                row_step_scale *= p.frozen_lr_scale;
         }
         if (touch && p.crop_damping_mask != nullptr &&
             primitive_idx < static_cast<uint>(p.crop_damping_mask_size) &&
@@ -850,7 +850,7 @@ namespace fast_lfs::rasterization::kernels {
             if (p.cropbox_lr_scale == 0.0f)
                 apply_step = false;
             else
-                row_step_size *= p.cropbox_lr_scale;
+                row_step_scale *= p.cropbox_lr_scale;
         }
 
         const int bidx = static_cast<int>(blockIdx.x);
@@ -872,6 +872,7 @@ namespace fast_lfs::rasterization::kernels {
 
         constexpr uint N_SLOTS = (ACTIVE_SH_BASES > 9) ? 12u : (ACTIVE_SH_BASES > 4) ? 6u
                                                                                      : 3u;
+        constexpr uint N_ACTIVE_CELLS = (ACTIVE_SH_BASES - 1u) * 3u;
 
         if (touch) {
 #pragma unroll
@@ -891,10 +892,23 @@ namespace fast_lfs::rasterization::kernels {
                     const float gci = (c == 0) ? gk.x : (c == 1) ? gk.y
                                                     : (c == 2)   ? gk.z
                                                                  : gk.w;
+                    const uint cell_lin = k * 4u + static_cast<uint>(c);
+                    const bool cell_active = cell_lin < N_ACTIVE_CELLS;
+                    const int band = cell_lin < 9u ? 0 : (cell_lin < 24u ? 1 : 2);
+                    const float cell_step_size = row_step_scale *
+                                                 (p.use_sh_band_corrections
+                                                      ? p.sh_band_step_size[band]
+                                                      : p.step_size);
+                    const float cell_bias_correction2_sqrt_rcp =
+                        p.use_sh_band_corrections
+                            ? p.sh_band_bias_correction2_sqrt_rcp[band]
+                            : p.bias_correction2_sqrt_rcp;
                     const int64_t cell = static_cast<int64_t>(slot) * 4 + c;
                     const float2 prim = shN_adam_moment_us<C>(
-                        gci, cell, p.joint_packed, old_mm, apply_step, active_slot,
-                        beta1, beta2, row_step_size, eps, p.bias_correction2_sqrt_rcp, pci);
+                        gci, cell, p.joint_packed, old_mm,
+                        apply_step && cell_active, cell_active,
+                        beta1, beta2, cell_step_size, eps,
+                        cell_bias_correction2_sqrt_rcp, pci);
                     if (c == 0)
                         pc.x = pci;
                     else if (c == 1)
@@ -904,7 +918,6 @@ namespace fast_lfs::rasterization::kernels {
                     else
                         pc.w = pci;
                     if (value_q16) {
-                        const uint cell_lin = k * 4u + static_cast<uint>(c);
                         if (cell_lin < n_value_cells) {
                             local_v_min = fminf(local_v_min, pci);
                             local_v_max = fmaxf(local_v_max, pci);
@@ -990,16 +1003,28 @@ namespace fast_lfs::rasterization::kernels {
                     const float gci = (c == 0) ? gk.x : (c == 1) ? gk.y
                                                     : (c == 2)   ? gk.z
                                                                  : gk.w;
+                    const uint cell_lin = k * 4u + static_cast<uint>(c);
+                    const bool cell_active = cell_lin < N_ACTIVE_CELLS;
+                    const int band = cell_lin < 9u ? 0 : (cell_lin < 24u ? 1 : 2);
+                    const float cell_step_size = row_step_scale *
+                                                 (p.use_sh_band_corrections
+                                                      ? p.sh_band_step_size[band]
+                                                      : p.step_size);
+                    const float cell_bias_correction2_sqrt_rcp =
+                        p.use_sh_band_corrections
+                            ? p.sh_band_bias_correction2_sqrt_rcp[band]
+                            : p.bias_correction2_sqrt_rcp;
                     const int64_t cell = static_cast<int64_t>(slot) * 4 + c;
                     const float2 prim = shN_adam_moment_us<C>(
-                        gci, cell, p.joint_packed, old_mm, apply_step, active_slot,
-                        beta1, beta2, row_step_size, eps, p.bias_correction2_sqrt_rcp, pci);
+                        gci, cell, p.joint_packed, old_mm,
+                        apply_step && cell_active, cell_active,
+                        beta1, beta2, cell_step_size, eps,
+                        cell_bias_correction2_sqrt_rcp, pci);
                     C::encode_us(p.joint_packed, cell, prim.x, prim.y,
                                  new_mm.x, new_mm.z, inv_u_range, inv_s_range);
                     // Always re-encode under new block bounds (frozen/crop-damped too),
                     // matching joint-moment encode. apply_step only gates the Adam update.
                     if (value_q16) {
-                        const uint cell_lin = k * 4u + static_cast<uint>(c);
                         if (cell_lin < n_value_cells) {
                             param_u16[lfs::core::sh_value::shAtU16(
                                 primitive_idx, cell_lin, n_value_cells)] =

--- a/tests/test_checkpoint_resume.cpp
+++ b/tests/test_checkpoint_resume.cpp
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <chrono>
 #include <cmath>
@@ -575,6 +576,11 @@ namespace {
         ASSERT_NE(means_state, nullptr);
         ASSERT_TRUE(means_state->is_joint()) << "expected joint codec moments";
         means_state->step_count = 11;
+        auto* shN_state = source_strategy.get_optimizer().get_state_mutable(
+            lfs::training::ParamType::ShN);
+        ASSERT_NE(shN_state, nullptr);
+        shN_state->step_count = 11;
+        shN_state->sh_band_step_count = {11, 7, 3};
         const int expected_joint_bits = means_state->joint_bits;
         const auto packed_shape = means_state->exp_avg.shape();
         const auto bounds_shape = means_state->joint_bounds.shape();
@@ -620,6 +626,12 @@ namespace {
         EXPECT_TRUE(restored_means->is_joint());
         EXPECT_EQ(restored_means->joint_bits, expected_joint_bits);
         EXPECT_EQ(restored_means->step_count, 11);
+        const auto* restored_shN = restored_opt.get_state(lfs::training::ParamType::ShN);
+        ASSERT_NE(restored_shN, nullptr);
+        EXPECT_EQ(restored_shN->step_count, 11);
+        EXPECT_EQ(
+            restored_shN->sh_band_step_count,
+            (std::array<int64_t, 3>{11, 7, 3}));
         EXPECT_EQ(restored_means->exp_avg.shape(), packed_shape);
         EXPECT_EQ(restored_means->joint_bounds.shape(), bounds_shape);
 

--- a/tests/test_dual_rep_optimizer.cpp
+++ b/tests/test_dual_rep_optimizer.cpp
@@ -18,6 +18,7 @@
 
 #include "adam_api.h"
 
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -80,6 +81,61 @@ namespace {
     }
 
 } // namespace
+
+TEST(DualRepOptimizer, ShNBandsUseIndependentAdamAges) {
+    CodecsOnGuard guard;
+    constexpr size_t n = 32;
+    constexpr size_t cap = 64;
+    constexpr float lr = 1e-3f;
+
+    auto splat = make_sh_splat(n, 3);
+    splat.set_active_sh_degree(1);
+    ASSERT_TRUE(sh_value::apply_shN_value_quant(splat));
+
+    AdamOptimizer opt(splat, make_cfg(cap));
+    opt.allocate_gradients(cap);
+
+    auto degree1 = opt.prepare_fastgs_fused_adam(1001);
+    ASSERT_TRUE(degree1.shN.enabled);
+    ASSERT_TRUE(degree1.shN.use_sh_band_corrections);
+    EXPECT_NEAR(degree1.shN.sh_band_step_size[0], lr / (1.0f - 0.9f), 1e-6f);
+    EXPECT_NEAR(
+        degree1.shN.sh_band_bias_correction2_sqrt_rcp[0],
+        1.0f / std::sqrt(1.0f - 0.999f), 1e-4f);
+    EXPECT_FLOAT_EQ(degree1.shN.sh_band_step_size[1], 0.0f);
+    EXPECT_FLOAT_EQ(degree1.shN.sh_band_step_size[2], 0.0f);
+    opt.commit_fastgs_fused_adam(1001);
+
+    auto* state = opt.get_state_mutable(ParamType::ShN);
+    ASSERT_NE(state, nullptr);
+    EXPECT_EQ(state->sh_band_step_count, (std::array<int64_t, 3>{1, 0, 0}));
+
+    // Emulate the degree-1 band having trained for 1,000 updates. Degree 2 must
+    // still start with t=1 rather than inheriting that age.
+    state->step_count = 1000;
+    state->sh_band_step_count = {1000, 0, 0};
+    splat.set_active_sh_degree(2);
+    auto degree2 = opt.prepare_fastgs_fused_adam(2001);
+    ASSERT_TRUE(degree2.shN.enabled);
+    EXPECT_LT(degree2.shN.sh_band_step_size[0], 0.002f);
+    EXPECT_NEAR(degree2.shN.sh_band_step_size[1], lr / (1.0f - 0.9f), 1e-6f);
+    EXPECT_FLOAT_EQ(degree2.shN.sh_band_step_size[2], 0.0f);
+    opt.commit_fastgs_fused_adam(2001);
+    EXPECT_EQ(state->sh_band_step_count, (std::array<int64_t, 3>{1001, 1, 0}));
+
+    // Degree 3 receives its own fresh correction while both older bands keep
+    // their accumulated ages.
+    state->step_count = 2000;
+    state->sh_band_step_count = {2000, 1000, 0};
+    splat.set_active_sh_degree(3);
+    auto degree3 = opt.prepare_fastgs_fused_adam(3001);
+    ASSERT_TRUE(degree3.shN.enabled);
+    EXPECT_LT(degree3.shN.sh_band_step_size[0], 0.002f);
+    EXPECT_LT(degree3.shN.sh_band_step_size[1], 0.002f);
+    EXPECT_NEAR(degree3.shN.sh_band_step_size[2], lr / (1.0f - 0.9f), 1e-6f);
+    opt.commit_fastgs_fused_adam(3001);
+    EXPECT_EQ(state->sh_band_step_count, (std::array<int64_t, 3>{2001, 1001, 1}));
+}
 
 // ---------------------------------------------------------------------------
 // joint shN moments sized from float layout, not q16 cell count

--- a/tests/test_gut_shN_joint_adam.cpp
+++ b/tests/test_gut_shN_joint_adam.cpp
@@ -11,6 +11,7 @@
 #include "lfs/training/sh_value_storage.hpp"
 #include "optimizer/adam_optimizer.hpp"
 
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <cuda_runtime.h>
@@ -181,10 +182,12 @@ TEST(GutShNJointAdam, StandaloneStepMatchesFusedKernelQ16Sh3) {
         fused.shN.sh_value_bits,
         fused.shN.sh_value_n_cells,
         fused.shN.step_size,
+        fused.shN.sh_band_step_size,
         fused.beta1,
         fused.beta2,
         fused.eps,
         fused.shN.bias_correction2_sqrt_rcp,
+        fused.shN.sh_band_bias_correction2_sqrt_rcp,
         nullptr);
     opt_fused.commit_fastgs_fused_adam(past_warmup);
 
@@ -214,4 +217,48 @@ TEST(GutShNJointAdam, StandaloneStepMatchesFusedKernelQ16Sh3) {
     const auto jbounds_step = tensor_bytes(st_step->joint_bounds);
     ASSERT_EQ(jbounds_fused.size(), jbounds_step.size());
     EXPECT_EQ(jbounds_fused, jbounds_step) << "joint moment bounds must match";
+}
+
+TEST(GutShNJointAdam, DegreeOneDoesNotUpdateDegreeTwoCellsInSharedSlot) {
+    constexpr size_t n = 32;
+    constexpr size_t cap = 32;
+    constexpr int past_warmup = 1001;
+
+    auto splat = make_mixed_splat(n, 3);
+    splat.set_active_sh_degree(1);
+    ASSERT_EQ(splat.shN().dtype(), DataType::Float32);
+
+    AdamOptimizer opt(splat, make_cfg(cap));
+    opt.allocate_gradients(cap);
+
+    const auto layout_rest = static_cast<uint32_t>(splat.max_sh_coeffs_rest());
+    const size_t float_layout = sh_swizzled_float_count(n, layout_rest);
+    auto& grad = opt.get_grad(ParamType::ShN);
+    ASSERT_EQ(static_cast<size_t>(grad.numel()), float_layout);
+
+    // Slot 2 straddles the exact degree boundary: component 0 is logical cell
+    // 8 (degree 1), while component 1 is cell 9 (degree 2).
+    const size_t slot = sh_swizzled_index(0, 2, layout_rest);
+    const size_t degree1_cell = slot * 4;
+    const size_t degree2_cell = degree1_cell + 1;
+    std::vector<float> grads_h(float_layout, 0.0f);
+    grads_h[degree1_cell] = 0.25f;
+    grads_h[degree2_cell] = 0.25f;
+    ASSERT_EQ(cudaMemcpy(grad.ptr<float>(), grads_h.data(),
+                         float_layout * sizeof(float), cudaMemcpyHostToDevice),
+              cudaSuccess);
+
+    const auto before = splat.shN().cpu();
+    ASSERT_NO_THROW(opt.step(past_warmup));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    const auto after = splat.shN().cpu();
+    const auto* before_values = before.ptr<float>();
+    const auto* after_values = after.ptr<float>();
+
+    EXPECT_NE(after_values[degree1_cell], before_values[degree1_cell]);
+    EXPECT_FLOAT_EQ(after_values[degree2_cell], before_values[degree2_cell]);
+
+    const auto* state = opt.get_state(ParamType::ShN);
+    ASSERT_NE(state, nullptr);
+    EXPECT_EQ(state->sh_band_step_count, (std::array<int64_t, 3>{1, 0, 0}));
 }

--- a/tests/training_snapshot_test_helpers.hpp
+++ b/tests/training_snapshot_test_helpers.hpp
@@ -30,6 +30,7 @@ namespace lfs::training::test {
     struct AdamStateByteSnapshot {
         bool present = false;
         std::int64_t step_count = 0;
+        std::array<std::int64_t, 3> sh_band_step_count{};
         std::size_t capacity = 0;
         std::size_t size = 0;
         // Serializer writes only these two tensors (joint codec).
@@ -106,6 +107,7 @@ namespace lfs::training::test {
             auto& captured = result.states[index];
             captured.present = true;
             captured.step_count = state->step_count;
+            captured.sh_band_step_count = state->sh_band_step_count;
             captured.capacity = state->capacity;
             captured.size = state->size;
             captured.exp_avg =
@@ -184,6 +186,10 @@ namespace lfs::training::test {
                 captured.step_count,
                 state->step_count)
                 << "Adam state index " << index;
+            EXPECT_EQ(
+                captured.sh_band_step_count,
+                state->sh_band_step_count)
+                << "Adam SH band state index " << index;
             EXPECT_EQ(captured.capacity, state->capacity)
                 << "Adam state index " << index;
             EXPECT_EQ(captured.size, state->size)


### PR DESCRIPTION
## Summary

New SH bands had fresh optimizer moments but inherited an old Adam timestep. This over-scaled their first updates during SH level changes, matching the instability reported in #1864.

## Changes

- Track separate Adam step counters for each SH band.
- Apply band-local corrections in fused and standalone optimizer paths.
- Freeze inactive packed SH cells and their optimizer moments.
- Preserve checkpoint compatibility with versions 1–3.
- Add regression coverage for progressive SH activation.
