### PR TITLE
fix: add missing <string> include to tinyusdz integerCoding.h

### DIFF
--- a/external/tinyusdz/src/integerCoding.h
+++ b/external/tinyusdz/src/integerCoding.h
@@ -29,6 +29,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 
 #define USD_API
 // PXR_NAMESPACE_OPEN_SCOPE


### PR DESCRIPTION
## Problem

After the USD replacement (#1953), Windows builds fail on MSVC 14.44 with:

`
external\tinyusdz\src\integerCoding.h(55): error C2039: 'string': is not a member of 'std'
external\tinyusdz\src\integerCoding.h(55): error C2061: syntax error: identifier 'string'
... (same for all std::string* parameters)
`

## Root cause

integerCoding.h declares std::string* parameters but only includes <cstdint> and <memory>. Older MSVC STL headers provided <string> transitively; the VS 2022 14.44 STL no longer does, so the header no longer compiles standalone.

## Fix

Add the missing #include <string> to xternal/tinyusdz/src/integerCoding.h.

## Verification

Full build with cleanbuild6.bat (VS 2022 x64 Native Tools, CUDA 12.8) — the previously failing tinyusdz TUs now compile and the build proceeds past them.