### PR TITLE
Marshal GUI-affine Python bindings to the viewer thread

### DIFF
--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -1567,10 +1567,13 @@ NB_MODULE(lichtfeld, m) {
         "project_set_reopen_last",
         [](const bool enabled) {
             nb::gil_scoped_release release;
-            lfs::core::events::cmd::
-                SetReopenLastProject{
-                    .enabled = enabled}
-                    .emit();
+            emit_project_cmd_marshaled(
+                "python.project_set_reopen_last",
+                [enabled] {
+                    lfs::core::events::cmd::SetReopenLastProject{
+                        .enabled = enabled}
+                        .emit();
+                });
         },
         nb::arg("enabled"),
         "Enable or disable reopening the last project at startup");
@@ -1596,10 +1599,13 @@ NB_MODULE(lichtfeld, m) {
         "project_set_auto_save_on_close",
         [](const bool enabled) {
             nb::gil_scoped_release release;
-            lfs::core::events::cmd::
-                SetAutoSaveOnClose{
-                    .enabled = enabled}
-                    .emit();
+            emit_project_cmd_marshaled(
+                "python.project_set_auto_save_on_close",
+                [enabled] {
+                    lfs::core::events::cmd::SetAutoSaveOnClose{
+                        .enabled = enabled}
+                        .emit();
+                });
         },
         nb::arg("enabled"),
         "Enable or disable automatic project save on close");
@@ -1621,9 +1627,13 @@ NB_MODULE(lichtfeld, m) {
         "project_set_embed_dataset_by_default",
         [](const bool enabled) {
             nb::gil_scoped_release release;
-            lfs::core::events::cmd::SetEmbedDatasetByDefault{
-                .enabled = enabled}
-                .emit();
+            emit_project_cmd_marshaled(
+                "python.project_set_embed_dataset_by_default",
+                [enabled] {
+                    lfs::core::events::cmd::SetEmbedDatasetByDefault{
+                        .enabled = enabled}
+                        .emit();
+                });
         },
         nb::arg("enabled"),
         "Set whether new projects copy datasets into the project by default");
@@ -1645,10 +1655,13 @@ NB_MODULE(lichtfeld, m) {
         "project_set_autosave_interval_seconds",
         [](const std::uint64_t seconds) {
             nb::gil_scoped_release release;
-            lfs::core::events::cmd::
-                SetProjectAutosaveInterval{
-                    .seconds = seconds}
-                    .emit();
+            emit_project_cmd_marshaled(
+                "python.project_set_autosave_interval_seconds",
+                [seconds] {
+                    lfs::core::events::cmd::SetProjectAutosaveInterval{
+                        .seconds = seconds}
+                        .emit();
+                });
         },
         nb::arg("seconds"),
         "Set the timed project autosave interval in seconds; zero disables the timer trigger");
@@ -1661,7 +1674,12 @@ NB_MODULE(lichtfeld, m) {
         },
         "Remove all nodes from the scene");
     m.def(
-        "switch_to_edit_mode", []() { lfs::core::events::cmd::SwitchToEditMode{}.emit(); },
+        "switch_to_edit_mode", []() {
+            nb::gil_scoped_release release;
+            emit_project_cmd_marshaled(
+                "python.switch_to_edit_mode",
+                [] { lfs::core::events::cmd::SwitchToEditMode{}.emit(); });
+        },
         "Switch from training to edit mode");
 
     m.def(
@@ -1706,7 +1724,13 @@ NB_MODULE(lichtfeld, m) {
     m.def(
         "load_config_file",
         [](const std::string& path) {
-            lfs::core::events::cmd::LoadConfigFile{.path = python_utf8_path(path)}.emit();
+            nb::gil_scoped_release release;
+            const auto config_path = python_utf8_path(path);
+            emit_project_cmd_marshaled(
+                "python.load_config_file",
+                [config_path] {
+                    lfs::core::events::cmd::LoadConfigFile{.path = config_path}.emit();
+                });
         },
         nb::arg("path"), "Load a JSON configuration file.");
 

--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -51,6 +51,7 @@
 #include "visualizer/operation/undo_history.hpp"
 #include "visualizer/operator/operator_context.hpp"
 #include "visualizer/operator/operator_registry.hpp"
+#include "visualizer/post_work_utils.hpp"
 #include "visualizer/rendering/rendering_manager.hpp"
 #include "visualizer/scene/scene_manager.hpp"
 #include "visualizer/theme/theme.hpp"
@@ -79,11 +80,14 @@
 #include <glm/glm.hpp>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <stack>
 #include <string_view>
 #include <thread>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #ifdef _WIN32
 #include <shellapi.h>
@@ -100,6 +104,43 @@ namespace lfs::python {
     using lfs::training::CommandCenter;
 
     namespace {
+
+        template <typename F>
+            requires(!std::is_void_v<std::invoke_result_t<F>>)
+        auto invoke_on_viewer(F&& fn, std::invoke_result_t<F> fallback) {
+            auto* const viewer = get_visualizer();
+            if (!viewer || viewer->isOnViewerThread())
+                return std::invoke(std::forward<F>(fn));
+            if (!viewer->acceptsPostedWork())
+                return fallback;
+
+            nb::gil_scoped_release release;
+            return lfs::vis::post_work_and_wait(
+                [viewer](lfs::vis::Visualizer::WorkItem work) {
+                    return viewer->postWork(std::move(work));
+                },
+                std::forward<F>(fn),
+                [fallback]() { return fallback; });
+        }
+
+        template <typename F>
+            requires(std::is_void_v<std::invoke_result_t<F>>)
+        void invoke_on_viewer(F&& fn) {
+            auto* const viewer = get_visualizer();
+            if (!viewer || viewer->isOnViewerThread()) {
+                std::invoke(std::forward<F>(fn));
+                return;
+            }
+            if (!viewer->acceptsPostedWork())
+                return;
+
+            nb::gil_scoped_release release;
+            lfs::vis::post_work_and_wait(
+                [viewer](lfs::vis::Visualizer::WorkItem work) {
+                    return viewer->postWork(std::move(work));
+                },
+                std::forward<F>(fn), [] {});
+        }
 
         std::string get_class_id(nb::object cls) {
             auto mod = nb::cast<std::string>(cls.attr("__module__"));
@@ -3914,10 +3955,12 @@ namespace lfs::python {
                 };
                 auto it = tool_map.find(id);
                 if (it != tool_map.end()) {
-                    if (auto* const editor = get_editor_context()) {
-                        editor->setActiveTool(it->second);
-                    }
-                    lfs::core::events::tools::SetToolbarTool{.tool_mode = static_cast<int>(it->second)}.emit();
+                    const auto tool = it->second;
+                    invoke_on_viewer([tool] {
+                        if (auto* const editor = get_editor_context())
+                            editor->setActiveTool(tool);
+                        lfs::core::events::tools::SetToolbarTool{.tool_mode = static_cast<int>(tool)}.emit();
+                    });
                 }
             },
             nb::arg("id"), "Set the active tool via C++ event");
@@ -3925,10 +3968,11 @@ namespace lfs::python {
         m.def(
             "set_active_operator",
             [](const std::string& id, const std::string& gizmo_type) {
-                if (auto* const editor = get_editor_context()) {
-                    editor->setActiveOperator(id, gizmo_type);
-                }
-                vis::UnifiedToolRegistry::instance().setActiveTool(id);
+                invoke_on_viewer([id, gizmo_type] {
+                    if (auto* const editor = get_editor_context())
+                        editor->setActiveOperator(id, gizmo_type);
+                    vis::UnifiedToolRegistry::instance().setActiveTool(id);
+                });
             },
             nb::arg("id"), nb::arg("gizmo_type") = "", "Set active operator with optional gizmo type");
 
@@ -3948,11 +3992,11 @@ namespace lfs::python {
 
         m.def(
             "clear_active_operator", []() {
-                auto* editor = get_editor_context();
-                if (editor) {
-                    editor->clearActiveOperator();
-                }
-                vis::UnifiedToolRegistry::instance().clearActiveTool();
+                invoke_on_viewer([] {
+                    if (auto* const editor = get_editor_context())
+                        editor->clearActiveOperator();
+                    vis::UnifiedToolRegistry::instance().clearActiveTool();
+                });
             },
             "Clear the active operator");
 
@@ -4064,14 +4108,16 @@ namespace lfs::python {
 
         m.def(
             "get_active_submode",
-            []() { return vis::UnifiedToolRegistry::instance().getActiveSubmode(); },
+            []() {
+                return invoke_on_viewer(
+                    [] { return std::string{vis::UnifiedToolRegistry::instance().getActiveSubmode()}; },
+                    std::string{});
+            },
             "Get active selection submode");
 
         m.def(
             "set_selection_mode",
             [](const std::string& mode) {
-                vis::UnifiedToolRegistry::instance().setActiveSubmode(mode);
-
                 static const std::unordered_map<std::string, int> MODE_MAP = {
                     {"centers", static_cast<int>(lfs::vis::SelectionSubMode::Centers)},
                     {"rectangle", static_cast<int>(lfs::vis::SelectionSubMode::Rectangle)},
@@ -4081,9 +4127,14 @@ namespace lfs::python {
                     {"color", static_cast<int>(lfs::vis::SelectionSubMode::Color)},
                     {"box", static_cast<int>(lfs::vis::SelectionSubMode::Box)},
                     {"sphere", static_cast<int>(lfs::vis::SelectionSubMode::Sphere)}};
-                if (const auto it = MODE_MAP.find(mode); it != MODE_MAP.end()) {
-                    lfs::core::events::tools::SetSelectionSubMode{.selection_mode = it->second}.emit();
-                }
+                const auto it = MODE_MAP.find(mode);
+                const std::optional<int> selection_mode =
+                    it == MODE_MAP.end() ? std::nullopt : std::optional{it->second};
+                invoke_on_viewer([mode, selection_mode] {
+                    vis::UnifiedToolRegistry::instance().setActiveSubmode(mode);
+                    if (selection_mode)
+                        lfs::core::events::tools::SetSelectionSubMode{.selection_mode = *selection_mode}.emit();
+                });
             },
             nb::arg("mode"), "Set selection mode");
 

--- a/src/python/lfs/py_ui_panels.cpp
+++ b/src/python/lfs/py_ui_panels.cpp
@@ -12,18 +12,61 @@
 #include "visualizer/gui/gui_manager.hpp"
 #include "visualizer/gui/panel_registry.hpp"
 #include "visualizer/gui/rmlui/rml_theme.hpp"
+#include "visualizer/post_work_utils.hpp"
 
 #include <algorithm>
 #include <array>
+#include <functional>
 #include <mutex>
+#include <optional>
 #include <stdexcept>
 #include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace lfs::python {
 
     namespace gui = lfs::vis::gui;
 
     namespace {
+        template <typename F>
+            requires(!std::is_void_v<std::invoke_result_t<F>>)
+        auto invoke_on_viewer(F&& fn, std::invoke_result_t<F> fallback) {
+            auto* const viewer = get_visualizer();
+            if (!viewer || viewer->isOnViewerThread())
+                return std::invoke(std::forward<F>(fn));
+            if (!viewer->acceptsPostedWork())
+                return fallback;
+
+            nb::gil_scoped_release release;
+            return vis::post_work_and_wait(
+                [viewer](vis::Visualizer::WorkItem work) {
+                    return viewer->postWork(std::move(work));
+                },
+                std::forward<F>(fn),
+                [fallback]() { return fallback; });
+        }
+
+        template <typename F>
+            requires(std::is_void_v<std::invoke_result_t<F>>)
+        void invoke_on_viewer(F&& fn) {
+            auto* const viewer = get_visualizer();
+            if (!viewer || viewer->isOnViewerThread()) {
+                std::invoke(std::forward<F>(fn));
+                return;
+            }
+            if (!viewer->acceptsPostedWork())
+                return;
+
+            nb::gil_scoped_release release;
+            vis::post_work_and_wait(
+                [viewer](vis::Visualizer::WorkItem work) {
+                    return viewer->postWork(std::move(work));
+                },
+                std::forward<F>(fn), [] {});
+        }
+
         void throw_type_error(const std::string& message) {
             throw nb::type_error(message.c_str());
         }
@@ -479,7 +522,12 @@ namespace lfs::python {
         info.initial_width = initial_width;
         info.initial_height = initial_height;
 
-        if (!gui::PanelRegistry::instance().register_panel(std::move(info))) {
+        const bool registered = invoke_on_viewer(
+            [info = std::move(info)]() mutable {
+                return gui::PanelRegistry::instance().register_panel(std::move(info));
+            },
+            false);
+        if (!registered) {
             throw_value_error(
                 std::string("register_panel: runtime rejected panel '") + panel_id + "'");
         }
@@ -610,81 +658,129 @@ namespace lfs::python {
 
         m.def(
             "get_panel_names", [](PanelSpace space) {
-                return gui::PanelRegistry::instance().get_panel_names(to_gui_space(space));
+                return invoke_on_viewer(
+                    [space] {
+                        return gui::PanelRegistry::instance().get_panel_names(to_gui_space(space));
+                    },
+                    std::vector<std::string>{});
             },
             nb::arg("space") = PanelSpace::Floating, "Get registered panel ids for a given space");
 
         m.def(
             "set_panel_enabled", [](const std::string& panel_id, bool enabled) {
-                gui::PanelRegistry::instance().set_panel_enabled(panel_id, enabled);
+                invoke_on_viewer([panel_id, enabled] {
+                    gui::PanelRegistry::instance().set_panel_enabled(panel_id, enabled);
+                });
             },
             nb::arg("panel_id"), nb::arg("enabled"), "Enable or disable a panel by id");
 
         m.def(
             "reset_layout", []() -> std::string {
-                auto* const gui_manager = get_gui_manager();
-                if (!gui_manager)
-                    return "GUI manager is unavailable";
-                const auto result = gui_manager->resetLayout();
-                return result ? std::string{} : result.error();
+                return invoke_on_viewer(
+                    []() -> std::string {
+                        auto* const gui_manager = get_gui_manager();
+                        if (!gui_manager)
+                            return "GUI manager is unavailable";
+                        const auto result = gui_manager->resetLayout();
+                        return result ? std::string{} : result.error();
+                    },
+                    "GUI manager is unavailable");
             },
             "Reset the saved UI layout and apply the default dock arrangement immediately.");
 
         m.def(
             "reset_window_state", []() -> std::string {
-                auto* const gui_manager = get_gui_manager();
-                if (!gui_manager)
-                    return "GUI manager is unavailable";
-                const auto result = gui_manager->resetWindowState();
-                return result ? std::string{} : result.error();
+                return invoke_on_viewer(
+                    []() -> std::string {
+                        auto* const gui_manager = get_gui_manager();
+                        if (!gui_manager)
+                            return "GUI manager is unavailable";
+                        const auto result = gui_manager->resetWindowState();
+                        return result ? std::string{} : result.error();
+                    },
+                    "GUI manager is unavailable");
             },
             "Reset persisted window geometry and apply the default geometry immediately.");
 
         m.def(
             "is_panel_enabled", [](const std::string& panel_id) {
-                return gui::PanelRegistry::instance().is_panel_enabled(panel_id);
+                return invoke_on_viewer(
+                    [panel_id] {
+                        return gui::PanelRegistry::instance().is_panel_enabled(panel_id);
+                    },
+                    false);
             },
             nb::arg("panel_id"), "Check if a panel is enabled");
 
         m.def(
             "get_main_panel_tabs", []() {
-                return gui::PanelRegistry::instance().get_panels_for_space(gui::PanelSpace::MainPanelTab);
+                return invoke_on_viewer(
+                    [] {
+                        return gui::PanelRegistry::instance().get_panels_for_space(
+                            gui::PanelSpace::MainPanelTab);
+                    },
+                    std::vector<gui::PanelSummary>{});
             },
             "Get all main panel tabs as typed panel summaries");
 
         m.def(
             "get_panel", [](const std::string& panel_id) {
-                return gui::PanelRegistry::instance().get_panel(panel_id);
+                return invoke_on_viewer(
+                    [panel_id] {
+                        return gui::PanelRegistry::instance().get_panel(panel_id);
+                    },
+                    std::optional<gui::PanelDetails>{});
             },
             nb::arg("panel_id"), "Get typed panel info by id (None if not found)");
 
         m.def(
             "set_panel_label", [](const std::string& panel_id, const std::string& new_label) {
-                return gui::PanelRegistry::instance().set_panel_label(panel_id, new_label);
+                return invoke_on_viewer(
+                    [panel_id, new_label] {
+                        return gui::PanelRegistry::instance().set_panel_label(panel_id, new_label);
+                    },
+                    false);
             },
             nb::arg("panel_id"), nb::arg("label"), "Set the display label for a panel");
 
         m.def(
             "set_panel_order", [](const std::string& panel_id, int new_order) {
-                return gui::PanelRegistry::instance().set_panel_order(panel_id, new_order);
+                return invoke_on_viewer(
+                    [panel_id, new_order] {
+                        return gui::PanelRegistry::instance().set_panel_order(panel_id, new_order);
+                    },
+                    false);
             },
             nb::arg("panel_id"), nb::arg("order"), "Set the sort order for a panel");
 
         m.def(
             "set_panel_space", [](const std::string& panel_id, PanelSpace space) {
-                return gui::PanelRegistry::instance().set_panel_space(panel_id, to_gui_space(space));
+                return invoke_on_viewer(
+                    [panel_id, space] {
+                        return gui::PanelRegistry::instance().set_panel_space(
+                            panel_id, to_gui_space(space));
+                    },
+                    false);
             },
             nb::arg("panel_id"), nb::arg("space"), "Set the panel space (where it renders)");
 
         m.def(
             "set_panel_parent", [](const std::string& panel_id, const std::string& parent_id) {
-                return gui::PanelRegistry::instance().set_panel_parent(panel_id, parent_id);
+                return invoke_on_viewer(
+                    [panel_id, parent_id] {
+                        return gui::PanelRegistry::instance().set_panel_parent(panel_id, parent_id);
+                    },
+                    false);
             },
             nb::arg("panel_id"), nb::arg("parent"), "Set the parent panel (embeds as collapsible section)");
 
         m.def(
             "has_main_panel_tabs", []() {
-                return gui::PanelRegistry::instance().has_panels(gui::PanelSpace::MainPanelTab);
+                return invoke_on_viewer(
+                    [] {
+                        return gui::PanelRegistry::instance().has_panels(gui::PanelSpace::MainPanelTab);
+                    },
+                    false);
             },
             "Check if any main panel tabs are registered");
     }


### PR DESCRIPTION
Several Python bindings took GUI-owned locks or mutated project state directly from the Python worker while holding the GIL. When the GUI thread was completing an asset load at the same moment, which acquires the GIL for the scene update, the two deadlocked: the worker owned the GIL and waited on a GUI lock, the GUI thread owned the lock path and waited on the GIL. The UI froze until the app was killed. This matches the three main-thread hangs in #1930; two of them used exactly these calls, and the full static lock analysis is in the issue's linked lane report.

set_panel_enabled and the other direct PanelRegistry, GuiManager and UnifiedToolRegistry bindings now run through a guarded viewer-thread post-and-wait that executes inline when already on the viewer thread and releases the GIL before waiting. The project preference setters, switch_to_edit_mode and load_config_file now use the existing emit_project_cmd_marshaled helper their sibling commands already use. Bindings that were already asynchronous or belong to other command families were audited and left alone; the audit table is in the lane report.

Stress regression on the fixed binary: eight debugger-supervised runs hammering the exact calls from the sightings against in-flight dataset and 3M-splat PLY loads, no hang, zero errors, with state readbacks proving the calls still take effect. Build green, full Python suite 1687 passed, error-debt clean.

Fixes #1930
