### PR TITLE
Fix normal/depth map generation aborting on mixed-orientation datasets

### DIFF
--- a/src/core/nn/models/moge2.cpp
+++ b/src/core/nn/models/moge2.cpp
@@ -52,7 +52,7 @@ namespace lfs::core::nn::models {
         // device copies is enough and dtype-correct.
         void recapture(Tensor& slot, const Tensor& src) {
             if (!slot.is_valid() || slot.dtype() != src.dtype() || slot.device() != src.device() ||
-                slot.numel() != src.numel()) {
+                slot.shape() != src.shape()) {
                 slot = src.clone();
                 return;
             }


### PR DESCRIPTION
Fixes #1942.

`recapture()` in the native MoGe-2 model reused its persistent hold tensor whenever dtype/device/element count matched, without checking shape. A landscape image at the default 518 max side yields a 35x52 token grid, portrait 52x35: same numel, different shape. On the first orientation change the portrait activation was copied into the stale landscape-shaped tensor, and the following concat hit `concat tensors differ on more than one dim`, aborting the whole run. Only the maps generated before the first flip were written, for depth and normals alike. Reuse now requires an identical shape.

Verified on a 194-image mixed-orientation dataset (2 landscape + 192 portrait, rewritten COLMAP poses validated by reprojection):
- pre-fix reproduces exactly (2/194 maps, run aborts) via CLI `preprocess` and the training-time normal auto-generate path
- post-fix: 194/194 normals and depth via `--mode normals/depth/both`, portrait maps at correct dimensions, depth anchors written, `--use-depth-loss`/`--use-normal-loss` training runs complete with both priors active
- landscape-only outputs unchanged (PSNR 84.7 vs pre-fix), compute-sanitizer memcheck clean
