### PR TITLE
Fix Windows link errors from the VMM intersect cache

### DIFF
--- a/src/core/cuda/memory_arena.hpp
+++ b/src/core/cuda/memory_arena.hpp
@@ -26,7 +26,7 @@ namespace lfs::core {
     class GlobalArenaManager;
     LFS_CORE_API GlobalArenaManager& global_arena_manager();
     LFS_CORE_API void shutdown_global_arena_manager();
-    LFS_CORE_API void log_arena_failure_vram_snapshot(
+    void log_arena_failure_vram_snapshot(
         std::string_view label, size_t committed_bytes, size_t frame_peak_bytes);
 
     class RasterizerMemoryArena {

--- a/src/core/include/core/cuda/vmm_device_buffer.hpp
+++ b/src/core/include/core/cuda/vmm_device_buffer.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "core/error.hpp"
-#include "core/export.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -15,7 +14,7 @@ namespace lfs::core {
     // A stable virtual reservation whose physical prefix is committed in
     // allocation-granularity increments. This is intentionally not
     // exportable: it has no shareable handles or initialization memset.
-    class LFS_CORE_API VmmDeviceBuffer final {
+    class VmmDeviceBuffer final {
     public:
         VmmDeviceBuffer() noexcept = default;
         VmmDeviceBuffer(const VmmDeviceBuffer&) = delete;

--- a/src/training/rasterization/gsplat/CMakeLists.txt
+++ b/src/training/rasterization/gsplat/CMakeLists.txt
@@ -63,6 +63,8 @@ target_link_libraries(gsplat_backend_lfs
         CUDA::cudart
         CUDA::curand
         glm::glm
+        PUBLIC
+        lfs_core_cuda
 )
 
 target_compile_options(gsplat_backend_lfs PRIVATE


### PR DESCRIPTION
Windows CI has failed on master since #1943 (see the master push run for 1d5bb3757 and every PR since):

```
lfs_cored.lib(lfs_cored.dll) : error LNK2005: lfs::core::log_arena_failure_vram_snapshot(...) already defined
gsplat_backend_lfs.lib(Intersect.cpp.obj) : error LNK2019: unresolved external symbol __declspec(dllimport) lfs::core::VmmDeviceBuffer::... (12 members)
lfs_visualizer.dll : fatal error LNK1120: 12 unresolved externals
```

`VmmDeviceBuffer` and `log_arena_failure_vram_snapshot` are compiled into the static `lfs_core_cuda` library, not the `lfs_core` DLL, but #1943 declared them `LFS_CORE_API`. On MSVC that means `dllimport` for every consumer: `Intersect.cpp` looks for import symbols the DLL never exports (nothing inside the DLL references `vmm_device_buffer.obj`), and the snapshot function ends up both exported by the DLL and defined by `lfs_core_cuda.lib` on the same link line. Linux is unaffected because the macro is only a visibility attribute there.

Fix: no export macro on `lfs_core_cuda` symbols, matching the existing pattern (`lanczos_resize`, used from `lfs_io`), and an explicit `lfs_core_cuda` link on `gsplat_backend_lfs`, which includes the header.
