### PR TITLE
Fix stack overflow when embedding dataset into project (on Windows)

### DIFF
--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 namespace lfs::io::project {
 
@@ -2807,7 +2808,7 @@ namespace lfs::io::project {
                     source.source_path.string(), "project.dataset_embed");
             }
             Hash128Stream hasher;
-            std::array<char, 1024 * 1024> buffer{};
+            std::vector<char> buffer(1024 * 1024);
             while (input) {
                 input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
                 const auto count = input.gcount();

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -427,7 +427,7 @@ namespace lfs::vis::project {
                     "project.dataset_embed");
             }
             lfs::io::project::Hash128Stream hasher;
-            std::array<char, 1024 * 1024> buffer{};
+            std::vector<char> buffer(1024 * 1024);
             while (input) {
                 input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
                 const auto count = input.gcount();
@@ -628,7 +628,7 @@ namespace lfs::vis::project {
                 lfs::io::project::Hash128Stream hasher;
                 auto copied = source->visit_stream(
                     [&](std::istream& input, const std::uint64_t size) -> lfs::Result<void> {
-                        std::array<char, 1024 * 1024> buffer{};
+                        std::vector<char> buffer(1024 * 1024);
                         std::uint64_t copied_bytes = 0;
                         while (input && copied_bytes < size) {
                             const auto remaining = size - copied_bytes;


### PR DESCRIPTION
Move the buffers to heap-allocated std::vector<char> instead.