### PR TITLE
Autosave no longer rewrites unchanged projects in a loop

### DIFF
--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -3216,6 +3216,7 @@ namespace lfs::io::project {
         std::span<const std::byte> preview_png = options.preview_png;
 #if !defined(LFS_FORMAT_TEST_TARGET)
         if (!is_autosave &&
+            !options.leave_unbound &&
             (options.commit.kind == CommitKind::Explicit ||
              options.commit.kind == CommitKind::Recovered)) {
             const auto project_root =

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -3268,6 +3268,8 @@ namespace lfs::vis::project {
         last_autosaved_scene_serial_ =
             scene_mutation_serial_.load(
                 std::memory_order_acquire);
+        last_autosaved_parameter_serial_.reset();
+        autosave_quiesce_logged_ = false;
         clearAutosaveFailureBackoff();
     }
 
@@ -5189,9 +5191,12 @@ namespace lfs::vis::project {
                     project_write_dirty_epoch_;
                 last_autosaved_scene_serial_ =
                     project_write_scene_serial_;
+                last_autosaved_parameter_serial_ =
+                    project_write_parameter_serial_;
                 last_autosave_at_ =
                     std::chrono::steady_clock::
                         now();
+                autosave_quiesce_logged_ = false;
                 autosave_memory_warning_published_ = false;
                 LOG_INFO(
                     "Autosave sidecar sequence {} published",
@@ -5422,11 +5427,19 @@ namespace lfs::vis::project {
         const auto scene_serial =
             scene_mutation_serial_.load(
                 std::memory_order_acquire);
+        const auto* const parameter_manager =
+            viewer_.getParameterManager();
+        const auto parameter_serial =
+            parameter_manager
+                ? parameter_manager->dirtySerial()
+                : 0;
         const bool plausibly_dirty =
             scene_dirty_.load(
                 std::memory_order_acquire) ||
             payload_dirty_.load(
                 std::memory_order_acquire) ||
+            (parameter_manager &&
+             parameter_manager->isDirty()) ||
             hasHardDirtyChapters(*document_);
         if (!plausibly_dirty) {
             return;
@@ -5457,6 +5470,23 @@ namespace lfs::vis::project {
                 settings_
                     .autosave_dirty_epoch_threshold);
         if (!(timer_due || epoch_due)) {
+            return;
+        }
+        if (last_autosaved_parameter_serial_ &&
+            scene_serial ==
+                last_autosaved_scene_serial_ &&
+            !scene_dirty_.load(
+                std::memory_order_acquire) &&
+            !payload_dirty_.load(
+                std::memory_order_acquire) &&
+            parameter_serial ==
+                *last_autosaved_parameter_serial_) {
+            if (!autosave_quiesce_logged_) {
+                LOG_DEBUG(
+                    "Autosave skipped: no changes since sequence {}",
+                    autosave_sequence_);
+                autosave_quiesce_logged_ = true;
+            }
             return;
         }
         if (isBackgroundAutosaveSuppressed()) {

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -669,6 +669,9 @@ namespace lfs::vis::project {
             last_autosaved_dirty_epoch_ = 0;
         std::uint64_t
             last_autosaved_scene_serial_ = 0;
+        std::optional<std::uint64_t>
+            last_autosaved_parameter_serial_;
+        bool autosave_quiesce_logged_ = false;
         std::uint64_t autosave_sequence_ = 0;
         bool autosave_memory_warning_published_ = false;
         bool application_close_pending_ = false;


### PR DESCRIPTION
The app was quietly burning CPU on autosaves that saved nothing new.

Two cases, both measured on an idle session:
- After importing a dataset, the app wrote a full project save every 1.2 seconds, forever — about 50 saves and 50 preview-image re-encodes per minute, with zero changes.
- With a project open, the autosave sidecar was republished every timer tick indefinitely, even though its content never changed.

Now the autosave scheduler checks whether anything actually changed since the last successful write (scene edits, parameter edits, dirty flags). If nothing did, it does nothing. A real edit still autosaves within the usual few seconds, and crash recovery behaves exactly as before. Bonus: parameter-only edits now count toward autosave eligibility, which they previously never did.

Verified live: one write after dataset import then silence; zero writes on an idle open project; an edit triggers a sidecar within 5 seconds and then it goes quiet again. Project-document and format test suites pass.