### PR TITLE
Training survives OOM, GUT gets edge scores, .licht keeps checkpoint history

### DIFF
--- a/docs/licht_format.md
+++ b/docs/licht_format.md
@@ -98,5 +98,10 @@ use `--headless --resume project.licht`; a complete autosave newer than the
 master head is recovered automatically. Ambiguous recovery candidates remain
 an error.
 
-The current grammar is **1.0** on this development branch. The framed payload layout is guarded by
+The current grammar is **1.1** on this development branch. Version 1.1 makes CKPT history
+explicit: SCNG binds exactly one resumable checkpoint when a training node exists, while
+additional live CKPT chapters are historical and are copied by compaction. The existing
+Version major/minor fields and commit minimum-reader fields are the compatibility mechanism;
+old 1.0 readers reject a 1.1 multi-checkpoint commit before validation with an unsupported
+version error rather than reporting data loss. The framed payload layout is guarded by
 reader/writer tests; no compatibility promise is made for pre-framed development files.

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -281,23 +281,21 @@ namespace lfs::app {
                 recovery_document(
                     std::move(*document),
                     std::move(recovery_session));
-            const auto checkpoint_uuids =
-                recovery_document.document()
-                    .checkpoint_uuids();
-            if (checkpoint_uuids.size() != 1) {
+            auto checkpoint_uuid =
+                recovery_document.document().bound_checkpoint_uuid();
+            if (!checkpoint_uuid) {
+                return std::move(checkpoint_uuid).error();
+            }
+            if (!*checkpoint_uuid) {
                 return training_project_error(
-                    lfs::ErrorCode::DataLoss,
-                    std::format(
-                        "Training project must contain exactly one CKPT "
-                        "instance (found {})",
-                        checkpoint_uuids.size()),
+                    lfs::ErrorCode::FailedPrecondition,
+                    "Training project has no SCNG-bound CKPT instance",
                     LFS_SOURCE_SITE_CURRENT());
             }
-            const auto checkpoint_uuid =
-                checkpoint_uuids.front();
+            const auto bound_checkpoint_uuid = **checkpoint_uuid;
             const auto* checkpoint =
                 recovery_document.document()
-                    .find_checkpoint(checkpoint_uuid);
+                    .find_checkpoint(bound_checkpoint_uuid);
             if (!checkpoint) {
                 return training_project_error(
                     lfs::ErrorCode::ContractViolation,
@@ -392,7 +390,7 @@ namespace lfs::app {
             if (!hydration->trainer_state_pending ||
                 !hydration->checkpoint_uuid ||
                 *hydration->checkpoint_uuid !=
-                    checkpoint_uuid ||
+                    bound_checkpoint_uuid ||
                 !hydration->checkpoint_header) {
                 return training_project_error(
                     lfs::ErrorCode::ContractViolation,
@@ -413,7 +411,7 @@ namespace lfs::app {
                 .params =
                     std::move(checkpoint_params),
                 .checkpoint_uuid =
-                    checkpoint_uuid,
+                    bound_checkpoint_uuid,
                 .iteration =
                     hydration
                         ->checkpoint_header

--- a/src/app/converter.cpp
+++ b/src/app/converter.cpp
@@ -337,9 +337,9 @@ namespace lfs::app {
                 lfs::io::project::ProjectDocumentOpenOptions options;
                 options.defer_geometry_payloads = true;
                 if (auto document = lfs::io::project::ProjectDocument::open(input, options)) {
-                    const auto checkpoints = document->checkpoint_uuids();
-                    if (checkpoints.size() == 1 && document->splat_uuids().empty()) {
-                        if (const auto* checkpoint = document->find_checkpoint(checkpoints.front())) {
+                    const auto bound = document->bound_checkpoint_uuid();
+                    if (bound && *bound && document->splat_uuids().empty()) {
+                        if (const auto* checkpoint = document->find_checkpoint(**bound)) {
                             fill_stamp_from_checkpoint_stream(stamp, *checkpoint);
                         }
                     }
@@ -358,9 +358,14 @@ namespace lfs::app {
                 return false;
             }
 
-            const auto checkpoints = document->checkpoint_uuids();
+            const auto bound = document->bound_checkpoint_uuid();
+            if (!bound) {
+                LOG_ERROR("Failed to resolve project training checkpoint: {}",
+                          lfs::format_for_developer(bound.error()));
+                return false;
+            }
             const auto splats = document->splat_uuids();
-            const auto model_count = checkpoints.size() + splats.size();
+            const auto model_count = (bound->has_value() ? 1u : 0u) + splats.size();
             if (model_count == 0) {
                 LOG_ERROR("Project contains no splat model: {}", path_to_utf8(input));
                 std::println(stderr, "  Error: project contains no splat model");
@@ -368,15 +373,15 @@ namespace lfs::app {
             }
             if (model_count > 1) {
                 LOG_ERROR("Project contains multiple splat models ({} checkpoint(s), {} splat(s)): {}",
-                          checkpoints.size(), splats.size(), path_to_utf8(input));
+                          bound->has_value() ? 1 : 0, splats.size(), path_to_utf8(input));
                 std::println(stderr,
                              "  Error: project contains {} checkpoint model(s) and {} splat model(s); export from the LichtFeld Studio GUI instead",
-                             checkpoints.size(), splats.size());
+                             bound->has_value() ? 1 : 0, splats.size());
                 return false;
             }
 
-            if (checkpoints.size() == 1) {
-                const auto* checkpoint = document->find_checkpoint(checkpoints.front());
+            if (bound->has_value()) {
+                const auto* checkpoint = document->find_checkpoint(**bound);
                 if (!checkpoint) {
                     LOG_ERROR("Project checkpoint handle disappeared: {}", path_to_utf8(input));
                     std::println(stderr, "  Error: project checkpoint handle disappeared");

--- a/src/core/cuda/CMakeLists.txt
+++ b/src/core/cuda/CMakeLists.txt
@@ -10,6 +10,7 @@
 set(LFS_CORE_CUDA_SOURCES
     memory_arena.cu
     exportable_storage.cpp
+    vmm_device_buffer.cpp
     lanczos_resize/lanczos_resize.cu
     undistort/undistort.cu
     kernels/selection_ops.cu

--- a/src/core/cuda/memory_arena.cu
+++ b/src/core/cuda/memory_arena.cu
@@ -18,6 +18,44 @@
 
 namespace lfs::core {
 
+    void log_arena_failure_vram_snapshot(
+        const std::string_view label, const size_t committed_bytes,
+        const size_t frame_peak_bytes) {
+        size_t free_bytes = 0;
+        size_t total_bytes = 0;
+        (void)cudaMemGetInfo(&free_bytes, &total_bytes);
+
+        std::uint64_t pool_used = 0;
+        std::uint64_t pool_reserved = 0;
+#if CUDART_VERSION >= 12080
+        int device = 0;
+        cudaMemPool_t pool = nullptr;
+        if (cudaGetDevice(&device) == cudaSuccess &&
+            cudaDeviceGetDefaultMemPool(&pool, device) == cudaSuccess) {
+            (void)cudaMemPoolGetAttribute(
+                pool, cudaMemPoolAttrUsedMemCurrent, &pool_used);
+            (void)cudaMemPoolGetAttribute(
+                pool, cudaMemPoolAttrReservedMemCurrent, &pool_reserved);
+        }
+#endif
+
+        const std::string label_text = label.empty() ? "unnamed" : std::string(label);
+        const auto profiler = lfs::diagnostics::VramProfiler::instance().snapshot();
+        const auto& process = profiler.process;
+        LOG_ERROR(
+            "Arena VRAM failure snapshot label=%s cuda_free=%zu MiB cuda_total=%zu MiB "
+            "arena_committed=%zu MiB frame_peak=%zu MiB exportable_splat=%zu MiB "
+            "shared_scratch=%zu MiB cuda_default_pool_reserved=%zu MiB "
+            "cuda_default_pool_used=%zu MiB",
+            label_text.c_str(),
+            free_bytes >> 20, total_bytes >> 20,
+            committed_bytes >> 20, frame_peak_bytes >> 20,
+            process.exportable_splat_bytes >> 20,
+            process.shared_scratch_bytes >> 20,
+            static_cast<size_t>(pool_reserved >> 20),
+            static_cast<size_t>(pool_used >> 20));
+    }
+
     // Default constructor implementation
     RasterizerMemoryArena::RasterizerMemoryArena()
         : RasterizerMemoryArena(Config{}) {
@@ -621,8 +659,9 @@ namespace lfs::core {
         arena.last_log_time = std::chrono::steady_clock::now();
     }
 
-    std::function<char*(size_t)> RasterizerMemoryArena::get_allocator(uint64_t frame_id) {
-        return [this, frame_id](size_t size) -> char* {
+    std::function<char*(size_t)> RasterizerMemoryArena::get_allocator(
+        const uint64_t frame_id, const char* label) {
+        return [this, frame_id, label](size_t size) -> char* {
             if (size == 0) {
                 return nullptr;
             }
@@ -637,7 +676,7 @@ namespace lfs::core {
                                "RasterizerMemoryArena allocation");
 
             Arena& arena = get_or_create_arena(device);
-            return allocate_internal(arena, size, frame_id);
+            return allocate_internal(arena, size, frame_id, label);
         };
     }
 
@@ -1666,7 +1705,9 @@ namespace lfs::core {
         return shrink_at_boundary(true);
     }
 
-    char* RasterizerMemoryArena::allocate_internal(Arena& arena, size_t size, uint64_t frame_id) {
+    char* RasterizerMemoryArena::allocate_internal(
+        Arena& arena, const size_t size, const uint64_t frame_id,
+        const char* label) {
         LFS_CUDA_BREADCRUMB("arena.allocate");
         size_t aligned_size = align_size(size);
 
@@ -1680,9 +1721,13 @@ namespace lfs::core {
 
         // Sanity check
         if (aligned_size > config_.max_physical) {
-            LOG_ERROR("Single allocation request %zu MB exceeds max physical size %zu MB",
+            LOG_ERROR("Arena allocation '%s' request %zu MB exceeds max physical size %zu MB",
+                      label ? label : "unnamed",
                       aligned_size >> 20,
                       config_.max_physical >> 20);
+            log_arena_failure_vram_snapshot(
+                label ? label : "unnamed", arena.committed_size,
+                arena.peak_usage.load(std::memory_order_relaxed));
             return nullptr;
         }
 
@@ -1831,15 +1876,22 @@ namespace lfs::core {
                     }
                     if (result == ExternalGrowResult::Failed) {
                         LOG_ERROR("External rasterizer arena '%s' exhausted and could not grow: "
-                                  "capacity=%zu MiB request=%zu MiB",
+                                  "capacity=%zu MiB request=%zu MiB allocation='%s'",
                                   arena.external_label.empty() ? "unnamed" : arena.external_label.c_str(),
                                   static_cast<size_t>(arena.committed_size >> 20),
-                                  static_cast<size_t>(aligned_size >> 20));
+                                  static_cast<size_t>(aligned_size >> 20),
+                                  label ? label : "unnamed");
+                        log_arena_failure_vram_snapshot(
+                            label ? label : "unnamed", arena.committed_size,
+                            arena.peak_usage.load(std::memory_order_relaxed));
                         return nullptr;
                     }
                     if (std::chrono::steady_clock::now() >= deadline) {
                         LOG_ERROR("External rasterizer arena '%s' grow timed out waiting for the render gate",
                                   arena.external_label.empty() ? "unnamed" : arena.external_label.c_str());
+                        log_arena_failure_vram_snapshot(
+                            label ? label : "unnamed", arena.committed_size,
+                            arena.peak_usage.load(std::memory_order_relaxed));
                         return nullptr;
                     }
                     std::this_thread::yield();
@@ -1862,8 +1914,12 @@ namespace lfs::core {
             // We need to grow - calculate how much
             const size_t growth_needed = total_needed - arena.committed_size;
             if (total_needed > config_.max_physical) {
-                LOG_ERROR("Capacity limit reached: max=%zu MB, requested=%zu MB",
+                LOG_ERROR("Arena allocation '%s' capacity limit reached: max=%zu MB, requested=%zu MB",
+                          label ? label : "unnamed",
                           config_.max_physical >> 20, aligned_size >> 20);
+                log_arena_failure_vram_snapshot(
+                    label ? label : "unnamed", arena.committed_size,
+                    arena.peak_usage.load(std::memory_order_relaxed));
                 return nullptr;
             }
 
@@ -1915,8 +1971,13 @@ namespace lfs::core {
                     std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     continue;
                 } else {
-                    LOG_ERROR("Out of memory after %d attempts: requested=%zu MB, usage=%zu MB, committed=%zu MB, max=%zu MB",
-                              MAX_RETRIES, size >> 20, current_offset >> 20, arena.committed_size >> 20, config_.max_physical >> 20);
+                    LOG_ERROR("Out of memory after %d attempts: allocation='%s' requested=%zu MB, usage=%zu MB, committed=%zu MB, max=%zu MB",
+                              MAX_RETRIES, label ? label : "unnamed",
+                              size >> 20, current_offset >> 20,
+                              arena.committed_size >> 20, config_.max_physical >> 20);
+                    log_arena_failure_vram_snapshot(
+                        label ? label : "unnamed", arena.committed_size,
+                        arena.peak_usage.load(std::memory_order_relaxed));
                     return nullptr;
                 }
             }
@@ -1924,7 +1985,10 @@ namespace lfs::core {
             // Growth succeeded, retry allocation
         }
 
-        LOG_ERROR("Allocation loop exhausted");
+        LOG_ERROR("Allocation loop exhausted for '%s'", label ? label : "unnamed");
+        log_arena_failure_vram_snapshot(
+            label ? label : "unnamed", arena.committed_size,
+            arena.peak_usage.load(std::memory_order_relaxed));
         return nullptr;
     }
 

--- a/src/core/cuda/memory_arena.cu
+++ b/src/core/cuda/memory_arena.cu
@@ -1914,9 +1914,9 @@ namespace lfs::core {
             // We need to grow - calculate how much
             const size_t growth_needed = total_needed - arena.committed_size;
             if (total_needed > config_.max_physical) {
-                LOG_ERROR("Arena allocation '%s' capacity limit reached: max=%zu MB, requested=%zu MB",
+                LOG_ERROR("Arena allocation '%s' capacity limit reached: max=%zu MB, total_needed=%zu MB, request=%zu MB",
                           label ? label : "unnamed",
-                          config_.max_physical >> 20, aligned_size >> 20);
+                          config_.max_physical >> 20, total_needed >> 20, aligned_size >> 20);
                 log_arena_failure_vram_snapshot(
                     label ? label : "unnamed", arena.committed_size,
                     arena.peak_usage.load(std::memory_order_relaxed));

--- a/src/core/cuda/memory_arena.hpp
+++ b/src/core/cuda/memory_arena.hpp
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -25,6 +26,8 @@ namespace lfs::core {
     class GlobalArenaManager;
     LFS_CORE_API GlobalArenaManager& global_arena_manager();
     LFS_CORE_API void shutdown_global_arena_manager();
+    LFS_CORE_API void log_arena_failure_vram_snapshot(
+        std::string_view label, size_t committed_bytes, size_t frame_peak_bytes);
 
     class RasterizerMemoryArena {
     public:
@@ -271,7 +274,8 @@ namespace lfs::core {
             uint32_t previous_ = 0;
         };
 
-        std::function<char*(size_t)> get_allocator(uint64_t frame_id);
+        std::function<char*(size_t)> get_allocator(uint64_t frame_id,
+                                                   const char* label = nullptr);
         std::vector<BufferHandle> get_frame_buffers(uint64_t frame_id) const;
         void reset_frame(uint64_t frame_id); // Keeps allocation, resets offset
         void cleanup_frames(int keep_recent = 3);
@@ -317,7 +321,8 @@ namespace lfs::core {
         // backing — a device sync cannot observe the in-flight Vulkan batch.
         void drain_external_release();
         bool install_external_backing_impl(ExternalBacking backing, bool wait);
-        char* allocate_internal(Arena& arena, size_t size, uint64_t frame_id);
+        char* allocate_internal(Arena& arena, size_t size, uint64_t frame_id,
+                                const char* label);
         void release_arena_storage(Arena& arena);
         bool grow_arena(Arena& arena, size_t required_size);
         size_t align_size(size_t size) const;

--- a/src/core/cuda/undistort/undistort.cu
+++ b/src/core/cuda/undistort/undistort.cu
@@ -639,7 +639,8 @@ namespace lfs::core {
         }
 
         if (!found_valid_border_point) {
-            LOG_WARN("Undistort crop solve found no valid border samples, keeping original intrinsics");
+            params.crop_solve_failed = true;
+            LOG_DEBUG("Undistort crop solve found no valid border samples, keeping original intrinsics");
             return params;
         }
 

--- a/src/core/cuda/undistort/undistort.hpp
+++ b/src/core/cuda/undistort/undistort.hpp
@@ -18,6 +18,7 @@ namespace lfs::core {
         CameraModelType model_type;
         float distortion[12];
         int num_distortion;
+        bool crop_solve_failed = false;
     };
 
     UndistortParams compute_undistort_params(

--- a/src/core/cuda/vmm_device_buffer.cpp
+++ b/src/core/cuda/vmm_device_buffer.cpp
@@ -1,0 +1,307 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/cuda/vmm_device_buffer.hpp"
+
+#include "core/crash_handler.hpp"
+#include "core/logger.hpp"
+#include "core/source_site.hpp"
+
+#include <algorithm>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <format>
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace lfs::core {
+
+    namespace {
+        [[nodiscard]] std::string driver_error_text(const CUresult status) {
+            const char* name = nullptr;
+            const char* description = nullptr;
+            (void)cuGetErrorName(status, &name);
+            (void)cuGetErrorString(status, &description);
+            return std::format("{} ({})", name ? name : "unknown CUDA error",
+                               description ? description : "no description");
+        }
+
+        [[nodiscard]] Error vmm_error(const ErrorCode code, const char* label,
+                                      const char* operation, const CUresult status,
+                                      const std::size_t bytes = 0) {
+            const std::string detail = std::format(
+                "{}{} failed: {}", label ? std::format("label={} ", label) : "",
+                operation, driver_error_text(status));
+            SmallFields fields;
+            if (bytes != 0) {
+                fields.add("bytes", static_cast<std::uint64_t>(bytes));
+            }
+            return make_error(ErrorInit{
+                .code = code,
+                .domain = ErrorDomain::CUDA,
+                .severity = Severity::Error,
+                .retryability = code == ErrorCode::ResourceExhausted
+                                    ? Retryability::Retryable
+                                    : Retryability::NotRetryable,
+                .user_message = std::format("VMM {} failed", operation),
+                .detail = detail,
+                .detection = LFS_SOURCE_SITE_CURRENT(),
+                .fields = std::move(fields),
+                .native = NativeError{
+                    .domain = ErrorDomain::CUDA,
+                    .code = static_cast<std::int64_t>(status),
+                    .name = driver_error_text(status),
+                },
+            });
+        }
+
+        [[nodiscard]] Error host_error(const ErrorCode code, const char* label,
+                                       const char* operation, const std::size_t bytes = 0) {
+            SmallFields fields;
+            if (bytes != 0) {
+                fields.add("bytes", static_cast<std::uint64_t>(bytes));
+            }
+            return make_error(ErrorInit{
+                .code = code,
+                .domain = ErrorDomain::CUDA,
+                .severity = Severity::Error,
+                .retryability = code == ErrorCode::ResourceExhausted
+                                    ? Retryability::Retryable
+                                    : Retryability::NotRetryable,
+                .user_message = std::format("VMM {} failed", operation),
+                .detail = label ? std::format("label={} bytes={}", label, bytes)
+                                : std::format("bytes={}", bytes),
+                .detection = LFS_SOURCE_SITE_CURRENT(),
+                .fields = std::move(fields),
+            });
+        }
+
+        [[nodiscard]] std::size_t align_up(const std::size_t value,
+                                           const std::size_t alignment) {
+            if (value > std::numeric_limits<std::size_t>::max() - alignment + 1) {
+                return 0;
+            }
+            return ((value + alignment - 1) / alignment) * alignment;
+        }
+
+        [[nodiscard]] std::size_t align_down(const std::size_t value,
+                                             const std::size_t alignment) {
+            return (value / alignment) * alignment;
+        }
+
+        [[nodiscard]] bool is_out_of_memory(const CUresult status) {
+            return status == CUDA_ERROR_OUT_OF_MEMORY;
+        }
+    } // namespace
+
+    VmmDeviceBuffer::VmmDeviceBuffer(VmmDeviceBuffer&& other) noexcept
+        : base_(std::exchange(other.base_, 0)),
+          reservation_bytes_(std::exchange(other.reservation_bytes_, 0)),
+          committed_bytes_(std::exchange(other.committed_bytes_, 0)),
+          granularity_bytes_(std::exchange(other.granularity_bytes_, kGranularityBytes)),
+          device_(other.device_),
+          label_(std::exchange(other.label_, nullptr)),
+          chunks_(std::move(other.chunks_)) {
+    }
+
+    VmmDeviceBuffer& VmmDeviceBuffer::operator=(VmmDeviceBuffer&& other) noexcept {
+        if (this != &other) {
+            release();
+            base_ = std::exchange(other.base_, 0);
+            reservation_bytes_ = std::exchange(other.reservation_bytes_, 0);
+            committed_bytes_ = std::exchange(other.committed_bytes_, 0);
+            granularity_bytes_ = std::exchange(other.granularity_bytes_, kGranularityBytes);
+            device_ = other.device_;
+            label_ = std::exchange(other.label_, nullptr);
+            chunks_ = std::move(other.chunks_);
+        }
+        return *this;
+    }
+
+    VmmDeviceBuffer::~VmmDeviceBuffer() {
+        release();
+    }
+
+    Result<VmmDeviceBuffer> VmmDeviceBuffer::create(
+        const std::size_t reservation_bytes, const char* label) {
+        int device = 0;
+        if (const cudaError_t status = cudaGetDevice(&device); status != cudaSuccess) {
+            return make_error(ErrorInit{
+                .code = ErrorCode::Unavailable,
+                .domain = ErrorDomain::CUDA,
+                .severity = Severity::Error,
+                .user_message = "Could not query the current CUDA device for VMM",
+                .detail = std::format("cudaGetDevice failed: {}", cudaGetErrorString(status)),
+                .detection = LFS_SOURCE_SITE_CURRENT(),
+            });
+        }
+
+        CUmemAllocationProp prop{};
+        prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+        prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        prop.location.id = device;
+        std::size_t granularity = 0;
+        if (cuMemGetAllocationGranularity(
+                &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM) != CUDA_SUCCESS ||
+            granularity == 0) {
+            granularity = kGranularityBytes;
+        }
+        const std::size_t reserved = align_up(reservation_bytes, granularity);
+        if (reserved == 0) {
+            return host_error(ErrorCode::InvalidArgument, label, "address reservation", reservation_bytes);
+        }
+
+        CUdeviceptr base = 0;
+        if (const CUresult status = cuMemAddressReserve(
+                &base, reserved, granularity, 0, 0);
+            status != CUDA_SUCCESS) {
+            return vmm_error(ErrorCode::ResourceExhausted, label,
+                             "cuMemAddressReserve", status, reserved);
+        }
+
+        VmmDeviceBuffer buffer;
+        buffer.base_ = base;
+        buffer.reservation_bytes_ = reserved;
+        buffer.granularity_bytes_ = granularity;
+        buffer.device_ = device;
+        buffer.label_ = label;
+        return buffer;
+    }
+
+    Status VmmDeviceBuffer::commit(const std::size_t required_bytes) {
+        const std::size_t required = align_up(required_bytes, granularity_bytes_);
+        if (required == 0 && required_bytes != 0) {
+            return Status::failure(host_error(ErrorCode::InvalidArgument, label_, "commit", required_bytes));
+        }
+        if (required <= committed_bytes_) {
+            return {};
+        }
+        if (required > reservation_bytes_) {
+            return Status::failure(host_error(ErrorCode::ResourceExhausted, label_, "commit exceeds reservation", required));
+        }
+
+        CUmemAllocationProp prop{};
+        prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+        prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+        prop.location.id = device_;
+
+        constexpr std::size_t kMaxChunkBytes = 128u * 1024u * 1024u;
+        const std::size_t max_chunk_bytes = std::max(
+            granularity_bytes_, align_down(kMaxChunkBytes, granularity_bytes_));
+        while (committed_bytes_ < required) {
+            const std::size_t offset = committed_bytes_;
+            const std::size_t bytes = std::min(required - offset, max_chunk_bytes);
+            CUmemGenericAllocationHandle handle = 0;
+            if (const CUresult status = cuMemCreate(&handle, bytes, &prop, 0);
+                status != CUDA_SUCCESS) {
+                return Status::failure(vmm_error(
+                    is_out_of_memory(status) ? ErrorCode::ResourceExhausted : ErrorCode::Internal,
+                    label_, "cuMemCreate", status, bytes));
+            }
+
+            if (const CUresult status = cuMemMap(base_ + offset, bytes, 0, handle, 0);
+                status != CUDA_SUCCESS) {
+                (void)cuMemRelease(handle);
+                return Status::failure(vmm_error(ErrorCode::Internal, label_, "cuMemMap", status, bytes));
+            }
+
+            CUmemAccessDesc access{};
+            access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+            access.location.id = device_;
+            access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+            if (const CUresult status = cuMemSetAccess(base_ + offset, bytes, &access, 1);
+                status != CUDA_SUCCESS) {
+                (void)cuMemUnmap(base_ + offset, bytes);
+                (void)cuMemRelease(handle);
+                return Status::failure(
+                    vmm_error(ErrorCode::Internal, label_, "cuMemSetAccess", status, bytes));
+            }
+
+            chunks_.push_back(Chunk{
+                .handle = handle,
+                .offset = offset,
+                .bytes = bytes,
+            });
+            committed_bytes_ += bytes;
+        }
+        return {};
+    }
+
+    Status VmmDeviceBuffer::decommit_tail(const std::size_t new_prefix_bytes) {
+        const std::size_t new_prefix = align_down(new_prefix_bytes, granularity_bytes_);
+        if (new_prefix >= committed_bytes_) {
+            return {};
+        }
+
+        while (!chunks_.empty() && chunks_.back().offset >= new_prefix) {
+            Chunk& chunk = chunks_.back();
+            if (chunk.mapped) {
+                if (const CUresult status = cuMemUnmap(
+                        base_ + chunk.offset, chunk.bytes);
+                    status != CUDA_SUCCESS) {
+                    return Status::failure(
+                        vmm_error(ErrorCode::Internal, label_, "cuMemUnmap decommit chunk",
+                                  status, chunk.bytes));
+                }
+                chunk.mapped = false;
+            }
+            chunk.bytes = 0;
+            if (const CUresult status = cuMemRelease(chunk.handle); status != CUDA_SUCCESS) {
+                return Status::failure(
+                    vmm_error(ErrorCode::Internal, label_, "cuMemRelease decommit chunk",
+                              status));
+            }
+            chunks_.pop_back();
+        }
+
+        committed_bytes_ = chunks_.empty() ? 0 : chunks_.back().offset + chunks_.back().bytes;
+        return {};
+    }
+
+    void VmmDeviceBuffer::release() noexcept {
+        if (gpu_process_teardown_started()) {
+            chunks_.clear();
+            base_ = 0;
+            reservation_bytes_ = 0;
+            committed_bytes_ = 0;
+            granularity_bytes_ = kGranularityBytes;
+            label_ = nullptr;
+            return;
+        }
+        if (base_ != 0) {
+            if (const cudaError_t status = cudaDeviceSynchronize(); status != cudaSuccess) {
+                LOG_ERROR("VMM CUDA cleanup device synchronization failed: {}",
+                          cudaGetErrorString(status));
+            }
+        }
+        for (const auto& chunk : chunks_) {
+            if (chunk.mapped) {
+                if (const CUresult status = cuMemUnmap(base_ + chunk.offset, chunk.bytes);
+                    status != CUDA_SUCCESS) {
+                    LOG_ERROR("VMM CUDA cleanup cuMemUnmap failed: {}",
+                              driver_error_text(status));
+                }
+            }
+            if (const CUresult status = cuMemRelease(chunk.handle); status != CUDA_SUCCESS) {
+                LOG_ERROR("VMM CUDA cleanup cuMemRelease failed: {}",
+                          driver_error_text(status));
+            }
+        }
+        chunks_.clear();
+        if (base_ != 0) {
+            if (const CUresult status = cuMemAddressFree(base_, reservation_bytes_);
+                status != CUDA_SUCCESS) {
+                LOG_ERROR("VMM CUDA cleanup cuMemAddressFree failed: {}",
+                          driver_error_text(status));
+            }
+        }
+        base_ = 0;
+        reservation_bytes_ = 0;
+        committed_bytes_ = 0;
+        granularity_bytes_ = kGranularityBytes;
+        label_ = nullptr;
+    }
+
+} // namespace lfs::core

--- a/src/core/include/core/cuda/vmm_device_buffer.hpp
+++ b/src/core/include/core/cuda/vmm_device_buffer.hpp
@@ -1,0 +1,77 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include "core/error.hpp"
+#include "core/export.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace lfs::core {
+
+    // A stable virtual reservation whose physical prefix is committed in
+    // allocation-granularity increments. This is intentionally not
+    // exportable: it has no shareable handles or initialization memset.
+    class LFS_CORE_API VmmDeviceBuffer final {
+    public:
+        VmmDeviceBuffer() noexcept = default;
+        VmmDeviceBuffer(const VmmDeviceBuffer&) = delete;
+        VmmDeviceBuffer& operator=(const VmmDeviceBuffer&) = delete;
+        VmmDeviceBuffer(VmmDeviceBuffer&& other) noexcept;
+        VmmDeviceBuffer& operator=(VmmDeviceBuffer&& other) noexcept;
+        ~VmmDeviceBuffer();
+
+        [[nodiscard]] static Result<VmmDeviceBuffer> create(
+            std::size_t reservation_bytes, const char* label = nullptr);
+
+        [[nodiscard]] Status commit(std::size_t required_bytes);
+        // Releases whole allocation chunks at or above the aligned target.
+        // If the target falls inside the kept chunk, committed_bytes() remains
+        // at that chunk's end, above the requested prefix.
+        [[nodiscard]] Status decommit_tail(std::size_t new_prefix_bytes);
+        void release() noexcept;
+
+        [[nodiscard]] void* data() const noexcept {
+            return reinterpret_cast<void*>(base_);
+        }
+        [[nodiscard]] std::size_t reservation_bytes() const noexcept {
+            return reservation_bytes_;
+        }
+        [[nodiscard]] std::size_t committed_bytes() const noexcept {
+            return committed_bytes_;
+        }
+        [[nodiscard]] std::size_t granularity_bytes() const noexcept {
+            return granularity_bytes_;
+        }
+        [[nodiscard]] explicit operator bool() const noexcept {
+            return base_ != 0;
+        }
+
+        template <class T>
+        [[nodiscard]] T* as() const noexcept {
+            return reinterpret_cast<T*>(data());
+        }
+
+        static constexpr std::size_t kGranularityBytes = 2u * 1024u * 1024u;
+
+    private:
+        struct Chunk {
+            std::uint64_t handle = 0;
+            std::size_t offset = 0;
+            std::size_t bytes = 0;
+            bool mapped = true;
+        };
+
+        std::uint64_t base_ = 0;
+        std::size_t reservation_bytes_ = 0;
+        std::size_t committed_bytes_ = 0;
+        std::size_t granularity_bytes_ = kGranularityBytes;
+        int device_ = 0;
+        const char* label_ = nullptr;
+        std::vector<Chunk> chunks_;
+    };
+
+} // namespace lfs::core

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -2376,6 +2376,9 @@ namespace lfs::io {
         bool used_recursive_image_lookup = false;
         size_t depth_matched_count = 0;
         size_t normal_matched_count = 0;
+        size_t undistort_crop_failures = 0;
+        size_t undistort_camera_count = 0;
+        size_t undistort_fisheye_crop_failures = 0;
 
         // Accumulate camera positions for scene center
         std::vector<float> camera_positions;
@@ -2701,6 +2704,14 @@ namespace lfs::io {
                 normal_path);
 
             camera->precompute_undistortion();
+            ++undistort_camera_count;
+            if (camera->undistort_params().crop_solve_failed) {
+                ++undistort_crop_failures;
+                if (camera_model_type == lfs::core::CameraModelType::FISHEYE ||
+                    camera_model_type == lfs::core::CameraModelType::THIN_PRISM_FISHEYE) {
+                    ++undistort_fisheye_crop_failures;
+                }
+            }
             attach_sfm_observations(*camera, img, cam_data, points_xyz);
             if (!image_file_present) {
                 camera->set_has_image(false);
@@ -2708,6 +2719,17 @@ namespace lfs::io {
             }
 
             cameras.push_back(std::move(camera));
+        }
+
+        if (undistort_crop_failures > 0) {
+            if (undistort_fisheye_crop_failures > 0) {
+                LOG_WARN("Undistort crop solve failed for {} of {} cameras; original intrinsics kept; "
+                         "fisheye-family lenses cannot be rectified to pinhole and are handled natively by GUT",
+                         undistort_crop_failures, undistort_camera_count);
+            } else {
+                LOG_WARN("Undistort crop solve failed for {} of {} cameras; original intrinsics kept",
+                         undistort_crop_failures, undistort_camera_count);
+            }
         }
 
         if (cameras.empty()) {

--- a/src/io/include/io/project_container.hpp
+++ b/src/io/include/io/project_container.hpp
@@ -48,7 +48,7 @@ namespace lfs::io::project {
         friend constexpr auto operator<=>(const Version&, const Version&) = default;
     };
 
-    inline constexpr Version CURRENT_CONTAINER_VERSION{1, 0};
+    inline constexpr Version CURRENT_CONTAINER_VERSION{1, 1};
 
     struct LFS_IO_API Fourcc {
         std::array<std::uint8_t, 4> bytes{};
@@ -552,8 +552,11 @@ namespace lfs::io::project {
         lfs::core::Uuid commit_uuid;
         lfs::core::Uuid snapshot_uuid;
         std::uint64_t wallclock_unix_ns = 0;
-        Version min_reader_version = CURRENT_CONTAINER_VERSION;
-        Version min_safe_writer_version = CURRENT_CONTAINER_VERSION;
+        // The 1.1 container can still carry 1.0-compatible commits.  A
+        // producer raises these fields when it publishes a feature that an
+        // older reader cannot preserve, such as checkpoint history.
+        Version min_reader_version{1, 0};
+        Version min_safe_writer_version{1, 0};
         CapabilitySet extra_reader_capabilities;
         CapabilitySet extra_writer_capabilities;
     };

--- a/src/io/include/io/project_document.hpp
+++ b/src/io/include/io/project_document.hpp
@@ -33,6 +33,10 @@ namespace lfs::io {
 
 namespace lfs::io::project {
 
+    // The current SCNG-bound checkpoint is resumable; older CKPT chapters are
+    // retained history. This cap counts only unbound historical chapters.
+    inline constexpr std::size_t CHECKPOINT_HISTORY_LIMIT = 16;
+
     // A binary chapter whose clean source range is also its lazy hydration
     // handle. Reading a clean value never marks it dirty; saving that same
     // value reuses its CleanProof byte-for-byte. An owned value retains the
@@ -274,6 +278,8 @@ namespace lfs::io::project {
 
         [[nodiscard]] const LazyChunkValue*
         find_checkpoint(const lfs::core::Uuid& instance_uuid) const noexcept;
+        [[nodiscard]] lfs::Result<std::optional<lfs::core::Uuid>>
+        bound_checkpoint_uuid() const;
         // Test-only: drop the file-backed CKPT CleanProof. find_checkpoint()
         // is const and LazyChunkValue::Impl is translation-unit local.
         void drop_checkpoint_clean_proof_for_testing(

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -1450,15 +1450,14 @@ namespace lfs::io::project {
                 }
             }
 
-            if (checkpoints.size() !=
-                static_cast<std::size_t>(bound_checkpoint.has_value())) {
+            if (*training && !bound_checkpoint && !checkpoints.empty()) {
                 return fail<void>(
                     lfs::ErrorCode::DataLoss,
-                    "The project contains an unbound training checkpoint.",
+                    "The project has unbound training checkpoint history.",
                     std::format(
-                        "{} CKPT chapters exist but SCNG binds {}",
-                        checkpoints.size(),
-                        bound_checkpoint ? 1 : 0),
+                        "SCNG declares a training node but binds no CKPT; {} "
+                        "historical CKPT chapter(s) are not resumable",
+                        checkpoints.size()),
                     "CKPT");
             }
             if (!checkpoints.empty() && !ppisp_payloads.empty()) {
@@ -2449,6 +2448,29 @@ namespace lfs::io::project {
                    : &found->second;
     }
 
+    lfs::Result<std::optional<lfs::core::Uuid>>
+    ProjectDocument::bound_checkpoint_uuid() const {
+        auto training = impl_->scene_graph.training_model_uuid();
+        if (!training) {
+            return std::move(training).error();
+        }
+        if (!*training) {
+            return std::optional<lfs::core::Uuid>{};
+        }
+        auto nodes = impl_->scene_graph.nodes();
+        if (!nodes) {
+            return std::move(nodes).error();
+        }
+        for (const auto& node : *nodes) {
+            if (node.uuid == **training && node.payload &&
+                node.payload->fourcc == "CKPT") {
+                return std::optional<lfs::core::Uuid>(
+                    node.payload->instance_uuid);
+            }
+        }
+        return std::optional<lfs::core::Uuid>{};
+    }
+
     void ProjectDocument::drop_checkpoint_clean_proof_for_testing(
         const lfs::core::Uuid& instance_uuid) {
         const auto found = impl_->checkpoints.find(instance_uuid);
@@ -2472,9 +2494,50 @@ namespace lfs::io::project {
                 "must share one non-null identity; payload must be non-empty",
                 "CKPT.instance_uuid");
         }
+        const auto bound = bound_checkpoint_uuid();
+        if (!bound) {
+            return lfs::Result<void>::failure(
+                std::move(bound).error());
+        }
+        const auto bound_uuid =
+            *bound ? **bound : lfs::core::Uuid{};
         impl_->checkpoints.insert_or_assign(
             instance_uuid, std::move(payload));
         impl_->mark(FOURCC_CKPT, instance_uuid);
+
+        std::vector<std::pair<lfs::core::Uuid, int>> historical;
+        historical.reserve(impl_->checkpoints.size());
+        for (const auto& [uuid, checkpoint] : impl_->checkpoints) {
+            if (!bound_uuid.is_nil() && uuid == bound_uuid) {
+                continue;
+            }
+            int iteration = std::numeric_limits<int>::max();
+            std::array<std::byte, sizeof(lfs::core::CheckpointHeader)> prefix{};
+            if (auto peeked = checkpoint.peek_prefix(prefix); peeked) {
+                SpanStreambuf buffer(std::span<const std::byte>(
+                    prefix.data(), prefix.size()));
+                std::istream stream(&buffer);
+                if (auto header = lfs::core::load_checkpoint_header(
+                        stream, checkpoint.size());
+                    header && header->iteration >= 0) {
+                    iteration = header->iteration;
+                }
+            }
+            historical.emplace_back(uuid, iteration);
+        }
+        std::ranges::sort(historical, [](const auto& lhs, const auto& rhs) {
+            if (lhs.second != rhs.second) {
+                return lhs.second < rhs.second;
+            }
+            return lhs.first.to_string() < rhs.first.to_string();
+        });
+        while (historical.size() > CHECKPOINT_HISTORY_LIMIT) {
+            const auto evicted = historical.front().first;
+            historical.erase(historical.begin());
+            if (impl_->checkpoints.erase(evicted) != 0) {
+                impl_->mark(FOURCC_CKPT, evicted);
+            }
+        }
         return {};
     }
 
@@ -3167,13 +3230,13 @@ namespace lfs::io::project {
                     ? impl_->source_reader
                           ->commit()
                           .min_reader_version
-                    : CURRENT_CONTAINER_VERSION,
+                    : Version{1, 0},
             .min_safe_writer_version =
                 impl_->source_reader
                     ? impl_->source_reader
                           ->commit()
                           .min_safe_writer_version
-                    : CURRENT_CONTAINER_VERSION,
+                    : Version{1, 0},
             .extra_reader_capabilities =
                 impl_->source_reader
                     ? impl_->source_reader
@@ -3360,9 +3423,12 @@ namespace lfs::io::project {
         if (commit.wallclock_unix_ns == 0) {
             commit.wallclock_unix_ns = unix_time_ns();
         }
-        if (impl_->checkpoints.size() == 1) {
-            const auto& snapshot_uuid =
-                impl_->checkpoints.begin()->first;
+        auto bound_checkpoint = bound_checkpoint_uuid();
+        if (!bound_checkpoint) {
+            return std::move(bound_checkpoint).error();
+        }
+        if (*bound_checkpoint) {
+            const auto& snapshot_uuid = **bound_checkpoint;
             if (commit.snapshot_uuid.is_nil()) {
                 commit.snapshot_uuid = snapshot_uuid;
             } else if (commit.snapshot_uuid != snapshot_uuid) {
@@ -3375,6 +3441,12 @@ namespace lfs::io::project {
                         snapshot_uuid.to_string()),
                     "commit.snapshot_uuid");
             }
+        }
+        if (impl_->checkpoints.size() > 1) {
+            commit.min_reader_version = std::max(
+                commit.min_reader_version, CURRENT_CONTAINER_VERSION);
+            commit.min_safe_writer_version = std::max(
+                commit.min_safe_writer_version, CURRENT_CONTAINER_VERSION);
         }
         if (is_autosave && commit.snapshot_uuid.is_nil()) {
             commit.snapshot_uuid =
@@ -4582,10 +4654,18 @@ namespace lfs::io::project {
             std::optional<lfs::core::param::TrainingParameters>
                 checkpoint_params;
             MaterializeRetirementSink ckpt_retirement;
+            auto bound_checkpoint = bound_checkpoint_uuid();
+            if (!bound_checkpoint) {
+                return std::move(bound_checkpoint).error();
+            }
             staged_checkpoint_splats.reserve(
-                impl_->checkpoints.size());
+                bound_checkpoint->has_value() ? 1 : 0);
             for (const auto& [uuid, payload] :
                  impl_->checkpoints) {
+                if (!bound_checkpoint->has_value() ||
+                    uuid != **bound_checkpoint) {
+                    continue;
+                }
                 std::optional<lfs::core::SplatData>
                     materialized;
                 const auto ckpt_started =

--- a/src/training/rasterization/edge_compute/rasterization/src/rasterization_api.cu
+++ b/src/training/rasterization/edge_compute/rasterization/src/rasterization_api.cu
@@ -61,7 +61,7 @@ namespace edge_compute::rasterization {
         uint64_t frame_id = arena.begin_frame(stream);
 
         // Get arena allocator for this frame
-        auto arena_allocator = arena.get_allocator(frame_id);
+        auto arena_allocator = arena.get_allocator(frame_id, "edge_compute.forward");
 
         try {
             // Workspace queries are part of the allocation transaction: if CUB
@@ -156,7 +156,7 @@ namespace edge_compute::rasterization {
         const int n_tiles = static_cast<int>(grid.x * grid.y);
         auto& arena = lfs::core::GlobalArenaManager::instance().get_arena();
         const uint64_t frame_id = arena.begin_frame(stream);
-        auto arena_allocator = arena.get_allocator(frame_id);
+        auto arena_allocator = arena.get_allocator(frame_id, "edge_compute.legacy");
         try {
             const size_t primitive_size = required<PerPrimitiveBuffers>(n_primitives);
             const size_t tile_size = required<PerTileBuffers>(n_tiles);

--- a/src/training/rasterization/fastgs/rasterization/src/rasterization_api.cu
+++ b/src/training/rasterization/fastgs/rasterization/src/rasterization_api.cu
@@ -294,8 +294,13 @@ namespace fast_lfs::rasterization {
                 n_tiles);
 
             // Get arena allocator for this frame
-            auto arena_allocator = arena->get_allocator(frame_id);
-            auto phase_arena = std::make_shared<FastGSPhaseArena>(arena_allocator, stream);
+            auto per_primitive_allocator =
+                arena->get_allocator(frame_id, "fastgs.per_primitive");
+            auto per_tile_allocator =
+                arena->get_allocator(frame_id, "fastgs.per_tile");
+            auto sort_phase_allocator =
+                arena->get_allocator(frame_id, "fastgs.sort_phase");
+            auto phase_arena = std::make_shared<FastGSPhaseArena>(sort_phase_allocator, stream);
             auto phase_forward_allocator =
                 phase_arena->allocator(FastGSPhaseArena::Phase::Forward);
             auto phase_backward_allocator =
@@ -305,7 +310,7 @@ namespace fast_lfs::rasterization {
             // visibility bookkeeping and compact primitive buffers through the
             // primitive callback after it knows this step's visible count.
             const size_t per_tile_size = required<PerTileBuffers>(n_tiles);
-            char* per_tile_buffers_blob = arena_allocator(per_tile_size);
+            char* per_tile_buffers_blob = per_tile_allocator(per_tile_size);
 
             if (!per_tile_buffers_blob) {
                 return fail("OUT_OF_MEMORY: Failed to allocate tile buffers from arena", true);
@@ -313,7 +318,7 @@ namespace fast_lfs::rasterization {
 
             // Create allocation wrappers
             std::function<char*(size_t)> per_primitive_buffers_func =
-                arena_allocator;
+                per_primitive_allocator;
 
             std::function<char*(size_t)> per_tile_buffers_func =
                 [&per_tile_buffers_blob](size_t size) -> char* {
@@ -415,6 +420,8 @@ namespace fast_lfs::rasterization {
             last_forward_error = e.what();
             ForwardContext error_ctx = {};
             error_ctx.success = false;
+            error_ctx.resource_exhausted =
+                last_forward_error.find("OUT_OF_MEMORY") != std::string::npos;
             error_ctx.error_message = last_forward_error.c_str();
             error_ctx.frame_id = frame_id;
             return error_ctx;

--- a/src/training/rasterization/gsplat/Intersect.cpp
+++ b/src/training/rasterization/gsplat/Intersect.cpp
@@ -5,13 +5,17 @@
 #include "Intersect.h"
 #include "Common.h"
 #include "Ops.h"
+#include "core/cuda/vmm_device_buffer.hpp"
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cuda_runtime.h>
 #include <format>
 #include <limits>
+#include <optional>
 #include <string_view>
 #include <utility>
 
@@ -19,11 +23,44 @@ namespace gsplat_lfs {
 
     namespace {
         struct IntersectBufferCache {
-            DirectDeviceBuffer cum_tiles;
-            // Each id/value pair is one exact block. This avoids paying the
-            // allocator's quantization independently for the two arrays.
-            DirectDeviceBuffer isect_pair;
-            DirectDeviceBuffer sort_pair;
+            struct RollingPeak {
+                static constexpr size_t kBucketCalls = 256;
+                static constexpr size_t kBucketCount = 2;
+
+                std::array<size_t, kBucketCount> maxima{};
+                std::array<size_t, kBucketCount> counts{};
+                size_t active_bucket = 0;
+                size_t samples = 0;
+
+                void observe(const size_t value) {
+                    if (counts[active_bucket] == kBucketCalls) {
+                        active_bucket = (active_bucket + 1) % kBucketCount;
+                        counts[active_bucket] = 0;
+                        maxima[active_bucket] = 0;
+                    }
+                    maxima[active_bucket] = std::max(maxima[active_bucket], value);
+                    ++counts[active_bucket];
+                    ++samples;
+                }
+
+                [[nodiscard]] size_t peak() const noexcept {
+                    return std::max(maxima[0], maxima[1]);
+                }
+
+                [[nodiscard]] bool has_samples() const noexcept {
+                    return samples != 0;
+                }
+            };
+
+            static constexpr size_t kTrimWindowCalls = 512;
+            static constexpr size_t kTrimHysteresisBytes = 64u * 1024u * 1024u;
+
+            lfs::core::VmmDeviceBuffer cum_tiles;
+            // Separate regions keep both addresses stable as the count grows.
+            std::optional<lfs::core::VmmDeviceBuffer> isect_ids_storage;
+            std::optional<lfs::core::VmmDeviceBuffer> isect_values_storage;
+            std::optional<lfs::core::VmmDeviceBuffer> sort_ids_storage;
+            std::optional<lfs::core::VmmDeviceBuffer> sort_values_storage;
             size_t cum_tiles_capacity = 0;
             size_t isect_capacity = 0;
             size_t sort_capacity = 0;
@@ -35,7 +72,12 @@ namespace gsplat_lfs {
             size_t cub_sort_ws_bytes = 0;
             int64_t cub_sort_n = 0;
             uint32_t cub_sort_end_bit = 0;
-            size_t pending_isect_capacity = 0;
+            RollingPeak cum_tiles_peak;
+            RollingPeak isect_peak;
+            size_t call_count = 0;
+            bool trim_used_in_window = false;
+            cudaStream_t bound_stream = nullptr;
+            bool has_bound_stream = false;
 
             IntersectBufferCache() {
 #if CUDART_VERSION >= 11020
@@ -56,70 +98,242 @@ namespace gsplat_lfs {
                 }
             }
 
-            static size_t pair_bytes(const size_t count) {
-                return checked_bytes(
-                    count, sizeof(int64_t) + sizeof(int32_t),
-                    "gsplat intersection id/value pair");
+            [[nodiscard]] size_t granularity_bytes() const noexcept {
+                if (cum_tiles) {
+                    return cum_tiles.granularity_bytes();
+                }
+                if (isect_ids_storage) {
+                    return isect_ids_storage->granularity_bytes();
+                }
+                if (isect_values_storage) {
+                    return isect_values_storage->granularity_bytes();
+                }
+                if (sort_ids_storage) {
+                    return sort_ids_storage->granularity_bytes();
+                }
+                if (sort_values_storage) {
+                    return sort_values_storage->granularity_bytes();
+                }
+                return lfs::core::VmmDeviceBuffer::kGranularityBytes;
+            }
+
+            size_t pair_reservation_bytes(const size_t element_bytes) const {
+                constexpr size_t kMaxIntersectionCount =
+                    static_cast<size_t>(std::numeric_limits<int32_t>::max());
+                constexpr size_t kPairBytes =
+                    kMaxIntersectionCount * (sizeof(int64_t) + sizeof(int32_t));
+
+                size_t free_bytes = 0;
+                size_t total_bytes = 0;
+                LFS_CUDA_CHECK_MSG(cudaMemGetInfo(&free_bytes, &total_bytes),
+                                   "gsplat VMM intersection reservation sizing");
+                (void)free_bytes;
+                const size_t granularity = granularity_bytes();
+                const size_t pair_budget = std::max(
+                    granularity, (std::min(total_bytes, kPairBytes) / granularity) * granularity);
+                const size_t element_budget = pair_budget / (sizeof(int64_t) + sizeof(int32_t));
+                return std::max(
+                    granularity,
+                    ((element_budget * element_bytes + granularity - 1) / granularity) *
+                        granularity);
+            }
+
+            static lfs::core::VmmDeviceBuffer create_vmm_buffer(
+                const size_t reservation_bytes, const char* label) {
+                auto result = lfs::core::VmmDeviceBuffer::create(reservation_bytes, label);
+                if (!result) {
+                    throw lfs::Exception(std::move(result).error());
+                }
+                return std::move(*result);
+            }
+
+            static void commit_vmm_buffer(lfs::core::VmmDeviceBuffer& buffer,
+                                          const size_t bytes) {
+                auto result = buffer.commit(bytes);
+                if (!result) {
+                    throw lfs::Exception(std::move(result).error());
+                }
+            }
+
+            static void decommit_vmm_buffer(lfs::core::VmmDeviceBuffer& buffer,
+                                            const size_t bytes) {
+                auto result = buffer.decommit_tail(bytes);
+                if (!result) {
+                    throw lfs::Exception(std::move(result).error());
+                }
+            }
+
+            static bool exceeds_hysteresis(const lfs::core::VmmDeviceBuffer& buffer,
+                                           const size_t required_bytes) {
+                return buffer && buffer.committed_bytes() > required_bytes &&
+                       buffer.committed_bytes() - required_bytes >= kTrimHysteresisBytes;
+            }
+
+            void update_capacities() {
+                cum_tiles_capacity = cum_tiles
+                                         ? cum_tiles.committed_bytes() / sizeof(int64_t)
+                                         : 0;
+                isect_capacity = isect_ids_storage && isect_values_storage
+                                     ? std::min(
+                                           isect_ids_storage->committed_bytes() / sizeof(int64_t),
+                                           isect_values_storage->committed_bytes() / sizeof(int32_t))
+                                     : 0;
+                sort_capacity = sort_ids_storage && sort_values_storage
+                                    ? std::min(
+                                          sort_ids_storage->committed_bytes() / sizeof(int64_t),
+                                          sort_values_storage->committed_bytes() / sizeof(int32_t))
+                                    : 0;
+            }
+
+            void trim_to_recent_peak() {
+                if (trim_used_in_window || !has_bound_stream) {
+                    return;
+                }
+
+                const size_t cum_need = cum_tiles_peak.has_samples()
+                                            ? checked_bytes(cum_tiles_peak.peak(), sizeof(int64_t),
+                                                            "gsplat cumulative tile trim")
+                                            : 0;
+                const size_t isect_need = isect_peak.has_samples()
+                                              ? checked_bytes(isect_peak.peak(), sizeof(int64_t),
+                                                              "gsplat intersection trim")
+                                              : 0;
+                const size_t value_need = isect_peak.has_samples()
+                                              ? checked_bytes(isect_peak.peak(), sizeof(int32_t),
+                                                              "gsplat flatten-id trim")
+                                              : 0;
+                const bool should_trim =
+                    exceeds_hysteresis(cum_tiles, cum_need) ||
+                    (isect_ids_storage && exceeds_hysteresis(*isect_ids_storage, isect_need)) ||
+                    (isect_values_storage &&
+                     exceeds_hysteresis(*isect_values_storage, value_need)) ||
+                    (sort_ids_storage && exceeds_hysteresis(*sort_ids_storage, isect_need)) ||
+                    (sort_values_storage &&
+                     exceeds_hysteresis(*sort_values_storage, value_need));
+                if (!should_trim) {
+                    return;
+                }
+
+                if (sort_reuse_event && sort_reuse_event_recorded) {
+                    LFS_CUDA_CHECK_MSG(
+                        cudaEventSynchronize(sort_reuse_event),
+                        "gsplat sort-cache trim event wait");
+                }
+                if (n_isects_ready_event) {
+                    LFS_CUDA_CHECK_MSG(
+                        cudaEventSynchronize(n_isects_ready_event),
+                        "gsplat intersection-count trim event wait");
+                }
+                LFS_CUDA_CHECK_MSG(
+                    cudaStreamSynchronize(bound_stream),
+                    "gsplat intersection-cache trim stream wait");
+
+                if (cum_tiles) {
+                    decommit_vmm_buffer(cum_tiles, cum_need);
+                }
+                if (isect_ids_storage) {
+                    decommit_vmm_buffer(*isect_ids_storage, isect_need);
+                }
+                if (isect_values_storage) {
+                    decommit_vmm_buffer(*isect_values_storage, value_need);
+                }
+                if (sort_ids_storage) {
+                    decommit_vmm_buffer(*sort_ids_storage, isect_need);
+                }
+                if (sort_values_storage) {
+                    decommit_vmm_buffer(*sort_values_storage, value_need);
+                }
+                update_capacities();
+                cub_sort_ws_bytes = 0;
+                cub_sort_n = 0;
+                trim_used_in_window = true;
+            }
+
+            void begin_call(const size_t n_elements, cudaStream_t stream) {
+                ++call_count;
+                if (call_count > 1 && (call_count - 1) % kTrimWindowCalls == 0) {
+                    trim_used_in_window = false;
+                }
+                cum_tiles_peak.observe(n_elements);
+                if (has_bound_stream && bound_stream != stream) {
+                    LFS_CUDA_CHECK_MSG(
+                        cudaStreamSynchronize(bound_stream),
+                        "gsplat intersection-cache stream handoff");
+                }
+                trim_to_recent_peak();
+                bound_stream = stream;
+                has_bound_stream = true;
+            }
+
+            void finish_call(const int64_t n_isects) {
+                if (n_isects >= 0) {
+                    isect_peak.observe(static_cast<size_t>(n_isects));
+                }
             }
 
             int64_t* isect_ids() const {
-                return isect_pair.as<int64_t>();
+                return isect_ids_storage ? isect_ids_storage->as<int64_t>() : nullptr;
             }
 
             int32_t* flatten_ids() const {
-                return reinterpret_cast<int32_t*>(
-                    static_cast<std::byte*>(isect_pair.get()) +
-                    isect_capacity * sizeof(int64_t));
+                return isect_values_storage ? isect_values_storage->as<int32_t>() : nullptr;
             }
 
             int64_t* sorted_isect_ids() const {
-                return sort_pair.as<int64_t>();
+                return sort_ids_storage ? sort_ids_storage->as<int64_t>() : nullptr;
             }
 
             int32_t* sorted_flatten_ids() const {
-                return reinterpret_cast<int32_t*>(
-                    static_cast<std::byte*>(sort_pair.get()) +
-                    sort_capacity * sizeof(int64_t));
+                return sort_values_storage ? sort_values_storage->as<int32_t>() : nullptr;
             }
 
             void ensure_cum_tiles(size_t n_elements, cudaStream_t stream) {
+                (void)stream;
                 if (n_elements <= cum_tiles_capacity && cum_tiles) {
-                    cum_tiles.bind_stream(stream);
                     return;
                 }
                 if (n_elements > cum_tiles_capacity) {
-                    const size_t new_cap = n_elements;
-                    DirectDeviceBuffer replacement(
-                        checked_bytes(new_cap, sizeof(int64_t), "gsplat cumulative tiles"),
-                        stream,
-                        "rasterizer.gsplat.cumulative_tiles");
-
-                    cum_tiles = std::move(replacement);
-                    cum_tiles_capacity = new_cap;
+                    if (!cum_tiles) {
+                        cum_tiles = create_vmm_buffer(
+                            pair_reservation_bytes(sizeof(int64_t)),
+                            "rasterizer.gsplat.cumulative_tiles");
+                    }
+                    commit_vmm_buffer(
+                        cum_tiles,
+                        checked_bytes(n_elements, sizeof(int64_t),
+                                      "gsplat cumulative tiles"));
+                    cum_tiles_capacity = cum_tiles.committed_bytes() / sizeof(int64_t);
                 }
-            }
-
-            static size_t grow_cap(size_t current, size_t needed) {
-                if (needed <= current) {
-                    return current;
-                }
-                return needed + needed / 4;
             }
 
             void ensure_isect_buffers(size_t n_isects, cudaStream_t stream) {
+                (void)stream;
                 if (n_isects == 0) {
                     return;
                 }
                 if (n_isects <= isect_capacity) {
-                    isect_pair.bind_stream(stream);
                     return;
                 }
-                const size_t new_cap = grow_cap(isect_capacity, n_isects);
-                DirectDeviceBuffer replacement(
-                    pair_bytes(new_cap), stream,
-                    "rasterizer.gsplat.intersection_id_value_pair");
-                isect_pair = std::move(replacement);
-                isect_capacity = new_cap;
+                if (!isect_ids_storage) {
+                    isect_ids_storage = create_vmm_buffer(
+                        pair_reservation_bytes(sizeof(int64_t)),
+                        "rasterizer.gsplat.intersection_ids");
+                }
+                if (!isect_values_storage) {
+                    isect_values_storage = create_vmm_buffer(
+                        pair_reservation_bytes(sizeof(int32_t)),
+                        "rasterizer.gsplat.intersection_flatten_ids");
+                }
+                commit_vmm_buffer(
+                    *isect_ids_storage,
+                    checked_bytes(n_isects, sizeof(int64_t), "gsplat intersection ids"));
+                commit_vmm_buffer(
+                    *isect_values_storage,
+                    checked_bytes(n_isects, sizeof(int32_t),
+                                  "gsplat intersection flatten ids"));
+                isect_capacity = std::min(
+                    isect_ids_storage->committed_bytes() / sizeof(int64_t),
+                    isect_values_storage->committed_bytes() / sizeof(int32_t));
                 cub_sort_ws_bytes = 0;
                 cub_sort_n = 0;
             }
@@ -136,16 +350,29 @@ namespace gsplat_lfs {
                         "gsplat sort-cache stream handoff");
                 }
                 if (n_isects > sort_capacity) {
-                    const size_t new_cap = grow_cap(sort_capacity, n_isects);
-                    DirectDeviceBuffer replacement(
-                        pair_bytes(new_cap), stream,
-                        "rasterizer.gsplat.sorted_intersection_id_value_pair");
-                    sort_pair = std::move(replacement);
-                    sort_capacity = new_cap;
+                    if (!sort_ids_storage) {
+                        sort_ids_storage = create_vmm_buffer(
+                            pair_reservation_bytes(sizeof(int64_t)),
+                            "rasterizer.gsplat.sorted_intersection_ids");
+                    }
+                    if (!sort_values_storage) {
+                        sort_values_storage = create_vmm_buffer(
+                            pair_reservation_bytes(sizeof(int32_t)),
+                            "rasterizer.gsplat.sorted_intersection_flatten_ids");
+                    }
+                    commit_vmm_buffer(
+                        *sort_ids_storage,
+                        checked_bytes(n_isects, sizeof(int64_t),
+                                      "gsplat sorted intersection ids"));
+                    commit_vmm_buffer(
+                        *sort_values_storage,
+                        checked_bytes(n_isects, sizeof(int32_t),
+                                      "gsplat sorted intersection flatten ids"));
+                    sort_capacity = std::min(
+                        sort_ids_storage->committed_bytes() / sizeof(int64_t),
+                        sort_values_storage->committed_bytes() / sizeof(int32_t));
                     cub_sort_ws_bytes = 0;
                     cub_sort_n = 0;
-                } else {
-                    sort_pair.bind_stream(stream);
                 }
             }
 
@@ -171,16 +398,23 @@ namespace gsplat_lfs {
             }
 
             bool release() noexcept {
-                cum_tiles.reset();
-                isect_pair.reset();
-                sort_pair.reset();
+                cum_tiles.release();
+                isect_ids_storage.reset();
+                isect_values_storage.reset();
+                sort_ids_storage.reset();
+                sort_values_storage.reset();
                 cum_tiles_capacity = 0;
                 isect_capacity = 0;
                 sort_capacity = 0;
+                cum_tiles_peak = {};
+                isect_peak = {};
+                call_count = 0;
+                trim_used_in_window = false;
+                bound_stream = nullptr;
+                has_bound_stream = false;
                 cub_sort_ws_bytes = 0;
                 cub_sort_n = 0;
                 cub_sort_end_bit = 0;
-                pending_isect_capacity = 0;
                 cudaEvent_t event = std::exchange(sort_reuse_event, nullptr);
                 sort_reuse_event_recorded = false;
                 if (event) {
@@ -196,7 +430,8 @@ namespace gsplat_lfs {
                 // mid-process release does not break a later forward on this thread.
                 const bool cub_released = release_gsplat_cub_workspace();
                 const bool color_grad_released = release_gsplat_color_grad_workspace();
-                return !cum_tiles && !isect_pair && !sort_pair &&
+                return !cum_tiles && !isect_ids_storage && !isect_values_storage &&
+                       !sort_ids_storage && !sort_values_storage &&
                        sort_reuse_event == nullptr && cub_released &&
                        color_grad_released;
             }
@@ -270,6 +505,9 @@ namespace gsplat_lfs {
             return result;
         }
 
+        auto& cache = get_cache();
+        cache.begin_call(n_elements, stream);
+
         launch_intersect_tile_kernel(
             means2d, radii, depths,
             nullptr, nullptr,
@@ -280,7 +518,6 @@ namespace gsplat_lfs {
             nullptr, nullptr,
             stream);
 
-        auto& cache = get_cache();
         cache.ensure_cum_tiles(n_elements, stream);
         int64_t* d_cum_tiles = cache.cum_tiles.as<int64_t>();
         compute_cumsum_gpu(tiles_per_gauss_out, d_cum_tiles, n_elements, stream);
@@ -308,16 +545,6 @@ namespace gsplat_lfs {
             return n;
         };
 
-        auto schedule_proactive_grow = [&](const int64_t n) {
-            if (n > 0 && n * 5 > static_cast<int64_t>(cache.isect_capacity) * 4) {
-                const size_t count = static_cast<size_t>(n);
-                const size_t want = count + count / 4;
-                if (want > cache.isect_capacity) {
-                    cache.pending_isect_capacity = want;
-                }
-            }
-        };
-
         LFS_CUDA_CHECK_MSG(
             cudaMemcpyAsync(cache.h_n_isects_pinned, d_cum_tiles + n_elements - 1,
                             sizeof(int64_t), cudaMemcpyDeviceToHost, stream),
@@ -327,11 +554,6 @@ namespace gsplat_lfs {
                 cudaEventRecord(cache.n_isects_ready_event, stream),
                 "gsplat n_isects event record");
         }
-
-        if (cache.pending_isect_capacity > cache.isect_capacity) {
-            cache.ensure_isect_buffers(cache.pending_isect_capacity, stream);
-        }
-        cache.pending_isect_capacity = 0;
 
         auto fill_and_sort_capacity = [&](const size_t cap) {
             cache.ensure_isect_buffers(cap, stream);
@@ -386,12 +608,13 @@ namespace gsplat_lfs {
             const int64_t n_isects = drain_count();
             result.n_isects = static_cast<int32_t>(n_isects);
             if (n_isects == 0) {
+                cache.finish_call(n_isects);
                 launch_offsets();
                 return result;
             }
             fill_and_sort_capacity(static_cast<size_t>(n_isects));
             launch_offsets();
-            schedule_proactive_grow(n_isects);
+            cache.finish_call(n_isects);
             return result;
         }
 
@@ -406,10 +629,9 @@ namespace gsplat_lfs {
                                "gsplat intersection overflow drain");
             fill_and_sort_capacity(static_cast<size_t>(n_isects));
             launch_offsets();
-        } else {
-            schedule_proactive_grow(n_isects);
         }
 
+        cache.finish_call(n_isects);
         return result;
     }
 

--- a/src/training/rasterization/gsplat/Intersect.cpp
+++ b/src/training/rasterization/gsplat/Intersect.cpp
@@ -103,14 +103,7 @@ namespace gsplat_lfs {
                 if (needed <= current) {
                     return current;
                 }
-                size_t grown = current * 2;
-                if (grown < needed * 2) {
-                    grown = needed * 2;
-                }
-                if (grown < needed) {
-                    grown = needed;
-                }
-                return grown;
+                return needed + needed / 4;
             }
 
             void ensure_isect_buffers(size_t n_isects, cudaStream_t stream) {
@@ -317,7 +310,8 @@ namespace gsplat_lfs {
 
         auto schedule_proactive_grow = [&](const int64_t n) {
             if (n > 0 && n * 5 > static_cast<int64_t>(cache.isect_capacity) * 4) {
-                const size_t want = static_cast<size_t>(n) * 2;
+                const size_t count = static_cast<size_t>(n);
+                const size_t want = count + count / 4;
                 if (want > cache.isect_capacity) {
                     cache.pending_isect_capacity = want;
                 }

--- a/src/training/rasterization/gsplat/Ops.h
+++ b/src/training/rasterization/gsplat/Ops.h
@@ -253,6 +253,8 @@ namespace gsplat_lfs {
         float* v_opacities,                   // [C, N]
         float* densification_info,            // [2, N] flattened or nullptr
         const float* densification_error_map, // [H, W] or nullptr
+        const float* edge_weight_map,         // [H, W] or nullptr
+        float* edge_score_out,                // [N] or nullptr
         cudaStream_t stream = nullptr);
 
     //=========================================================================
@@ -381,6 +383,8 @@ namespace gsplat_lfs {
         float* v_sh_coeffs,                   // [N, K, 3]
         float* densification_info,            // [2, N] flattened or nullptr
         const float* densification_error_map, // [H, W] or nullptr
+        const float* edge_weight_map,         // [H, W] or nullptr
+        float* edge_score_out,                // [N] or nullptr
         cudaStream_t stream = nullptr);
 
 } // namespace gsplat_lfs

--- a/src/training/rasterization/gsplat/Rasterization.cpp
+++ b/src/training/rasterization/gsplat/Rasterization.cpp
@@ -138,6 +138,8 @@ namespace gsplat_lfs {
         float* v_opacities,
         float* densification_info,
         const float* densification_error_map,
+        const float* edge_weight_map,
+        float* edge_score_out,
         cudaStream_t stream) {
         gsplat_lfs::debug_validate_cuda_pointer(means, "means");
         gsplat_lfs::debug_validate_cuda_pointer(quats, "quats");
@@ -168,7 +170,8 @@ namespace gsplat_lfs {
             render_alphas, last_ids,                                 \
             v_render_colors, v_render_alphas,                        \
             v_means, v_quats, v_scales, v_colors, v_opacities,       \
-            densification_info, densification_error_map, stream);    \
+            densification_info, densification_error_map,             \
+            edge_weight_map, edge_score_out, stream);                \
         break;
 
         switch (channels) {
@@ -369,6 +372,8 @@ namespace gsplat_lfs {
         float* v_sh_coeffs,
         float* densification_info,
         const float* densification_error_map,
+        const float* edge_weight_map,
+        float* edge_score_out,
         cudaStream_t stream) {
         // Determine output channels
         uint32_t channels = 3;
@@ -404,6 +409,7 @@ namespace gsplat_lfs {
             v_render_colors, v_render_alphas,
             v_means, v_quats, v_scales, v_colors, v_opacities,
             densification_info, densification_error_map,
+            edge_weight_map, edge_score_out,
             stream);
 
         // Backward through SH

--- a/src/training/rasterization/gsplat/Rasterization.h
+++ b/src/training/rasterization/gsplat/Rasterization.h
@@ -100,6 +100,8 @@ namespace gsplat_lfs {
         float* v_opacities,                   // [C, N]
         float* densification_info,            // [2, N] flattened or nullptr
         const float* densification_error_map, // [H, W] or nullptr
+        const float* edge_weight_map,         // [H, W] or nullptr
+        float* edge_score_out,                // [N] or nullptr
         cudaStream_t stream = nullptr);
 
     /////////////////////////////////////////////////

--- a/src/training/rasterization/gsplat/RasterizeToPixelsFromWorld3DGSBwd.cu
+++ b/src/training/rasterization/gsplat/RasterizeToPixelsFromWorld3DGSBwd.cu
@@ -99,6 +99,7 @@ namespace gsplat_lfs {
         pix.pixel_error = do_dens ? densification_error_map[pix.pix_id] : 0.f;
     }
 
+    template <bool kEdgeScoring>
     __device__ __forceinline__ bool contribute_pixel(
         PixelBwd& pix,
         const int32_t isect_idx,
@@ -120,6 +121,8 @@ namespace gsplat_lfs {
         float& v_opacity,
         float& dens_w,
         float& dens_e,
+        const float* edge_weight_map,
+        float& edge_score,
         mat3& R,
         bool& have_R) {
         bool valid = pix.active;
@@ -143,6 +146,13 @@ namespace gsplat_lfs {
         const float ra = 1.0f / (1.0f - alpha);
         pix.T *= ra;
         const float fac = alpha * pix.T;
+        if constexpr (kEdgeScoring) {
+            const float edge_weight = edge_weight_map[pix.pix_id];
+            const float edge_contribution = fac * edge_weight;
+            if (edge_weight > 0.0f && isfinite(edge_contribution)) {
+                edge_score += edge_contribution;
+            }
+        }
         v_rgb[0] += fac * pix.v_render_c[0];
         v_rgb[1] += fac * pix.v_render_c[1];
         v_rgb[2] += fac * pix.v_render_c[2];
@@ -184,7 +194,7 @@ namespace gsplat_lfs {
         return true;
     }
 
-    template <bool kSharedOrigin>
+    template <bool kSharedOrigin, bool kEdgeScoring>
     __device__ __forceinline__ void contribute_pixel_pair(
         PixelBwd& pix0,
         PixelBwd& pix1,
@@ -205,6 +215,8 @@ namespace gsplat_lfs {
         float& v_opacity,
         float& dens_w,
         float& dens_e,
+        const float* edge_weight_map,
+        float& edge_score,
         bool& hit0,
         bool& hit1) {
         const float opac = xyz_opac[3];
@@ -224,14 +236,14 @@ namespace gsplat_lfs {
         }
         mat3 R;
         bool have_R = false;
-        hit0 = contribute_pixel(
+        hit0 = contribute_pixel<kEdgeScoring>(
             pix0, isect_idx, opac, Mt, gro0, o_minus_mu0, scale_act, quat,
             rgb0, rgb1, rgb2, have_bg, do_dens, v_rgb, v_mean, v_scale, v_quat,
-            v_opacity, dens_w, dens_e, R, have_R);
-        hit1 = contribute_pixel(
+            v_opacity, dens_w, dens_e, edge_weight_map, edge_score, R, have_R);
+        hit1 = contribute_pixel<kEdgeScoring>(
             pix1, isect_idx, opac, Mt, gro1, o_minus_mu1, scale_act, quat,
             rgb0, rgb1, rgb2, have_bg, do_dens, v_rgb, v_mean, v_scale, v_quat,
-            v_opacity, dens_w, dens_e, R, have_R);
+            v_opacity, dens_w, dens_e, edge_weight_map, edge_score, R, have_R);
     }
 
     __device__ __forceinline__ float reduce_field(float v, const unsigned n_contrib, const int src_lane) {
@@ -288,7 +300,7 @@ namespace gsplat_lfs {
         }
     }
 
-    template <typename scalar_t, bool kSharedOrigin, bool kPerfectPinhole>
+    template <typename scalar_t, bool kSharedOrigin, bool kPerfectPinhole, bool kEdgeScoring>
     __global__ void rasterize_to_pixels_from_world_3dgs_bwd_dual_kernel(
         const uint32_t C,
         const uint32_t N,
@@ -328,7 +340,9 @@ namespace gsplat_lfs {
         scalar_t* __restrict__ v_colors,
         scalar_t* __restrict__ v_opacities,
         float* __restrict__ densification_info,
-        const scalar_t* __restrict__ densification_error_map) {
+        const scalar_t* __restrict__ densification_error_map,
+        const float* __restrict__ edge_weight_map,
+        float* __restrict__ edge_score_out) {
         auto block = cg::this_thread_block();
         const uint32_t cid = block.group_index().x;
         const uint32_t tile_id =
@@ -352,6 +366,10 @@ namespace gsplat_lfs {
         }
         if (masks != nullptr) {
             masks += cid * tile_height * tile_width;
+        }
+        if constexpr (kEdgeScoring) {
+            edge_weight_map += cid * image_height * image_width;
+            edge_score_out += cid * N;
         }
         if (masks != nullptr && !masks[tile_id]) {
             return;
@@ -386,6 +404,10 @@ namespace gsplat_lfs {
         vec4* quat_batch = reinterpret_cast<vec4*>(&scale_batch[kBwdDualBatch]);
         mat3* mt_batch = reinterpret_cast<mat3*>(&quat_batch[kBwdDualBatch]);
         float* rgbs_batch = reinterpret_cast<float*>(&mt_batch[kBwdDualBatch]);
+        float* edge_score_batch = nullptr;
+        if constexpr (kEdgeScoring) {
+            edge_score_batch = reinterpret_cast<float*>(&rgbs_batch[kBwdDualBatch * 3u]);
+        }
 
         const uint32_t tr = block.thread_rank();
         cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
@@ -417,6 +439,12 @@ namespace gsplat_lfs {
 
         for (uint32_t b = 0; b < num_batches; ++b) {
             block.sync();
+            if constexpr (kEdgeScoring) {
+                for (uint32_t slot = tr; slot < kBwdDualBatch; slot += block.size()) {
+                    edge_score_batch[slot] = 0.f;
+                }
+                block.sync();
+            }
             const int32_t batch_end = range_end - 1 - static_cast<int32_t>(kBwdDualBatch * b);
             const int32_t batch_size = min(static_cast<int32_t>(kBwdDualBatch), batch_end + 1 - range_start);
             stage_splat(batch_end - static_cast<int32_t>(tr), tr);
@@ -440,50 +468,71 @@ namespace gsplat_lfs {
                 float v_opacity_local = 0.f;
                 float densification_weight_local = 0.f;
                 float densification_error_weighted_local = 0.f;
+                float edge_score_local = 0.f;
 
                 bool hit0 = false;
                 bool hit1 = false;
-                contribute_pixel_pair<kSharedOrigin>(
+                contribute_pixel_pair<kSharedOrigin, kEdgeScoring>(
                     pix0, pix1, isect_idx, xyz_opac, Mt, scale_act, quat, rgb0, rgb1, rgb2,
                     have_bg, do_dens, v_rgb_local, v_mean_local, v_scale_local, v_quat_local,
                     v_opacity_local, densification_weight_local, densification_error_weighted_local,
-                    hit0, hit1);
+                    edge_weight_map, edge_score_local, hit0, hit1);
 
                 const unsigned valid_mask = __ballot_sync(0xffffffffu, hit0 || hit1);
                 if (valid_mask == 0u) {
-                    continue;
+                    if constexpr (!kEdgeScoring) {
+                        continue;
+                    }
                 }
-                const unsigned n_contrib = __popc(valid_mask);
-                const int src_lane = __ffs(valid_mask) - 1;
-                v_rgb_local[0] = reduce_field(v_rgb_local[0], n_contrib, src_lane);
-                v_rgb_local[1] = reduce_field(v_rgb_local[1], n_contrib, src_lane);
-                v_rgb_local[2] = reduce_field(v_rgb_local[2], n_contrib, src_lane);
-                v_mean_local.x = reduce_field(v_mean_local.x, n_contrib, src_lane);
-                v_mean_local.y = reduce_field(v_mean_local.y, n_contrib, src_lane);
-                v_mean_local.z = reduce_field(v_mean_local.z, n_contrib, src_lane);
-                v_scale_local.x = reduce_field(v_scale_local.x, n_contrib, src_lane);
-                v_scale_local.y = reduce_field(v_scale_local.y, n_contrib, src_lane);
-                v_scale_local.z = reduce_field(v_scale_local.z, n_contrib, src_lane);
-                v_quat_local.x = reduce_field(v_quat_local.x, n_contrib, src_lane);
-                v_quat_local.y = reduce_field(v_quat_local.y, n_contrib, src_lane);
-                v_quat_local.z = reduce_field(v_quat_local.z, n_contrib, src_lane);
-                v_quat_local.w = reduce_field(v_quat_local.w, n_contrib, src_lane);
-                v_opacity_local = reduce_field(v_opacity_local, n_contrib, src_lane);
-                densification_weight_local = reduce_field(densification_weight_local, n_contrib, src_lane);
-                densification_error_weighted_local =
-                    reduce_field(densification_error_weighted_local, n_contrib, src_lane);
-                if (warp.thread_rank() == 0) {
-                    flush_splat_grads(
-                        id_batch[t], N, do_dens, v_rgb_local, v_mean_local, v_scale_local,
-                        v_quat_local, v_opacity_local, densification_weight_local,
-                        densification_error_weighted_local, scale_act, xyz_opac[3],
-                        v_means, v_quats, v_scales, v_colors, v_opacities, densification_info);
+                if (valid_mask != 0u) {
+                    const unsigned n_contrib = __popc(valid_mask);
+                    const int src_lane = __ffs(valid_mask) - 1;
+                    v_rgb_local[0] = reduce_field(v_rgb_local[0], n_contrib, src_lane);
+                    v_rgb_local[1] = reduce_field(v_rgb_local[1], n_contrib, src_lane);
+                    v_rgb_local[2] = reduce_field(v_rgb_local[2], n_contrib, src_lane);
+                    v_mean_local.x = reduce_field(v_mean_local.x, n_contrib, src_lane);
+                    v_mean_local.y = reduce_field(v_mean_local.y, n_contrib, src_lane);
+                    v_mean_local.z = reduce_field(v_mean_local.z, n_contrib, src_lane);
+                    v_scale_local.x = reduce_field(v_scale_local.x, n_contrib, src_lane);
+                    v_scale_local.y = reduce_field(v_scale_local.y, n_contrib, src_lane);
+                    v_scale_local.z = reduce_field(v_scale_local.z, n_contrib, src_lane);
+                    v_quat_local.x = reduce_field(v_quat_local.x, n_contrib, src_lane);
+                    v_quat_local.y = reduce_field(v_quat_local.y, n_contrib, src_lane);
+                    v_quat_local.z = reduce_field(v_quat_local.z, n_contrib, src_lane);
+                    v_quat_local.w = reduce_field(v_quat_local.w, n_contrib, src_lane);
+                    v_opacity_local = reduce_field(v_opacity_local, n_contrib, src_lane);
+                    densification_weight_local = reduce_field(densification_weight_local, n_contrib, src_lane);
+                    densification_error_weighted_local =
+                        reduce_field(densification_error_weighted_local, n_contrib, src_lane);
+                    if constexpr (kEdgeScoring) {
+                        edge_score_local = reduce_field(edge_score_local, n_contrib, src_lane);
+                    }
+                    if (warp.thread_rank() == 0) {
+                        flush_splat_grads(
+                            id_batch[t], N, do_dens, v_rgb_local, v_mean_local, v_scale_local,
+                            v_quat_local, v_opacity_local, densification_weight_local,
+                            densification_error_weighted_local, scale_act, xyz_opac[3],
+                            v_means, v_quats, v_scales, v_colors, v_opacities, densification_info);
+                    }
                 }
+                if constexpr (kEdgeScoring) {
+                    warpSum(edge_score_local, warp);
+                    if (warp.thread_rank() == 0) {
+                        gpuAtomicAdd(&edge_score_batch[t], edge_score_local);
+                    }
+                }
+            }
+            if constexpr (kEdgeScoring) {
+                block.sync();
+                for (uint32_t t = tr; t < static_cast<uint32_t>(batch_size); t += block.size()) {
+                    gpuAtomicAdd(&edge_score_out[id_batch[t]], edge_score_batch[t]);
+                }
+                block.sync();
             }
         }
     }
 
-    template <uint32_t CDIM, typename scalar_t, bool kPerfectPinhole>
+    template <uint32_t CDIM, typename scalar_t, bool kPerfectPinhole, bool kEdgeScoring>
     __global__ void rasterize_to_pixels_from_world_3dgs_bwd_kernel(
         const uint32_t C,
         const uint32_t N,
@@ -524,14 +573,15 @@ namespace gsplat_lfs {
         const scalar_t* __restrict__ v_render_colors, // [C, CDIM, image_height, image_width]
         const scalar_t* __restrict__ v_render_alphas, // [C, image_height, image_width, 1]
         // grad inputs
-        vec3* __restrict__ v_means,                          // [N, 3]
-        vec4* __restrict__ v_quats,                          // [N, 4]
-        vec3* __restrict__ v_scales,                         // [N, 3]
-        scalar_t* __restrict__ v_colors,                     // [C, N, CDIM] or [nnz, CDIM]
-        scalar_t* __restrict__ v_opacities,                  // [C, N] or [nnz]
-        float* __restrict__ densification_info,              // [2, N] flattened or nullptr
-        const scalar_t* __restrict__ densification_error_map // [H, W] or nullptr
-    ) {
+        vec3* __restrict__ v_means,                           // [N, 3]
+        vec4* __restrict__ v_quats,                           // [N, 4]
+        vec3* __restrict__ v_scales,                          // [N, 3]
+        scalar_t* __restrict__ v_colors,                      // [C, N, CDIM] or [nnz, CDIM]
+        scalar_t* __restrict__ v_opacities,                   // [C, N] or [nnz]
+        float* __restrict__ densification_info,               // [2, N] flattened or nullptr
+        const scalar_t* __restrict__ densification_error_map, // [H, W] or nullptr
+        const float* __restrict__ edge_weight_map,
+        float* __restrict__ edge_score_out) {
         auto block = cg::this_thread_block();
         uint32_t cid = block.group_index().x;
         uint32_t tile_id =
@@ -552,6 +602,10 @@ namespace gsplat_lfs {
         }
         if (masks != nullptr) {
             masks += cid * tile_height * tile_width;
+        }
+        if constexpr (kEdgeScoring) {
+            edge_weight_map += cid * image_height * image_width;
+            edge_score_out += cid * N;
         }
 
         // when the mask is provided, do nothing and return if
@@ -597,6 +651,10 @@ namespace gsplat_lfs {
             reinterpret_cast<mat3*>(&quat_batch[block_size]); // [block_size]
         float* rgbs_batch =
             reinterpret_cast<float*>(&mt_batch[block_size]); // [block_size * CDIM]
+        float* edge_score_batch = nullptr;
+        if constexpr (kEdgeScoring) {
+            edge_score_batch = reinterpret_cast<float*>(&rgbs_batch[block_size * CDIM]);
+        }
 
         // this is the T AFTER the last gaussian in this pixel
         float T_final = 1.0f - render_alphas[pix_id];
@@ -640,6 +698,12 @@ namespace gsplat_lfs {
         for (uint32_t b = 0; b < num_batches; ++b) {
             // resync all threads before writing next batch of shared mem
             block.sync();
+            if constexpr (kEdgeScoring) {
+                for (uint32_t slot = tr; slot < block_size; slot += block.size()) {
+                    edge_score_batch[slot] = 0.f;
+                }
+                block.sync();
+            }
 
             // each thread fetch 1 gaussian from back to front
             // 0 index will be furthest back in batch
@@ -706,9 +770,10 @@ namespace gsplat_lfs {
 
                 const unsigned valid_mask = __ballot_sync(0xffffffffu, valid);
                 if (valid_mask == 0u) {
-                    continue;
+                    if constexpr (!kEdgeScoring) {
+                        continue;
+                    }
                 }
-
                 float v_rgb_local[CDIM] = {0.f};
                 vec3 v_mean_local = {0.f, 0.f, 0.f};
                 vec3 v_scale_local = {0.f, 0.f, 0.f};
@@ -716,91 +781,114 @@ namespace gsplat_lfs {
                 float v_opacity_local = 0.f;
                 float densification_weight_local = 0.f;
                 float densification_error_weighted_local = 0.f;
-                if (valid) {
+                float edge_score_local = 0.f;
+                if (valid_mask != 0u) {
                     const float ra = 1.0f / (1.0f - alpha);
-                    T *= ra;
-                    const float fac = alpha * T;
+                    if (valid) {
+                        T *= ra;
+                        const float fac = alpha * T;
 #pragma unroll
-                    for (uint32_t k = 0; k < CDIM; ++k) {
-                        v_rgb_local[k] = fac * v_render_c[k];
-                    }
-                    if (do_dens) {
-                        densification_weight_local = fac;
-                        densification_error_weighted_local = fac * pixel_error;
-                    }
-                    float v_alpha = 0.f;
+                        for (uint32_t k = 0; k < CDIM; ++k) {
+                            v_rgb_local[k] = fac * v_render_c[k];
+                        }
+                        if (do_dens) {
+                            densification_weight_local = fac;
+                            densification_error_weighted_local = fac * pixel_error;
+                        }
+                        if constexpr (kEdgeScoring) {
+                            const float edge_weight = edge_weight_map[pix_id];
+                            const float edge_contribution = fac * edge_weight;
+                            if (edge_weight > 0.0f && isfinite(edge_contribution)) {
+                                edge_score_local = edge_contribution;
+                            }
+                        }
+                        float v_alpha = 0.f;
 #pragma unroll
-                    for (uint32_t k = 0; k < CDIM; ++k) {
-                        v_alpha += (rgbs_batch[t * CDIM + k] * T - buffer[k] * ra) *
-                                   v_render_c[k];
-                    }
-                    v_alpha += T_final * ra * v_render_a;
-                    if (have_bg) {
-                        v_alpha += -T_final * ra * bg_accum;
-                    }
+                        for (uint32_t k = 0; k < CDIM; ++k) {
+                            v_alpha += (rgbs_batch[t * CDIM + k] * T - buffer[k] * ra) *
+                                       v_render_c[k];
+                        }
+                        v_alpha += T_final * ra * v_render_a;
+                        if (have_bg) {
+                            v_alpha += -T_final * ra * bg_accum;
+                        }
 
-                    if (opac * vis <= 0.999f) {
-                        const float v_vis = opac * v_alpha;
-                        const float v_gradDist = -0.5f * vis * v_vis;
-                        const vec3 v_gcrod = 2.0f * v_gradDist * gcrod;
-                        const vec3 v_grd_n = -glm::cross(v_gcrod, gro);
-                        const vec3 v_gro = glm::cross(v_gcrod, grd_n);
-                        const vec3 v_grd = safe_normalize_bw(grd, v_grd_n);
-                        const mat3 v_Mt = glm::outerProduct(v_grd, ray_d) +
-                                          glm::outerProduct(v_gro, o_minus_mu);
-                        const vec3 v_o_minus_mu = glm::transpose(Mt) * v_gro;
-                        v_mean_local += -v_o_minus_mu;
+                        if (opac * vis <= 0.999f) {
+                            const float v_vis = opac * v_alpha;
+                            const float v_gradDist = -0.5f * vis * v_vis;
+                            const vec3 v_gcrod = 2.0f * v_gradDist * gcrod;
+                            const vec3 v_grd_n = -glm::cross(v_gcrod, gro);
+                            const vec3 v_gro = glm::cross(v_gcrod, grd_n);
+                            const vec3 v_grd = safe_normalize_bw(grd, v_grd_n);
+                            const mat3 v_Mt = glm::outerProduct(v_grd, ray_d) +
+                                              glm::outerProduct(v_gro, o_minus_mu);
+                            const vec3 v_o_minus_mu = glm::transpose(Mt) * v_gro;
+                            v_mean_local += -v_o_minus_mu;
+                            const vec3 scale_act = scale_batch[t];
+                            const vec4 quat = quat_batch[t];
+                            const mat3 R = quat_to_rotmat(quat);
+                            quat_scale_to_preci_half_vjp(
+                                quat, scale_act, R, glm::transpose(v_Mt), v_quat_local, v_scale_local);
+                            v_opacity_local = vis * v_alpha;
+                        }
+
+#pragma unroll
+                        for (uint32_t k = 0; k < CDIM; ++k) {
+                            buffer[k] += rgbs_batch[t * CDIM + k] * fac;
+                        }
+                    }
+                    warpSum<CDIM>(v_rgb_local, warp);
+                    warpSum(v_mean_local, warp);
+                    warpSum(v_scale_local, warp);
+                    warpSum(v_quat_local, warp);
+                    warpSum(v_opacity_local, warp);
+                    warpSum(densification_weight_local, warp);
+                    warpSum(densification_error_weighted_local, warp);
+                    if (warp.thread_rank() == 0) {
+                        const int32_t g = id_batch[t];
+                        float* v_rgb_ptr = (float*)(v_colors) + CDIM * g;
+#pragma unroll
+                        for (uint32_t k = 0; k < CDIM; ++k) {
+                            gpuAtomicAdd(v_rgb_ptr + k, v_rgb_local[k]);
+                        }
+                        float* v_mean_ptr = (float*)(v_means) + 3 * g;
+                        gpuAtomicAdd(v_mean_ptr, v_mean_local.x);
+                        gpuAtomicAdd(v_mean_ptr + 1, v_mean_local.y);
+                        gpuAtomicAdd(v_mean_ptr + 2, v_mean_local.z);
+
+                        float* v_scale_ptr = (float*)(v_scales) + 3 * g;
                         const vec3 scale_act = scale_batch[t];
-                        const vec4 quat = quat_batch[t];
-                        const mat3 R = quat_to_rotmat(quat);
-                        quat_scale_to_preci_half_vjp(
-                            quat, scale_act, R, glm::transpose(v_Mt), v_quat_local, v_scale_local);
-                        v_opacity_local = vis * v_alpha;
-                    }
+                        gpuAtomicAdd(v_scale_ptr, v_scale_local.x * scale_act.x);
+                        gpuAtomicAdd(v_scale_ptr + 1, v_scale_local.y * scale_act.y);
+                        gpuAtomicAdd(v_scale_ptr + 2, v_scale_local.z * scale_act.z);
 
-#pragma unroll
-                    for (uint32_t k = 0; k < CDIM; ++k) {
-                        buffer[k] += rgbs_batch[t * CDIM + k] * fac;
-                    }
-                }
-                warpSum<CDIM>(v_rgb_local, warp);
-                warpSum(v_mean_local, warp);
-                warpSum(v_scale_local, warp);
-                warpSum(v_quat_local, warp);
-                warpSum(v_opacity_local, warp);
-                warpSum(densification_weight_local, warp);
-                warpSum(densification_error_weighted_local, warp);
-                if (warp.thread_rank() == 0) {
-                    const int32_t g = id_batch[t];
-                    float* v_rgb_ptr = (float*)(v_colors) + CDIM * g;
-#pragma unroll
-                    for (uint32_t k = 0; k < CDIM; ++k) {
-                        gpuAtomicAdd(v_rgb_ptr + k, v_rgb_local[k]);
-                    }
-                    float* v_mean_ptr = (float*)(v_means) + 3 * g;
-                    gpuAtomicAdd(v_mean_ptr, v_mean_local.x);
-                    gpuAtomicAdd(v_mean_ptr + 1, v_mean_local.y);
-                    gpuAtomicAdd(v_mean_ptr + 2, v_mean_local.z);
+                        float* v_quat_ptr = (float*)(v_quats) + 4 * g;
+                        gpuAtomicAdd(v_quat_ptr, v_quat_local.x);
+                        gpuAtomicAdd(v_quat_ptr + 1, v_quat_local.y);
+                        gpuAtomicAdd(v_quat_ptr + 2, v_quat_local.z);
+                        gpuAtomicAdd(v_quat_ptr + 3, v_quat_local.w);
 
-                    float* v_scale_ptr = (float*)(v_scales) + 3 * g;
-                    const vec3 scale_act = scale_batch[t];
-                    gpuAtomicAdd(v_scale_ptr, v_scale_local.x * scale_act.x);
-                    gpuAtomicAdd(v_scale_ptr + 1, v_scale_local.y * scale_act.y);
-                    gpuAtomicAdd(v_scale_ptr + 2, v_scale_local.z * scale_act.z);
-
-                    float* v_quat_ptr = (float*)(v_quats) + 4 * g;
-                    gpuAtomicAdd(v_quat_ptr, v_quat_local.x);
-                    gpuAtomicAdd(v_quat_ptr + 1, v_quat_local.y);
-                    gpuAtomicAdd(v_quat_ptr + 2, v_quat_local.z);
-                    gpuAtomicAdd(v_quat_ptr + 3, v_quat_local.w);
-
-                    const float opac_act = xyz_opacity_batch[t][3];
-                    gpuAtomicAdd(v_opacities + g, v_opacity_local * opac_act * (1.0f - opac_act));
-                    if (do_dens) {
-                        gpuAtomicAdd(densification_info + g, densification_weight_local);
-                        gpuAtomicAdd(densification_info + N + g, densification_error_weighted_local);
+                        const float opac_act = xyz_opacity_batch[t][3];
+                        gpuAtomicAdd(v_opacities + g, v_opacity_local * opac_act * (1.0f - opac_act));
+                        if (do_dens) {
+                            gpuAtomicAdd(densification_info + g, densification_weight_local);
+                            gpuAtomicAdd(densification_info + N + g, densification_error_weighted_local);
+                        }
                     }
                 }
+                if constexpr (kEdgeScoring) {
+                    warpSum(edge_score_local, warp);
+                    if (warp.thread_rank() == 0) {
+                        gpuAtomicAdd(&edge_score_batch[t], edge_score_local);
+                    }
+                }
+            }
+            if constexpr (kEdgeScoring) {
+                block.sync();
+                for (uint32_t t = tr; t < static_cast<uint32_t>(batch_size); t += block.size()) {
+                    gpuAtomicAdd(edge_score_out + id_batch[t], edge_score_batch[t]);
+                }
+                block.sync();
             }
         }
     }
@@ -847,6 +935,8 @@ namespace gsplat_lfs {
         float* v_opacities,
         float* densification_info,
         const float* densification_error_map,
+        const float* edge_weight_map,
+        float* edge_score_out,
         cudaStream_t stream) {
         const bool packed = false; // Only support non-packed for now
         const uint32_t tile_width = (image_width + tile_size - 1) / tile_size;
@@ -903,7 +993,9 @@ namespace gsplat_lfs {
                 v_colors,
                 v_opacities,
                 densification_info,
-                densification_error_map);
+                densification_error_map,
+                edge_weight_map,
+                edge_score_out);
             LFS_CUDA_LAUNCH_CHECK(stream, "gsplat.rasterize_to_pixels_bwd");
         };
 
@@ -915,21 +1007,41 @@ namespace gsplat_lfs {
                     int64_t(kBwdDualBatch) *
                     (sizeof(int32_t) + sizeof(vec4) + sizeof(vec3) + sizeof(vec4) +
                      sizeof(mat3) + sizeof(float) * CDIM);
+                const int64_t edge_shmem_size =
+                    shmem_size + int64_t(kBwdDualBatch) * sizeof(float);
                 if (global_shutter) {
                     if (perfect_pinhole) {
-                        launch_args(
-                            rasterize_to_pixels_from_world_3dgs_bwd_dual_kernel<float, true, true>,
-                            grid, threads, shmem_size);
+                        if (edge_weight_map != nullptr && edge_score_out != nullptr) {
+                            launch_args(
+                                rasterize_to_pixels_from_world_3dgs_bwd_dual_kernel<float, true, true, true>,
+                                grid, threads, edge_shmem_size);
+                        } else {
+                            launch_args(
+                                rasterize_to_pixels_from_world_3dgs_bwd_dual_kernel<float, true, true, false>,
+                                grid, threads, shmem_size);
+                        }
                     } else {
-                        launch_args(
-                            rasterize_to_pixels_from_world_3dgs_bwd_dual_kernel<float, true, false>,
-                            grid, threads, shmem_size);
+                        if (edge_weight_map != nullptr && edge_score_out != nullptr) {
+                            launch_args(
+                                rasterize_to_pixels_from_world_3dgs_bwd_dual_kernel<float, true, false, true>,
+                                grid, threads, edge_shmem_size);
+                        } else {
+                            launch_args(
+                                rasterize_to_pixels_from_world_3dgs_bwd_dual_kernel<float, true, false, false>,
+                                grid, threads, shmem_size);
+                        }
                     }
                     return;
                 }
-                launch_args(
-                    rasterize_to_pixels_from_world_3dgs_bwd_dual_kernel<float, false, false>,
-                    grid, threads, shmem_size);
+                if (edge_weight_map != nullptr && edge_score_out != nullptr) {
+                    launch_args(
+                        rasterize_to_pixels_from_world_3dgs_bwd_dual_kernel<float, false, false, true>,
+                        grid, threads, edge_shmem_size);
+                } else {
+                    launch_args(
+                        rasterize_to_pixels_from_world_3dgs_bwd_dual_kernel<float, false, false, false>,
+                        grid, threads, shmem_size);
+                }
                 return;
             }
         }
@@ -946,17 +1058,30 @@ namespace gsplat_lfs {
                 shmem_size = kOccCapBytes;
             }
         }
+        const int64_t edge_shmem_size = shmem_size + tile_size * tile_size * sizeof(float);
         if constexpr (CDIM == 3) {
             if (global_shutter && perfect_pinhole) {
-                launch_args(
-                    rasterize_to_pixels_from_world_3dgs_bwd_kernel<CDIM, float, true>,
-                    grid, threads, shmem_size);
+                if (edge_weight_map != nullptr && edge_score_out != nullptr) {
+                    launch_args(
+                        rasterize_to_pixels_from_world_3dgs_bwd_kernel<CDIM, float, true, true>,
+                        grid, threads, edge_shmem_size);
+                } else {
+                    launch_args(
+                        rasterize_to_pixels_from_world_3dgs_bwd_kernel<CDIM, float, true, false>,
+                        grid, threads, shmem_size);
+                }
                 return;
             }
         }
-        launch_args(
-            rasterize_to_pixels_from_world_3dgs_bwd_kernel<CDIM, float, false>,
-            grid, threads, shmem_size);
+        if (edge_weight_map != nullptr && edge_score_out != nullptr) {
+            launch_args(
+                rasterize_to_pixels_from_world_3dgs_bwd_kernel<CDIM, float, false, true>,
+                grid, threads, edge_shmem_size);
+        } else {
+            launch_args(
+                rasterize_to_pixels_from_world_3dgs_bwd_kernel<CDIM, float, false, false>,
+                grid, threads, shmem_size);
+        }
     }
 
     ////////////////////////////////////////////////////////////////
@@ -1001,6 +1126,8 @@ namespace gsplat_lfs {
         float* v_opacities,                                                    \
         float* densification_info,                                             \
         const float* densification_error_map,                                  \
+        const float* edge_weight_map,                                          \
+        float* edge_score_out,                                                 \
         cudaStream_t stream);
 
     __INS__(1)

--- a/src/training/rasterization/gsplat_rasterizer.cpp
+++ b/src/training/rasterization/gsplat_rasterizer.cpp
@@ -116,7 +116,7 @@ namespace lfs::training {
         // Begin arena frame for memory allocation
         auto& arena = core::GlobalArenaManager::instance().get_arena();
         uint64_t frame_id = arena.begin_frame(core::getCurrentCUDAStream());
-        auto arena_allocator = arena.get_allocator(frame_id);
+        auto arena_allocator = arena.get_allocator(frame_id, "gsplat.forward");
         try {
 
             // Full image dimensions
@@ -630,11 +630,13 @@ namespace lfs::training {
         const core::Tensor& grad_alpha,
         core::SplatData& gaussian_model,
         AdamOptimizer& optimizer,
-        const core::Tensor& pixel_error_map) {
+        const core::Tensor& pixel_error_map,
+        const core::Tensor& edge_weight_map,
+        core::Tensor edge_score_out) {
 
         // Get arena for temporary allocations
         auto& arena = core::GlobalArenaManager::instance().get_arena();
-        auto arena_allocator = arena.get_allocator(ctx.frame_id);
+        auto arena_allocator = arena.get_allocator(ctx.frame_id, "gsplat.backward");
         // Run the backward work + arena frame release on the exact stream the
         // forward began the frame on (ctx.stream), so begin_frame and end_frame
         // chain on the same stream rather than relying on the caller's guard
@@ -753,6 +755,20 @@ namespace lfs::training {
             const float* const pixel_error_map_ptr = (update_densification_info && error_map_2d.is_valid())
                                                          ? error_map_2d.ptr<float>()
                                                          : nullptr;
+            const bool edge_scoring =
+                edge_weight_map.is_valid() && edge_score_out.is_valid() &&
+                edge_weight_map.device() == core::Device::CUDA &&
+                edge_score_out.device() == core::Device::CUDA &&
+                edge_weight_map.dtype() == core::DataType::Float32 &&
+                edge_score_out.dtype() == core::DataType::Float32 &&
+                edge_weight_map.ndim() == 2 && edge_score_out.ndim() == 1 &&
+                edge_weight_map.shape()[0] == static_cast<size_t>(H) &&
+                edge_weight_map.shape()[1] == static_cast<size_t>(W) &&
+                edge_score_out.numel() == static_cast<size_t>(N);
+            const float* const edge_weight_map_ptr =
+                edge_scoring ? edge_weight_map.ptr<float>() : nullptr;
+            float* const edge_score_out_ptr =
+                edge_scoring ? edge_score_out.ptr<float>() : nullptr;
 
             // Call backward with raw pointers
             gsplat_lfs::rasterize_from_world_with_sh_bwd(
@@ -809,6 +825,8 @@ namespace lfs::training {
                 v_sh_coeffs_ptr,
                 densification_info_ptr,
                 pixel_error_map_ptr,
+                edge_weight_map_ptr,
+                edge_score_out_ptr,
                 stream);
 
             // ============ Accumulate gradients into optimizer using CUDA kernels ============

--- a/src/training/rasterization/gsplat_rasterizer.hpp
+++ b/src/training/rasterization/gsplat_rasterizer.hpp
@@ -129,7 +129,9 @@ namespace lfs::training {
         const lfs::core::Tensor& grad_alpha,
         lfs::core::SplatData& gaussian_model,
         AdamOptimizer& optimizer,
-        const lfs::core::Tensor& pixel_error_map = {});
+        const lfs::core::Tensor& pixel_error_map = {},
+        const lfs::core::Tensor& edge_weight_map = {},
+        lfs::core::Tensor edge_score_out = {});
 
     // Release per-thread renderer caches before the owning CUDA stream is torn down.
     bool release_gsplat_rasterizer_thread_local_caches() noexcept;

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -4964,14 +4964,6 @@ namespace lfs::training {
                                             "stage project parameter snapshot",
                                             LFS_SOURCE_SITE_CURRENT()));
                             }
-                            for (const auto& uuid :
-                                 document
-                                     ->checkpoint_uuids()) {
-                                static_cast<void>(
-                                    document
-                                        ->remove_checkpoint(
-                                            uuid));
-                            }
                             auto lazy =
                                 lfs::io::project::
                                     LazyChunkValue::from_owned(
@@ -5769,6 +5761,14 @@ namespace lfs::training {
     }
 
     lfs::Status Trainer::recover_forward_oom(const lfs::Error& cause) {
+        if (auto* arena = lfs::core::GlobalArenaManager::instance().try_get_arena()) {
+            const auto info = arena->get_memory_info();
+            lfs::core::log_arena_failure_vram_snapshot(
+                "trainer.recover_forward_oom", info.arena_capacity, info.peak_usage);
+        } else {
+            lfs::core::log_arena_failure_vram_snapshot(
+                "trainer.recover_forward_oom", 0, 0);
+        }
         const auto synchronize = [this] {
             return recovery_sync_for_testing_ ? recovery_sync_for_testing_()
                                               : cudaDeviceSynchronize();
@@ -6180,21 +6180,30 @@ namespace lfs::training {
                 lfs::core::Tensor fused_scale_reg_loss_gpu;
                 lfs::core::Tensor fused_opacity_reg_loss_gpu;
                 lfs::core::Tensor sparsity_loss_gpu;
+                const bool run_gut_gaussian_backward =
+                    params_.optimization.gut && update_gaussians_this_iter;
+                if (run_fastgs_gaussian_backward || run_gut_gaussian_backward) {
+                    auto& model = strategy_->get_model();
+                    edge_score_scratch = strategy_->edge_score_scratch(iter);
+                    if (edge_score_scratch.is_valid() &&
+                        edge_score_scratch.dtype() == lfs::core::DataType::Float32 &&
+                        edge_score_scratch.numel() == static_cast<size_t>(model.size())) {
+                        edge_weight_map = get_edge_weight_map(cam->uid(), gt_image);
+                        edge_weight_scoring_active_ = true;
+                    } else if (edge_weight_scoring_active_) {
+                        clearEdgeWeightCache();
+                    }
+                } else if (edge_weight_scoring_active_) {
+                    clearEdgeWeightCache();
+                }
                 if (fastgs_path) {
                     LFS_VRAM_SCOPE("train.regularizers.fastgs_forward_only");
                     LOG_VRAM_DIFF("train.regularizers.fastgs_forward_only");
                     auto& model = strategy_->get_model();
                     if (run_fastgs_gaussian_backward) {
-                        edge_score_scratch = strategy_->edge_score_scratch(iter);
-                        if (edge_score_scratch.is_valid() &&
-                            edge_score_scratch.dtype() == lfs::core::DataType::Float32 &&
-                            edge_score_scratch.numel() == static_cast<size_t>(model.size())) {
-                            edge_weight_map = get_edge_weight_map(cam->uid(), gt_image);
+                        if (edge_weight_scoring_active_) {
                             fused_extra_gradients.edge_weight_map = edge_weight_map.ptr<float>();
                             fused_extra_gradients.edge_score_out = edge_score_scratch.ptr<float>();
-                            edge_weight_scoring_active_ = true;
-                        } else if (edge_weight_scoring_active_) {
-                            clearEdgeWeightCache();
                         }
                         fused_extra_gradients.scale_reg_weight = params_.optimization.scale_reg;
                         // Fused path shares the configured opacity_reg weight between gradient and loss accumulation.
@@ -6313,27 +6322,60 @@ namespace lfs::training {
                         LOG_VRAM_DIFF("train.rasterize_forward");
                         current_phase = StepPhase::Forward;
                         if (params_.optimization.gut) {
-                            auto rasterize_result = gsplat_rasterize_forward(
-                                *cam, strategy_->get_model(), bg,
-                                0, 0, 0, 0,
-                                1.0f, false, GsplatRenderMode::RGB, true, bg_tile);
-
-                            if (!rasterize_result) {
-                                nvtxRangePop(); // rasterize_forward
-                                nvtxRangePop(); // tile
-                                return lfs::from_legacy_expected<StepDisposition>(
-                                           std::unexpected(rasterize_result.error()),
-                                           lfs::LegacyErrorContext{
-                                               .code = lfs::ErrorCode::Internal,
-                                               .domain = lfs::ErrorDomain::Rendering,
-                                               .operation = "gsplat_rasterize_forward",
-                                               .source = LFS_SOURCE_SITE_CURRENT(),
-                                           })
-                                    .error();
+                            const MutationStamp forward_stamp{
+                                static_cast<std::uint64_t>(iter), mutation_epoch_,
+                                StepPhase::Forward, fastgs_strategy_hooks_at_start};
+                            unsigned forward_attempts = 0;
+                            for (;;) {
+                                ++forward_attempts;
+                                try {
+                                    auto rasterize_result = gsplat_rasterize_forward(
+                                        *cam, strategy_->get_model(), bg,
+                                        0, 0, 0, 0,
+                                        1.0f, false, GsplatRenderMode::RGB, true, bg_tile);
+                                    if (!rasterize_result) {
+                                        auto typed = lfs::from_legacy_expected<
+                                            std::pair<RenderOutput, GsplatRasterizeContext>>(
+                                            std::move(rasterize_result),
+                                            lfs::LegacyErrorContext{
+                                                .code = lfs::ErrorCode::Internal,
+                                                .domain = lfs::ErrorDomain::Rendering,
+                                                .operation = "gsplat_rasterize_forward",
+                                                .source = LFS_SOURCE_SITE_CURRENT(),
+                                            });
+                                        if (!typed) {
+                                            nvtxRangePop(); // rasterize_forward
+                                            nvtxRangePop(); // tile
+                                            return std::move(typed).error();
+                                        }
+                                        auto gut_result = std::move(typed).value();
+                                        output = std::move(gut_result.first);
+                                        gsplat_ctx.emplace(std::move(gut_result.second));
+                                    } else {
+                                        output = std::move(rasterize_result->first);
+                                        gsplat_ctx.emplace(std::move(rasterize_result->second));
+                                    }
+                                    break;
+                                } catch (const lfs::Exception& exception) {
+                                    const lfs::Error forward_error = exception.error();
+                                    const RetryDecision decision = classify_forward_retry(
+                                        forward_error, forward_stamp, forward_attempts);
+                                    if (decision == RetryDecision::DoNotRetry) {
+                                        nvtxRangePop(); // rasterize_forward
+                                        nvtxRangePop(); // tile
+                                        return forward_error;
+                                    }
+                                    LOG_ERROR(
+                                        "GUT forward exhausted a resource (attempt {}): {}",
+                                        forward_attempts, forward_error.detail());
+                                    if (lfs::Status recovery = recover_forward_oom(forward_error);
+                                        !recovery) {
+                                        nvtxRangePop(); // rasterize_forward
+                                        nvtxRangePop(); // tile
+                                        return std::move(recovery).error();
+                                    }
+                                }
                             }
-
-                            output = std::move(rasterize_result->first);
-                            gsplat_ctx.emplace(std::move(rasterize_result->second));
                         } else {
                             const bool render_normal =
                                 normal_supervision_started &&
@@ -7434,7 +7476,12 @@ namespace lfs::training {
                                 tile_context_guard.release();
                                 gsplat_rasterize_backward(*gsplat_ctx, raster_grad, grad_alpha,
                                                           strategy_->get_model(), strategy_->get_optimizer(),
-                                                          use_pixel_error_densification ? tile_error_map : lfs::core::Tensor{});
+                                                          use_pixel_error_densification ? tile_error_map : lfs::core::Tensor{},
+                                                          edge_weight_scoring_active_ ? edge_weight_map : lfs::core::Tensor{},
+                                                          edge_weight_scoring_active_ ? edge_score_scratch : lfs::core::Tensor{});
+                                if (edge_weight_scoring_active_) {
+                                    strategy_->on_edge_score_accumulated(iter);
+                                }
                             } else {
                                 tile_context_guard.release();
                                 if (run_fastgs_gaussian_backward) {
@@ -7678,6 +7725,23 @@ namespace lfs::training {
                     strategy_->pre_step(iter, r_output);
                 }
 
+                const bool save_regular_phase_output =
+                    get_active_sparsify_steps() > 0 &&
+                    iter == get_sparsity_boundary_iteration();
+                TrainerProjectSavePolicy project_save_policy;
+                std::optional<std::filesystem::path> step_project_path;
+                {
+                    std::lock_guard lock(project_snapshot_mutex_);
+                    project_save_policy = trainer_project_save_policy_;
+                    if (live_project_path_ &&
+                        !live_project_path_->empty()) {
+                        step_project_path = *live_project_path_;
+                    }
+                }
+                const bool may_save_at_step_boundary =
+                    project_save_policy.at_step_boundaries &&
+                    step_project_path.has_value();
+
                 {
                     DeferredEvents deferred;
                     {
@@ -7783,6 +7847,43 @@ namespace lfs::training {
                             strategy_->step(iter);
                         }
 
+                        if (save_regular_phase_output &&
+                            may_save_at_step_boundary) {
+                            LOG_INFO(
+                                "Capturing regular-phase .licht generation at iteration {} before sparsity pruning",
+                                iter);
+                            // This boundary capture has priority over a writer
+                            // still in flight: otherwise the request would be
+                            // coalesced until after pruning.
+                            finish_project_writer();
+                            static_cast<void>(
+                                request_project_save(
+                                    *step_project_path));
+                            if (need_exclusive) {
+                                if (combined_model_lock.owns_lock()) {
+                                    combined_model_lock.unlock();
+                                }
+                                lock.unlock();
+                            } else {
+                                model_write_lock.unlock();
+                            }
+                            consume_requested_project_snapshot(iter);
+                            if (need_exclusive) {
+                                lock.lock();
+                                if (scene_) {
+                                    combined_model_lock =
+                                        scene_->acquireCombinedModelExclusive();
+                                }
+                            } else {
+                                model_write_lock.lock();
+                            }
+                            waitForModelReaders();
+                        } else if (save_regular_phase_output) {
+                            LOG_DEBUG(
+                                "Skipping regular-phase project capture at iteration {}: trainer-initiated saves are not authorized",
+                                iter);
+                        }
+
                         if (sparsity_optimizer_ &&
                             sparsity_optimizer_->is_initialized() &&
                             static_cast<size_t>(model.size()) != model_size_before) {
@@ -7878,36 +7979,7 @@ namespace lfs::training {
                         photometric_loss_.arena().shrink_to_required();
                     }
 
-                    const bool save_regular_phase_output = get_active_sparsify_steps() > 0 &&
-                                                           iter == get_sparsity_boundary_iteration();
                     current_phase = StepPhase::TerminalCleanup;
-                    TrainerProjectSavePolicy project_save_policy;
-                    std::optional<std::filesystem::path> step_project_path;
-                    {
-                        std::lock_guard lock(project_snapshot_mutex_);
-                        project_save_policy = trainer_project_save_policy_;
-                        if (live_project_path_ &&
-                            !live_project_path_->empty()) {
-                            step_project_path = *live_project_path_;
-                        }
-                    }
-                    const bool may_save_at_step_boundary =
-                        project_save_policy.at_step_boundaries &&
-                        step_project_path.has_value();
-                    if (save_regular_phase_output) {
-                        if (may_save_at_step_boundary) {
-                            LOG_INFO(
-                                "Queuing regular-phase .licht generation at iteration {} before sparsification",
-                                iter);
-                            static_cast<void>(
-                                request_project_save(
-                                    *step_project_path));
-                        } else {
-                            LOG_DEBUG(
-                                "Skipping regular-phase project save at iteration {}: trainer-initiated saves are not authorized",
-                                iter);
-                        }
-                    }
 
                     // Publish a project generation at specified steps unless
                     // the sparsity-boundary save already handled it.
@@ -8690,49 +8762,68 @@ namespace lfs::training {
             saving_model_.store(true, std::memory_order_release);
             try {
                 LOG_INFO("Saving {} project at iteration {}...",
-                         terminal_error ? "recovery" : (user_stopped ? "stopped" : "final"),
+                         terminal_error ? "emergency" : (user_stopped ? "stopped" : "final"),
                          terminal_iteration);
                 if (auto save_result = save_project_to(
                         *terminal_project_path,
                         terminal_iteration);
                     !save_result) {
-                    std::optional<lfs::Error> typed_save_error;
-                    {
-                        std::lock_guard lock(project_snapshot_mutex_);
-                        typed_save_error =
-                            last_project_writer_typed_error_;
-                    }
-                    if (typed_save_error) {
-                        append_terminal_error(
-                            std::move(*typed_save_error));
+                    if (terminal_error) {
+                        LOG_ERROR("Emergency project save failed at iteration {} to '{}': {} "
+                                  "(original training error preserved)",
+                                  terminal_iteration,
+                                  lfs::core::path_to_utf8(*terminal_project_path),
+                                  save_result.error());
                     } else {
-                        append_terminal_error(lfs::make_error(lfs::ErrorInit{
-                            .code = lfs::ErrorCode::Internal,
-                            .domain = lfs::ErrorDomain::Training,
-                            .user_message = "Terminal training save failed.",
-                            .detail = std::format("Terminal save failed at iteration {}: {}",
-                                                  terminal_iteration, save_result.error()),
-                            .detection = LFS_SOURCE_SITE_CURRENT(),
-                        }));
+                        std::optional<lfs::Error> typed_save_error;
+                        {
+                            std::lock_guard lock(project_snapshot_mutex_);
+                            typed_save_error = last_project_writer_typed_error_;
+                        }
+                        if (typed_save_error) {
+                            append_terminal_error(std::move(*typed_save_error));
+                        } else {
+                            append_terminal_error(lfs::make_error(lfs::ErrorInit{
+                                .code = lfs::ErrorCode::Internal,
+                                .domain = lfs::ErrorDomain::Training,
+                                .user_message = "Terminal training save failed.",
+                                .detail = std::format("Terminal save failed at iteration {}: {}",
+                                                      terminal_iteration, save_result.error()),
+                                .detection = LFS_SOURCE_SITE_CURRENT(),
+                            }));
+                        }
                     }
                 } else {
+                    if (terminal_error) {
+                        LOG_INFO("Emergency project save succeeded at iteration {} to '{}'",
+                                 terminal_iteration,
+                                 lfs::core::path_to_utf8(*save_result));
+                    }
                     const auto params = getParams();
                     if (!params.optimization.headless) {
                         export_final_splats(*this, params);
                     }
                 }
             } catch (const std::exception& e) {
-                append_terminal_error(lfs::make_error(lfs::ErrorInit{
-                    .code = lfs::ErrorCode::Internal,
-                    .domain = lfs::ErrorDomain::Training,
-                    .user_message = "Terminal training save failed.",
-                    .detail = std::format("Terminal save threw at iteration {}: {}",
-                                          terminal_iteration, e.what()),
-                    .detection = LFS_SOURCE_SITE_CURRENT(),
-                }));
+                if (terminal_error) {
+                    LOG_ERROR("Emergency project save threw at iteration {} to '{}': {} "
+                              "(original training error preserved)",
+                              terminal_iteration,
+                              lfs::core::path_to_utf8(*terminal_project_path),
+                              e.what());
+                } else {
+                    append_terminal_error(lfs::make_error(lfs::ErrorInit{
+                        .code = lfs::ErrorCode::Internal,
+                        .domain = lfs::ErrorDomain::Training,
+                        .user_message = "Terminal training save failed.",
+                        .detail = std::format("Terminal save threw at iteration {}: {}",
+                                              terminal_iteration, e.what()),
+                        .detection = LFS_SOURCE_SITE_CURRENT(),
+                    }));
+                }
             }
             LOG_INFO("Terminal {} save phase took {:.3f}s",
-                     user_stopped ? "stop" : "completion",
+                     terminal_error ? "emergency" : (user_stopped ? "stop" : "completion"),
                      std::chrono::duration<double>(std::chrono::steady_clock::now() - terminal_save_started).count());
             pending_snapshot_finish_reason_ =
                 lfs::io::project::TrainingFinishReason::None;

--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -67,7 +67,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_ExplicitSaveAfterUnadoptedTrainerAppendUsesCurrentHead_Test;
     class VisualizerImplResetTest_ExplicitSaveAfterTrainerRewriteUsesCurrentHead_Test;
     class VisualizerImplResetTest_UntitledTrainerRewriteAdoptThenSaveAsUsesCurrentHead_Test;
-    class VisualizerImplResetTest_EditModeSaveDropsFormerTrainingCheckpoint_Test;
+    class VisualizerImplResetTest_EditModeSaveRetainsUnboundCheckpointHistory_Test;
     class VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionRegistersProjectInMru_Test;
     class VisualizerImplResetTest_SaveAsAfterAutoCreatedTrainingKeepsOriginalAndCheckpoint_Test;
     class VisualizerImplResetTest_CompletedAutoCreatedTrainingSavesRealMasterOnClose_Test;
@@ -431,7 +431,7 @@ namespace lfs::training {
         friend class lfs::vis::VisualizerImplResetTest_ExplicitSaveAfterUnadoptedTrainerAppendUsesCurrentHead_Test;
         friend class lfs::vis::VisualizerImplResetTest_ExplicitSaveAfterTrainerRewriteUsesCurrentHead_Test;
         friend class lfs::vis::VisualizerImplResetTest_UntitledTrainerRewriteAdoptThenSaveAsUsesCurrentHead_Test;
-        friend class lfs::vis::VisualizerImplResetTest_EditModeSaveDropsFormerTrainingCheckpoint_Test;
+        friend class lfs::vis::VisualizerImplResetTest_EditModeSaveRetainsUnboundCheckpointHistory_Test;
         friend class lfs::vis::VisualizerImplResetTest_UntitledTrainingSnapshotAdoptionRegistersProjectInMru_Test;
         friend class lfs::vis::VisualizerImplResetTest_SaveAsAfterAutoCreatedTrainingKeepsOriginalAndCheckpoint_Test;
         friend class lfs::vis::VisualizerImplResetTest_CompletedAutoCreatedTrainingSavesRealMasterOnClose_Test;

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -4352,14 +4352,16 @@ namespace lfs::vis::project {
             return std::nullopt;
         }
         if (hasSourcePath() && document_) {
-            const auto uuids =
-                document_->checkpoint_uuids();
-            if (!uuids.empty()) {
+            const auto bound = document_->bound_checkpoint_uuid();
+            if (!bound) {
+                return -1;
+            }
+            if (*bound) {
                 if (cached_bound_checkpoint_iteration_) {
                     return *cached_bound_checkpoint_iteration_;
                 }
                 const auto* checkpoint =
-                    document_->find_checkpoint(uuids.front());
+                    document_->find_checkpoint(**bound);
                 if (!checkpoint) {
                     return std::nullopt;
                 }
@@ -4388,14 +4390,16 @@ namespace lfs::vis::project {
                 if (!opened) {
                     return -1;
                 }
-                const auto disk_uuids =
-                    opened->checkpoint_uuids();
-                if (disk_uuids.empty()) {
+                const auto disk_bound =
+                    opened->bound_checkpoint_uuid();
+                if (!disk_bound) {
+                    return -1;
+                }
+                if (!*disk_bound) {
                     return std::nullopt;
                 }
                 const auto* checkpoint =
-                    opened->find_checkpoint(
-                        disk_uuids.front());
+                    opened->find_checkpoint(**disk_bound);
                 if (!checkpoint) {
                     return -1;
                 }
@@ -4430,16 +4434,16 @@ namespace lfs::vis::project {
         if (!trainer || !document_) {
             return false;
         }
-        const auto uuids = document_->checkpoint_uuids();
-        if (uuids.empty()) {
-            return true;
-        }
         if (cached_bound_checkpoint_iteration_) {
             return *cached_bound_checkpoint_iteration_ !=
                    trainer->get_current_iteration();
         }
+        const auto bound = document_->bound_checkpoint_uuid();
+        if (!bound || !*bound) {
+            return true;
+        }
         const auto* checkpoint =
-            document_->find_checkpoint(uuids.front());
+            document_->find_checkpoint(**bound);
         if (!checkpoint) {
             return true;
         }
@@ -5914,64 +5918,14 @@ namespace lfs::vis::project {
             document_->edit_scene_graph() =
                 std::move(*captured_scene);
         }
-        // Entering Edit Mode turns the live training model into an ordinary
-        // splat and clears its SCNG training binding.  A full sync must also
-        // retire the formerly resumable CKPT; otherwise validation correctly
-        // rejects the now-orphaned checkpoint.  Keep it during lightweight
-        // autosaves while a training session is still bound.
+        // Entering Edit Mode clears the SCNG training binding. Existing CKPT
+        // chapters remain live historical data (not resumable without a
+        // binding) and survive saves and compaction.
         if ((mode == DocumentSyncMode::Default ||
              mode == DocumentSyncMode::Autosave) &&
-            training_uuid.is_nil() &&
-            !keepStoredCheckpointChapters()) {
-            const auto checkpoint_uuids =
-                document_->checkpoint_uuids();
-            for (const auto& uuid : checkpoint_uuids) {
-                static_cast<void>(
-                    document_->remove_checkpoint(uuid));
-            }
-            if (!checkpoint_uuids.empty()) {
-                cached_bound_checkpoint_iteration_.reset();
-                clearStoredTrainingSession();
-            }
-        }
-        // Light autosave omits the unbound live training
-        // node from SCNG. Drop CKPT chapters that node no
-        // longer binds; otherwise V21 rejects the sidecar.
-        // A stored-but-not-hydrated session keeps both the
-        // SCNG training binding and the CKPT bytes.
-        if (mode ==
-                DocumentSyncMode::
-                    LightTrainingAutosave &&
-            !omit_unbound_training.empty() &&
-            !keepStoredCheckpointChapters()) {
-            std::unordered_set<lfs::core::Uuid>
-                bound_checkpoints;
-            if (const auto nodes =
-                    document_->scene_graph().nodes();
-                nodes) {
-                for (const auto& node : *nodes) {
-                    if (node.payload &&
-                        node.payload->fourcc == "CKPT") {
-                        bound_checkpoints.insert(
-                            node.payload->instance_uuid);
-                    }
-                }
-            }
-            const auto checkpoint_uuids =
-                document_->checkpoint_uuids();
-            bool removed_any = false;
-            for (const auto& uuid : checkpoint_uuids) {
-                if (!bound_checkpoints.contains(uuid)) {
-                    static_cast<void>(
-                        document_->remove_checkpoint(
-                            uuid));
-                    removed_any = true;
-                }
-            }
-            if (removed_any) {
-                cached_bound_checkpoint_iteration_.reset();
-                clearStoredTrainingSession();
-            }
+            training_uuid.is_nil()) {
+            cached_bound_checkpoint_iteration_.reset();
+            clearStoredTrainingSession();
         }
         // Same bookkeeping as the trainer writer after a
         // wholesale SCNG install: drop SPLT/PCLD/MESH

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -3437,11 +3437,11 @@ namespace lfs::vis {
         // the render thread in reimportSharedScratchIfGrown.
         const auto make_grow_fn = [this](std::shared_ptr<lfs::core::ExportableBlock> block) {
             return [this, block = std::move(block)](std::size_t need) -> std::size_t {
-                const std::size_t want =
-                    need > (std::numeric_limits<std::size_t>::max() / 2) ? need : need + need / 2;
-                auto grew = lfs::core::growExportableDeviceBlock(block, want);
+                const std::size_t exact_need = alignUp(need, kSharedScratchPageBytes);
+                auto grew = lfs::core::growExportableDeviceBlock(block, exact_need);
                 if (!grew) {
-                    return std::size_t{0};
+                    LOG_ERROR("VkSplat shared scratch grow to {} MiB failed: {}",
+                              exact_need >> 20, grew.error());
                 }
                 return block->committedPrefixBytes();
             };
@@ -3560,7 +3560,13 @@ namespace lfs::vis {
                 ++shared_scratch_.generation;
                 return true;
             };
-            if (!lfs::core::GlobalArenaManager::instance().grow_external_backing(device_ptr, target_bytes, commit)) {
+            const std::size_t exact_required_bytes = alignUp(required_bytes, kSharedScratchPageBytes);
+            bool grew = lfs::core::GlobalArenaManager::instance().grow_external_backing(
+                device_ptr, exact_required_bytes, commit);
+            if (!grew) {
+                LOG_ERROR("VkSplat shared scratch grow to {} MiB failed: {}",
+                          exact_required_bytes >> 20,
+                          commit_error.empty() ? "unknown error" : commit_error);
                 return std::unexpected(commit_error.empty()
                                            ? std::string("VkSplat shared scratch training rasterizer arena is busy")
                                            : std::format("VkSplat shared scratch grow failed: {}", commit_error));

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -277,7 +277,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_ScratchDirectoryIsFixedUnderRootRegardlessOfPreferences_Test;
         friend class VisualizerImplResetTest_ProjectCreateWhileTrainingPromptsWithCreatePath_Test;
         friend class VisualizerImplResetTest_RecoveredScratchSaveStillRefusesAndStaysOutOfMru_Test;
-        friend class VisualizerImplResetTest_EditModeWithoutHydratedSessionDropsCheckpoint_Test;
+        friend class VisualizerImplResetTest_EditModeWithoutHydratedSessionRetainsCheckpointHistory_Test;
         friend class VisualizerImplResetTest_RestoreThenTrainWritesNewCheckpoint_Test;
         friend class VisualizerImplResetTest_HeadlessOpenPrintsHydrationStagesWhenBenchPathSet_Test;
         friend class VisualizerImplResetTest_ResetTrainingPreservesExplicitInitPath_Test;
@@ -382,7 +382,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_TrainingCheckpointReopenRestoresPausedResumableState_Test;
         friend class VisualizerImplResetTest_ErrorFinishedCheckpointProjectReopensPausedAndResumable_Test;
         friend class VisualizerImplResetTest_CompletedCheckpointProjectStillReopensFinished_Test;
-        friend class VisualizerImplResetTest_EditModeSaveDropsFormerTrainingCheckpoint_Test;
+        friend class VisualizerImplResetTest_EditModeSaveRetainsUnboundCheckpointHistory_Test;
         friend class VisualizerImplResetTest_ReopenedTwoSplatProjectBuildsExternalCombinedModel_Test;
         friend class VisualizerImplResetTest_ForceExitDiscardDeletesAutosaveSidecarOnTeardown_Test;
         friend class VisualizerImplResetTest_EmergencyForceExitKeepsAutosaveSidecarOnTeardown_Test;

--- a/tests/test_arena_metrics_contention.cpp
+++ b/tests/test_arena_metrics_contention.cpp
@@ -13,10 +13,14 @@
 #include <cuda_runtime.h>
 #include <future>
 #include <gtest/gtest.h>
+#include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include "core/cuda/memory_arena.hpp"
+#include "core/logger.hpp"
 
 using lfs::core::RasterizerMemoryArena;
 
@@ -185,6 +189,151 @@ TEST_F(ArenaMetricsContentionTest, ExternalGrowWaitsForPendingRender) {
     EXPECT_EQ(arena.get_statistics().capacity, physical_bytes);
 
     arena.end_frame(frame, nullptr, /*from_rendering=*/false);
+}
+
+TEST_F(ArenaMetricsContentionTest, ExternalGrowFailureRetainsCommittedCapacity) {
+    constexpr size_t MiB = 1024 * 1024;
+    constexpr size_t physical_bytes = 4 * MiB;
+    constexpr size_t initial_committed_bytes = 1 * MiB;
+
+    void* device_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&device_ptr, physical_bytes), cudaSuccess);
+    auto owner = std::shared_ptr<void>(device_ptr, [](void* ptr) {
+        EXPECT_EQ(cudaFree(ptr), cudaSuccess);
+    });
+
+    RasterizerMemoryArena::Config config;
+    config.max_physical = physical_bytes;
+    config.enable_vmm = false;
+    config.granularity = MiB;
+    RasterizerMemoryArena arena(config);
+    std::atomic<int> grow_calls{0};
+    std::atomic<size_t> requested_bytes{0};
+    RasterizerMemoryArena::ExternalBacking backing{
+        .device_ptr = device_ptr,
+        .size = initial_committed_bytes,
+        .device = 0,
+        .owner = owner,
+        .label = "test.external.failure",
+        .grow = [&](const size_t requested) {
+            grow_calls.fetch_add(1, std::memory_order_relaxed);
+            requested_bytes.store(requested, std::memory_order_release);
+            return size_t{0};
+        },
+    };
+    ASSERT_TRUE(arena.install_external_backing(std::move(backing)));
+
+    std::mutex log_mutex;
+    std::vector<std::string> error_logs;
+    const auto log_handler = lfs::core::Logger::get().add_log_handler(
+        [&](const lfs::core::LogLevel level, const lfs::core::SourceSite&, const std::string_view message) {
+            if (level == lfs::core::LogLevel::Error) {
+                std::scoped_lock lock(log_mutex);
+                error_logs.emplace_back(message);
+            }
+        });
+
+    const uint64_t frame = arena.begin_frame(nullptr, false);
+    auto allocate = arena.get_allocator(frame, "arena.failure.identity");
+    EXPECT_EQ(allocate(2 * MiB), nullptr);
+    EXPECT_EQ(grow_calls.load(std::memory_order_relaxed), 1);
+    EXPECT_EQ(requested_bytes.load(std::memory_order_acquire), 2 * MiB);
+    EXPECT_EQ(arena.get_statistics().capacity, initial_committed_bytes);
+    arena.end_frame(frame, nullptr, false);
+    lfs::core::Logger::get().remove_log_handler(log_handler);
+
+    std::string joined_logs;
+    for (const auto& message : error_logs) {
+        joined_logs += message;
+        joined_logs += '\n';
+    }
+    EXPECT_NE(joined_logs.find("test.external.failure"), std::string::npos);
+    EXPECT_NE(joined_logs.find("arena.failure.identity"), std::string::npos);
+    EXPECT_NE(joined_logs.find("capacity=1 MiB"), std::string::npos);
+    EXPECT_NE(joined_logs.find("Arena VRAM failure snapshot"), std::string::npos);
+    EXPECT_NE(joined_logs.find("cuda_free="), std::string::npos);
+}
+
+TEST_F(ArenaMetricsContentionTest, ExternalGrowCommitsExactAlignedNeed) {
+    constexpr size_t MiB = 1024 * 1024;
+    constexpr size_t initial_committed_bytes = 1 * MiB;
+    constexpr size_t aligned_need = 2 * MiB;
+
+    void* device_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&device_ptr, 4 * MiB), cudaSuccess);
+    auto owner = std::shared_ptr<void>(device_ptr, [](void* ptr) {
+        EXPECT_EQ(cudaFree(ptr), cudaSuccess);
+    });
+
+    RasterizerMemoryArena::Config config;
+    config.max_physical = 4 * MiB;
+    config.enable_vmm = false;
+    config.granularity = MiB;
+    RasterizerMemoryArena arena(config);
+    RasterizerMemoryArena::ExternalBacking backing{
+        .device_ptr = device_ptr,
+        .size = initial_committed_bytes,
+        .device = 0,
+        .owner = owner,
+        .label = "test.external.exact_policy",
+    };
+    ASSERT_TRUE(arena.install_external_backing(std::move(backing)));
+
+    std::vector<size_t> requests;
+    const bool grew = arena.grow_external_backing(
+        device_ptr, aligned_need,
+        [&](const size_t requested) {
+            requests.push_back(requested);
+            return requested <= aligned_need;
+        });
+    ASSERT_TRUE(grew);
+    ASSERT_EQ(requests.size(), 1u);
+    EXPECT_EQ(requests[0], aligned_need);
+    EXPECT_EQ(arena.get_statistics().capacity, aligned_need);
+}
+
+TEST_F(ArenaMetricsContentionTest, FullResetRetainsExternalBackingAndCapacity) {
+    constexpr size_t MiB = 1024 * 1024;
+    constexpr size_t physical_bytes = 8 * MiB;
+    constexpr size_t initial_committed_bytes = 1 * MiB;
+
+    void* device_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&device_ptr, physical_bytes), cudaSuccess);
+    auto owner = std::shared_ptr<void>(device_ptr, [](void* ptr) {
+        EXPECT_EQ(cudaFree(ptr), cudaSuccess);
+    });
+
+    RasterizerMemoryArena::Config config;
+    config.max_physical = physical_bytes;
+    config.enable_vmm = false;
+    config.granularity = MiB;
+    RasterizerMemoryArena arena(config);
+    RasterizerMemoryArena::ExternalBacking backing{
+        .device_ptr = device_ptr,
+        .size = initial_committed_bytes,
+        .device = 0,
+        .owner = owner,
+        .label = "test.external.reset",
+        .grow = [physical_bytes](const size_t requested) {
+            return requested <= physical_bytes ? physical_bytes : size_t{0};
+        },
+    };
+    ASSERT_TRUE(arena.install_external_backing(std::move(backing)));
+
+    const uint64_t frame = arena.begin_frame(nullptr, false);
+    auto allocate = arena.get_allocator(frame);
+    ASSERT_NE(allocate(2 * MiB), nullptr);
+    arena.end_frame(frame, nullptr, false);
+    ASSERT_EQ(arena.get_statistics().capacity, physical_bytes);
+
+    arena.full_reset();
+    EXPECT_TRUE(arena.using_external_backing());
+    EXPECT_EQ(arena.get_statistics().capacity, physical_bytes);
+
+    const uint64_t post_reset_frame = arena.begin_frame(nullptr, false);
+    auto post_reset_allocate = arena.get_allocator(post_reset_frame);
+    EXPECT_NE(post_reset_allocate(3 * MiB), nullptr);
+    arena.end_frame(post_reset_frame, nullptr, false);
 }
 
 TEST_F(ArenaMetricsContentionTest, FullResetDecommitsVmmHighWater) {

--- a/tests/test_checkpoint_resume.cpp
+++ b/tests/test_checkpoint_resume.cpp
@@ -12,6 +12,7 @@
 #include <format>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <iostream>
 #include <iterator>
 #include <memory>
 #include <optional>
@@ -219,6 +220,28 @@ namespace {
         ASSERT_EQ(result.error().suppressed().size(), 1u);
         EXPECT_EQ(result.error().suppressed().front().code(),
                   lfs::ErrorCode::ResourceExhausted);
+    }
+
+    TEST(TrainerRetrySemantics, RecoverySuccessCompletesTheForwardRetryPreparation) {
+        lfs::core::Scene scene;
+        const auto cameras = scene.addGroup("Cameras");
+        auto camera = std::make_shared<lfs::core::Camera>(
+            lfs::core::Tensor::eye(3, lfs::core::Device::CPU),
+            lfs::core::Tensor::zeros({3}, lfs::core::Device::CPU),
+            100.0f, 100.0f, 32.0f, 32.0f,
+            lfs::core::Tensor(), lfs::core::Tensor(),
+            lfs::core::CameraModelType::PINHOLE,
+            "camera.png", std::filesystem::path{}, std::filesystem::path{},
+            64, 64, 0);
+        scene.addCamera("camera.png", cameras, std::move(camera));
+        lfs::training::Trainer trainer(scene);
+        const auto cause = make_retry_test_error(lfs::ErrorCode::ResourceExhausted);
+
+        const auto result = lfs::training::TrainerRetryTestAccess::recover_with_sync_status(
+            trainer, cause, cudaSuccess);
+        EXPECT_TRUE(result.has_value());
+        EXPECT_TRUE(lfs::training::TrainerRetryTestAccess::should_retry(cause, 1));
+        EXPECT_FALSE(lfs::training::TrainerRetryTestAccess::should_retry(cause, 2));
     }
 
     constexpr const char* TEST_IMAGES = "images_4";
@@ -1532,9 +1555,13 @@ namespace {
                 << lfs::format_for_developer(document.error());
             const auto checkpoint_uuids =
                 document->checkpoint_uuids();
-            ASSERT_EQ(checkpoint_uuids.size(), 1u);
+            ASSERT_GE(checkpoint_uuids.size(), 2u);
+            const auto bound = document->bound_checkpoint_uuid();
+            ASSERT_TRUE(bound);
+            ASSERT_TRUE(*bound);
+            const auto checkpoint_uuid = **bound;
             const auto* checkpoint =
-                document->find_checkpoint(checkpoint_uuids.front());
+                document->find_checkpoint(checkpoint_uuid);
             ASSERT_NE(checkpoint, nullptr);
 
             std::optional<lfs::core::CheckpointParametersLoadResult>
@@ -1576,7 +1603,7 @@ namespace {
             ASSERT_TRUE(hydration->trainer_state_pending);
             ASSERT_EQ(
                 hydration->checkpoint_uuid,
-                std::optional(checkpoint_uuids.front()));
+                std::optional(checkpoint_uuid));
             ASSERT_TRUE(hydration->checkpoint_header.has_value());
 
             const auto* display_model =
@@ -1590,7 +1617,7 @@ namespace {
                 lfs::training::
                     installTrainerFromProjectCheckpoint(
                         scene, *document,
-                        checkpoint_uuids.front(),
+                        checkpoint_uuid,
                         resumed_params,
                         lfs::core::path_to_utf8(
                             project_path),
@@ -1672,10 +1699,13 @@ namespace {
         }
         const auto continued_checkpoints =
             continued->checkpoint_uuids();
-        ASSERT_EQ(continued_checkpoints.size(), 1u);
+        ASSERT_GE(continued_checkpoints.size(), 2u);
+        const auto continued_bound = continued->bound_checkpoint_uuid();
+        ASSERT_TRUE(continued_bound);
+        ASSERT_TRUE(*continued_bound);
         const auto* continued_checkpoint =
             continued->find_checkpoint(
-                continued_checkpoints.front());
+                **continued_bound);
         ASSERT_NE(continued_checkpoint, nullptr);
         std::optional<int> continued_iteration;
         const auto continued_header =
@@ -2145,6 +2175,83 @@ namespace {
             std::min<size_t>(500, stop_refine);
         params.optimization.stop_refine = stop_refine;
         return params;
+    }
+
+    TEST_F(ProjectCheckpointTrainerInstall,
+           SparsityBoundaryRetainsPrePruneCheckpointAcrossSaveAs) {
+        const auto output_path =
+            std::filesystem::temp_directory_path() /
+            "lfs_test_sparsity_checkpoint_history";
+        std::error_code ec;
+        std::filesystem::remove_all(output_path, ec);
+        std::filesystem::create_directories(output_path);
+
+        auto params = make_tiny_headless_params(output_path, 4);
+        params.optimization.enable_sparsity = true;
+        params.optimization.sparsify_steps = 1;
+        params.optimization.prune_ratio = 0.25f;
+        params.optimization.save_steps = {1};
+
+        lfs::core::Scene scene;
+        ASSERT_TRUE(lfs::training::loadTrainingDataIntoScene(params, scene));
+        ASSERT_TRUE(lfs::training::initializeTrainingModel(params, scene));
+        auto trainer = std::make_unique<lfs::training::Trainer>(scene);
+        ASSERT_TRUE(trainer->initialize(params));
+        lfs::training::grant_headless_project_saves(*trainer, params);
+        auto train = trainer->train();
+        ASSERT_TRUE(train)
+            << lfs::format_for_developer(train.error());
+        trainer->shutdown();
+
+        const auto master = output_path / "project.licht";
+        auto document = lfs::io::project::ProjectDocument::open(master);
+        ASSERT_TRUE(document)
+            << lfs::format_for_developer(document.error());
+        const auto bound = document->bound_checkpoint_uuid();
+        ASSERT_TRUE(bound);
+        ASSERT_TRUE(*bound);
+        EXPECT_EQ(document->checkpoint_uuids().size(), 3u);
+
+        std::vector<int> iterations;
+        for (const auto& uuid : document->checkpoint_uuids()) {
+            std::optional<lfs::core::CheckpointHeader> header;
+            ASSERT_TRUE(document->find_checkpoint(uuid)->visit_stream(
+                [&](std::istream& stream, const std::uint64_t bytes)
+                    -> lfs::Result<void> {
+                    if (auto parsed =
+                            lfs::core::load_checkpoint_header(stream, bytes);
+                        parsed) {
+                        header = *parsed;
+                    }
+                    return {};
+                }));
+            ASSERT_TRUE(header);
+            iterations.push_back(header->iteration);
+        }
+        std::ranges::sort(iterations);
+        EXPECT_EQ(iterations, (std::vector<int>{1, 4, 5}));
+
+        const auto copy = output_path / "project-copy.licht";
+        auto saved_as = document->save_as(copy);
+        ASSERT_TRUE(saved_as)
+            << lfs::format_for_developer(saved_as.error());
+        auto reopened = lfs::io::project::ProjectDocument::open(copy);
+        ASSERT_TRUE(reopened)
+            << lfs::format_for_developer(reopened.error());
+        EXPECT_EQ(reopened->checkpoint_uuids().size(), 3u);
+        const auto reopened_bound = reopened->bound_checkpoint_uuid();
+        ASSERT_TRUE(reopened_bound);
+        EXPECT_EQ(*reopened_bound, *bound);
+        std::cout << "checkpoint_history path=" << copy
+                  << " bound=" << (*reopened_bound)->to_string()
+                  << " iterations=";
+        for (const int iteration : iterations) {
+            std::cout << iteration << ',';
+        }
+        std::cout << " count=" << reopened->checkpoint_uuids().size()
+                  << '\n';
+
+        std::filesystem::remove_all(output_path, ec);
     }
 
     TEST_F(ProjectCheckpointTrainerInstall,

--- a/tests/test_gsplat_rasterizer.cpp
+++ b/tests/test_gsplat_rasterizer.cpp
@@ -7,6 +7,7 @@
 #include "core/alloc_counter.hpp"
 #include "core/camera.hpp"
 #include "core/cuda/memory_arena.hpp"
+#include "core/cuda/vmm_device_buffer.hpp"
 #include "core/splat_data.hpp"
 #include "core/tensor.hpp"
 #include "lfs/training/sh_value_codec.hpp"
@@ -18,6 +19,7 @@
 #include "training/rasterization/gsplat_rasterizer.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdlib>
 #include <cuda_runtime.h>
@@ -295,6 +297,56 @@ protected:
     Tensor means_, sh0_, shN_, scaling_, rotation_, opacity_;
     Tensor bg_color_;
 };
+
+TEST(VmmDeviceBufferTest, GrowsInPlace) {
+    constexpr size_t kMiB = 1024u * 1024u;
+    constexpr size_t kFirstCommit = 256u * kMiB;
+    constexpr size_t kSecondCommit = 512u * kMiB;
+    constexpr size_t kKeptPrefix = 128u * kMiB;
+    auto result = VmmDeviceBuffer::create(1024u * kMiB,
+                                          "test.gsplat.vmm_intersection");
+    ASSERT_TRUE(result) << format_for_developer(result.error());
+    auto buffer = std::move(*result);
+    const size_t granularity = buffer.granularity_bytes();
+
+    ASSERT_TRUE(buffer.commit(kFirstCommit));
+    void* const initial_address = buffer.data();
+    EXPECT_EQ(buffer.committed_bytes(), kFirstCommit);
+
+    ASSERT_TRUE(buffer.commit(kSecondCommit));
+    EXPECT_EQ(buffer.data(), initial_address);
+    EXPECT_EQ(buffer.committed_bytes(), kSecondCommit);
+
+    ASSERT_EQ(cudaMemset(buffer.data(), 0x5a, kKeptPrefix), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    size_t free_before = 0;
+    size_t total_bytes = 0;
+    ASSERT_EQ(cudaMemGetInfo(&free_before, &total_bytes), cudaSuccess);
+    ASSERT_TRUE(buffer.decommit_tail(kKeptPrefix));
+    EXPECT_EQ(buffer.data(), initial_address);
+    EXPECT_GE(buffer.committed_bytes(), kKeptPrefix);
+    EXPECT_EQ(buffer.committed_bytes() % granularity, 0u);
+
+    std::array<unsigned char, 4> kept_prefix{};
+    ASSERT_EQ(cudaMemcpy(kept_prefix.data(), buffer.data(), kept_prefix.size(), cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_EQ(kept_prefix, (std::array<unsigned char, 4>{0x5a, 0x5a, 0x5a, 0x5a}));
+
+    size_t free_after = 0;
+    ASSERT_EQ(cudaMemGetInfo(&free_after, &total_bytes), cudaSuccess);
+    ASSERT_TRUE(buffer.commit(kSecondCommit));
+    EXPECT_EQ(buffer.data(), initial_address);
+    EXPECT_EQ(buffer.committed_bytes(), kSecondCommit);
+    ASSERT_EQ(cudaMemcpy(kept_prefix.data(), buffer.data(), kept_prefix.size(), cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_EQ(kept_prefix, (std::array<unsigned char, 4>{0x5a, 0x5a, 0x5a, 0x5a}));
+
+    if (free_after < free_before + 256u * kMiB) {
+        GTEST_SKIP() << "CUDA free-memory jitter masked VMM decommit reclaim: before="
+                     << free_before << " after=" << free_after;
+    }
+}
 
 #if LFS_CUDA_FAILURE_INJECTION_ENABLED
 TEST_F(GsplatRasterizerTest, CudaAllocationFailureAbortsAndRecovers) {

--- a/tests/test_gsplat_rasterizer.cpp
+++ b/tests/test_gsplat_rasterizer.cpp
@@ -12,6 +12,7 @@
 #include "lfs/training/sh_value_codec.hpp"
 #include "lfs/training/sh_value_storage.hpp"
 #include "optimizer/adam_optimizer.hpp"
+#include "training/rasterization/fast_rasterizer.hpp"
 #include "training/rasterization/gsplat/Common.h"
 #include "training/rasterization/gsplat/Ops.h"
 #include "training/rasterization/gsplat_rasterizer.hpp"
@@ -526,6 +527,172 @@ TEST(GsplatRasterizerQuantTest, RejectsFloat16ShRestWithoutQ16Bounds) {
         EXPECT_NE(std::string_view(error.what()).find("unsupported SH-rest storage"),
                   std::string_view::npos);
     }
+}
+
+TEST(GsplatRasterizerEdgeScores, GutFusedScoresRespectEdgeMapAndCameraModel) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "CUDA device unavailable";
+    }
+
+    auto run = [](Camera camera, const Tensor& edge_map) {
+        auto splat = make_visible_splat(32);
+        AdamConfig cfg;
+        cfg.lr = 1e-3f;
+        cfg.initial_capacity = 64;
+        AdamOptimizer optimizer(*splat, cfg);
+        optimizer.allocate_gradients(64);
+        auto background = Tensor::zeros({3}, Device::CUDA);
+        auto scores = Tensor::zeros({32}, Device::CUDA);
+
+        auto result = gsplat_rasterize_forward(
+            camera, *splat, background, 0, 0, 0, 0, 1.0f, false,
+            GsplatRenderMode::RGB, true);
+        EXPECT_TRUE(result.has_value()) << result.error();
+        if (!result) {
+            return scores.cpu();
+        }
+        auto output = std::move(result->first);
+        auto context = std::move(result->second);
+        if (context.n_isects == 0) {
+            ADD_FAILURE() << "fixture must produce intersections";
+            return scores.cpu();
+        }
+        auto grad_image = Tensor::ones_like(output.image);
+        auto grad_alpha = Tensor::zeros_like(output.alpha);
+        gsplat_rasterize_backward(
+            context, grad_image, grad_alpha, *splat, optimizer, Tensor{}, edge_map, scores);
+        return scores.cpu();
+    };
+
+    const auto pinhole_ones = run(make_camera(64, 64), Tensor::ones({64, 64}, Device::CUDA));
+    bool has_positive = false;
+    for (size_t i = 0; i < static_cast<size_t>(pinhole_ones.numel()); ++i) {
+        const float value = pinhole_ones.ptr<float>()[i];
+        ASSERT_TRUE(std::isfinite(value));
+        ASSERT_GE(value, 0.0f);
+        has_positive |= value > 0.0f;
+    }
+    EXPECT_TRUE(has_positive);
+
+    const auto pinhole_zeros = run(make_camera(64, 64), Tensor::zeros({64, 64}, Device::CUDA));
+    for (size_t i = 0; i < static_cast<size_t>(pinhole_zeros.numel()); ++i) {
+        EXPECT_FLOAT_EQ(pinhole_zeros.ptr<float>()[i], 0.0f);
+    }
+
+    const auto fisheye_ones = run(make_fisheye_camera(64, 64), Tensor::ones({64, 64}, Device::CUDA));
+    bool fisheye_has_positive = false;
+    for (size_t i = 0; i < static_cast<size_t>(fisheye_ones.numel()); ++i) {
+        const float value = fisheye_ones.ptr<float>()[i];
+        ASSERT_TRUE(std::isfinite(value));
+        ASSERT_GE(value, 0.0f);
+        fisheye_has_positive |= value > 0.0f;
+    }
+    EXPECT_TRUE(fisheye_has_positive);
+}
+
+TEST(GsplatRasterizerEdgeScores, GutAndFastGsHavePositiveScoreCorrelation) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "CUDA device unavailable";
+    }
+
+    constexpr int width = 64;
+    constexpr int height = 64;
+    constexpr int count = 32;
+    auto camera = make_camera(width, height);
+    const auto edge_map = Tensor::ones({height, width}, Device::CUDA);
+
+    auto gut_model = make_visible_splat(count);
+    AdamConfig gut_config;
+    gut_config.lr = 1e-3f;
+    gut_config.initial_capacity = 64;
+    AdamOptimizer gut_optimizer(*gut_model, gut_config);
+    gut_optimizer.allocate_gradients(64);
+    auto background = Tensor::zeros({3}, Device::CUDA);
+    auto gut_scores = Tensor::zeros({count}, Device::CUDA);
+    auto gut_result = gsplat_rasterize_forward(
+        camera, *gut_model, background, 0, 0, 0, 0, 1.0f, false,
+        GsplatRenderMode::RGB, true);
+    ASSERT_TRUE(gut_result.has_value()) << gut_result.error();
+    auto gut_output = std::move(gut_result->first);
+    auto gut_context = std::move(gut_result->second);
+    gsplat_rasterize_backward(
+        gut_context, Tensor::ones_like(gut_output.image), Tensor::zeros_like(gut_output.alpha),
+        *gut_model, gut_optimizer, Tensor{}, edge_map, gut_scores);
+
+    auto fast_model = make_visible_splat(count);
+    AdamOptimizer fast_optimizer(*fast_model, gut_config);
+    fast_optimizer.allocate_gradients(64);
+    auto fast_result = fast_rasterize_forward(
+        camera, *fast_model, background, 0, 0, 0, 0, false);
+    ASSERT_TRUE(fast_result.has_value()) << lfs::format_for_developer(fast_result.error());
+    auto fast_output = std::move(fast_result->first);
+    auto fast_context = std::move(fast_result->second);
+    auto fast_scores = Tensor::zeros({count}, Device::CUDA);
+    FastGSFusedExtraGradients fused;
+    fused.edge_weight_map = edge_map.ptr<float>();
+    fused.edge_score_out = fast_scores.ptr<float>();
+    fast_rasterize_backward(
+        fast_context, Tensor::ones_like(fast_output.image), *fast_model, fast_optimizer,
+        Tensor{}, Tensor{}, DensificationType::None, 0, fused);
+
+    const auto gut_cpu = gut_scores.cpu();
+    const auto fast_cpu = fast_scores.cpu();
+    float gut_mean = 0.0f;
+    float fast_mean = 0.0f;
+    for (int i = 0; i < count; ++i) {
+        gut_mean += gut_cpu.ptr<float>()[i];
+        fast_mean += fast_cpu.ptr<float>()[i];
+    }
+    gut_mean /= static_cast<float>(count);
+    fast_mean /= static_cast<float>(count);
+    float covariance = 0.0f;
+    float gut_variance = 0.0f;
+    float fast_variance = 0.0f;
+    for (int i = 0; i < count; ++i) {
+        const float gut_delta = gut_cpu.ptr<float>()[i] - gut_mean;
+        const float fast_delta = fast_cpu.ptr<float>()[i] - fast_mean;
+        covariance += gut_delta * fast_delta;
+        gut_variance += gut_delta * gut_delta;
+        fast_variance += fast_delta * fast_delta;
+    }
+    ASSERT_GT(gut_variance, 0.0f);
+    ASSERT_GT(fast_variance, 0.0f);
+    const float correlation = covariance / std::sqrt(gut_variance * fast_variance);
+    EXPECT_GT(correlation, 0.75f);
+}
+
+TEST(GsplatRasterizerErrors, GutArenaExhaustionPreservesTypedResourceError) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "CUDA device unavailable";
+    }
+
+    lfs::core::RasterizerMemoryArena::Config config;
+    config.virtual_size = 64ULL << 20;
+    config.max_physical = 4ULL << 10;
+    config.granularity = 4ULL << 10;
+    config.enable_vmm = false;
+    auto& manager = lfs::core::GlobalArenaManager::instance();
+    manager.reconfigure_for_testing(config);
+
+    auto camera = make_camera(64, 64);
+    auto splat = make_visible_splat(32);
+    auto background = Tensor::zeros({3}, Device::CUDA);
+    bool caught_typed_resource_error = false;
+    try {
+        (void)gsplat_rasterize_forward(
+            camera, *splat, background, 0, 0, 0, 0, 1.0f, false,
+            GsplatRenderMode::RGB, true);
+    } catch (const lfs::Exception& exception) {
+        caught_typed_resource_error =
+            exception.error().code() == lfs::ErrorCode::ResourceExhausted &&
+            exception.error().detail().find("gsplat forward arena allocation failed") !=
+                std::string::npos;
+    }
+    manager.reset();
+    EXPECT_TRUE(caught_typed_resource_error);
 }
 
 TEST_F(GsplatRasterizerTest, ForwardWritesChwAndBackwardIsStable) {

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -3659,8 +3659,9 @@ namespace {
             disk.commit().commit_uuid);
     }
 
-    LazyChunkValue make_autosave_checkpoint_payload(
-        const Uuid& checkpoint_uuid) {
+    LazyChunkValue make_autosave_checkpoint_payload_at(
+        const Uuid& checkpoint_uuid,
+        const int iteration) {
         auto model = make_splat(2);
         lfs::training::MCMC strategy(*model);
         lfs::core::param::TrainingParameters parameters;
@@ -3674,7 +3675,7 @@ namespace {
             std::ios::binary | std::ios::out);
         (void)require_result(
             lfs::training::serialize_checkpoint(
-                stream, 11, strategy, parameters,
+                stream, iteration, strategy, parameters,
                 nullptr, nullptr, nullptr, nullptr));
         const auto encoded = stream.str();
         std::vector<std::byte> bytes(encoded.size());
@@ -3683,6 +3684,11 @@ namespace {
         auto payload = LazyChunkValue::from_owned(
             std::move(bytes), checkpoint_uuid);
         return require_result(std::move(payload));
+    }
+
+    LazyChunkValue make_autosave_checkpoint_payload(
+        const Uuid& checkpoint_uuid) {
+        return make_autosave_checkpoint_payload_at(checkpoint_uuid, 11);
     }
 
     void install_bound_autosave_checkpoint(
@@ -3849,7 +3855,7 @@ namespace {
     }
 
     TEST(ProjectDocumentTest,
-         UnboundCheckpointIsRemovedWhenCapturedSceneHasNoBinding) {
+         UnboundCheckpointRemainsLiveWhenCapturedSceneHasNoBinding) {
         const auto training_uuid = fixed_uuid(9970);
         const auto checkpoint_uuid = fixed_uuid(9971);
         auto document = make_empty_document(fixed_uuid(9972), 100);
@@ -3876,30 +3882,12 @@ namespace {
         document->edit_scene_graph() = SceneGraphChapter{};
         Scene live;
         auto before_prune = document->stage_hydration(live);
-        ASSERT_FALSE(before_prune);
-        EXPECT_EQ(
-            before_prune.error().code(), lfs::ErrorCode::DataLoss);
-
-        std::unordered_set<Uuid> bound;
-        if (const auto nodes = document->scene_graph().nodes();
-            nodes) {
-            for (const auto& node : *nodes) {
-                if (node.payload && node.payload->fourcc == "CKPT") {
-                    bound.insert(node.payload->instance_uuid);
-                }
-            }
-        }
-        for (const auto& uuid : document->checkpoint_uuids()) {
-            if (!bound.contains(uuid)) {
-                EXPECT_TRUE(document->remove_checkpoint(uuid));
-            }
-        }
-        EXPECT_TRUE(document->checkpoint_uuids().empty());
-
-        Scene after_scene;
-        auto after_prune = document->stage_hydration(after_scene);
-        ASSERT_TRUE(after_prune)
-            << lfs::format_for_developer(after_prune.error());
+        ASSERT_TRUE(before_prune)
+            << lfs::format_for_developer(before_prune.error());
+        EXPECT_EQ(document->checkpoint_uuids().size(), 1u);
+        const auto bound = document->bound_checkpoint_uuid();
+        ASSERT_TRUE(bound);
+        EXPECT_FALSE(*bound);
 
         TemporaryDirectory temporary;
         const auto path =
@@ -3907,7 +3895,10 @@ namespace {
         (void)require_result(
             document->save(path, save_options(9973, 200)));
         auto reopened = require_result_ptr(ProjectDocument::open(path));
-        EXPECT_TRUE(reopened->checkpoint_uuids().empty());
+        EXPECT_EQ(reopened->checkpoint_uuids().size(), 1u);
+        const auto reopened_bound = reopened->bound_checkpoint_uuid();
+        ASSERT_TRUE(reopened_bound);
+        EXPECT_FALSE(*reopened_bound);
     }
 
     TEST(ProjectDocumentTest,
@@ -3950,6 +3941,209 @@ namespace {
         }
         ASSERT_EQ(document->checkpoint_uuids().size(), 1u);
         EXPECT_EQ(document->checkpoint_uuids().front(), checkpoint_uuid);
+    }
+
+    TEST(ProjectDocumentTest,
+         CheckpointHistorySurvivesSaveAsAndCompaction) {
+        TemporaryDirectory temporary;
+        const auto master = temporary.path / "history-master.licht";
+        const auto copy = temporary.path / "history-copy.licht";
+        const Uuid training_uuid = fixed_uuid(9980);
+        const Uuid first_uuid = fixed_uuid(9981);
+        const Uuid current_uuid = fixed_uuid(9982);
+        auto document = make_empty_document(fixed_uuid(9983), 100);
+        install_bound_autosave_checkpoint(
+            *document, training_uuid, first_uuid);
+        require_status(document->edit_scene_graph().upsert_node(
+            SceneNodeRecord{
+                .uuid = training_uuid,
+                .type = "splat",
+                .name = "Training",
+                .child_order = 0,
+                .payload = PayloadBinding{
+                    .fourcc = "CKPT",
+                    .instance_uuid = current_uuid,
+                    .source_kind = "training",
+                },
+            }));
+        require_status(document->set_checkpoint(
+            current_uuid,
+            make_autosave_checkpoint_payload_at(current_uuid, 22)));
+        auto master_options = save_options(9984, 200);
+        master_options.commit.snapshot_uuid = current_uuid;
+        ASSERT_TRUE(document->save(master, master_options));
+
+        auto reopened = require_result_ptr(ProjectDocument::open(master));
+        EXPECT_EQ(reopened->checkpoint_uuids().size(), 2u);
+        const auto bound = require_result(reopened->bound_checkpoint_uuid());
+        ASSERT_TRUE(bound);
+        EXPECT_EQ(*bound, current_uuid);
+
+        auto foreign = make_empty_document(fixed_uuid(9989), 250);
+        ASSERT_TRUE(foreign->save(copy, save_options(9990, 250)));
+        auto copy_options = save_options(9985, 300);
+        copy_options.commit.snapshot_uuid = current_uuid;
+        copy_options.allow_existing_destination_replacement = true;
+        ASSERT_TRUE(reopened->save_as(copy, copy_options));
+        ASSERT_TRUE(ProjectWriter::compact(
+            copy,
+            CompactionOptions{
+                .new_file_uuid = fixed_uuid(9986),
+                .commit_uuid = fixed_uuid(9987),
+                .snapshot_uuid = current_uuid,
+                .creation_time_unix_ns = 400,
+                .wallclock_unix_ns = 500,
+                .disk_reserve_bytes = 0,
+            }));
+        auto compacted = require_result_ptr(ProjectDocument::open(copy));
+        EXPECT_EQ(compacted->checkpoint_uuids().size(), 2u);
+        EXPECT_NE(compacted->find_checkpoint(first_uuid), nullptr);
+        EXPECT_NE(compacted->find_checkpoint(current_uuid), nullptr);
+        EXPECT_EQ(
+            require_result(compacted->bound_checkpoint_uuid()),
+            std::optional(current_uuid));
+    }
+
+    TEST(ProjectDocumentTest,
+         CheckpointHistoryRetentionEvictsOldestUnboundEntry) {
+        auto document = make_empty_document(fixed_uuid(9988), 100);
+        for (int iteration = 1;
+             iteration <= static_cast<int>(CHECKPOINT_HISTORY_LIMIT) + 2;
+             ++iteration) {
+            const auto uuid = fixed_uuid(9988 + iteration);
+            require_status(document->set_checkpoint(
+                uuid,
+                make_autosave_checkpoint_payload_at(uuid, iteration)));
+        }
+        const auto uuids = document->checkpoint_uuids();
+        EXPECT_EQ(uuids.size(), CHECKPOINT_HISTORY_LIMIT);
+        EXPECT_EQ(document->find_checkpoint(fixed_uuid(9989)), nullptr);
+        EXPECT_EQ(document->find_checkpoint(fixed_uuid(9990)), nullptr);
+        EXPECT_NE(document->find_checkpoint(fixed_uuid(9991)), nullptr);
+    }
+
+    TEST(ProjectDocumentTest,
+         LightweightAutosaveRefreshDoesNotGrowCheckpointHistory) {
+        TemporaryDirectory temporary;
+        const auto master = temporary.path / "autosave-master.licht";
+        write_phase_a_fixture(master);
+        auto document = require_result_ptr(ProjectDocument::open(master));
+        const auto checkpoint_uuid = fixed_uuid(10010);
+        install_bound_autosave_checkpoint(
+            *document, fixed_uuid(10009), checkpoint_uuid);
+        auto master_options = save_options(10011, 200);
+        master_options.commit.snapshot_uuid = checkpoint_uuid;
+        ASSERT_TRUE(document->save(master, master_options));
+        const auto base = require_result(ProjectReader::open(master));
+        const auto sidecar = autosave_sidecar_path(master);
+
+        for (std::uint64_t sequence = 1; sequence <= 2; ++sequence) {
+            auto saved = document->save_autosave(
+                sidecar,
+                ProjectDocumentAutosaveOptions{
+                    .file_uuid = fixed_uuid(10011 + sequence),
+                    .base_explicit_commit_uuid =
+                        base.commit().commit_uuid,
+                    .autosave_sequence = sequence,
+                    .snapshot_uuid = checkpoint_uuid,
+                    .index_compression =
+                        IndexCompression::StoredForDeterministicTests,
+                    .disk_reserve_bytes = 0,
+                });
+            ASSERT_TRUE(saved)
+                << lfs::format_for_developer(saved.error());
+            EXPECT_EQ(document->checkpoint_uuids().size(), 1u);
+            EXPECT_EQ(
+                require_result(document->bound_checkpoint_uuid()),
+                std::optional(checkpoint_uuid));
+        }
+    }
+
+    TEST(ProjectDocumentTest,
+         TrainingNodeWithoutBoundCheckpointIsRejected) {
+        auto document = make_empty_document(fixed_uuid(9995), 100);
+        const Uuid training_uuid = fixed_uuid(9996);
+        const Uuid checkpoint_uuid = fixed_uuid(9997);
+        require_status(document->edit_scene_graph().upsert_node(
+            SceneNodeRecord{
+                .uuid = training_uuid,
+                .type = "splat",
+                .name = "Training",
+                .child_order = 0,
+                .payload = PayloadBinding{
+                    .fourcc = "CKPT",
+                    .instance_uuid = checkpoint_uuid,
+                    .source_kind = "training",
+                },
+            }));
+        require_status(document->edit_scene_graph()
+                           .set_training_model_uuid(training_uuid));
+        TemporaryDirectory temporary;
+        auto invalid_options = save_options(9998, 200);
+        invalid_options.commit.snapshot_uuid = {};
+        auto saved = document->save(
+            temporary.path / "invalid-training.licht",
+            invalid_options);
+        ASSERT_FALSE(saved);
+        EXPECT_EQ(saved.error().code(), lfs::ErrorCode::DataLoss);
+    }
+
+    TEST(ProjectDocumentTest,
+         TrainingNodeWithoutBoundCheckpointWithHistoryIsRejected) {
+        auto document = make_empty_document(fixed_uuid(10002), 100);
+        const Uuid training_uuid = fixed_uuid(10003);
+        const Uuid checkpoint_uuid = fixed_uuid(10004);
+        require_status(document->edit_scene_graph().upsert_node(
+            SceneNodeRecord{
+                .uuid = training_uuid,
+                .type = "group",
+                .name = "Training",
+                .child_order = 0,
+            }));
+        require_status(document->edit_scene_graph()
+                           .set_training_model_uuid(training_uuid));
+        require_status(document->set_checkpoint(
+            checkpoint_uuid,
+            make_autosave_checkpoint_payload(checkpoint_uuid)));
+
+        TemporaryDirectory temporary;
+        auto saved = document->save(
+            temporary.path / "unbound-training-history.licht",
+            save_options(10005, 200));
+        ASSERT_FALSE(saved);
+        EXPECT_EQ(saved.error().code(), lfs::ErrorCode::DataLoss);
+        EXPECT_NE(
+            lfs::format_for_developer(saved.error()).find("historical CKPT"),
+            std::string::npos);
+    }
+
+    TEST(ProjectDocumentTest,
+         FreshTrainingNodeWithoutCheckpointHistoryLoads) {
+        auto document = make_empty_document(fixed_uuid(9999), 100);
+        const Uuid training_uuid = fixed_uuid(10000);
+        require_status(document->edit_scene_graph().upsert_node(
+            SceneNodeRecord{
+                .uuid = training_uuid,
+                .type = "group",
+                .name = "Training",
+                .child_order = 0,
+            }));
+        require_status(document->edit_scene_graph()
+                           .set_training_model_uuid(training_uuid));
+
+        TemporaryDirectory temporary;
+        const auto path = temporary.path / "fresh-training.licht";
+        auto saved = document->save(path, save_options(10001, 200));
+        ASSERT_TRUE(saved)
+            << lfs::format_for_developer(saved.error());
+
+        auto reopened = ProjectDocument::open(path);
+        ASSERT_TRUE(reopened)
+            << lfs::format_for_developer(reopened.error());
+        EXPECT_TRUE(reopened->checkpoint_uuids().empty());
+        const auto bound = reopened->bound_checkpoint_uuid();
+        ASSERT_TRUE(bound);
+        EXPECT_FALSE(*bound);
     }
 
     TEST(ProjectDocumentTest,

--- a/tests/test_undistort.cpp
+++ b/tests/test_undistort.cpp
@@ -248,6 +248,17 @@ TEST(UndistortPinhole, StrongPincushionDistortion) {
     run_image_undistort(params);
 }
 
+TEST(UndistortDiagnostics, ReportsCropSolveFailure) {
+    const auto params = compute_undistort_params(
+        TEST_FX, TEST_FY, TEST_CX, TEST_CY, 0, 0,
+        Tensor::from_vector({0.1f, -0.02f, 0.003f, -0.0004f}, {4}, Device::CPU),
+        Tensor(), CameraModelType::FISHEYE);
+
+    EXPECT_TRUE(params.crop_solve_failed);
+    EXPECT_EQ(params.dst_width, 0);
+    EXPECT_EQ(params.dst_height, 0);
+}
+
 // ====================== Fisheye model tests ======================
 
 TEST(UndistortFisheye, SimpleRadialFisheye) {

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -189,6 +189,37 @@ namespace {
         return {std::move(uuids), std::move(bytes)};
     }
 
+    std::pair<lfs::core::Uuid, std::vector<std::byte>>
+    bound_checkpoint_identity(const std::filesystem::path& path) {
+        auto opened = lfs::test::licht::require_result_ptr(
+            lfs::io::project::ProjectDocument::open(
+                path,
+                {
+                    .defer_geometry_payloads = true,
+                }));
+        const auto bound = lfs::test::licht::require_result(
+            opened->bound_checkpoint_uuid());
+        std::vector<std::byte> bytes;
+        if (!bound) {
+            return {lfs::core::Uuid{}, std::move(bytes)};
+        }
+        const auto bound_uuid = *bound;
+        const auto* checkpoint =
+            opened->find_checkpoint(bound_uuid);
+        if (!checkpoint || checkpoint->size() == 0) {
+            return {bound_uuid, std::move(bytes)};
+        }
+        bytes.resize(static_cast<std::size_t>(
+            checkpoint->size()));
+        auto read = checkpoint->read_at(
+            0, std::span<std::byte>(
+                   bytes.data(), bytes.size()));
+        if (!read) {
+            bytes.clear();
+        }
+        return {bound_uuid, std::move(bytes)};
+    }
+
     lfs::Error posted_work_cancelled_error() {
         return lfs::make_error(lfs::ErrorInit{
             .code = lfs::ErrorCode::Cancelled,
@@ -7963,6 +7994,8 @@ namespace lfs::vis {
                     return node.name ==
                            "Light edit before first ckpt";
                 }));
+            // This fixture has no checkpoint history yet. Light autosave
+            // preserves existing CKPT chapters but never creates one.
             EXPECT_TRUE(restored->checkpoint_uuids()
                             .empty());
         }
@@ -13146,7 +13179,7 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           EditModeSaveDropsFormerTrainingCheckpoint) {
+           EditModeSaveRetainsUnboundCheckpointHistory) {
         if (!cuda_device_available()) {
             GTEST_SKIP() << "CUDA device unavailable";
         }
@@ -13246,8 +13279,12 @@ namespace lfs::vis {
             lfs::test::licht::require_result_ptr(
                 lfs::io::project::ProjectDocument::open(
                     project_path));
-        EXPECT_TRUE(saved_document->checkpoint_uuids()
-                        .empty());
+        // Owner decision B: Edit Mode drops only the binding; historical CKPT
+        // chapters remain live and unbound through save and compaction.
+        EXPECT_EQ(saved_document->checkpoint_uuids().size(), 1u);
+        const auto bound = saved_document->bound_checkpoint_uuid();
+        ASSERT_TRUE(bound);
+        EXPECT_FALSE(*bound);
         const auto training_uuid =
             saved_document->scene_graph()
                 .training_model_uuid();
@@ -13521,7 +13558,7 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
-           EditModeWithoutHydratedSessionDropsCheckpoint) {
+           EditModeWithoutHydratedSessionRetainsCheckpointHistory) {
         if (!cuda_device_available()) {
             GTEST_SKIP() << "CUDA device unavailable";
         }
@@ -13575,8 +13612,12 @@ namespace lfs::vis {
             lfs::test::licht::require_result_ptr(
                 lfs::io::project::ProjectDocument::open(
                     project_path));
-        EXPECT_TRUE(saved_document->checkpoint_uuids()
-                        .empty());
+        // Owner decision B: a non-hydrated Edit Mode transition drops only
+        // the binding; the former checkpoint remains historical and unbound.
+        EXPECT_EQ(saved_document->checkpoint_uuids().size(), 1u);
+        const auto bound = saved_document->bound_checkpoint_uuid();
+        ASSERT_TRUE(bound);
+        EXPECT_FALSE(*bound);
     }
 
     TEST_F(VisualizerImplResetTest,
@@ -13611,7 +13652,9 @@ namespace lfs::vis {
             lfs::core::generate_uuid_v4(),
             dataset_path);
         const auto before =
-            checkpoint_identity(project_path);
+            bound_checkpoint_identity(project_path);
+        ASSERT_FALSE(before.first.is_nil());
+        ASSERT_FALSE(before.second.empty());
 
         auto options = projectOptions();
         VisualizerImpl viewer(options);
@@ -13662,8 +13705,11 @@ namespace lfs::vis {
                     JobType::ProjectWrite);
             }));
         const auto after =
-            checkpoint_identity(project_path);
-        ASSERT_FALSE(after.first.empty());
+            bound_checkpoint_identity(project_path);
+        ASSERT_FALSE(after.first.is_nil());
+        ASSERT_FALSE(after.second.empty());
+        // The old CKPT remains historical; compare the newly bound chapter.
+        EXPECT_NE(after.first, before.first);
         EXPECT_NE(after.second, before.second);
     }
 


### PR DESCRIPTION
A 6 hour fisheye training died overnight with "RasterizerMemoryArena allocation failed for 3277 MiB". The grow path asked for 1.5x more memory than needed, threw away the CUDA error text, and training had no way to recover. Root cause analysis of the reported log traced it to MRNF's old pinhole edge pass exploding on a fisheye scene plus the grow policy. This PR fixes the chain and everything found along the way.

- the shared CUDA/Vulkan scratch grows by exactly what is needed and logs the real error when it can't
- a GUT training step that runs out of memory frees caches and retries once instead of dying, same as fastgs
- on a training error the trainer saves the model to the project one last time, so an overnight failure no longer loses the run
- MRNF edge scores now work with GUT too, fused into the backward pass, no extra buffers, pinhole and fisheye
- .licht keeps checkpoint history: the current checkpoint stays bound for resume, older ones survive save, save as and compaction. This fixes the reported checkpoint loss on "Save as" and "Save project". Edit mode no longer purges them either. The container grammar goes to 1.1 only when a project actually holds more than one checkpoint, so old builds show a clear version error instead of "data loss"
- the sparsity boundary checkpoint is now captured before pruning, as its log message always claimed
- arena failures log a VRAM snapshot and which subsystem asked for the memory
- the per-image "no valid border samples" warning is now one summary line with a note that GUT handles fisheye natively
- fastgs out-of-memory errors classify as retryable again (regression)
- GUT intersection caches grow with 25 percent headroom instead of 2x

Tests: arena grow policy and failure paths, full_reset with external backing installed, GUT OOM retry, GUT edge scores including fisheye and a fastgs parity check, checkpoint history across save, save as and reopen, edit mode retention, validator rules, format compatibility, undistort summary. 288 targeted tests green, memcheck and racecheck clean, MRNF and MCMC GUT smokes on bicycle green, GUI checked with a PLY load.