### PR TITLE
COLMAP dataset import is almost 5x faster

### DIFF
--- a/src/core/camera.cpp
+++ b/src/core/camera.cpp
@@ -865,6 +865,11 @@ namespace lfs::core {
         _undistort_precomputed = true;
     }
 
+    void Camera::adopt_undistortion(const UndistortParams& params) noexcept {
+        _undistort_params = params;
+        _undistort_precomputed = true;
+    }
+
     void Camera::prepare_undistortion(float blank_pixels) {
         if (_undistort_prepared)
             return;

--- a/src/core/include/core/camera.hpp
+++ b/src/core/include/core/camera.hpp
@@ -218,6 +218,9 @@ namespace lfs::core {
         void translate(const Tensor& trans);
 
         void precompute_undistortion(float blank_pixels = 0.0f);
+        // Install parameters computed for an equivalent camera record without
+        // repeating the distortion solve or its device-to-host copies.
+        void adopt_undistortion(const UndistortParams& params) noexcept;
         bool is_undistort_precomputed() const noexcept { return _undistort_precomputed; }
         void prepare_undistortion(float blank_pixels = 0.0f);
         bool is_undistort_prepared() const noexcept { return _undistort_prepared; }

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -34,6 +34,7 @@
 #include <string_view>
 #include <system_error>
 #include <tbb/parallel_for.h>
+#include <tbb/task_group.h>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -402,7 +403,7 @@ namespace lfs::io {
     // -----------------------------------------------------------------------------
     //  Quaternion to rotation matrix (torch-free)
     // -----------------------------------------------------------------------------
-    inline Tensor qvec2rotmat(const std::vector<float>& q_raw) {
+    inline std::array<float, 9> qvec2rotmat_values(const std::vector<float>& q_raw) {
         LFS_ASSERT_MSG(q_raw.size() == 4,
                        std::format("quaternion must have four elements "
                                    "(component_count={})",
@@ -428,12 +429,15 @@ namespace lfs::io {
         float z = q_raw[3] / len;
 
         // Build rotation matrix [3, 3]
-        std::vector<float> R_data = {
+        return {
             1.0f - 2.0f * (y * y + z * z), 2.0f * (x * y - z * w), 2.0f * (x * z + y * w),
             2.0f * (x * y + z * w), 1.0f - 2.0f * (x * x + z * z), 2.0f * (y * z - x * w),
             2.0f * (x * z - y * w), 2.0f * (y * z + x * w), 1.0f - 2.0f * (x * x + y * y)};
+    }
 
-        return Tensor::from_vector(R_data, {3, 3}, Device::CPU);
+    inline Tensor qvec2rotmat(const std::vector<float>& q_raw) {
+        const auto values = qvec2rotmat_values(q_raw);
+        return Tensor::from_vector(std::vector<float>(values.begin(), values.end()), {3, 3}, Device::CPU);
     }
 
     namespace {
@@ -876,7 +880,36 @@ namespace lfs::io {
         }
     }
 
-    static Result<void> validate_colmap_dataset_layout_impl(
+    struct ColmapDatasetCaches {
+        std::unique_ptr<RecursiveFileCache> images;
+        std::unique_ptr<MaskDirCache> masks;
+        std::unique_ptr<DepthDirCache> depths;
+        std::unique_ptr<NormalDirCache> normals;
+    };
+
+    static ColmapDatasetCaches build_colmap_dataset_caches(
+        const fs::path& base,
+        const fs::path& images_path,
+        const LoadOptions& options) {
+        ColmapDatasetCaches caches;
+        tbb::task_group tasks;
+        tasks.run([&] {
+            caches.images = std::make_unique<RecursiveFileCache>(images_path, options.cancel_requested);
+        });
+        tasks.run([&] {
+            caches.masks = std::make_unique<MaskDirCache>(base, options.cancel_requested);
+        });
+        tasks.run([&] {
+            caches.depths = std::make_unique<DepthDirCache>(base, options.cancel_requested);
+        });
+        tasks.run([&] {
+            caches.normals = std::make_unique<NormalDirCache>(base, options.cancel_requested);
+        });
+        tasks.wait();
+        return caches;
+    }
+
+    static Result<ColmapDatasetCaches> validate_colmap_dataset_layout_impl(
         const fs::path& base,
         const std::string& images_folder,
         const std::vector<ImageData>& images,
@@ -893,14 +926,10 @@ namespace lfs::io {
 
         log_unused_sidecars(base, options);
         const auto basename_layout = scan_image_basename_layout(images_path, options);
-        RecursiveFileCache image_cache(images_path, options.cancel_requested);
-        std::optional<MaskDirCache> mask_cache;
-        std::optional<DepthDirCache> depth_cache;
-        if (options.load_masks) {
-            mask_cache.emplace(base, options.cancel_requested);
-        }
-        if (options.load_depths) {
-            depth_cache.emplace(base, options.cancel_requested);
+        ColmapDatasetCaches caches;
+        {
+            LOG_TIMER_DEBUG("COLMAP assemble: caches");
+            caches = build_colmap_dataset_caches(base, images_path, options);
         }
 
         std::unordered_map<std::string, size_t> basename_only_metadata_counts;
@@ -938,11 +967,11 @@ namespace lfs::io {
                 }
             }
 
-            if (auto image_lookup = image_cache.lookup(image_rel_path); image_lookup.found()) {
-                if (options.load_masks && mask_cache->lookup(image.name).ambiguous()) {
+            if (auto image_lookup = caches.images->lookup(image_rel_path); image_lookup.found()) {
+                if (options.load_masks && caches.masks->lookup(image.name).ambiguous()) {
                     return make_ambiguous_mask_reference_error(base, image.name);
                 }
-                if (options.load_depths && depth_cache->lookup(image.name).ambiguous()) {
+                if (options.load_depths && caches.depths->lookup(image.name).ambiguous()) {
                     return make_error(
                         ErrorCode::INVALID_DATASET,
                         std::format("Depth map for image '{}' is ambiguous across the dataset depth folders. "
@@ -966,7 +995,7 @@ namespace lfs::io {
                 images_path);
         }
 
-        return {};
+        return caches;
     }
 
     // -----------------------------------------------------------------------------
@@ -1547,12 +1576,12 @@ namespace lfs::io {
                                                          const LoadOptions& options = {},
                                                          SkipTally* tally = nullptr) {
         LOG_TIMER_TRACE("Read points3D.bin");
-        LOG_TIMER_DEBUG("COLMAP points3D parse");
         std::unique_ptr<BinaryBuffer> buf_owner;
         {
-            LOG_TIMER_DEBUG("COLMAP points3D.bin read");
+            LOG_TIMER_DEBUG("COLMAP points3D read");
             buf_owner = read_binary(file_path);
         }
+        LOG_TIMER_DEBUG("COLMAP points3D parse");
         const char* cur = buf_owner->data();
         const char* end = cur + buf_owner->size();
 
@@ -1614,6 +1643,13 @@ namespace lfs::io {
         }
         LOG_DEBUG("Reading {} 3D points from binary file", N);
         std::vector<Point3DData> parsed(N);
+        // Keep the public Point3DData::track representation, but perform its
+        // vector allocations in one ordered pass. The parallel pass then only
+        // fills already-sized storage and cannot serialize on the allocator.
+        for (size_t i = 0; i < static_cast<size_t>(N); ++i) {
+            parsed[i].track_count = static_cast<size_t>(records[i].track_length);
+            parsed[i].track.resize(static_cast<size_t>(records[i].track_length));
+        }
         std::vector<uint8_t> valid(N, 0);
         std::vector<SkipTally> local_tallies(tally ? N : 0);
         std::atomic<bool> cancelled = false;
@@ -1638,7 +1674,6 @@ namespace lfs::io {
                 point_valid = point_valid && std::isfinite(point.error);
                 const uint64_t track_len = read_u64(record_cur, record_end, "points3D.bin track length");
                 point.track_count = static_cast<size_t>(track_len);
-                point.track.resize(static_cast<size_t>(track_len));
                 for (uint64_t j = 0; j < track_len; ++j) {
                     auto& track = point.track[static_cast<size_t>(j)];
                     track.image_id = read_u32(record_cur, record_end, "points3D.bin track image id");
@@ -2786,6 +2821,7 @@ namespace lfs::io {
                             const std::vector<ImageData>& images,
                             const std::string& images_folder,
                             const LoadOptions& options = {},
+                            ColmapDatasetCaches caches = {},
                             const ColmapPointPositions& points_xyz = {}) {
 
         LOG_TIMER_TRACE("Assemble COLMAP cameras");
@@ -2822,10 +2858,12 @@ namespace lfs::io {
         std::vector<SkipTally> image_tallies(images.size());
         std::vector<std::optional<Error>> errors(images.size());
 
-        RecursiveFileCache image_cache(images_path, options.cancel_requested);
-        MaskDirCache mask_cache(base_path, options.cancel_requested);
-        DepthDirCache depth_cache(base_path, options.cancel_requested);
-        NormalDirCache normal_cache(base_path, options.cancel_requested);
+        LFS_ASSERT_MSG(caches.images && caches.masks && caches.depths && caches.normals,
+                       "COLMAP camera assembly requires validated dataset caches");
+        const auto& image_cache = *caches.images;
+        const auto& mask_cache = *caches.masks;
+        const auto& depth_cache = *caches.depths;
+        const auto& normal_cache = *caches.normals;
         size_t depth_matched_count = 0;
         size_t normal_matched_count = 0;
         size_t undistort_crop_failures = 0;
@@ -2878,236 +2916,253 @@ namespace lfs::io {
 
         std::atomic<bool> cancelled = false;
         std::atomic<bool> used_recursive_image_lookup = false;
-        tbb::parallel_for(size_t{0}, images.size(), [&](const size_t i) {
-            if (should_poll_cancel(i) && is_load_cancel_requested(options)) {
-                cancelled.store(true, std::memory_order_relaxed);
-                return;
-            }
-            const ImageData& img = images[i];
-            auto& output = assembled[i];
-            output.image = &img;
-            const std::filesystem::path image_rel_path = lfs::core::utf8_to_path(img.name);
-            std::filesystem::path image_path = images_path / image_rel_path;
-
-            if (!safe_exists(image_path)) {
-                if (auto image_lookup = image_cache.lookup(image_rel_path);
-                    image_lookup.found()) {
-                    used_recursive_image_lookup.store(true, std::memory_order_relaxed);
-                    image_path = std::move(image_lookup.path);
-                } else if (image_lookup.ambiguous()) {
-                    errors[i] = make_ambiguous_image_reference_error(images_path, img.name).error();
+        auto rotation_storage = std::make_shared<std::vector<float>>(images.size() * 9);
+        auto translation_storage = std::make_shared<std::vector<float>>(images.size() * 3);
+        const Tensor rotation_batch = Tensor::from_external_owner(
+            rotation_storage->data(), {images.size(), 3, 3}, Device::CPU, DataType::Float32,
+            rotation_storage, images.size());
+        const Tensor translation_batch = Tensor::from_external_owner(
+            translation_storage->data(), {images.size(), 3}, Device::CPU, DataType::Float32,
+            translation_storage, images.size());
+        {
+            LOG_TIMER_DEBUG("COLMAP assemble: parallel build");
+            tbb::parallel_for(size_t{0}, images.size(), [&](const size_t i) {
+                if (should_poll_cancel(i) && is_load_cancel_requested(options)) {
+                    cancelled.store(true, std::memory_order_relaxed);
                     return;
                 }
-            }
+                const ImageData& img = images[i];
+                auto& output = assembled[i];
+                output.image = &img;
+                const std::filesystem::path image_rel_path = lfs::core::utf8_to_path(img.name);
+                std::filesystem::path image_path = images_path / image_rel_path;
 
-            const bool image_file_present = safe_is_regular_file(image_path);
-
-            auto it = cam_map.find(img.camera_id);
-            if (it == cam_map.end()) {
-                image_tallies[i].record(img.name);
-                return;
-            }
-
-            const auto& cam_data = it->second;
-
-            const auto model_it = camera_model_ids.find(cam_data.model_id);
-            if (model_it == camera_model_ids.end()) {
-                errors[i] = make_error(
-                                ErrorCode::UNSUPPORTED_FORMAT,
-                                std::format("Invalid camera model ID {} for image '{}'", cam_data.model_id, img.name),
-                                image_path)
-                                .error();
-                return;
-            }
-            const auto calibration_it = calibrations.find(img.camera_id);
-            if (calibration_it == calibrations.end()) {
-                image_tallies[i].record(img.name);
-                return;
-            }
-            const auto& calibration = calibration_it->second;
-
-            // Convert quaternion to rotation matrix
-            Tensor R = qvec2rotmat(img.qvec);
-
-            // Create translation tensor
-            Tensor T = Tensor::from_vector(img.tvec, {3}, Device::CPU);
-
-            // Calculate camera position: -R^T * T
-            float RT[9];
-            const float* R_ptr = R.ptr<float>();
-            for (int r = 0; r < 3; ++r) {
-                for (int c = 0; c < 3; ++c) {
-                    RT[r * 3 + c] = R_ptr[c * 3 + r]; // Transpose
+                if (!safe_exists(image_path)) {
+                    if (auto image_lookup = image_cache.lookup(image_rel_path);
+                        image_lookup.found()) {
+                        used_recursive_image_lookup.store(true, std::memory_order_relaxed);
+                        image_path = std::move(image_lookup.path);
+                    } else if (image_lookup.ambiguous()) {
+                        errors[i] = make_ambiguous_image_reference_error(images_path, img.name).error();
+                        return;
+                    }
                 }
-            }
 
-            float cam_pos[3] = {0, 0, 0};
-            const float* T_ptr = T.ptr<float>();
-            for (int r = 0; r < 3; ++r) {
-                for (int c = 0; c < 3; ++c) {
-                    cam_pos[r] -= RT[r * 3 + c] * T_ptr[c];
-                }
-            }
+                const bool image_file_present = safe_is_regular_file(image_path);
 
-            output.position = {cam_pos[0], cam_pos[1], cam_pos[2]};
-
-            std::filesystem::path mask_path;
-            if (auto mask_lookup = mask_cache.lookup(img.name); mask_lookup.found()) {
-                mask_path = std::move(mask_lookup.path);
-            } else if (mask_lookup.ambiguous()) {
-                if (options.load_masks) {
-                    errors[i] = make_ambiguous_mask_reference_error(base_path, img.name).error();
+                auto it = cam_map.find(img.camera_id);
+                if (it == cam_map.end()) {
+                    image_tallies[i].record(img.name);
                     return;
                 }
-                LOG_WARN("Mask for image '{}' is ambiguous; skipping sidecar because mask usage is disabled",
-                         img.name);
-            }
 
-            std::filesystem::path depth_path;
-            if (auto depth_lookup = depth_cache.lookup(img.name); depth_lookup.found()) {
-                depth_path = std::move(depth_lookup.path);
-                output.depth_matched = true;
-            } else if (depth_lookup.ambiguous()) {
-                if (options.load_depths) {
+                const auto& cam_data = it->second;
+
+                const auto model_it = camera_model_ids.find(cam_data.model_id);
+                if (model_it == camera_model_ids.end()) {
                     errors[i] = make_error(
-                                    ErrorCode::INVALID_DATASET,
-                                    std::format("Depth map for image '{}' is ambiguous across the dataset depth folders. "
-                                                "Keep depth maps in the same relative subdirectories as the images or rename them uniquely.",
-                                                img.name),
-                                    base_path)
+                                    ErrorCode::UNSUPPORTED_FORMAT,
+                                    std::format("Invalid camera model ID {} for image '{}'", cam_data.model_id, img.name),
+                                    image_path)
                                     .error();
                     return;
                 }
-                LOG_WARN("Depth map for image '{}' is ambiguous; skipping sidecar because depth usage is disabled",
-                         img.name);
-            }
+                const auto calibration_it = calibrations.find(img.camera_id);
+                if (calibration_it == calibrations.end()) {
+                    image_tallies[i].record(img.name);
+                    return;
+                }
+                const auto& calibration = calibration_it->second;
 
-            std::filesystem::path normal_path;
-            if (auto normal_lookup = normal_cache.lookup(img.name); normal_lookup.found()) {
-                normal_path = std::move(normal_lookup.path);
-                output.normal_matched = true;
-            } else if (normal_lookup.ambiguous()) {
-                if (options.load_normals) {
-                    errors[i] = make_error(
-                                    ErrorCode::INVALID_DATASET,
-                                    std::format("Normal map for image '{}' is ambiguous across the dataset normal folders. "
-                                                "Keep normal maps in the same relative subdirectories as the images or rename them uniquely.",
-                                                img.name),
-                                    base_path)
-                                    .error();
-                    return;
-                }
-                LOG_WARN("Normal map for image '{}' is ambiguous; skipping sidecar because normal usage is disabled",
-                         img.name);
-            }
+                // Keep the per-image pose data in pageable batch storage. CPU
+                // Tensor::empty uses the pinned allocator, whose mutex would turn
+                // these tiny per-image allocations into a serial section.
+                const auto rotation = qvec2rotmat_values(img.qvec);
+                std::copy(rotation.begin(), rotation.end(), rotation_storage->begin() + i * 9);
+                std::copy(img.tvec.begin(), img.tvec.end(), translation_storage->begin() + i * 3);
+                // Drop the batch dimension before handing the views to Camera. Both
+                // slices are dense, so contiguous() preserves the shared pageable
+                // storage and its lifetime while making the tensor contract explicit.
+                Tensor R = rotation_batch.slice(0, i, i + 1).squeeze(0).contiguous();
+                Tensor T = translation_batch.slice(0, i, i + 1).squeeze(0).contiguous();
 
-            // Validate mask/depth dimensions match image dimensions
-            std::optional<std::tuple<int, int, int>> image_info;
-            auto get_image_info_cached = [&]() {
-                if (!image_info.has_value()) {
-                    image_info = lfs::core::get_image_info(image_path);
+                // Calculate camera position: -R^T * T
+                float RT[9];
+                const float* R_ptr = R.ptr<float>();
+                for (int r = 0; r < 3; ++r) {
+                    for (int c = 0; c < 3; ++c) {
+                        RT[r * 3 + c] = R_ptr[c * 3 + r]; // Transpose
+                    }
                 }
-                return *image_info;
-            };
-            if (image_file_present && options.load_masks && !mask_path.empty()) {
-                auto [img_w, img_h, img_c] = get_image_info_cached();
-                auto [mask_w, mask_h, mask_c] = lfs::core::get_image_info(mask_path);
-                if (img_w != mask_w || img_h != mask_h) {
-                    errors[i] = make_error(
-                                    ErrorCode::MASK_SIZE_MISMATCH,
-                                    std::format("Mask '{}' is {}x{} but image '{}' is {}x{}",
-                                                lfs::core::path_to_utf8(mask_path.filename()), mask_w, mask_h,
-                                                img.name, img_w, img_h),
-                                    mask_path)
-                                    .error();
-                    return;
+
+                float cam_pos[3] = {0, 0, 0};
+                const float* T_ptr = T.ptr<float>();
+                for (int r = 0; r < 3; ++r) {
+                    for (int c = 0; c < 3; ++c) {
+                        cam_pos[r] -= RT[r * 3 + c] * T_ptr[c];
+                    }
                 }
-            }
-            if (image_file_present && options.load_depths && !depth_path.empty()) {
-                auto [img_w, img_h, img_c] = get_image_info_cached();
-                auto [depth_w, depth_h, depth_c] = lfs::core::get_image_info(depth_path);
-                if (!sidecar_dimensions_match_contract(depth_w,
-                                                       depth_h,
-                                                       img_w,
-                                                       img_h,
-                                                       cam_data.original_width,
-                                                       cam_data.original_height)) {
-                    errors[i] = make_error(
-                                    ErrorCode::DEPTH_SIZE_MISMATCH,
-                                    std::format("Depth map '{}' is {}x{} but image '{}' is {}x{}",
-                                                lfs::core::path_to_utf8(depth_path.filename()), depth_w, depth_h,
-                                                img.name, img_w, img_h),
-                                    depth_path)
-                                    .error();
-                    return;
+
+                output.position = {cam_pos[0], cam_pos[1], cam_pos[2]};
+
+                std::filesystem::path mask_path;
+                if (auto mask_lookup = mask_cache.lookup(img.name); mask_lookup.found()) {
+                    mask_path = std::move(mask_lookup.path);
+                } else if (mask_lookup.ambiguous()) {
+                    if (options.load_masks) {
+                        errors[i] = make_ambiguous_mask_reference_error(base_path, img.name).error();
+                        return;
+                    }
+                    LOG_WARN("Mask for image '{}' is ambiguous; skipping sidecar because mask usage is disabled",
+                             img.name);
                 }
-            }
-            if (image_file_present && options.load_normals && !normal_path.empty()) {
-                auto [img_w, img_h, img_c] = get_image_info_cached();
-                auto [normal_w, normal_h, normal_c] = lfs::core::get_image_info(normal_path);
-                if (!sidecar_dimensions_match_contract(normal_w,
-                                                       normal_h,
-                                                       img_w,
-                                                       img_h,
-                                                       cam_data.original_width,
-                                                       cam_data.original_height)) {
-                    if (options.normal_auto_generate) {
-                        LOG_WARN("Normal map '{}' is {}x{} but image '{}' is {}x{}; "
-                                 "ignoring it so auto-generate can overwrite that file",
-                                 lfs::core::path_to_utf8(normal_path.filename()),
-                                 normal_w, normal_h, img.name, img_w, img_h);
-                        output.normal_matched = false;
-                        normal_path.clear();
-                    } else {
+
+                std::filesystem::path depth_path;
+                if (auto depth_lookup = depth_cache.lookup(img.name); depth_lookup.found()) {
+                    depth_path = std::move(depth_lookup.path);
+                    output.depth_matched = true;
+                } else if (depth_lookup.ambiguous()) {
+                    if (options.load_depths) {
                         errors[i] = make_error(
-                                        ErrorCode::NORMAL_SIZE_MISMATCH,
-                                        std::format("Normal map '{}' is {}x{} but image '{}' is {}x{}",
-                                                    lfs::core::path_to_utf8(normal_path.filename()), normal_w, normal_h,
+                                        ErrorCode::INVALID_DATASET,
+                                        std::format("Depth map for image '{}' is ambiguous across the dataset depth folders. "
+                                                    "Keep depth maps in the same relative subdirectories as the images or rename them uniquely.",
+                                                    img.name),
+                                        base_path)
+                                        .error();
+                        return;
+                    }
+                    LOG_WARN("Depth map for image '{}' is ambiguous; skipping sidecar because depth usage is disabled",
+                             img.name);
+                }
+
+                std::filesystem::path normal_path;
+                if (auto normal_lookup = normal_cache.lookup(img.name); normal_lookup.found()) {
+                    normal_path = std::move(normal_lookup.path);
+                    output.normal_matched = true;
+                } else if (normal_lookup.ambiguous()) {
+                    if (options.load_normals) {
+                        errors[i] = make_error(
+                                        ErrorCode::INVALID_DATASET,
+                                        std::format("Normal map for image '{}' is ambiguous across the dataset normal folders. "
+                                                    "Keep normal maps in the same relative subdirectories as the images or rename them uniquely.",
+                                                    img.name),
+                                        base_path)
+                                        .error();
+                        return;
+                    }
+                    LOG_WARN("Normal map for image '{}' is ambiguous; skipping sidecar because normal usage is disabled",
+                             img.name);
+                }
+
+                // Validate mask/depth dimensions match image dimensions
+                std::optional<std::tuple<int, int, int>> image_info;
+                auto get_image_info_cached = [&]() {
+                    if (!image_info.has_value()) {
+                        image_info = lfs::core::get_image_info(image_path);
+                    }
+                    return *image_info;
+                };
+                if (image_file_present && options.load_masks && !mask_path.empty()) {
+                    auto [img_w, img_h, img_c] = get_image_info_cached();
+                    auto [mask_w, mask_h, mask_c] = lfs::core::get_image_info(mask_path);
+                    if (img_w != mask_w || img_h != mask_h) {
+                        errors[i] = make_error(
+                                        ErrorCode::MASK_SIZE_MISMATCH,
+                                        std::format("Mask '{}' is {}x{} but image '{}' is {}x{}",
+                                                    lfs::core::path_to_utf8(mask_path.filename()), mask_w, mask_h,
                                                     img.name, img_w, img_h),
-                                        normal_path)
+                                        mask_path)
                                         .error();
                         return;
                     }
                 }
-            }
-
-            // Create Camera
-            auto camera = std::make_shared<Camera>(
-                R,
-                T,
-                calibration.focal_x, calibration.focal_y,
-                calibration.center_x, calibration.center_y,
-                calibration.radial_distortion,
-                calibration.tangential_distortion,
-                calibration.camera_model_type,
-                img.name,
-                image_path,
-                mask_path,
-                cam_data.width,
-                cam_data.height,
-                camera_indices[i],
-                static_cast<int>(img.camera_id),
-                depth_path,
-                normal_path);
-
-            const auto undistort_it = undistort_cache.find(img.camera_id);
-            if (undistort_it != undistort_cache.end() && undistort_it->second) {
-                camera->adopt_undistortion(*undistort_it->second);
-            }
-            if (camera->undistort_params().crop_solve_failed) {
-                output.undistort_crop_failures = 1;
-                if (calibration.camera_model_type == lfs::core::CameraModelType::FISHEYE ||
-                    calibration.camera_model_type == lfs::core::CameraModelType::THIN_PRISM_FISHEYE) {
-                    output.undistort_fisheye_crop_failures = 1;
+                if (image_file_present && options.load_depths && !depth_path.empty()) {
+                    auto [img_w, img_h, img_c] = get_image_info_cached();
+                    auto [depth_w, depth_h, depth_c] = lfs::core::get_image_info(depth_path);
+                    if (!sidecar_dimensions_match_contract(depth_w,
+                                                           depth_h,
+                                                           img_w,
+                                                           img_h,
+                                                           cam_data.original_width,
+                                                           cam_data.original_height)) {
+                        errors[i] = make_error(
+                                        ErrorCode::DEPTH_SIZE_MISMATCH,
+                                        std::format("Depth map '{}' is {}x{} but image '{}' is {}x{}",
+                                                    lfs::core::path_to_utf8(depth_path.filename()), depth_w, depth_h,
+                                                    img.name, img_w, img_h),
+                                        depth_path)
+                                        .error();
+                        return;
+                    }
                 }
-            }
-            if (!image_file_present) {
-                camera->set_has_image(false);
-                output.missing_image = true;
-            }
-            output.camera_data = &cam_data;
-            output.camera = std::move(camera);
-        });
+                if (image_file_present && options.load_normals && !normal_path.empty()) {
+                    auto [img_w, img_h, img_c] = get_image_info_cached();
+                    auto [normal_w, normal_h, normal_c] = lfs::core::get_image_info(normal_path);
+                    if (!sidecar_dimensions_match_contract(normal_w,
+                                                           normal_h,
+                                                           img_w,
+                                                           img_h,
+                                                           cam_data.original_width,
+                                                           cam_data.original_height)) {
+                        if (options.normal_auto_generate) {
+                            LOG_WARN("Normal map '{}' is {}x{} but image '{}' is {}x{}; "
+                                     "ignoring it so auto-generate can overwrite that file",
+                                     lfs::core::path_to_utf8(normal_path.filename()),
+                                     normal_w, normal_h, img.name, img_w, img_h);
+                            output.normal_matched = false;
+                            normal_path.clear();
+                        } else {
+                            errors[i] = make_error(
+                                            ErrorCode::NORMAL_SIZE_MISMATCH,
+                                            std::format("Normal map '{}' is {}x{} but image '{}' is {}x{}",
+                                                        lfs::core::path_to_utf8(normal_path.filename()), normal_w, normal_h,
+                                                        img.name, img_w, img_h),
+                                            normal_path)
+                                            .error();
+                            return;
+                        }
+                    }
+                }
+
+                // Create Camera
+                auto camera = std::make_shared<Camera>(
+                    R,
+                    T,
+                    calibration.focal_x, calibration.focal_y,
+                    calibration.center_x, calibration.center_y,
+                    calibration.radial_distortion,
+                    calibration.tangential_distortion,
+                    calibration.camera_model_type,
+                    img.name,
+                    image_path,
+                    mask_path,
+                    cam_data.width,
+                    cam_data.height,
+                    camera_indices[i],
+                    static_cast<int>(img.camera_id),
+                    depth_path,
+                    normal_path);
+
+                const auto undistort_it = undistort_cache.find(img.camera_id);
+                if (undistort_it != undistort_cache.end() && undistort_it->second) {
+                    camera->adopt_undistortion(*undistort_it->second);
+                }
+                if (camera->undistort_params().crop_solve_failed) {
+                    output.undistort_crop_failures = 1;
+                    if (calibration.camera_model_type == lfs::core::CameraModelType::FISHEYE ||
+                        calibration.camera_model_type == lfs::core::CameraModelType::THIN_PRISM_FISHEYE) {
+                        output.undistort_fisheye_crop_failures = 1;
+                    }
+                }
+                if (!image_file_present) {
+                    camera->set_has_image(false);
+                    output.missing_image = true;
+                }
+                output.camera_data = &cam_data;
+                output.camera = std::move(camera);
+            });
+        }
 
         if (cancelled.load(std::memory_order_relaxed)) {
             throw_if_load_cancel_requested(options, "COLMAP camera assembly cancelled");
@@ -3122,24 +3177,27 @@ namespace lfs::io {
                      "falling back to recursive image lookup",
                      lfs::core::path_to_utf8(images_path));
         }
-        for (size_t i = 0; i < assembled.size(); ++i) {
-            auto& output = assembled[i];
-            image_tally.merge(image_tallies[i]);
-            if (!output.camera) {
-                continue;
+        {
+            LOG_TIMER_DEBUG("COLMAP assemble: compact");
+            for (size_t i = 0; i < assembled.size(); ++i) {
+                auto& output = assembled[i];
+                image_tally.merge(image_tallies[i]);
+                if (!output.camera) {
+                    continue;
+                }
+                camera_positions.insert(camera_positions.end(), output.position.begin(), output.position.end());
+                camera_images.push_back(output.image);
+                camera_data.push_back(output.camera_data);
+                cameras.push_back(std::move(output.camera));
+                if (output.missing_image) {
+                    missing_images.push_back(output.image->name);
+                }
+                depth_matched_count += output.depth_matched ? 1 : 0;
+                normal_matched_count += output.normal_matched ? 1 : 0;
+                undistort_camera_count += 1;
+                undistort_crop_failures += output.undistort_crop_failures;
+                undistort_fisheye_crop_failures += output.undistort_fisheye_crop_failures;
             }
-            camera_positions.insert(camera_positions.end(), output.position.begin(), output.position.end());
-            camera_images.push_back(output.image);
-            camera_data.push_back(output.camera_data);
-            cameras.push_back(std::move(output.camera));
-            if (output.missing_image) {
-                missing_images.push_back(output.image->name);
-            }
-            depth_matched_count += output.depth_matched ? 1 : 0;
-            normal_matched_count += output.normal_matched ? 1 : 0;
-            undistort_camera_count += 1;
-            undistort_crop_failures += output.undistort_crop_failures;
-            undistort_fisheye_crop_failures += output.undistort_fisheye_crop_failures;
         }
 
         std::atomic<bool> observation_cancelled = false;
@@ -3189,9 +3247,13 @@ namespace lfs::io {
                 images_path);
         }
 
-        // Compute scene center as mean of camera positions
-        Tensor scene_center_tensor = Tensor::from_vector(camera_positions, {cameras.size(), 3}, Device::CPU);
-        Tensor scene_center = scene_center_tensor.mean({0}, false);
+        Tensor scene_center;
+        {
+            LOG_TIMER_DEBUG("COLMAP assemble: scene center");
+            // Compute scene center as mean of camera positions
+            Tensor scene_center_tensor = Tensor::from_vector(camera_positions, {cameras.size(), 3}, Device::CPU);
+            scene_center = scene_center_tensor.mean({0}, false);
+        }
 
         const size_t training_image_count = static_cast<size_t>(
             std::count_if(cameras.begin(), cameras.end(), [](const auto& camera) {
@@ -4299,7 +4361,11 @@ namespace lfs::io {
                 images = read_images_text_camera_metadata_only(images_txt, options);
             }
 
-            return validate_colmap_dataset_layout_impl(base, images_folder, images, options);
+            auto validation = validate_colmap_dataset_layout_impl(base, images_folder, images, options);
+            if (!validation) {
+                return std::unexpected(validation.error());
+            }
+            return {};
         } catch (const LoadCancelledError& e) {
             return make_error(ErrorCode::CANCELLED, e.what(), base);
         } catch (const lfs::Exception& e) {
@@ -4335,7 +4401,8 @@ namespace lfs::io {
             auto images = read_images_binary(images_file, options, &pose_tally, &point2d_tally);
 
             LOG_INFO("Read {} cameras and {} images from COLMAP", cam_map.size(), images.size());
-            if (auto validation = validate_colmap_dataset_layout_impl(base, images_folder, images, options); !validation) {
+            auto validation = validate_colmap_dataset_layout_impl(base, images_folder, images, options);
+            if (!validation) {
                 return std::unexpected(validation.error());
             }
 
@@ -4346,7 +4413,8 @@ namespace lfs::io {
                     point_records->warnings.push_back(std::move(*diagnostic));
                 }
             }
-            auto assembled = assemble_colmap_cameras(base, cam_map, images, images_folder, options, points_xyz);
+            auto assembled = assemble_colmap_cameras(
+                base, cam_map, images, images_folder, options, std::move(*validation), points_xyz);
             if (!assembled) {
                 return std::unexpected(assembled.error());
             }
@@ -4448,11 +4516,13 @@ namespace lfs::io {
             auto images = read_images_text_camera_metadata_only(images_file, options, &pose_tally);
 
             LOG_INFO("Read {} cameras and {} images from COLMAP text files", cam_map.size(), images.size());
-            if (auto validation = validate_colmap_dataset_layout_impl(base, images_folder, images, options); !validation) {
+            auto validation = validate_colmap_dataset_layout_impl(base, images_folder, images, options);
+            if (!validation) {
                 return std::unexpected(validation.error());
             }
             auto points_xyz = load_colmap_point_positions_if_needed(base, images, options);
-            auto assembled = assemble_colmap_cameras(base, cam_map, images, images_folder, options, points_xyz);
+            auto assembled = assemble_colmap_cameras(
+                base, cam_map, images, images_folder, options, std::move(*validation), points_xyz);
             if (!assembled) {
                 return std::unexpected(assembled.error());
             }

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -38,10 +38,20 @@
 #include <unordered_set>
 #include <vector>
 
-#ifdef __linux__
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#elif defined(__unix__) || defined(__APPLE__)
 #include <cerrno>
 #include <fcntl.h>
+#endif
+
+#ifdef __linux__
 #include <sys/syscall.h>
+#endif
+#if defined(__unix__) || defined(__APPLE__)
 #include <unistd.h>
 #endif
 
@@ -1020,22 +1030,119 @@ namespace lfs::io {
         buf->byte_size = static_cast<size_t>(file_size);
         buf->storage = std::make_unique_for_overwrite<char[]>(buf->byte_size);
 
-        f.seekg(0, std::ios::beg);
-        if (!f.good()) {
-            throw_colmap_error(lfs::ErrorCode::Internal,
-                               std::format("Could not seek binary file: {}",
-                                           lfs::core::path_to_utf8(p)));
-        }
+        constexpr size_t READ_CHUNK_BYTES = 64ull * 1024ull * 1024ull;
         if (sz > 0) {
+            const size_t byte_count = static_cast<size_t>(sz);
+            const size_t chunk_count = byte_count / READ_CHUNK_BYTES +
+                                       (byte_count % READ_CHUNK_BYTES != 0 ? 1 : 0);
+            std::vector<size_t> chunk_actual(chunk_count, 0);
+            std::vector<uint8_t> chunk_failed(chunk_count, 0);
+
+#if defined(_WIN32)
+            f.close();
+            HANDLE handle = CreateFileW(p.c_str(), GENERIC_READ,
+                                        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                        nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, nullptr);
+            if (handle == INVALID_HANDLE_VALUE) {
+                throw_colmap_error(lfs::ErrorCode::Internal,
+                                   "Failed to open " + lfs::core::path_to_utf8(p));
+            }
+            tbb::parallel_for(size_t{0}, chunk_count, [&](const size_t chunk) {
+                const size_t offset = chunk * READ_CHUNK_BYTES;
+                const DWORD request = static_cast<DWORD>(
+                    std::min(READ_CHUNK_BYTES, byte_count - offset));
+                OVERLAPPED operation{};
+                operation.Offset = static_cast<DWORD>(offset);
+                operation.OffsetHigh = static_cast<DWORD>(offset >> 32);
+                operation.hEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+                if (operation.hEvent == nullptr) {
+                    chunk_failed[chunk] = 1;
+                    return;
+                }
+                DWORD transferred = 0;
+                const BOOL immediate = ReadFile(handle, buf->data() + offset, request,
+                                                nullptr, &operation);
+                if (!immediate) {
+                    if (GetLastError() != ERROR_IO_PENDING ||
+                        !GetOverlappedResult(handle, &operation, &transferred, TRUE)) {
+                        CloseHandle(operation.hEvent);
+                        chunk_failed[chunk] = 1;
+                        return;
+                    }
+                } else {
+                    transferred = request;
+                }
+                CloseHandle(operation.hEvent);
+                chunk_actual[chunk] = static_cast<size_t>(transferred);
+                if (transferred != request) {
+                    chunk_failed[chunk] = 1;
+                }
+            });
+            CloseHandle(handle);
+#elif defined(__unix__) || defined(__APPLE__)
+            f.close();
+            const int fd = ::open(p.c_str(), O_RDONLY);
+            if (fd < 0) {
+                throw_colmap_error(lfs::ErrorCode::Internal,
+                                   "Failed to open " + lfs::core::path_to_utf8(p));
+            }
+            tbb::parallel_for(size_t{0}, chunk_count, [&](const size_t chunk) {
+                const size_t offset = chunk * READ_CHUNK_BYTES;
+                const size_t request = std::min(READ_CHUNK_BYTES, byte_count - offset);
+                size_t completed = 0;
+                while (completed < request) {
+                    const ssize_t count = ::pread(fd, buf->data() + offset + completed,
+                                                  request - completed,
+                                                  static_cast<off_t>(offset + completed));
+                    if (count < 0) {
+                        if (errno == EINTR) {
+                            continue;
+                        }
+                        chunk_failed[chunk] = 1;
+                        break;
+                    }
+                    if (count == 0) {
+                        chunk_failed[chunk] = 1;
+                        break;
+                    }
+                    completed += static_cast<size_t>(count);
+                }
+                chunk_actual[chunk] = completed;
+                if (completed != request) {
+                    chunk_failed[chunk] = 1;
+                }
+            });
+            ::close(fd);
+#else
+            f.seekg(0, std::ios::beg);
+            if (!f.good()) {
+                throw_colmap_error(lfs::ErrorCode::Internal,
+                                   std::format("Could not seek binary file: {}",
+                                               lfs::core::path_to_utf8(p)));
+            }
             f.read(buf->data(), sz);
-        }
-        if (!f || f.gcount() != sz) {
-            throw_colmap_error(
-                lfs::ErrorCode::DataLoss,
-                "Short read on " + lfs::core::path_to_utf8(p),
-                lfs::SmallFields{}
-                    .add("expected_bytes", static_cast<std::int64_t>(sz))
-                    .add("actual_bytes", static_cast<std::int64_t>(f.gcount())));
+            chunk_actual[0] = static_cast<size_t>(f.gcount());
+            if (!f || f.gcount() != sz) {
+                chunk_failed[0] = 1;
+            }
+#endif
+
+            for (size_t chunk = 0; chunk < chunk_count; ++chunk) {
+                if (chunk_failed[chunk]) {
+#if defined(_WIN32) || defined(__unix__) || defined(__APPLE__)
+                    const size_t expected = std::min(READ_CHUNK_BYTES,
+                                                     byte_count - chunk * READ_CHUNK_BYTES);
+#else
+                    const size_t expected = byte_count;
+#endif
+                    throw_colmap_error(
+                        lfs::ErrorCode::DataLoss,
+                        "Short read on " + lfs::core::path_to_utf8(p),
+                        lfs::SmallFields{}
+                            .add("expected_bytes", static_cast<std::int64_t>(expected))
+                            .add("actual_bytes", static_cast<std::int64_t>(chunk_actual[chunk])));
+                }
+            }
         }
         LOG_TRACE("Read {} bytes from {}", sz, lfs::core::path_to_utf8(p));
         return buf;
@@ -1441,7 +1548,11 @@ namespace lfs::io {
                                                          SkipTally* tally = nullptr) {
         LOG_TIMER_TRACE("Read points3D.bin");
         LOG_TIMER_DEBUG("COLMAP points3D parse");
-        auto buf_owner = read_binary(file_path);
+        std::unique_ptr<BinaryBuffer> buf_owner;
+        {
+            LOG_TIMER_DEBUG("COLMAP points3D.bin read");
+            buf_owner = read_binary(file_path);
+        }
         const char* cur = buf_owner->data();
         const char* end = cur + buf_owner->size();
 
@@ -1527,12 +1638,11 @@ namespace lfs::io {
                 point_valid = point_valid && std::isfinite(point.error);
                 const uint64_t track_len = read_u64(record_cur, record_end, "points3D.bin track length");
                 point.track_count = static_cast<size_t>(track_len);
-                point.track.reserve(track_len);
+                point.track.resize(static_cast<size_t>(track_len));
                 for (uint64_t j = 0; j < track_len; ++j) {
-                    Point3DTrackElement track;
+                    auto& track = point.track[static_cast<size_t>(j)];
                     track.image_id = read_u32(record_cur, record_end, "points3D.bin track image id");
                     track.point2D_idx = read_u32(record_cur, record_end, "points3D.bin track point index");
-                    point.track.push_back(track);
                 }
                 valid[i] = point_valid ? 1 : 0;
                 if (!point_valid && tally) {
@@ -2521,6 +2631,152 @@ namespace lfs::io {
         camera.set_sfm_observations(std::move(observations));
     }
 
+    struct ColmapCameraCalibration {
+        float focal_x = 0.0f;
+        float focal_y = 0.0f;
+        float center_x = 0.0f;
+        float center_y = 0.0f;
+        Tensor radial_distortion;
+        Tensor tangential_distortion;
+        lfs::core::CameraModelType camera_model_type = lfs::core::CameraModelType::PINHOLE;
+    };
+
+    static std::optional<ColmapCameraCalibration>
+    make_colmap_camera_calibration(const CameraDataIntermediate& cam_data) {
+        const auto model_it = camera_model_ids.find(cam_data.model_id);
+        if (model_it == camera_model_ids.end()) {
+            return std::nullopt;
+        }
+
+        const CAMERA_MODEL model = model_it->second.first;
+        const auto& params = cam_data.params;
+        ColmapCameraCalibration calibration;
+        switch (model) {
+        case CAMERA_MODEL::SIMPLE_PINHOLE:
+            calibration.focal_x = calibration.focal_y = params[0];
+            calibration.center_x = params[1];
+            calibration.center_y = params[2];
+            calibration.radial_distortion = Tensor::empty({0}, Device::CPU);
+            calibration.tangential_distortion = Tensor::empty({0}, Device::CPU);
+            break;
+
+        case CAMERA_MODEL::PINHOLE:
+            calibration.focal_x = params[0];
+            calibration.focal_y = params[1];
+            calibration.center_x = params[2];
+            calibration.center_y = params[3];
+            calibration.radial_distortion = Tensor::empty({0}, Device::CPU);
+            calibration.tangential_distortion = Tensor::empty({0}, Device::CPU);
+            break;
+
+        case CAMERA_MODEL::SIMPLE_RADIAL:
+            calibration.focal_x = calibration.focal_y = params[0];
+            calibration.center_x = params[1];
+            calibration.center_y = params[2];
+            calibration.radial_distortion = params[3] != 0.0f
+                                                ? Tensor::from_vector({params[3]}, {1}, Device::CPU)
+                                                : Tensor::empty({0}, Device::CPU);
+            calibration.tangential_distortion = Tensor::empty({0}, Device::CPU);
+            break;
+
+        case CAMERA_MODEL::RADIAL:
+            calibration.focal_x = calibration.focal_y = params[0];
+            calibration.center_x = params[1];
+            calibration.center_y = params[2];
+            calibration.radial_distortion = make_distortion_tensor({params[3], params[4]});
+            calibration.tangential_distortion = Tensor::empty({0}, Device::CPU);
+            break;
+
+        case CAMERA_MODEL::OPENCV:
+            calibration.focal_x = params[0];
+            calibration.focal_y = params[1];
+            calibration.center_x = params[2];
+            calibration.center_y = params[3];
+            calibration.radial_distortion = make_distortion_tensor({params[4], params[5]});
+            calibration.tangential_distortion = make_distortion_tensor({params[6], params[7]});
+            break;
+
+        case CAMERA_MODEL::FULL_OPENCV:
+            calibration.focal_x = params[0];
+            calibration.focal_y = params[1];
+            calibration.center_x = params[2];
+            calibration.center_y = params[3];
+            calibration.radial_distortion = make_distortion_tensor(
+                {params[4], params[5], params[8], params[9], params[10], params[11]});
+            calibration.tangential_distortion = make_distortion_tensor({params[6], params[7]});
+            break;
+
+        case CAMERA_MODEL::OPENCV_FISHEYE:
+            calibration.focal_x = params[0];
+            calibration.focal_y = params[1];
+            calibration.center_x = params[2];
+            calibration.center_y = params[3];
+            calibration.radial_distortion = Tensor::from_vector(
+                {params[4], params[5], params[6], params[7]}, {4}, Device::CPU);
+            calibration.tangential_distortion = Tensor::empty({0}, Device::CPU);
+            calibration.camera_model_type = lfs::core::CameraModelType::FISHEYE;
+            break;
+
+        case CAMERA_MODEL::RADIAL_FISHEYE:
+            calibration.focal_x = calibration.focal_y = params[0];
+            calibration.center_x = params[1];
+            calibration.center_y = params[2];
+            calibration.radial_distortion = Tensor::from_vector({params[3], params[4]}, {2}, Device::CPU);
+            calibration.tangential_distortion = Tensor::empty({0}, Device::CPU);
+            calibration.camera_model_type = lfs::core::CameraModelType::FISHEYE;
+            break;
+
+        case CAMERA_MODEL::SIMPLE_RADIAL_FISHEYE:
+            calibration.focal_x = calibration.focal_y = params[0];
+            calibration.center_x = params[1];
+            calibration.center_y = params[2];
+            calibration.radial_distortion = Tensor::from_vector({params[3]}, {1}, Device::CPU);
+            calibration.tangential_distortion = Tensor::empty({0}, Device::CPU);
+            calibration.camera_model_type = lfs::core::CameraModelType::FISHEYE;
+            break;
+
+        case CAMERA_MODEL::THIN_PRISM_FISHEYE:
+            // fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, sx1, sy1
+            calibration.focal_x = params[0];
+            calibration.focal_y = params[1];
+            calibration.center_x = params[2];
+            calibration.center_y = params[3];
+            calibration.radial_distortion = Tensor::from_vector(
+                {params[4], params[5], params[8], params[9]}, {4}, Device::CPU);
+            calibration.tangential_distortion = Tensor::from_vector(
+                {params[6], params[7], params[10], params[11]}, {4}, Device::CPU);
+            calibration.camera_model_type = lfs::core::CameraModelType::THIN_PRISM_FISHEYE;
+            break;
+
+        case CAMERA_MODEL::EQUIRECTANGULAR:
+            calibration.focal_x = calibration.focal_y = EQUIRECTANGULAR_DUMMY_FOCAL;
+            calibration.center_x = 0.5f * static_cast<float>(cam_data.width);
+            calibration.center_y = 0.5f * static_cast<float>(cam_data.height);
+            calibration.radial_distortion = Tensor::empty({0}, Device::CPU);
+            calibration.tangential_distortion = Tensor::empty({0}, Device::CPU);
+            calibration.camera_model_type = lfs::core::CameraModelType::EQUIRECTANGULAR;
+            break;
+
+        case CAMERA_MODEL::FOV:
+        default:
+            return std::nullopt;
+        }
+        return calibration;
+    }
+
+    static bool colmap_calibration_has_distortion(const ColmapCameraCalibration& calibration) {
+        if (calibration.camera_model_type == lfs::core::CameraModelType::EQUIRECTANGULAR) {
+            return false;
+        }
+        if (calibration.radial_distortion.is_valid() && calibration.radial_distortion.numel() > 0) {
+            return true;
+        }
+        if (calibration.tangential_distortion.is_valid() && calibration.tangential_distortion.numel() > 0) {
+            return true;
+        }
+        return calibration.camera_model_type != lfs::core::CameraModelType::PINHOLE;
+    }
+
     // -----------------------------------------------------------------------------
     //  Assemble cameras with dimension verification
     // -----------------------------------------------------------------------------
@@ -2551,11 +2807,25 @@ namespace lfs::io {
         SkipTally image_tally;
         std::vector<std::string> missing_images;
 
+        struct CameraAssemblyEntry {
+            std::shared_ptr<Camera> camera;
+            const ImageData* image = nullptr;
+            const CameraDataIntermediate* camera_data = nullptr;
+            std::array<float, 3> position{};
+            bool missing_image = false;
+            bool depth_matched = false;
+            bool normal_matched = false;
+            size_t undistort_crop_failures = 0;
+            size_t undistort_fisheye_crop_failures = 0;
+        };
+        std::vector<CameraAssemblyEntry> assembled(images.size());
+        std::vector<SkipTally> image_tallies(images.size());
+        std::vector<std::optional<Error>> errors(images.size());
+
         RecursiveFileCache image_cache(images_path, options.cancel_requested);
         MaskDirCache mask_cache(base_path, options.cancel_requested);
         DepthDirCache depth_cache(base_path, options.cancel_requested);
         NormalDirCache normal_cache(base_path, options.cancel_requested);
-        bool used_recursive_image_lookup = false;
         size_t depth_matched_count = 0;
         size_t normal_matched_count = 0;
         size_t undistort_crop_failures = 0;
@@ -2563,31 +2833,70 @@ namespace lfs::io {
         size_t undistort_fisheye_crop_failures = 0;
         std::unordered_map<uint32_t, std::optional<lfs::core::UndistortParams>> undistort_cache;
         undistort_cache.reserve(cam_map.size());
+        std::unordered_map<uint32_t, ColmapCameraCalibration> calibrations;
+        calibrations.reserve(cam_map.size());
+
+        // Undistortion depends only on the COLMAP camera calibration, not on
+        // the image pose. Compute it once per camera before workers start so
+        // the image loop only installs an immutable memoized value.
+        for (const auto& [camera_id, cam_data] : cam_map) {
+            auto calibration = make_colmap_camera_calibration(cam_data);
+            if (!calibration) {
+                continue;
+            }
+            if (colmap_calibration_has_distortion(*calibration)) {
+                LOG_TIMER_DEBUG("COLMAP assemble: undistort");
+                undistort_cache.emplace(
+                    camera_id,
+                    lfs::core::compute_undistort_params(
+                        calibration->focal_x, calibration->focal_y,
+                        calibration->center_x, calibration->center_y,
+                        cam_data.width, cam_data.height,
+                        calibration->radial_distortion,
+                        calibration->tangential_distortion,
+                        calibration->camera_model_type));
+            } else {
+                undistort_cache.emplace(camera_id, std::nullopt);
+            }
+            calibrations.emplace(camera_id, std::move(*calibration));
+        }
+
+        // Preserve the serial loader's compact UID assignment even though
+        // camera construction below is indexed by the source image.
+        std::vector<int> camera_indices(images.size(), -1);
+        int next_camera_index = 0;
+        for (size_t i = 0; i < images.size(); ++i) {
+            const auto camera_it = cam_map.find(images[i].camera_id);
+            if (camera_it != cam_map.end() && calibrations.contains(images[i].camera_id)) {
+                camera_indices[i] = next_camera_index++;
+            }
+        }
 
         // Accumulate camera positions for scene center
         std::vector<float> camera_positions;
         camera_positions.reserve(images.size() * 3);
 
-        for (size_t i = 0; i < images.size(); ++i) {
-            if (should_poll_cancel(i)) {
-                throw_if_load_cancel_requested(options, "COLMAP camera assembly cancelled");
+        std::atomic<bool> cancelled = false;
+        std::atomic<bool> used_recursive_image_lookup = false;
+        tbb::parallel_for(size_t{0}, images.size(), [&](const size_t i) {
+            if (should_poll_cancel(i) && is_load_cancel_requested(options)) {
+                cancelled.store(true, std::memory_order_relaxed);
+                return;
             }
             const ImageData& img = images[i];
+            auto& output = assembled[i];
+            output.image = &img;
             const std::filesystem::path image_rel_path = lfs::core::utf8_to_path(img.name);
             std::filesystem::path image_path = images_path / image_rel_path;
 
             if (!safe_exists(image_path)) {
                 if (auto image_lookup = image_cache.lookup(image_rel_path);
                     image_lookup.found()) {
-                    if (!used_recursive_image_lookup) {
-                        LOG_WARN("COLMAP images are not in the expected flat layout under '{}'; "
-                                 "falling back to recursive image lookup",
-                                 lfs::core::path_to_utf8(images_path));
-                        used_recursive_image_lookup = true;
-                    }
+                    used_recursive_image_lookup.store(true, std::memory_order_relaxed);
                     image_path = std::move(image_lookup.path);
                 } else if (image_lookup.ambiguous()) {
-                    return make_ambiguous_image_reference_error(images_path, img.name);
+                    errors[i] = make_ambiguous_image_reference_error(images_path, img.name).error();
+                    return;
                 }
             }
 
@@ -2595,11 +2904,27 @@ namespace lfs::io {
 
             auto it = cam_map.find(img.camera_id);
             if (it == cam_map.end()) {
-                image_tally.record(img.name);
-                continue;
+                image_tallies[i].record(img.name);
+                return;
             }
 
             const auto& cam_data = it->second;
+
+            const auto model_it = camera_model_ids.find(cam_data.model_id);
+            if (model_it == camera_model_ids.end()) {
+                errors[i] = make_error(
+                                ErrorCode::UNSUPPORTED_FORMAT,
+                                std::format("Invalid camera model ID {} for image '{}'", cam_data.model_id, img.name),
+                                image_path)
+                                .error();
+                return;
+            }
+            const auto calibration_it = calibrations.find(img.camera_id);
+            if (calibration_it == calibrations.end()) {
+                image_tallies[i].record(img.name);
+                return;
+            }
+            const auto& calibration = calibration_it->second;
 
             // Convert quaternion to rotation matrix
             Tensor R = qvec2rotmat(img.qvec);
@@ -2624,148 +2949,15 @@ namespace lfs::io {
                 }
             }
 
-            // Extract camera parameters based on model
-            auto model_it = camera_model_ids.find(cam_data.model_id);
-            if (model_it == camera_model_ids.end()) {
-                return make_error(ErrorCode::UNSUPPORTED_FORMAT,
-                                  std::format("Invalid camera model ID {} for image '{}'", cam_data.model_id, img.name),
-                                  image_path);
-            }
-
-            CAMERA_MODEL model = model_it->second.first;
-            const auto& params = cam_data.params;
-
-            float focal_x = 0, focal_y = 0, center_x = 0, center_y = 0;
-            Tensor radial_dist, tangential_dist;
-            lfs::core::CameraModelType camera_model_type = lfs::core::CameraModelType::PINHOLE;
-
-            switch (model) {
-            case CAMERA_MODEL::SIMPLE_PINHOLE:
-                focal_x = focal_y = params[0];
-                center_x = params[1];
-                center_y = params[2];
-                radial_dist = Tensor::empty({0}, Device::CPU);
-                tangential_dist = Tensor::empty({0}, Device::CPU);
-                break;
-
-            case CAMERA_MODEL::PINHOLE:
-                focal_x = params[0];
-                focal_y = params[1];
-                center_x = params[2];
-                center_y = params[3];
-                radial_dist = Tensor::empty({0}, Device::CPU);
-                tangential_dist = Tensor::empty({0}, Device::CPU);
-                break;
-
-            case CAMERA_MODEL::SIMPLE_RADIAL:
-                focal_x = focal_y = params[0];
-                center_x = params[1];
-                center_y = params[2];
-                if (params[3] != 0.0f) {
-                    radial_dist = Tensor::from_vector({params[3]}, {1}, Device::CPU);
-                } else {
-                    radial_dist = Tensor::empty({0}, Device::CPU);
-                }
-                tangential_dist = Tensor::empty({0}, Device::CPU);
-                camera_model_type = lfs::core::CameraModelType::PINHOLE;
-                break;
-
-            case CAMERA_MODEL::RADIAL:
-                focal_x = focal_y = params[0];
-                center_x = params[1];
-                center_y = params[2];
-                radial_dist = make_distortion_tensor({params[3], params[4]});
-                tangential_dist = Tensor::empty({0}, Device::CPU);
-                break;
-
-            case CAMERA_MODEL::OPENCV:
-                focal_x = params[0];
-                focal_y = params[1];
-                center_x = params[2];
-                center_y = params[3];
-                radial_dist = make_distortion_tensor({params[4], params[5]});
-                tangential_dist = make_distortion_tensor({params[6], params[7]});
-                break;
-
-            case CAMERA_MODEL::FULL_OPENCV:
-                focal_x = params[0];
-                focal_y = params[1];
-                center_x = params[2];
-                center_y = params[3];
-                radial_dist = make_distortion_tensor({params[4], params[5], params[8], params[9], params[10], params[11]});
-                tangential_dist = make_distortion_tensor({params[6], params[7]});
-                break;
-
-            case CAMERA_MODEL::OPENCV_FISHEYE:
-                focal_x = params[0];
-                focal_y = params[1];
-                center_x = params[2];
-                center_y = params[3];
-                radial_dist = Tensor::from_vector({params[4], params[5], params[6], params[7]}, {4}, Device::CPU);
-                tangential_dist = Tensor::empty({0}, Device::CPU);
-                camera_model_type = lfs::core::CameraModelType::FISHEYE;
-                break;
-
-            case CAMERA_MODEL::RADIAL_FISHEYE:
-                focal_x = focal_y = params[0];
-                center_x = params[1];
-                center_y = params[2];
-                radial_dist = Tensor::from_vector({params[3], params[4]}, {2}, Device::CPU);
-                tangential_dist = Tensor::empty({0}, Device::CPU);
-                camera_model_type = lfs::core::CameraModelType::FISHEYE;
-                break;
-
-            case CAMERA_MODEL::SIMPLE_RADIAL_FISHEYE:
-                focal_x = focal_y = params[0];
-                center_x = params[1];
-                center_y = params[2];
-                radial_dist = Tensor::from_vector({params[3]}, {1}, Device::CPU);
-                tangential_dist = Tensor::empty({0}, Device::CPU);
-                camera_model_type = lfs::core::CameraModelType::FISHEYE;
-                break;
-
-            case CAMERA_MODEL::THIN_PRISM_FISHEYE:
-                // fx, fy, cx, cy, k1, k2, p1, p2, k3, k4, sx1, sy1
-                focal_x = params[0];
-                focal_y = params[1];
-                center_x = params[2];
-                center_y = params[3];
-                radial_dist = Tensor::from_vector({params[4], params[5], params[8], params[9]}, {4}, Device::CPU);       // k1,k2,k3,k4
-                tangential_dist = Tensor::from_vector({params[6], params[7], params[10], params[11]}, {4}, Device::CPU); // p1,p2,sx1,sy1
-                camera_model_type = lfs::core::CameraModelType::THIN_PRISM_FISHEYE;
-                break;
-
-            case CAMERA_MODEL::FOV:
-                image_tally.record(img.name);
-                continue;
-
-            case CAMERA_MODEL::EQUIRECTANGULAR:
-                // Equirectangular 360 panorama. params = [width, height]; no real
-                // intrinsics. The EQUIRECTANGULAR rasterizer derives projection
-                // from the image dimensions, so we only set placeholder focal/center.
-                focal_x = focal_y = EQUIRECTANGULAR_DUMMY_FOCAL;
-                center_x = 0.5f * static_cast<float>(cam_data.width);
-                center_y = 0.5f * static_cast<float>(cam_data.height);
-                radial_dist = Tensor::empty({0}, Device::CPU);
-                tangential_dist = Tensor::empty({0}, Device::CPU);
-                camera_model_type = lfs::core::CameraModelType::EQUIRECTANGULAR;
-                break;
-
-            default:
-                image_tally.record(img.name);
-                continue;
-            }
-
-            camera_positions.push_back(cam_pos[0]);
-            camera_positions.push_back(cam_pos[1]);
-            camera_positions.push_back(cam_pos[2]);
+            output.position = {cam_pos[0], cam_pos[1], cam_pos[2]};
 
             std::filesystem::path mask_path;
             if (auto mask_lookup = mask_cache.lookup(img.name); mask_lookup.found()) {
                 mask_path = std::move(mask_lookup.path);
             } else if (mask_lookup.ambiguous()) {
                 if (options.load_masks) {
-                    return make_ambiguous_mask_reference_error(base_path, img.name);
+                    errors[i] = make_ambiguous_mask_reference_error(base_path, img.name).error();
+                    return;
                 }
                 LOG_WARN("Mask for image '{}' is ambiguous; skipping sidecar because mask usage is disabled",
                          img.name);
@@ -2774,15 +2966,17 @@ namespace lfs::io {
             std::filesystem::path depth_path;
             if (auto depth_lookup = depth_cache.lookup(img.name); depth_lookup.found()) {
                 depth_path = std::move(depth_lookup.path);
-                ++depth_matched_count;
+                output.depth_matched = true;
             } else if (depth_lookup.ambiguous()) {
                 if (options.load_depths) {
-                    return make_error(
-                        ErrorCode::INVALID_DATASET,
-                        std::format("Depth map for image '{}' is ambiguous across the dataset depth folders. "
-                                    "Keep depth maps in the same relative subdirectories as the images or rename them uniquely.",
-                                    img.name),
-                        base_path);
+                    errors[i] = make_error(
+                                    ErrorCode::INVALID_DATASET,
+                                    std::format("Depth map for image '{}' is ambiguous across the dataset depth folders. "
+                                                "Keep depth maps in the same relative subdirectories as the images or rename them uniquely.",
+                                                img.name),
+                                    base_path)
+                                    .error();
+                    return;
                 }
                 LOG_WARN("Depth map for image '{}' is ambiguous; skipping sidecar because depth usage is disabled",
                          img.name);
@@ -2791,15 +2985,17 @@ namespace lfs::io {
             std::filesystem::path normal_path;
             if (auto normal_lookup = normal_cache.lookup(img.name); normal_lookup.found()) {
                 normal_path = std::move(normal_lookup.path);
-                ++normal_matched_count;
+                output.normal_matched = true;
             } else if (normal_lookup.ambiguous()) {
                 if (options.load_normals) {
-                    return make_error(
-                        ErrorCode::INVALID_DATASET,
-                        std::format("Normal map for image '{}' is ambiguous across the dataset normal folders. "
-                                    "Keep normal maps in the same relative subdirectories as the images or rename them uniquely.",
-                                    img.name),
-                        base_path);
+                    errors[i] = make_error(
+                                    ErrorCode::INVALID_DATASET,
+                                    std::format("Normal map for image '{}' is ambiguous across the dataset normal folders. "
+                                                "Keep normal maps in the same relative subdirectories as the images or rename them uniquely.",
+                                                img.name),
+                                    base_path)
+                                    .error();
+                    return;
                 }
                 LOG_WARN("Normal map for image '{}' is ambiguous; skipping sidecar because normal usage is disabled",
                          img.name);
@@ -2817,11 +3013,14 @@ namespace lfs::io {
                 auto [img_w, img_h, img_c] = get_image_info_cached();
                 auto [mask_w, mask_h, mask_c] = lfs::core::get_image_info(mask_path);
                 if (img_w != mask_w || img_h != mask_h) {
-                    return make_error(ErrorCode::MASK_SIZE_MISMATCH,
-                                      std::format("Mask '{}' is {}x{} but image '{}' is {}x{}",
-                                                  lfs::core::path_to_utf8(mask_path.filename()), mask_w, mask_h,
-                                                  img.name, img_w, img_h),
-                                      mask_path);
+                    errors[i] = make_error(
+                                    ErrorCode::MASK_SIZE_MISMATCH,
+                                    std::format("Mask '{}' is {}x{} but image '{}' is {}x{}",
+                                                lfs::core::path_to_utf8(mask_path.filename()), mask_w, mask_h,
+                                                img.name, img_w, img_h),
+                                    mask_path)
+                                    .error();
+                    return;
                 }
             }
             if (image_file_present && options.load_depths && !depth_path.empty()) {
@@ -2833,11 +3032,14 @@ namespace lfs::io {
                                                        img_h,
                                                        cam_data.original_width,
                                                        cam_data.original_height)) {
-                    return make_error(ErrorCode::DEPTH_SIZE_MISMATCH,
-                                      std::format("Depth map '{}' is {}x{} but image '{}' is {}x{}",
-                                                  lfs::core::path_to_utf8(depth_path.filename()), depth_w, depth_h,
-                                                  img.name, img_w, img_h),
-                                      depth_path);
+                    errors[i] = make_error(
+                                    ErrorCode::DEPTH_SIZE_MISMATCH,
+                                    std::format("Depth map '{}' is {}x{} but image '{}' is {}x{}",
+                                                lfs::core::path_to_utf8(depth_path.filename()), depth_w, depth_h,
+                                                img.name, img_w, img_h),
+                                    depth_path)
+                                    .error();
+                    return;
                 }
             }
             if (image_file_present && options.load_normals && !normal_path.empty()) {
@@ -2854,15 +3056,17 @@ namespace lfs::io {
                                  "ignoring it so auto-generate can overwrite that file",
                                  lfs::core::path_to_utf8(normal_path.filename()),
                                  normal_w, normal_h, img.name, img_w, img_h);
-                        if (normal_matched_count > 0)
-                            --normal_matched_count;
+                        output.normal_matched = false;
                         normal_path.clear();
                     } else {
-                        return make_error(ErrorCode::NORMAL_SIZE_MISMATCH,
-                                          std::format("Normal map '{}' is {}x{} but image '{}' is {}x{}",
-                                                      lfs::core::path_to_utf8(normal_path.filename()), normal_w, normal_h,
-                                                      img.name, img_w, img_h),
-                                          normal_path);
+                        errors[i] = make_error(
+                                        ErrorCode::NORMAL_SIZE_MISMATCH,
+                                        std::format("Normal map '{}' is {}x{} but image '{}' is {}x{}",
+                                                    lfs::core::path_to_utf8(normal_path.filename()), normal_w, normal_h,
+                                                    img.name, img_w, img_h),
+                                        normal_path)
+                                        .error();
+                        return;
                     }
                 }
             }
@@ -2871,48 +3075,71 @@ namespace lfs::io {
             auto camera = std::make_shared<Camera>(
                 R,
                 T,
-                focal_x, focal_y,
-                center_x, center_y,
-                radial_dist,
-                tangential_dist,
-                camera_model_type,
+                calibration.focal_x, calibration.focal_y,
+                calibration.center_x, calibration.center_y,
+                calibration.radial_distortion,
+                calibration.tangential_distortion,
+                calibration.camera_model_type,
                 img.name,
                 image_path,
                 mask_path,
                 cam_data.width,
                 cam_data.height,
-                static_cast<int>(cameras.size()),
+                camera_indices[i],
                 static_cast<int>(img.camera_id),
                 depth_path,
                 normal_path);
 
             const auto undistort_it = undistort_cache.find(img.camera_id);
-            if (undistort_it == undistort_cache.end()) {
-                if (camera->has_distortion()) {
-                    LOG_TIMER_DEBUG("COLMAP assemble: undistort");
-                    camera->precompute_undistortion();
-                    undistort_cache.emplace(img.camera_id, camera->undistort_params());
-                } else {
-                    undistort_cache.emplace(img.camera_id, std::nullopt);
-                }
-            } else if (undistort_it->second) {
+            if (undistort_it != undistort_cache.end() && undistort_it->second) {
                 camera->adopt_undistortion(*undistort_it->second);
             }
-            ++undistort_camera_count;
             if (camera->undistort_params().crop_solve_failed) {
-                ++undistort_crop_failures;
-                if (camera_model_type == lfs::core::CameraModelType::FISHEYE ||
-                    camera_model_type == lfs::core::CameraModelType::THIN_PRISM_FISHEYE) {
-                    ++undistort_fisheye_crop_failures;
+                output.undistort_crop_failures = 1;
+                if (calibration.camera_model_type == lfs::core::CameraModelType::FISHEYE ||
+                    calibration.camera_model_type == lfs::core::CameraModelType::THIN_PRISM_FISHEYE) {
+                    output.undistort_fisheye_crop_failures = 1;
                 }
             }
             if (!image_file_present) {
                 camera->set_has_image(false);
-                missing_images.push_back(img.name);
+                output.missing_image = true;
             }
-            camera_images.push_back(&img);
-            camera_data.push_back(&cam_data);
-            cameras.push_back(std::move(camera));
+            output.camera_data = &cam_data;
+            output.camera = std::move(camera);
+        });
+
+        if (cancelled.load(std::memory_order_relaxed)) {
+            throw_if_load_cancel_requested(options, "COLMAP camera assembly cancelled");
+        }
+        for (const auto& error : errors) {
+            if (error) {
+                return std::unexpected<Error>(*error);
+            }
+        }
+        if (used_recursive_image_lookup.load(std::memory_order_relaxed)) {
+            LOG_WARN("COLMAP images are not in the expected flat layout under '{}'; "
+                     "falling back to recursive image lookup",
+                     lfs::core::path_to_utf8(images_path));
+        }
+        for (size_t i = 0; i < assembled.size(); ++i) {
+            auto& output = assembled[i];
+            image_tally.merge(image_tallies[i]);
+            if (!output.camera) {
+                continue;
+            }
+            camera_positions.insert(camera_positions.end(), output.position.begin(), output.position.end());
+            camera_images.push_back(output.image);
+            camera_data.push_back(output.camera_data);
+            cameras.push_back(std::move(output.camera));
+            if (output.missing_image) {
+                missing_images.push_back(output.image->name);
+            }
+            depth_matched_count += output.depth_matched ? 1 : 0;
+            normal_matched_count += output.normal_matched ? 1 : 0;
+            undistort_camera_count += 1;
+            undistort_crop_failures += output.undistort_crop_failures;
+            undistort_fisheye_crop_failures += output.undistort_fisheye_crop_failures;
         }
 
         std::atomic<bool> observation_cancelled = false;
@@ -3985,24 +4212,16 @@ namespace lfs::io {
             if (point_records && point_records->loaded) {
                 records = std::move(point_records->records);
                 warnings = std::move(point_records->warnings);
+                point_records->records.clear();
+                point_records->warnings.clear();
                 point_records->loaded = false;
             } else {
                 records = read_point3D_binary_records(points3d_file, options, &tally);
-                if (point_records) {
-                    point_records->warnings.clear();
-                    if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
-                        warnings.push_back(*diagnostic);
-                        point_records->warnings.push_back(std::move(*diagnostic));
-                    }
-                    point_records->loaded = false;
-                }
-            }
-            auto cloud = point3D_records_to_point_cloud(records);
-            if (!point_records) {
                 if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
                     warnings.push_back(std::move(*diagnostic));
                 }
             }
+            auto cloud = point3D_records_to_point_cloud(records);
             return LoadOutcome<PointCloud>{std::move(cloud), std::move(warnings)};
         } catch (const LoadCancelledError& e) {
             return make_error(ErrorCode::CANCELLED, e.what(), filepath);
@@ -4030,24 +4249,16 @@ namespace lfs::io {
             if (point_records && point_records->loaded) {
                 records = std::move(point_records->records);
                 warnings = std::move(point_records->warnings);
+                point_records->records.clear();
+                point_records->warnings.clear();
                 point_records->loaded = false;
             } else {
                 records = read_point3D_binary_records(points3d_file, options, &tally);
-                if (point_records) {
-                    point_records->warnings.clear();
-                    if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
-                        warnings.push_back(*diagnostic);
-                        point_records->warnings.push_back(std::move(*diagnostic));
-                    }
-                    point_records->loaded = false;
-                }
-            }
-            auto stats = point3D_records_to_point_cloud_with_stats(std::move(records), options);
-            if (!point_records) {
                 if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
                     warnings.push_back(std::move(*diagnostic));
                 }
             }
+            auto stats = point3D_records_to_point_cloud_with_stats(std::move(records), options);
             return LoadOutcome<ColmapPointCloudLoadStats>{std::move(stats), std::move(warnings)};
         } catch (const LoadCancelledError& e) {
             return make_error(ErrorCode::CANCELLED, e.what(), filepath);

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -426,40 +426,6 @@ namespace lfs::io {
         return Tensor::from_vector(R_data, {3, 3}, Device::CPU);
     }
 
-    // -----------------------------------------------------------------------------
-    //  Image data structure
-    // -----------------------------------------------------------------------------
-    constexpr uint64_t INVALID_POINT3D_ID = std::numeric_limits<uint64_t>::max();
-
-    struct ImagePoint2D {
-        double x = 0.0;
-        double y = 0.0;
-        uint64_t point3D_id = INVALID_POINT3D_ID;
-    };
-
-    struct ImageData {
-        uint32_t image_id = 0;
-        uint32_t camera_id = 0;
-        std::string name;
-        std::vector<float> qvec = {1.0f, 0.0f, 0.0f, 0.0f}; // [w, x, y, z]
-        std::vector<float> tvec = {0.0f, 0.0f, 0.0f};
-        std::vector<ImagePoint2D> points2D;
-    };
-
-    struct Point3DTrackElement {
-        uint32_t image_id = 0;
-        uint32_t point2D_idx = 0;
-    };
-
-    struct Point3DData {
-        uint64_t point3D_id = 0;
-        double xyz[3] = {0.0, 0.0, 0.0};
-        uint8_t color[3] = {255, 255, 255};
-        double error = 0.0;
-        size_t track_count = 0;
-        std::vector<Point3DTrackElement> track;
-    };
-
     namespace {
         struct Point3DTextPointCloudData {
             std::vector<float> positions;
@@ -996,7 +962,18 @@ namespace lfs::io {
     // -----------------------------------------------------------------------------
     //  Binary-file loader
     // -----------------------------------------------------------------------------
-    static std::unique_ptr<std::vector<char>>
+    struct BinaryBuffer {
+        std::unique_ptr<char[]> storage;
+        size_t byte_size = 0;
+
+        [[nodiscard]] char* data() noexcept { return storage.get(); }
+        [[nodiscard]] const char* data() const noexcept { return storage.get(); }
+        [[nodiscard]] size_t size() const noexcept { return byte_size; }
+        [[nodiscard]] const char* begin() const noexcept { return data(); }
+        [[nodiscard]] const char* end() const noexcept { return data() + size(); }
+    };
+
+    static std::unique_ptr<BinaryBuffer>
     read_binary(const std::filesystem::path& p) {
         LOG_TRACE("Reading binary file: {}", lfs::core::path_to_utf8(p));
         std::ifstream f;
@@ -1039,7 +1016,9 @@ namespace lfs::io {
         }
 
         const auto sz = static_cast<std::streamsize>(file_size);
-        auto buf = std::make_unique<std::vector<char>>(static_cast<size_t>(file_size));
+        auto buf = std::make_unique<BinaryBuffer>();
+        buf->byte_size = static_cast<size_t>(file_size);
+        buf->storage = std::make_unique_for_overwrite<char[]>(buf->byte_size);
 
         f.seekg(0, std::ios::beg);
         if (!f.good()) {
@@ -1159,7 +1138,11 @@ namespace lfs::io {
                                               SkipTally* pose_tally = nullptr,
                                               SkipTally* point2d_tally = nullptr) {
         LOG_TIMER_TRACE("Read images.bin");
-        auto buf_owner = read_binary(file_path);
+        std::unique_ptr<BinaryBuffer> buf_owner;
+        {
+            LOG_TIMER_DEBUG("COLMAP images.bin read");
+            buf_owner = read_binary(file_path);
+        }
         const char* cur = buf_owner->data();
         const char* end = cur + buf_owner->size();
 
@@ -1181,45 +1164,35 @@ namespace lfs::io {
                     .add("image_count", n_images)
                     .add("remaining_bytes", static_cast<std::uint64_t>(end - cur)));
         }
-        LOG_DEBUG("Reading {} images from binary file", n_images);
-        std::vector<ImageData> images;
-        images.reserve(n_images);
-        std::unordered_set<uint32_t> image_ids;
-        std::unordered_set<std::string> image_names;
+        struct ImageRecordSpan {
+            const char* begin = nullptr;
+            const char* end = nullptr;
+        };
+        std::vector<ImageRecordSpan> records(n_images);
 
+        // The offset pass performs every structural read in record order. It
+        // therefore retains the old first-error taxonomy while making the
+        // independent record bodies available to the parallel parser.
         for (uint64_t i = 0; i < n_images; ++i) {
             if (should_poll_cancel(static_cast<size_t>(i))) {
                 throw_if_load_cancel_requested(options, "COLMAP image metadata load cancelled");
             }
-            ImageData img;
-            img.image_id = read_u32(cur, end, "images.bin image id");
-
-            // Read quaternion [w, x, y, z]
-            for (int k = 0; k < 4; ++k) {
-                img.qvec[k] = static_cast<float>(read_f64(cur, end, "images.bin quaternion"));
+            records[i].begin = cur;
+            const uint32_t image_id = read_u32(cur, end, "images.bin image id");
+            for (int k = 0; k < 7; ++k) {
+                (void)read_f64(cur, end, k < 4 ? "images.bin quaternion" : "images.bin translation");
             }
-
-            // Read translation [x, y, z]
-            for (int k = 0; k < 3; ++k) {
-                img.tvec[k] = static_cast<float>(read_f64(cur, end, "images.bin translation"));
-            }
-
-            img.camera_id = read_u32(cur, end, "images.bin camera id");
-
+            (void)read_u32(cur, end, "images.bin camera id");
             const void* terminator = std::memchr(cur, '\0', static_cast<size_t>(end - cur));
             if (terminator == nullptr) {
                 throw_colmap_error(
                     lfs::ErrorCode::DataLoss,
                     std::format("images.bin image name must be null-terminated "
                                 "(record_index={}, image_id={}, remaining_bytes={})",
-                                i, img.image_id, static_cast<size_t>(end - cur)),
+                                i, image_id, static_cast<size_t>(end - cur)),
                     lfs::SmallFields{}.add("record_index", i));
             }
-            const char* name_end = static_cast<const char*>(terminator);
-            img.name.assign(cur, name_end);
-            cur = name_end + 1;
-            bool valid = !img.name.empty();
-
+            cur = static_cast<const char*>(terminator) + 1;
             const uint64_t npts = read_u64(cur, end, "images.bin point2D count");
             constexpr size_t POINT2D_RECORD_BYTES = 2 * sizeof(double) + sizeof(uint64_t);
             if (npts > static_cast<uint64_t>(end - cur) / POINT2D_RECORD_BYTES) {
@@ -1227,34 +1200,81 @@ namespace lfs::io {
                     lfs::ErrorCode::DataLoss,
                     std::format("images.bin point2D count exceeds the remaining payload "
                                 "(image_id={}, point_count={}, remaining_bytes={}, record_bytes={})",
-                                img.image_id, npts, static_cast<size_t>(end - cur),
-                                POINT2D_RECORD_BYTES),
+                                image_id, npts, static_cast<size_t>(end - cur), POINT2D_RECORD_BYTES),
                     lfs::SmallFields{}
                         .add("point_count", npts)
                         .add("remaining_bytes", static_cast<std::uint64_t>(end - cur)));
             }
-            img.points2D.reserve(npts);
-            for (uint64_t j = 0; j < npts; ++j) {
-                ImagePoint2D point;
-                point.x = read_f64(cur, end, "images.bin point2D x");
-                point.y = read_f64(cur, end, "images.bin point2D y");
-                point.point3D_id = read_u64(cur, end, "images.bin point3D id");
-                if (std::isfinite(point.x) && std::isfinite(point.y)) {
-                    img.points2D.push_back(point);
-                } else if (point2d_tally) {
-                    point2d_tally->record(std::format("image_id={},point_index={}", img.image_id, j));
+            cur += static_cast<size_t>(npts) * POINT2D_RECORD_BYTES;
+            records[i].end = cur;
+        }
+
+        LOG_DEBUG("Reading {} images from binary file", n_images);
+        std::vector<ImageData> parsed(n_images);
+        std::vector<uint8_t> valid(n_images, 0);
+        std::vector<SkipTally> point2d_tallies(point2d_tally ? n_images : 0);
+        std::atomic<bool> cancelled = false;
+        {
+            LOG_TIMER_DEBUG("COLMAP images.bin parse");
+            tbb::parallel_for(size_t{0}, static_cast<size_t>(n_images), [&](const size_t i) {
+                if (should_poll_cancel(i) && is_load_cancel_requested(options)) {
+                    cancelled.store(true, std::memory_order_relaxed);
+                    return;
                 }
+                const char* record_cur = records[i].begin;
+                const char* record_end = records[i].end;
+                auto& img = parsed[i];
+                img.image_id = read_u32(record_cur, record_end, "images.bin image id");
+                for (int k = 0; k < 4; ++k) {
+                    img.qvec[k] = static_cast<float>(read_f64(record_cur, record_end, "images.bin quaternion"));
+                }
+                for (int k = 0; k < 3; ++k) {
+                    img.tvec[k] = static_cast<float>(read_f64(record_cur, record_end, "images.bin translation"));
+                }
+                img.camera_id = read_u32(record_cur, record_end, "images.bin camera id");
+                const char* name_end = static_cast<const char*>(
+                    std::memchr(record_cur, '\0', static_cast<size_t>(record_end - record_cur)));
+                img.name.assign(record_cur, name_end);
+                record_cur = name_end + 1;
+                bool image_valid = !img.name.empty();
+                const uint64_t npts = read_u64(record_cur, record_end, "images.bin point2D count");
+                img.points2D.reserve(npts);
+                auto* local_point2d_tally = point2d_tally ? &point2d_tallies[i] : nullptr;
+                for (uint64_t j = 0; j < npts; ++j) {
+                    ImagePoint2D point;
+                    point.x = read_f64(record_cur, record_end, "images.bin point2D x");
+                    point.y = read_f64(record_cur, record_end, "images.bin point2D y");
+                    point.point3D_id = read_u64(record_cur, record_end, "images.bin point3D id");
+                    if (std::isfinite(point.x) && std::isfinite(point.y)) {
+                        img.points2D.push_back(point);
+                    } else if (local_point2d_tally) {
+                        local_point2d_tally->record(std::format("image_id={},point_index={}", img.image_id, j));
+                    }
+                }
+                const double qnorm = std::sqrt(
+                    static_cast<double>(img.qvec[0]) * img.qvec[0] +
+                    static_cast<double>(img.qvec[1]) * img.qvec[1] +
+                    static_cast<double>(img.qvec[2]) * img.qvec[2] +
+                    static_cast<double>(img.qvec[3]) * img.qvec[3]);
+                image_valid = image_valid && std::isfinite(qnorm) && std::abs(qnorm - 1.0) <= 1e-4 &&
+                              std::ranges::all_of(img.tvec, [](const float value) { return std::isfinite(value); });
+                valid[i] = image_valid ? 1 : 0;
+            });
+        }
+        if (cancelled.load(std::memory_order_relaxed)) {
+            throw_if_load_cancel_requested(options, "COLMAP image metadata load cancelled");
+        }
+
+        std::vector<ImageData> images;
+        images.reserve(n_images);
+        std::unordered_set<uint32_t> image_ids;
+        std::unordered_set<std::string> image_names;
+        for (size_t i = 0; i < parsed.size(); ++i) {
+            if (point2d_tally) {
+                point2d_tally->merge(point2d_tallies[i]);
             }
-
-            const double qnorm = std::sqrt(
-                static_cast<double>(img.qvec[0]) * img.qvec[0] +
-                static_cast<double>(img.qvec[1]) * img.qvec[1] +
-                static_cast<double>(img.qvec[2]) * img.qvec[2] +
-                static_cast<double>(img.qvec[3]) * img.qvec[3]);
-            valid = valid && std::isfinite(qnorm) && std::abs(qnorm - 1.0) <= 1e-4 &&
-                    std::ranges::all_of(img.tvec, [](const float value) { return std::isfinite(value); });
-
-            if (!valid) {
+            auto& img = parsed[i];
+            if (!valid[i]) {
                 if (pose_tally) {
                     pose_tally->record(std::format("image_id={}", img.image_id));
                 }
@@ -1265,7 +1285,7 @@ namespace lfs::io {
                                    std::format("images.bin image ids must be unique among kept images "
                                                "(record_index={}, image_id={})",
                                                i, img.image_id),
-                                   lfs::SmallFields{}.add("image_id", static_cast<std::uint64_t>(img.image_id)));
+                                   lfs::SmallFields{}.add("image_id", static_cast<uint64_t>(img.image_id)));
             }
             if (!image_names.insert(img.name).second) {
                 throw_colmap_error(lfs::ErrorCode::DataLoss,
@@ -1276,7 +1296,6 @@ namespace lfs::io {
             }
             images.push_back(std::move(img));
         }
-
         if (cur != end) {
             throw_colmap_error(lfs::ErrorCode::DataLoss,
                                "images.bin: trailing bytes",
@@ -1421,6 +1440,7 @@ namespace lfs::io {
                                                          const LoadOptions& options = {},
                                                          SkipTally* tally = nullptr) {
         LOG_TIMER_TRACE("Read points3D.bin");
+        LOG_TIMER_DEBUG("COLMAP points3D parse");
         auto buf_owner = read_binary(file_path);
         const char* cur = buf_owner->data();
         const char* end = cur + buf_owner->size();
@@ -1439,62 +1459,100 @@ namespace lfs::io {
                     .add("point_count", N)
                     .add("remaining_bytes", static_cast<std::uint64_t>(end - cur)));
         }
-        LOG_DEBUG("Reading {} 3D points from binary file", N);
-
-        std::vector<Point3DData> points;
-        points.reserve(N);
-        std::unordered_set<uint64_t> point_ids;
-
+        struct PointRecordSpan {
+            const char* begin = nullptr;
+            const char* end = nullptr;
+            uint64_t point_id = 0;
+            uint64_t track_length = 0;
+        };
+        std::vector<PointRecordSpan> records(N);
         for (uint64_t i = 0; i < N; ++i) {
             if (should_poll_cancel(static_cast<size_t>(i))) {
                 throw_if_load_cancel_requested(options, "COLMAP point cloud load cancelled");
             }
-            Point3DData point;
-            point.point3D_id = read_u64(cur, end, "points3D.bin point id");
-
-            point.xyz[0] = read_f64(cur, end, "points3D.bin x");
-            point.xyz[1] = read_f64(cur, end, "points3D.bin y");
-            point.xyz[2] = read_f64(cur, end, "points3D.bin z");
-            bool valid = std::ranges::all_of(point.xyz, [](const double value) { return std::isfinite(value); });
-
+            records[i].begin = cur;
+            records[i].point_id = read_u64(cur, end, "points3D.bin point id");
+            (void)read_f64(cur, end, "points3D.bin x");
+            (void)read_f64(cur, end, "points3D.bin y");
+            (void)read_f64(cur, end, "points3D.bin z");
             if (static_cast<size_t>(end - cur) < 3) {
                 throw_colmap_error(
                     lfs::ErrorCode::DataLoss,
                     std::format("points3D.bin color payload requires three remaining bytes "
                                 "(point_id={}, remaining_bytes={}, required_bytes=3, record_index={})",
-                                point.point3D_id, static_cast<size_t>(end - cur), i),
+                                records[i].point_id, static_cast<size_t>(end - cur), i),
                     lfs::SmallFields{}.add("remaining_bytes", static_cast<std::uint64_t>(end - cur)));
             }
-            point.color[0] = static_cast<uint8_t>(*cur++);
-            point.color[1] = static_cast<uint8_t>(*cur++);
-            point.color[2] = static_cast<uint8_t>(*cur++);
-
-            point.error = read_f64(cur, end, "points3D.bin error");
-            valid = valid && std::isfinite(point.error);
+            cur += 3;
+            (void)read_f64(cur, end, "points3D.bin error");
             const uint64_t track_len = read_u64(cur, end, "points3D.bin track length");
             if (track_len > static_cast<uint64_t>(end - cur) / (2 * sizeof(uint32_t))) {
                 throw_colmap_error(
                     lfs::ErrorCode::DataLoss,
                     std::format("points3D.bin track length must fit the remaining payload "
                                 "(point_id={}, track_length={}, remaining_bytes={}, track_record_bytes={})",
-                                point.point3D_id, track_len, static_cast<size_t>(end - cur),
+                                records[i].point_id, track_len, static_cast<size_t>(end - cur),
                                 2 * sizeof(uint32_t)),
                     lfs::SmallFields{}
                         .add("track_length", track_len)
                         .add("remaining_bytes", static_cast<std::uint64_t>(end - cur)));
             }
-            point.track_count = static_cast<size_t>(track_len);
-            point.track.reserve(track_len);
-            for (uint64_t j = 0; j < track_len; ++j) {
-                Point3DTrackElement track;
-                track.image_id = read_u32(cur, end, "points3D.bin track image id");
-                track.point2D_idx = read_u32(cur, end, "points3D.bin track point index");
-                point.track.push_back(track);
-            }
-            if (!valid) {
-                if (tally) {
-                    tally->record(std::format("point_id={}", point.point3D_id));
+            cur += static_cast<size_t>(track_len) * 2 * sizeof(uint32_t);
+            records[i].track_length = track_len;
+            records[i].end = cur;
+        }
+        LOG_DEBUG("Reading {} 3D points from binary file", N);
+        std::vector<Point3DData> parsed(N);
+        std::vector<uint8_t> valid(N, 0);
+        std::vector<SkipTally> local_tallies(tally ? N : 0);
+        std::atomic<bool> cancelled = false;
+        {
+            tbb::parallel_for(size_t{0}, static_cast<size_t>(N), [&](const size_t i) {
+                if (should_poll_cancel(i) && is_load_cancel_requested(options)) {
+                    cancelled.store(true, std::memory_order_relaxed);
+                    return;
                 }
+                const char* record_cur = records[i].begin;
+                const char* record_end = records[i].end;
+                auto& point = parsed[i];
+                point.point3D_id = read_u64(record_cur, record_end, "points3D.bin point id");
+                point.xyz[0] = read_f64(record_cur, record_end, "points3D.bin x");
+                point.xyz[1] = read_f64(record_cur, record_end, "points3D.bin y");
+                point.xyz[2] = read_f64(record_cur, record_end, "points3D.bin z");
+                bool point_valid = std::ranges::all_of(point.xyz, [](const double value) { return std::isfinite(value); });
+                point.color[0] = static_cast<uint8_t>(*record_cur++);
+                point.color[1] = static_cast<uint8_t>(*record_cur++);
+                point.color[2] = static_cast<uint8_t>(*record_cur++);
+                point.error = read_f64(record_cur, record_end, "points3D.bin error");
+                point_valid = point_valid && std::isfinite(point.error);
+                const uint64_t track_len = read_u64(record_cur, record_end, "points3D.bin track length");
+                point.track_count = static_cast<size_t>(track_len);
+                point.track.reserve(track_len);
+                for (uint64_t j = 0; j < track_len; ++j) {
+                    Point3DTrackElement track;
+                    track.image_id = read_u32(record_cur, record_end, "points3D.bin track image id");
+                    track.point2D_idx = read_u32(record_cur, record_end, "points3D.bin track point index");
+                    point.track.push_back(track);
+                }
+                valid[i] = point_valid ? 1 : 0;
+                if (!point_valid && tally) {
+                    local_tallies[i].record(std::format("point_id={}", point.point3D_id));
+                }
+            });
+        }
+        if (cancelled.load(std::memory_order_relaxed)) {
+            throw_if_load_cancel_requested(options, "COLMAP point cloud load cancelled");
+        }
+
+        std::vector<Point3DData> points;
+        points.reserve(N);
+        std::unordered_set<uint64_t> point_ids;
+        for (size_t i = 0; i < parsed.size(); ++i) {
+            if (tally) {
+                tally->merge(local_tallies[i]);
+            }
+            auto& point = parsed[i];
+            if (!valid[i]) {
                 continue;
             }
             if (!point_ids.insert(point.point3D_id).second) {
@@ -1506,13 +1564,11 @@ namespace lfs::io {
             }
             points.push_back(std::move(point));
         }
-
         if (cur != end) {
             throw_colmap_error(lfs::ErrorCode::DataLoss,
                                "points3D.bin: trailing bytes",
                                lfs::SmallFields{}.add("points_read", points.size()));
         }
-
         return points;
     }
 
@@ -1569,6 +1625,56 @@ namespace lfs::io {
     PointCloud read_point3D_binary(const std::filesystem::path& file_path,
                                    const LoadOptions& options = {}) {
         return point3D_records_to_point_cloud(read_point3D_binary_records(file_path, options));
+    }
+
+    Result<LoadOutcome<std::vector<ImageData>>> read_colmap_images_binary(
+        const std::filesystem::path& file_path,
+        const LoadOptions& options) {
+        try {
+            SkipTally pose_tally;
+            SkipTally point2d_tally;
+            auto images = read_images_binary(file_path, options, &pose_tally, &point2d_tally);
+            std::vector<Diagnostic> warnings;
+            if (auto diagnostic = pose_tally.to_diagnostic(
+                    lfs::ErrorCode::DataLoss, "image(s) with an invalid pose")) {
+                warnings.push_back(std::move(*diagnostic));
+            }
+            if (auto diagnostic = point2d_tally.to_diagnostic(
+                    lfs::ErrorCode::DataLoss, "point2D observation(s)")) {
+                warnings.push_back(std::move(*diagnostic));
+            }
+            return LoadOutcome<std::vector<ImageData>>{std::move(images), std::move(warnings)};
+        } catch (const LoadCancelledError& e) {
+            return make_error(ErrorCode::CANCELLED, e.what(), file_path);
+        } catch (const lfs::Exception& e) {
+            return std::unexpected(from_lfs_error(lfs::Error(e.error()).with_context(
+                "read COLMAP images.bin", LFS_SOURCE_SITE_CURRENT())));
+        } catch (const std::exception& e) {
+            return make_error(ErrorCode::CORRUPTED_DATA,
+                              std::format("Failed to read COLMAP images.bin: {}", e.what()), file_path);
+        }
+    }
+
+    Result<LoadOutcome<std::vector<Point3DData>>> read_colmap_point3D_binary_records(
+        const std::filesystem::path& file_path,
+        const LoadOptions& options) {
+        try {
+            SkipTally tally;
+            auto records = read_point3D_binary_records(file_path, options, &tally);
+            std::vector<Diagnostic> warnings;
+            if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
+                warnings.push_back(std::move(*diagnostic));
+            }
+            return LoadOutcome<std::vector<Point3DData>>{std::move(records), std::move(warnings)};
+        } catch (const LoadCancelledError& e) {
+            return make_error(ErrorCode::CANCELLED, e.what(), file_path);
+        } catch (const lfs::Exception& e) {
+            return std::unexpected(from_lfs_error(lfs::Error(e.error()).with_context(
+                "read COLMAP points3D.bin", LFS_SOURCE_SITE_CURRENT())));
+        } catch (const std::exception& e) {
+            return make_error(ErrorCode::CORRUPTED_DATA,
+                              std::format("Failed to read COLMAP points3D.bin: {}", e.what()), file_path);
+        }
     }
 
     // -----------------------------------------------------------------------------
@@ -2034,7 +2140,7 @@ namespace lfs::io {
         if (buffer->size() < POINTS3D_PARALLEL_MIN_BYTES) {
             points.reserve(std::max<size_t>(buffer->size() / 96, 1));
             file_lines = for_each_data_line(
-                std::span<const char>(*buffer),
+                std::span<const char>(buffer->data(), buffer->size()),
                 options,
                 "COLMAP point cloud parse cancelled",
                 [&](const std::string_view line, const size_t source_line) {
@@ -2053,7 +2159,8 @@ namespace lfs::io {
                 SkipTally tally;
             };
 
-            const auto chunks = split_line_aligned_chunks(std::span<const char>(*buffer));
+            const auto chunks = split_line_aligned_chunks(
+                std::span<const char>(buffer->data(), buffer->size()));
             std::vector<RecordChunkResult> results(chunks.size());
             // oneTBB propagates parse/cancellation exceptions to the caller and cancels sibling work.
             tbb::parallel_for(size_t{0}, chunks.size(), [&](const size_t chunk_index) {
@@ -2136,7 +2243,7 @@ namespace lfs::io {
             }
 
             data.file_lines = for_each_data_line(
-                std::span<const char>(*buffer),
+                std::span<const char>(buffer->data(), buffer->size()),
                 options,
                 "COLMAP point cloud parse cancelled",
                 [&](const std::string_view line, const size_t source_line) {
@@ -2158,7 +2265,8 @@ namespace lfs::io {
                 SkipTally tally;
             };
 
-            const auto chunks = split_line_aligned_chunks(std::span<const char>(*buffer));
+            const auto chunks = split_line_aligned_chunks(
+                std::span<const char>(buffer->data(), buffer->size()));
             std::vector<PointCloudChunkResult> results(chunks.size());
             // oneTBB propagates parse/cancellation exceptions to the caller and cancels sibling work.
             tbb::parallel_for(size_t{0}, chunks.size(), [&](const size_t chunk_index) {
@@ -2260,11 +2368,79 @@ namespace lfs::io {
         return cloud;
     }
 
-    std::unordered_map<uint64_t, std::array<float, 3>>
+    struct ColmapPointPositions {
+        std::unordered_map<uint64_t, std::array<float, 3>> sparse;
+        std::vector<std::array<float, 3>> dense;
+        std::vector<uint8_t> dense_valid;
+
+        [[nodiscard]] bool empty() const noexcept {
+            return sparse.empty() && dense.empty();
+        }
+
+        [[nodiscard]] const std::array<float, 3>* find(const uint64_t id) const noexcept {
+            if (!dense.empty()) {
+                if (id < dense_valid.size() && dense_valid[static_cast<size_t>(id)]) {
+                    return &dense[static_cast<size_t>(id)];
+                }
+                return nullptr;
+            }
+            const auto it = sparse.find(id);
+            return it == sparse.end() ? nullptr : &it->second;
+        }
+    };
+
+    ColmapPointPositions make_colmap_point_positions(const std::vector<Point3DData>& records) {
+        ColmapPointPositions positions;
+        uint64_t max_id = 0;
+        size_t valid_count = 0;
+        for (const auto& point : records) {
+            if (std::isfinite(point.xyz[0]) && std::isfinite(point.xyz[1]) &&
+                std::isfinite(point.xyz[2])) {
+                max_id = std::max(max_id, point.point3D_id);
+                ++valid_count;
+            }
+        }
+        constexpr uint64_t DENSE_ID_MULTIPLIER = 4;
+        if (valid_count > 0 && max_id <= DENSE_ID_MULTIPLIER * records.size() &&
+            max_id < static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+            const auto dense_size = static_cast<size_t>(max_id) + 1;
+            positions.dense.resize(dense_size);
+            positions.dense_valid.resize(dense_size, 0);
+            for (const auto& point : records) {
+                if (std::isfinite(point.xyz[0]) && std::isfinite(point.xyz[1]) &&
+                    std::isfinite(point.xyz[2])) {
+                    const auto index = static_cast<size_t>(point.point3D_id);
+                    positions.dense[index] = {
+                        static_cast<float>(point.xyz[0]),
+                        static_cast<float>(point.xyz[1]),
+                        static_cast<float>(point.xyz[2])};
+                    positions.dense_valid[index] = 1;
+                }
+            }
+        } else {
+            positions.sparse.reserve(records.size());
+            for (const auto& point : records) {
+                if (std::isfinite(point.xyz[0]) && std::isfinite(point.xyz[1]) &&
+                    std::isfinite(point.xyz[2])) {
+                    positions.sparse.emplace(
+                        point.point3D_id,
+                        std::array<float, 3>{
+                            static_cast<float>(point.xyz[0]),
+                            static_cast<float>(point.xyz[1]),
+                            static_cast<float>(point.xyz[2])});
+                }
+            }
+        }
+        return positions;
+    }
+
+    ColmapPointPositions
     load_colmap_point_positions_if_needed(const std::filesystem::path& base,
                                           const std::vector<ImageData>& images,
-                                          const LoadOptions& options) {
-        std::unordered_map<uint64_t, std::array<float, 3>> points_xyz;
+                                          const LoadOptions& options,
+                                          ColmapPointCloudRecords* shared_records = nullptr,
+                                          SkipTally* point_tally = nullptr) {
+        ColmapPointPositions points_xyz;
         bool any_observations = false;
         for (const auto& image : images) {
             if (!image.points2D.empty()) {
@@ -2281,23 +2457,24 @@ namespace lfs::io {
             const fs::path points_bin = find_file_in_paths(search_paths, "points3D.bin");
             const fs::path points_txt = find_file_in_paths(search_paths, "points3D.txt");
             std::vector<Point3DData> records;
-            if (!points_bin.empty()) {
-                records = read_point3D_binary_records(points_bin, options);
+            const std::vector<Point3DData>* records_ptr = nullptr;
+            if (shared_records && shared_records->loaded) {
+                records_ptr = &shared_records->records;
+            } else if (!points_bin.empty()) {
+                records = read_point3D_binary_records(points_bin, options, point_tally);
+                if (shared_records) {
+                    shared_records->records = std::move(records);
+                    shared_records->loaded = true;
+                    records_ptr = &shared_records->records;
+                } else {
+                    records_ptr = &records;
+                }
             } else if (!points_txt.empty()) {
                 records = read_point3D_text_records(points_txt, options, TrackParseMode::CountOnly);
+                records_ptr = &records;
             }
-            points_xyz.reserve(records.size());
-            for (const auto& point : records) {
-                if (!std::isfinite(point.xyz[0]) || !std::isfinite(point.xyz[1]) ||
-                    !std::isfinite(point.xyz[2])) {
-                    continue;
-                }
-                points_xyz.emplace(
-                    point.point3D_id,
-                    std::array<float, 3>{
-                        static_cast<float>(point.xyz[0]),
-                        static_cast<float>(point.xyz[1]),
-                        static_cast<float>(point.xyz[2])});
+            if (records_ptr) {
+                points_xyz = make_colmap_point_positions(*records_ptr);
             }
         } catch (const std::exception& e) {
             LOG_WARN("COLMAP SfM points unavailable for eval depth_absrel: {}", e.what());
@@ -2309,7 +2486,7 @@ namespace lfs::io {
         Camera& camera,
         const ImageData& image,
         const CameraDataIntermediate& cam_data,
-        const std::unordered_map<uint64_t, std::array<float, 3>>& points_xyz) {
+        const ColmapPointPositions& points_xyz) {
         if (image.points2D.empty() || points_xyz.empty()) {
             return;
         }
@@ -2327,8 +2504,8 @@ namespace lfs::io {
             if (point.point3D_id == INVALID_POINT3D_ID) {
                 continue;
             }
-            const auto xyz = points_xyz.find(point.point3D_id);
-            if (xyz == points_xyz.end()) {
+            const auto* xyz = points_xyz.find(point.point3D_id);
+            if (!xyz) {
                 continue;
             }
             if (!std::isfinite(point.x) || !std::isfinite(point.y)) {
@@ -2337,9 +2514,9 @@ namespace lfs::io {
             observations.push_back(Camera::SfmObservation{
                 .u = static_cast<float>(point.x) * u_scale,
                 .v = static_cast<float>(point.y) * v_scale,
-                .x = xyz->second[0],
-                .y = xyz->second[1],
-                .z = xyz->second[2]});
+                .x = (*xyz)[0],
+                .y = (*xyz)[1],
+                .z = (*xyz)[2]});
         }
         camera.set_sfm_observations(std::move(observations));
     }
@@ -2353,9 +2530,10 @@ namespace lfs::io {
                             const std::vector<ImageData>& images,
                             const std::string& images_folder,
                             const LoadOptions& options = {},
-                            const std::unordered_map<uint64_t, std::array<float, 3>>& points_xyz = {}) {
+                            const ColmapPointPositions& points_xyz = {}) {
 
         LOG_TIMER_TRACE("Assemble COLMAP cameras");
+        LOG_TIMER_DEBUG("COLMAP assemble: cameras");
 
         std::filesystem::path images_path = base_path / lfs::core::utf8_to_path(images_folder);
 
@@ -2366,6 +2544,10 @@ namespace lfs::io {
 
         std::vector<std::shared_ptr<Camera>> cameras;
         cameras.reserve(images.size());
+        std::vector<const ImageData*> camera_images;
+        std::vector<const CameraDataIntermediate*> camera_data;
+        camera_images.reserve(images.size());
+        camera_data.reserve(images.size());
         SkipTally image_tally;
         std::vector<std::string> missing_images;
 
@@ -2379,6 +2561,8 @@ namespace lfs::io {
         size_t undistort_crop_failures = 0;
         size_t undistort_camera_count = 0;
         size_t undistort_fisheye_crop_failures = 0;
+        std::unordered_map<uint32_t, std::optional<lfs::core::UndistortParams>> undistort_cache;
+        undistort_cache.reserve(cam_map.size());
 
         // Accumulate camera positions for scene center
         std::vector<float> camera_positions;
@@ -2424,20 +2608,19 @@ namespace lfs::io {
             Tensor T = Tensor::from_vector(img.tvec, {3}, Device::CPU);
 
             // Calculate camera position: -R^T * T
-            auto R_cpu = R.cpu();
-            auto T_cpu = T.cpu();
-
             float RT[9];
+            const float* R_ptr = R.ptr<float>();
             for (int r = 0; r < 3; ++r) {
                 for (int c = 0; c < 3; ++c) {
-                    RT[r * 3 + c] = R_cpu.ptr<float>()[c * 3 + r]; // Transpose
+                    RT[r * 3 + c] = R_ptr[c * 3 + r]; // Transpose
                 }
             }
 
             float cam_pos[3] = {0, 0, 0};
+            const float* T_ptr = T.ptr<float>();
             for (int r = 0; r < 3; ++r) {
                 for (int c = 0; c < 3; ++c) {
-                    cam_pos[r] -= RT[r * 3 + c] * T_cpu.ptr<float>()[c];
+                    cam_pos[r] -= RT[r * 3 + c] * T_ptr[c];
                 }
             }
 
@@ -2703,7 +2886,18 @@ namespace lfs::io {
                 depth_path,
                 normal_path);
 
-            camera->precompute_undistortion();
+            const auto undistort_it = undistort_cache.find(img.camera_id);
+            if (undistort_it == undistort_cache.end()) {
+                if (camera->has_distortion()) {
+                    LOG_TIMER_DEBUG("COLMAP assemble: undistort");
+                    camera->precompute_undistortion();
+                    undistort_cache.emplace(img.camera_id, camera->undistort_params());
+                } else {
+                    undistort_cache.emplace(img.camera_id, std::nullopt);
+                }
+            } else if (undistort_it->second) {
+                camera->adopt_undistortion(*undistort_it->second);
+            }
             ++undistort_camera_count;
             if (camera->undistort_params().crop_solve_failed) {
                 ++undistort_crop_failures;
@@ -2712,13 +2906,32 @@ namespace lfs::io {
                     ++undistort_fisheye_crop_failures;
                 }
             }
-            attach_sfm_observations(*camera, img, cam_data, points_xyz);
             if (!image_file_present) {
                 camera->set_has_image(false);
                 missing_images.push_back(img.name);
             }
-
+            camera_images.push_back(&img);
+            camera_data.push_back(&cam_data);
             cameras.push_back(std::move(camera));
+        }
+
+        std::atomic<bool> observation_cancelled = false;
+        {
+            LOG_TIMER_DEBUG("COLMAP assemble: sfm observations");
+            tbb::parallel_for(tbb::blocked_range<size_t>(0, cameras.size(), 32),
+                              [&](const tbb::blocked_range<size_t>& range) {
+                                  for (size_t i = range.begin(); i != range.end(); ++i) {
+                                      if (should_poll_cancel(i) && is_load_cancel_requested(options)) {
+                                          observation_cancelled.store(true, std::memory_order_relaxed);
+                                          return;
+                                      }
+                                      attach_sfm_observations(*cameras[i], *camera_images[i],
+                                                              *camera_data[i], points_xyz);
+                                  }
+                              });
+        }
+        if (observation_cancelled.load(std::memory_order_relaxed)) {
+            throw_if_load_cancel_requested(options, "COLMAP camera assembly cancelled");
         }
 
         if (undistort_crop_failures > 0) {
@@ -3761,16 +3974,34 @@ namespace lfs::io {
 
     Result<LoadOutcome<PointCloud>> read_colmap_point_cloud(
         const std::filesystem::path& filepath,
-        const LoadOptions& options) {
+        const LoadOptions& options,
+        ColmapPointCloudRecords* point_records) {
         LOG_TIMER_TRACE("Read COLMAP point cloud");
         try {
             const fs::path points3d_file = get_sparse_file_path(filepath, "points3D.bin");
             SkipTally tally;
-            auto records = read_point3D_binary_records(points3d_file, options, &tally);
-            auto cloud = point3D_records_to_point_cloud(records);
+            std::vector<Point3DData> records;
             std::vector<Diagnostic> warnings;
-            if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
-                warnings.push_back(std::move(*diagnostic));
+            if (point_records && point_records->loaded) {
+                records = std::move(point_records->records);
+                warnings = std::move(point_records->warnings);
+                point_records->loaded = false;
+            } else {
+                records = read_point3D_binary_records(points3d_file, options, &tally);
+                if (point_records) {
+                    point_records->warnings.clear();
+                    if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
+                        warnings.push_back(*diagnostic);
+                        point_records->warnings.push_back(std::move(*diagnostic));
+                    }
+                    point_records->loaded = false;
+                }
+            }
+            auto cloud = point3D_records_to_point_cloud(records);
+            if (!point_records) {
+                if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
+                    warnings.push_back(std::move(*diagnostic));
+                }
             }
             return LoadOutcome<PointCloud>{std::move(cloud), std::move(warnings)};
         } catch (const LoadCancelledError& e) {
@@ -3788,16 +4019,34 @@ namespace lfs::io {
 
     Result<LoadOutcome<ColmapPointCloudLoadStats>> read_colmap_point_cloud_with_stats(
         const std::filesystem::path& filepath,
-        const LoadOptions& options) {
+        const LoadOptions& options,
+        ColmapPointCloudRecords* point_records) {
         LOG_TIMER_TRACE("Read COLMAP point cloud");
         try {
             const fs::path points3d_file = get_sparse_file_path(filepath, "points3D.bin");
             SkipTally tally;
-            auto records = read_point3D_binary_records(points3d_file, options, &tally);
-            auto stats = point3D_records_to_point_cloud_with_stats(std::move(records), options);
+            std::vector<Point3DData> records;
             std::vector<Diagnostic> warnings;
-            if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
-                warnings.push_back(std::move(*diagnostic));
+            if (point_records && point_records->loaded) {
+                records = std::move(point_records->records);
+                warnings = std::move(point_records->warnings);
+                point_records->loaded = false;
+            } else {
+                records = read_point3D_binary_records(points3d_file, options, &tally);
+                if (point_records) {
+                    point_records->warnings.clear();
+                    if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
+                        warnings.push_back(*diagnostic);
+                        point_records->warnings.push_back(std::move(*diagnostic));
+                    }
+                    point_records->loaded = false;
+                }
+            }
+            auto stats = point3D_records_to_point_cloud_with_stats(std::move(records), options);
+            if (!point_records) {
+                if (auto diagnostic = tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
+                    warnings.push_back(std::move(*diagnostic));
+                }
             }
             return LoadOutcome<ColmapPointCloudLoadStats>{std::move(stats), std::move(warnings)};
         } catch (const LoadCancelledError& e) {
@@ -3857,7 +4106,8 @@ namespace lfs::io {
     Result<LoadOutcome<std::tuple<std::vector<std::shared_ptr<Camera>>, Tensor>>>
     read_colmap_cameras_and_images(const std::filesystem::path& base,
                                    const std::string& images_folder,
-                                   const LoadOptions& options) {
+                                   const LoadOptions& options,
+                                   ColmapPointCloudRecords* point_records) {
 
         LOG_TIMER_TRACE("Read COLMAP cameras and images");
 
@@ -3869,6 +4119,7 @@ namespace lfs::io {
             SkipTally camera_tally;
             SkipTally pose_tally;
             SkipTally point2d_tally;
+            SkipTally point_tally;
             auto cam_map = read_cameras_binary(cams_file, scale_factor, options, &camera_tally);
             auto images = read_images_binary(images_file, options, &pose_tally, &point2d_tally);
 
@@ -3877,7 +4128,13 @@ namespace lfs::io {
                 return std::unexpected(validation.error());
             }
 
-            auto points_xyz = load_colmap_point_positions_if_needed(base, images, options);
+            auto points_xyz = load_colmap_point_positions_if_needed(
+                base, images, options, point_records, point_records ? &point_tally : nullptr);
+            if (point_records && point_records->loaded) {
+                if (auto diagnostic = point_tally.to_diagnostic(lfs::ErrorCode::DataLoss, "point(s)")) {
+                    point_records->warnings.push_back(std::move(*diagnostic));
+                }
+            }
             auto assembled = assemble_colmap_cameras(base, cam_map, images, images_folder, options, points_xyz);
             if (!assembled) {
                 return std::unexpected(assembled.error());

--- a/src/io/formats/colmap.hpp
+++ b/src/io/formats/colmap.hpp
@@ -65,10 +65,9 @@ namespace lfs::io {
         std::vector<Point3DTrackElement> track;
     };
 
-    // Optional hand-off between the camera/image and point-cloud phases of a
-    // binary COLMAP load. The camera phase fills this only when SfM
-    // observations require points; the point-cloud phase then consumes the
-    // records instead of reading points3D.bin again.
+    // Filled only by read_colmap_cameras_and_images when SfM observations
+    // require the points; consumed (and cleared) by the first point-cloud
+    // read; never mutated otherwise.
     struct ColmapPointCloudRecords {
         std::vector<Point3DData> records;
         std::vector<Diagnostic> warnings;

--- a/src/io/formats/colmap.hpp
+++ b/src/io/formats/colmap.hpp
@@ -13,7 +13,9 @@
 #include <cstdint>
 #include <filesystem>
 #include <glm/glm.hpp>
+#include <limits>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace lfs::io {
@@ -31,6 +33,55 @@ namespace lfs::io {
         std::size_t points_after_filtering = 0;
         bool track_filter_applied = false;
     };
+
+    constexpr uint64_t INVALID_POINT3D_ID = std::numeric_limits<uint64_t>::max();
+
+    struct ImagePoint2D {
+        double x = 0.0;
+        double y = 0.0;
+        uint64_t point3D_id = INVALID_POINT3D_ID;
+    };
+
+    struct ImageData {
+        uint32_t image_id = 0;
+        uint32_t camera_id = 0;
+        std::string name;
+        std::vector<float> qvec = {1.0f, 0.0f, 0.0f, 0.0f};
+        std::vector<float> tvec = {0.0f, 0.0f, 0.0f};
+        std::vector<ImagePoint2D> points2D;
+    };
+
+    struct Point3DTrackElement {
+        uint32_t image_id = 0;
+        uint32_t point2D_idx = 0;
+    };
+
+    struct Point3DData {
+        uint64_t point3D_id = 0;
+        double xyz[3] = {0.0, 0.0, 0.0};
+        uint8_t color[3] = {255, 255, 255};
+        double error = 0.0;
+        size_t track_count = 0;
+        std::vector<Point3DTrackElement> track;
+    };
+
+    // Optional hand-off between the camera/image and point-cloud phases of a
+    // binary COLMAP load. The camera phase fills this only when SfM
+    // observations require points; the point-cloud phase then consumes the
+    // records instead of reading points3D.bin again.
+    struct ColmapPointCloudRecords {
+        std::vector<Point3DData> records;
+        std::vector<Diagnostic> warnings;
+        bool loaded = false;
+    };
+
+    Result<LoadOutcome<std::vector<ImageData>>> read_colmap_images_binary(
+        const std::filesystem::path& file_path,
+        const LoadOptions& options = {});
+
+    Result<LoadOutcome<std::vector<Point3DData>>> read_colmap_point3D_binary_records(
+        const std::filesystem::path& file_path,
+        const LoadOptions& options = {});
 
     // Camera data structure used for intermediate loading before Camera creation
     struct CameraData {
@@ -71,7 +122,8 @@ namespace lfs::io {
     read_colmap_cameras_and_images(
         const std::filesystem::path& base,
         const std::string& images_folder = "images",
-        const LoadOptions& options = {});
+        const LoadOptions& options = {},
+        ColmapPointCloudRecords* point_records = nullptr);
 
     /**
      * @brief Read COLMAP point cloud (binary format)
@@ -80,11 +132,13 @@ namespace lfs::io {
      */
     Result<LoadOutcome<PointCloud>> read_colmap_point_cloud(
         const std::filesystem::path& filepath,
-        const LoadOptions& options = {});
+        const LoadOptions& options = {},
+        ColmapPointCloudRecords* point_records = nullptr);
 
     Result<LoadOutcome<ColmapPointCloudLoadStats>> read_colmap_point_cloud_with_stats(
         const std::filesystem::path& filepath,
-        const LoadOptions& options = {});
+        const LoadOptions& options = {},
+        ColmapPointCloudRecords* point_records = nullptr);
 
     /**
      * @brief Read COLMAP cameras and images from text files

--- a/src/io/loaders/colmap_loader.cpp
+++ b/src/io/loaders/colmap_loader.cpp
@@ -208,11 +208,13 @@ namespace lfs::io {
             std::vector<std::shared_ptr<Camera>> cameras;
             Tensor scene_center;
             std::vector<std::string> warnings;
+            ColmapPointCloudRecords binary_point_records;
 
             if (has_cameras && has_images) {
                 LOG_DEBUG("Reading binary COLMAP data");
                 LOG_TIMER_DEBUG("COLMAP read binary cameras and images");
-                auto result = read_colmap_cameras_and_images(path, actual_images_folder, options);
+                auto result = read_colmap_cameras_and_images(
+                    path, actual_images_folder, options, &binary_point_records);
                 if (!result) {
                     return std::unexpected(result.error());
                 }
@@ -293,7 +295,8 @@ namespace lfs::io {
                 LOG_DEBUG("Loading binary point cloud");
                 LOG_TIMER_DEBUG("COLMAP load binary point cloud");
                 if (use_colmap_track_filter) {
-                    auto pc_result = read_colmap_point_cloud_with_stats(path, options);
+                    auto pc_result = read_colmap_point_cloud_with_stats(
+                        path, options, &binary_point_records);
                     if (!pc_result) {
                         return std::unexpected(pc_result.error());
                     }
@@ -310,7 +313,7 @@ namespace lfs::io {
                         warnings.push_back(diagnostic.message);
                     }
                 } else {
-                    auto pc_result = read_colmap_point_cloud(path, options);
+                    auto pc_result = read_colmap_point_cloud(path, options, &binary_point_records);
                     if (!pc_result) {
                         return std::unexpected(pc_result.error());
                     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -477,6 +477,7 @@ set(TEST_FILES
     test_missing_dataset_images.cpp
     test_colmap_points3d_text.cpp
     test_colmap_binary_error_taxonomy.cpp
+    test_colmap_binary_parallel_parse.cpp
     test_splat_simplify.cpp
     test_rml_text_input_handler.cpp
     test_rml_im_mode_layout.cpp

--- a/tests/test_colmap_binary_parallel_parse.cpp
+++ b/tests/test_colmap_binary_parallel_parse.cpp
@@ -18,6 +18,7 @@
 
 namespace {
     namespace fs = std::filesystem;
+    constexpr size_t READ_CHUNK_BYTES = 64ull * 1024ull * 1024ull;
 
     template <typename T>
     void append_pod(std::vector<char>& bytes, const T value) {
@@ -31,6 +32,24 @@ namespace {
         std::memcpy(&value, bytes.data() + offset, sizeof(T));
         offset += sizeof(T);
         return value;
+    }
+
+    void append_valid_image(std::vector<char>& bytes,
+                            const uint32_t image_id,
+                            const uint32_t camera_id,
+                            const std::string_view name) {
+        append_pod(bytes, image_id);
+        append_pod(bytes, 1.0);
+        append_pod(bytes, 0.0);
+        append_pod(bytes, 0.0);
+        append_pod(bytes, 0.0);
+        append_pod(bytes, 0.0);
+        append_pod(bytes, 0.0);
+        append_pod(bytes, 0.0);
+        append_pod(bytes, camera_id);
+        bytes.insert(bytes.end(), name.begin(), name.end());
+        bytes.push_back('\0');
+        append_pod(bytes, uint64_t{0});
     }
 
     struct ImageReference {
@@ -268,6 +287,39 @@ namespace {
         for (size_t i = 0; i < point_reference.size(); ++i) {
             expect_point_equal(points_result->value[i], point_reference[i]);
         }
+
+        fs::remove_all(temp_dir, ec);
+    }
+
+    TEST(ColmapBinaryParallelParseTest, ReadsFilesBelowAndAcrossParallelReadChunks) {
+        const fs::path temp_dir = fs::temp_directory_path() / "lfs_colmap_binary_parallel_read_chunks";
+        std::error_code ec;
+        fs::remove_all(temp_dir, ec);
+        ASSERT_TRUE(fs::create_directories(temp_dir));
+
+        std::vector<char> small_bytes;
+        append_pod(small_bytes, uint64_t{1});
+        append_valid_image(small_bytes, 1, 7, "small.png");
+        ASSERT_LT(small_bytes.size(), READ_CHUNK_BYTES);
+        const fs::path small_path = temp_dir / "small_images.bin";
+        write_bytes(small_path, small_bytes);
+        const auto small_result = lfs::io::read_colmap_images_binary(small_path);
+        ASSERT_TRUE(small_result.has_value()) << small_result.error().format();
+        ASSERT_EQ(small_result->value.size(), 1u);
+        EXPECT_EQ(small_result->value.front().name, "small.png");
+
+        std::string long_name(2 * READ_CHUNK_BYTES + 123, 'x');
+        std::vector<char> spanning_bytes;
+        append_pod(spanning_bytes, uint64_t{1});
+        append_valid_image(spanning_bytes, 2, 7, long_name);
+        ASSERT_GT(spanning_bytes.size(), 2 * READ_CHUNK_BYTES);
+        const fs::path spanning_path = temp_dir / "spanning_images.bin";
+        write_bytes(spanning_path, spanning_bytes);
+        const auto spanning_result = lfs::io::read_colmap_images_binary(spanning_path);
+        ASSERT_TRUE(spanning_result.has_value()) << spanning_result.error().format();
+        ASSERT_EQ(spanning_result->value.size(), 1u);
+        EXPECT_EQ(spanning_result->value.front().name.size(), long_name.size());
+        EXPECT_EQ(spanning_result->value.front().name, long_name);
 
         fs::remove_all(temp_dir, ec);
     }

--- a/tests/test_colmap_binary_parallel_parse.cpp
+++ b/tests/test_colmap_binary_parallel_parse.cpp
@@ -1,0 +1,274 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "io/formats/colmap.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+    namespace fs = std::filesystem;
+
+    template <typename T>
+    void append_pod(std::vector<char>& bytes, const T value) {
+        const auto* begin = reinterpret_cast<const char*>(&value);
+        bytes.insert(bytes.end(), begin, begin + sizeof(T));
+    }
+
+    template <typename T>
+    T read_pod(const std::vector<char>& bytes, size_t& offset) {
+        T value{};
+        std::memcpy(&value, bytes.data() + offset, sizeof(T));
+        offset += sizeof(T);
+        return value;
+    }
+
+    struct ImageReference {
+        std::vector<lfs::io::ImageData> images;
+        size_t invalid_pose_count = 0;
+        std::vector<std::string> invalid_pose_samples;
+        size_t invalid_point_count = 0;
+        std::vector<std::string> invalid_point_samples;
+    };
+
+    ImageReference parse_images_serial(const std::vector<char>& bytes) {
+        ImageReference reference;
+        size_t offset = 0;
+        const auto count = read_pod<uint64_t>(bytes, offset);
+        reference.images.reserve(count);
+        for (uint64_t index = 0; index < count; ++index) {
+            lfs::io::ImageData image;
+            image.image_id = read_pod<uint32_t>(bytes, offset);
+            for (float& value : image.qvec) {
+                value = static_cast<float>(read_pod<double>(bytes, offset));
+            }
+            for (float& value : image.tvec) {
+                value = static_cast<float>(read_pod<double>(bytes, offset));
+            }
+            image.camera_id = read_pod<uint32_t>(bytes, offset);
+            const auto* name_begin = bytes.data() + offset;
+            const auto* name_end = static_cast<const char*>(
+                std::memchr(name_begin, '\0', bytes.size() - offset));
+            image.name.assign(name_begin, name_end);
+            offset += static_cast<size_t>(name_end - name_begin) + 1;
+            bool valid = !image.name.empty();
+            const auto point_count = read_pod<uint64_t>(bytes, offset);
+            image.points2D.reserve(point_count);
+            for (uint64_t point_index = 0; point_index < point_count; ++point_index) {
+                lfs::io::ImagePoint2D point;
+                point.x = read_pod<double>(bytes, offset);
+                point.y = read_pod<double>(bytes, offset);
+                point.point3D_id = read_pod<uint64_t>(bytes, offset);
+                if (std::isfinite(point.x) && std::isfinite(point.y)) {
+                    image.points2D.push_back(point);
+                } else {
+                    ++reference.invalid_point_count;
+                    if (reference.invalid_point_samples.size() < 8) {
+                        reference.invalid_point_samples.push_back(
+                            std::format("image_id={},point_index={}", image.image_id, point_index));
+                    }
+                }
+            }
+            const double qnorm = std::sqrt(
+                static_cast<double>(image.qvec[0]) * image.qvec[0] +
+                static_cast<double>(image.qvec[1]) * image.qvec[1] +
+                static_cast<double>(image.qvec[2]) * image.qvec[2] +
+                static_cast<double>(image.qvec[3]) * image.qvec[3]);
+            valid = valid && std::isfinite(qnorm) && std::abs(qnorm - 1.0) <= 1e-4 &&
+                    std::ranges::all_of(image.tvec, [](const float value) {
+                        return std::isfinite(value);
+                    });
+            if (!valid) {
+                ++reference.invalid_pose_count;
+                if (reference.invalid_pose_samples.size() < 8) {
+                    reference.invalid_pose_samples.push_back(
+                        std::format("image_id={}", image.image_id));
+                }
+            } else {
+                reference.images.push_back(std::move(image));
+            }
+        }
+        return reference;
+    }
+
+    std::vector<lfs::io::Point3DData> parse_points_serial(const std::vector<char>& bytes) {
+        std::vector<lfs::io::Point3DData> points;
+        size_t offset = 0;
+        const auto count = read_pod<uint64_t>(bytes, offset);
+        points.reserve(count);
+        for (uint64_t index = 0; index < count; ++index) {
+            lfs::io::Point3DData point;
+            point.point3D_id = read_pod<uint64_t>(bytes, offset);
+            for (double& value : point.xyz) {
+                value = read_pod<double>(bytes, offset);
+            }
+            for (uint8_t& value : point.color) {
+                value = read_pod<uint8_t>(bytes, offset);
+            }
+            point.error = read_pod<double>(bytes, offset);
+            const auto track_count = read_pod<uint64_t>(bytes, offset);
+            point.track_count = static_cast<size_t>(track_count);
+            point.track.reserve(track_count);
+            for (uint64_t track_index = 0; track_index < track_count; ++track_index) {
+                point.track.push_back(lfs::io::Point3DTrackElement{
+                    .image_id = read_pod<uint32_t>(bytes, offset),
+                    .point2D_idx = read_pod<uint32_t>(bytes, offset)});
+            }
+            if (std::isfinite(point.xyz[0]) && std::isfinite(point.xyz[1]) &&
+                std::isfinite(point.xyz[2]) && std::isfinite(point.error)) {
+                points.push_back(std::move(point));
+            }
+        }
+        return points;
+    }
+
+    void write_bytes(const fs::path& path, const std::vector<char>& bytes) {
+        std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(stream.is_open());
+        stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        ASSERT_TRUE(stream.good());
+    }
+
+    void expect_image_equal(const lfs::io::ImageData& actual,
+                            const lfs::io::ImageData& expected) {
+        EXPECT_EQ(actual.image_id, expected.image_id);
+        EXPECT_EQ(actual.camera_id, expected.camera_id);
+        EXPECT_EQ(actual.name, expected.name);
+        EXPECT_EQ(actual.qvec, expected.qvec);
+        EXPECT_EQ(actual.tvec, expected.tvec);
+        ASSERT_EQ(actual.points2D.size(), expected.points2D.size());
+        for (size_t i = 0; i < actual.points2D.size(); ++i) {
+            EXPECT_EQ(actual.points2D[i].x, expected.points2D[i].x);
+            EXPECT_EQ(actual.points2D[i].y, expected.points2D[i].y);
+            EXPECT_EQ(actual.points2D[i].point3D_id, expected.points2D[i].point3D_id);
+        }
+    }
+
+    void expect_point_equal(const lfs::io::Point3DData& actual,
+                            const lfs::io::Point3DData& expected) {
+        EXPECT_EQ(actual.point3D_id, expected.point3D_id);
+        for (size_t i = 0; i < 3; ++i) {
+            EXPECT_EQ(actual.xyz[i], expected.xyz[i]);
+            EXPECT_EQ(actual.color[i], expected.color[i]);
+        }
+        EXPECT_EQ(actual.error, expected.error);
+        EXPECT_EQ(actual.track_count, expected.track_count);
+        ASSERT_EQ(actual.track.size(), expected.track.size());
+        for (size_t i = 0; i < actual.track.size(); ++i) {
+            EXPECT_EQ(actual.track[i].image_id, expected.track[i].image_id);
+            EXPECT_EQ(actual.track[i].point2D_idx, expected.track[i].point2D_idx);
+        }
+    }
+
+    std::string diagnostic_message(const size_t count,
+                                   const std::vector<std::string>& samples,
+                                   const std::string_view noun) {
+        std::string joined;
+        for (size_t i = 0; i < samples.size(); ++i) {
+            if (i != 0) {
+                joined += ", ";
+            }
+            joined += samples[i];
+        }
+        return std::format("COLMAP import skipped {} {} ({} sampled: {})",
+                           count, noun, samples.size(), joined);
+    }
+
+    TEST(ColmapBinaryParallelParseTest, MatchesSerialReferenceAndDiagnosticOrder) {
+        const fs::path temp_dir = fs::temp_directory_path() / "lfs_colmap_binary_parallel_parse";
+        std::error_code ec;
+        fs::remove_all(temp_dir, ec);
+        ASSERT_TRUE(fs::create_directories(temp_dir));
+
+        std::vector<char> image_bytes;
+        constexpr uint64_t image_count = 201;
+        append_pod(image_bytes, image_count);
+        for (uint64_t image_index = 0; image_index < image_count; ++image_index) {
+            const uint32_t image_id = static_cast<uint32_t>(1000 + image_index);
+            append_pod(image_bytes, image_id);
+            append_pod(image_bytes, image_index == 137 ? 2.0 : 1.0);
+            append_pod(image_bytes, 0.01 * static_cast<double>(image_index));
+            append_pod(image_bytes, -0.02 * static_cast<double>(image_index));
+            append_pod(image_bytes, 0.03 * static_cast<double>(image_index));
+            append_pod(image_bytes, 0.1 * static_cast<double>(image_index));
+            append_pod(image_bytes, -0.2 * static_cast<double>(image_index));
+            append_pod(image_bytes, 0.3 * static_cast<double>(image_index));
+            append_pod(image_bytes, uint32_t{7});
+            const std::string name = std::format("frame_{:04}.png", image_index);
+            image_bytes.insert(image_bytes.end(), name.begin(), name.end());
+            image_bytes.push_back('\0');
+            const uint64_t point_count = image_index == 0 ? 0 : image_index * 25;
+            append_pod(image_bytes, point_count);
+            for (uint64_t point_index = 0; point_index < point_count; ++point_index) {
+                const bool non_finite = point_index % 997 == 0;
+                append_pod(image_bytes, non_finite ? std::numeric_limits<double>::quiet_NaN()
+                                                   : static_cast<double>(point_index) + 0.25);
+                append_pod(image_bytes, non_finite ? 1.0 : static_cast<double>(point_index) + 0.5);
+                append_pod(image_bytes, point_index % 257);
+            }
+        }
+
+        std::vector<char> point_bytes;
+        constexpr uint64_t point_count = 257;
+        append_pod(point_bytes, point_count);
+        for (uint64_t point_index = 0; point_index < point_count; ++point_index) {
+            append_pod(point_bytes, point_index);
+            append_pod(point_bytes, static_cast<double>(point_index) + 0.1);
+            append_pod(point_bytes, static_cast<double>(point_index) + 0.2);
+            append_pod(point_bytes, static_cast<double>(point_index) + 0.3);
+            append_pod(point_bytes, static_cast<uint8_t>(point_index));
+            append_pod(point_bytes, static_cast<uint8_t>(point_index + 1));
+            append_pod(point_bytes, static_cast<uint8_t>(point_index + 2));
+            append_pod(point_bytes, 0.001 * static_cast<double>(point_index));
+            const uint64_t track_count = point_index % 5;
+            append_pod(point_bytes, track_count);
+            for (uint64_t track_index = 0; track_index < track_count; ++track_index) {
+                append_pod(point_bytes, static_cast<uint32_t>(1000 + track_index));
+                append_pod(point_bytes, static_cast<uint32_t>(point_index + track_index));
+            }
+        }
+
+        const fs::path image_path = temp_dir / "images.bin";
+        const fs::path point_path = temp_dir / "points3D.bin";
+        write_bytes(image_path, image_bytes);
+        write_bytes(point_path, point_bytes);
+
+        const auto image_reference = parse_images_serial(image_bytes);
+        const auto point_reference = parse_points_serial(point_bytes);
+        const auto images_result = lfs::io::read_colmap_images_binary(image_path);
+        ASSERT_TRUE(images_result.has_value()) << images_result.error().format();
+        ASSERT_EQ(images_result->value.size(), image_reference.images.size());
+        for (size_t i = 0; i < image_reference.images.size(); ++i) {
+            expect_image_equal(images_result->value[i], image_reference.images[i]);
+        }
+        ASSERT_EQ(images_result->warnings.size(), 2u);
+        EXPECT_EQ(images_result->warnings[0].message,
+                  diagnostic_message(image_reference.invalid_pose_count,
+                                     image_reference.invalid_pose_samples,
+                                     "image(s) with an invalid pose"));
+        EXPECT_EQ(images_result->warnings[1].message,
+                  diagnostic_message(image_reference.invalid_point_count,
+                                     image_reference.invalid_point_samples,
+                                     "point2D observation(s)"));
+
+        const auto points_result = lfs::io::read_colmap_point3D_binary_records(point_path);
+        ASSERT_TRUE(points_result.has_value()) << points_result.error().format();
+        ASSERT_EQ(points_result->value.size(), point_reference.size());
+        ASSERT_TRUE(points_result->warnings.empty());
+        for (size_t i = 0; i < point_reference.size(); ++i) {
+            expect_point_equal(points_result->value[i], point_reference[i]);
+        }
+
+        fs::remove_all(temp_dir, ec);
+    }
+} // namespace


### PR DESCRIPTION
Importing a COLMAP dataset is almost 5x faster, with identical results.

| alameda (1740 images, 504 MB images.bin) | before | after |
|---|---|---|
| import | 2.3–2.7 s | **0.52 s** |

What was slow
- The undistortion solve ran once per image although all 1740 images share one camera record (and logged a line each time). It now runs once per camera record.
- SfM observations were attached with ~21M serial hash lookups. They now use a dense id table and run in parallel across cameras, in the same order.
- images.bin was parsed serially, field by field; points3D.bin was parsed twice. Both are parsed once with a sequential offset pass (all structural checks and error messages unchanged) followed by a parallel fill.
- The 504 MB file was read through a single ifstream read into a zero-filled buffer (330 ms). It is now read in 64 MiB chunks in parallel (77 ms).
- Cameras are assembled in parallel into an index-addressed vector and compacted in source order, so order, UIDs and observation order are unchanged. Directory caches are built once and concurrently instead of twice; per-camera R/T tensors come from two batch tensors instead of 3480 pinned allocations.

Verification: camera-by-camera hash (ids, names, paths, sizes, intrinsics, R, T, K, view matrix), point cloud hash, scene center and loader warnings are identical before and after. New gtest compares the parallel readers with a serial reference on synthetic files including non-finite points, an invalid quaternion and tally ordering. 86 COLMAP/PythonIO/checkpoint-install gtests; error-debt census clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMPCqzauodZECqva5aeFRM
