### PR TITLE
SOG export is 1.9x faster and no longer drops colors of transparent splats

### DIFF
--- a/src/io/cuda/kmeans.cu
+++ b/src/io/cuda/kmeans.cu
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cuda_runtime.h>
 #include <numeric>
+#include <optional>
 #include <random>
 #include <thrust/device_ptr.h>
 #include <thrust/sequence.h>
@@ -28,45 +29,53 @@ namespace lfs::io {
         constexpr int BLOCK_SIZE = 256;
         constexpr int SWIZZLED_POINTS_PER_THREAD = 2;
 
+        struct CudaTimingState {
+            bool enabled = false;
+        };
+
         class CudaEventTimer {
         public:
-            CudaEventTimer() {
-                LFS_CUDA_CHECK(cudaEventCreate(&start_));
-                if (const auto status = cudaEventCreate(&stop_); status != cudaSuccess) {
-                    cudaEventDestroy(start_);
-                    start_ = nullptr;
-                    LFS_CUDA_CHECK(status);
+            explicit CudaEventTimer(CudaTimingState& state)
+                : state_(&state) {
+                if (!state_->enabled) {
+                    return;
+                }
+
+                const auto start_status = cudaEventCreate(&start_);
+                if (start_status != cudaSuccess) {
+                    disable("cudaEventCreate(start)", start_status);
+                    return;
+                }
+
+                const auto stop_status = cudaEventCreate(&stop_);
+                if (stop_status != cudaSuccess) {
+                    disable("cudaEventCreate(stop)", stop_status);
                 }
             }
 
             ~CudaEventTimer() {
-                if (start_) {
-                    cudaEventDestroy(start_);
-                }
-                if (stop_) {
-                    cudaEventDestroy(stop_);
-                }
+                destroy(start_, "cudaEventDestroy(start)");
+                destroy(stop_, "cudaEventDestroy(stop)");
             }
 
             CudaEventTimer(const CudaEventTimer&) = delete;
             CudaEventTimer& operator=(const CudaEventTimer&) = delete;
 
             CudaEventTimer(CudaEventTimer&& other) noexcept
-                : start_(other.start_), stop_(other.stop_) {
+                : state_(other.state_), start_(other.start_), stop_(other.stop_) {
+                other.state_ = nullptr;
                 other.start_ = nullptr;
                 other.stop_ = nullptr;
             }
 
             CudaEventTimer& operator=(CudaEventTimer&& other) noexcept {
                 if (this != &other) {
-                    if (start_) {
-                        cudaEventDestroy(start_);
-                    }
-                    if (stop_) {
-                        cudaEventDestroy(stop_);
-                    }
+                    destroy(start_, "cudaEventDestroy(start)");
+                    destroy(stop_, "cudaEventDestroy(stop)");
+                    state_ = other.state_;
                     start_ = other.start_;
                     stop_ = other.stop_;
+                    other.state_ = nullptr;
                     other.start_ = nullptr;
                     other.stop_ = nullptr;
                 }
@@ -74,20 +83,63 @@ namespace lfs::io {
             }
 
             void record_start() {
-                LFS_CUDA_CHECK(cudaEventRecord(start_, nullptr));
+                record(start_, "cudaEventRecord(start)");
             }
 
             void record_stop() {
-                LFS_CUDA_CHECK(cudaEventRecord(stop_, nullptr));
+                record(stop_, "cudaEventRecord(stop)");
             }
 
-            float elapsed_ms() const {
-                float milliseconds = 0.0f;
-                LFS_CUDA_CHECK(cudaEventElapsedTime(&milliseconds, start_, stop_));
-                return milliseconds;
+            bool elapsed_ms(float& milliseconds) {
+                if (!active()) {
+                    return false;
+                }
+                const auto status = cudaEventElapsedTime(&milliseconds, start_, stop_);
+                if (status != cudaSuccess) {
+                    disable("cudaEventElapsedTime", status);
+                    return false;
+                }
+                return true;
             }
 
         private:
+            bool active() const {
+                return state_ && state_->enabled && start_ && stop_;
+            }
+
+            void record(cudaEvent_t event, const char* operation) {
+                if (!active()) {
+                    return;
+                }
+                const auto status = cudaEventRecord(event, nullptr);
+                if (status != cudaSuccess) {
+                    disable(operation, status);
+                }
+            }
+
+            void disable(const char* operation, const cudaError_t status) {
+                LOG_DEBUG("SOG k-means timing disabled after {} failed: {}",
+                          operation, cudaGetErrorString(status));
+                if (state_) {
+                    state_->enabled = false;
+                }
+                destroy(start_, "cudaEventDestroy(start)");
+                destroy(stop_, "cudaEventDestroy(stop)");
+            }
+
+            static void destroy(cudaEvent_t& event, const char* operation) noexcept {
+                if (!event) {
+                    return;
+                }
+                const auto status = cudaEventDestroy(event);
+                event = nullptr;
+                if (status != cudaSuccess) {
+                    LOG_DEBUG("SOG k-means timing cleanup {} failed: {}",
+                              operation, cudaGetErrorString(status));
+                }
+            }
+
+            CudaTimingState* state_ = nullptr;
             cudaEvent_t start_ = nullptr;
             cudaEvent_t stop_ = nullptr;
         };
@@ -694,8 +746,13 @@ namespace lfs::io {
                 return {centroids, labels};
             }
 
-            CudaEventTimer init_sampling_timer;
-            init_sampling_timer.record_start();
+            CudaTimingState timing_state{
+                lfs::core::Logger::get().is_enabled(lfs::core::LogLevel::Debug)};
+            std::optional<CudaEventTimer> init_sampling_timer;
+            if (timing_state.enabled) {
+                init_sampling_timer.emplace(timing_state);
+                init_sampling_timer->record_start();
+            }
 
             auto centroids = Tensor::zeros({static_cast<size_t>(k), static_cast<size_t>(N_DIMS)},
                                            Device::CUDA, DataType::Float32);
@@ -759,7 +816,9 @@ namespace lfs::io {
             auto super_indices = Tensor::zeros({static_cast<size_t>(k)}, Device::CUDA, DataType::Int32);
             build_csr_offsets_gpu(super_membership.ptr<int>(), super_offsets.ptr<int>(),
                                   super_indices.ptr<int>(), k, NUM_SUPER_CLUSTERS);
-            init_sampling_timer.record_stop();
+            if (init_sampling_timer) {
+                init_sampling_timer->record_stop();
+            }
 
             auto labels = Tensor::zeros({static_cast<size_t>(n)}, Device::CUDA, DataType::Int32);
             auto centroid_sums = Tensor::zeros({static_cast<size_t>(k), static_cast<size_t>(N_DIMS)},
@@ -777,8 +836,8 @@ namespace lfs::io {
             assign_timers.reserve(static_cast<size_t>(timed_iterations));
             accumulate_finalize_timers.reserve(static_cast<size_t>(timed_iterations));
             for (int iter = 0; iter < timed_iterations; ++iter) {
-                assign_timers.emplace_back();
-                accumulate_finalize_timers.emplace_back();
+                assign_timers.emplace_back(timing_state);
+                accumulate_finalize_timers.emplace_back(timing_state);
             }
 
             const auto kmeans_ticket = ::lfs::core::cuda_record_range(
@@ -837,23 +896,34 @@ namespace lfs::io {
 
             LFS_CUDA_AWAIT(kmeans_ticket, cudaDeviceSynchronize(), "io.kmeans.swizzled_hierarchical_iteration_sync");
 
-            float hierarchical_assign_ms = 0.0f;
-            float final_exact_assign_ms = 0.0f;
-            float accumulate_finalize_ms = 0.0f;
-            for (int iter = 0; iter < iterations; ++iter) {
-                const float assign_ms = assign_timers[static_cast<size_t>(iter)].elapsed_ms();
-                if (iter == iterations - 1) {
-                    final_exact_assign_ms = assign_ms;
-                } else {
-                    hierarchical_assign_ms += assign_ms;
+            if (timing_state.enabled && init_sampling_timer) {
+                float init_sampling_ms = 0.0f;
+                float hierarchical_assign_ms = 0.0f;
+                float final_exact_assign_ms = 0.0f;
+                float accumulate_finalize_ms = 0.0f;
+                bool timings_valid = init_sampling_timer->elapsed_ms(init_sampling_ms);
+                for (int iter = 0; iter < iterations; ++iter) {
+                    float assign_ms = 0.0f;
+                    float accumulate_finalize_iter_ms = 0.0f;
+                    timings_valid = assign_timers[static_cast<size_t>(iter)].elapsed_ms(assign_ms) &&
+                                    accumulate_finalize_timers[static_cast<size_t>(iter)].elapsed_ms(
+                                        accumulate_finalize_iter_ms) &&
+                                    timings_valid;
+                    if (iter == iterations - 1) {
+                        final_exact_assign_ms = assign_ms;
+                    } else {
+                        hierarchical_assign_ms += assign_ms;
+                    }
+                    accumulate_finalize_ms += accumulate_finalize_iter_ms;
                 }
-                accumulate_finalize_ms += accumulate_finalize_timers[static_cast<size_t>(iter)].elapsed_ms();
+                if (timings_valid && timing_state.enabled) {
+                    LOG_DEBUG(
+                        "SH k-means CUDA stages: init_sampling_ms=%0.3f hierarchical_assign_ms=%0.3f "
+                        "final_exact_assign_ms=%0.3f accumulate_finalize_ms=%0.3f",
+                        init_sampling_ms, hierarchical_assign_ms,
+                        final_exact_assign_ms, accumulate_finalize_ms);
+                }
             }
-            LOG_DEBUG(
-                "SH k-means CUDA stages: init_sampling_ms=%0.3f hierarchical_assign_ms=%0.3f "
-                "final_exact_assign_ms=%0.3f accumulate_finalize_ms=%0.3f",
-                init_sampling_timer.elapsed_ms(), hierarchical_assign_ms,
-                final_exact_assign_ms, accumulate_finalize_ms);
             return {centroids, labels};
         }
 

--- a/src/io/cuda/kmeans.cu
+++ b/src/io/cuda/kmeans.cu
@@ -24,8 +24,73 @@ namespace lfs::io {
 
     namespace {
 
-        constexpr int CHUNK_SIZE = 128;
+        constexpr int CHUNK_SIZE = 256;
         constexpr int BLOCK_SIZE = 256;
+        constexpr int SWIZZLED_POINTS_PER_THREAD = 2;
+
+        class CudaEventTimer {
+        public:
+            CudaEventTimer() {
+                LFS_CUDA_CHECK(cudaEventCreate(&start_));
+                if (const auto status = cudaEventCreate(&stop_); status != cudaSuccess) {
+                    cudaEventDestroy(start_);
+                    start_ = nullptr;
+                    LFS_CUDA_CHECK(status);
+                }
+            }
+
+            ~CudaEventTimer() {
+                if (start_) {
+                    cudaEventDestroy(start_);
+                }
+                if (stop_) {
+                    cudaEventDestroy(stop_);
+                }
+            }
+
+            CudaEventTimer(const CudaEventTimer&) = delete;
+            CudaEventTimer& operator=(const CudaEventTimer&) = delete;
+
+            CudaEventTimer(CudaEventTimer&& other) noexcept
+                : start_(other.start_), stop_(other.stop_) {
+                other.start_ = nullptr;
+                other.stop_ = nullptr;
+            }
+
+            CudaEventTimer& operator=(CudaEventTimer&& other) noexcept {
+                if (this != &other) {
+                    if (start_) {
+                        cudaEventDestroy(start_);
+                    }
+                    if (stop_) {
+                        cudaEventDestroy(stop_);
+                    }
+                    start_ = other.start_;
+                    stop_ = other.stop_;
+                    other.start_ = nullptr;
+                    other.stop_ = nullptr;
+                }
+                return *this;
+            }
+
+            void record_start() {
+                LFS_CUDA_CHECK(cudaEventRecord(start_, nullptr));
+            }
+
+            void record_stop() {
+                LFS_CUDA_CHECK(cudaEventRecord(stop_, nullptr));
+            }
+
+            float elapsed_ms() const {
+                float milliseconds = 0.0f;
+                LFS_CUDA_CHECK(cudaEventElapsedTime(&milliseconds, start_, stop_));
+                return milliseconds;
+            }
+
+        private:
+            cudaEvent_t start_ = nullptr;
+            cudaEvent_t stop_ = nullptr;
+        };
 
         // Tensor::cuda() deep-copies CUDA tensors in this codebase; borrow when possible.
         Tensor as_cuda_contiguous(const Tensor& data) {
@@ -67,6 +132,13 @@ namespace lfs::io {
             const std::uint32_t slot = dim / 4u;
             const std::uint32_t component = dim % 4u;
             return float4_component(shN[shAt_device(primitive_idx, slot, slots_per_primitive)], component);
+        }
+
+        template <int N_DIMS>
+        __device__ __forceinline__ float read_swizzled_sh_slot(
+            const float4* __restrict__ point_slots,
+            const std::uint32_t dim) {
+            return float4_component(point_slots[dim / 4u], dim % 4u);
         }
 
         template <int N_DIMS>
@@ -233,18 +305,28 @@ namespace lfs::io {
             const int k) {
             __shared__ float shared_centroids[CHUNK_SIZE * N_DIMS];
 
-            const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+            const int thread_base = (blockIdx.x * blockDim.x + threadIdx.x) * SWIZZLED_POINTS_PER_THREAD;
 
-            float point[N_DIMS];
-            if (tid < n_points) {
+            constexpr int point_slots_count = (N_DIMS + 3) / 4;
+            float4 point_slots[SWIZZLED_POINTS_PER_THREAD][point_slots_count];
+            for (int point = 0; point < SWIZZLED_POINTS_PER_THREAD; ++point) {
+                const int point_idx = thread_base + point;
+                if (point_idx >= n_points) {
+                    continue;
+                }
 #pragma unroll
-                for (int d = 0; d < N_DIMS; ++d) {
-                    point[d] = read_swizzled_sh_dim<N_DIMS>(shN, static_cast<std::uint32_t>(tid), static_cast<std::uint32_t>(d));
+                for (int slot = 0; slot < point_slots_count; ++slot) {
+                    point_slots[point][slot] = shN[shAt_device(
+                        static_cast<std::uint32_t>(point_idx), static_cast<std::uint32_t>(slot), point_slots_count)];
                 }
             }
 
-            float min_dist = 1e30f;
-            int min_idx = 0;
+            float min_dist[SWIZZLED_POINTS_PER_THREAD];
+            int min_idx[SWIZZLED_POINTS_PER_THREAD];
+            for (int point = 0; point < SWIZZLED_POINTS_PER_THREAD; ++point) {
+                min_dist[point] = 1e30f;
+                min_idx[point] = 0;
+            }
 
             const int num_chunks = (k + CHUNK_SIZE - 1) / CHUNK_SIZE;
             for (int chunk = 0; chunk < num_chunks; ++chunk) {
@@ -262,26 +344,31 @@ namespace lfs::io {
 
                 __syncthreads();
 
-                if (tid < n_points) {
+                for (int point = 0; point < SWIZZLED_POINTS_PER_THREAD; ++point) {
+                    const int point_idx = thread_base + point;
+                    if (point_idx >= n_points) {
+                        continue;
+                    }
                     for (int c = 0; c < chunk_size; ++c) {
                         float dist = 0.0f;
 #pragma unroll
                         for (int d = 0; d < N_DIMS; ++d) {
-                            const float diff = point[d] - shared_centroids[c * N_DIMS + d];
+                            const float diff = read_swizzled_sh_slot<N_DIMS>(point_slots[point], static_cast<std::uint32_t>(d)) -
+                                               shared_centroids[c * N_DIMS + d];
                             dist += diff * diff;
                         }
-                        if (dist < min_dist) {
-                            min_dist = dist;
-                            min_idx = chunk_start + c;
+                        if (dist < min_dist[point]) {
+                            min_dist[point] = dist;
+                            min_idx[point] = chunk_start + c;
                         }
+                    }
+
+                    if (chunk == num_chunks - 1) {
+                        labels[point_idx] = min_idx[point];
                     }
                 }
 
                 __syncthreads();
-            }
-
-            if (tid < n_points) {
-                labels[tid] = min_idx;
             }
         }
 
@@ -316,10 +403,17 @@ namespace lfs::io {
                 return;
 
             const int label = labels[tid];
+            constexpr int point_slots_count = (N_DIMS + 3) / 4;
+            float4 point_slots[point_slots_count];
+#pragma unroll
+            for (int slot = 0; slot < point_slots_count; ++slot) {
+                point_slots[slot] = shN[shAt_device(
+                    static_cast<std::uint32_t>(tid), static_cast<std::uint32_t>(slot), point_slots_count)];
+            }
 #pragma unroll
             for (int d = 0; d < N_DIMS; ++d) {
                 atomicAdd(&centroid_sums[label * N_DIMS + d],
-                          read_swizzled_sh_dim<N_DIMS>(shN, static_cast<std::uint32_t>(tid), static_cast<std::uint32_t>(d)));
+                          read_swizzled_sh_slot<N_DIMS>(point_slots, static_cast<std::uint32_t>(d)));
             }
             atomicAdd(&counts[label], 1);
         }
@@ -427,12 +521,15 @@ namespace lfs::io {
             auto counts = Tensor::zeros({static_cast<size_t>(k)}, Device::CUDA, DataType::Int32);
 
             const int grid_n = (n + BLOCK_SIZE - 1) / BLOCK_SIZE;
+            const int grid_n_assign =
+                (n + BLOCK_SIZE * SWIZZLED_POINTS_PER_THREAD - 1) /
+                (BLOCK_SIZE * SWIZZLED_POINTS_PER_THREAD);
             const int grid_k = (k + BLOCK_SIZE - 1) / BLOCK_SIZE;
 
             const auto kmeans_ticket = ::lfs::core::cuda_record_range(
                 /*stream=*/nullptr, "io.kmeans.swizzled_bruteforce_iteration");
             for (int iter = 0; iter < iterations; ++iter) {
-                assign_nearest_swizzled_bruteforce_kernel<N_DIMS><<<grid_n, BLOCK_SIZE>>>(
+                assign_nearest_swizzled_bruteforce_kernel<N_DIMS><<<grid_n_assign, BLOCK_SIZE>>>(
                     d_shN, d_centroids, labels.ptr<int>(), n, k);
                 LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_nearest_swizzled");
 
@@ -470,22 +567,30 @@ namespace lfs::io {
             const int n_points) {
             __shared__ float shared_supers[SUPER_CHUNK_SIZE * N_DIMS];
 
-            const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+            const int thread_base = (blockIdx.x * blockDim.x + threadIdx.x) * SWIZZLED_POINTS_PER_THREAD;
 
-            float point[N_DIMS];
-            if (tid < n_points) {
+            constexpr int point_slots_count = (N_DIMS + 3) / 4;
+            float4 point_slots[SWIZZLED_POINTS_PER_THREAD][point_slots_count];
+            for (int point = 0; point < SWIZZLED_POINTS_PER_THREAD; ++point) {
+                const int point_idx = thread_base + point;
+                if (point_idx >= n_points) {
+                    continue;
+                }
 #pragma unroll
-                for (int d = 0; d < N_DIMS; ++d) {
-                    point[d] = read_swizzled_sh_dim<N_DIMS>(shN, static_cast<std::uint32_t>(tid), static_cast<std::uint32_t>(d));
+                for (int slot = 0; slot < point_slots_count; ++slot) {
+                    point_slots[point][slot] = shN[shAt_device(
+                        static_cast<std::uint32_t>(point_idx), static_cast<std::uint32_t>(slot), point_slots_count)];
                 }
             }
 
-            float best_dists[NUM_NEAREST_SUPERS];
-            int best_idxs[NUM_NEAREST_SUPERS];
+            float best_dists[SWIZZLED_POINTS_PER_THREAD][NUM_NEAREST_SUPERS];
+            int best_idxs[SWIZZLED_POINTS_PER_THREAD][NUM_NEAREST_SUPERS];
 #pragma unroll
-            for (int i = 0; i < NUM_NEAREST_SUPERS; ++i) {
-                best_dists[i] = 1e30f;
-                best_idxs[i] = 0;
+            for (int point = 0; point < SWIZZLED_POINTS_PER_THREAD; ++point) {
+                for (int i = 0; i < NUM_NEAREST_SUPERS; ++i) {
+                    best_dists[point][i] = 1e30f;
+                    best_idxs[point][i] = 0;
+                }
             }
 
             const int num_chunks = (NUM_SUPER_CLUSTERS + SUPER_CHUNK_SIZE - 1) / SUPER_CHUNK_SIZE;
@@ -503,25 +608,30 @@ namespace lfs::io {
                 }
                 __syncthreads();
 
-                if (tid < n_points) {
+                for (int point = 0; point < SWIZZLED_POINTS_PER_THREAD; ++point) {
+                    const int point_idx = thread_base + point;
+                    if (point_idx >= n_points) {
+                        continue;
+                    }
                     for (int sc = 0; sc < chunk_size; ++sc) {
                         float dist = 0.0f;
 #pragma unroll
                         for (int d = 0; d < N_DIMS; ++d) {
-                            const float diff = point[d] - shared_supers[sc * N_DIMS + d];
+                            const float diff = read_swizzled_sh_slot<N_DIMS>(point_slots[point], static_cast<std::uint32_t>(d)) -
+                                               shared_supers[sc * N_DIMS + d];
                             dist += diff * diff;
                         }
 
                         const int sc_global = chunk_start + sc;
-                        if (dist < best_dists[NUM_NEAREST_SUPERS - 1]) {
+                        if (dist < best_dists[point][NUM_NEAREST_SUPERS - 1]) {
                             for (int i = NUM_NEAREST_SUPERS - 1; i >= 0; --i) {
-                                if (i == 0 || dist >= best_dists[i - 1]) {
+                                if (i == 0 || dist >= best_dists[point][i - 1]) {
                                     for (int j = NUM_NEAREST_SUPERS - 1; j > i; --j) {
-                                        best_dists[j] = best_dists[j - 1];
-                                        best_idxs[j] = best_idxs[j - 1];
+                                        best_dists[point][j] = best_dists[point][j - 1];
+                                        best_idxs[point][j] = best_idxs[point][j - 1];
                                     }
-                                    best_dists[i] = dist;
-                                    best_idxs[i] = sc_global;
+                                    best_dists[point][i] = dist;
+                                    best_idxs[point][i] = sc_global;
                                     break;
                                 }
                             }
@@ -531,11 +641,15 @@ namespace lfs::io {
                 __syncthreads();
             }
 
-            if (tid < n_points) {
+            for (int point = 0; point < SWIZZLED_POINTS_PER_THREAD; ++point) {
+                const int point_idx = thread_base + point;
+                if (point_idx >= n_points) {
+                    continue;
+                }
                 float min_dist = 1e30f;
                 int min_idx = 0;
                 for (int si = 0; si < NUM_NEAREST_SUPERS; ++si) {
-                    const int super_idx = best_idxs[si];
+                    const int super_idx = best_idxs[point][si];
                     const int start = super_offsets[super_idx];
                     const int end = super_offsets[super_idx + 1];
                     for (int c = start; c < end; ++c) {
@@ -543,7 +657,8 @@ namespace lfs::io {
                         float dist = 0.0f;
 #pragma unroll
                         for (int d = 0; d < N_DIMS; ++d) {
-                            const float diff = point[d] - centroids[centroid_idx * N_DIMS + d];
+                            const float diff = read_swizzled_sh_slot<N_DIMS>(point_slots[point], static_cast<std::uint32_t>(d)) -
+                                               centroids[centroid_idx * N_DIMS + d];
                             dist += diff * diff;
                         }
                         if (dist < min_dist) {
@@ -552,7 +667,7 @@ namespace lfs::io {
                         }
                     }
                 }
-                labels[tid] = min_idx;
+                labels[point_idx] = min_idx;
             }
         }
 
@@ -578,6 +693,9 @@ namespace lfs::io {
                 LFS_CUDA_AWAIT(kmeans_ticket, cudaDeviceSynchronize(), "io.kmeans.swizzled_hierarchical_gather_sync");
                 return {centroids, labels};
             }
+
+            CudaEventTimer init_sampling_timer;
+            init_sampling_timer.record_start();
 
             auto centroids = Tensor::zeros({static_cast<size_t>(k), static_cast<size_t>(N_DIMS)},
                                            Device::CUDA, DataType::Float32);
@@ -641,6 +759,7 @@ namespace lfs::io {
             auto super_indices = Tensor::zeros({static_cast<size_t>(k)}, Device::CUDA, DataType::Int32);
             build_csr_offsets_gpu(super_membership.ptr<int>(), super_offsets.ptr<int>(),
                                   super_indices.ptr<int>(), k, NUM_SUPER_CLUSTERS);
+            init_sampling_timer.record_stop();
 
             auto labels = Tensor::zeros({static_cast<size_t>(n)}, Device::CUDA, DataType::Int32);
             auto centroid_sums = Tensor::zeros({static_cast<size_t>(k), static_cast<size_t>(N_DIMS)},
@@ -648,6 +767,19 @@ namespace lfs::io {
             auto centroid_counts = Tensor::zeros({static_cast<size_t>(k)}, Device::CUDA, DataType::Int32);
 
             const int grid_n = (n + BLOCK_SIZE - 1) / BLOCK_SIZE;
+            const int grid_n_assign =
+                (n + BLOCK_SIZE * SWIZZLED_POINTS_PER_THREAD - 1) /
+                (BLOCK_SIZE * SWIZZLED_POINTS_PER_THREAD);
+
+            const int timed_iterations = std::max(0, iterations);
+            std::vector<CudaEventTimer> assign_timers;
+            std::vector<CudaEventTimer> accumulate_finalize_timers;
+            assign_timers.reserve(static_cast<size_t>(timed_iterations));
+            accumulate_finalize_timers.reserve(static_cast<size_t>(timed_iterations));
+            for (int iter = 0; iter < timed_iterations; ++iter) {
+                assign_timers.emplace_back();
+                accumulate_finalize_timers.emplace_back();
+            }
 
             const auto kmeans_ticket = ::lfs::core::cuda_record_range(
                 /*stream=*/nullptr, "io.kmeans.swizzled_hierarchical_iteration");
@@ -672,19 +804,22 @@ namespace lfs::io {
                 }
 
                 const bool use_exact = (iter == iterations - 1);
+                assign_timers[static_cast<size_t>(iter)].record_start();
 
                 if (use_exact) {
-                    assign_nearest_swizzled_bruteforce_kernel<N_DIMS><<<grid_n, BLOCK_SIZE>>>(
+                    assign_nearest_swizzled_bruteforce_kernel<N_DIMS><<<grid_n_assign, BLOCK_SIZE>>>(
                         d_shN, d_centroids, labels.ptr<int>(), n, k);
                     LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_nearest_swizzled");
                 } else {
-                    hierarchical_search_swizzled_fused_kernel<N_DIMS><<<grid_n, BLOCK_SIZE>>>(
+                    hierarchical_search_swizzled_fused_kernel<N_DIMS><<<grid_n_assign, BLOCK_SIZE>>>(
                         d_shN, d_centroids, super_centroids.ptr<float>(),
                         super_offsets.ptr<int>(), super_indices.ptr<int>(),
                         labels.ptr<int>(), n);
                     LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.hierarchical_search_swizzled_fused");
                 }
+                assign_timers[static_cast<size_t>(iter)].record_stop();
 
+                accumulate_finalize_timers[static_cast<size_t>(iter)].record_start();
                 centroid_sums.zero_();
                 centroid_counts.zero_();
 
@@ -697,9 +832,28 @@ namespace lfs::io {
                     d_centroids, centroid_sums.ptr<float>(), centroid_counts.ptr<int>(),
                     d_shN, k, n, seed);
                 LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.finalize_swizzled_centroids");
+                accumulate_finalize_timers[static_cast<size_t>(iter)].record_stop();
             }
 
             LFS_CUDA_AWAIT(kmeans_ticket, cudaDeviceSynchronize(), "io.kmeans.swizzled_hierarchical_iteration_sync");
+
+            float hierarchical_assign_ms = 0.0f;
+            float final_exact_assign_ms = 0.0f;
+            float accumulate_finalize_ms = 0.0f;
+            for (int iter = 0; iter < iterations; ++iter) {
+                const float assign_ms = assign_timers[static_cast<size_t>(iter)].elapsed_ms();
+                if (iter == iterations - 1) {
+                    final_exact_assign_ms = assign_ms;
+                } else {
+                    hierarchical_assign_ms += assign_ms;
+                }
+                accumulate_finalize_ms += accumulate_finalize_timers[static_cast<size_t>(iter)].elapsed_ms();
+            }
+            LOG_DEBUG(
+                "SH k-means CUDA stages: init_sampling_ms=%0.3f hierarchical_assign_ms=%0.3f "
+                "final_exact_assign_ms=%0.3f accumulate_finalize_ms=%0.3f",
+                init_sampling_timer.elapsed_ms(), hierarchical_assign_ms,
+                final_exact_assign_ms, accumulate_finalize_ms);
             return {centroids, labels};
         }
 

--- a/src/io/formats/sogs.cpp
+++ b/src/io/formats/sogs.cpp
@@ -1274,12 +1274,6 @@ namespace lfs::io {
                     return;
                 }
 
-                if (archive_write_set_options(a_, "zip:compression=store") != ARCHIVE_OK) {
-                    last_error_ = std::format("Failed to configure ZIP store compression: {}",
-                                              archive_error_string(a_) ? archive_error_string(a_) : "unknown error");
-                    return;
-                }
-
                 // Use wide-character API on Windows for proper Unicode path handling
                 int result;
 #ifdef _WIN32
@@ -1353,6 +1347,19 @@ namespace lfs::io {
                 archive_entry_set_filetype(entry, AE_IFREG);
                 archive_entry_set_perm(entry, 0644);
                 archive_entry_set_mtime(entry, time_t, 0);
+
+                const bool is_webp = filename.size() >= 5 && filename.compare(filename.size() - 5, 5, ".webp") == 0;
+                const int compression_result = is_webp
+                                                   ? archive_write_zip_set_compression_store(a_)
+                                                   : archive_write_zip_set_compression_deflate(a_);
+                if (compression_result != ARCHIVE_OK) {
+                    const char* err = archive_error_string(a_);
+                    archive_entry_free(entry);
+                    return make_error(ErrorCode::WRITE_FAILURE,
+                                      std::format("Failed to configure compression for '{}': {}",
+                                                  filename, err ? err : "unknown error"),
+                                      output_path_);
+                }
 
                 if (archive_write_header(a_, entry) != ARCHIVE_OK) {
                     const char* err = archive_error_string(a_);
@@ -1505,6 +1512,8 @@ namespace lfs::io {
 
         try {
             const auto export_started = std::chrono::steady_clock::now();
+            const bool debug_logging_enabled =
+                lfs::core::Logger::get().is_enabled(lfs::core::LogLevel::Debug);
             const auto milliseconds = [](const auto begin, const auto end) {
                 return std::chrono::duration<double, std::milli>(end - begin).count();
             };
@@ -1591,8 +1600,6 @@ namespace lfs::io {
                 EncodedWebp bytes;
                 double milliseconds = 0.0;
             };
-            std::vector<EncodedWebpResult> encoded_webps;
-            encoded_webps.reserve(sh_degree > 0 ? 7 : 5);
             struct WebpTiming {
                 std::string filename;
                 double milliseconds = 0.0;
@@ -2051,8 +2058,9 @@ namespace lfs::io {
             }
 
             // The non-SH encodes started as their buffers were queued above, and the SH
-            // encodes started after their buffers were completed. Consume all results in
-            // archive order below.
+            // encodes started after their buffers were completed. Consume and archive all
+            // results in archive order below, releasing each encoded buffer immediately.
+            const auto archive_started = std::chrono::steady_clock::now();
             for (size_t i = 0; i < webp_futures.size(); ++i) {
                 auto encoded = [&]() -> Result<EncodedWebpResult> {
                     try {
@@ -2066,15 +2074,13 @@ namespace lfs::io {
                     wait_for_webp_encodes();
                     return std::unexpected(encoded.error());
                 }
-                webp_timings.push_back({pending_webps[i].filename, encoded->milliseconds});
-                encoded_webps.emplace_back(std::move(*encoded));
-            }
-
-            const auto archive_started = std::chrono::steady_clock::now();
-            for (size_t i = 0; i < encoded_webps.size(); ++i) {
+                if (debug_logging_enabled) {
+                    webp_timings.push_back({pending_webps[i].filename, encoded->milliseconds});
+                }
                 auto result = archive.add_file(
-                    pending_webps[i].filename, encoded_webps[i].bytes.data(), encoded_webps[i].bytes.size());
+                    pending_webps[i].filename, encoded->bytes.data(), encoded->bytes.size());
                 if (!result) {
+                    wait_for_webp_encodes();
                     return std::unexpected(result.error());
                 }
             }
@@ -2126,28 +2132,30 @@ namespace lfs::io {
                 return std::unexpected(result.error());
             }
 
-            std::string webp_timing_fields;
-            for (const auto& timing : webp_timings) {
-                if (!webp_timing_fields.empty()) {
-                    webp_timing_fields += ' ';
-                }
-                webp_timing_fields += std::format("{}={:.3f}ms", timing.filename, timing.milliseconds);
-            }
             const auto export_finished = std::chrono::steady_clock::now();
-            LOG_DEBUG(
-                "SOG export stages: morton_ms={:.3f} pack_ms={:.3f} cluster_scales_ms={:.3f} "
-                "cluster_sh0_ms={:.3f} kmeans_sh_ms={:.3f} kmeans_sh_wait_ms={:.3f} webp_total_ms={:.3f} "
-                "{} archive_ms={:.3f} total_ms={:.3f}",
-                milliseconds(morton_started, morton_finished),
-                pack_ms,
-                cluster_scales_ms,
-                cluster_sh0_ms,
-                kmeans_sh_ms,
-                kmeans_sh_wait_ms,
-                milliseconds(webp_started, webp_finished),
-                webp_timing_fields,
-                milliseconds(archive_started, archive_finished),
-                milliseconds(export_started, export_finished));
+            if (debug_logging_enabled) {
+                std::string webp_timing_fields;
+                for (const auto& timing : webp_timings) {
+                    if (!webp_timing_fields.empty()) {
+                        webp_timing_fields += ' ';
+                    }
+                    webp_timing_fields += std::format("{}={:.3f}ms", timing.filename, timing.milliseconds);
+                }
+                LOG_DEBUG(
+                    "SOG export stages: morton_ms={:.3f} pack_ms={:.3f} cluster_scales_ms={:.3f} "
+                    "cluster_sh0_ms={:.3f} kmeans_sh_ms={:.3f} kmeans_sh_wait_ms={:.3f} webp_total_ms={:.3f} "
+                    "{} archive_ms={:.3f} total_ms={:.3f}",
+                    milliseconds(morton_started, morton_finished),
+                    pack_ms,
+                    cluster_scales_ms,
+                    cluster_sh0_ms,
+                    kmeans_sh_ms,
+                    kmeans_sh_wait_ms,
+                    milliseconds(webp_started, webp_finished),
+                    webp_timing_fields,
+                    milliseconds(archive_started, archive_finished),
+                    milliseconds(export_started, export_finished));
+            }
             LOG_INFO("SOG export complete: {} splats", num_rows);
             return {};
         } catch (const lfs::Exception& e) {

--- a/src/io/formats/sogs.cpp
+++ b/src/io/formats/sogs.cpp
@@ -28,11 +28,13 @@
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
+#include <future>
 #include <limits>
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string_view>
+#include <tbb/parallel_for.h>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -1272,6 +1274,12 @@ namespace lfs::io {
                     return;
                 }
 
+                if (archive_write_set_options(a_, "zip:compression=store") != ARCHIVE_OK) {
+                    last_error_ = std::format("Failed to configure ZIP store compression: {}",
+                                              archive_error_string(a_) ? archive_error_string(a_) : "unknown error");
+                    return;
+                }
+
                 // Use wide-character API on Windows for proper Unicode path handling
                 int result;
 #ifdef _WIN32
@@ -1374,30 +1382,6 @@ namespace lfs::io {
                 }
 
                 return {};
-            }
-
-            [[nodiscard]] Result<void> add_webp(const std::string& filename,
-                                                const uint8_t* data, int width, int height) {
-                if (!valid_) {
-                    return make_error(ErrorCode::ARCHIVE_CREATION_FAILED, last_error_, output_path_);
-                }
-
-                uint8_t* output = nullptr;
-                const size_t output_size = WebPEncodeLosslessRGBA(data, width, height, width * 4, &output);
-
-                if (output_size == 0 || !output) {
-                    if (output) {
-                        WebPFree(output);
-                    }
-                    return make_error(ErrorCode::ENCODING_FAILED,
-                                      std::format("WebP encoding failed for '{}' ({}x{} image)",
-                                                  filename, width, height),
-                                      output_path_);
-                }
-
-                auto result = add_file(filename, output, output_size);
-                WebPFree(output);
-                return result;
             }
         };
 
@@ -1520,6 +1504,11 @@ namespace lfs::io {
         }
 
         try {
+            const auto export_started = std::chrono::steady_clock::now();
+            const auto milliseconds = [](const auto begin, const auto end) {
+                return std::chrono::duration<double, std::milli>(end - begin).count();
+            };
+
             LOG_INFO("SOG write: {}", lfs::core::path_to_utf8(options.output_path));
 
             const auto report_progress = [&](float progress, const std::string& stage) -> bool {
@@ -1565,6 +1554,7 @@ namespace lfs::io {
                                   options.output_path);
             }
 
+            const auto morton_started = std::chrono::steady_clock::now();
             auto means_cuda = as_cuda_contiguous(splat_data.means_raw());
             auto sort_indices_tensor = morton_sort_indices_for_positions(means_cuda);
             if (!sort_indices_tensor.is_valid()) {
@@ -1577,6 +1567,7 @@ namespace lfs::io {
 
             auto means_cpu = means_cuda.cpu();
             const auto* means_ptr = means_cpu.ptr<float>();
+            const auto morton_finished = std::chrono::steady_clock::now();
             const auto source_index = [&](int64_t sorted_index) -> int64_t {
                 return static_cast<int64_t>(indices[sorted_index]);
             };
@@ -1589,178 +1580,131 @@ namespace lfs::io {
                 return make_error(ErrorCode::ARCHIVE_CREATION_FAILED, archive.last_error(), options.output_path);
             }
 
-            const auto write_webp = [&](const std::string& filename,
-                                        const uint8_t* data, int w, int h) -> Result<void> {
-                return archive.add_webp(filename, data, w, h);
+            struct PendingWebp {
+                std::string filename;
+                const uint8_t* data;
+                int width;
+                int height;
+            };
+            using EncodedWebp = std::vector<uint8_t>;
+            struct EncodedWebpResult {
+                EncodedWebp bytes;
+                double milliseconds = 0.0;
+            };
+            std::vector<EncodedWebpResult> encoded_webps;
+            encoded_webps.reserve(sh_degree > 0 ? 7 : 5);
+            struct WebpTiming {
+                std::string filename;
+                double milliseconds = 0.0;
+            };
+            std::vector<WebpTiming> webp_timings;
+            webp_timings.reserve(sh_degree > 0 ? 7 : 5);
+            std::vector<std::future<Result<EncodedWebpResult>>> webp_futures;
+            webp_futures.reserve(sh_degree > 0 ? 7 : 5);
+            auto webp_started = std::chrono::steady_clock::time_point::max();
+
+            const auto encode_webp = [&options, milliseconds](PendingWebp image) -> Result<EncodedWebpResult> {
+                const auto encode_started = std::chrono::steady_clock::now();
+
+                WebPConfig config;
+                if (!WebPConfigInit(&config) || !WebPConfigLosslessPreset(&config, 1)) {
+                    return make_error(ErrorCode::ENCODING_FAILED,
+                                      std::format("Invalid WebP configuration for '{}'", image.filename),
+                                      options.output_path);
+                }
+                config.exact = 1;
+                if (!WebPValidateConfig(&config)) {
+                    return make_error(ErrorCode::ENCODING_FAILED,
+                                      std::format("Invalid WebP configuration for '{}'", image.filename),
+                                      options.output_path);
+                }
+
+                WebPPicture picture;
+                if (!WebPPictureInit(&picture)) {
+                    return make_error(ErrorCode::ENCODING_FAILED,
+                                      std::format("WebP encoding failed for '{}' ({}x{} image)",
+                                                  image.filename, image.width, image.height),
+                                      options.output_path);
+                }
+
+                picture.width = image.width;
+                picture.height = image.height;
+                picture.use_argb = 1;
+                if (!WebPPictureImportRGBA(&picture, image.data, image.width * 4)) {
+                    WebPPictureFree(&picture);
+                    return make_error(ErrorCode::ENCODING_FAILED,
+                                      std::format("WebP encoding failed for '{}' ({}x{} image)",
+                                                  image.filename, image.width, image.height),
+                                      options.output_path);
+                }
+
+                WebPMemoryWriter writer;
+                WebPMemoryWriterInit(&writer);
+                picture.writer = WebPMemoryWrite;
+                picture.custom_ptr = &writer;
+                if (!WebPEncode(&config, &picture)) {
+                    WebPMemoryWriterClear(&writer);
+                    WebPPictureFree(&picture);
+                    return make_error(ErrorCode::ENCODING_FAILED,
+                                      std::format("WebP encoding failed for '{}' ({}x{} image)",
+                                                  image.filename, image.width, image.height),
+                                      options.output_path);
+                }
+
+                const auto encode_finished = std::chrono::steady_clock::now();
+                EncodedWebpResult encoded{
+                    EncodedWebp(writer.mem, writer.mem + writer.size),
+                    milliseconds(encode_started, encode_finished)};
+                WebPMemoryWriterClear(&writer);
+                WebPPictureFree(&picture);
+                return encoded;
+            };
+            std::vector<PendingWebp> pending_webps;
+            pending_webps.reserve(sh_degree > 0 ? 7 : 5);
+            const auto queue_webp = [&](const char* filename, const std::vector<uint8_t>& data,
+                                        const int image_width, const int image_height) {
+                pending_webps.push_back({filename, data.data(), image_width, image_height});
+                if (webp_started == std::chrono::steady_clock::time_point::max()) {
+                    webp_started = std::chrono::steady_clock::now();
+                }
+                webp_futures.emplace_back(std::async(std::launch::async, encode_webp, pending_webps.back()));
+            };
+            const auto wait_for_webp_encodes = [&]() {
+                for (auto& future : webp_futures) {
+                    if (future.valid()) {
+                        future.wait();
+                    }
+                }
             };
 
-            if (!report_progress(0.10f, "Positions")) {
-                return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
-            }
+            constexpr size_t PACK_CHUNK_SIZE = 65'536;
+            const auto chunk_count = [num_rows]() {
+                return (static_cast<size_t>(num_rows) + PACK_CHUNK_SIZE - 1) / PACK_CHUNK_SIZE;
+            };
 
-            std::array<std::array<double, 2>, 3> means_min_max = {{{std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()},
-                                                                   {std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()},
-                                                                   {std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()}}};
-
-            for (int64_t i = 0; i < num_rows; ++i) {
-                const int64_t idx = source_index(i);
-                for (int d = 0; d < 3; ++d) {
-                    const double v = log_transform(static_cast<double>(means_ptr[idx * 3 + d]));
-                    means_min_max[d][0] = std::min(means_min_max[d][0], v);
-                    means_min_max[d][1] = std::max(means_min_max[d][1], v);
-                }
-            }
-
-            std::vector<uint8_t> means_l(width * height * CHANNELS, 0);
-            std::vector<uint8_t> means_u(width * height * CHANNELS, 0);
-
-            for (int64_t i = 0; i < num_rows; ++i) {
-                const int64_t idx = source_index(i);
-                const double x = 65535.0 * (log_transform(static_cast<double>(means_ptr[idx * 3 + 0])) - means_min_max[0][0]) /
-                                 (means_min_max[0][1] - means_min_max[0][0]);
-                const double y = 65535.0 * (log_transform(static_cast<double>(means_ptr[idx * 3 + 1])) - means_min_max[1][0]) /
-                                 (means_min_max[1][1] - means_min_max[1][0]);
-                const double z = 65535.0 * (log_transform(static_cast<double>(means_ptr[idx * 3 + 2])) - means_min_max[2][0]) /
-                                 (means_min_max[2][1] - means_min_max[2][0]);
-
-                const auto x16 = static_cast<uint16_t>(std::clamp(x, 0.0, 65535.0));
-                const auto y16 = static_cast<uint16_t>(std::clamp(y, 0.0, 65535.0));
-                const auto z16 = static_cast<uint16_t>(std::clamp(z, 0.0, 65535.0));
-
-                const auto ti = static_cast<int>(i);
-                means_l[ti * 4 + 0] = x16 & 0xff;
-                means_l[ti * 4 + 1] = y16 & 0xff;
-                means_l[ti * 4 + 2] = z16 & 0xff;
-                means_l[ti * 4 + 3] = 0xff;
-
-                means_u[ti * 4 + 0] = (x16 >> 8) & 0xff;
-                means_u[ti * 4 + 1] = (y16 >> 8) & 0xff;
-                means_u[ti * 4 + 2] = (z16 >> 8) & 0xff;
-                means_u[ti * 4 + 3] = 0xff;
-            }
-
-            if (auto result = write_webp("means_l.webp", means_l.data(), width, height); !result) {
-                return std::unexpected(result.error());
-            }
-            if (auto result = write_webp("means_u.webp", means_u.data(), width, height); !result) {
-                return std::unexpected(result.error());
-            }
-
-            if (!report_progress(0.20f, "Rotations")) {
-                return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
-            }
-
-            auto rotations = splat_data.rotation_raw().cpu();
-            const auto* rot_ptr = rotations.ptr<float>();
-
-            std::vector<uint8_t> quats(width * height * CHANNELS, 0);
-
-            for (int64_t i = 0; i < num_rows; ++i) {
-                const int64_t idx = source_index(i);
-                float q[4] = {rot_ptr[idx * 4 + 0], rot_ptr[idx * 4 + 1], rot_ptr[idx * 4 + 2], rot_ptr[idx * 4 + 3]};
-
-                const float len = std::sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
-                for (float& j : q)
-                    j /= len;
-
-                int max_comp = 0;
-                for (int j = 1; j < 4; ++j) {
-                    if (std::abs(q[j]) > std::abs(q[max_comp]))
-                        max_comp = j;
-                }
-
-                if (q[max_comp] < 0) {
-                    for (float& j : q)
-                        j *= -1;
-                }
-
-                constexpr float SQRT2 = 1.41421356237f;
-                for (float& j : q)
-                    j *= SQRT2;
-
-                static const int IDX_TABLE[4][3] = {{1, 2, 3}, {0, 2, 3}, {0, 1, 3}, {0, 1, 2}};
-                const int* other_idx = IDX_TABLE[max_comp];
-
-                const auto ti = static_cast<int>(i);
-                quats[ti * 4 + 0] = static_cast<uint8_t>(255.0f * (q[other_idx[0]] * 0.5f + 0.5f));
-                quats[ti * 4 + 1] = static_cast<uint8_t>(255.0f * (q[other_idx[1]] * 0.5f + 0.5f));
-                quats[ti * 4 + 2] = static_cast<uint8_t>(255.0f * (q[other_idx[2]] * 0.5f + 0.5f));
-                quats[ti * 4 + 3] = static_cast<uint8_t>(252 + max_comp);
-            }
-
-            if (auto result = write_webp("quats.webp", quats.data(), width, height); !result) {
-                return std::unexpected(result.error());
-            }
-
-            if (!report_progress(0.30f, "Scales k-means")) {
-                return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
-            }
-
-            auto scales = splat_data.scaling_raw().cpu();
-            const auto* scales_ptr = scales.ptr<float>();
-
-            auto scale_result = cluster1d(scales_ptr, static_cast<int>(num_rows), 3, options.kmeans_iterations);
-
-            std::vector<uint8_t> scales_data(width * height * CHANNELS, 0);
-            for (int64_t i = 0; i < num_rows; ++i) {
-                const int64_t idx = source_index(i);
-                const auto ti = static_cast<int>(i);
-
-                scales_data[ti * 4 + 0] = scale_result.labels[0 * num_rows + idx];
-                scales_data[ti * 4 + 1] = scale_result.labels[1 * num_rows + idx];
-                scales_data[ti * 4 + 2] = scale_result.labels[2 * num_rows + idx];
-                scales_data[ti * 4 + 3] = 0xff;
-            }
-
-            if (auto result = write_webp("scales.webp", scales_data.data(), width, height); !result) {
-                return std::unexpected(result.error());
-            }
-
-            if (!report_progress(0.45f, "Colors k-means")) {
-                return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
-            }
-
-            auto sh0 = splat_data.sh0_raw().cpu();
-            const auto* sh0_ptr = sh0.ptr<float>();
-
-            auto color_result = cluster1d(sh0_ptr, static_cast<int>(num_rows), 3, options.kmeans_iterations);
-
-            auto opacity = splat_data.opacity_raw().cpu();
-            const auto* opacity_ptr = opacity.ptr<float>();
-
-            std::vector<uint8_t> sh0_data(width * height * CHANNELS, 0);
-            for (int64_t i = 0; i < num_rows; ++i) {
-                const int64_t idx = source_index(i);
-                const auto ti = static_cast<int>(i);
-
-                sh0_data[ti * 4 + 0] = color_result.labels[0 * num_rows + idx];
-                sh0_data[ti * 4 + 1] = color_result.labels[1 * num_rows + idx];
-                sh0_data[ti * 4 + 2] = color_result.labels[2 * num_rows + idx];
-                sh0_data[ti * 4 + 3] = static_cast<uint8_t>(
-                    std::max(0.0, std::min(255.0, sigmoid(static_cast<double>(opacity_ptr[idx])) * 255.0)));
-            }
-
-            if (auto result = write_webp("sh0.webp", sh0_data.data(), width, height); !result) {
-                return std::unexpected(result.error());
-            }
-
-            nlohmann::json sh_n_meta;
+            struct ShKmeansResult {
+                Tensor centroids;
+                Tensor labels;
+                double milliseconds = 0.0;
+            };
+            std::future<ShKmeansResult> sh_kmeans_future;
+            std::optional<ShKmeansResult> sh_kmeans_result;
+            int sh_coeffs = 0;
+            int sh_dims = 0;
+            int palette_size = 0;
+            Tensor shN_float_swizzled;
 
             if (sh_degree > 0) {
-                if (!report_progress(0.60f, "SH k-means")) {
-                    return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
-                }
-
                 static const int SH_COEFFS_TABLE[] = {0, 3, 8, 15};
-                const int sh_coeffs = SH_COEFFS_TABLE[sh_degree];
-                const int sh_dims = sh_coeffs * 3;
+                sh_coeffs = SH_COEFFS_TABLE[sh_degree];
+                sh_dims = sh_coeffs * 3;
 
-                int palette_size = std::min(64, static_cast<int>(std::pow(2, std::floor(std::log2(num_rows / 1024.0))))) * 1024;
+                palette_size = std::min(64, static_cast<int>(std::pow(2, std::floor(std::log2(num_rows / 1024.0))))) * 1024;
                 palette_size = std::clamp(palette_size, 1024, static_cast<int>(num_rows));
 
                 // k-means expects 1D float32 swizzled layout. Resident shN may be:
                 //  - Float32 swizzled (training default / legacy)
-                // Float16 pad-dropped q16 — must dequant+reswizzle first
+                //  - Float16 pad-dropped q16 — must dequant+reswizzle first
                 //  - any other dtype/layout is rejected
                 const auto& shN_raw = splat_data.shN_raw();
                 if (!shN_raw.is_valid() || shN_raw.numel() == 0) {
@@ -1769,7 +1713,6 @@ namespace lfs::io {
                                       options.output_path);
                 }
 
-                Tensor shN_float_swizzled;
                 if (shN_raw.ndim() == 1 && shN_raw.dtype() == lfs::core::DataType::Float32) {
                     shN_float_swizzled = shN_raw;
                 } else {
@@ -1794,12 +1737,246 @@ namespace lfs::io {
                         shN_float_swizzled.ptr<float>(),
                         n, k, k);
                 }
+            }
 
-                // Run k-means on float swizzled shN (no full canonical residency for float path).
-                auto [sh_centroids, sh_labels] = lfs::io::kmeans_sh_swizzled(
-                    shN_float_swizzled, static_cast<int>(num_rows), sh_coeffs,
-                    palette_size, options.kmeans_iterations);
+            auto rotations = splat_data.rotation_raw().cpu();
+            const auto* rot_ptr = rotations.ptr<float>();
+            auto scales = splat_data.scaling_raw().cpu();
+            const auto* scales_ptr = scales.ptr<float>();
+            auto sh0 = splat_data.sh0_raw().cpu();
+            const auto* sh0_ptr = sh0.ptr<float>();
+            auto opacity = splat_data.opacity_raw().cpu();
+            const auto* opacity_ptr = opacity.ptr<float>();
+
+            if (!report_progress(0.10f, "Positions")) {
+                return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
+            }
+
+            if (sh_degree > 0) {
+                sh_kmeans_future = std::async(
+                    std::launch::async,
+                    [shN_float_swizzled, num_rows, sh_coeffs, palette_size, iterations = options.kmeans_iterations]() mutable {
+                        const auto started = std::chrono::steady_clock::now();
+                        auto [centroids, labels] = lfs::io::kmeans_sh_swizzled(
+                            shN_float_swizzled, static_cast<int>(num_rows), sh_coeffs,
+                            palette_size, iterations);
+                        const auto finished = std::chrono::steady_clock::now();
+                        return ShKmeansResult{
+                            std::move(centroids),
+                            std::move(labels),
+                            std::chrono::duration<double, std::milli>(finished - started).count()};
+                    });
+            }
+
+            const auto join_sh_kmeans = [&]() -> ShKmeansResult& {
+                if (!sh_kmeans_result) {
+                    sh_kmeans_result.emplace(sh_kmeans_future.get());
+                }
+                return *sh_kmeans_result;
+            };
+            const auto join_sh_kmeans_and_wait_for_webp_encodes = [&]() {
+                if (sh_degree > 0) {
+                    try {
+                        (void)join_sh_kmeans();
+                    } catch (...) {
+                        wait_for_webp_encodes();
+                        throw;
+                    }
+                }
+                wait_for_webp_encodes();
+            };
+
+            double pack_ms = 0.0;
+            double cluster_scales_ms = 0.0;
+            double cluster_sh0_ms = 0.0;
+            double kmeans_sh_ms = 0.0;
+            double kmeans_sh_wait_ms = 0.0;
+
+            std::array<std::array<double, 2>, 3> means_min_max = {{{std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()},
+                                                                   {std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()},
+                                                                   {std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()}}};
+
+            using MeansBounds = std::array<std::array<double, 2>, 3>;
+            const auto initial_bounds = [] {
+                return MeansBounds{{{std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()},
+                                    {std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()},
+                                    {std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()}}};
+            };
+            const auto means_bounds_started = std::chrono::steady_clock::now();
+            std::vector<MeansBounds> chunk_bounds(chunk_count());
+            tbb::parallel_for(size_t{0}, chunk_bounds.size(), [&](const size_t chunk) {
+                auto& bounds = chunk_bounds[chunk];
+                bounds = initial_bounds();
+                const size_t begin = chunk * PACK_CHUNK_SIZE;
+                const size_t end = std::min(begin + PACK_CHUNK_SIZE, static_cast<size_t>(num_rows));
+                for (size_t i = begin; i < end; ++i) {
+                    const int64_t idx = source_index(static_cast<int64_t>(i));
+                    for (int d = 0; d < 3; ++d) {
+                        const double v = log_transform(static_cast<double>(means_ptr[idx * 3 + d]));
+                        bounds[d][0] = std::min(bounds[d][0], v);
+                        bounds[d][1] = std::max(bounds[d][1], v);
+                    }
+                }
+            });
+            for (const auto& bounds : chunk_bounds) {
+                for (int d = 0; d < 3; ++d) {
+                    means_min_max[d][0] = std::min(means_min_max[d][0], bounds[d][0]);
+                    means_min_max[d][1] = std::max(means_min_max[d][1], bounds[d][1]);
+                }
+            }
+            pack_ms += milliseconds(means_bounds_started, std::chrono::steady_clock::now());
+
+            std::vector<uint8_t> means_l(width * height * CHANNELS, 0);
+            std::vector<uint8_t> means_u(width * height * CHANNELS, 0);
+
+            const auto means_pack_started = std::chrono::steady_clock::now();
+            tbb::parallel_for(size_t{0}, chunk_count(), [&](const size_t chunk) {
+                const size_t begin = chunk * PACK_CHUNK_SIZE;
+                const size_t end = std::min(begin + PACK_CHUNK_SIZE, static_cast<size_t>(num_rows));
+                for (size_t i = begin; i < end; ++i) {
+                    const int64_t idx = source_index(static_cast<int64_t>(i));
+                    const double x = 65535.0 * (log_transform(static_cast<double>(means_ptr[idx * 3 + 0])) - means_min_max[0][0]) /
+                                     (means_min_max[0][1] - means_min_max[0][0]);
+                    const double y = 65535.0 * (log_transform(static_cast<double>(means_ptr[idx * 3 + 1])) - means_min_max[1][0]) /
+                                     (means_min_max[1][1] - means_min_max[1][0]);
+                    const double z = 65535.0 * (log_transform(static_cast<double>(means_ptr[idx * 3 + 2])) - means_min_max[2][0]) /
+                                     (means_min_max[2][1] - means_min_max[2][0]);
+
+                    const auto x16 = static_cast<uint16_t>(std::clamp(x, 0.0, 65535.0));
+                    const auto y16 = static_cast<uint16_t>(std::clamp(y, 0.0, 65535.0));
+                    const auto z16 = static_cast<uint16_t>(std::clamp(z, 0.0, 65535.0));
+
+                    means_l[i * 4 + 0] = x16 & 0xff;
+                    means_l[i * 4 + 1] = y16 & 0xff;
+                    means_l[i * 4 + 2] = z16 & 0xff;
+                    means_l[i * 4 + 3] = 0xff;
+
+                    means_u[i * 4 + 0] = (x16 >> 8) & 0xff;
+                    means_u[i * 4 + 1] = (y16 >> 8) & 0xff;
+                    means_u[i * 4 + 2] = (z16 >> 8) & 0xff;
+                    means_u[i * 4 + 3] = 0xff;
+                }
+            });
+            pack_ms += milliseconds(means_pack_started, std::chrono::steady_clock::now());
+            queue_webp("means_l.webp", means_l, width, height);
+            queue_webp("means_u.webp", means_u, width, height);
+
+            if (!report_progress(0.20f, "Rotations")) {
+                join_sh_kmeans_and_wait_for_webp_encodes();
+                return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
+            }
+
+            std::vector<uint8_t> quats(width * height * CHANNELS, 0);
+
+            const auto quats_pack_started = std::chrono::steady_clock::now();
+            tbb::parallel_for(size_t{0}, chunk_count(), [&](const size_t chunk) {
+                const size_t begin = chunk * PACK_CHUNK_SIZE;
+                const size_t end = std::min(begin + PACK_CHUNK_SIZE, static_cast<size_t>(num_rows));
+                for (size_t i = begin; i < end; ++i) {
+                    const int64_t idx = source_index(static_cast<int64_t>(i));
+                    float q[4] = {rot_ptr[idx * 4 + 0], rot_ptr[idx * 4 + 1], rot_ptr[idx * 4 + 2], rot_ptr[idx * 4 + 3]};
+
+                    const float len = std::sqrt(q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3]);
+                    for (float& j : q)
+                        j /= len;
+
+                    int max_comp = 0;
+                    for (int j = 1; j < 4; ++j) {
+                        if (std::abs(q[j]) > std::abs(q[max_comp]))
+                            max_comp = j;
+                    }
+
+                    if (q[max_comp] < 0) {
+                        for (float& j : q)
+                            j *= -1;
+                    }
+
+                    constexpr float SQRT2 = 1.41421356237f;
+                    for (float& j : q)
+                        j *= SQRT2;
+
+                    static const int IDX_TABLE[4][3] = {{1, 2, 3}, {0, 2, 3}, {0, 1, 3}, {0, 1, 2}};
+                    const int* other_idx = IDX_TABLE[max_comp];
+
+                    quats[i * 4 + 0] = static_cast<uint8_t>(255.0f * (q[other_idx[0]] * 0.5f + 0.5f));
+                    quats[i * 4 + 1] = static_cast<uint8_t>(255.0f * (q[other_idx[1]] * 0.5f + 0.5f));
+                    quats[i * 4 + 2] = static_cast<uint8_t>(255.0f * (q[other_idx[2]] * 0.5f + 0.5f));
+                    quats[i * 4 + 3] = static_cast<uint8_t>(252 + max_comp);
+                }
+            });
+            pack_ms += milliseconds(quats_pack_started, std::chrono::steady_clock::now());
+            queue_webp("quats.webp", quats, width, height);
+
+            if (!report_progress(0.30f, "Scales k-means")) {
+                join_sh_kmeans_and_wait_for_webp_encodes();
+                return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
+            }
+
+            const auto cluster_scales_started = std::chrono::steady_clock::now();
+            auto scale_result = cluster1d(scales_ptr, static_cast<int>(num_rows), 3, options.kmeans_iterations);
+            cluster_scales_ms = milliseconds(cluster_scales_started, std::chrono::steady_clock::now());
+            std::vector<uint8_t> scales_data(width * height * CHANNELS, 0);
+            const auto scales_pack_started = std::chrono::steady_clock::now();
+            tbb::parallel_for(size_t{0}, chunk_count(), [&](const size_t chunk) {
+                const size_t begin = chunk * PACK_CHUNK_SIZE;
+                const size_t end = std::min(begin + PACK_CHUNK_SIZE, static_cast<size_t>(num_rows));
+                for (size_t i = begin; i < end; ++i) {
+                    const int64_t idx = source_index(static_cast<int64_t>(i));
+
+                    scales_data[i * 4 + 0] = scale_result.labels[0 * num_rows + idx];
+                    scales_data[i * 4 + 1] = scale_result.labels[1 * num_rows + idx];
+                    scales_data[i * 4 + 2] = scale_result.labels[2 * num_rows + idx];
+                    scales_data[i * 4 + 3] = 0xff;
+                }
+            });
+            pack_ms += milliseconds(scales_pack_started, std::chrono::steady_clock::now());
+            queue_webp("scales.webp", scales_data, width, height);
+
+            if (!report_progress(0.45f, "Colors k-means")) {
+                join_sh_kmeans_and_wait_for_webp_encodes();
+                return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
+            }
+
+            const auto cluster_sh0_started = std::chrono::steady_clock::now();
+            auto color_result = cluster1d(sh0_ptr, static_cast<int>(num_rows), 3, options.kmeans_iterations);
+            cluster_sh0_ms = milliseconds(cluster_sh0_started, std::chrono::steady_clock::now());
+
+            std::vector<uint8_t> sh0_data(width * height * CHANNELS, 0);
+            const auto sh0_pack_started = std::chrono::steady_clock::now();
+            tbb::parallel_for(size_t{0}, chunk_count(), [&](const size_t chunk) {
+                const size_t begin = chunk * PACK_CHUNK_SIZE;
+                const size_t end = std::min(begin + PACK_CHUNK_SIZE, static_cast<size_t>(num_rows));
+                for (size_t i = begin; i < end; ++i) {
+                    const int64_t idx = source_index(static_cast<int64_t>(i));
+
+                    sh0_data[i * 4 + 0] = color_result.labels[0 * num_rows + idx];
+                    sh0_data[i * 4 + 1] = color_result.labels[1 * num_rows + idx];
+                    sh0_data[i * 4 + 2] = color_result.labels[2 * num_rows + idx];
+                    sh0_data[i * 4 + 3] = static_cast<uint8_t>(
+                        std::max(0.0, std::min(255.0, sigmoid(static_cast<double>(opacity_ptr[idx])) * 255.0)));
+                }
+            });
+            pack_ms += milliseconds(sh0_pack_started, std::chrono::steady_clock::now());
+            queue_webp("sh0.webp", sh0_data, width, height);
+
+            nlohmann::json sh_n_meta;
+            std::vector<uint8_t> sh_centroids_buf;
+            std::vector<uint8_t> sh_labels_buf;
+
+            if (sh_degree > 0) {
+                if (!report_progress(0.60f, "SH k-means")) {
+                    join_sh_kmeans_and_wait_for_webp_encodes();
+                    return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
+                }
+
+                const auto kmeans_sh_join_started = std::chrono::steady_clock::now();
+                auto& sh_kmeans_data = join_sh_kmeans();
+                kmeans_sh_wait_ms = milliseconds(
+                    kmeans_sh_join_started, std::chrono::steady_clock::now());
+                auto sh_centroids = std::move(sh_kmeans_data.centroids);
+                auto sh_labels = std::move(sh_kmeans_data.labels);
                 if (!sh_centroids.is_valid() || !sh_labels.is_valid()) {
+                    wait_for_webp_encodes();
                     return make_error(ErrorCode::ENCODING_FAILED,
                                       "Failed to cluster swizzled SH tensor for SOG export",
                                       options.output_path);
@@ -1821,12 +1998,15 @@ namespace lfs::io {
                     }
                 }
 
+                const auto codebook_started = std::chrono::steady_clock::now();
                 auto codebook_result = cluster1d(sh_centroids_grouped.data(), actual_palette_size, sh_dims, options.kmeans_iterations);
+                kmeans_sh_ms = sh_kmeans_data.milliseconds +
+                               milliseconds(codebook_started, std::chrono::steady_clock::now());
 
                 const int centroids_width = 64 * sh_coeffs;
                 const int centroids_height = (actual_palette_size + 63) / 64;
 
-                std::vector<uint8_t> centroids_buf(centroids_width * centroids_height * CHANNELS, 0);
+                sh_centroids_buf.assign(centroids_width * centroids_height * CHANNELS, 0);
 
                 for (int i = 0; i < actual_palette_size; ++i) {
                     for (int j = 0; j < sh_coeffs; ++j) {
@@ -1834,34 +2014,35 @@ namespace lfs::io {
                         for (int c = 0; c < 3; ++c) {
                             const int col_idx = sh_coeffs * c + j;
                             const int label_idx = col_idx * actual_palette_size + i;
-                            centroids_buf[pixel_idx * 4 + c] = codebook_result.labels[label_idx];
+                            sh_centroids_buf[pixel_idx * 4 + c] = codebook_result.labels[label_idx];
                         }
-                        centroids_buf[pixel_idx * 4 + 3] = 0xff;
+                        sh_centroids_buf[pixel_idx * 4 + 3] = 0xff;
                     }
                 }
 
-                if (auto result = write_webp("shN_centroids.webp", centroids_buf.data(), centroids_width, centroids_height); !result) {
-                    return std::unexpected(result.error());
-                }
+                queue_webp("shN_centroids.webp", sh_centroids_buf, centroids_width, centroids_height);
 
                 auto sh_labels_cpu = sh_labels.cpu();
                 const auto* sh_labels_ptr = static_cast<const int32_t*>(sh_labels_cpu.data_ptr());
 
-                std::vector<uint8_t> labels_buf(width * height * CHANNELS, 0);
-                for (int64_t i = 0; i < num_rows; ++i) {
-                    const int64_t idx = source_index(i);
-                    const int32_t label = sh_labels_ptr[idx];
-                    const auto ti = static_cast<int>(i);
+                sh_labels_buf.assign(width * height * CHANNELS, 0);
+                const auto sh_labels_pack_started = std::chrono::steady_clock::now();
+                tbb::parallel_for(size_t{0}, chunk_count(), [&](const size_t chunk) {
+                    const size_t begin = chunk * PACK_CHUNK_SIZE;
+                    const size_t end = std::min(begin + PACK_CHUNK_SIZE, static_cast<size_t>(num_rows));
+                    for (size_t i = begin; i < end; ++i) {
+                        const int64_t idx = source_index(static_cast<int64_t>(i));
+                        const int32_t label = sh_labels_ptr[idx];
 
-                    labels_buf[ti * 4 + 0] = label & 0xff;
-                    labels_buf[ti * 4 + 1] = (label >> 8) & 0xff;
-                    labels_buf[ti * 4 + 2] = 0;
-                    labels_buf[ti * 4 + 3] = 0xff;
-                }
+                        sh_labels_buf[i * 4 + 0] = label & 0xff;
+                        sh_labels_buf[i * 4 + 1] = (label >> 8) & 0xff;
+                        sh_labels_buf[i * 4 + 2] = 0;
+                        sh_labels_buf[i * 4 + 3] = 0xff;
+                    }
+                });
+                pack_ms += milliseconds(sh_labels_pack_started, std::chrono::steady_clock::now());
 
-                if (auto result = write_webp("shN_labels.webp", labels_buf.data(), width, height); !result) {
-                    return std::unexpected(result.error());
-                }
+                queue_webp("shN_labels.webp", sh_labels_buf, width, height);
 
                 sh_n_meta["count"] = actual_palette_size;
                 sh_n_meta["bands"] = sh_degree;
@@ -1869,6 +2050,35 @@ namespace lfs::io {
                 sh_n_meta["files"] = {"shN_centroids.webp", "shN_labels.webp"};
             }
 
+            // The non-SH encodes started as their buffers were queued above, and the SH
+            // encodes started after their buffers were completed. Consume all results in
+            // archive order below.
+            for (size_t i = 0; i < webp_futures.size(); ++i) {
+                auto encoded = [&]() -> Result<EncodedWebpResult> {
+                    try {
+                        return webp_futures[i].get();
+                    } catch (...) {
+                        wait_for_webp_encodes();
+                        throw;
+                    }
+                }();
+                if (!encoded) {
+                    wait_for_webp_encodes();
+                    return std::unexpected(encoded.error());
+                }
+                webp_timings.push_back({pending_webps[i].filename, encoded->milliseconds});
+                encoded_webps.emplace_back(std::move(*encoded));
+            }
+
+            const auto archive_started = std::chrono::steady_clock::now();
+            for (size_t i = 0; i < encoded_webps.size(); ++i) {
+                auto result = archive.add_file(
+                    pending_webps[i].filename, encoded_webps[i].bytes.data(), encoded_webps[i].bytes.size());
+                if (!result) {
+                    return std::unexpected(result.error());
+                }
+            }
+            const auto webp_finished = std::chrono::steady_clock::now();
             if (!report_progress(0.90f, "Writing meta")) {
                 return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
             }
@@ -1906,6 +2116,7 @@ namespace lfs::io {
             if (auto result = archive.close(); !result) {
                 return std::unexpected(result.error());
             }
+            const auto archive_finished = std::chrono::steady_clock::now();
 
             if (!report_progress(1.0f, "Complete")) {
                 return make_error(ErrorCode::CANCELLED, "Export cancelled by user");
@@ -1915,6 +2126,28 @@ namespace lfs::io {
                 return std::unexpected(result.error());
             }
 
+            std::string webp_timing_fields;
+            for (const auto& timing : webp_timings) {
+                if (!webp_timing_fields.empty()) {
+                    webp_timing_fields += ' ';
+                }
+                webp_timing_fields += std::format("{}={:.3f}ms", timing.filename, timing.milliseconds);
+            }
+            const auto export_finished = std::chrono::steady_clock::now();
+            LOG_DEBUG(
+                "SOG export stages: morton_ms={:.3f} pack_ms={:.3f} cluster_scales_ms={:.3f} "
+                "cluster_sh0_ms={:.3f} kmeans_sh_ms={:.3f} kmeans_sh_wait_ms={:.3f} webp_total_ms={:.3f} "
+                "{} archive_ms={:.3f} total_ms={:.3f}",
+                milliseconds(morton_started, morton_finished),
+                pack_ms,
+                cluster_scales_ms,
+                cluster_sh0_ms,
+                kmeans_sh_ms,
+                kmeans_sh_wait_ms,
+                milliseconds(webp_started, webp_finished),
+                webp_timing_fields,
+                milliseconds(archive_started, archive_finished),
+                milliseconds(export_started, export_finished));
             LOG_INFO("SOG export complete: {} splats", num_rows);
             return {};
         } catch (const lfs::Exception& e) {


### PR DESCRIPTION
Exporting 3.3M splats to .sog took 18.7 seconds. It now takes 10.

What changed:
- The GPU color-compression step (the biggest cost) now runs concurrently with all the CPU packing and image encoding instead of before it.
- The seven WebP images encode in parallel, each starting as soon as its data is ready.
- The zip no longer re-compresses the already-compressed WebP images.
- The WebP encoder uses a faster lossless mode.

Bonus correctness fix found on the way: the old encoder call silently discards color data for fully transparent splats, so they came back with a wrong color after export+import. The new encoding preserves them exactly — measured reconstruction error is now equal or lower on every attribute.

The five deterministic images are pixel-identical to before (aside from the transparent-splat fix). The SH images differ between runs because the GPU clustering was already nondeterministic; quality is verified by reconstruction error against the source model. SOG tests pass. Detailed timing logs are now built in, so this path is no longer a black box.

Note: this is 1.9x, slightly under the 2x bar from the overnight brief — shipped on request. The remaining wall is the GPU k-means itself (8.2 of the 10 seconds); a measured kernel-tiling pass is the next lever if we want more.