### PR TITLE
Add an FOV slider with reset to the HTML viewer

### DIFF
--- a/src/visualizer/gui/resources/viewer/index.css
+++ b/src/visualizer/gui/resources/viewer/index.css
@@ -330,6 +330,24 @@ button {
   margin: 8px 0;
   background-color: #666;
 }
+#settingsPanel > .settingsRow > .fovLabel {
+  cursor: default;
+  white-space: nowrap;
+}
+#settingsPanel > .settingsRow > #fovSlider {
+  flex-grow: 1;
+  margin: 8px 4px;
+  accent-color: #F60;
+}
+#settingsPanel > .settingsRow > #fovValue {
+  min-width: 38px;
+  text-align: center;
+  white-space: nowrap;
+}
+#settingsPanel > .settingsRow > #fovReset {
+  flex-grow: 0;
+  padding: 10px 12px;
+}
 
 /* infoPanel */
 #infoPanel {

--- a/src/visualizer/gui/resources/viewer/index.js
+++ b/src/visualizer/gui/resources/viewer/index.js
@@ -99846,6 +99846,7 @@ const initUI = (global) => {
         'orbitCamera', 'flyCamera', 'orthoCamera',
         'hqCheck', 'hqOption', 'lqCheck', 'lqOption',
         'reset', 'frame',
+        'fovSlider', 'fovValue', 'fovReset',
         'loadingText', 'loadingBar',
         'joystickBase', 'joystick',
         'tooltip'
@@ -100089,6 +100090,19 @@ const initUI = (global) => {
     dom.frame.addEventListener('click', (event) => {
         events.fire('inputEvent', 'frame', event);
     });
+    // FOV slider
+    const updateFovSlider = () => {
+        dom.fovSlider.value = state.fov;
+        dom.fovValue.textContent = `${state.fov}°`;
+    };
+    dom.fovSlider.addEventListener('input', () => {
+        state.fov = parseFloat(dom.fovSlider.value);
+    });
+    dom.fovReset.addEventListener('click', () => {
+        state.fov = state.defaultFov;
+    });
+    events.on('fov:changed', updateFovSlider);
+    updateFovSlider();
     // update UI based on touch joystick updates
     events.on('touchJoystickUpdate', (base, stick) => {
         if (base === null) {
@@ -100120,6 +100134,8 @@ const initUI = (global) => {
     tooltip.register(dom.orthoCamera, 'Orthographic Mode', 'top');
     tooltip.register(dom.reset, 'Reset Camera', 'bottom');
     tooltip.register(dom.frame, 'Frame Scene', 'bottom');
+    tooltip.register(dom.fovSlider, 'Camera Field of View', 'top');
+    tooltip.register(dom.fovReset, 'Reset FOV', 'bottom');
     tooltip.register(dom.settings, 'Settings', 'top');
     tooltip.register(dom.info, 'Help', 'top');
     tooltip.register(dom.arMode, 'Enter AR', 'top');
@@ -101655,13 +101671,15 @@ class Viewer {
         });
         const applyCamera = (camera) => {
             const cameraEntity = global.camera;
+            // use the user-adjusted fov unless an animation track is driving the camera
+            const fov = state.cameraMode === 'anim' ? camera.fov : state.fov;
             cameraEntity.setPosition(camera.position);
             cameraEntity.setEulerAngles(camera.angles);
-            cameraEntity.camera.fov = camera.fov;
+            cameraEntity.camera.fov = fov;
             if (cameraEntity.camera.projection === PROJECTION_ORTHOGRAPHIC) {
                 // match the orthographic frustum size to the current view distance so
                 // wheel zoom and orbiting keep working in orthographic mode
-                let orthoHeight = camera.distance * Math.tan(0.5 * camera.fov * Math.PI / 180);
+                let orthoHeight = camera.distance * Math.tan(0.5 * fov * Math.PI / 180);
                 if (cameraEntity.camera.horizontalFov) {
                     orthoHeight /= cameraEntity.camera.aspectRatio;
                 }
@@ -102450,6 +102468,8 @@ const loadSkybox = (app, url) => {
 };
 const main = (app, camera, settingsJson, config) => {
     const events = new EventHandler();
+    const settings = importSettings(settingsJson);
+    const initialFov = settings.cameras?.[0]?.initial?.fov || 65;
     const state = observe(events, {
         readyToRender: false,
         hqMode: true,
@@ -102463,11 +102483,13 @@ const main = (app, camera, settingsJson, config) => {
         hasAR: false,
         hasVR: false,
         isFullscreen: false,
-        controlsHidden: false
+        controlsHidden: false,
+        fov: initialFov,
+        defaultFov: initialFov
     });
     const global = {
         app,
-        settings: importSettings(settingsJson),
+        settings,
         config,
         state,
         events,

--- a/src/visualizer/gui/resources/viewer/viewer_template.html
+++ b/src/visualizer/gui/resources/viewer/viewer_template.html
@@ -170,6 +170,12 @@
                 </div>
                 <div class="divider"></div>
                 <div class="settingsRow">
+                    <div id="fovLabel">FOV</div>
+                    <input id="fovSlider" type="range" min="10" max="120" step="0.5" value="50">
+                    <div id="fovValue">50°</div>
+                    <button id="fovReset">Reset FOV</button>
+                </div>
+                <div class="settingsRow">
                     <button id="frame">Frame</button>
                     <button id="reset">Reset</button>
                 </div>


### PR DESCRIPTION
Adds a camera field-of-view slider to the HTML export viewer's settings panel, plus a button to reset the FOV back to the exported default.

## Changes
- `viewer_template.html`: FOV slider row (10-120 deg, step 0.5) with a value readout and a "Reset FOV" button in the settings panel
- `index.js`:
  - `state.fov` / `state.defaultFov` initialized from `settings.cameras[0].initial.fov` (the exported FOV)
  - `applyCamera` applies the user-adjusted FOV every frame (animation tracks keep driving their own FOV); the orthographic frustum size now derives from the effective FOV so ortho mode stays in sync with the slider
  - slider + reset wiring and tooltips in `initUI`
- `index.css`: slider styling with the existing orange accent

No C++ changes needed: the exporter reads the viewer files from disk at export time, so the next export picks this up automatically.

## Verification
- `node --check` on the bundle passes
- `index.js` diff is line-ending clean (the file's original CRLF lines are preserved, so the diff only contains the feature lines)
- Verified in a browser with a fresh HTML export: the slider changes the FOV live in orbit, fly, and ortho modes, and "Reset FOV" restores the default
