### PR TITLE
Follow-ups: depth-edit mark expiry, typed autosave toast, honest restore-start message

### DIFF
--- a/src/python/lfs_plugins/selection_controls.py
+++ b/src/python/lfs_plugins/selection_controls.py
@@ -3,6 +3,7 @@
 """Selection controls controller for the viewport selection overlay."""
 
 import math
+import time
 
 import lichtfeld as lf
 
@@ -22,6 +23,7 @@ _DEPTH_MAX = 1000.0
 _DEPTH_GAP = 0.01
 _DEPTH_SLIDER_HALF_WINDOW = 20.0
 _DEPTH_SLIDER_MIN_SPAN = 1.0
+_DEPTH_USER_EDIT_MARK_TTL = 0.75
 _DEFAULT_DEPTH_NEAR = 0.0
 _DEFAULT_DEPTH_FAR = 6.0
 _DEFAULT_FRUSTUM_HALF_WIDTH = 1.35
@@ -129,7 +131,7 @@ class SelectionControlsController:
         self._last_state_key = None
         self._last_state_items = None
         self._depth_echo_holdoff = 0
-        self._depth_user_edit_pending = set()
+        self._depth_user_edit_pending = {}
         self._depth_text_bufs = {
             "selection_depth_near_str": None,
             "selection_depth_far_str": None,
@@ -399,13 +401,16 @@ class SelectionControlsController:
         self._apply_depth_range(self._depth_enabled, self._depth_near, far)
 
     def _mark_depth_user_edit(self, key):
-        self._depth_user_edit_pending.add(key)
+        self._depth_user_edit_pending[key] = time.monotonic()
 
     def _depth_setter_allowed(self, key):
         if not self._visible or self._last_state_key is None:
             return False
-        user_edit = key in self._depth_user_edit_pending
-        self._depth_user_edit_pending.discard(key)
+        marked_at = self._depth_user_edit_pending.pop(key, None)
+        user_edit = (
+            marked_at is not None
+            and time.monotonic() - marked_at <= _DEPTH_USER_EDIT_MARK_TTL
+        )
         return self._depth_echo_holdoff == 0 or user_edit
 
     def _apply_depth_range(self, enabled, near, far):

--- a/src/visualizer/core/job_registry.cpp
+++ b/src/visualizer/core/job_registry.cpp
@@ -112,7 +112,8 @@ namespace lfs::vis {
     void JobRegistry::finishWork(
         const JobHandle handle, const bool canceled,
         std::string error,
-        const std::optional<lfs::ErrorCode> error_code) {
+        const std::optional<lfs::ErrorCode> error_code,
+        std::optional<lfs::Error> typed_error) {
         assert(
             std::this_thread::get_id() != main_thread_ &&
             "JobRegistry::finishWork must run on a worker thread");
@@ -129,6 +130,7 @@ namespace lfs::vis {
             entry->error = std::move(error);
         }
         entry->error_code = error_code;
+        entry->typed_error = std::move(typed_error);
         entry->status = JobStatus::CompletionPending;
     }
 
@@ -152,6 +154,7 @@ namespace lfs::vis {
             .stage = entry->stage,
             .error = entry->error,
             .error_code = entry->error_code,
+            .typed_error = entry->typed_error,
             .cancel_requested =
                 entry->cancel_requested,
             .worker_canceled =
@@ -269,6 +272,7 @@ namespace lfs::vis {
             .stage = entry->stage,
             .error = entry->error,
             .error_code = entry->error_code,
+            .typed_error = entry->typed_error,
             .cancel_requested = entry->cancel_requested,
             .worker_canceled = entry->worker_canceled,
         };

--- a/src/visualizer/core/job_registry.hpp
+++ b/src/visualizer/core/job_registry.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "core/error_codes.hpp"
+#include "core/error.hpp"
 #include "core/export.hpp"
 
 #include <cstdint>
@@ -56,6 +56,7 @@ namespace lfs::vis {
         std::string stage;
         std::string error;
         std::optional<lfs::ErrorCode> error_code;
+        std::optional<lfs::Error> typed_error;
         bool cancel_requested = false;
         bool worker_canceled = false;
 
@@ -90,7 +91,8 @@ namespace lfs::vis {
                     std::optional<std::string> error = std::nullopt);
         void finishWork(JobHandle handle, bool canceled,
                         std::string error = {},
-                        std::optional<lfs::ErrorCode> error_code = std::nullopt);
+                        std::optional<lfs::ErrorCode> error_code = std::nullopt,
+                        std::optional<lfs::Error> typed_error = std::nullopt);
 
         // Main thread: observes and performs lifecycle transitions.
         [[nodiscard]] std::optional<JobSnapshot>
@@ -119,6 +121,7 @@ namespace lfs::vis {
             std::string stage;
             std::string error;
             std::optional<lfs::ErrorCode> error_code;
+            std::optional<lfs::Error> typed_error;
             bool cancel_requested = false;
             bool worker_canceled = false;
         };

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -1503,9 +1503,17 @@ namespace lfs::vis::project {
                             if (auto started =
                                     viewer_.startTraining();
                                 !started) {
-                                LOG_ERROR(
-                                    "Failed to start training after session restore: {}",
-                                    started.error());
+                                const auto session =
+                                    trainingSessionState();
+                                if (session.completed) {
+                                    LOG_WARN(
+                                        "Training start after session restore was not accepted: {}",
+                                        started.error());
+                                } else {
+                                    LOG_ERROR(
+                                        "Failed to start training after session restore: {}",
+                                        started.error());
+                                }
                             }
                         },
                     .cancel = {},
@@ -3630,6 +3638,7 @@ namespace lfs::vis::project {
                 : 0;
         last_project_write_error_.clear();
         last_project_write_error_code_.reset();
+        last_project_write_typed_error_.reset();
         std::vector<std::byte> owned_preview(
             options.preview_png.begin(),
             options.preview_png.end());
@@ -3688,8 +3697,10 @@ namespace lfs::vis::project {
                                                      options));
                         std::string error;
                         std::optional<lfs::ErrorCode> error_code;
+                        std::optional<lfs::Error> typed_error;
                         if (!saved) {
                             error_code = saved.error().code();
+                            typed_error = saved.error();
                             error =
                                 developerError(
                                     saved.error());
@@ -3702,7 +3713,8 @@ namespace lfs::vis::project {
                             handle,
                             stop.stop_requested(),
                             std::move(error),
-                            error_code);
+                            error_code,
+                            std::move(typed_error));
                         queueProjectWriteSettlement(
                             handle);
                     });
@@ -3803,6 +3815,7 @@ namespace lfs::vis::project {
         const auto destination = project_write_destination_;
         last_project_write_error_.clear();
         last_project_write_error_code_.reset();
+        last_project_write_typed_error_.reset();
         try {
             project_write_thread_ = std::jthread(
                 [this, document = std::move(document), root = *root,
@@ -3814,7 +3827,8 @@ namespace lfs::vis::project {
                     const auto fail_worker = [&](const lfs::Error& error) {
                         const auto detail = developerError(error);
                         LOG_ERROR("Dataset embed failed: {}", detail);
-                        jobs.finishWork(handle, false, detail, error.code());
+                        jobs.finishWork(
+                            handle, false, detail, error.code(), error);
                         queueProjectWriteSettlement(handle);
                     };
                     std::string images_folder;
@@ -4052,6 +4066,7 @@ namespace lfs::vis::project {
                 : 0;
         last_project_write_error_.clear();
         last_project_write_error_code_.reset();
+        last_project_write_typed_error_.reset();
         try {
             project_write_thread_ =
                 std::jthread(
@@ -4819,6 +4834,7 @@ namespace lfs::vis::project {
             automatic;
         last_project_write_error_.clear();
         last_project_write_error_code_.reset();
+        last_project_write_typed_error_.reset();
         try {
             project_write_thread_ =
                 std::jthread(
@@ -4879,6 +4895,10 @@ namespace lfs::vis::project {
                                 ? std::optional<lfs::ErrorCode>{}
                                 : std::optional{
                                       compacted.error().code()};
+                        const auto compact_typed_error =
+                            compacted
+                                ? std::optional<lfs::Error>{}
+                                : std::optional{compacted.error()};
                         jobs.finishWork(
                             handle,
                             stop.stop_requested(),
@@ -4887,7 +4907,8 @@ namespace lfs::vis::project {
                                 : developerError(
                                       compacted
                                           .error()),
-                            compact_error_code);
+                            compact_error_code,
+                            compact_typed_error);
                         queueProjectWriteSettlement(
                             handle);
                     });
@@ -4955,12 +4976,18 @@ namespace lfs::vis::project {
 
         std::string error = snapshot->error;
         last_project_write_error_code_ = snapshot->error_code;
+        last_project_write_typed_error_ = snapshot->typed_error;
         if (snapshot->worker_canceled &&
             error.empty()) {
             last_project_write_error_code_ =
                 lfs::ErrorCode::Cancelled;
             error =
                 "The project write was canceled.";
+            last_project_write_typed_error_ = lifecycleError(
+                lfs::ErrorCode::Cancelled,
+                error,
+                "Project write worker reported cancellation",
+                "project.job");
         }
         if (!error.empty() &&
             project_write_purpose_ ==
@@ -4995,6 +5022,8 @@ namespace lfs::vis::project {
                     !adopted) {
                     last_project_write_error_code_ =
                         adopted.error().code();
+                    last_project_write_typed_error_ =
+                        adopted.error();
                     error =
                         developerError(
                             adopted.error());
@@ -5010,6 +5039,8 @@ namespace lfs::vis::project {
                 !adopted) {
                 last_project_write_error_code_ =
                     adopted.error().code();
+                last_project_write_typed_error_ =
+                    adopted.error();
                 error =
                     developerError(
                         adopted.error());
@@ -5098,6 +5129,8 @@ namespace lfs::vis::project {
             if (!reopened) {
                 last_project_write_error_code_ =
                     reopened.error().code();
+                last_project_write_typed_error_ =
+                    reopened.error();
                 error = developerError(
                     reopened.error());
             } else {
@@ -5249,8 +5282,13 @@ namespace lfs::vis::project {
                     LOG_WARN(
                         "Autosave deferred: {}",
                         error);
-                    publishAutosaveMemoryWarning(
-                        error, error);
+                    if (last_project_write_typed_error_) {
+                        publishAutosaveMemoryWarning(
+                            *last_project_write_typed_error_);
+                    } else {
+                        publishAutosaveMemoryWarning(
+                            error, error);
+                    }
                     autosave_memory_warning_published_ = true;
                 } else {
                     LOG_ERROR(

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -695,6 +695,7 @@ namespace lfs::vis::project {
         bool project_write_automatic_ = false;
         std::string last_project_write_error_;
         std::optional<lfs::ErrorCode> last_project_write_error_code_;
+        std::optional<lfs::Error> last_project_write_typed_error_;
         lfs::io::project::ProjectStorageStats
             storage_stats_;
         bool compaction_suggested_ = false;

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -3605,6 +3605,16 @@ namespace lfs::vis {
             trainer_manager_->resumeTraining();
             return {};
         }
+        if (!trainer_manager_->canStart()) {
+            if (trainer_manager_->isFinished()) {
+                return std::unexpected(std::format(
+                    "Training already completed at iteration {}; starting a new training run requires overwrite consent.",
+                    trainer_manager_->getCurrentIteration()));
+            }
+            return std::unexpected(std::string(
+                trainer_manager_->getActionBlockedReason(
+                    TrainingAction::Start)));
+        }
         if (project_lifecycle_) {
             if (auto prepared =
                     project_lifecycle_
@@ -3616,7 +3626,7 @@ namespace lfs::vis {
             }
         }
         if (!trainer_manager_->startTraining())
-            return std::unexpected("Failed to start training");
+            return std::unexpected("The training manager rejected the start request");
         return {};
     }
 

--- a/tests/python/test_selection_controls_panel.py
+++ b/tests/python/test_selection_controls_panel.py
@@ -258,6 +258,28 @@ def test_selection_depth_toggle_and_sliders_use_selection_api(selection_controls
     assert state.depth_calls[-1] == (True, 1.5, 2.0, 1.35)
 
 
+def test_selection_depth_user_edit_mark_expires(selection_controls_module, monkeypatch):
+    module, state = selection_controls_module
+    panel = module.SelectionControlsController()
+    model = _DataModelStub()
+
+    panel.bind_model(model)
+    panel.update(_DocumentStub())
+    panel._depth_echo_holdoff = 1
+    panel._mark_depth_user_edit("near")
+    marked_at = module.time.monotonic()
+    monkeypatch.setattr(
+        module.time,
+        "monotonic",
+        lambda: marked_at + module._DEPTH_USER_EDIT_MARK_TTL + 0.01,
+    )
+
+    model.bound_binds["selection_depth_near_value"][1]("1.5")
+
+    assert state.depth_calls == []
+    assert "near" not in panel._depth_user_edit_pending
+
+
 def test_selection_depth_text_fields_commit_like_panel_inputs(selection_controls_module):
     module, state = selection_controls_module
     panel = module.SelectionControlsController()


### PR DESCRIPTION
Three follow-ups from the review of #1925 and #1927 and from today's verification runs.

Depth user-edit marks now expire after 0.75 seconds, closing the two edges the #1927 review noted: a stale mark from a mousedown that never produced a value change could bless a later state echo, and an echo arriving between mousedown and the value event could consume the mark and drop the real edit. A regression test covers the expiry.

The background project writer keeps the typed error next to the error code, so the autosave memory-pressure toast from #1925 shows the short user message ("Not enough free memory ...") instead of the full developer-formatted error text in its rare background-writer path.

Starting training over a restored completed session used to fail with the doubled "Failed to start training after session restore: Failed to start training" at error level. It now says the actual precondition (training already completed at iteration N; a new run needs overwrite consent) and the restore path logs it as a warning. The GUI Start button is unaffected: it already routes through the overwrite dialog. The scripted MCP start still reports the pre-existing #1909 no-op on finished trainers; that remains the documented iteration-extension gap.

Gates: build green, full Python suite 1687 passed, error-debt clean.
