### PR TITLE
Fix 16-bit color runs never hitting the compressed image cache

### DIFF
--- a/src/io/pipelined_image_loader.cpp
+++ b/src/io/pipelined_image_loader.cpp
@@ -2311,12 +2311,22 @@ namespace lfs::io {
 
                 std::vector<size_t> rgb_batch_indices;
                 rgb_batch_indices.reserve(batch.size());
+                std::vector<size_t> rgb_jpeg2k_batch_indices;
+                rgb_jpeg2k_batch_indices.reserve(batch.size());
                 bool rgb_dtype_initialized = false;
                 bool rgb_output_uint8 = false;
                 for (size_t i = 0; i < batch.size(); ++i) {
                     if (!batch[i].is_mask && !batch[i].is_depth && !batch[i].is_normal &&
                         !batch[i].needs_processing &&
                         batch[i].jpeg_data) {
+                        const auto& bytes = *batch[i].jpeg_data;
+                        const bool is_jpeg2k = bytes.size() >= 2 && bytes[0] == 0xff && bytes[1] == 0x4f;
+                        if (is_jpeg2k) {
+                            rgb_jpeg2k_batch_indices.push_back(i);
+                            continue;
+                        }
+                        if (!is_jpeg_data(bytes))
+                            continue;
                         if (!rgb_dtype_initialized) {
                             rgb_dtype_initialized = true;
                             rgb_output_uint8 = batch[i].params.output_uint8;
@@ -2362,6 +2372,41 @@ namespace lfs::io {
                         try_complete_pair(batch[index].sequence_id, batch[index].loader_generation,
                                           std::move(decoded[j]), std::nullopt, nullptr, std::nullopt,
                                           std::nullopt, nullptr, std::move(lease));
+                        decoded_as_pair[index] = true;
+                    }
+                }
+
+                if (!rgb_jpeg2k_batch_indices.empty()) {
+                    std::vector<std::pair<const uint8_t*, size_t>> spans;
+                    spans.reserve(rgb_jpeg2k_batch_indices.size());
+                    for (const size_t index : rgb_jpeg2k_batch_indices) {
+                        spans.emplace_back(batch[index].jpeg_data->data(), batch[index].jpeg_data->size());
+                    }
+                    auto decoded = nvcodec->decode_jpeg2k_16bit_batch_from_spans(
+                        spans, decode_stream_, false);
+                    if (decoded.size() != rgb_jpeg2k_batch_indices.size()) {
+                        throw std::runtime_error("JPEG2000 RGB batch decode returned wrong size");
+                    }
+                    for (size_t j = 0; j < rgb_jpeg2k_batch_indices.size(); ++j) {
+                        const size_t index = rgb_jpeg2k_batch_indices[j];
+                        auto& tensor = decoded[j];
+                        if (!tensor.is_valid() || tensor.ndim() != 3 || tensor.shape()[2] != 3) {
+                            throw std::runtime_error("Decoded RGB JPEG2000 cache is not [H,W,3]");
+                        }
+                        tensor = tensor.permute({2, 0, 1}).contiguous();
+                        tensor.set_stream(decode_stream_);
+                        if (batch[index].params.output_uint8) {
+                            auto uint8_tensor = lfs::core::Tensor::empty(
+                                tensor.shape(), lfs::core::Device::CUDA, lfs::core::DataType::UInt8);
+                            uint8_tensor.set_stream(decode_stream_);
+                            cuda::launch_float32_chw_to_uint8_chw(
+                                tensor.ptr<float>(), uint8_tensor.ptr<uint8_t>(),
+                                tensor.shape()[1], tensor.shape()[2], tensor.shape()[0], decode_stream_);
+                            tensor = std::move(uint8_tensor);
+                        }
+                        try_complete_pair(batch[index].sequence_id, batch[index].loader_generation,
+                                          std::move(tensor), std::nullopt, nullptr, std::nullopt,
+                                          std::nullopt, nullptr);
                         decoded_as_pair[index] = true;
                     }
                 }

--- a/tests/test_compressed_blob_tier.cpp
+++ b/tests/test_compressed_blob_tier.cpp
@@ -5,6 +5,7 @@
 
 #include "core/camera.hpp"
 #include "core/cuda/undistort/undistort.hpp"
+#include "io/nvcodec_image_loader.hpp"
 #include "io/pipelined_image_loader.hpp"
 #include "training/dataset.hpp"
 
@@ -63,6 +64,45 @@ TEST(CompressedBlobTier, HostCacheHit) {
     const auto stats = loader.get_stats();
     EXPECT_GT(stats.jpeg_cache_bytes, 0u);
     EXPECT_GT(stats.jpeg_cache_entries, 0u);
+}
+
+TEST(CompressedBlobTier, SixteenBitRgbCacheHitUsesJpeg2000GpuPath) {
+    const auto source = bicycle_image("_DSC8739.JPG");
+    if (!std::filesystem::is_regular_file(source))
+        GTEST_SKIP() << "bicycle dataset is absent: " << source;
+    if (!lfs::io::NvCodecImageLoader::is_available())
+        GTEST_SKIP() << "nvImageCodec is unavailable";
+
+    const auto cached_source = std::filesystem::temp_directory_path() /
+                               ("lfs_pipelined_loader_16bit_" +
+                                std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) +
+                                ".JPG");
+    ASSERT_TRUE(std::filesystem::copy_file(source, cached_source));
+
+    lfs::io::PipelinedLoaderConfig config;
+    config.jpeg_batch_size = 2;
+    config.prefetch_count = 2;
+    config.output_queue_size = 1;
+    config.use_16bit_color = true;
+    lfs::io::PipelinedImageLoader loader(config);
+
+    const auto cold = load_one(loader, 1, cached_source);
+    ASSERT_TRUE(cold.error.empty()) << cold.error;
+    ASSERT_TRUE(cold.tensor.is_valid());
+    ASSERT_EQ(cold.tensor.dtype(), lfs::core::DataType::Float32);
+    ASSERT_GT(loader.get_stats().jpeg_cache_entries, 0u);
+
+    ASSERT_NO_THROW(std::filesystem::resize_file(cached_source, 0));
+    const auto hot = load_one(loader, 2, cached_source);
+    EXPECT_TRUE(hot.error.empty()) << hot.error;
+    ASSERT_TRUE(hot.tensor.is_valid());
+    EXPECT_EQ(hot.tensor.dtype(), lfs::core::DataType::Float32);
+    EXPECT_EQ(hot.tensor.shape(), cold.tensor.shape());
+
+    const auto stats = loader.get_stats();
+    EXPECT_GE(stats.hot_path_hits, 1u);
+    EXPECT_EQ(stats.cold_path_misses, 1u);
+    ASSERT_TRUE(std::filesystem::remove(cached_source));
 }
 
 TEST(CompressedBlobTier, CacheHitMatchesProcessedReferenceWithResizeAndUndistort) {


### PR DESCRIPTION
With `--use-16bit`, the run cache stores lossless JPEG 2000 blobs, but the GPU batch decoder pushed every cache hit into the 8-bit JPEG batch decoder, which hard-rejects them ("JPEG batch input is not an 8-bit JPEG"); the batch-level fallback then silently re-read and cold-decoded every image, every epoch.

**Empirical confirmation** (bicycle, images_4, mcmc, 500 iters, 194 images):
- Before: 503 `Batch decode error` lines, 511 recorded "hits" that all failed, training 14.5s.
- 8-bit control (7k iters): 7003 hits, zero errors — cache fine in 8-bit.
- After: **0 errors, 508 real hits, 5.3s** for the same workload (~2.7x on this run; the gap grows with epochs since every epoch re-decoded from disk before).

**Fix** (45 lines in `gpu_batch_decode_thread_func`): cached primary blobs are classified by content signature — 8-bit JPEEGs keep the existing batch path, JPEG 2000 (SOC marker) hits decode through the existing `decode_jpeg2k_16bit_batch_from_spans`, converted to the CHW output contract with `output_uint8` preserved; anything else falls through to the per-item decoder. Fallback paths unchanged.

**Verification**: new `CompressedBlobTier.SixteenBitRgbCacheHitUsesJpeg2000GpuPath` regression test (seeds a 16-bit cache entry, truncates the source file, proves the hit never touches disk); full `CompressedBlobTier` suite green; `compute-sanitizer` memcheck and racecheck clean on the new routing; error-debt gate and clang-format clean. Repro numbers above re-run independently.