### PR TITLE
Fix Windows link failures for lfs_mcp and lfs_visualizer

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -71,6 +71,7 @@ set(CORE_SOURCES
         host_metrics.cpp
         failure_report.cpp
         cuda/memory_arena_owner.cpp
+        cuda/vmm_device_buffer.cpp
         memory_pressure.cpp
         memory_domain.cpp
         operator_callbacks.cpp

--- a/src/core/cuda/CMakeLists.txt
+++ b/src/core/cuda/CMakeLists.txt
@@ -10,7 +10,6 @@
 set(LFS_CORE_CUDA_SOURCES
     memory_arena.cu
     exportable_storage.cpp
-    vmm_device_buffer.cpp
     lanczos_resize/lanczos_resize.cu
     undistort/undistort.cu
     kernels/selection_ops.cu

--- a/src/core/cuda/memory_arena.cu
+++ b/src/core/cuda/memory_arena.cu
@@ -18,44 +18,6 @@
 
 namespace lfs::core {
 
-    void log_arena_failure_vram_snapshot(
-        const std::string_view label, const size_t committed_bytes,
-        const size_t frame_peak_bytes) {
-        size_t free_bytes = 0;
-        size_t total_bytes = 0;
-        (void)cudaMemGetInfo(&free_bytes, &total_bytes);
-
-        std::uint64_t pool_used = 0;
-        std::uint64_t pool_reserved = 0;
-#if CUDART_VERSION >= 12080
-        int device = 0;
-        cudaMemPool_t pool = nullptr;
-        if (cudaGetDevice(&device) == cudaSuccess &&
-            cudaDeviceGetDefaultMemPool(&pool, device) == cudaSuccess) {
-            (void)cudaMemPoolGetAttribute(
-                pool, cudaMemPoolAttrUsedMemCurrent, &pool_used);
-            (void)cudaMemPoolGetAttribute(
-                pool, cudaMemPoolAttrReservedMemCurrent, &pool_reserved);
-        }
-#endif
-
-        const std::string label_text = label.empty() ? "unnamed" : std::string(label);
-        const auto profiler = lfs::diagnostics::VramProfiler::instance().snapshot();
-        const auto& process = profiler.process;
-        LOG_ERROR(
-            "Arena VRAM failure snapshot label=%s cuda_free=%zu MiB cuda_total=%zu MiB "
-            "arena_committed=%zu MiB frame_peak=%zu MiB exportable_splat=%zu MiB "
-            "shared_scratch=%zu MiB cuda_default_pool_reserved=%zu MiB "
-            "cuda_default_pool_used=%zu MiB",
-            label_text.c_str(),
-            free_bytes >> 20, total_bytes >> 20,
-            committed_bytes >> 20, frame_peak_bytes >> 20,
-            process.exportable_splat_bytes >> 20,
-            process.shared_scratch_bytes >> 20,
-            static_cast<size_t>(pool_reserved >> 20),
-            static_cast<size_t>(pool_used >> 20));
-    }
-
     // Default constructor implementation
     RasterizerMemoryArena::RasterizerMemoryArena()
         : RasterizerMemoryArena(Config{}) {

--- a/src/core/cuda/memory_arena_owner.cpp
+++ b/src/core/cuda/memory_arena_owner.cpp
@@ -4,6 +4,9 @@
 
 #include "memory_arena.hpp"
 
+#include "core/logger.hpp"
+#include "diagnostics/vram_profiler.hpp"
+
 namespace lfs::core {
 
     GlobalArenaManager& global_arena_manager() {
@@ -25,6 +28,44 @@ namespace lfs::core {
 
         manager.arena_->full_reset();
         manager.arena_.reset();
+    }
+
+    void log_arena_failure_vram_snapshot(
+        const std::string_view label, const size_t committed_bytes,
+        const size_t frame_peak_bytes) {
+        size_t free_bytes = 0;
+        size_t total_bytes = 0;
+        (void)cudaMemGetInfo(&free_bytes, &total_bytes);
+
+        std::uint64_t pool_used = 0;
+        std::uint64_t pool_reserved = 0;
+#if CUDART_VERSION >= 12080
+        int device = 0;
+        cudaMemPool_t pool = nullptr;
+        if (cudaGetDevice(&device) == cudaSuccess &&
+            cudaDeviceGetDefaultMemPool(&pool, device) == cudaSuccess) {
+            (void)cudaMemPoolGetAttribute(
+                pool, cudaMemPoolAttrUsedMemCurrent, &pool_used);
+            (void)cudaMemPoolGetAttribute(
+                pool, cudaMemPoolAttrReservedMemCurrent, &pool_reserved);
+        }
+#endif
+
+        const std::string label_text = label.empty() ? "unnamed" : std::string(label);
+        const auto profiler = lfs::diagnostics::VramProfiler::instance().snapshot();
+        const auto& process = profiler.process;
+        LOG_ERROR(
+            "Arena VRAM failure snapshot label=%s cuda_free=%zu MiB cuda_total=%zu MiB "
+            "arena_committed=%zu MiB frame_peak=%zu MiB exportable_splat=%zu MiB "
+            "shared_scratch=%zu MiB cuda_default_pool_reserved=%zu MiB "
+            "cuda_default_pool_used=%zu MiB",
+            label_text.c_str(),
+            free_bytes >> 20, total_bytes >> 20,
+            committed_bytes >> 20, frame_peak_bytes >> 20,
+            process.exportable_splat_bytes >> 20,
+            process.shared_scratch_bytes >> 20,
+            static_cast<size_t>(pool_reserved >> 20),
+            static_cast<size_t>(pool_used >> 20));
     }
 
 } // namespace lfs::core


### PR DESCRIPTION
Windows Release builds of `lfs_mcp.dll` and `lfs_visualizer.dll` failed at link time with:

- `LNK2005`: `log_arena_failure_vram_snapshot` defined in both `lfs_core.dll` and `lfs_core_cuda.lib`
- `LNK2019` x6: unresolved `VmmDeviceBuffer` inline members (default ctor, `data()`, `committed_bytes()`, `granularity_bytes()`, `operator bool()`, `kGranularityBytes`)

Both are MSVC `dllimport`/`dllexport` boundary issues (Linux builds pass because visibility attributes don't create import thunks).

## Root causes & fix

**1. `log_arena_failure_vram_snapshot` (LNK2005).** Declared `LFS_CORE_API` in `memory_arena.hpp` — i.e. every consumer compiles it as `__declspec(dllimport)` from `lfs_core.dll` — but defined in `memory_arena.cu`, which is part of the static `lfs_core_cuda`. When `memory_arena.cu.obj` was pulled into a consumer link, the local definition collided with the DLL import. The definition now lives in `memory_arena_owner.cpp` (built into `lfs_core`), next to its siblings `global_arena_manager()` / `shutdown_global_arena_manager()`, so it is genuinely exported from `lfs_core.dll` as declared.

**2. `VmmDeviceBuffer` (LNK2019/LNK2001/LNK4217).** The class is declared `LFS_CORE_API`, but `vmm_device_buffer.cpp` was compiled into `lfs_core_cuda` without `LFS_CORE_EXPORTS`. That TU saw the class as `dllimport`, so MSVC emitted `__imp_` references instead of definitions for the header-inline members — and since no `LFS_CORE_EXPORTS` TU ever defined them, `lfs_core.dll` never exported them and the import thunks didn't exist. `vmm_device_buffer.cpp` now compiles into `lfs_core` (with `LFS_CORE_EXPORTS`), so all members — inline, defaulted ctor, `kGranularityBytes`, and the out-of-line ones — are exported from `lfs_core.dll` and imported by consumers (`gsplat_backend_lfs`, `lfs_training`, …). This mirrors the existing `OperationId`/`SmallFields` pattern in `error.hpp`.

## Verification

Full Windows Release build (ninja, same toolchain as CI): `lfs_core.dll`, `lfs_mcp.dll`, and `lfs_visualizer.dll` now link cleanly; no LNK2005/LNK2019/LNK4217 remaining.
