### PR TITLE
Never drop the final project save under memory pressure, and warn the user

### DIFF
--- a/src/core/include/core/resource_messages.hpp
+++ b/src/core/include/core/resource_messages.hpp
@@ -1,0 +1,13 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+namespace lfs::core {
+
+    // Host-RAM exhaustion shares ResourceExhausted/Training with GPU OOM. The
+    // snapshot service starts its user message with this prefix so error
+    // surfaces can tell the two apart without new event plumbing.
+    inline constexpr const char* HOST_MEMORY_SAVE_ERROR_PREFIX =
+        "Not enough free memory to save the project";
+
+} // namespace lfs::core

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -4154,6 +4154,8 @@ namespace lfs::training {
         const TrainingSnapshotCaptureRequest request{
             .iteration = capture_iteration,
             .snapshot_uuid = snapshot_uuid,
+            .relaxed_host_memory_gate =
+                write_kind == ProjectSnapshotWriteKind::Explicit,
             .strategy = *strategy_,
             .params = checkpoint_params,
             .bilateral_grid = bilateral_grid_.get(),
@@ -4178,6 +4180,8 @@ namespace lfs::training {
                 "at iteration {}: {}",
                 capture_iteration, message);
             std::lock_guard lock(project_snapshot_mutex_);
+            last_project_writer_typed_error_ =
+                prepared.error();
             fail_project_request_locked(
                 request_id, message);
             if (prestaged_project_request_id_ ==
@@ -4398,6 +4402,8 @@ namespace lfs::training {
         TrainingSnapshotCaptureRequest request{
             .iteration = iteration,
             .snapshot_uuid = snapshot_uuid,
+            .relaxed_host_memory_gate =
+                cpu_write_kind == ProjectSnapshotWriteKind::Explicit,
             .strategy = *strategy_,
             .params = checkpoint_params,
             .bilateral_grid = bilateral_grid_.get(),
@@ -4513,6 +4519,8 @@ namespace lfs::training {
                 std::lock_guard lock(
                     project_snapshot_mutex_);
                 last_project_writer_error_ = message;
+                last_project_writer_typed_error_ =
+                    pending.error();
                 // A topology-changing step may invalidate a preplanned
                 // layout. Coalesce and replan at the next post-step point.
                 if (!requested_project_path_) {
@@ -4548,6 +4556,7 @@ namespace lfs::training {
                 project_snapshot_mutex_);
             last_project_writer_error_ =
                 "Snapshot CPU-state UUID/iteration proof failed";
+            last_project_writer_typed_error_.reset();
             last_failed_project_request_id_ =
                 std::max(
                     last_failed_project_request_id_,
@@ -5318,6 +5327,8 @@ namespace lfs::training {
                                 lfs::format_for_developer(
                                     writer_result
                                         .error());
+                            last_project_writer_typed_error_ =
+                                writer_result.error();
                             last_failed_project_request_id_ =
                                 std::max(
                                     last_failed_project_request_id_,
@@ -8503,14 +8514,25 @@ namespace lfs::training {
                         *terminal_project_path,
                         terminal_iteration);
                     !save_result) {
-                    append_terminal_error(lfs::make_error(lfs::ErrorInit{
-                        .code = lfs::ErrorCode::Internal,
-                        .domain = lfs::ErrorDomain::Training,
-                        .user_message = "Terminal training save failed.",
-                        .detail = std::format("Terminal save failed at iteration {}: {}",
-                                              terminal_iteration, save_result.error()),
-                        .detection = LFS_SOURCE_SITE_CURRENT(),
-                    }));
+                    std::optional<lfs::Error> typed_save_error;
+                    {
+                        std::lock_guard lock(project_snapshot_mutex_);
+                        typed_save_error =
+                            last_project_writer_typed_error_;
+                    }
+                    if (typed_save_error) {
+                        append_terminal_error(
+                            std::move(*typed_save_error));
+                    } else {
+                        append_terminal_error(lfs::make_error(lfs::ErrorInit{
+                            .code = lfs::ErrorCode::Internal,
+                            .domain = lfs::ErrorDomain::Training,
+                            .user_message = "Terminal training save failed.",
+                            .detail = std::format("Terminal save failed at iteration {}: {}",
+                                                  terminal_iteration, save_result.error()),
+                            .detection = LFS_SOURCE_SITE_CURRENT(),
+                        }));
+                    }
                 } else {
                     const auto params = getParams();
                     if (!params.optimization.headless) {
@@ -8743,6 +8765,7 @@ namespace lfs::training {
                 std::move(*chapters);
             prestaged_project_request_id_ = 0;
             last_project_writer_error_.clear();
+            last_project_writer_typed_error_.reset();
         }
 
         prepare_project_snapshot_at_safe_point(

--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -794,6 +794,8 @@ namespace lfs::training {
             project_step_regression_;
         std::filesystem::path last_project_snapshot_path_;
         std::string last_project_writer_error_;
+        std::optional<lfs::Error>
+            last_project_writer_typed_error_;
         std::optional<std::filesystem::path>
             live_project_path_;
         TrainerProjectSavePolicy trainer_project_save_policy_{};

--- a/src/training/training_snapshot_service.cpp
+++ b/src/training/training_snapshot_service.cpp
@@ -9,6 +9,7 @@
 #include "core/cuda/sh_layout.cuh"
 #include "core/cuda_error_typed.hpp"
 #include "core/logger.hpp"
+#include "core/resource_messages.hpp"
 #include "core/sh_value_quant.hpp"
 #include "core/sh_value_quant_kernels.hpp"
 #include "core/splat_exportable_storage.hpp"
@@ -21,6 +22,7 @@
 #include <cmath>
 #include <condition_variable>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <deque>
 #include <exception>
@@ -93,6 +95,45 @@ namespace lfs::training {
             });
         }
 
+        [[nodiscard]] std::string format_memory_size(
+            const std::uint64_t bytes) {
+            constexpr double BYTES_PER_MIB =
+                1024.0 * 1024.0;
+            constexpr double BYTES_PER_GIB =
+                1024.0 * 1024.0 * 1024.0;
+            if (bytes >=
+                static_cast<std::uint64_t>(BYTES_PER_GIB)) {
+                return std::format(
+                    "{:.1f} GiB",
+                    static_cast<double>(bytes) /
+                        BYTES_PER_GIB);
+            }
+            return std::format(
+                "{:.1f} MiB",
+                static_cast<double>(bytes) /
+                    BYTES_PER_MIB);
+        }
+
+        [[nodiscard]] lfs::Error snapshot_host_memory_error(
+            const std::uint64_t required_bytes,
+            const std::uint64_t available_bytes,
+            std::string detail,
+            const lfs::core::SourceSite source) {
+            return lfs::make_error(lfs::ErrorInit{
+                .code = lfs::ErrorCode::ResourceExhausted,
+                .domain = lfs::ErrorDomain::Training,
+                .user_message = std::format(
+                    "{}: needed {}, available {}.",
+                    lfs::core::HOST_MEMORY_SAVE_ERROR_PREFIX,
+                    format_memory_size(required_bytes),
+                    format_memory_size(available_bytes)),
+                .detail = std::move(detail),
+                .detection = source,
+                .fields = lfs::SmallFields{}.add(
+                    "resource", "host_memory"),
+            });
+        }
+
         std::uint64_t read_rss_bytes() {
 #if defined(__linux__)
             std::ifstream input("/proc/self/status");
@@ -121,11 +162,12 @@ namespace lfs::training {
         };
 
         HostMemoryInfo read_host_memory_info() {
+            HostMemoryInfo result;
 #if defined(_WIN32)
             MEMORYSTATUSEX status{};
             status.dwLength = sizeof(status);
             if (GlobalMemoryStatusEx(&status)) {
-                return {
+                result = {
                     .total_bytes = status.ullTotalPhys,
                     .available_bytes = status.ullAvailPhys,
                 };
@@ -133,7 +175,6 @@ namespace lfs::training {
 #elif defined(__linux__)
             std::ifstream input("/proc/meminfo");
             std::string line;
-            HostMemoryInfo result;
             while (std::getline(input, line)) {
                 unsigned long long kib = 0;
                 if (std::sscanf(
@@ -149,9 +190,29 @@ namespace lfs::training {
                         static_cast<std::uint64_t>(kib) * 1024;
                 }
             }
-            return result;
 #endif
-            return {};
+            const auto read_override = [](const char* name)
+                -> std::optional<std::uint64_t> {
+                const auto* value = std::getenv(name);
+                if (!value) {
+                    return std::nullopt;
+                }
+                unsigned long long bytes = 0;
+                char trailing = '\0';
+                if (std::sscanf(value, "%llu %c", &bytes, &trailing) != 1) {
+                    return std::nullopt;
+                }
+                return static_cast<std::uint64_t>(bytes);
+            };
+            if (const auto total = read_override(
+                    "LFS_TRAINING_SNAPSHOT_HOST_MEMORY_TOTAL_BYTES")) {
+                result.total_bytes = *total;
+            }
+            if (const auto available = read_override(
+                    "LFS_TRAINING_SNAPSHOT_HOST_MEMORY_AVAILABLE_BYTES")) {
+                result.available_bytes = *available;
+            }
+            return result;
         }
 
 #if defined(__x86_64__) || defined(_M_X64)
@@ -1953,9 +2014,11 @@ namespace lfs::training {
             const auto host_memory =
                 read_host_memory_info();
             const auto reserve_bytes =
-                std::max<std::uint64_t>(
-                    MIN_HOST_MEMORY_RESERVE_BYTES,
-                    host_memory.total_bytes / 5);
+                request.relaxed_host_memory_gate
+                    ? HOST_MEMORY_GATE_HEADROOM_BYTES
+                    : std::max<std::uint64_t>(
+                          MIN_HOST_MEMORY_RESERVE_BYTES,
+                          host_memory.total_bytes / 5);
             if (prepared->checkpoint_bytes >
                 std::numeric_limits<std::uint64_t>::max() -
                     reserve_bytes) {
@@ -1969,11 +2032,15 @@ namespace lfs::training {
             if (host_memory.available_bytes == 0 ||
                 host_memory.available_bytes <
                     required_host_memory) {
-                return snapshot_error(
-                    lfs::ErrorCode::ResourceExhausted,
+                return snapshot_host_memory_error(
+                    required_host_memory,
+                    host_memory.available_bytes,
                     std::format(
-                        "Training snapshot deferred: {} bytes available, "
+                        "Training snapshot {}: {} bytes available, "
                         "{} required ({} snapshot + {} reserve)",
+                        request.relaxed_host_memory_gate
+                            ? "rejected"
+                            : "deferred",
                         host_memory.available_bytes,
                         required_host_memory,
                         prepared->checkpoint_bytes,

--- a/src/training/training_snapshot_service.hpp
+++ b/src/training/training_snapshot_service.hpp
@@ -146,6 +146,9 @@ namespace lfs::training {
         // inter-step work can overlap rendering, never optimizer mutation.
         // A nil UUID asks the service to generate one during prepare().
         lfs::core::Uuid snapshot_uuid;
+        // Explicit saves may use the smaller headroom-only host-memory
+        // reserve; autosave captures retain the full safety reserve.
+        bool relaxed_host_memory_gate = false;
         // Optional origin for the one optimizer-pause clock. The caller sets
         // this immediately before draining model readers/locks so those waits
         // are included with the service-side stream synchronizations.

--- a/src/visualizer/gui/error_event_bridge.cpp
+++ b/src/visualizer/gui/error_event_bridge.cpp
@@ -10,6 +10,7 @@
 #include "core/logger.hpp"
 #include "core/path_utils.hpp"
 #include "core/source_site.hpp"
+#include "gui/error_surface_types.hpp"
 #include "gui/string_keys.hpp"
 
 #include <algorithm>
@@ -92,6 +93,9 @@ namespace lfs::vis::gui {
         const lfs::ErrorCode code =
             e.resource_exhausted ? lfs::ErrorCode::ResourceExhausted : lfs::ErrorCode::Internal;
         std::string message = e.error.value_or(LOC(lichtfeld::Strings::Runtime::TRAINING_UNKNOWN_ERROR));
+        if (isHostMemorySaveMessage(message)) {
+            message = LOCF("runtime.training_save_no_memory", message);
+        }
         return makeNotification(code, lfs::ErrorDomain::Training, lfs::Severity::Error,
                                 std::move(message), error_op::kTrain, LFS_SOURCE_SITE_CURRENT());
     }

--- a/src/visualizer/gui/error_surface_types.hpp
+++ b/src/visualizer/gui/error_surface_types.hpp
@@ -2,7 +2,9 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 #pragma once
 
+#include <core/error.hpp>
 #include <core/export.hpp>
+#include <core/resource_messages.hpp>
 
 #include <cstdint>
 #include <string>
@@ -31,5 +33,17 @@ namespace lfs::vis::gui {
     // error text cannot corrupt the document. Shared by the modal consumer and
     // the toast overlay.
     [[nodiscard]] LFS_VIS_API std::string escapeRmlText(std::string_view text);
+
+    // Host-RAM exhaustion (e.g. a refused project save) shares
+    // ResourceExhausted/Training with GPU OOM; the snapshot service prefixes
+    // its user message with HOST_MEMORY_SAVE_ERROR_PREFIX so the surfaces can
+    // keep the GPU-OOM presentation for actual GPU failures.
+    [[nodiscard]] inline bool isHostMemorySaveMessage(const std::string_view message) noexcept {
+        return message.find(lfs::core::HOST_MEMORY_SAVE_ERROR_PREFIX) != std::string_view::npos;
+    }
+
+    [[nodiscard]] inline bool isHostMemoryExhaustion(const lfs::Error& error) noexcept {
+        return isHostMemorySaveMessage(error.user_message());
+    }
 
 } // namespace lfs::vis::gui

--- a/src/visualizer/gui/gui_error_consumer.cpp
+++ b/src/visualizer/gui/gui_error_consumer.cpp
@@ -8,6 +8,7 @@
 #include "core/error_reporter.hpp"
 #include "core/event_bridge/localization_manager.hpp"
 #include "gui/error_event_bridge.hpp"
+#include "gui/error_surface_types.hpp"
 #include "gui/string_keys.hpp"
 
 #include <format>
@@ -41,7 +42,8 @@ namespace lfs::vis::gui {
         [[nodiscard]] bool isOutOfMemory(const lfs::Error& error) noexcept {
             const lfs::ErrorDomain domain = error.domain();
             return error.code() == lfs::ErrorCode::ResourceExhausted &&
-                   domain == lfs::ErrorDomain::Training;
+                   domain == lfs::ErrorDomain::Training &&
+                   !isHostMemoryExhaustion(error);
         }
 
         [[nodiscard]] const char* titleKeyFor(const lfs::Error& error) {

--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -2279,6 +2279,8 @@
     "perf_hud_tooltip": "Show or hide the performance HUD"
   },
   "runtime": {
+    "training_save_no_memory": "Projekt konnte nicht gespeichert werden: {}",
+    "autosave_deferred_no_memory": "Automatisches Speichern ist pausiert: nicht genug freier Speicher ({}). Das Training läuft weiter; das automatische Speichern wird fortgesetzt, sobald wieder Speicher frei ist.",
     "grouped_changes": "Gruppierte Änderungen",
     "untitled_change": "Unbenannte Änderung",
     "history_summary": "{0} Rückgängig / {1} Wiederholen · {2} gesamt",

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -2279,6 +2279,8 @@
     "perf_hud_tooltip": "Show or hide the performance HUD"
   },
   "runtime": {
+    "training_save_no_memory": "Project save failed: {}",
+    "autosave_deferred_no_memory": "Autosave is paused: not enough free memory ({}). Training continues; autosave resumes when memory frees up.",
     "grouped_changes": "Grouped changes",
     "untitled_change": "Untitled change",
     "history_summary": "{0} undo / {1} redo · {2} total",

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -2279,6 +2279,8 @@
     "perf_hud_tooltip": "Show or hide the performance HUD"
   },
   "runtime": {
+    "training_save_no_memory": "No se pudo guardar el proyecto: {}",
+    "autosave_deferred_no_memory": "El guardado automático está en pausa: no hay suficiente memoria libre ({}). El entrenamiento continúa; el guardado automático se reanudará cuando se libere memoria.",
     "grouped_changes": "Cambios agrupados",
     "untitled_change": "Cambio sin título",
     "history_summary": "{0} deshacer / {1} rehacer · {2} en total",

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -2279,6 +2279,8 @@
     "perf_hud_tooltip": "Show or hide the performance HUD"
   },
   "runtime": {
+    "training_save_no_memory": "Échec de l'enregistrement du projet : {}",
+    "autosave_deferred_no_memory": "L'enregistrement automatique est en pause : mémoire libre insuffisante ({}). L'entraînement continue ; l'enregistrement automatique reprendra dès que de la mémoire sera libérée.",
     "grouped_changes": "Modifications groupées",
     "untitled_change": "Modification sans titre",
     "history_summary": "{0} annulations / {1} rétablissements · {2} au total",

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -2279,6 +2279,8 @@
     "perf_hud_tooltip": "Show or hide the performance HUD"
   },
   "runtime": {
+    "training_save_no_memory": "Salvataggio del progetto non riuscito: {}",
+    "autosave_deferred_no_memory": "Il salvataggio automatico è in pausa: memoria libera insufficiente ({}). L'addestramento continua; il salvataggio automatico riprenderà quando si libererà memoria.",
     "grouped_changes": "Modifiche raggruppate",
     "untitled_change": "Modifica senza titolo",
     "history_summary": "{0} annullamenti / {1} ripetizioni · {2} totali",

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -2279,6 +2279,8 @@
     "perf_hud_tooltip": "Show or hide the performance HUD"
   },
   "runtime": {
+    "training_save_no_memory": "プロジェクトを保存できませんでした: {}",
+    "autosave_deferred_no_memory": "自動保存は一時停止中です: 空きメモリが不足しています（{}）。トレーニングは継続します。メモリが解放されると自動保存を再開します。",
     "grouped_changes": "グループ化された変更",
     "untitled_change": "無題の変更",
     "history_summary": "元に戻す {0} 件 / やり直す {1} 件 · 合計 {2}",

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -2279,6 +2279,8 @@
     "perf_hud_tooltip": "Show or hide the performance HUD"
   },
   "runtime": {
+    "training_save_no_memory": "프로젝트를 저장하지 못했습니다: {}",
+    "autosave_deferred_no_memory": "자동 저장이 일시 중지되었습니다: 여유 메모리가 부족합니다({}). 학습은 계속되며, 메모리가 확보되면 자동 저장이 재개됩니다.",
     "grouped_changes": "그룹화된 변경 사항",
     "untitled_change": "제목 없는 변경",
     "history_summary": "실행 취소 {0}개 / 다시 실행 {1}개 · 총 {2}",

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -2279,6 +2279,8 @@
     "perf_hud_tooltip": "Show or hide the performance HUD"
   },
   "runtime": {
+    "training_save_no_memory": "Project opslaan mislukt: {}",
+    "autosave_deferred_no_memory": "Automatisch opslaan is gepauzeerd: onvoldoende vrij geheugen ({}). De training gaat door; automatisch opslaan wordt hervat zodra er geheugen vrijkomt.",
     "grouped_changes": "Gegroepeerde wijzigingen",
     "untitled_change": "Naamloze wijziging",
     "history_summary": "{0} ongedaan maken / {1} opnieuw uitvoeren · {2} totaal",

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -2279,6 +2279,8 @@
     "perf_hud_tooltip": "Show or hide the performance HUD"
   },
   "runtime": {
+    "training_save_no_memory": "Nie udało się zapisać projektu: {}",
+    "autosave_deferred_no_memory": "Autozapis został wstrzymany: za mało wolnej pamięci ({}). Trening jest kontynuowany; autozapis wznowi się, gdy pamięć zostanie zwolniona.",
     "grouped_changes": "Zgrupowane zmiany",
     "untitled_change": "Zmiana bez tytułu",
     "history_summary": "{0} cofnięć / {1} ponowień · łącznie {2}",

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -2279,6 +2279,8 @@
     "perf_hud_tooltip": "Show or hide the performance HUD"
   },
   "runtime": {
+    "training_save_no_memory": "项目保存失败：{}",
+    "autosave_deferred_no_memory": "自动保存已暂停：可用内存不足（{}）。训练将继续；内存释放后自动保存会恢复。",
     "grouped_changes": "已分组的更改",
     "untitled_change": "未命名更改",
     "history_summary": "撤销 {0} 次 / 重做 {1} 次 · 共计 {2}",

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -279,6 +279,38 @@ namespace lfs::vis::project {
                 operation);
         }
 
+        void publishAutosaveMemoryWarning(
+            std::string shortfall,
+            std::string detail) {
+            auto warning = lfs::make_error(
+                lfs::ErrorInit{
+                    .code = lfs::ErrorCode::ResourceExhausted,
+                    .domain = lfs::ErrorDomain::Training,
+                    .severity = lfs::Severity::Warning,
+                    .retryability =
+                        lfs::Retryability::RetryableWithBackoff,
+                    .operation_id = {},
+                    .user_message = LOCF(
+                        "runtime.autosave_deferred_no_memory",
+                        shortfall),
+                    .detail = std::move(detail),
+                    .detection = LFS_SOURCE_SITE_CURRENT(),
+                    .fields = {},
+                    .native = std::nullopt,
+                });
+            publishProjectToast(std::move(warning), "autosave");
+        }
+
+        void publishAutosaveMemoryWarning(
+            const lfs::Error& cause) {
+            const auto shortfall =
+                cause.user_message().empty()
+                    ? developerError(cause)
+                    : std::string(cause.user_message());
+            publishAutosaveMemoryWarning(
+                shortfall, developerError(cause));
+        }
+
         void notifyTrainerRestoreFailure(
             VisualizerImpl& viewer,
             const std::string& detail) {
@@ -4468,6 +4500,7 @@ namespace lfs::vis::project {
                 last_autosave_at_ =
                     std::chrono::steady_clock::
                         now();
+                autosave_memory_warning_published_ = false;
                 LOG_INFO(
                     "Autosave sidecar sequence {} published",
                     autosave_sequence_);
@@ -4545,15 +4578,32 @@ namespace lfs::vis::project {
                     "Autosave skipped because the master moved: {}",
                     error);
             } else {
-                LOG_ERROR(
-                    "Project background write failed: {}",
-                    error);
-                publishProjectToast(
-                    last_project_write_error_code_.value_or(
-                        lfs::ErrorCode::Unavailable),
-                    lfs::ErrorDomain::IO,
-                    error,
-                    gui::error_op::kSave);
+                const bool memory_deferred =
+                    was_autosave &&
+                    last_project_write_error_code_ ==
+                        lfs::ErrorCode::ResourceExhausted &&
+                    viewer_.getTrainerManager() &&
+                    viewer_.getTrainerManager()
+                        ->isTrainingActive() &&
+                    !autosave_memory_warning_published_;
+                if (memory_deferred) {
+                    LOG_WARN(
+                        "Autosave deferred: {}",
+                        error);
+                    publishAutosaveMemoryWarning(
+                        error, error);
+                    autosave_memory_warning_published_ = true;
+                } else {
+                    LOG_ERROR(
+                        "Project background write failed: {}",
+                        error);
+                    publishProjectToast(
+                        last_project_write_error_code_.value_or(
+                            lfs::ErrorCode::Unavailable),
+                        lfs::ErrorDomain::IO,
+                        error,
+                        gui::error_op::kSave);
+                }
             }
             if (was_autosave &&
                 !isStaleAutosaveBasePublicationError(
@@ -4639,6 +4689,9 @@ namespace lfs::vis::project {
             viewer_.getTrainerManager() &&
             viewer_.getTrainerManager()
                 ->isTrainingActive();
+        if (!training) {
+            autosave_memory_warning_published_ = false;
+        }
         const bool training_write_window =
             isTrainingWriteWindowOpen();
         if (!training_write_window &&
@@ -4729,12 +4782,28 @@ namespace lfs::vis::project {
         }
         if (auto started = startAutosave();
             !started) {
+            const auto& cause = started.error();
             last_project_write_error_ =
                 developerError(
-                    started.error());
-            LOG_WARN(
-                "Autosave deferred: {}",
-                last_project_write_error_);
+                    cause);
+            if (training &&
+                cause.code() ==
+                    lfs::ErrorCode::ResourceExhausted &&
+                !autosave_memory_warning_published_) {
+                const auto message =
+                    cause.user_message().empty()
+                        ? last_project_write_error_
+                        : std::string(cause.user_message());
+                LOG_WARN(
+                    "Autosave deferred: {}",
+                    message);
+                publishAutosaveMemoryWarning(cause);
+                autosave_memory_warning_published_ = true;
+            } else {
+                LOG_WARN(
+                    "Autosave deferred: {}",
+                    last_project_write_error_);
+            }
             scheduleAutosaveFailureBackoff();
         }
     }

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -665,6 +665,7 @@ namespace lfs::vis::project {
         std::uint64_t
             last_autosaved_scene_serial_ = 0;
         std::uint64_t autosave_sequence_ = 0;
+        bool autosave_memory_warning_published_ = false;
         bool application_close_pending_ = false;
         bool close_discard_requested_ = false;
         bool suppress_training_adoption_ = false;

--- a/tests/test_training_snapshot_service.cpp
+++ b/tests/test_training_snapshot_service.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <format>
@@ -139,6 +140,45 @@ namespace {
                count > 0;
     }
 
+    class ScopedEnvironmentVariable {
+    public:
+        ScopedEnvironmentVariable(const char* name, const std::string& value)
+            : name_(name) {
+            if (const char* previous = std::getenv(name)) {
+                previous_ = previous;
+            }
+            set(value);
+        }
+
+        ~ScopedEnvironmentVariable() {
+            set(previous_);
+        }
+
+        void set(const std::string& value) const {
+#if defined(_WIN32)
+            (void)_putenv_s(name_.c_str(), value.c_str());
+#else
+            (void)setenv(name_.c_str(), value.c_str(), 1);
+#endif
+        }
+
+        void set(const std::optional<std::string>& value) const {
+#if defined(_WIN32)
+            (void)_putenv_s(name_.c_str(), value ? value->c_str() : "");
+#else
+            if (value) {
+                (void)setenv(name_.c_str(), value->c_str(), 1);
+            } else {
+                (void)unsetenv(name_.c_str());
+            }
+#endif
+        }
+
+    private:
+        std::string name_;
+        std::optional<std::string> previous_;
+    };
+
     TEST(TrainingSnapshotServiceConfigTest,
          RejectsPinnedRingLargerThan512MiB) {
         EXPECT_THROW(
@@ -152,10 +192,71 @@ namespace {
     }
 
     TEST(TrainingSnapshotServiceTest,
+         ExplicitSavesUseRelaxedHostMemoryGate) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+
+        constexpr std::size_t GAUSSIAN_COUNT = 8192;
+        constexpr std::uint64_t GIB = 1024ull * 1024 * 1024;
+        constexpr std::uint64_t MIB = 1024ull * 1024;
+        auto params = make_snapshot_test_params(GAUSSIAN_COUNT);
+        auto model = make_snapshot_test_splat(GAUSSIAN_COUNT);
+        lfs::training::MCMC strategy(*model);
+        strategy.initialize(params.optimization);
+
+        std::ostringstream reference_stream(std::ios::binary | std::ios::out);
+        const auto reference = lfs::training::serialize_checkpoint(
+            reference_stream, 500, strategy, params, nullptr, nullptr, nullptr, nullptr);
+        ASSERT_TRUE(reference.has_value())
+            << lfs::format_for_developer(reference.error());
+
+        const auto checkpoint_bytes = reference->bytes;
+        const ScopedEnvironmentVariable total_memory(
+            "LFS_TRAINING_SNAPSHOT_HOST_MEMORY_TOTAL_BYTES", std::to_string(16 * GIB));
+        ScopedEnvironmentVariable available_memory(
+            "LFS_TRAINING_SNAPSHOT_HOST_MEMORY_AVAILABLE_BYTES",
+            std::to_string(checkpoint_bytes + GIB));
+
+        lfs::training::TrainingSnapshotService service({
+            .ring_slots = 4,
+            .band_bytes = 64 * 1024,
+            .calibration_bytes = 64,
+            .calibration_iterations = 4,
+        });
+        lfs::training::TrainingSnapshotCaptureRequest request{
+            .iteration = 500,
+            .strategy = strategy,
+            .params = params,
+        };
+        ASSERT_TRUE(service.initialize(request));
+
+        auto autosave = service.prepare(request);
+        ASSERT_FALSE(autosave.has_value());
+        EXPECT_NE(lfs::format_for_developer(autosave.error()).find("deferred"),
+                  std::string::npos);
+
+        request.relaxed_host_memory_gate = true;
+        auto explicit_save = service.prepare(request);
+        ASSERT_TRUE(explicit_save.has_value())
+            << lfs::format_for_developer(explicit_save.error());
+
+        available_memory.set(std::to_string(checkpoint_bytes + 768 * MIB - 1));
+        auto near_oom_explicit_save = service.prepare(request);
+        ASSERT_FALSE(near_oom_explicit_save.has_value());
+        EXPECT_NE(
+            lfs::format_for_developer(near_oom_explicit_save.error()).find("rejected"),
+            std::string::npos);
+    }
+
+    TEST(TrainingSnapshotServiceTest,
          CapturesByteExactLfkpAndOwnsPostResumeBytes) {
         if (!cuda_device_available()) {
             GTEST_SKIP() << "CUDA device unavailable";
         }
+        const ScopedEnvironmentVariable pinned_host_memory(
+            "LFS_TRAINING_SNAPSHOT_HOST_MEMORY_AVAILABLE_BYTES",
+            std::to_string(64ull * 1024 * 1024 * 1024));
 
         constexpr std::size_t GAUSSIAN_COUNT = 8192;
         constexpr int SAVED_ITERATION = 137;
@@ -399,6 +500,9 @@ namespace {
         if (!cuda_device_available()) {
             GTEST_SKIP() << "CUDA device unavailable";
         }
+        const ScopedEnvironmentVariable pinned_host_memory(
+            "LFS_TRAINING_SNAPSHOT_HOST_MEMORY_AVAILABLE_BYTES",
+            std::to_string(64ull * 1024 * 1024 * 1024));
 
         constexpr std::size_t GAUSSIAN_COUNT = 4096;
         constexpr int SAVED_ITERATION = 6;
@@ -613,6 +717,9 @@ namespace {
         if (!cuda_device_available()) {
             GTEST_SKIP() << "CUDA device unavailable";
         }
+        const ScopedEnvironmentVariable pinned_host_memory(
+            "LFS_TRAINING_SNAPSHOT_HOST_MEMORY_AVAILABLE_BYTES",
+            std::to_string(64ull * 1024 * 1024 * 1024));
 
         constexpr std::size_t GAUSSIAN_COUNT =
             1'300'000;


### PR DESCRIPTION
Training's terminal and explicit .licht saves were gated on max(4 GiB, a fifth of total RAM) of free host memory. When a machine was busy, the final save of a completed run was refused and the trained project silently vanished; the log said "Terminal completion save phase took 0.000s" and nothing else told the user. Both 16-bit verification runs today lost their final project this way, and on 16 GB machines the 4 GiB floor makes it likely during normal use.

Explicit and terminal saves now only require the checkpoint size plus 768 MiB of headroom, so a 21 MB save no longer needs 6.7 GB of free RAM. Background autosaves keep the conservative reserve, but the first memory deferral of a run now shows a warning toast instead of only logging, and it can warn again after a recovery. Failures name the numbers ("Not enough free memory to save the project: needed 788.5 MiB, available 381.5 MiB") in the dialog, the training panel and the log, with the wrapper text translated in all ten languages. A refused save is presented as a save failure now, not as the out-of-GPU-memory dialog with GPU advice.

LFS_TRAINING_SNAPSHOT_HOST_MEMORY_TOTAL_BYTES and LFS_TRAINING_SNAPSHOT_HOST_MEMORY_AVAILABLE_BYTES override the readings for tests; a new gtest covers deferral, relaxed success and the honest near-OOM rejection, and the three capture tests are pinned so they no longer depend on the build host's live memory. Verified end to end: the exact failing 16-bit run now publishes its project on a loaded machine with zero error lines, and the rejection dialog and messages were exercised live in the GUI with a lowered override.
