### PR TITLE
Wrap long status text in viewport status overlays

### DIFF
--- a/src/visualizer/gui/rmlui/resources/viewport_overlay.rcss
+++ b/src/visualizer/gui/rmlui/resources/viewport_overlay.rcss
@@ -1758,6 +1758,8 @@ body {
 .viewport-status-panel .status-success,
 .viewport-status-panel .status-error {
     line-height: 1.3;
+    min-width: 0;
+    word-break: break-word;
 }
 
 .viewport-status-progress {


### PR DESCRIPTION
The Import Failed overlay draws its error line as a bare span inside the 420dp status panel. A long path with no spaces (for example a missing images directory error) is never broken, so the red text runs past the panel edge and over the right side panel.

Fix: add `word-break: break-word` and `min-width: 0` to the status overlay text rules in `viewport_overlay.rcss`, matching what the import dialog already does for its path values. Covers the import and video status overlays, which share `.viewport-status-panel`.

Verified in the GUI: loading a dataset folder with a long name and no `images` directory now shows the path and the error wrapped inside the panel.