### PR TITLE
Give the New Project name field a full-size input box

### DIFF
--- a/src/visualizer/gui/rmlui/resources/new_project_panel.rml
+++ b/src/visualizer/gui/rmlui/resources/new_project_panel.rml
@@ -11,7 +11,9 @@
     <div class="impdlg-control-group">
       <span class="impdlg-field-label text-muted">@tr:new_project.name</span>
       <div class="impdlg-control-main">
-        <input type="text" class="impdlg-input" data-value="name" />
+        <div class="impdlg-control-row">
+          <input type="text" class="impdlg-input" data-value="name" />
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Reported on Discord by Shady: the New Project popup's project-name box renders as a thin line you can barely see or hit.

The name input was the only impdlg input placed directly in the column flex container, where the shared flex: 1 rule gives it a zero height basis and it collapses to a few pixels. It now sits in an impdlg-control-row like every other input in this dialog family, which restores its full height and width. Verified visually in the running app.
