### PR TITLE
Create training projects in the project location instead of hidden temp files

### DIFF
--- a/src/core/include/core/events.hpp
+++ b/src/core/include/core/events.hpp
@@ -69,11 +69,12 @@ namespace lfs::core {
             EVENT(NewProject, bool discard_changes = false; bool stop_training = false;);
             EVENT(ProjectSave, bool regenerate_preview = true;);
             EVENT(ProjectSaveAs, std::filesystem::path path;);
+            EVENT(ProjectCreate, std::filesystem::path path; bool discard_changes = false; bool stop_training = false;);
             EVENT(ProjectOpen, std::filesystem::path path; bool discard_changes = false; bool stop_training = false; bool keep_asset_manager_open = false;);
             EVENT(ProjectCompact, );
-            EVENT(ShowProjectSwitchConfirmation, bool new_project = false; std::filesystem::path path; bool keep_asset_manager_open = false;);
+            EVENT(ShowProjectSwitchConfirmation, bool new_project = false; std::filesystem::path path; bool keep_asset_manager_open = false; std::filesystem::path create_path = {};);
             EVENT(ShowLoadFileConfirmation, std::vector<std::filesystem::path> paths; bool is_dataset = false; bool replace = false;);
-            EVENT(ShowStopTrainingConfirmation, bool new_project = false; std::filesystem::path path; bool discard_changes = false; bool keep_asset_manager_open = false;);
+            EVENT(ShowStopTrainingConfirmation, bool new_project = false; std::filesystem::path path; bool discard_changes = false; bool keep_asset_manager_open = false; std::filesystem::path create_path = {};);
             EVENT(SetReopenLastProject, bool enabled;);
             EVENT(SetAutoSaveOnClose, bool enabled;);
             EVENT(SetProjectAutosaveInterval, std::uint64_t seconds;);

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -1090,6 +1090,26 @@ NB_MODULE(lichtfeld, m) {
         },
         nb::arg("discard_changes") = false, nb::arg("stop_training") = false, "Clear all project state and start a new project");
     m.def(
+        "project_create",
+        [](const std::string& path,
+           const bool discard_changes,
+           const bool stop_training) {
+            nb::gil_scoped_release release;
+            const auto project_path = python_utf8_path(path);
+            emit_project_cmd_marshaled(
+                "python.project_create",
+                [project_path, discard_changes, stop_training] {
+                    lfs::core::events::cmd::ProjectCreate{
+                        .path = project_path,
+                        .discard_changes = discard_changes,
+                        .stop_training = stop_training}
+                        .emit();
+                });
+        },
+        nb::arg("path"), nb::arg("discard_changes") = false,
+        nb::arg("stop_training") = false,
+        "Create and bind a new .licht project at path");
+    m.def(
         "project_save",
         [](const bool wait, const bool regenerate_preview) {
             nb::gil_scoped_release release;

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -280,6 +280,9 @@ def is_training_active() -> bool:
 def new_project(discard_changes: bool = False, stop_training: bool = False) -> None:
     """Clear all project state and start a new project"""
 
+def project_create(path: str, discard_changes: bool = False, stop_training: bool = False) -> None:
+    """Create and bind a new .licht project at path"""
+
 def project_save(wait: bool = False, regenerate_preview: bool = True) -> bool:
     """Save the active .licht project, prompting for a path when needed"""
 

--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -67,9 +67,9 @@ namespace lfs::vis {
     class VisualizerImplResetTest_ExplicitSaveAfterTrainerRewriteUsesCurrentHead_Test;
     class VisualizerImplResetTest_UntitledTrainerRewriteAdoptThenSaveAsUsesCurrentHead_Test;
     class VisualizerImplResetTest_EditModeSaveDropsFormerTrainingCheckpoint_Test;
-    class VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionKeepsSessionUntitledAndOutOfMru_Test;
-    class VisualizerImplResetTest_SaveAsAfterUntitledTrainingMigratesTempIncludingCheckpoint_Test;
-    class VisualizerImplResetTest_CompletedUntitledTrainingBlocksCleanClose_Test;
+    class VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionRegistersProjectInMru_Test;
+    class VisualizerImplResetTest_SaveAsAfterAutoCreatedTrainingKeepsOriginalAndCheckpoint_Test;
+    class VisualizerImplResetTest_CompletedAutoCreatedTrainingSavesRealMasterOnClose_Test;
     class VisualizerImplResetTest_SaveAsAfterUntitledTrainingRoutesThroughFinishedTrainer_Test;
 } // namespace lfs::vis
 
@@ -431,9 +431,9 @@ namespace lfs::training {
         friend class lfs::vis::VisualizerImplResetTest_ExplicitSaveAfterTrainerRewriteUsesCurrentHead_Test;
         friend class lfs::vis::VisualizerImplResetTest_UntitledTrainerRewriteAdoptThenSaveAsUsesCurrentHead_Test;
         friend class lfs::vis::VisualizerImplResetTest_EditModeSaveDropsFormerTrainingCheckpoint_Test;
-        friend class lfs::vis::VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionKeepsSessionUntitledAndOutOfMru_Test;
-        friend class lfs::vis::VisualizerImplResetTest_SaveAsAfterUntitledTrainingMigratesTempIncludingCheckpoint_Test;
-        friend class lfs::vis::VisualizerImplResetTest_CompletedUntitledTrainingBlocksCleanClose_Test;
+        friend class lfs::vis::VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionRegistersProjectInMru_Test;
+        friend class lfs::vis::VisualizerImplResetTest_SaveAsAfterAutoCreatedTrainingKeepsOriginalAndCheckpoint_Test;
+        friend class lfs::vis::VisualizerImplResetTest_CompletedAutoCreatedTrainingSavesRealMasterOnClose_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsAfterUntitledTrainingRoutesThroughFinishedTrainer_Test;
         friend class lfs::vis::project::ProjectLifecycle;
         friend struct TrainerRetryTestAccess;

--- a/src/visualizer/include/visualizer/visualizer.hpp
+++ b/src/visualizer/include/visualizer/visualizer.hpp
@@ -199,6 +199,11 @@ namespace lfs::vis {
         virtual lfs::Result<void>
         projectSaveAs(const std::filesystem::path& path,
                       bool regenerate_preview = true) = 0;
+        virtual lfs::Result<void>
+        projectCreateAt(
+            const std::filesystem::path& path,
+            ProjectSwitchDisposition disposition =
+                ProjectSwitchDisposition::RequireClean) = 0;
         virtual lfs::Result<ProjectOpenOutcome>
         projectOpen(
             const std::filesystem::path& path,

--- a/src/visualizer/preferences.cpp
+++ b/src/visualizer/preferences.cpp
@@ -205,6 +205,13 @@ namespace lfs::vis {
             return resolved->rootDir();
         }
 
+        [[nodiscard]] std::filesystem::path defaultProjectLocationPath() {
+            const auto resolved = lfs::core::UserPaths::resolve();
+            if (!resolved)
+                return {};
+            return resolved->rootDir() / "projects";
+        }
+
         [[nodiscard]] std::filesystem::path defaultAssetManagerDirectoryPath() {
             const auto resolved = lfs::core::UserPaths::resolve();
             if (!resolved)
@@ -604,6 +611,44 @@ namespace lfs::vis {
         impl_->saveLocked();
     }
 
+    lfs::Status UserPreferences::setProjectLocation(
+        const std::filesystem::path& path) {
+        auto resolved = validateWritableDirectory(
+            path, "project_location", "The project location",
+            ".lfs-project-write-probe-");
+        if (!resolved)
+            return lfs::Status::failure(std::move(resolved).error());
+        std::scoped_lock lock(impl_->mutex);
+        impl_->loadLocked();
+        impl_->values["project_location"] =
+            lfs::core::path_to_utf8(*resolved);
+        impl_->saveLocked();
+        return {};
+    }
+
+    std::filesystem::path UserPreferences::projectLocation() {
+        const auto raw = projectLocationPreference();
+        return raw.empty() ? defaultProjectLocationPath() : raw;
+    }
+
+    std::filesystem::path UserPreferences::projectLocationPreference() {
+        std::scoped_lock lock(impl_->mutex);
+        impl_->loadLocked();
+        const auto it = impl_->values.find("project_location");
+        if (it == impl_->values.end() || !it->is_string())
+            return {};
+        const std::string stored = it->get<std::string>();
+        return stored.empty() ? std::filesystem::path{}
+                              : lfs::core::utf8_to_path(stored);
+    }
+
+    void UserPreferences::clearProjectLocation() {
+        std::scoped_lock lock(impl_->mutex);
+        impl_->loadLocked();
+        impl_->values["project_location"] = "";
+        impl_->saveLocked();
+    }
+
     lfs::Status UserPreferences::setAssetManagerDirectory(
         const std::filesystem::path& path) {
         auto resolved = validateWritableAssetManagerDirectory(path);
@@ -658,6 +703,22 @@ namespace lfs::vis {
         if (root.empty())
             return {};
         return root / "tmp";
+    }
+    lfs::Status setProjectLocationPreference(
+        const std::filesystem::path& path) {
+        return UserPreferences::instance().setProjectLocation(path);
+    }
+    std::filesystem::path loadProjectLocationPreference() {
+        return UserPreferences::instance().projectLocation();
+    }
+    std::filesystem::path projectLocationPreferenceRaw() {
+        return UserPreferences::instance().projectLocationPreference();
+    }
+    void clearProjectLocationPreference() {
+        UserPreferences::instance().clearProjectLocation();
+    }
+    std::filesystem::path defaultProjectLocation() {
+        return defaultProjectLocationPath();
     }
     lfs::Status setAssetManagerDirectoryPreference(const std::filesystem::path& path) {
         return UserPreferences::instance().setAssetManagerDirectory(path);

--- a/src/visualizer/preferences.hpp
+++ b/src/visualizer/preferences.hpp
@@ -64,6 +64,12 @@ namespace lfs::vis {
         [[nodiscard]] std::filesystem::path workingDirectoryPreference();
         void clearWorkingDirectory();
 
+        [[nodiscard]] lfs::Status setProjectLocation(
+            const std::filesystem::path& path);
+        [[nodiscard]] std::filesystem::path projectLocation();
+        [[nodiscard]] std::filesystem::path projectLocationPreference();
+        void clearProjectLocation();
+
         [[nodiscard]] lfs::Status setAssetManagerDirectory(const std::filesystem::path& path);
         [[nodiscard]] std::filesystem::path assetManagerDirectory();
         [[nodiscard]] std::filesystem::path assetManagerDirectoryPreference();
@@ -107,6 +113,14 @@ namespace lfs::vis {
     LFS_VIS_API void clearWorkingDirectoryPreference();
     [[nodiscard]] LFS_VIS_API std::filesystem::path defaultWorkingDirectory();
     [[nodiscard]] LFS_VIS_API std::filesystem::path tempProjectDirectoryPreference();
+    [[nodiscard]] LFS_VIS_API lfs::Status
+    setProjectLocationPreference(const std::filesystem::path& path);
+    [[nodiscard]] LFS_VIS_API std::filesystem::path
+    loadProjectLocationPreference();
+    [[nodiscard]] LFS_VIS_API std::filesystem::path
+    projectLocationPreferenceRaw();
+    LFS_VIS_API void clearProjectLocationPreference();
+    [[nodiscard]] LFS_VIS_API std::filesystem::path defaultProjectLocation();
     [[nodiscard]] LFS_VIS_API lfs::Status
     setAssetManagerDirectoryPreference(const std::filesystem::path& path);
     [[nodiscard]] LFS_VIS_API std::filesystem::path loadAssetManagerDirectoryPreference();

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -1532,6 +1532,58 @@ namespace lfs::vis::project {
             return resolved;
         }
 
+        [[nodiscard]] std::string sanitizedProjectFileStem(
+            const std::string& value) {
+            std::string sanitized;
+            sanitized.reserve(value.size());
+            for (const unsigned char character : value) {
+                if (character == '/' || character == '\\') {
+                    continue;
+                }
+                const bool invalid =
+                    character < 0x20 || character == '<' ||
+                    character == '>' || character == ':' ||
+                    character == '"' || character == '|' ||
+                    character == '?' || character == '*';
+                sanitized.push_back(invalid ? '-' : static_cast<char>(character));
+            }
+            while (!sanitized.empty() &&
+                   (std::isspace(static_cast<unsigned char>(
+                        sanitized.back())) ||
+                    sanitized.back() == '.')) {
+                sanitized.pop_back();
+            }
+            std::size_t first = 0;
+            while (first < sanitized.size() &&
+                   (std::isspace(static_cast<unsigned char>(
+                        sanitized[first])) ||
+                    sanitized[first] == '.')) {
+                ++first;
+            }
+            if (first != 0) {
+                sanitized.erase(0, first);
+            }
+            const auto uppercase = [](const unsigned char character) {
+                return static_cast<char>(std::toupper(character));
+            };
+            std::string device_name;
+            device_name.reserve(sanitized.size());
+            std::ranges::transform(
+                sanitized, std::back_inserter(device_name), uppercase);
+            const bool reserved_device =
+                device_name == "CON" || device_name == "PRN" ||
+                device_name == "AUX" || device_name == "NUL" ||
+                (device_name.size() == 4 &&
+                 (device_name.starts_with("COM") ||
+                  device_name.starts_with("LPT")) &&
+                 device_name.back() >= '1' &&
+                 device_name.back() <= '9');
+            if (reserved_device) {
+                sanitized += "-project";
+            }
+            return sanitized.empty() ? "untitled" : sanitized;
+        }
+
         [[nodiscard]] bool sameBytes(
             const std::span<const std::byte> lhs,
             const std::span<const std::byte> rhs) {
@@ -3507,59 +3559,67 @@ namespace lfs::vis::project {
                 }
             }
         } else if (!hasSourcePath()) {
-            if (auto waited =
-                    waitOutBackgroundAutosaveForExplicitSave();
-                !waited) {
-                return waited;
+            const auto location = loadProjectLocationPreference();
+            std::error_code create_error;
+            std::filesystem::create_directories(
+                location, create_error);
+            if (create_error) {
+                return fail<void>(
+                    lfs::ErrorCode::PermissionDenied,
+                    "The Project location could not be created.",
+                    create_error.message(),
+                    "project.project_location");
             }
-            if (auto locked = lockScratchAutosave();
-                !locked) {
-                return locked;
-            }
-            if (document_ && !document_->source_path()) {
-                if (auto synchronized =
-                        synchronizeDocumentFromViewer();
-                    !synchronized) {
-                    return synchronized;
-                }
-                lfs::io::project::
-                    ProjectDocumentSaveOptions options;
-                options.commit.kind =
-                    lfs::io::project::CommitKind::
-                        Explicit;
-                options.commit.commit_uuid =
-                    lfs::core::generate_uuid_v4();
-                options.file_uuid =
-                    lfs::core::generate_uuid_v4();
-                options.index_compression =
-                    lfs::io::project::
-                        IndexCompression::Zstd;
-                options.disk_reserve_bytes =
-                    64ull * 1024 * 1024;
-                options.allow_existing_destination_replacement =
-                    true;
-                options.leave_unbound = false;
-                options.writer_lock_lease = scratch_lock_;
-                auto started = startDocumentWrite(
-                    ProjectWritePurpose::Autosave,
-                    document_, *scratch_autosave_path_,
-                    std::move(options));
-                if (!started) {
-                    return started;
-                }
-                if (project_write_thread_.joinable()) {
-                    project_write_thread_.join();
-                    settleProjectWrite();
-                }
-                if (!document_->source_path()) {
+            const auto stem = sanitizedProjectFileStem(
+                dataset.data_path.filename().string());
+            lfs::Error last_error = lifecycleError(
+                lfs::ErrorCode::Unavailable,
+                "The training project could not be created.",
+                "no available project location candidate",
+                "project.project_location");
+            bool bound = false;
+            for (int attempt = 0; attempt <= 1000; ++attempt) {
+                const auto suffix =
+                    attempt == 0
+                        ? std::string{}
+                        : std::format("-{}", attempt + 1);
+                const auto candidate =
+                    location / (stem + suffix + ".licht");
+                std::error_code exists_error;
+                const bool exists =
+                    std::filesystem::exists(candidate, exists_error) ||
+                    std::filesystem::exists(
+                        std::filesystem::path(candidate.string() + ".lock"),
+                        exists_error);
+                if (exists_error) {
                     return fail<void>(
-                        lfs::ErrorCode::Unavailable,
-                        "The training project could not be created.",
-                        last_project_write_error_.empty()
-                            ? "Temp project first bind did not set a source path"
-                            : last_project_write_error_,
-                        "project.training");
+                        lfs::ErrorCode::PermissionDenied,
+                        "The Project location could not be inspected.",
+                        exists_error.message(),
+                        "project.project_location");
                 }
+                if (exists) {
+                    continue;
+                }
+                auto bound_result =
+                    bindUntitledSessionToMaster(candidate);
+                if (bound_result) {
+                    bound = true;
+                    break;
+                }
+                last_error = bound_result.error();
+                if (last_error.code() !=
+                    lfs::ErrorCode::AlreadyExists) {
+                    return bound_result;
+                }
+                if (attempt == 1000) {
+                    return lfs::Status::failure(
+                        std::move(last_error));
+                }
+            }
+            if (!bound) {
+                return lfs::Status::failure(
+                    std::move(last_error));
             }
         }
 
@@ -3989,7 +4049,7 @@ namespace lfs::vis::project {
         const bool automatic) {
         if (!document_ ||
             !document_->source_path() ||
-            isTempProject()) {
+            isScratchBoundSession()) {
             return fail<void>(
                 lfs::ErrorCode::FailedPrecondition,
                 "This project has no durable master to compact.",
@@ -4574,7 +4634,7 @@ namespace lfs::vis::project {
         const bool training_write_window =
             isTrainingWriteWindowOpen();
         if (!training_write_window &&
-            !isTempProject() &&
+            !isScratchBoundSession() &&
             compaction_suggested_ &&
             settings_.compaction_idle_seconds !=
                 0 &&
@@ -5769,7 +5829,7 @@ namespace lfs::vis::project {
         }
         if (!document_ ||
             !document_->source_path() ||
-            isTempProject()) {
+            isScratchBoundSession()) {
             return fail<void>(
                 lfs::ErrorCode::FailedPrecondition,
                 "This project has no path; use Save As.",
@@ -7192,12 +7252,97 @@ namespace lfs::vis::project {
         return hasDirtyProject();
     }
 
+    lfs::Result<void>
+    ProjectLifecycle::bindUntitledSessionToMaster(
+        const std::filesystem::path& destination) {
+        if (auto waited =
+                waitOutBackgroundAutosaveForExplicitSave();
+            !waited) {
+            return waited;
+        }
+        if (!document_) {
+            return fail<void>(
+                lfs::ErrorCode::FailedPrecondition,
+                "The project document is unavailable.",
+                "first project binding requires a live project document",
+                "project.document");
+        }
+        if (auto synchronized = synchronizeDocumentFromViewer();
+            !synchronized) {
+            return synchronized;
+        }
+        ProjectDocumentSaveOptions options;
+        options.commit.kind =
+            lfs::io::project::CommitKind::Explicit;
+        options.commit.commit_uuid =
+            lfs::core::generate_uuid_v4();
+        options.file_uuid = lfs::core::generate_uuid_v4();
+        options.index_compression =
+            lfs::io::project::IndexCompression::Zstd;
+        options.disk_reserve_bytes = 64ull * 1024 * 1024;
+        options.allow_existing_destination_replacement = false;
+        options.leave_unbound = false;
+        auto started = startDocumentWrite(
+            ProjectWritePurpose::SaveAs,
+            document_, destination, std::move(options));
+        if (!started) {
+            return started;
+        }
+        if (project_write_thread_.joinable()) {
+            project_write_thread_.join();
+            settleProjectWrite();
+        }
+        if (!document_->source_path()) {
+            return fail<void>(
+                last_project_write_error_code_.value_or(
+                    lfs::ErrorCode::Unavailable),
+                "The project could not be created.",
+                last_project_write_error_.empty()
+                    ? "first project binding did not set a source path"
+                    : last_project_write_error_,
+                "project.path");
+        }
+        return {};
+    }
+
+    lfs::Result<void>
+    ProjectLifecycle::createProjectAt(
+        const std::filesystem::path& path,
+        const ProjectSwitchDisposition disposition) {
+        auto normalized = normalizedProjectPath(path);
+        if (!normalized) {
+            return lfs::Status::failure(
+                std::move(normalized).error());
+        }
+        if (isScratchPath(*normalized)) {
+            return fail<void>(
+                lfs::ErrorCode::InvalidArgument,
+                "A project cannot be created in scratch storage.",
+                "the requested destination is reserved for crash recovery",
+                "project.path");
+        }
+        if (auto created = newProject(disposition); !created) {
+            return created;
+        }
+        std::error_code create_error;
+        std::filesystem::create_directories(
+            normalized->parent_path(), create_error);
+        if (create_error) {
+            return fail<void>(
+                lfs::ErrorCode::PermissionDenied,
+                "The project folder could not be created.",
+                create_error.message(),
+                "project.path");
+        }
+        return bindUntitledSessionToMaster(*normalized);
+    }
+
     bool ProjectLifecycle::hasSourcePath() const {
         if (recovered_master_path_) {
             return !isScratchPath(*recovered_master_path_);
         }
         return document_ && document_->source_path() &&
-               !isTempProject();
+               !isScratchBoundSession();
     }
 
     bool ProjectLifecycle::hasDirtyProject() {
@@ -7246,7 +7391,7 @@ namespace lfs::vis::project {
         if (isBlankUntitledSession()) {
             return false;
         }
-        if (isTempProject()) {
+        if (isScratchBoundSession()) {
             return true;
         }
         if (canFlushFinishedTrainerSnapshot()) {
@@ -7325,7 +7470,7 @@ namespace lfs::vis::project {
         if (!settings_.auto_save_on_close ||
             !document_ ||
             !document_->source_path() ||
-            isTempProject()) {
+            isScratchBoundSession()) {
             return CloseSaveStatus::NeedsPrompt;
         }
         if (viewer_.getTrainer()) {
@@ -7549,7 +7694,7 @@ namespace lfs::vis::project {
         if (document_) {
             poll.generation = document_->generation();
             poll.path =
-                isTempProject()
+                isScratchBoundSession()
                     ? std::nullopt
                     : (recovered_master_path_
                            ? recovered_master_path_
@@ -7662,7 +7807,7 @@ namespace lfs::vis::project {
                 : document_->dirty_chapters();
         const bool hard_dirty =
             training_forces_dirty ||
-            isTempProject() ||
+            isScratchBoundSession() ||
             canFlushFinishedTrainerSnapshot() ||
             (!blank_untitled &&
              (scene_dirty_.load(
@@ -7676,7 +7821,7 @@ namespace lfs::vis::project {
             hasSessionSoftDirtyChapters(*document_);
         ProjectInfo result{
             .path =
-                isTempProject()
+                isScratchBoundSession()
                     ? std::nullopt
                     : (recovered_master_path_
                            ? recovered_master_path_
@@ -7826,6 +7971,14 @@ namespace lfs::vis::project {
             lfs::io::project::sweep_stale_scratch_autosaves(
                 legacy_recovery_directory_);
         }
+        if (!legacy_working_tmp_directory_.empty() &&
+            freezeNormalizedPath(legacy_working_tmp_directory_) !=
+                freezeNormalizedPath(temp_project_directory_) &&
+            freezeNormalizedPath(legacy_working_tmp_directory_) !=
+                freezeNormalizedPath(legacy_recovery_directory_)) {
+            lfs::io::project::sweep_stale_scratch_autosaves(
+                legacy_working_tmp_directory_);
+        }
 
         // Never auto-restore from MRU. Startup without an
         // explicit CLI project path leaves a blank session
@@ -7952,6 +8105,13 @@ namespace lfs::vis::project {
             freezeNormalizedPath(legacy_recovery_directory_) !=
                 freezeNormalizedPath(temp_project_directory_)) {
             scratch_dirs.push_back(legacy_recovery_directory_);
+        }
+        if (!legacy_working_tmp_directory_.empty() &&
+            freezeNormalizedPath(legacy_working_tmp_directory_) !=
+                freezeNormalizedPath(temp_project_directory_) &&
+            freezeNormalizedPath(legacy_working_tmp_directory_) !=
+                freezeNormalizedPath(legacy_recovery_directory_)) {
+            scratch_dirs.push_back(legacy_working_tmp_directory_);
         }
         for (const auto& scratch_dir : scratch_dirs) {
             for (auto& inspection :
@@ -8376,10 +8536,12 @@ namespace lfs::vis::project {
         return lfs::io::project::is_scratch_autosave_path(
                    path, temp_project_directory_) ||
                lfs::io::project::is_scratch_autosave_path(
-                   path, legacy_recovery_directory_);
+                   path, legacy_recovery_directory_) ||
+               lfs::io::project::is_scratch_autosave_path(
+                   path, legacy_working_tmp_directory_);
     }
 
-    bool ProjectLifecycle::isTempProject() const {
+    bool ProjectLifecycle::isScratchBoundSession() const {
         if (recovered_master_path_ &&
             isScratchPath(*recovered_master_path_)) {
             return true;
@@ -8396,15 +8558,22 @@ namespace lfs::vis::project {
                 settings_path_.parent_path() / "recovery");
             return;
         }
-        const auto working = loadWorkingDirectoryPreference();
-        temp_project_directory_ =
-            working.empty()
-                ? std::filesystem::path{}
-                : freezeNormalizedPath(working / "tmp");
         const auto paths = lfs::core::UserPaths::resolve();
+        temp_project_directory_ =
+            paths ? freezeNormalizedPath(paths->rootDir() / "tmp")
+                  : std::filesystem::path{};
         legacy_recovery_directory_ =
             paths ? freezeNormalizedPath(paths->recoveryDir())
                   : std::filesystem::path{};
+        const auto raw_working = workingDirectoryPreferenceRaw();
+        legacy_working_tmp_directory_ =
+            raw_working.empty()
+                ? std::filesystem::path{}
+                : freezeNormalizedPath(raw_working / "tmp");
+        if (freezeNormalizedPath(legacy_working_tmp_directory_) ==
+            freezeNormalizedPath(temp_project_directory_)) {
+            legacy_working_tmp_directory_.clear();
+        }
     }
 
     std::optional<lfs::io::project::WriterLockLease>
@@ -8430,11 +8599,24 @@ namespace lfs::vis::project {
                 freezeNormalizedPath(temp_project_directory_)) {
             directories.push_back(legacy_recovery_directory_);
         }
+        if (!legacy_working_tmp_directory_.empty() &&
+            freezeNormalizedPath(legacy_working_tmp_directory_) !=
+                freezeNormalizedPath(temp_project_directory_) &&
+            freezeNormalizedPath(legacy_working_tmp_directory_) !=
+                freezeNormalizedPath(legacy_recovery_directory_)) {
+            directories.push_back(legacy_working_tmp_directory_);
+        }
+        const auto project_location =
+            freezeNormalizedPath(loadProjectLocationPreference());
         std::optional<std::filesystem::path> keep_normalized;
         if (keep && !keep->empty()) {
             keep_normalized = freezeNormalizedPath(*keep);
         }
         for (const auto& directory : directories) {
+            if (!project_location.empty() &&
+                freezeNormalizedPath(directory) == project_location) {
+                continue;
+            }
             std::error_code error;
             if (!std::filesystem::is_directory(directory, error) ||
                 error) {
@@ -8550,6 +8732,29 @@ namespace lfs::vis::project {
                    std::memory_order_acquire);
     }
 
+    bool ProjectLifecycle::isBlankProject() const {
+        if (!document_ || !document_->source_path() ||
+            isScratchBoundSession()) {
+            return false;
+        }
+        const auto hydration =
+            hydration_.load(std::memory_order_acquire);
+        if (hydration != Hydration::Empty &&
+            hydration != Hydration::Complete) {
+            return false;
+        }
+        const auto* manager = viewer_.getSceneManager();
+        if (!manager ||
+            !manager->getScene().getNodes().empty()) {
+            return false;
+        }
+        return !scene_dirty_.load(
+                   std::memory_order_acquire) &&
+               !payload_dirty_.load(
+                   std::memory_order_acquire) &&
+               !hasHardDirtyChapters(*document_);
+    }
+
     lfs::Result<void>
     ProjectLifecycle::ensureScratchAutosaveBinding() {
         if (!document_) {
@@ -8566,9 +8771,9 @@ namespace lfs::vis::project {
         if (temp_project_directory_.empty()) {
             return fail<void>(
                 lfs::ErrorCode::Unavailable,
-                "The working folder could not be resolved. Set it in Preferences.",
+                "Internal project scratch storage could not be resolved.",
                 "the temp project directory could not be resolved",
-                "project.temp_project_directory");
+                "project.scratch_directory");
         }
         const auto destination =
             lfs::io::project::scratch_autosave_path(

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -50,15 +50,15 @@ namespace lfs::vis {
     class VisualizerImplResetTest_ProgressedPausedTrainerStillBlocksCleanClose_Test;
     class VisualizerImplResetTest_CloseSaveRoutesTrainingSnapshotToLiveDocument_Test;
     class VisualizerImplResetTest_TrainerOwnedSaveTargetsLiveDocumentPath_Test;
-    class VisualizerImplResetTest_StartTrainingUntitledBindsTempProjectAndStaysUntitled_Test;
+    class VisualizerImplResetTest_StartTrainingUntitledCreatesRealProjectInProjectLocation_Test;
     class VisualizerImplResetTest_StartTrainingWithCliOutputPathBindsProjectThere_Test;
-    class VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionKeepsSessionUntitledAndOutOfMru_Test;
-    class VisualizerImplResetTest_SaveAsAfterUntitledTrainingMigratesTempIncludingCheckpoint_Test;
+    class VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionRegistersProjectInMru_Test;
+    class VisualizerImplResetTest_SaveAsAfterAutoCreatedTrainingKeepsOriginalAndCheckpoint_Test;
     class VisualizerImplResetTest_UntitledStartConflictNeverReportsExistingOutputProject_Test;
-    class VisualizerImplResetTest_CompletedUntitledTrainingBlocksCleanClose_Test;
-    class VisualizerImplResetTest_TempProjectSaveRefusesAndStaysOutOfMru_Test;
-    class VisualizerImplResetTest_TempSessionLightAutosaveWritesSidecarWithScratchLease_Test;
-    class VisualizerImplResetTest_WorkingDirectoryPreferenceChangeAppliesToNextSession_Test;
+    class VisualizerImplResetTest_CompletedAutoCreatedTrainingSavesRealMasterOnClose_Test;
+    class VisualizerImplResetTest_SaveSucceedsOnAutoCreatedTrainingProject_Test;
+    class VisualizerImplResetTest_LightAutosaveWritesSidecarNextToAutoCreatedProject_Test;
+    class VisualizerImplResetTest_ProjectLocationPreferenceGovernsTrainingAutoCreate_Test;
     class VisualizerImplResetTest_StartupPrunesOlderUnlockedScratchFilesAfterOffer_Test;
     class VisualizerImplResetTest_StartupScansLegacyRecoveryDirectory_Test;
     class VisualizerImplResetTest_StartConflictSeesDiskCheckpointAfterTrainerReplacement_Test;
@@ -109,11 +109,23 @@ namespace lfs::vis {
     class VisualizerImplResetTest_RecoverLegacyScratchThenSaveAsRemovesLegacyFile_Test;
     class VisualizerImplResetTest_StartTrainingWaitsOutInFlightScratchAutosave_Test;
     class VisualizerImplResetTest_SaveAsAfterUntitledTrainingRoutesThroughFinishedTrainer_Test;
-    class VisualizerImplResetTest_ForceExitDiscardOnTempSessionLeavesNoFilesAndNoWarning_Test;
+    class VisualizerImplResetTest_ForceExitDiscardOnAutoCreatedProjectLeavesProjectAndNoAutosave_Test;
     class VisualizerImplResetTest_DatasetLoadIntoTitledProjectStartsUntitledSessionAndKeepsProjectFile_Test;
-    class VisualizerImplResetTest_DatasetLoadIntoTrainedTempSessionRemovesOldTempFile_Test;
+    class VisualizerImplResetTest_DatasetLoadIntoTrainedAutoCreatedProjectStartsUntitledSessionAndKeepsProjectFile_Test;
     class VisualizerImplResetTest_SplatDropOntoTitledDatasetProjectStartsUntitledSessionAndKeepsProjectFile_Test;
     class VisualizerImplResetTest_OpenWithoutRestoreKeepsCheckpointBytesOnAutosave_Test;
+    class VisualizerImplResetTest_CreateProjectAtWritesBindsAndRegistersMru_Test;
+    class VisualizerImplResetTest_CreateProjectAtRefusesExistingDestination_Test;
+    class VisualizerImplResetTest_CreateProjectAtRejectsScratchAndUnpublishedPaths_Test;
+    class VisualizerImplResetTest_CreateProjectRequireCleanFailsOnDirtySession_Test;
+    class VisualizerImplResetTest_TrainingStartAutoCreateSuffixesOnCollision_Test;
+    class VisualizerImplResetTest_DatasetLoadIntoBlankCreatedProjectKeepsBinding_Test;
+    class VisualizerImplResetTest_ProjectCreateOnDirtyEmitsCreatePath_Test;
+    class VisualizerImplResetTest_StartupScansLegacyWorkingTmpDirectory_Test;
+    class VisualizerImplResetTest_StartupPruneNeverTouchesProjectLocation_Test;
+    class VisualizerImplResetTest_ScratchDirectoryIsFixedUnderRootRegardlessOfPreferences_Test;
+    class VisualizerImplResetTest_ProjectCreateWhileTrainingPromptsWithCreatePath_Test;
+    class VisualizerImplResetTest_RecoveredScratchSaveStillRefusesAndStaysOutOfMru_Test;
 } // namespace lfs::vis
 
 namespace lfs::vis::project {
@@ -200,9 +212,15 @@ namespace lfs::vis::project {
         newProject(
             ProjectSwitchDisposition disposition =
                 ProjectSwitchDisposition::RequireClean);
+        [[nodiscard]] lfs::Result<void>
+        createProjectAt(
+            const std::filesystem::path& path,
+            ProjectSwitchDisposition disposition =
+                ProjectSwitchDisposition::RequireClean);
         [[nodiscard]] bool isDirty();
         [[nodiscard]] bool hasSourcePath() const;
-        [[nodiscard]] bool isTempProject() const;
+        [[nodiscard]] bool isScratchBoundSession() const;
+        [[nodiscard]] bool isBlankProject() const;
         [[nodiscard]] bool isBlankUntitledSession() const;
         [[nodiscard]] lfs::Result<ProjectInfo> info();
         [[nodiscard]] ProjectWritePoll pollWrite();
@@ -251,7 +269,7 @@ namespace lfs::vis::project {
         // Returns the blocking conflict a fresh training start would overwrite, if any:
         // the bound checkpoint iteration of the open titled project (in memory or
         // on the titled master), or -1 when an existing titled master is unreadable.
-        // Untitled and temp sessions never report a conflict.
+        // Untitled and scratch-bound sessions never report a conflict.
         [[nodiscard]] std::optional<int>
         trainingStartOverwriteConflict();
         [[nodiscard]] lfs::Result<void>
@@ -305,15 +323,15 @@ namespace lfs::vis::project {
         friend class lfs::vis::VisualizerImplResetTest_ProgressedPausedTrainerStillBlocksCleanClose_Test;
         friend class lfs::vis::VisualizerImplResetTest_CloseSaveRoutesTrainingSnapshotToLiveDocument_Test;
         friend class lfs::vis::VisualizerImplResetTest_TrainerOwnedSaveTargetsLiveDocumentPath_Test;
-        friend class lfs::vis::VisualizerImplResetTest_StartTrainingUntitledBindsTempProjectAndStaysUntitled_Test;
+        friend class lfs::vis::VisualizerImplResetTest_StartTrainingUntitledCreatesRealProjectInProjectLocation_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartTrainingWithCliOutputPathBindsProjectThere_Test;
-        friend class lfs::vis::VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionKeepsSessionUntitledAndOutOfMru_Test;
-        friend class lfs::vis::VisualizerImplResetTest_SaveAsAfterUntitledTrainingMigratesTempIncludingCheckpoint_Test;
+        friend class lfs::vis::VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionRegistersProjectInMru_Test;
+        friend class lfs::vis::VisualizerImplResetTest_SaveAsAfterAutoCreatedTrainingKeepsOriginalAndCheckpoint_Test;
         friend class lfs::vis::VisualizerImplResetTest_UntitledStartConflictNeverReportsExistingOutputProject_Test;
-        friend class lfs::vis::VisualizerImplResetTest_CompletedUntitledTrainingBlocksCleanClose_Test;
-        friend class lfs::vis::VisualizerImplResetTest_TempProjectSaveRefusesAndStaysOutOfMru_Test;
-        friend class lfs::vis::VisualizerImplResetTest_TempSessionLightAutosaveWritesSidecarWithScratchLease_Test;
-        friend class lfs::vis::VisualizerImplResetTest_WorkingDirectoryPreferenceChangeAppliesToNextSession_Test;
+        friend class lfs::vis::VisualizerImplResetTest_CompletedAutoCreatedTrainingSavesRealMasterOnClose_Test;
+        friend class lfs::vis::VisualizerImplResetTest_SaveSucceedsOnAutoCreatedTrainingProject_Test;
+        friend class lfs::vis::VisualizerImplResetTest_LightAutosaveWritesSidecarNextToAutoCreatedProject_Test;
+        friend class lfs::vis::VisualizerImplResetTest_ProjectLocationPreferenceGovernsTrainingAutoCreate_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartupPrunesOlderUnlockedScratchFilesAfterOffer_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartupScansLegacyRecoveryDirectory_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartConflictSeesDiskCheckpointAfterTrainerReplacement_Test;
@@ -364,11 +382,23 @@ namespace lfs::vis::project {
         friend class lfs::vis::VisualizerImplResetTest_RecoverLegacyScratchThenSaveAsRemovesLegacyFile_Test;
         friend class lfs::vis::VisualizerImplResetTest_StartTrainingWaitsOutInFlightScratchAutosave_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsAfterUntitledTrainingRoutesThroughFinishedTrainer_Test;
-        friend class lfs::vis::VisualizerImplResetTest_ForceExitDiscardOnTempSessionLeavesNoFilesAndNoWarning_Test;
+        friend class lfs::vis::VisualizerImplResetTest_ForceExitDiscardOnAutoCreatedProjectLeavesProjectAndNoAutosave_Test;
         friend class lfs::vis::VisualizerImplResetTest_DatasetLoadIntoTitledProjectStartsUntitledSessionAndKeepsProjectFile_Test;
-        friend class lfs::vis::VisualizerImplResetTest_DatasetLoadIntoTrainedTempSessionRemovesOldTempFile_Test;
+        friend class lfs::vis::VisualizerImplResetTest_DatasetLoadIntoTrainedAutoCreatedProjectStartsUntitledSessionAndKeepsProjectFile_Test;
         friend class lfs::vis::VisualizerImplResetTest_SplatDropOntoTitledDatasetProjectStartsUntitledSessionAndKeepsProjectFile_Test;
         friend class lfs::vis::VisualizerImplResetTest_OpenWithoutRestoreKeepsCheckpointBytesOnAutosave_Test;
+        friend class lfs::vis::VisualizerImplResetTest_CreateProjectAtWritesBindsAndRegistersMru_Test;
+        friend class lfs::vis::VisualizerImplResetTest_CreateProjectAtRefusesExistingDestination_Test;
+        friend class lfs::vis::VisualizerImplResetTest_CreateProjectAtRejectsScratchAndUnpublishedPaths_Test;
+        friend class lfs::vis::VisualizerImplResetTest_CreateProjectRequireCleanFailsOnDirtySession_Test;
+        friend class lfs::vis::VisualizerImplResetTest_TrainingStartAutoCreateSuffixesOnCollision_Test;
+        friend class lfs::vis::VisualizerImplResetTest_DatasetLoadIntoBlankCreatedProjectKeepsBinding_Test;
+        friend class lfs::vis::VisualizerImplResetTest_ProjectCreateOnDirtyEmitsCreatePath_Test;
+        friend class lfs::vis::VisualizerImplResetTest_StartupScansLegacyWorkingTmpDirectory_Test;
+        friend class lfs::vis::VisualizerImplResetTest_StartupPruneNeverTouchesProjectLocation_Test;
+        friend class lfs::vis::VisualizerImplResetTest_ScratchDirectoryIsFixedUnderRootRegardlessOfPreferences_Test;
+        friend class lfs::vis::VisualizerImplResetTest_ProjectCreateWhileTrainingPromptsWithCreatePath_Test;
+        friend class lfs::vis::VisualizerImplResetTest_RecoveredScratchSaveStillRefusesAndStaysOutOfMru_Test;
         enum class Hydration {
             Empty,
             ShellReady,
@@ -520,6 +550,9 @@ namespace lfs::vis::project {
         [[nodiscard]] lfs::Result<void>
         adoptCompletedTrainingSnapshot(
             bool allow_during_application_close = false);
+        [[nodiscard]] lfs::Result<void>
+        bindUntitledSessionToMaster(
+            const std::filesystem::path& destination);
         void resetAdoptedSnapshotCountOnServiceRestart(
             std::uint64_t completed_snapshots);
         [[nodiscard]] lfs::Result<void>
@@ -594,6 +627,7 @@ namespace lfs::vis::project {
         std::filesystem::path settings_path_;
         std::filesystem::path temp_project_directory_;
         std::filesystem::path legacy_recovery_directory_;
+        std::filesystem::path legacy_working_tmp_directory_;
         bool isolated_scratch_storage_ = false;
         bool settings_persistence_enabled_ = true;
         std::atomic<std::uint64_t> epoch_{0};

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -1365,6 +1365,16 @@ namespace lfs::vis {
                 }
             };
 
+        cmd::ProjectCreate::when(
+            [this](const auto& command) {
+                handleCreateProject(
+                    command.path,
+                    command.discard_changes
+                        ? ProjectSwitchDisposition::DiscardChanges
+                        : ProjectSwitchDisposition::RequireClean,
+                    command.stop_training);
+            });
+
         cmd::SwitchToEditMode::when(
             [this, publish_project_error](const auto&) {
                 if (project_lifecycle_) {
@@ -2867,6 +2877,9 @@ namespace lfs::vis {
         if (!project_lifecycle_) {
             return true;
         }
+        if (project_lifecycle_->isBlankProject()) {
+            return true;
+        }
         if (project_lifecycle_->isBlankUntitledSession()) {
             return true;
         }
@@ -3048,6 +3061,98 @@ namespace lfs::vis {
         }
     }
 
+    void VisualizerImpl::handleCreateProject(
+        const std::filesystem::path& path,
+        const ProjectSwitchDisposition disposition,
+        const bool stop_training) {
+        if (pending_training_action_ ==
+                PendingTrainingAction::CloseSave ||
+            pending_training_action_ ==
+                PendingTrainingAction::CloseDiscard) {
+            return;
+        }
+        if (!project_lifecycle_) {
+            return;
+        }
+        if (auto preflight = project_lifecycle_->preflightSwitch(
+                disposition, stop_training);
+            !preflight) {
+            if (isDirtyProjectSwitchError(preflight.error())) {
+                lfs::core::events::cmd::ShowProjectSwitchConfirmation{
+                    .new_project = true,
+                    .path = {},
+                    .create_path = path}
+                    .emit();
+                return;
+            }
+            if (!stop_training &&
+                isTrainingProjectSwitchError(preflight.error()) &&
+                trainer_manager_ &&
+                trainer_manager_->isTrainingActive()) {
+                lfs::core::events::cmd::ShowStopTrainingConfirmation{
+                    .new_project = true,
+                    .path = {},
+                    .discard_changes =
+                        disposition ==
+                        ProjectSwitchDisposition::DiscardChanges,
+                    .create_path = path}
+                    .emit();
+                return;
+            }
+            LOG_ERROR(
+                "Create Project preflight failed: {}",
+                lfs::format_for_developer(preflight.error()));
+            lfs::Error contextual = preflight.error();
+            lfs::ErrorBus::instance().publish(lfs::ErrorNotification{
+                .error = std::move(contextual).with_context(gui::error_op::kNewProject, LFS_SOURCE_SITE_CURRENT()),
+                .surface = lfs::ErrorSurface::Toast,
+                .actions = {},
+                .operation_id = lfs::OperationId::generate(),
+            });
+            return;
+        }
+        if (gui_manager_) {
+            gui_manager_->asyncTasks().cancelImport();
+        }
+        pending_view_paths_.clear();
+        pending_dataset_path_.clear();
+        pending_auto_train_ = false;
+        if (shouldDeferProjectSwitchForTraining()) {
+            pending_training_action_ =
+                PendingTrainingAction::CreateProject;
+            pending_create_project_path_ = path;
+            pending_new_project_disposition_ = disposition;
+            requestStopThenPendingAction();
+            return;
+        }
+        pending_training_action_ = PendingTrainingAction::None;
+        pending_create_project_path_.clear();
+        performCreateProject(path, disposition);
+    }
+
+    void VisualizerImpl::performCreateProject(
+        const std::filesystem::path& path,
+        const ProjectSwitchDisposition disposition) {
+        keep_asset_manager_open_after_restore_ = false;
+        if (!project_lifecycle_) {
+            return;
+        }
+        if (auto created = project_lifecycle_->createProjectAt(
+                path, disposition);
+            !created) {
+            LOG_ERROR(
+                "Create Project failed: {}",
+                lfs::format_for_developer(created.error()));
+            lfs::Error contextual = created.error();
+            lfs::ErrorBus::instance().publish(lfs::ErrorNotification{
+                .error = std::move(contextual).with_context(gui::error_op::kNewProject, LFS_SOURCE_SITE_CURRENT()),
+                .surface = lfs::ErrorSurface::Toast,
+                .actions = {},
+                .operation_id = lfs::OperationId::generate(),
+            });
+        }
+    }
+
     void VisualizerImpl::handleOpenProject(
         const std::filesystem::path& path,
         const ProjectSwitchDisposition disposition,
@@ -3187,6 +3292,7 @@ namespace lfs::vis {
         pending_open_disposition_ =
             ProjectSwitchDisposition::RequireClean;
         pending_open_keep_asset_manager_open_ = false;
+        pending_create_project_path_.clear();
         pending_load_files_.clear();
         gui_session_restore_.clear();
         pending_project_tools_restore_.reset();
@@ -3482,6 +3588,21 @@ namespace lfs::vis {
         }
         return project_lifecycle_->saveAs(
             path, regenerate_preview);
+    }
+
+    lfs::Result<void>
+    VisualizerImpl::projectCreateAt(
+        const std::filesystem::path& path,
+        const ProjectSwitchDisposition disposition) {
+        if (!project_lifecycle_) {
+            return visualizerFailure<void>(
+                lfs::ErrorCode::Unavailable,
+                "Project lifecycle is unavailable.",
+                "The visualizer did not initialize its project lifecycle service",
+                "project.lifecycle");
+        }
+        return project_lifecycle_->createProjectAt(
+            path, disposition);
     }
 
     lfs::Result<void>
@@ -3870,6 +3991,17 @@ namespace lfs::vis {
                 ProjectSwitchDisposition::
                     RequireClean;
             break;
+        case PendingTrainingAction::CreateProject: {
+            const auto path = std::exchange(
+                pending_create_project_path_, {});
+            const auto disposition = std::exchange(
+                pending_new_project_disposition_,
+                ProjectSwitchDisposition::RequireClean);
+            if (!path.empty()) {
+                performCreateProject(path, disposition);
+            }
+            break;
+        }
         case PendingTrainingAction::OpenProject: {
             const auto path =
                 std::exchange(

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -99,6 +99,11 @@ namespace lfs::vis {
         lfs::Result<void>
         projectSaveAs(const std::filesystem::path& path,
                       bool regenerate_preview = true) override;
+        lfs::Result<void>
+        projectCreateAt(
+            const std::filesystem::path& path,
+            ProjectSwitchDisposition disposition =
+                ProjectSwitchDisposition::RequireClean) override;
         lfs::Result<void> projectSaveAsExplicit(
             const std::filesystem::path& path,
             bool regenerate_preview = true);
@@ -254,6 +259,18 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_StoredSessionAtPrmsIterationsReportsCompleted_Test;
         friend class VisualizerImplResetTest_StoredSessionBelowPrmsIterationsReportsNotCompleted_Test;
         friend class VisualizerImplResetTest_OpenWithoutRestoreKeepsCheckpointBytesOnAutosave_Test;
+        friend class VisualizerImplResetTest_CreateProjectAtWritesBindsAndRegistersMru_Test;
+        friend class VisualizerImplResetTest_CreateProjectAtRefusesExistingDestination_Test;
+        friend class VisualizerImplResetTest_CreateProjectAtRejectsScratchAndUnpublishedPaths_Test;
+        friend class VisualizerImplResetTest_CreateProjectRequireCleanFailsOnDirtySession_Test;
+        friend class VisualizerImplResetTest_TrainingStartAutoCreateSuffixesOnCollision_Test;
+        friend class VisualizerImplResetTest_DatasetLoadIntoBlankCreatedProjectKeepsBinding_Test;
+        friend class VisualizerImplResetTest_ProjectCreateOnDirtyEmitsCreatePath_Test;
+        friend class VisualizerImplResetTest_StartupScansLegacyWorkingTmpDirectory_Test;
+        friend class VisualizerImplResetTest_StartupPruneNeverTouchesProjectLocation_Test;
+        friend class VisualizerImplResetTest_ScratchDirectoryIsFixedUnderRootRegardlessOfPreferences_Test;
+        friend class VisualizerImplResetTest_ProjectCreateWhileTrainingPromptsWithCreatePath_Test;
+        friend class VisualizerImplResetTest_RecoveredScratchSaveStillRefusesAndStaysOutOfMru_Test;
         friend class VisualizerImplResetTest_EditModeWithoutHydratedSessionDropsCheckpoint_Test;
         friend class VisualizerImplResetTest_RestoreThenTrainWritesNewCheckpoint_Test;
         friend class VisualizerImplResetTest_HeadlessOpenPrintsHydrationStagesWhenBenchPathSet_Test;
@@ -300,16 +317,16 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_ProgressedPausedTrainerStillBlocksCleanClose_Test;
         friend class VisualizerImplResetTest_CloseSaveRoutesTrainingSnapshotToLiveDocument_Test;
         friend class VisualizerImplResetTest_TrainerOwnedSaveTargetsLiveDocumentPath_Test;
-        friend class VisualizerImplResetTest_StartTrainingUntitledBindsTempProjectAndStaysUntitled_Test;
+        friend class VisualizerImplResetTest_StartTrainingUntitledCreatesRealProjectInProjectLocation_Test;
         friend class VisualizerImplResetTest_PrepareTrainingStartProjectSucceedsAfterInitPlyLoad_Test;
         friend class VisualizerImplResetTest_StartTrainingWithCliOutputPathBindsProjectThere_Test;
-        friend class VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionKeepsSessionUntitledAndOutOfMru_Test;
-        friend class VisualizerImplResetTest_SaveAsAfterUntitledTrainingMigratesTempIncludingCheckpoint_Test;
+        friend class VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionRegistersProjectInMru_Test;
+        friend class VisualizerImplResetTest_SaveAsAfterAutoCreatedTrainingKeepsOriginalAndCheckpoint_Test;
         friend class VisualizerImplResetTest_UntitledStartConflictNeverReportsExistingOutputProject_Test;
-        friend class VisualizerImplResetTest_CompletedUntitledTrainingBlocksCleanClose_Test;
-        friend class VisualizerImplResetTest_TempProjectSaveRefusesAndStaysOutOfMru_Test;
-        friend class VisualizerImplResetTest_TempSessionLightAutosaveWritesSidecarWithScratchLease_Test;
-        friend class VisualizerImplResetTest_WorkingDirectoryPreferenceChangeAppliesToNextSession_Test;
+        friend class VisualizerImplResetTest_CompletedAutoCreatedTrainingSavesRealMasterOnClose_Test;
+        friend class VisualizerImplResetTest_SaveSucceedsOnAutoCreatedTrainingProject_Test;
+        friend class VisualizerImplResetTest_LightAutosaveWritesSidecarNextToAutoCreatedProject_Test;
+        friend class VisualizerImplResetTest_ProjectLocationPreferenceGovernsTrainingAutoCreate_Test;
         friend class VisualizerImplResetTest_StartupPrunesOlderUnlockedScratchFilesAfterOffer_Test;
         friend class VisualizerImplResetTest_StartupScansLegacyRecoveryDirectory_Test;
         friend class VisualizerImplResetTest_PausedUngrantedStartTrainingGrantsAndBinds_Test;
@@ -389,10 +406,10 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_LoadFileStopTrainingDefersSplatLoadUntilTrainerStops_Test;
         friend class VisualizerImplResetTest_LoadFileStopTrainingDefersWholeBatchInOrder_Test;
         friend class VisualizerImplResetTest_LoadDatasetApiDoesNotDeferOrPrompt_Test;
-        friend class VisualizerImplResetTest_ForceExitDiscardOnTempSessionLeavesNoFilesAndNoWarning_Test;
+        friend class VisualizerImplResetTest_ForceExitDiscardOnAutoCreatedProjectLeavesProjectAndNoAutosave_Test;
         friend class VisualizerImplResetTest_DatasetLoadIntoTitledProjectStartsUntitledSessionAndKeepsProjectFile_Test;
         friend class VisualizerImplResetTest_DatasetLoadPreservesImportParameters_Test;
-        friend class VisualizerImplResetTest_DatasetLoadIntoTrainedTempSessionRemovesOldTempFile_Test;
+        friend class VisualizerImplResetTest_DatasetLoadIntoTrainedAutoCreatedProjectStartsUntitledSessionAndKeepsProjectFile_Test;
         friend class VisualizerImplResetTest_SplatDropOntoTitledDatasetProjectStartsUntitledSessionAndKeepsProjectFile_Test;
         friend class VisualizerImplResetTest_SplatAddOntoSplatSceneKeepsTitledProject_Test;
         friend class VisualizerImplResetTest_PreTrainingProjectSaveRestoresCameraEnabledAndHidden_Test;
@@ -451,6 +468,13 @@ namespace lfs::vis {
             ProjectSwitchDisposition disposition,
             bool stop_training = false);
         void performNewProject(
+            ProjectSwitchDisposition disposition);
+        void handleCreateProject(
+            const std::filesystem::path& path,
+            ProjectSwitchDisposition disposition,
+            bool stop_training = false);
+        void performCreateProject(
+            const std::filesystem::path& path,
             ProjectSwitchDisposition disposition);
         void handleOpenProject(
             const std::filesystem::path& path,
@@ -593,6 +617,7 @@ namespace lfs::vis {
             None,
             Reset,
             NewProject,
+            CreateProject,
             OpenProject,
             LoadDataset,
             CloseSave,
@@ -604,6 +629,7 @@ namespace lfs::vis {
             pending_new_project_disposition_ =
                 ProjectSwitchDisposition::RequireClean;
         std::filesystem::path pending_open_path_;
+        std::filesystem::path pending_create_project_path_;
         ProjectSwitchDisposition
             pending_open_disposition_ =
                 ProjectSwitchDisposition::RequireClean;

--- a/tests/test_mcp_app_utils.cpp
+++ b/tests/test_mcp_app_utils.cpp
@@ -85,6 +85,11 @@ namespace {
             const std::filesystem::path&, bool) override {
             return {};
         }
+        lfs::Result<void> projectCreateAt(
+            const std::filesystem::path&,
+            lfs::vis::ProjectSwitchDisposition) override {
+            return {};
+        }
         lfs::Result<lfs::vis::ProjectOpenOutcome> projectOpen(
             const std::filesystem::path&,
             lfs::vis::ProjectSwitchDisposition) override {

--- a/tests/test_mcp_sequencer_tools.cpp
+++ b/tests/test_mcp_sequencer_tools.cpp
@@ -91,6 +91,11 @@ namespace {
             const std::filesystem::path&, bool) override {
             return {};
         }
+        lfs::Result<void> projectCreateAt(
+            const std::filesystem::path&,
+            lfs::vis::ProjectSwitchDisposition) override {
+            return {};
+        }
         lfs::Result<lfs::vis::ProjectOpenOutcome> projectOpen(
             const std::filesystem::path&,
             lfs::vis::ProjectSwitchDisposition) override {

--- a/tests/test_python_integration.cpp
+++ b/tests/test_python_integration.cpp
@@ -162,6 +162,11 @@ namespace {
             const std::filesystem::path&, bool) override {
             return {};
         }
+        lfs::Result<void> projectCreateAt(
+            const std::filesystem::path&,
+            lfs::vis::ProjectSwitchDisposition) override {
+            return {};
+        }
         lfs::Result<lfs::vis::ProjectOpenOutcome> projectOpen(
             const std::filesystem::path&,
             lfs::vis::ProjectSwitchDisposition) override {

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -16,6 +16,7 @@
 #include "core/path_utils.hpp"
 #include "core/scene.hpp"
 #include "core/services.hpp"
+#include "core/user_paths.hpp"
 #include "gui/scene_tree_session.hpp"
 #include "gui/string_keys.hpp"
 #include "input/input_controller.hpp"
@@ -209,6 +210,11 @@ namespace {
             const std::filesystem::path&, bool) override {
             return {};
         }
+        lfs::Result<void> projectCreateAt(
+            const std::filesystem::path&,
+            lfs::vis::ProjectSwitchDisposition) override {
+            return {};
+        }
         lfs::Result<lfs::vis::ProjectOpenOutcome> projectOpen(
             const std::filesystem::path&,
             lfs::vis::ProjectSwitchDisposition) override {
@@ -326,10 +332,13 @@ TEST(VisualizerPostedWorkTest, GuardedShutdownCancellationMakesWaitingFutureRead
 class VisualizerImplResetTest : public ::testing::Test {
 protected:
     void SetUp() override {
+        isolated_home_.emplace(temporary_.path / "home");
         lfs::event::EventBridge::instance().clear_all();
         lfs::core::event::bus().clear_all();
         lfs::vis::services().clear();
         lfs::vis::op::undoHistory().clear();
+        static_cast<void>(lfs::vis::setProjectLocationPreference(
+            temporary_.path / "projects"));
     }
 
     void TearDown() override {
@@ -337,6 +346,8 @@ protected:
         lfs::vis::services().clear();
         lfs::core::event::bus().clear_all();
         lfs::event::EventBridge::instance().clear_all();
+        lfs::vis::clearProjectLocationPreference();
+        isolated_home_.reset();
     }
 
     [[nodiscard]] lfs::vis::ViewerOptions projectOptions() const {
@@ -440,6 +451,7 @@ protected:
     }
 
     lfs::test::licht::TemporaryDirectory temporary_{"lfs-visualizer-project"};
+    std::optional<ScopedLfsHome> isolated_home_;
 };
 
 namespace {
@@ -3728,7 +3740,7 @@ namespace lfs::vis {
                                    lichtfeld::Strings::Recovery::RECOVER)});
             ASSERT_TRUE(viewer.project_lifecycle_->document_);
             EXPECT_TRUE(
-                viewer.project_lifecycle_->isTempProject());
+                viewer.project_lifecycle_->isScratchBoundSession());
             EXPECT_FALSE(
                 viewer.project_lifecycle_->hasSourcePath());
             EXPECT_TRUE(
@@ -3790,7 +3802,7 @@ namespace lfs::vis {
                 lifecycle->scratch_lock_->owns(master));
             EXPECT_FALSE(lifecycle->recovered_master_path_);
             EXPECT_FALSE(lifecycle->recovery_session_);
-            EXPECT_TRUE(lifecycle->isTempProject());
+            EXPECT_TRUE(lifecycle->isScratchBoundSession());
             EXPECT_FALSE(lifecycle->hasSourcePath());
             EXPECT_FALSE(std::filesystem::exists(sidecar));
             lfs::core::events::cmd::ForceExit{
@@ -3815,7 +3827,7 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           ForceExitDiscardOnTempSessionLeavesNoFilesAndNoWarning) {
+           ForceExitDiscardOnAutoCreatedProjectLeavesProjectAndNoAutosave) {
         auto options = projectOptions();
         std::vector<std::string> warnings;
         const auto handler_token =
@@ -3897,7 +3909,7 @@ namespace lfs::vis {
         }
         lfs::core::Logger::get().remove_log_handler(
             handler_token);
-        EXPECT_FALSE(std::filesystem::exists(master));
+        EXPECT_TRUE(std::filesystem::exists(master));
         EXPECT_FALSE(std::filesystem::exists(sidecar));
         EXPECT_FALSE(std::filesystem::exists(lock_path));
         for (const auto& warning : warnings) {
@@ -5514,7 +5526,7 @@ namespace lfs::vis {
                 }));
 
             EXPECT_FALSE(lifecycle->hasSourcePath());
-            EXPECT_FALSE(lifecycle->isTempProject());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             const auto has_path = viewer.projectHasPath();
             ASSERT_TRUE(has_path);
             EXPECT_FALSE(*has_path);
@@ -5627,7 +5639,7 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           DatasetLoadIntoTrainedTempSessionRemovesOldTempFile) {
+           DatasetLoadIntoTrainedAutoCreatedProjectStartsUntitledSessionAndKeepsProjectFile) {
         auto options = projectOptions();
         {
             VisualizerImpl viewer(options);
@@ -5650,7 +5662,7 @@ namespace lfs::vis {
                     scene));
             ASSERT_TRUE(
                 lifecycle->prepareTrainingStartProject());
-            EXPECT_TRUE(lifecycle->isTempProject());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             const auto bound =
                 viewer.getTrainer()->bound_project_path();
             ASSERT_TRUE(bound.has_value());
@@ -5676,8 +5688,8 @@ namespace lfs::vis {
                 }));
 
             EXPECT_FALSE(lifecycle->hasSourcePath());
-            EXPECT_FALSE(lifecycle->isTempProject());
-            EXPECT_FALSE(std::filesystem::exists(*bound));
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
+            EXPECT_TRUE(std::filesystem::exists(*bound));
             EXPECT_FALSE(std::filesystem::exists(lock_path));
             EXPECT_FALSE(std::filesystem::exists(sidecar));
         }
@@ -5743,7 +5755,7 @@ namespace lfs::vis {
                 .emit();
 
             EXPECT_FALSE(lifecycle->hasSourcePath());
-            EXPECT_FALSE(lifecycle->isTempProject());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             EXPECT_EQ(
                 viewer.getSceneManager()->getContentType(),
                 SceneManager::ContentType::SplatFiles);
@@ -5806,7 +5818,7 @@ namespace lfs::vis {
                 .emit();
 
             EXPECT_TRUE(lifecycle->hasSourcePath());
-            EXPECT_FALSE(lifecycle->isTempProject());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             const auto has_path = viewer.projectHasPath();
             ASSERT_TRUE(has_path);
             EXPECT_TRUE(*has_path);
@@ -8096,7 +8108,7 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           StartTrainingUntitledBindsTempProjectAndStaysUntitled) {
+           StartTrainingUntitledCreatesRealProjectInProjectLocation) {
         const auto& temporary = temporary_.path;
         const auto output_path =
             temporary / "train-start-out";
@@ -8136,17 +8148,15 @@ namespace lfs::vis {
             ASSERT_TRUE(prepared)
                 << lfs::format_for_developer(
                        prepared.error());
-            EXPECT_FALSE(lifecycle->hasSourcePath());
-            EXPECT_TRUE(lifecycle->isTempProject());
+            EXPECT_TRUE(lifecycle->hasSourcePath());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             const auto bound =
                 trainer->bound_project_path();
             ASSERT_TRUE(bound.has_value());
             EXPECT_EQ(
                 bound->parent_path().lexically_normal(),
-                (temporary / "tmp").lexically_normal());
-            EXPECT_TRUE(
-                lfs::io::project::is_scratch_autosave_path(
-                    *bound, temporary / "tmp"));
+                (temporary / "projects").lexically_normal());
+            EXPECT_TRUE(std::filesystem::is_regular_file(*bound));
             EXPECT_EQ(
                 bound->lexically_normal(),
                 lifecycle->document_->source_path()
@@ -8283,7 +8293,7 @@ namespace lfs::vis {
                 << lfs::format_for_developer(
                        prepared.error());
             EXPECT_TRUE(lifecycle->hasSourcePath());
-            EXPECT_FALSE(lifecycle->isTempProject());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             const auto expected =
                 std::filesystem::absolute(
                     output_path / "project.licht")
@@ -8340,20 +8350,12 @@ namespace lfs::vis {
                 lifecycle->prepareTrainingStartProject();
             ASSERT_TRUE(prepared)
                 << lfs::format_for_developer(prepared.error());
-            EXPECT_FALSE(lifecycle->hasSourcePath());
-            EXPECT_TRUE(lifecycle->isTempProject());
+            EXPECT_TRUE(lifecycle->hasSourcePath());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             ASSERT_TRUE(lifecycle->document_);
             ASSERT_TRUE(lifecycle->document_->source_path());
-            ASSERT_TRUE(lifecycle->scratch_autosave_path_);
-            EXPECT_EQ(
-                lifecycle->scratch_autosave_path_
-                    ->lexically_normal(),
-                lifecycle->document_->source_path()
-                    ->lexically_normal());
-            ASSERT_TRUE(lifecycle->scratch_lock_);
-            EXPECT_TRUE(
-                lifecycle->scratch_lock_->owns(
-                    *lifecycle->document_->source_path()));
+            EXPECT_FALSE(lifecycle->scratch_autosave_path_);
+            EXPECT_FALSE(lifecycle->scratch_lock_);
             EXPECT_FALSE(viewer.jobs().anyRunning(
                 JobType::ProjectWrite));
         }
@@ -8416,14 +8418,14 @@ namespace lfs::vis {
             EXPECT_TRUE(policy.on_completion);
             EXPECT_TRUE(policy.at_step_boundaries);
             EXPECT_FALSE(policy.on_stop_or_error);
-            EXPECT_FALSE(lifecycle->hasSourcePath());
-            EXPECT_TRUE(lifecycle->isTempProject());
+            EXPECT_TRUE(lifecycle->hasSourcePath());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             const auto bound =
                 trainer->bound_project_path();
             ASSERT_TRUE(bound.has_value());
-            EXPECT_TRUE(
-                lfs::io::project::is_scratch_autosave_path(
-                    *bound, temporary / "tmp"));
+            EXPECT_EQ(
+                bound->parent_path().lexically_normal(),
+                (temporary / "projects").lexically_normal());
             EXPECT_FALSE(std::filesystem::exists(
                 output_path / "project.licht"));
 
@@ -8441,7 +8443,7 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           UntitledTrainingSnapshotAdoptionKeepsSessionUntitledAndOutOfMru) {
+           UntitledTrainingSnapshotAdoptionRegistersProjectInMru) {
         const auto& temporary = temporary_.path;
         auto options = projectOptions();
         {
@@ -8467,8 +8469,6 @@ namespace lfs::vis {
                 << lfs::format_for_developer(prepared.error());
             const auto bound = trainer->bound_project_path();
             ASSERT_TRUE(bound.has_value());
-            const auto mru_before =
-                lifecycle->menuInfo().recent_projects.size();
             lifecycle->scratch_lock_.reset();
             std::filesystem::remove(*bound);
             const auto training_uuid = lfs::core::generate_uuid_v4();
@@ -8484,14 +8484,19 @@ namespace lfs::vis {
             auto adopted = lifecycle->adoptCompletedTrainingSnapshot();
             ASSERT_TRUE(adopted)
                 << lfs::format_for_developer(adopted.error());
-            EXPECT_FALSE(lifecycle->hasSourcePath());
-            EXPECT_TRUE(lifecycle->isTempProject());
+            EXPECT_TRUE(lifecycle->hasSourcePath());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             ASSERT_NE(lifecycle->document_, nullptr);
             EXPECT_FALSE(
                 lifecycle->document_->checkpoint_uuids().empty());
-            EXPECT_EQ(
-                lifecycle->menuInfo().recent_projects.size(),
-                mru_before);
+            const auto recent =
+                lifecycle->menuInfo().recent_projects;
+            EXPECT_TRUE(std::any_of(
+                recent.begin(), recent.end(),
+                [&](const auto& entry) {
+                    return entry.last_known_path.lexically_normal() ==
+                           bound->lexically_normal();
+                }));
             const auto still_bound = trainer->bound_project_path();
             ASSERT_TRUE(still_bound.has_value());
             EXPECT_EQ(
@@ -8501,7 +8506,7 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           SaveAsAfterUntitledTrainingMigratesTempIncludingCheckpoint) {
+           SaveAsAfterAutoCreatedTrainingKeepsOriginalAndCheckpoint) {
         const auto& temporary = temporary_.path;
         const auto destination = temporary / "migrated-temp.licht";
         auto options = projectOptions();
@@ -8527,10 +8532,15 @@ namespace lfs::vis {
             const auto bound = trainer->bound_project_path();
             ASSERT_TRUE(bound.has_value());
             lifecycle->scratch_lock_.reset();
+            auto bound_lock = *bound;
+            bound_lock += ".lock";
+            std::filesystem::remove(bound_lock);
             std::filesystem::remove(*bound);
-            write_project_with_specified_checkpoint(
+            const auto checkpoint_uuid =
+                lfs::core::generate_uuid_v4();
+            write_resumable_project_with_checkpoint(
                 *bound, lfs::core::generate_uuid_v4(),
-                lfs::core::generate_uuid_v4());
+                checkpoint_uuid, temporary / "dataset");
             trainer->last_project_snapshot_path_ = *bound;
             trainer->last_project_writer_error_.clear();
             ASSERT_NE(trainer->project_snapshot_service_, nullptr);
@@ -8541,6 +8551,11 @@ namespace lfs::vis {
             ASSERT_NE(lifecycle->document_, nullptr);
             EXPECT_FALSE(
                 lifecycle->document_->checkpoint_uuids().empty());
+            auto full_document =
+                lfs::io::project::ProjectDocument::open(*bound);
+            ASSERT_TRUE(full_document)
+                << lfs::format_for_developer(
+                       full_document.error());
             lfs::io::project::ProjectDocumentSaveOptions
                 save_options;
             save_options.allow_existing_destination_replacement =
@@ -8553,7 +8568,7 @@ namespace lfs::vis {
                 lfs::core::generate_uuid_v4();
             save_options.index_compression =
                 lfs::io::project::IndexCompression::Zstd;
-            auto saved = lifecycle->document_->save_as(
+            auto saved = full_document->save_as(
                 destination, save_options);
             ASSERT_TRUE(saved)
                 << lfs::format_for_developer(saved.error());
@@ -8563,10 +8578,7 @@ namespace lfs::vis {
             ASSERT_TRUE(opened)
                 << lfs::format_for_developer(opened.error());
             EXPECT_FALSE(opened->checkpoint_uuids().empty());
-            EXPECT_FALSE(std::filesystem::exists(*bound));
-            auto lock_path = *bound;
-            lock_path += ".lock";
-            EXPECT_FALSE(std::filesystem::exists(lock_path));
+            EXPECT_TRUE(std::filesystem::exists(*bound));
         }
     }
 
@@ -8609,7 +8621,7 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           CompletedUntitledTrainingBlocksCleanClose) {
+           CompletedAutoCreatedTrainingSavesRealMasterOnClose) {
         const auto& temporary = temporary_.path;
         auto options = projectOptions();
         {
@@ -8635,7 +8647,6 @@ namespace lfs::vis {
             ASSERT_TRUE(lifecycle->prepareTrainingStartProject());
             const auto bound = trainer->bound_project_path();
             ASSERT_TRUE(bound.has_value());
-            lifecycle->scratch_lock_.reset();
             std::filesystem::remove(*bound);
             write_project_with_specified_checkpoint(
                 *bound, lfs::core::generate_uuid_v4(),
@@ -8647,6 +8658,9 @@ namespace lfs::vis {
                 ->testing_advance_completed_snapshots(1);
             lifecycle->adopted_training_snapshot_count_ = 0;
             ASSERT_TRUE(lifecycle->adoptCompletedTrainingSnapshot());
+            ASSERT_NE(
+                scene.addGroup("post-training close dirt"),
+                lfs::core::NULL_NODE);
             auto& state_machine =
                 const_cast<TrainingStateMachine&>(
                     viewer.getTrainerManager()->getStateMachine());
@@ -8667,13 +8681,13 @@ namespace lfs::vis {
             EXPECT_EQ(
                 lifecycle->beginOrPollCloseSave(),
                 project::ProjectLifecycle::CloseSaveStatus::
-                    NeedsPrompt);
+                    Saving);
             EXPECT_TRUE(std::filesystem::is_regular_file(*bound));
         }
     }
 
     TEST_F(VisualizerImplResetTest,
-           TempProjectSaveRefusesAndStaysOutOfMru) {
+           SaveSucceedsOnAutoCreatedTrainingProject) {
         auto options = projectOptions();
         {
             VisualizerImpl viewer(options);
@@ -8695,14 +8709,12 @@ namespace lfs::vis {
             const auto mru_before =
                 lifecycle->menuInfo().recent_projects.size();
             auto saved = lifecycle->save(false);
-            ASSERT_FALSE(saved);
-            EXPECT_EQ(
-                saved.error().code(),
-                lfs::ErrorCode::FailedPrecondition);
-            EXPECT_FALSE(lifecycle->hasSourcePath());
+            ASSERT_TRUE(saved)
+                << lfs::format_for_developer(saved.error());
+            EXPECT_TRUE(lifecycle->hasSourcePath());
             const auto info = lifecycle->info();
             ASSERT_TRUE(info);
-            EXPECT_FALSE(info->path.has_value());
+            EXPECT_TRUE(info->path.has_value());
             EXPECT_EQ(
                 lifecycle->menuInfo().recent_projects.size(),
                 mru_before);
@@ -8710,7 +8722,7 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           TempSessionLightAutosaveWritesSidecarWithScratchLease) {
+           LightAutosaveWritesSidecarNextToAutoCreatedProject) {
         auto options = projectOptions();
         {
             VisualizerImpl viewer(options);
@@ -8735,6 +8747,7 @@ namespace lfs::vis {
             ASSERT_TRUE(lifecycle->prepareTrainingStartProject());
             const auto bound = trainer->bound_project_path();
             ASSERT_TRUE(bound.has_value());
+            EXPECT_FALSE(lifecycle->scratch_lock_);
             const auto master_bytes =
                 std::filesystem::file_size(*bound);
             auto& state_machine =
@@ -8768,15 +8781,18 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           WorkingDirectoryPreferenceChangeAppliesToNextSession) {
+           ProjectLocationPreferenceGovernsTrainingAutoCreate) {
         const auto& temporary = temporary_.path;
         const auto home = temporary / "pref-home";
         const auto first_root = temporary / "working-a";
         const auto second_root = temporary / "working-b";
+        const auto project_location = temporary / "project-location";
         std::filesystem::create_directories(home);
         std::filesystem::create_directories(first_root);
         std::filesystem::create_directories(second_root);
         const ScopedLfsHome lfs_home(home);
+        ASSERT_TRUE(lfs::vis::setProjectLocationPreference(
+            project_location));
         auto first_set =
             lfs::vis::setWorkingDirectoryPreference(first_root);
         ASSERT_TRUE(first_set)
@@ -8804,7 +8820,7 @@ namespace lfs::vis {
             first_bound = *bound;
             EXPECT_EQ(
                 bound->parent_path().lexically_normal(),
-                (first_root / "tmp").lexically_normal());
+                project_location.lexically_normal());
             ASSERT_TRUE(
                 lfs::vis::setWorkingDirectoryPreference(second_root));
             EXPECT_EQ(
@@ -8832,11 +8848,34 @@ namespace lfs::vis {
             ASSERT_TRUE(bound.has_value());
             EXPECT_EQ(
                 bound->parent_path().lexically_normal(),
-                (second_root / "tmp").lexically_normal());
+                project_location.lexically_normal());
             EXPECT_NE(
                 bound->lexically_normal(),
                 first_bound.lexically_normal());
         }
+        lfs::vis::clearWorkingDirectoryPreference();
+        lfs::vis::clearProjectLocationPreference();
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           ScratchDirectoryIsFixedUnderRootRegardlessOfPreferences) {
+        const auto home = temporary_.path / "fixed-scratch-home";
+        std::filesystem::create_directories(home);
+        const ScopedLfsHome lfs_home(home);
+        const auto working = temporary_.path / "legacy-working";
+        ASSERT_TRUE(lfs::vis::setWorkingDirectoryPreference(working));
+        const auto paths = lfs::core::UserPaths::resolve();
+        ASSERT_TRUE(paths);
+        lfs::vis::ViewerOptions options;
+        options.show_startup_overlay = false;
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        EXPECT_EQ(
+            viewer.project_lifecycle_->scratchAutosaveDirectory(),
+            (paths->rootDir() / "tmp").lexically_normal());
+        EXPECT_NE(
+            viewer.project_lifecycle_->scratchAutosaveDirectory(),
+            (working / "tmp").lexically_normal());
         lfs::vis::clearWorkingDirectoryPreference();
     }
 
@@ -8954,7 +8993,7 @@ namespace lfs::vis {
                 lifecycle->scratch_lock_->owns(legacy_scratch));
             EXPECT_FALSE(lifecycle->recovered_master_path_);
             EXPECT_FALSE(lifecycle->recovery_session_);
-            EXPECT_TRUE(lifecycle->isTempProject());
+            EXPECT_TRUE(lifecycle->isScratchBoundSession());
             EXPECT_FALSE(lifecycle->hasSourcePath());
             auto saved = lifecycle->saveAs(destination, false, true);
             ASSERT_TRUE(saved)
@@ -8967,11 +9006,46 @@ namespace lfs::vis {
                 }));
             EXPECT_TRUE(std::filesystem::is_regular_file(destination));
             EXPECT_TRUE(lifecycle->hasSourcePath());
-            EXPECT_FALSE(lifecycle->isTempProject());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
         }
         EXPECT_FALSE(std::filesystem::exists(legacy_scratch));
         EXPECT_FALSE(std::filesystem::exists(lock_path));
         EXPECT_TRUE(std::filesystem::is_regular_file(destination));
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           RecoveredScratchSaveStillRefusesAndStaysOutOfMru) {
+        auto options = projectOptions();
+        const auto scratch_dir = temporary_.path / "recovery";
+        std::filesystem::create_directories(scratch_dir);
+        const auto scratch = lfs::io::project::scratch_autosave_path(
+            scratch_dir, lfs::core::generate_uuid_v4());
+        write_project_with_specified_checkpoint(
+            scratch, lfs::core::generate_uuid_v4(),
+            lfs::core::generate_uuid_v4());
+        {
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+            viewer.input_controller_ =
+                std::make_unique<InputController>(
+                    nullptr, viewer.getViewport());
+            auto* const lifecycle = viewer.project_lifecycle_.get();
+            ASSERT_NE(lifecycle, nullptr);
+            ASSERT_TRUE(lifecycle->openScratchRecovered(
+                scratch, ProjectSwitchDisposition::RequireClean));
+            const auto mru_before =
+                lifecycle->menuInfo().recent_projects.size();
+            auto saved = lifecycle->save(false);
+            ASSERT_FALSE(saved);
+            EXPECT_EQ(
+                saved.error().code(),
+                lfs::ErrorCode::FailedPrecondition);
+            EXPECT_FALSE(lifecycle->hasSourcePath());
+            EXPECT_TRUE(lifecycle->isScratchBoundSession());
+            EXPECT_EQ(
+                lifecycle->menuInfo().recent_projects.size(),
+                mru_before);
+        }
     }
 
     TEST_F(VisualizerImplResetTest,
@@ -9366,8 +9440,8 @@ namespace lfs::vis {
             auto prepared = lifecycle->prepareTrainingStartProject();
             ASSERT_TRUE(prepared)
                 << lfs::format_for_developer(prepared.error());
-            EXPECT_FALSE(lifecycle->hasSourcePath());
-            EXPECT_TRUE(lifecycle->isTempProject());
+            EXPECT_TRUE(lifecycle->hasSourcePath());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             const auto bound = trainer->bound_project_path();
             ASSERT_TRUE(bound.has_value());
             auto sidecar =
@@ -9438,13 +9512,13 @@ namespace lfs::vis {
                 << lfs::format_for_developer(opened.error());
             EXPECT_FALSE(opened->checkpoint_uuids().empty());
             EXPECT_TRUE(lifecycle->hasSourcePath());
-            EXPECT_FALSE(lifecycle->isTempProject());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             const auto recent = lifecycle->menuInfo().recent_projects;
-            ASSERT_EQ(recent.size(), 1u);
+            ASSERT_EQ(recent.size(), 2u);
             EXPECT_EQ(
                 recent.front().last_known_path.lexically_normal(),
                 destination.lexically_normal());
-            EXPECT_FALSE(std::filesystem::exists(*bound));
+            EXPECT_TRUE(std::filesystem::exists(*bound));
             EXPECT_FALSE(std::filesystem::exists(sidecar));
             EXPECT_FALSE(std::filesystem::exists(lock_path));
         }
@@ -10746,6 +10820,235 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
+           CreateProjectAtWritesBindsAndRegistersMru) {
+        const auto path =
+            temporary_.path / "created" / "project.licht";
+        VisualizerImpl viewer(projectOptions());
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        viewer.input_controller_ =
+            std::make_unique<InputController>(
+                nullptr, viewer.getViewport());
+
+        auto created = viewer.projectCreateAt(path);
+        ASSERT_TRUE(created)
+            << lfs::format_for_developer(created.error());
+        ASSERT_TRUE(std::filesystem::is_regular_file(path));
+        EXPECT_TRUE(viewer.projectHasPath().value());
+        const auto info = viewer.projectGetInfo();
+        ASSERT_TRUE(info);
+        ASSERT_TRUE(info->path);
+        EXPECT_EQ(info->path->lexically_normal(), path.lexically_normal());
+        const auto recent = viewer.project_lifecycle_->menuInfo().recent_projects;
+        ASSERT_FALSE(recent.empty());
+        EXPECT_EQ(recent.front().last_known_path.lexically_normal(),
+                  path.lexically_normal());
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           CreateProjectAtRefusesExistingDestination) {
+        const auto path = temporary_.path / "existing.licht";
+        write_empty_project(path);
+        VisualizerImpl viewer(projectOptions());
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        viewer.input_controller_ =
+            std::make_unique<InputController>(
+                nullptr, viewer.getViewport());
+
+        auto created = viewer.projectCreateAt(path);
+        ASSERT_FALSE(created);
+        EXPECT_EQ(created.error().code(), lfs::ErrorCode::AlreadyExists);
+        EXPECT_FALSE(viewer.projectHasPath().value());
+        EXPECT_TRUE(std::filesystem::is_regular_file(path));
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           CreateProjectAtRejectsScratchAndUnpublishedPaths) {
+        VisualizerImpl viewer(projectOptions());
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        viewer.input_controller_ =
+            std::make_unique<InputController>(
+                nullptr, viewer.getViewport());
+        const auto scratch = lfs::io::project::scratch_autosave_path(
+            viewer.project_lifecycle_->temp_project_directory_,
+            lfs::core::generate_uuid_v4());
+        auto scratch_result = viewer.projectCreateAt(scratch);
+        ASSERT_FALSE(scratch_result);
+        EXPECT_EQ(scratch_result.error().code(),
+                  lfs::ErrorCode::InvalidArgument);
+        const auto unpublished =
+            temporary_.path / "new.project-write.test.licht";
+        auto unpublished_result = viewer.projectCreateAt(unpublished);
+        ASSERT_FALSE(unpublished_result);
+        EXPECT_EQ(unpublished_result.error().code(),
+                  lfs::ErrorCode::InvalidArgument);
+        EXPECT_FALSE(viewer.projectHasPath().value());
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           CreateProjectRequireCleanFailsOnDirtySession) {
+        const auto path = temporary_.path / "discard-dirty.licht";
+        VisualizerImpl viewer(projectOptions());
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        viewer.input_controller_ =
+            std::make_unique<InputController>(
+                nullptr, viewer.getViewport());
+        ASSERT_NE(viewer.getScene().addGroup("dirty"),
+                  lfs::core::NULL_NODE);
+        auto blocked = viewer.projectCreateAt(path);
+        ASSERT_FALSE(blocked);
+        EXPECT_EQ(blocked.error().code(),
+                  lfs::ErrorCode::FailedPrecondition);
+        EXPECT_FALSE(std::filesystem::exists(path));
+        auto discarded = viewer.project_lifecycle_->createProjectAt(
+            path, ProjectSwitchDisposition::DiscardChanges);
+        ASSERT_TRUE(discarded)
+            << lfs::format_for_developer(discarded.error());
+        EXPECT_TRUE(std::filesystem::is_regular_file(path));
+        EXPECT_TRUE(viewer.projectHasPath().value());
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           TrainingStartAutoCreateSuffixesOnCollision) {
+        const auto location = temporary_.path / "projects";
+        write_empty_project(location / "untitled.licht");
+        write_empty_project(location / "untitled-2.licht");
+        VisualizerImpl viewer(projectOptions());
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        viewer.input_controller_ =
+            std::make_unique<InputController>(
+                nullptr, viewer.getViewport());
+        auto& scene = viewer.getScene();
+        scene.addCamera(
+            "camera.png", scene.addGroup("Train cameras"),
+            make_project_request_test_camera());
+        viewer.getTrainerManager()->setTrainer(
+            std::make_unique<lfs::training::Trainer>(scene));
+
+        auto prepared =
+            viewer.project_lifecycle_->prepareTrainingStartProject();
+        ASSERT_TRUE(prepared)
+            << lfs::format_for_developer(prepared.error());
+        const auto bound =
+            viewer.getTrainer()->bound_project_path();
+        ASSERT_TRUE(bound);
+        EXPECT_EQ(bound->lexically_normal(),
+                  (location / "untitled-3.licht").lexically_normal());
+        EXPECT_TRUE(std::filesystem::is_regular_file(*bound));
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           DatasetLoadIntoBlankCreatedProjectKeepsBinding) {
+        const auto path = temporary_.path / "blank-created.licht";
+        VisualizerImpl viewer(projectOptions());
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        viewer.input_controller_ =
+            std::make_unique<InputController>(
+                nullptr, viewer.getViewport());
+        ASSERT_TRUE(viewer.projectCreateAt(path));
+        ASSERT_TRUE(viewer.resetUntitledSessionForReplaceLoad());
+        const auto info = viewer.projectGetInfo();
+        ASSERT_TRUE(info);
+        ASSERT_TRUE(info->path);
+        EXPECT_EQ(info->path->lexically_normal(), path.lexically_normal());
+        EXPECT_TRUE(std::filesystem::is_regular_file(path));
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           ProjectCreateOnDirtyEmitsCreatePath) {
+        const auto path = temporary_.path / "dirty-create.licht";
+        VisualizerImpl viewer(projectOptions());
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        viewer.input_controller_ =
+            std::make_unique<InputController>(
+                nullptr, viewer.getViewport());
+        ASSERT_NE(viewer.getScene().addGroup("dirty"),
+                  lfs::core::NULL_NODE);
+        bool prompted = false;
+        std::filesystem::path create_path;
+        lfs::core::events::cmd::ShowProjectSwitchConfirmation::when(
+            [&](const auto& event) {
+                prompted = true;
+                create_path = event.create_path;
+            });
+        lfs::core::events::cmd::ProjectCreate{.path = path}.emit();
+        EXPECT_TRUE(prompted);
+        EXPECT_EQ(create_path.lexically_normal(), path.lexically_normal());
+        EXPECT_FALSE(std::filesystem::exists(path));
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           ProjectCreateWhileTrainingPromptsWithCreatePath) {
+        const auto path = temporary_.path / "training-create.licht";
+        VisualizerImpl viewer(projectOptions());
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        viewer.input_controller_ =
+            std::make_unique<InputController>(
+                nullptr, viewer.getViewport());
+        ASSERT_TRUE(arm_running_trainer(viewer));
+        bool prompted = false;
+        std::filesystem::path create_path;
+        lfs::core::events::cmd::ShowStopTrainingConfirmation::when(
+            [&](const auto& event) {
+                prompted = true;
+                create_path = event.create_path;
+                EXPECT_TRUE(event.new_project);
+            });
+        lfs::core::events::cmd::ProjectCreate{.path = path}.emit();
+        EXPECT_TRUE(prompted);
+        EXPECT_EQ(create_path.lexically_normal(), path.lexically_normal());
+        EXPECT_EQ(
+            viewer.pending_training_action_,
+            VisualizerImpl::PendingTrainingAction::None);
+        EXPECT_TRUE(viewer.pending_create_project_path_.empty());
+        EXPECT_TRUE(viewer.getTrainerManager()->isTrainingActive());
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           StartupScansLegacyWorkingTmpDirectory) {
+        const auto home = temporary_.path / "legacy-home";
+        std::filesystem::create_directories(home);
+        const ScopedLfsHome lfs_home(home);
+        const auto legacy_root = temporary_.path / "legacy-working";
+        ASSERT_TRUE(lfs::vis::setWorkingDirectoryPreference(legacy_root));
+        const auto scratch = lfs::io::project::scratch_autosave_path(
+            legacy_root / "tmp", lfs::core::generate_uuid_v4());
+        write_project_with_specified_checkpoint(
+            scratch, lfs::core::generate_uuid_v4(),
+            lfs::core::generate_uuid_v4());
+        lfs::vis::ViewerOptions options;
+        options.show_startup_overlay = false;
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        viewer.project_lifecycle_->openStartupProject(std::nullopt);
+        EXPECT_TRUE(viewer.project_lifecycle_->recovery_prompt_pending_);
+        lfs::vis::clearWorkingDirectoryPreference();
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           StartupPruneNeverTouchesProjectLocation) {
+        const auto home = temporary_.path / "prune-home";
+        std::filesystem::create_directories(home);
+        const ScopedLfsHome lfs_home(home);
+        const auto working = temporary_.path / "project-parent";
+        const auto project_location = working / "tmp";
+        ASSERT_TRUE(lfs::vis::setWorkingDirectoryPreference(working));
+        ASSERT_TRUE(lfs::vis::setProjectLocationPreference(project_location));
+        const auto scratch = lfs::io::project::scratch_autosave_path(
+            project_location, lfs::core::generate_uuid_v4());
+        write_project_with_specified_checkpoint(
+            scratch, lfs::core::generate_uuid_v4(),
+            lfs::core::generate_uuid_v4());
+        lfs::vis::ViewerOptions options;
+        options.show_startup_overlay = false;
+        VisualizerImpl viewer(options);
+        ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+        viewer.project_lifecycle_->pruneUnlockedScratchFilesExcept(std::nullopt);
+        EXPECT_TRUE(std::filesystem::is_regular_file(scratch));
+        lfs::vis::clearWorkingDirectoryPreference();
+        lfs::vis::clearProjectLocationPreference();
+    }
+
+    TEST_F(VisualizerImplResetTest,
            UntitledTrainerRewriteAdoptThenSaveAsUsesCurrentHead) {
         // Same rewrite/adopt gap on this branch's temp
         // master. Save As must rebase onto the rewritten
@@ -10776,8 +11079,8 @@ namespace lfs::vis {
             ASSERT_TRUE(prepared)
                 << lfs::format_for_developer(
                        prepared.error());
-            EXPECT_FALSE(lifecycle->hasSourcePath());
-            EXPECT_TRUE(lifecycle->isTempProject());
+            EXPECT_TRUE(lifecycle->hasSourcePath());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
             const auto bound = trainer->bound_project_path();
             ASSERT_TRUE(bound.has_value());
             ASSERT_NE(lifecycle->document_, nullptr);
@@ -10843,7 +11146,7 @@ namespace lfs::vis {
                 << lfs::format_for_developer(
                        opened.error());
             EXPECT_TRUE(lifecycle->hasSourcePath());
-            EXPECT_FALSE(lifecycle->isTempProject());
+            EXPECT_FALSE(lifecycle->isScratchBoundSession());
         }
     }
 


### PR DESCRIPTION
Part of #1847 (core half; the Project-location preference merge + New Project dialog follow in a second PR).

## What changes

- Training start in an untitled session creates a real `<project location>/<dataset-stem>.licht` (collision-suffixed `-2`, `-3`, ...) instead of a hidden bound temp project. The project shows a path, title, and MRU entry from the first iteration; Save works during and after training; close-save writes the real master silently when auto-save-on-close is on; Save As is a rebind-copy that leaves the original file in place.
- New `cmd::ProjectCreate` / `lf.project_create(path, discard_changes, stop_training)` creates an empty bound project up-front (the New Project dialog in the follow-up PR sits on top of this). Dirty/training preflights surface the existing confirmation dialogs, which now carry a `create_path` field for the follow-up to consume.
- Crash-scratch autosave for genuinely untitled sessions (blank startup, PLY quick view) is unchanged but pinned to `<root>/tmp` regardless of preferences. Legacy `<working folder>/tmp` scratch files are still scanned and offered at startup; the startup prune never touches the project location.
- Dataset replace-load keeps the binding of a freshly created blank project, so create-then-load lands the dataset in the created project.
- New `project_location` preference seam (default `<root>/projects`). The CLI/headless `-o` path is untouched.
- `isTempProject` renamed to `isScratchBoundSession`; the untitled-masking predicates now guard recovered crash-scratch sessions only.

## Verification

- `VisualizerImplResetTest.*`: 175 pass + 1 pre-existing env-gated skip, run without `LFS_HOME` (the fixture now scopes its own home; a run leaves the real preferences.json byte-identical).
- Error-debt gate and clang-format clean.
- 7k-iteration bicycle smoke (mcmc, `-o`): completes, `project.licht` written to the explicit output path.
- GUI smoke on an isolated `LFS_HOME`: dataset load + training auto-creates `projects/bicycle.licht` (no `tmp/` dir at all), save-during-training works, PLY quick view stays untitled with no files, `lf.project_create` binds immediately; zero errors in the log.