### PR TITLE
Fix decoded image corruption during training

### DIFF
--- a/src/io/nvcodec_image_loader.cpp
+++ b/src/io/nvcodec_image_loader.cpp
@@ -1452,6 +1452,9 @@ namespace lfs::io {
                     } else {
                         output = Tensor::empty(output_shape, Device::CUDA, DataType::UInt8);
                     }
+                    if (cuda_stream) {
+                        output.set_stream(static_cast<cudaStream_t>(cuda_stream));
+                    }
                     cuda::launch_uint8_hwc_to_uint8_chw(
                         hwc[i].ptr<uint8_t>(), output.ptr<uint8_t>(),
                         heights[i], widths[i], 3, static_cast<cudaStream_t>(cuda_stream));
@@ -1471,6 +1474,9 @@ namespace lfs::io {
                     } else {
                         output = Tensor::empty(output_shape, Device::CUDA, DataType::Float32);
                     }
+                    if (cuda_stream) {
+                        output.set_stream(static_cast<cudaStream_t>(cuda_stream));
+                    }
                     cuda::launch_uint8_hwc_to_float32_chw(
                         hwc[i].ptr<uint8_t>(), output.ptr<float>(),
                         heights[i], widths[i], 3, static_cast<cudaStream_t>(cuda_stream));
@@ -1478,9 +1484,6 @@ namespace lfs::io {
                         *(*reusable_outputs)[i] = output;
                     }
                     outputs.push_back(std::move(output));
-                }
-                if (cuda_stream) {
-                    outputs.back().set_stream(static_cast<cudaStream_t>(cuda_stream));
                 }
             }
             if (synchronize) {


### PR DESCRIPTION
Decoded image buffers can be reused while the training CUDA stream is still reading them. This can corrupt ground-truth images and permanently reduce training quality.

nvImageCodec decodes JPEGs asynchronously on the decode stream, after which LFS converts the HWC result into a reusable CHW buffer. That buffer may still belong to the training stream, so calling `set_stream` after conversion schedules the CUDA wait too late and can overwrite an in-flight training read.

Fix:

- Move reusable outputs to the decode stream before launching the conversion kernel.
- Apply the ordering to both UInt8 and Float32 decode paths.
- Keep batched decoding and buffer reuse without device-wide synchronization.
- possible fix for #1864 