### PR TITLE
Saving projects is 2.2x faster

### DIFF
--- a/src/io/include/io/project_container.hpp
+++ b/src/io/include/io/project_container.hpp
@@ -586,8 +586,13 @@ namespace lfs::io::project {
         [[nodiscard]] static lfs::Result<void>
         compact(const std::filesystem::path& path, const CompactionOptions& options = {});
         // Compacts source_path into a new destination without first cloning
-        // the complete source file. The source is only read; publication of
-        // destination remains transactional and fully validated.
+        // the complete source file. Writer locks for both paths are held for
+        // the duration (one lock when the paths are equal). Normal compaction
+        // publishes the destination transactionally after full CRC validation
+        // and durability. With private_staging, the destination is a private
+        // intermediate: only its authority tuple is validated here; full CRC
+        // validation and durability are deferred to the caller's final commit
+        // before publication.
         [[nodiscard]] static lfs::Result<void>
         compact_to(const std::filesystem::path& source_path,
                    const std::filesystem::path& destination_path,

--- a/src/io/include/io/project_container.hpp
+++ b/src/io/include/io/project_container.hpp
@@ -571,6 +571,10 @@ namespace lfs::io::project {
         std::uint64_t wallclock_unix_ns = 0;
         std::uint64_t disk_reserve_bytes = 64ull * 1024 * 1024;
         CommitBoundaryObserver boundary_observer;
+        // Save As compaction writes a private intermediate file. The caller
+        // must complete the final append, full CRC verification, and durable
+        // publication before exposing it as the destination.
+        bool private_staging = false;
     };
 
     class LFS_IO_API ProjectWriter {
@@ -581,6 +585,13 @@ namespace lfs::io::project {
         append(const std::filesystem::path& path, const AppendOptions& options = {});
         [[nodiscard]] static lfs::Result<void>
         compact(const std::filesystem::path& path, const CompactionOptions& options = {});
+        // Compacts source_path into a new destination without first cloning
+        // the complete source file. The source is only read; publication of
+        // destination remains transactional and fully validated.
+        [[nodiscard]] static lfs::Result<void>
+        compact_to(const std::filesystem::path& source_path,
+                   const std::filesystem::path& destination_path,
+                   const CompactionOptions& options = {});
 
         ProjectWriter(ProjectWriter&&) noexcept;
         ProjectWriter& operator=(ProjectWriter&&) noexcept;

--- a/src/io/project/project_container.cpp
+++ b/src/io/project/project_container.cpp
@@ -2996,8 +2996,11 @@ namespace lfs::io::project {
         // in verify_chunk does not increment this counter).
         lfs::Result<void> verify_stored_payload_crc32c(const ReaderState& state,
                                                        const ChunkInfo& row) {
+            const auto verify_started = std::chrono::steady_clock::now();
             if (row.stored_bytes == 0) {
-                if (0u != row.payload_crc32c) {
+                if (0u != row.payload_crc32c ||
+                    (row.block_crc_table.has_value() &&
+                     !row.block_crc_table->entries.empty())) {
                     return status_failure(format_error(
                         state.path, row.payload_offset,
                         std::format("payload[{}].crc32c", row.key_string()),
@@ -3026,21 +3029,30 @@ namespace lfs::io::project {
 
             const auto max_workers =
                 std::max(1u, std::thread::hardware_concurrency());
+            const std::uint64_t block_count =
+                (row.stored_bytes + BLOCK_CRC_BYTES - 1) / BLOCK_CRC_BYTES;
+            if (row.block_crc_table.has_value() &&
+                row.block_crc_table->entries.size() != block_count) {
+                return status_failure(format_error(
+                    state.path, row.block_crc_table->offset + 40,
+                    std::format("payload[{}].block_count", row.key_string()),
+                    std::to_string(block_count),
+                    std::to_string(row.block_crc_table->entries.size())));
+            }
             const std::uint64_t range_count = std::min<std::uint64_t>(
-                max_workers,
-                std::max<std::uint64_t>(
-                    1, (row.stored_bytes + BLOCK_CRC_BYTES - 1) /
-                           BLOCK_CRC_BYTES));
+                max_workers, block_count);
             struct Range {
                 std::uint64_t offset = 0;
                 std::uint64_t size = 0;
             };
             std::vector<Range> ranges(static_cast<std::size_t>(range_count));
-            const std::uint64_t base = row.stored_bytes / range_count;
-            const std::uint64_t extra = row.stored_bytes % range_count;
+            const std::uint64_t base = block_count / range_count;
+            const std::uint64_t extra = block_count % range_count;
             std::uint64_t cursor = 0;
             for (std::uint64_t i = 0; i < range_count; ++i) {
-                const std::uint64_t size = base + (i < extra ? 1 : 0);
+                const std::uint64_t blocks = base + (i < extra ? 1 : 0);
+                const std::uint64_t size = std::min<std::uint64_t>(
+                    row.stored_bytes - cursor, blocks * BLOCK_CRC_BYTES);
                 ranges[static_cast<std::size_t>(i)] = Range{
                     .offset = cursor,
                     .size = size,
@@ -3059,7 +3071,8 @@ namespace lfs::io::project {
                 const std::size_t buffer_size = static_cast<std::size_t>(
                     std::min<std::uint64_t>(BLOCK_CRC_BYTES, range.size));
                 std::vector<std::byte> buffer(buffer_size);
-                std::uint32_t crc = 0;
+                std::uint32_t range_crc = 0;
+                std::uint32_t block_crc = 0;
                 std::uint64_t remaining = range.size;
                 std::uint64_t relative = 0;
                 while (remaining > 0) {
@@ -3080,11 +3093,33 @@ namespace lfs::io::project {
                         }
                         return;
                     }
-                    crc = crc32c(crc, dest.data(), dest.size());
+                    range_crc = crc32c(range_crc, dest.data(), dest.size());
+                    if (row.block_crc_table.has_value()) {
+                        block_crc = crc32c(block_crc, dest.data(), dest.size());
+                        const auto block_index = static_cast<std::size_t>(
+                            (range.offset + relative) / BLOCK_CRC_BYTES);
+                        if (block_index >=
+                                row.block_crc_table->entries.size() ||
+                            block_crc != row.block_crc_table->entries[block_index]) {
+                            std::scoped_lock lock(mutex);
+                            if (!error) {
+                                error = format_error(
+                                    state.path,
+                                    row.payload_offset + range.offset + relative,
+                                    std::format("payload[{}].block[{}].crc32c",
+                                                row.key_string(), block_index),
+                                    std::format("0x{:08x}",
+                                                row.block_crc_table->entries[block_index]),
+                                    std::format("0x{:08x}", block_crc));
+                            }
+                            return;
+                        }
+                        block_crc = 0;
+                    }
                     relative += count;
                     remaining -= count;
                 }
-                partial[index] = crc;
+                partial[index] = range_crc;
             };
 
             if (ranges.size() == 1) {
@@ -3172,6 +3207,12 @@ namespace lfs::io::project {
                     std::format("0x{:08x}", row.payload_crc32c),
                     std::format("0x{:08x}", running_crc)));
             }
+            LOG_DEBUG(
+                "Project payload verify stages: chunk={} stored_bytes={} ranges={} parallel_crc={:.3f} ms",
+                row.key_string(), row.stored_bytes, ranges.size(),
+                std::chrono::duration<double, std::milli>(
+                    std::chrono::steady_clock::now() - verify_started)
+                    .count());
             return {};
         }
 
@@ -3697,61 +3738,9 @@ namespace lfs::io::project {
             return status_failure(std::move(resolved).error());
         }
         const ChunkInfo& row = **resolved;
-        std::uint32_t running_crc = 0;
-        std::uint64_t relative = 0;
-        std::size_t block_index = 0;
-        while (relative < row.stored_bytes) {
-            const std::uint64_t count =
-                std::min<std::uint64_t>(BLOCK_CRC_BYTES,
-                                        row.stored_bytes - relative);
-            if (impl_->state->options
-                    .payload_bytes_read) {
-                impl_->state->options
-                    .payload_bytes_read
-                    ->fetch_add(
-                        count,
-                        std::memory_order_relaxed);
-            }
-            auto bytes = read_vector(*impl_->state->file,
-                                     row.payload_offset + relative, count,
-                                     impl_->state->physical_size,
-                                     commit().committed_file_end, "payload.verify",
-                                     BLOCK_CRC_BYTES);
-            if (!bytes) {
-                return status_failure(std::move(bytes).error());
-            }
-            const std::uint32_t block_crc =
-                crc32c(0, bytes->data(), bytes->size());
-            if (row.block_crc_table.has_value()) {
-                const auto& entries = row.block_crc_table->entries;
-                assert(block_index < entries.size());
-                if (block_crc != entries[block_index]) {
-                    return status_failure(format_error(
-                        path(), row.payload_offset + relative,
-                        std::format("payload[{}].block[{}].crc32c",
-                                    row.key_string(), block_index),
-                        std::format("0x{:08x}", entries[block_index]),
-                        std::format("0x{:08x}", block_crc)));
-                }
-            }
-            running_crc = crc32c(running_crc, bytes->data(), bytes->size());
-            relative += count;
-            ++block_index;
-        }
-        if (running_crc != row.payload_crc32c) {
-            return status_failure(format_error(
-                path(), row.payload_offset,
-                std::format("payload[{}].crc32c", row.key_string()),
-                std::format("0x{:08x}", row.payload_crc32c),
-                std::format("0x{:08x}", running_crc)));
-        }
-        if (row.block_crc_table.has_value() &&
-            block_index != row.block_crc_table->entries.size()) {
-            return status_failure(format_error(
-                path(), row.block_crc_table->offset + 40,
-                std::format("payload[{}].block_count", row.key_string()),
-                std::to_string(row.block_crc_table->entries.size()),
-                std::to_string(block_index)));
+        if (auto verified = verify_stored_payload_crc32c(*impl_->state, row);
+            !verified) {
+            return verified;
         }
         if (row.compression == Compression::ZstdFramed ||
             row.compression == Compression::ByteShuffleZstdFramed) {

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -4138,29 +4138,49 @@ namespace lfs::io::project {
             options.file_uuid.is_nil()
                 ? lfs::core::generate_uuid_v4()
                 : options.file_uuid;
+        const CompactionOptions compaction_options{
+            .compatibility =
+                impl_->source_reader
+                    ? impl_->source_reader
+                          ->reader_options()
+                    : ReaderOptions{},
+            .new_file_uuid = file_uuid,
+            .new_project_uuid =
+                save_as_project_uuid,
+            .commit_uuid =
+                options.save_as_compaction_commit_uuid.is_nil()
+                    ? lfs::core::generate_uuid_v4()
+                    : options.save_as_compaction_commit_uuid,
+            .snapshot_uuid = options.commit.snapshot_uuid,
+            .creation_time_unix_ns =
+                options.save_as_creation_time_unix_ns,
+            .wallclock_unix_ns = options.commit.wallclock_unix_ns,
+            .disk_reserve_bytes = options.disk_reserve_bytes,
+            .boundary_observer = {},
+            .private_staging = true,
+        };
         auto compacted = ProjectWriter::compact_to(
-            original_path, temporary,
-            CompactionOptions{
-                .compatibility =
-                    impl_->source_reader
-                        ? impl_->source_reader
-                              ->reader_options()
-                        : ReaderOptions{},
-                .new_file_uuid = file_uuid,
-                .new_project_uuid =
-                    save_as_project_uuid,
-                .commit_uuid =
-                    options.save_as_compaction_commit_uuid.is_nil()
-                        ? lfs::core::generate_uuid_v4()
-                        : options.save_as_compaction_commit_uuid,
-                .snapshot_uuid = options.commit.snapshot_uuid,
-                .creation_time_unix_ns =
-                    options.save_as_creation_time_unix_ns,
-                .wallclock_unix_ns = options.commit.wallclock_unix_ns,
-                .disk_reserve_bytes = options.disk_reserve_bytes,
-                .boundary_observer = {},
-                .private_staging = true,
-            });
+            original_path, temporary, compaction_options);
+        if (!compacted &&
+            compacted.error().code() == lfs::ErrorCode::Unavailable) {
+            // Save As is read-only on the original and may proceed while
+            // another process holds its writer lock. In that case, first
+            // make the private source snapshot that the old Save As path
+            // used, then compact that snapshot under its own writer lock.
+            error.clear();
+            if (!std::filesystem::copy_file(
+                    original_path, temporary,
+                    std::filesystem::copy_options::none, error)) {
+                remove_temporary();
+                return fail<ProjectDocumentSaveReport>(
+                    lfs::ErrorCode::Unavailable,
+                    "The project could not be staged for Save As.",
+                    std::format("copy_file failed: {}", error.message()),
+                    "project.save_as.copy");
+            }
+            compacted = ProjectWriter::compact(
+                temporary, compaction_options);
+        }
         if (!compacted) {
             remove_temporary();
             return std::move(compacted).error();

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -3202,6 +3202,26 @@ namespace lfs::io::project {
         const ProjectDocumentSaveOptions& options,
         const ProjectDocumentAutosaveOptions* autosave) {
         const bool is_autosave = autosave != nullptr;
+        const auto save_started = std::chrono::steady_clock::now();
+        auto preview_finished = save_started;
+        auto payload_finished = save_started;
+        auto writer_setup_finished = save_started;
+        auto chunks_finished = save_started;
+        const auto log_save_stages = [&](const auto finished) {
+            const auto milliseconds = [](const auto begin, const auto end) {
+                return std::chrono::duration<double, std::milli>(end - begin)
+                    .count();
+            };
+            LOG_DEBUG(
+                "Project document save stages: autosave={} preview_prepare={:.3f} ms payload_prepare={:.3f} ms writer_setup={:.3f} ms chunk_write={:.3f} ms commit={:.3f} ms total={:.3f} ms",
+                is_autosave,
+                milliseconds(save_started, preview_finished),
+                milliseconds(preview_finished, payload_finished),
+                milliseconds(payload_finished, writer_setup_finished),
+                milliseconds(writer_setup_finished, chunks_finished),
+                milliseconds(chunks_finished, finished),
+                milliseconds(save_started, finished));
+        };
         if (!options.preview_png.empty() &&
             ((options.commit.kind != CommitKind::Explicit &&
               options.commit.kind != CommitKind::Recovered) ||
@@ -3239,6 +3259,7 @@ namespace lfs::io::project {
             }
         }
 #endif
+        preview_finished = std::chrono::steady_clock::now();
         auto normalized = normalized_absolute_path(path);
         if (!normalized) {
             return std::move(normalized).error();
@@ -3553,6 +3574,7 @@ namespace lfs::io::project {
         }
         add_encoded(project_key, staged_project->to_bytes(),
                     json_options());
+        payload_finished = std::chrono::steady_clock::now();
 
         std::set<ChunkKey, ChunkKeyLess> desired{
             project_key,
@@ -3742,6 +3764,7 @@ namespace lfs::io::project {
         if (auto result = writer->preflight(*planned_bytes); !result) {
             return std::move(result).error();
         }
+        writer_setup_finished = std::chrono::steady_clock::now();
 
         ProjectDocumentSaveReport report;
         if (!preview_png.empty()) {
@@ -3952,9 +3975,12 @@ namespace lfs::io::project {
             }
             ++report.rewritten_chunks;
         }
+        chunks_finished = std::chrono::steady_clock::now();
         if (auto result = writer->commit(); !result) {
             return std::move(result).error();
         }
+        const auto commit_finished = std::chrono::steady_clock::now();
+        log_save_stages(commit_finished);
         writer.reset();
 
         if (is_autosave || options.leave_unbound) {
@@ -3999,6 +4025,13 @@ namespace lfs::io::project {
     ProjectDocument::save_as(
         const std::filesystem::path& path,
         const ProjectDocumentSaveOptions& options) {
+        const auto save_as_started = std::chrono::steady_clock::now();
+        auto save_as_preflight_finished = save_as_started;
+        auto save_as_compaction_finished = save_as_started;
+        auto save_as_rebind_finished = save_as_started;
+        auto save_as_save_finished = save_as_started;
+        auto save_as_validate_finished = save_as_started;
+        auto save_as_restore_finished = save_as_started;
         if (impl_->source_reader) {
             const auto compatibility =
                 impl_->source_reader->write_compatibility();
@@ -4075,6 +4108,7 @@ namespace lfs::io::project {
                 std::format("filesystem::exists failed: {}", error.message()),
                 "project.path");
         }
+        save_as_preflight_finished = std::chrono::steady_clock::now();
 
         const auto original_path = *impl_->source_path;
         const auto original_dirty = impl_->dirty;
@@ -4100,23 +4134,12 @@ namespace lfs::io::project {
             std::error_code lock_error;
             std::filesystem::remove(lock_path, lock_error);
         };
-        if (!std::filesystem::copy_file(
-                original_path, temporary,
-                std::filesystem::copy_options::none, error)) {
-            remove_temporary();
-            return fail<ProjectDocumentSaveReport>(
-                lfs::ErrorCode::Unavailable,
-                "The project could not be staged for Save As.",
-                std::format("copy_file failed: {}", error.message()),
-                "project.save_as.copy");
-        }
-
         const auto file_uuid =
             options.file_uuid.is_nil()
                 ? lfs::core::generate_uuid_v4()
                 : options.file_uuid;
-        auto compacted = ProjectWriter::compact(
-            temporary,
+        auto compacted = ProjectWriter::compact_to(
+            original_path, temporary,
             CompactionOptions{
                 .compatibility =
                     impl_->source_reader
@@ -4136,11 +4159,13 @@ namespace lfs::io::project {
                 .wallclock_unix_ns = options.commit.wallclock_unix_ns,
                 .disk_reserve_bytes = options.disk_reserve_bytes,
                 .boundary_observer = {},
+                .private_staging = true,
             });
         if (!compacted) {
             remove_temporary();
             return std::move(compacted).error();
         }
+        save_as_compaction_finished = std::chrono::steady_clock::now();
 
         const auto rebind_preserving_dirty_lazy =
             [this](
@@ -4263,6 +4288,7 @@ namespace lfs::io::project {
             remove_temporary();
             return std::move(rebound).error();
         }
+        save_as_rebind_finished = std::chrono::steady_clock::now();
 
         auto staging_options = options;
         staging_options.writer_lock_lease.reset();
@@ -4277,6 +4303,7 @@ namespace lfs::io::project {
             }
             return save_error;
         }
+        save_as_save_finished = std::chrono::steady_clock::now();
 
         lfs::core::Uuid expected_commit_uuid;
         std::optional<lfs::Error> staged_failure;
@@ -4309,6 +4336,7 @@ namespace lfs::io::project {
             }
             return std::move(*staged_failure);
         }
+        save_as_validate_finished = std::chrono::steady_clock::now();
 
         auto post_save_dirty = impl_->dirty;
         auto post_save_keys = impl_->normalized_source_keys;
@@ -4327,6 +4355,7 @@ namespace lfs::io::project {
                 std::move(replacement).error();
             return cause;
         }
+        save_as_restore_finished = std::chrono::steady_clock::now();
         auto published =
             ProjectReader::open(*normalized);
         if (!published ||
@@ -4340,21 +4369,6 @@ namespace lfs::io::project {
                           "The published commit UUID does not match the independently validated staged project.",
                           "project.save_as.publish")
                     : std::move(published).error();
-            auto rollback =
-                detail::rollback_atomic_replace(
-                    *replacement, *normalized);
-            if (!rollback) {
-                cause = std::move(cause)
-                            .with_suppressed(
-                                std::move(rollback)
-                                    .error());
-            }
-            return cause;
-        }
-        if (auto verified = published->verify_all();
-            !verified) {
-            auto cause =
-                std::move(verified).error();
             auto rollback =
                 detail::rollback_atomic_replace(
                     *replacement, *normalized);
@@ -4391,6 +4405,22 @@ namespace lfs::io::project {
             !finished) {
             return std::move(finished).error();
         }
+        const auto save_as_finished = std::chrono::steady_clock::now();
+        const auto milliseconds = [](const auto begin, const auto end) {
+            return std::chrono::duration<double, std::milli>(end - begin)
+                .count();
+        };
+        LOG_DEBUG(
+            "Project Save As stages: preflight={:.3f} ms compact={:.3f} ms rebind={:.3f} ms document_save={:.3f} ms staged_validate={:.3f} ms restore={:.3f} ms publish={:.3f} ms total={:.3f} ms source={} destination={}",
+            milliseconds(save_as_started, save_as_preflight_finished),
+            milliseconds(save_as_preflight_finished, save_as_compaction_finished),
+            milliseconds(save_as_compaction_finished, save_as_rebind_finished),
+            milliseconds(save_as_rebind_finished, save_as_save_finished),
+            milliseconds(save_as_save_finished, save_as_validate_finished),
+            milliseconds(save_as_validate_finished, save_as_restore_finished),
+            milliseconds(save_as_restore_finished, save_as_finished),
+            milliseconds(save_as_started, save_as_finished),
+            original_path.string(), normalized->string());
         saved->generation = impl_->generation;
         return saved;
     }

--- a/src/io/project/project_writer.cpp
+++ b/src/io/project/project_writer.cpp
@@ -244,11 +244,29 @@ namespace lfs::io::project {
             const auto* src =
                 reinterpret_cast<const std::uint8_t*>(interleaved.data());
             auto* dst = reinterpret_cast<std::uint8_t*>(out.data());
-            for (std::size_t w = 0; w < n_words; ++w) {
-                dst[0 * n_words + w] = src[w * 4 + 0];
-                dst[1 * n_words + w] = src[w * 4 + 1];
-                dst[2 * n_words + w] = src[w * 4 + 2];
-                dst[3 * n_words + w] = src[w * 4 + 3];
+            const auto copy_range = [=](const std::size_t begin,
+                                        const std::size_t end) {
+                for (std::size_t w = begin; w < end; ++w) {
+                    dst[0 * n_words + w] = src[w * 4 + 0];
+                    dst[1 * n_words + w] = src[w * 4 + 1];
+                    dst[2 * n_words + w] = src[w * 4 + 2];
+                    dst[3 * n_words + w] = src[w * 4 + 3];
+                }
+            };
+            constexpr std::size_t PARALLEL_THRESHOLD_WORDS = 1ull << 20;
+            if (n_words < PARALLEL_THRESHOLD_WORDS) {
+                copy_range(0, n_words);
+                return out;
+            }
+            const std::size_t worker_count = std::min<std::size_t>(
+                n_words,
+                std::max(1u, std::thread::hardware_concurrency()));
+            std::vector<std::jthread> workers;
+            workers.reserve(worker_count);
+            for (std::size_t worker = 0; worker < worker_count; ++worker) {
+                const std::size_t begin = n_words * worker / worker_count;
+                const std::size_t end = n_words * (worker + 1) / worker_count;
+                workers.emplace_back([=] { copy_range(begin, end); });
             }
             return out;
         }
@@ -773,26 +791,42 @@ namespace lfs::io::project {
             return crc32c(0, encoded.data(), encoded.size());
         }
 
-        std::vector<std::uint32_t>
-        calculate_block_crcs(const std::span<const std::byte> stored) {
-            std::vector<std::uint32_t> entries;
+        struct PayloadCrcs {
+            std::uint32_t stored = 0;
+            std::vector<std::uint32_t> blocks;
+        };
+
+        PayloadCrcs calculate_payload_crcs(
+            const std::span<const std::byte> stored,
+            const bool with_blocks) {
+            PayloadCrcs result;
             if (stored.empty()) {
-                return entries;
+                return result;
             }
-            const std::uint64_t count =
-                stored.size() / BLOCK_CRC_BYTES +
-                (stored.size() % BLOCK_CRC_BYTES != 0 ? 1 : 0);
-            entries.reserve(static_cast<std::size_t>(count));
+            if (with_blocks) {
+                const std::uint64_t count =
+                    stored.size() / BLOCK_CRC_BYTES +
+                    (stored.size() % BLOCK_CRC_BYTES != 0 ? 1 : 0);
+                result.blocks.reserve(static_cast<std::size_t>(count));
+            }
             std::size_t offset = 0;
             while (offset < stored.size()) {
                 const std::size_t bytes = static_cast<std::size_t>(
                     std::min<std::uint64_t>(stored.size() - offset,
                                             BLOCK_CRC_BYTES));
-                entries.push_back(
-                    crc32c(0, stored.data() + offset, bytes));
+                if (with_blocks) {
+                    const auto block_crc =
+                        crc32c(0, stored.data() + offset, bytes);
+                    result.blocks.push_back(block_crc);
+                    result.stored = crc32c_combine(
+                        result.stored, block_crc, bytes);
+                } else {
+                    result.stored = crc32c(
+                        result.stored, stored.data() + offset, bytes);
+                }
                 offset += bytes;
             }
-            return entries;
+            return result;
         }
 
     } // namespace
@@ -991,6 +1025,7 @@ namespace lfs::io::project {
         bool keep_temporary = false;
         bool used_clean_proof_reuse = false;
         bool used_opaque_carry_forward = false;
+        bool private_staging = false;
         std::optional<lfs::Error> post_publish_note;
 
         ~Impl() {
@@ -1141,6 +1176,8 @@ namespace lfs::io::project {
             const bool with_blocks =
                 options.block_crcs ||
                 stored.size() >= BLOCK_CRC_REQUIRED_AT;
+            const auto payload_crcs =
+                calculate_payload_crcs(stored, with_blocks);
             std::vector<std::uint32_t> entries;
             std::uint64_t table_bytes = 0;
             if (with_blocks) {
@@ -1151,7 +1188,7 @@ namespace lfs::io::project {
                         "block_count must be at least one",
                         "chunk.block_crcs");
                 }
-                entries = calculate_block_crcs(stored);
+                entries = payload_crcs.blocks;
                 auto entry_bytes = detail::checked_multiply(
                     entries.size(), sizeof(std::uint32_t), active_path,
                     *table_offset, "block_table.entries");
@@ -1201,8 +1238,7 @@ namespace lfs::io::project {
                 return std::move(write).error();
             }
 
-            const std::uint32_t stored_crc =
-                crc32c(0, stored.data(), stored.size());
+            const std::uint32_t stored_crc = payload_crcs.stored;
             if (preserve_stored_crc && stored_crc != expected_stored_crc) {
                 return writer_error(
                     lfs::ErrorCode::DataLoss, destination_path,
@@ -1338,7 +1374,7 @@ namespace lfs::io::project {
                 return std::move(zero).error();
             }
 
-            constexpr std::size_t COPY_BUFFER_BYTES = 5 * 1024 * 1024;
+            constexpr std::size_t COPY_BUFFER_BYTES = 32 * 1024 * 1024;
             std::vector<std::byte> buffer(
                 static_cast<std::size_t>(std::min<std::uint64_t>(
                     std::max<std::uint64_t>(source_row.stored_bytes, 1),
@@ -1391,6 +1427,16 @@ namespace lfs::io::project {
                 entries.push_back(block_crc);
             }
             assert(entries.size() == block_count);
+            if (with_blocks &&
+                (!source_row.block_crc_table.has_value() ||
+                 entries != source_row.block_crc_table->entries)) {
+                return writer_error(
+                    lfs::ErrorCode::DataLoss, destination_path,
+                    "A source project chunk failed block CRC validation during compaction.",
+                    std::format("block CRC table for {} does not match its payload",
+                                source_row.key_string()),
+                    "chunk.block_crc32c");
+            }
             if (stored_crc != source_row.payload_crc32c) {
                 return writer_error(
                     lfs::ErrorCode::DataLoss, destination_path,
@@ -2816,15 +2862,19 @@ namespace lfs::io::project {
             return boundary;
         }
         const auto commit_written = std::chrono::steady_clock::now();
-        if (auto flush = impl_->file->sync_data(); !flush) {
-            impl_->poisoned = true;
-            return flush;
+        if (!impl_->private_staging) {
+            if (auto flush = impl_->file->sync_data(); !flush) {
+                impl_->poisoned = true;
+                return flush;
+            }
         }
         const auto data_flushed = std::chrono::steady_clock::now();
-        if (auto boundary =
-                impl_->notify(CommitBoundary::AppendFlushed);
-            !boundary) {
-            return boundary;
+        if (!impl_->private_staging) {
+            if (auto boundary =
+                    impl_->notify(CommitBoundary::AppendFlushed);
+                !boundary) {
+                return boundary;
+            }
         }
 
         HeadInfo head{
@@ -2850,20 +2900,25 @@ namespace lfs::io::project {
             !boundary) {
             return boundary;
         }
-        if (auto flush = impl_->file->sync_all(); !flush) {
-            impl_->poisoned = true;
-            return flush;
+        if (!impl_->private_staging) {
+            if (auto flush = impl_->file->sync_all(); !flush) {
+                impl_->poisoned = true;
+                return flush;
+            }
         }
         const auto all_flushed = std::chrono::steady_clock::now();
         LOG_DEBUG(
-            "Project commit stages: write_commit={:.3f} ms sync_data={:.3f} ms sync_all={:.3f} ms total={:.3f} ms",
+            "Project commit stages: write_commit={:.3f} ms sync_data={:.3f} ms sync_all={:.3f} ms deferred_durability={} total={:.3f} ms",
             std::chrono::duration<double, std::milli>(commit_written - commit_started).count(),
             std::chrono::duration<double, std::milli>(data_flushed - commit_written).count(),
             std::chrono::duration<double, std::milli>(all_flushed - data_flushed).count(),
+            impl_->private_staging,
             std::chrono::duration<double, std::milli>(all_flushed - commit_started).count());
-        if (auto boundary = impl_->notify(CommitBoundary::HeadFlushed);
-            !boundary) {
-            return boundary;
+        if (!impl_->private_staging) {
+            if (auto boundary = impl_->notify(CommitBoundary::HeadFlushed);
+                !boundary) {
+                return boundary;
+            }
         }
 
         ReaderOptions validation_options;
@@ -2969,7 +3024,9 @@ namespace lfs::io::project {
 
         auto validation = impl_->mode == Impl::Mode::Append
                               ? validate_authority(impl_->active_path)
-                              : validate_path(impl_->active_path);
+                              : (impl_->private_staging
+                                     ? validate_authority(impl_->active_path)
+                                     : validate_path(impl_->active_path));
         if (!validation) {
             impl_->poisoned = true;
             impl_->keep_temporary = impl_->mode == Impl::Mode::Create;
@@ -3065,19 +3122,32 @@ namespace lfs::io::project {
     lfs::Result<void>
     ProjectWriter::compact(const std::filesystem::path& path,
                            const CompactionOptions& options) {
-        if (path.empty()) {
+        return compact_to(path, path, options);
+    }
+
+    lfs::Result<void>
+    ProjectWriter::compact_to(
+        const std::filesystem::path& source_path,
+        const std::filesystem::path& destination_path,
+        const CompactionOptions& options) {
+        const auto compact_started = std::chrono::steady_clock::now();
+        auto source_ready = compact_started;
+        auto copy_finished = compact_started;
+        if (source_path.empty() || destination_path.empty()) {
             return status_failure(writer_error(
-                lfs::ErrorCode::InvalidArgument, path,
+                lfs::ErrorCode::InvalidArgument,
+                source_path.empty() ? source_path : destination_path,
                 "The project path is empty.",
-                "compact requires an existing destination path",
+                "compact requires nonempty source and destination paths",
                 "project.path"));
         }
-        auto lock_result = detail::WriterLock::acquire(path);
+        const auto& path = source_path;
+        auto lock_result = detail::WriterLock::acquire(destination_path);
         if (!lock_result) {
             return status_failure(std::move(lock_result).error());
         }
         auto source_result =
-            ProjectReader::open(path, options.compatibility);
+            ProjectReader::open(source_path, options.compatibility);
         if (!source_result) {
             return status_failure(std::move(source_result).error());
         }
@@ -3126,9 +3196,7 @@ namespace lfs::io::project {
                         .commit_uuid.to_string()),
                 "compaction.autosave_binding"));
         }
-        if (auto verify = source_result->verify_all(); !verify) {
-            return verify;
-        }
+        source_ready = std::chrono::steady_clock::now();
 
         auto file_uuid =
             assigned_uuid(options.new_file_uuid, path, "file_uuid");
@@ -3145,9 +3213,9 @@ namespace lfs::io::project {
 
         auto impl = std::make_unique<Impl>();
         impl->mode = Impl::Mode::Create;
-        impl->destination_path = path;
+        impl->destination_path = destination_path;
         impl->active_path =
-            detail::make_sibling_temp_path(path, "compact");
+            detail::make_sibling_temp_path(destination_path, "compact");
         impl->lock.emplace(std::move(*lock_result));
         impl->superblock = SuperblockInfo{
             .format = CURRENT_CONTAINER_VERSION,
@@ -3173,6 +3241,7 @@ namespace lfs::io::project {
         impl->disk_reserve_bytes = options.disk_reserve_bytes;
         impl->index_compression = IndexCompression::Zstd;
         impl->observer = options.boundary_observer;
+        impl->private_staging = options.private_staging;
 
         if (auto current = impl->notify(CommitBoundary::CurrentHeadValidated);
             !current) {
@@ -3260,7 +3329,24 @@ namespace lfs::io::project {
             // Tombstones are discarded on compaction (spec MAY; no keep_tombstones producer).
         }
 
-        return writer.commit();
+        copy_finished = std::chrono::steady_clock::now();
+        const auto commit_started = copy_finished;
+        auto committed = writer.commit();
+        if (committed) {
+            const auto finished = std::chrono::steady_clock::now();
+            const auto milliseconds = [](const auto begin, const auto end) {
+                return std::chrono::duration<double, std::milli>(end - begin)
+                    .count();
+            };
+            LOG_DEBUG(
+                "Project compaction stages: source={} destination={} source_open_metadata={:.3f} ms copy_crc_write={:.3f} ms commit={:.3f} ms total={:.3f} ms",
+                source_path.string(), destination_path.string(),
+                milliseconds(compact_started, source_ready),
+                milliseconds(source_ready, copy_finished),
+                milliseconds(commit_started, finished),
+                milliseconds(compact_started, finished));
+        }
+        return committed;
     }
 
 } // namespace lfs::io::project

--- a/src/io/project/project_writer.cpp
+++ b/src/io/project/project_writer.cpp
@@ -3142,9 +3142,43 @@ namespace lfs::io::project {
                 "project.path"));
         }
         const auto& path = source_path;
-        auto lock_result = detail::WriterLock::acquire(destination_path);
-        if (!lock_result) {
-            return status_failure(std::move(lock_result).error());
+        std::optional<detail::WriterLock> source_lock;
+        std::optional<detail::WriterLock> destination_lock;
+        const auto acquire_lock =
+            [](const std::filesystem::path& lock_path,
+               std::optional<detail::WriterLock>& target)
+            -> lfs::Result<void> {
+            auto lock_result = detail::WriterLock::acquire(lock_path);
+            if (!lock_result) {
+                return lfs::Result<void>::failure(
+                    std::move(lock_result).error());
+            }
+            target.emplace(std::move(*lock_result));
+            return {};
+        };
+        if (source_path == destination_path) {
+            if (auto locked = acquire_lock(destination_path, destination_lock);
+                !locked) {
+                return status_failure(std::move(locked).error());
+            }
+        } else if (source_path < destination_path) {
+            if (auto locked = acquire_lock(source_path, source_lock);
+                !locked) {
+                return status_failure(std::move(locked).error());
+            }
+            if (auto locked = acquire_lock(destination_path, destination_lock);
+                !locked) {
+                return status_failure(std::move(locked).error());
+            }
+        } else {
+            if (auto locked = acquire_lock(destination_path, destination_lock);
+                !locked) {
+                return status_failure(std::move(locked).error());
+            }
+            if (auto locked = acquire_lock(source_path, source_lock);
+                !locked) {
+                return status_failure(std::move(locked).error());
+            }
         }
         auto source_result =
             ProjectReader::open(source_path, options.compatibility);
@@ -3216,7 +3250,7 @@ namespace lfs::io::project {
         impl->destination_path = destination_path;
         impl->active_path =
             detail::make_sibling_temp_path(destination_path, "compact");
-        impl->lock.emplace(std::move(*lock_result));
+        impl->lock.emplace(std::move(*destination_lock));
         impl->superblock = SuperblockInfo{
             .format = CURRENT_CONTAINER_VERSION,
             .role = ContainerRole::Master,

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -3508,6 +3508,8 @@ namespace lfs::vis::project {
             lfs::io::project::
                 ProjectDocumentAutosaveOptions>
             autosave) {
+        const auto start_write_started =
+            std::chrono::steady_clock::now();
         auto license = document->project().license();
         if (!license) {
             return lfs::Status::failure(std::move(license).error());
@@ -3731,6 +3733,15 @@ namespace lfs::vis::project {
                 "The project writer could not start.",
                 error.what(), "project.job");
         }
+        const auto start_write_finished =
+            std::chrono::steady_clock::now();
+        LOG_DEBUG(
+            "Project GUI save stages: purpose={} worker_start={:.3f} ms destination={}",
+            static_cast<int>(purpose),
+            std::chrono::duration<double, std::milli>(
+                start_write_finished - start_write_started)
+                .count(),
+            project_write_destination_.string());
         return {};
     }
 
@@ -5759,6 +5770,10 @@ namespace lfs::vis::project {
     lfs::Result<void>
     ProjectLifecycle::synchronizeDocumentFromViewer(
         const DocumentSyncMode mode) {
+        const auto sync_started = std::chrono::steady_clock::now();
+        auto scene_capture_finished = sync_started;
+        auto payload_capture_finished = sync_started;
+        auto selection_capture_finished = sync_started;
         if (!document_) {
             return fail<void>(
                 lfs::ErrorCode::FailedPrecondition,
@@ -5879,6 +5894,7 @@ namespace lfs::vis::project {
             document_->scene_graph().to_bytes();
         const auto new_scene_bytes =
             captured_scene->to_bytes();
+        scene_capture_finished = std::chrono::steady_clock::now();
         if (!sameBytes(
                 old_scene_bytes, new_scene_bytes)) {
             document_->edit_scene_graph() =
@@ -6136,6 +6152,7 @@ namespace lfs::vis::project {
                     document_->remove_mesh(uuid));
             }
         }
+        payload_capture_finished = std::chrono::steady_clock::now();
 
         const bool all_geometry_loaded =
             std::ranges::all_of(
@@ -6294,6 +6311,7 @@ namespace lfs::vis::project {
             last_captured_selection_serial_ =
                 selection_serial;
         }
+        selection_capture_finished = std::chrono::steady_clock::now();
 
         const auto project_root =
             projectRootFor(*document_);
@@ -6450,6 +6468,25 @@ namespace lfs::vis::project {
             false, std::memory_order_release);
         payload_dirty_.store(
             false, std::memory_order_release);
+        const auto sync_finished = std::chrono::steady_clock::now();
+        LOG_DEBUG(
+            "Project document synchronization stages: mode={} scene_capture={:.3f} ms payload_capture={:.3f} ms selection_capture={:.3f} ms metadata_capture={:.3f} ms total={:.3f} ms",
+            static_cast<int>(mode),
+            std::chrono::duration<double, std::milli>(
+                scene_capture_finished - sync_started)
+                .count(),
+            std::chrono::duration<double, std::milli>(
+                payload_capture_finished - scene_capture_finished)
+                .count(),
+            std::chrono::duration<double, std::milli>(
+                selection_capture_finished - payload_capture_finished)
+                .count(),
+            std::chrono::duration<double, std::milli>(
+                sync_finished - selection_capture_finished)
+                .count(),
+            std::chrono::duration<double, std::milli>(
+                sync_finished - sync_started)
+                .count());
         return {};
     }
 


### PR DESCRIPTION
Saving a 1.4GB project took 8.1 seconds. It now takes 3.7.

The save pipeline was reading and checksum-verifying the entire file three separate times, and flushing it to disk twice. Now it verifies the source while copying it, runs one full checksum validation of the staged file before the atomic rename (in parallel across blocks), and syncs once.

No safety was removed: the file is still fully checksum-verified and durably flushed before it replaces the old one, and a failed validation still aborts the save. The written payload is byte-identical to before. The full save path also now has permanent timing logs, so future regressions are visible instead of a black box.

Verified: 3 timed runs each way, saved file reopens with all 4M splats, format and project test suites pass.