### PR TITLE
Let explicit depth edits through the selection panel echo holdoff

### DIFF
--- a/src/python/lfs_plugins/selection_controls.py
+++ b/src/python/lfs_plugins/selection_controls.py
@@ -129,6 +129,7 @@ class SelectionControlsController:
         self._last_state_key = None
         self._last_state_items = None
         self._depth_echo_holdoff = 0
+        self._depth_user_edit_pending = set()
         self._depth_text_bufs = {
             "selection_depth_near_str": None,
             "selection_depth_far_str": None,
@@ -195,6 +196,18 @@ class SelectionControlsController:
 
         self._mount_depth_text_input(doc, "selection-depth-near", "selection_depth_near_str")
         self._mount_depth_text_input(doc, "selection-depth-far", "selection_depth_far_str")
+        for element_id, key in (
+            ("selection-depth-near-slider", "near"),
+            ("selection-depth-far-slider", "far"),
+        ):
+            slider = doc.get_element_by_id(element_id)
+            if slider is not None:
+                slider.add_event_listener(
+                    "mousedown", lambda _event, k=key: self._mark_depth_user_edit(k)
+                )
+                slider.add_event_listener(
+                    "focus", lambda _event, k=key: self._mark_depth_user_edit(k)
+                )
 
     def update(self, doc):
         dirty = False
@@ -240,6 +253,7 @@ class SelectionControlsController:
         self._last_state_key = None
         self._last_state_items = None
         self._depth_echo_holdoff = 0
+        self._depth_user_edit_pending.clear()
         self._editing_depth_text.clear()
         self._escape_revert.clear()
 
@@ -370,7 +384,7 @@ class SelectionControlsController:
             return False
 
     def _set_depth_near(self, value):
-        if not self._visible or self._last_state_key is None or self._depth_echo_holdoff > 0:
+        if not self._depth_setter_allowed("near"):
             return
         self._refresh_depth_state()
         near = _clamp(_parse_float(value, self._depth_near), _DEPTH_MIN, _DEPTH_MAX - _DEPTH_GAP)
@@ -378,11 +392,21 @@ class SelectionControlsController:
         self._apply_depth_range(self._depth_enabled, near, far)
 
     def _set_depth_far(self, value):
-        if not self._visible or self._last_state_key is None or self._depth_echo_holdoff > 0:
+        if not self._depth_setter_allowed("far"):
             return
         self._refresh_depth_state()
         far = _clamp(_parse_float(value, self._depth_far), self._depth_near + _DEPTH_GAP, _DEPTH_MAX)
         self._apply_depth_range(self._depth_enabled, self._depth_near, far)
+
+    def _mark_depth_user_edit(self, key):
+        self._depth_user_edit_pending.add(key)
+
+    def _depth_setter_allowed(self, key):
+        if not self._visible or self._last_state_key is None:
+            return False
+        user_edit = key in self._depth_user_edit_pending
+        self._depth_user_edit_pending.discard(key)
+        return self._depth_echo_holdoff == 0 or user_edit
 
     def _apply_depth_range(self, enabled, near, far):
         self._depth_enabled = bool(enabled)
@@ -428,6 +452,10 @@ class SelectionControlsController:
 
     def _begin_depth_text_edit(self, key):
         self._editing_depth_text.add(key)
+        if key == "selection_depth_near_str":
+            self._mark_depth_user_edit("near")
+        elif key == "selection_depth_far_str":
+            self._mark_depth_user_edit("far")
 
     def _end_depth_text_edit(self, key):
         self._editing_depth_text.discard(key)
@@ -448,8 +476,10 @@ class SelectionControlsController:
                 self._sync_depth_text_bufs(force=True)
                 return
             if key == "selection_depth_near_str":
+                self._mark_depth_user_edit("near")
                 self._set_depth_near(parsed)
             elif key == "selection_depth_far_str":
+                self._mark_depth_user_edit("far")
                 self._set_depth_far(parsed)
 
         self._sync_depth_text_bufs(force=True)
@@ -479,6 +509,7 @@ class SelectionControlsController:
 
         action = str(args[0])
         if action == "toggle_depth":
+            self._depth_echo_holdoff = 0
             self._refresh_depth_state()
             self._apply_depth_range(not self._depth_enabled, self._depth_near, self._depth_far)
         elif action == "delete":

--- a/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
+++ b/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
@@ -666,6 +666,7 @@
                 <div class="viewport-transform-axis viewport-selection-depth-axis" data-tooltip="tooltip.selection_depth_near">
                     <span class="viewport-transform-axis-label">{{ui_near_label}}</span>
                     <input type="range"
+                           id="selection-depth-near-slider"
                            class="setting-slider viewport-selection-slider"
                            min="0"
                            max="1000"
@@ -683,6 +684,7 @@
                 <div class="viewport-transform-axis viewport-selection-depth-axis" data-tooltip="tooltip.selection_depth_far">
                     <span class="viewport-transform-axis-label">{{ui_far_label}}</span>
                     <input type="range"
+                           id="selection-depth-far-slider"
                            class="setting-slider viewport-selection-slider"
                            min="0"
                            max="1000"


### PR DESCRIPTION
The reopen echo holdoff from #1798 protects the selection depth range from being collapsed by stale state echoes, but it also swallowed genuine edits: a slider drag or text commit made right after the panel refreshes was silently dropped, and the two contract tests for explicit depth edits have been red since.

Slider mousedown and focus, and depth text edit begin and commit, now mark the edit as user-originated, and the setters let a marked edit through even while the echo window is active. The depth toggle clears the stale window before applying. State echoes stay suppressed, and the #1798 reopen protection keeps its regression coverage. Both previously failing tests pass along with the rest of the selection-controls file.
