### PR TITLE
Add an optional license to the .licht format

### DIFF
--- a/docs/licht_format.md
+++ b/docs/licht_format.md
@@ -81,6 +81,8 @@ crashes happen, and files outlive programs.
 - **Checksummed throughout.** Every record and payload carries a CRC32c to catch corruption.
 - **Organized into chapters.** State is split into typed chapters (model, scene graph, parameters,
   layout, sequencer, camera, …); each chapter is the single source of truth for its fields.
+- The `PROJ` chapter may optionally carry a `license` object with a non-empty `identifier` and an
+  optional `notice`; omitted `license` means that no project license is declared.
 - **Autosave & recovery.** A periodic autosave writes to a separate `<project>.licht.autosave`
   sidecar. Recovery validates that sidecar against the master head and can materialize it into a
   retained recovery session before the next durable save. Compaction and recovery publication

--- a/src/app/mcp_gui_tools.cpp
+++ b/src/app/mcp_gui_tools.cpp
@@ -156,6 +156,7 @@ namespace lfs::app {
                            *info.path))
                      : json(nullptr)},
                 {"project_uuid", info.project_uuid},
+                {"license_identifier", info.license_identifier},
                 {"generation", info.generation},
                 {"dirty", info.dirty},
                 {"session_dirty",

--- a/src/io/include/io/project_chapters.hpp
+++ b/src/io/include/io/project_chapters.hpp
@@ -77,6 +77,13 @@ namespace lfs::io::project {
         friend bool operator==(const ProjectManifest&, const ProjectManifest&) = default;
     };
 
+    struct ProjectLicense {
+        std::string identifier;
+        std::string notice;
+
+        friend bool operator==(const ProjectLicense&, const ProjectLicense&) = default;
+    };
+
     enum class WorldOriginProvenance : std::uint8_t {
         None,
         CentralizeByPointCloud,
@@ -197,6 +204,9 @@ namespace lfs::io::project {
         [[nodiscard]] lfs::Result<ProjectGeoreference> georeference() const;
         [[nodiscard]] lfs::Result<void>
         set_georeference(const ProjectGeoreference& value);
+        [[nodiscard]] lfs::Result<std::optional<ProjectLicense>> license() const;
+        [[nodiscard]] lfs::Result<void> set_license(const ProjectLicense& value);
+        [[nodiscard]] lfs::Result<void> clear_license();
 
         [[nodiscard]] lfs::Result<std::vector<EmbedDecision>> embed_decisions() const;
         [[nodiscard]] lfs::Result<void> upsert_embed_decision(const EmbedDecision& value);

--- a/src/io/include/io/project_document.hpp
+++ b/src/io/include/io/project_document.hpp
@@ -246,6 +246,8 @@ namespace lfs::io::project {
 
         [[nodiscard]] const ProjectChapter& project() const noexcept;
         [[nodiscard]] ProjectChapter& edit_project() noexcept;
+        [[nodiscard]] lfs::Result<void> set_license(const ProjectLicense& value);
+        [[nodiscard]] lfs::Result<void> clear_license();
         [[nodiscard]] const ReferencesChapter& references() const noexcept;
         [[nodiscard]] ReferencesChapter& edit_references() noexcept;
         [[nodiscard]] const SceneGraphChapter& scene_graph() const noexcept;

--- a/src/io/project/project_chapters.cpp
+++ b/src/io/project/project_chapters.cpp
@@ -1346,6 +1346,61 @@ namespace lfs::io::project {
         return dom_.set_json("georeference", std::move(merged));
     }
 
+    lfs::Result<std::optional<ProjectLicense>> ProjectChapter::license() const {
+        const auto value = dom_.get_json("license");
+        if (!value || value->is_null()) {
+            return std::optional<ProjectLicense>{};
+        }
+        if (auto valid = require_object(*value, "PROJ", "license"); !valid) {
+            return std::move(valid).error();
+        }
+        auto identifier = required<std::string>(*value, "identifier", "PROJ", "license");
+        auto notice = optional<std::string>(*value, "notice", "PROJ", "license");
+        if (!identifier) {
+            return std::move(identifier).error();
+        }
+        if (!notice) {
+            return std::move(notice).error();
+        }
+        if (identifier->empty()) {
+            return fail<std::optional<ProjectLicense>>(
+                lfs::ErrorCode::DataLoss,
+                "The project license identifier is empty.",
+                "PROJ.license.identifier must be non-empty", "PROJ",
+                "license.identifier");
+        }
+        return std::optional<ProjectLicense>(ProjectLicense{
+            .identifier = std::move(*identifier),
+            .notice = notice->value_or(std::string{}),
+        });
+    }
+
+    lfs::Result<void> ProjectChapter::set_license(const ProjectLicense& value) {
+        if (value.identifier.empty()) {
+            return fail<void>(
+                lfs::ErrorCode::InvalidArgument,
+                "The project license identifier cannot be empty.",
+                "PROJ.license.identifier must be non-empty", "PROJ",
+                "license.identifier");
+        }
+        Json known{{"identifier", value.identifier}};
+        if (!value.notice.empty()) {
+            known["notice"] = value.notice;
+        }
+        Json merged = merge_known(
+            dom_.get_json("license").value_or(Json::object()), known);
+        if (value.notice.empty()) {
+            merged.erase("notice");
+        }
+        return dom_.set_json("license", std::move(merged));
+    }
+
+    lfs::Result<void> ProjectChapter::clear_license() {
+        auto removed = dom_.remove("license");
+        return removed ? lfs::Result<void>{}
+                       : lfs::Result<void>::failure(std::move(removed).error());
+    }
+
     lfs::Result<std::vector<EmbedDecision>> ProjectChapter::embed_decisions() const {
         auto items = dom_.array_items("embed_decisions");
         if (!items) {

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -189,7 +189,7 @@ namespace lfs::io::project {
                 known = {"schema_version", "manifest", "project_uuid",
                          "created_at_unix_ns", "modified_at_unix_ns",
                          "dataset_reference_uuid", "project_lineage",
-                         "georeference", "embed_decisions", "provenance",
+                         "georeference", "license", "embed_decisions", "provenance",
                          "embedded_payloads"};
             } else if (fourcc == FOURCC_REFS) {
                 known = {"schema_version", "references"};
@@ -2333,6 +2333,14 @@ namespace lfs::io::project {
         return impl_->project;
     }
 
+    lfs::Result<void> ProjectDocument::set_license(const ProjectLicense& value) {
+        return edit_project().set_license(value);
+    }
+
+    lfs::Result<void> ProjectDocument::clear_license() {
+        return edit_project().clear_license();
+    }
+
     const ReferencesChapter& ProjectDocument::references() const noexcept {
         return impl_->references;
     }
@@ -3023,6 +3031,7 @@ namespace lfs::io::project {
 
         CommitOptions commit = options.commit;
         const bool retains_unknown_json =
+            impl_->project.dom().get_json("license").has_value() ||
             has_unknown_json_root(FOURCC_PROJ, impl_->project.dom()) ||
             has_unknown_json_root(FOURCC_REFS, impl_->references.dom()) ||
             has_unknown_json_root(FOURCC_SCNG, impl_->scene_graph.dom()) ||

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -248,6 +248,63 @@ namespace {
             }));
     }
 
+    lfs::Error python_viewer_shutdown_error();
+
+    lfs::Result<std::optional<lfs::io::project::ProjectLicense>>
+    post_project_license_get_to_viewer(lfs::vis::Visualizer& viewer) {
+        if (viewer.isOnViewerThread()) {
+            return viewer.projectGetLicense();
+        }
+        const lfs::core::TaskContext context{
+            .name = "python.project_get_license",
+            .domain = lfs::ErrorDomain::Python,
+            .operation_id = lfs::OperationId::generate(),
+            .site = LFS_SOURCE_SITE_CURRENT(),
+        };
+        return lfs::vis::post_guarded_and_wait<
+            std::optional<lfs::io::project::ProjectLicense>>(
+            viewer, context,
+            [&viewer] { return viewer.projectGetLicense(); },
+            python_viewer_shutdown_error());
+    }
+
+    lfs::Result<void> post_project_license_set_to_viewer(
+        lfs::vis::Visualizer& viewer,
+        lfs::io::project::ProjectLicense license) {
+        if (viewer.isOnViewerThread()) {
+            return viewer.projectSetLicense(license);
+        }
+        const lfs::core::TaskContext context{
+            .name = "python.project_set_license",
+            .domain = lfs::ErrorDomain::Python,
+            .operation_id = lfs::OperationId::generate(),
+            .site = LFS_SOURCE_SITE_CURRENT(),
+        };
+        return lfs::vis::post_guarded_and_wait<void>(
+            viewer, context,
+            [&viewer, license = std::move(license)]() mutable {
+                return viewer.projectSetLicense(license);
+            },
+            python_viewer_shutdown_error());
+    }
+
+    lfs::Result<void> post_project_license_clear_to_viewer(
+        lfs::vis::Visualizer& viewer) {
+        if (viewer.isOnViewerThread()) {
+            return viewer.projectClearLicense();
+        }
+        const lfs::core::TaskContext context{
+            .name = "python.project_clear_license",
+            .domain = lfs::ErrorDomain::Python,
+            .operation_id = lfs::OperationId::generate(),
+            .site = LFS_SOURCE_SITE_CURRENT(),
+        };
+        return lfs::vis::post_guarded_and_wait<void>(
+            viewer, context,
+            [&viewer] { return viewer.projectClearLicense(); },
+            python_viewer_shutdown_error());
+    }
+
     lfs::Error python_viewer_shutdown_error() {
         return lfs::make_error(lfs::ErrorInit{
             .code = lfs::ErrorCode::Cancelled,
@@ -1147,6 +1204,70 @@ NB_MODULE(lichtfeld, m) {
         nb::arg("path") = "",
         nb::arg("wait") = false,
         "Save the active project to a new .licht path");
+    m.def(
+        "project_get_license", []() -> std::optional<nb::dict> {
+            auto* const viewer = lfs::python::get_visualizer();
+            if (!viewer) {
+                return std::nullopt;
+            }
+            auto license = [&] {
+                nb::gil_scoped_release release;
+                return post_project_license_get_to_viewer(*viewer);
+            }();
+            if (!license) {
+                throw std::runtime_error(std::format(
+                    "project_get_license failed: {}",
+                    lfs::format_for_developer(license.error())));
+            }
+            if (!license->has_value()) {
+                return std::nullopt;
+            }
+            nb::dict result;
+            result["identifier"] = (*license)->identifier;
+            result["notice"] = (*license)->notice;
+            return result;
+        },
+        "Return the license metadata for the active project, or None");
+    m.def(
+        "project_set_license",
+        [](const std::string& identifier, const std::string& notice) {
+            auto* const viewer = lfs::python::get_visualizer();
+            if (!viewer) {
+                throw std::runtime_error(
+                    "project_set_license failed: no visualizer is available");
+            }
+            auto result = [&] {
+                nb::gil_scoped_release release;
+                return post_project_license_set_to_viewer(
+                    *viewer,
+                    lfs::io::project::ProjectLicense{identifier, notice});
+            }();
+            if (!result) {
+                throw std::runtime_error(std::format(
+                    "project_set_license failed: {}",
+                    lfs::format_for_developer(result.error())));
+            }
+        },
+        nb::arg("identifier"), nb::arg("notice") = "",
+        "Set the license metadata for the active project");
+    m.def(
+        "project_clear_license", []() {
+            auto* const viewer = lfs::python::get_visualizer();
+            if (!viewer) {
+                throw std::runtime_error(
+                    "project_clear_license failed: no visualizer is available");
+            }
+            auto result = [&] {
+                nb::gil_scoped_release release;
+                return post_project_license_clear_to_viewer(*viewer);
+            }();
+            if (!result) {
+                throw std::runtime_error(std::format(
+                    "project_clear_license failed: {}",
+                    lfs::format_for_developer(result.error())));
+            }
+        },
+        "Clear the license metadata for the active project");
     m.def(
         "project_poll_write", []() {
             nb::dict result;

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -286,6 +286,15 @@ def project_save(wait: bool = False, regenerate_preview: bool = True) -> bool:
 def project_save_as(path: str = '', wait: bool = False) -> bool:
     """Save the active project to a new .licht path"""
 
+def project_get_license() -> dict | None:
+    """Return the license metadata for the active project, or None"""
+
+def project_set_license(identifier: str, notice: str = '') -> None:
+    """Set the license metadata for the active project"""
+
+def project_clear_license() -> None:
+    """Clear the license metadata for the active project"""
+
 def project_poll_write() -> dict:
     """Return the active .licht project write state"""
 

--- a/src/visualizer/include/visualizer/visualizer.hpp
+++ b/src/visualizer/include/visualizer/visualizer.hpp
@@ -6,6 +6,7 @@
 
 #include "core/error.hpp"
 #include "core/export.hpp"
+#include "io/project_chapters.hpp"
 
 #include <cstdint>
 #include <expected>
@@ -114,6 +115,7 @@ namespace lfs::vis {
     struct LFS_VIS_API ProjectInfo {
         std::optional<std::filesystem::path> path;
         std::string project_uuid;
+        std::string license_identifier;
         std::uint64_t generation = 0;
         bool dirty = false;
         bool session_dirty = false;
@@ -212,6 +214,12 @@ namespace lfs::vis {
         projectHasPath() = 0;
         virtual lfs::Result<ProjectInfo>
         projectGetInfo() = 0;
+        virtual lfs::Result<std::optional<lfs::io::project::ProjectLicense>>
+        projectGetLicense() = 0;
+        virtual lfs::Result<void>
+        projectSetLicense(const lfs::io::project::ProjectLicense& license) = 0;
+        virtual lfs::Result<void>
+        projectClearLicense() = 0;
         virtual lfs::Result<ProjectWritePoll>
         projectPollWrite() {
             return ProjectWritePoll{};

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -3060,6 +3060,10 @@ namespace lfs::vis::project {
             lfs::io::project::
                 ProjectDocumentAutosaveOptions>
             autosave) {
+        auto license = document->project().license();
+        if (!license) {
+            return lfs::Status::failure(std::move(license).error());
+        }
         if (!cached_project_info_) {
             cached_project_info_ =
                 ProjectInfo{
@@ -3072,6 +3076,10 @@ namespace lfs::vis::project {
                         document
                             ->project_uuid()
                             .to_string(),
+                    .license_identifier =
+                        license->has_value()
+                            ? (*license)->identifier
+                            : std::string{},
                     .generation =
                         document->generation(),
                     .dirty =
@@ -7192,6 +7200,46 @@ namespace lfs::vis::project {
         return hasDirtyProject();
     }
 
+    lfs::Result<std::optional<lfs::io::project::ProjectLicense>>
+    ProjectLifecycle::license() {
+        if (!document_) {
+            return fail<std::optional<lfs::io::project::ProjectLicense>>(
+                lfs::ErrorCode::FailedPrecondition,
+                "There is no active project document.",
+                "Project lifecycle has not created or opened a document",
+                "project.document");
+        }
+        const std::lock_guard document_lock(document_access_mutex_);
+        return document_->project().license();
+    }
+
+    lfs::Result<void> ProjectLifecycle::setLicense(
+        const lfs::io::project::ProjectLicense& license) {
+        if (!document_) {
+            return fail<void>(
+                lfs::ErrorCode::FailedPrecondition,
+                "There is no active project document.",
+                "Project lifecycle has not created or opened a document",
+                "project.document");
+        }
+        const std::lock_guard document_lock(document_access_mutex_);
+        cached_project_info_.reset();
+        return document_->set_license(license);
+    }
+
+    lfs::Result<void> ProjectLifecycle::clearLicense() {
+        if (!document_) {
+            return fail<void>(
+                lfs::ErrorCode::FailedPrecondition,
+                "There is no active project document.",
+                "Project lifecycle has not created or opened a document",
+                "project.document");
+        }
+        const std::lock_guard document_lock(document_access_mutex_);
+        cached_project_info_.reset();
+        return document_->clear_license();
+    }
+
     bool ProjectLifecycle::hasSourcePath() const {
         if (recovered_master_path_) {
             return !isScratchPath(*recovered_master_path_);
@@ -7674,6 +7722,10 @@ namespace lfs::vis::project {
         const bool session_dirty =
             !blank_untitled &&
             hasSessionSoftDirtyChapters(*document_);
+        auto license = document_->project().license();
+        if (!license) {
+            return std::move(license).error();
+        }
         ProjectInfo result{
             .path =
                 isTempProject()
@@ -7683,6 +7735,10 @@ namespace lfs::vis::project {
                            : document_->source_path()),
             .project_uuid =
                 document_->project_uuid().to_string(),
+            .license_identifier =
+                license->has_value()
+                    ? (*license)->identifier
+                    : std::string{},
             .generation = document_->generation(),
             .dirty = hard_dirty,
             .session_dirty = session_dirty,

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -205,6 +205,11 @@ namespace lfs::vis::project {
         [[nodiscard]] bool isTempProject() const;
         [[nodiscard]] bool isBlankUntitledSession() const;
         [[nodiscard]] lfs::Result<ProjectInfo> info();
+        [[nodiscard]] lfs::Result<std::optional<lfs::io::project::ProjectLicense>>
+        license();
+        [[nodiscard]] lfs::Result<void>
+        setLicense(const lfs::io::project::ProjectLicense& license);
+        [[nodiscard]] lfs::Result<void> clearLicense();
         [[nodiscard]] ProjectWritePoll pollWrite();
         void joinPendingWrite();
         [[nodiscard]] ProjectMenuInfo menuInfo() const;

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -3661,6 +3661,41 @@ namespace lfs::vis {
         return project_lifecycle_->info();
     }
 
+    lfs::Result<std::optional<lfs::io::project::ProjectLicense>>
+    VisualizerImpl::projectGetLicense() {
+        if (!project_lifecycle_) {
+            return visualizerFailure<std::optional<lfs::io::project::ProjectLicense>>(
+                lfs::ErrorCode::Unavailable,
+                "Project lifecycle is unavailable.",
+                "The visualizer did not initialize its project lifecycle service",
+                "project.lifecycle");
+        }
+        return project_lifecycle_->license();
+    }
+
+    lfs::Result<void> VisualizerImpl::projectSetLicense(
+        const lfs::io::project::ProjectLicense& license) {
+        if (!project_lifecycle_) {
+            return visualizerFailure<void>(
+                lfs::ErrorCode::Unavailable,
+                "Project lifecycle is unavailable.",
+                "The visualizer did not initialize its project lifecycle service",
+                "project.lifecycle");
+        }
+        return project_lifecycle_->setLicense(license);
+    }
+
+    lfs::Result<void> VisualizerImpl::projectClearLicense() {
+        if (!project_lifecycle_) {
+            return visualizerFailure<void>(
+                lfs::ErrorCode::Unavailable,
+                "Project lifecycle is unavailable.",
+                "The visualizer did not initialize its project lifecycle service",
+                "project.lifecycle");
+        }
+        return project_lifecycle_->clearLicense();
+    }
+
     lfs::Result<ProjectWritePoll>
     VisualizerImpl::projectPollWrite() {
         if (!project_lifecycle_) {

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -128,6 +128,11 @@ namespace lfs::vis {
         projectHasPath() override;
         lfs::Result<ProjectInfo>
         projectGetInfo() override;
+        lfs::Result<std::optional<lfs::io::project::ProjectLicense>>
+        projectGetLicense() override;
+        lfs::Result<void> projectSetLicense(
+            const lfs::io::project::ProjectLicense& license) override;
+        lfs::Result<void> projectClearLicense() override;
         lfs::Result<ProjectWritePoll>
         projectPollWrite() override;
         bool consumeProjectSaveStarted() override;

--- a/tests/test_mcp_app_utils.cpp
+++ b/tests/test_mcp_app_utils.cpp
@@ -108,6 +108,15 @@ namespace {
             info.project_write_running = false;
             return info;
         }
+        lfs::Result<std::optional<lfs::io::project::ProjectLicense>>
+        projectGetLicense() override {
+            return std::optional<lfs::io::project::ProjectLicense>{};
+        }
+        lfs::Result<void> projectSetLicense(
+            const lfs::io::project::ProjectLicense&) override {
+            return {};
+        }
+        lfs::Result<void> projectClearLicense() override { return {}; }
 
         lfs::Result<lfs::vis::ProjectWritePoll>
         projectPollWrite() override {

--- a/tests/test_mcp_sequencer_tools.cpp
+++ b/tests/test_mcp_sequencer_tools.cpp
@@ -109,6 +109,15 @@ namespace {
         projectGetInfo() override {
             return lfs::vis::ProjectInfo{};
         }
+        lfs::Result<std::optional<lfs::io::project::ProjectLicense>>
+        projectGetLicense() override {
+            return std::optional<lfs::io::project::ProjectLicense>{};
+        }
+        lfs::Result<void> projectSetLicense(
+            const lfs::io::project::ProjectLicense&) override {
+            return {};
+        }
+        lfs::Result<void> projectClearLicense() override { return {}; }
 
     private:
         lfs::core::Scene scene_;

--- a/tests/test_project_chapters.cpp
+++ b/tests/test_project_chapters.cpp
@@ -23,6 +23,41 @@ namespace {
     using namespace lfs::io::project;
     using namespace lfs::test::licht;
 
+    TEST(ProjectChapterTest, LicenseRoundTripsAndOmitsEmptyNotice) {
+        ProjectChapter chapter;
+        ASSERT_TRUE(chapter.set_license(ProjectLicense{
+            .identifier = "CC BY-NC",
+            .notice = "Copyright 2026",
+        }));
+
+        auto license = chapter.license();
+        ASSERT_TRUE(license);
+        ASSERT_TRUE(license->has_value());
+        EXPECT_EQ(*license, (ProjectLicense{
+                                .identifier = "CC BY-NC",
+                                .notice = "Copyright 2026",
+                            }));
+
+        ASSERT_TRUE(chapter.set_license(ProjectLicense{
+            .identifier = "CC BY-NC",
+        }));
+        license = chapter.license();
+        ASSERT_TRUE(license);
+        ASSERT_TRUE(license->has_value());
+        EXPECT_TRUE((*license)->notice.empty());
+        EXPECT_FALSE(chapter.dom().get_json("license.notice"));
+
+        ASSERT_TRUE(chapter.clear_license());
+        license = chapter.license();
+        ASSERT_TRUE(license);
+        EXPECT_FALSE(license->has_value());
+        EXPECT_FALSE(chapter.dom().get_json("license"));
+
+        const auto rejected = chapter.set_license(ProjectLicense{});
+        ASSERT_FALSE(rejected);
+        EXPECT_EQ(rejected.error().code(), lfs::ErrorCode::InvalidArgument);
+    }
+
     ParameterManagerSnapshot parameter_snapshot() {
         ParameterManagerSnapshot result;
         result.active_strategy = "mrnf";

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -132,6 +132,75 @@ namespace {
         lfs::core::save_image_u8(path, image);
     }
 
+    TEST(ProjectDocumentTest, LicensePersistsAcrossSaveAsAndCompaction) {
+        TemporaryDirectory temporary;
+        const auto source = temporary.path / "license-source.licht";
+        const auto destination = temporary.path / "license-destination.licht";
+
+        auto document = make_empty_document(fixed_uuid(19'150), 100);
+        ASSERT_TRUE(document->set_license(ProjectLicense{
+            .identifier = "CC BY-NC",
+            .notice = "Use with attribution",
+        }));
+        ASSERT_TRUE(document->save(source, save_options(19'151, 200)));
+
+        auto source_reader = require_result(ProjectReader::open(source));
+        EXPECT_TRUE(source_reader.commit().required_writer_capabilities.contains(
+            RETAINED_JSON_FIELDS));
+        auto source_project = require_result(ProjectDocument::open(source));
+        auto source_license = require_result(source_project.project().license());
+        ASSERT_TRUE(source_license.has_value());
+        EXPECT_EQ(*source_license, (ProjectLicense{
+                                       .identifier = "CC BY-NC",
+                                       .notice = "Use with attribution",
+                                   }));
+
+        ASSERT_TRUE(source_project.save_as(destination, save_options(19'152, 300)));
+        auto destination_reader = require_result(ProjectReader::open(destination));
+        const auto* destination_project_row = destination_reader.find(
+            FOURCC_PROJ, destination_reader.superblock().project_uuid);
+        ASSERT_NE(destination_project_row, nullptr);
+        const auto before_compaction =
+            require_result(destination_reader.read_chunk(*destination_project_row));
+        auto destination_project = require_result(ProjectDocument::open(destination));
+        auto destination_license = require_result(destination_project.project().license());
+        ASSERT_TRUE(destination_license.has_value());
+        EXPECT_EQ(*destination_license, *source_license);
+
+        ASSERT_TRUE(ProjectWriter::compact(
+            destination,
+            CompactionOptions{
+                .new_file_uuid = fixed_uuid(19'153),
+                .commit_uuid = fixed_uuid(19'154),
+                .snapshot_uuid = destination_reader.commit().snapshot_uuid,
+                .creation_time_unix_ns = 400,
+                .wallclock_unix_ns = 500,
+                .disk_reserve_bytes = 0,
+            }));
+        auto compacted_reader = require_result(ProjectReader::open(destination));
+        const auto* compacted_project_row = compacted_reader.find(
+            FOURCC_PROJ, compacted_reader.superblock().project_uuid);
+        ASSERT_NE(compacted_project_row, nullptr);
+        EXPECT_EQ(require_result(compacted_reader.read_chunk(*compacted_project_row)),
+                  before_compaction);
+
+        destination_project = require_result(ProjectDocument::open(destination));
+        ASSERT_TRUE(destination_project.clear_license());
+        auto cleared_save = destination_project.save(destination, save_options(19'155, 600));
+        ASSERT_TRUE(cleared_save) << lfs::format_for_developer(cleared_save.error());
+        auto cleared = require_result(ProjectDocument::open(destination));
+        auto cleared_license = require_result(cleared.project().license());
+        EXPECT_FALSE(cleared_license.has_value());
+
+        auto plain = make_empty_document(fixed_uuid(19'156), 100);
+        ASSERT_TRUE(plain->save(temporary.path / "license-absent.licht",
+                                save_options(19'157, 700)));
+        auto plain_reader = require_result(ProjectReader::open(
+            temporary.path / "license-absent.licht"));
+        EXPECT_FALSE(plain_reader.commit().required_writer_capabilities.contains(
+            RETAINED_JSON_FIELDS));
+    }
+
     lfs::core::Uuid bind_dataset(ProjectDocument& document,
                                  const fs::path& dataset_root) {
         const auto uuid = require_result(upsert_path_reference(

--- a/tests/test_python_integration.cpp
+++ b/tests/test_python_integration.cpp
@@ -180,6 +180,19 @@ namespace {
         projectGetInfo() override {
             return lfs::vis::ProjectInfo{};
         }
+        lfs::Result<std::optional<lfs::io::project::ProjectLicense>>
+        projectGetLicense() override {
+            return project_license_;
+        }
+        lfs::Result<void> projectSetLicense(
+            const lfs::io::project::ProjectLicense& license) override {
+            project_license_ = license;
+            return {};
+        }
+        lfs::Result<void> projectClearLicense() override {
+            project_license_.reset();
+            return {};
+        }
 
         [[nodiscard]] bool waitForQueuedWork(const std::chrono::milliseconds timeout) {
             std::unique_lock lock(queued_work_mutex);
@@ -212,6 +225,7 @@ namespace {
 
     private:
         lfs::core::Scene scene_;
+        std::optional<lfs::io::project::ProjectLicense> project_license_;
         std::mutex queued_work_mutex;
         std::condition_variable queued_work_cv;
         std::deque<WorkItem> queued_work;
@@ -924,6 +938,27 @@ result_values = [1.0 if outcome is lf.ProjectOpenOutcome.RECOVERY_PROMPT_PENDING
     ASSERT_EQ(result.values.size(), 1u);
     EXPECT_FLOAT_EQ(result.values[0], 1.0F);
     EXPECT_EQ(viewer.post_work_calls, 1);
+}
+
+TEST_F(PythonIntegrationTest, ProjectLicenseRoundTripsThroughBinding) {
+    TestVisualizer viewer;
+    const ScopedVisualizer scoped_viewer(&viewer);
+
+    const auto result = runPythonTensorSnippet(R"PY(
+import lichtfeld as lf
+assert lf.project_get_license() is None
+lf.project_set_license("CC BY-NC", "Use with attribution")
+license = lf.project_get_license()
+set_ok = license == {"identifier": "CC BY-NC", "notice": "Use with attribution"}
+lf.project_clear_license()
+clear_ok = lf.project_get_license() is None
+result_shape = (2,)
+result_values = [1.0 if set_ok else 0.0, 1.0 if clear_ok else 0.0]
+)PY");
+
+    ASSERT_EQ(result.values.size(), 2u);
+    EXPECT_FLOAT_EQ(result.values[0], 1.0F);
+    EXPECT_FLOAT_EQ(result.values[1], 1.0F);
 }
 
 TEST_F(PythonIntegrationTest, CaptureViewportReleasesGilWhileWaitingForViewerThread) {

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -227,6 +227,15 @@ namespace {
         projectGetInfo() override {
             return lfs::vis::ProjectInfo{};
         }
+        lfs::Result<std::optional<lfs::io::project::ProjectLicense>>
+        projectGetLicense() override {
+            return std::optional<lfs::io::project::ProjectLicense>{};
+        }
+        lfs::Result<void> projectSetLicense(
+            const lfs::io::project::ProjectLicense&) override {
+            return {};
+        }
+        lfs::Result<void> projectClearLicense() override { return {}; }
 
         void rejectPostedWork() { accepts_work_ = false; }
 


### PR DESCRIPTION
Implements #1915 at the format level, per the decision to get the field into the format early and leave the UI for later — this PR deliberately ships **no UI** (no panel, dialog, menu, RML, or locale changes).

## What changes

- The PROJ chapter accepts an optional `license` root key: `{ "identifier": "CC BY-NC", "notice": "..." }`. `identifier` is required non-empty (SPDX id or free text), `notice` optional; absent key = no license. Unknown nested members inside the object are preserved, so the shape can grow later without another compatibility step.
- **Old-reader safety**: commits whose PROJ carries the key declare the retained-JSON-fields capability — without this, older builds would mark licensed projects read-only. No reader-version bump. The field survives save, Save As, and compaction.
- Accessors: `ProjectChapter::license/set_license/clear_license`, `ProjectDocument` passthroughs with dirty marking; `ProjectInfo::license_identifier` + the MCP `project_get_info` field so a future UI is display-only; `lf.project_get_license()" / "set" / "clear` Python bindings for headless/scripted use (stubs refreshed).

## Verification

- Chapter round-trip (incl. empty-notice omission), document save/reopen/clear/Save As/compaction survival, capability-declaration assertion, and a Python binding round-trip — all green; 225 gtests in the touched cohorts + the master visualizer regression suite (163 + 1 pre-existing skip) pass; error-debt gate and clang-format clean.