### PR TITLE
GT comparison: cheaper frames, cached depth/normal previews, no cross-thread syncs

### DIFF
--- a/src/core/include/core/scene.hpp
+++ b/src/core/include/core/scene.hpp
@@ -506,8 +506,12 @@ namespace lfs::core {
 
         [[nodiscard]] bool hasTrainingData() const;
 
+        [[nodiscard]] std::shared_ptr<lfs::core::Camera> getCameraByUid(int uid);
         [[nodiscard]] std::shared_ptr<const lfs::core::Camera> getCameraByUid(int uid) const;
         [[nodiscard]] std::vector<std::shared_ptr<lfs::core::Camera>> getAllCameras() const;
+        [[nodiscard]] std::uint64_t cameraListGeneration() const noexcept {
+            return camera_list_generation_;
+        }
         [[nodiscard]] std::vector<std::shared_ptr<lfs::core::Camera>> getActiveCameras() const;
         // Rebases every camera node's asset paths from old_root to new_root and
         // refreshes the SceneNode mirror strings. Returns the number of cameras
@@ -524,6 +528,7 @@ namespace lfs::core {
         void setCameraTrainingEnabled(NodeId id, bool enabled);
 
         [[nodiscard]] std::unordered_set<int> getTrainingDisabledCameraUids() const;
+        [[nodiscard]] bool isCameraTrainingEnabled(int uid) const;
 
         [[nodiscard]] lfs::core::SplatData* getTrainingModel();
         [[nodiscard]] const lfs::core::SplatData* getTrainingModel() const;
@@ -613,6 +618,7 @@ namespace lfs::core {
 
         uint32_t pending_mutations_ = 0;
         int transaction_depth_ = 0;
+        std::uint64_t camera_list_generation_ = 0;
         void flushMutations();
         void removeConsolidatedNodeData(NodeId id);
         void rebuildConsolidatedTransformIndices() const;

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -126,6 +126,13 @@ namespace lfs::core {
         }
         pending_mutations_ |= static_cast<uint32_t>(type);
 
+        if (type == MutationType::NODE_ADDED ||
+            type == MutationType::NODE_REMOVED ||
+            type == MutationType::NODE_REPARENTED ||
+            type == MutationType::CLEARED) {
+            ++camera_list_generation_;
+        }
+
         switch (type) {
         case MutationType::TRANSFORM_CHANGED:
             invalidateTransformCache();
@@ -1573,6 +1580,15 @@ namespace lfs::core {
             }
         }
         return result;
+    }
+
+    bool Scene::isCameraTrainingEnabled(const int uid) const {
+        for (const auto& node : nodes_) {
+            if (node->type == NodeType::CAMERA && node->camera && node->camera->uid() == uid) {
+                return node->training_enabled;
+            }
+        }
+        return true;
     }
 
     const SceneNode* Scene::getNode(const std::string& name) const {
@@ -3249,6 +3265,7 @@ namespace lfs::core {
 
         pending_mutations_ = 0;
         transaction_depth_ = 0;
+        ++camera_list_generation_;
         return staged;
     }
 
@@ -4722,7 +4739,16 @@ namespace lfs::core {
         return counts;
     }
 
-    std::shared_ptr<const lfs::core::Camera> Scene::getCameraByUid(int uid) const {
+    std::shared_ptr<lfs::core::Camera> Scene::getCameraByUid(const int uid) {
+        for (const auto& node : nodes_) {
+            if (node->type == NodeType::CAMERA && node->camera && node->camera->uid() == uid) {
+                return node->camera;
+            }
+        }
+        return nullptr;
+    }
+
+    std::shared_ptr<const lfs::core::Camera> Scene::getCameraByUid(const int uid) const {
         for (const auto& node : nodes_) {
             if (node->type == NodeType::CAMERA && node->camera && node->camera->uid() == uid) {
                 return node->camera;

--- a/src/io/include/io/pipelined_image_loader.hpp
+++ b/src/io/include/io/pipelined_image_loader.hpp
@@ -185,6 +185,7 @@ namespace lfs::io {
             double cold_process_time_ms = 0;
             size_t total_bytes_read = 0;
             size_t total_decode_calls = 0;
+            size_t cpu_decode_calls = 0;
             // Mask loading stats
             size_t masks_loaded = 0;
             size_t mask_cache_hits = 0;
@@ -500,7 +501,8 @@ namespace lfs::io {
         // Non-blocking stream for the hot GPU decode path, so image decode and
         // H2D work overlap training instead of serializing on the legacy stream.
         // Images are still stream-synced before handoff (materialized on arrival).
-        cudaStream_t decode_stream_ = nullptr;
+        mutable std::mutex decode_stream_mutex_;
+        mutable cudaStream_t decode_stream_ = nullptr;
         std::vector<cudaStream_t> sidecar_streams_;
 
         ThreadSafeQueue<ImageRequest> prefetch_queue_;
@@ -536,7 +538,7 @@ namespace lfs::io {
         std::atomic<bool> jpeg2k_cache_available_{true};
 
         mutable std::mutex stats_mutex_;
-        CacheStats stats_;
+        mutable CacheStats stats_;
         mutable std::mutex adaptive_mutex_;
         double decode_latency_ema_ms_ = 0.0;
         double train_latency_ema_ms_ = 0.0;

--- a/src/io/pipelined_image_loader.cpp
+++ b/src/io/pipelined_image_loader.cpp
@@ -478,6 +478,8 @@ namespace lfs::io {
         }
 
         void synchronize_async_upload_before_free(cudaStream_t stream, const char* context) {
+            // A null stream means the legacy default stream. Synchronizing it
+            // here would impose a device-wide barrier on unrelated callers.
             if (!stream) {
                 return;
             }
@@ -994,7 +996,7 @@ namespace lfs::io {
 
             try {
                 auto nvcodec = acquire_nvcodec_loader(config_.decoder_pool_size);
-                auto tensor = decode_cached_rgb_tensor(nvcodec, jpeg_data, params, false);
+                auto tensor = decode_cached_rgb_tensor(nvcodec, jpeg_data, params, needs_requested_processing);
                 if (tensor.is_valid() && tensor.numel() > 0)
                     return tensor;
             } catch (...) {}
@@ -1028,7 +1030,7 @@ namespace lfs::io {
                               describe_current_exception("non-standard nvImageCodec exception"));
                 }
             }
-        } else if (!config_.use_16bit_color) {
+        } else if (!config_.use_16bit_color && !needs_requested_processing) {
             const std::string path_str = lfs::core::path_to_utf8(path);
             int w = 0, h = 0, ch = 0;
             unsigned char* img_data = stbi_load(path_str.c_str(), &w, &h, &ch, 3);
@@ -1161,8 +1163,29 @@ namespace lfs::io {
         using lfs::core::Tensor;
         using lfs::core::TensorShape;
 
+        {
+            std::lock_guard<std::mutex> stats_lock(stats_mutex_);
+            ++stats_.cpu_decode_calls;
+        }
+
         Tensor decoded;
         Tensor gpu_staging;
+        cudaStream_t stream = params.cuda_stream
+                                  ? static_cast<cudaStream_t>(params.cuda_stream)
+                                  : nullptr;
+        if (!stream) {
+            std::lock_guard stream_lock(decode_stream_mutex_);
+            if (!decode_stream_) {
+                if (const cudaError_t err =
+                        cudaStreamCreateWithFlags(&decode_stream_, cudaStreamNonBlocking);
+                    err != cudaSuccess) {
+                    throw std::runtime_error(
+                        std::string("Failed to create image decode stream: ") +
+                        cudaGetErrorString(err));
+                }
+            }
+            stream = decode_stream_;
+        }
         if (config_.use_16bit_color) {
             auto [img_data, width, height, channels] = lfs::core::load_image_u16(
                 path, params.resize_factor, params.max_width);
@@ -1176,20 +1199,21 @@ namespace lfs::io {
             // Float16 is only a 2-byte container for the uint16 samples (no UInt16 dtype).
             auto cpu_tensor = Tensor::from_blob(
                 img_data, TensorShape({H, W, C}), Device::CPU, DataType::Float16);
-            gpu_staging = cpu_tensor.to(Device::CUDA);
-            lfs::core::free_image(img_data);
+            gpu_staging = cpu_tensor.to(Device::CUDA, stream);
 
             if (params.output_uint8) {
                 decoded = Tensor::empty(TensorShape({C, H, W}), Device::CUDA, DataType::UInt8);
                 cuda::launch_uint16_hwc_to_uint8_chw(
                     reinterpret_cast<const uint16_t*>(gpu_staging.data_ptr()),
-                    decoded.ptr<uint8_t>(), H, W, C, nullptr);
+                    decoded.ptr<uint8_t>(), H, W, C, stream);
             } else {
                 decoded = Tensor::empty(TensorShape({C, H, W}), Device::CUDA, DataType::Float32);
                 cuda::launch_uint16_hwc_to_float32_chw(
                     reinterpret_cast<const uint16_t*>(gpu_staging.data_ptr()),
-                    decoded.ptr<float>(), H, W, C, nullptr);
+                    decoded.ptr<float>(), H, W, C, stream);
             }
+            synchronize_async_upload_before_free(stream, "image");
+            lfs::core::free_image(img_data);
         } else {
             auto [img_data, width, height, channels] = lfs::core::load_image(
                 path, params.resize_factor, params.max_width);
@@ -1202,23 +1226,21 @@ namespace lfs::io {
 
             auto cpu_tensor = Tensor::from_blob(
                 img_data, TensorShape({H, W, C}), Device::CPU, DataType::UInt8);
-            gpu_staging = cpu_tensor.to(Device::CUDA);
-            lfs::core::free_image(img_data);
+            gpu_staging = cpu_tensor.to(Device::CUDA, stream);
 
             if (params.output_uint8) {
                 decoded = Tensor::empty(TensorShape({C, H, W}), Device::CUDA, DataType::UInt8);
                 cuda::launch_uint8_hwc_to_uint8_chw(
-                    gpu_staging.ptr<uint8_t>(), decoded.ptr<uint8_t>(), H, W, C, nullptr);
+                    gpu_staging.ptr<uint8_t>(), decoded.ptr<uint8_t>(), H, W, C, stream);
             } else {
                 decoded = Tensor::empty(TensorShape({C, H, W}), Device::CUDA, DataType::Float32);
                 cuda::launch_uint8_hwc_to_float32_chw(
-                    gpu_staging.ptr<uint8_t>(), decoded.ptr<float>(), H, W, C, nullptr);
+                    gpu_staging.ptr<uint8_t>(), decoded.ptr<float>(), H, W, C, stream);
             }
+            synchronize_async_upload_before_free(stream, "image");
+            lfs::core::free_image(img_data);
         }
 
-        if (const cudaError_t err = cudaDeviceSynchronize(); err != cudaSuccess) {
-            throw std::runtime_error(std::string("CUDA sync failed: ") + cudaGetErrorString(err));
-        }
         return decoded;
     }
 
@@ -2750,7 +2772,7 @@ namespace lfs::io {
                             auto cpu_tensor = lfs::core::Tensor::from_blob(
                                 gray16, shape, lfs::core::Device::CPU, lfs::core::DataType::Float16);
                             auto gpu_staging = cpu_tensor.to(lfs::core::Device::CUDA, aux_stream);
-                            synchronize_async_upload_before_free(aux_stream, "depth");
+                            synchronize_async_upload_before_free(gpu_staging.stream(), "depth");
                             stbi_image_free(gray16);
                             gpu_gray = lfs::core::Tensor::empty(
                                 shape, lfs::core::Device::CUDA, lfs::core::DataType::Float32);
@@ -2881,7 +2903,7 @@ namespace lfs::io {
                                 {static_cast<size_t>(src_h), static_cast<size_t>(src_w), 3}),
                             lfs::core::Device::CPU, lfs::core::DataType::Float16);
                         gpu_staging = cpu_tensor.to(lfs::core::Device::CUDA, sidecar_stream);
-                        synchronize_async_upload_before_free(sidecar_stream, "normal");
+                        synchronize_async_upload_before_free(gpu_staging.stream(), "normal");
                         stbi_image_free(rgb16);
                     } else {
                         stbi_uc* const rgb8 = stbi_load(path_utf8.c_str(), &src_w, &src_h, &channels, 3);
@@ -2893,7 +2915,7 @@ namespace lfs::io {
                                 {static_cast<size_t>(src_h), static_cast<size_t>(src_w), 3}),
                             lfs::core::Device::CPU, lfs::core::DataType::UInt8);
                         gpu_staging = cpu_tensor.to(lfs::core::Device::CUDA, sidecar_stream);
-                        synchronize_async_upload_before_free(sidecar_stream, "normal");
+                        synchronize_async_upload_before_free(gpu_staging.stream(), "normal");
                         stbi_image_free(rgb8);
                     }
 

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -3301,18 +3301,76 @@ namespace lfs::training {
             return std::unexpected("trainer is not initialized");
         }
         const auto params = getParams();
+        const auto gt_config = getGTLoadConfigSnapshot();
+        const auto image_loader = getActiveImageLoader();
+        const auto& opt_params = params.optimization;
 
-        auto inputs = load_camera_metrics_inputs(
-            camera,
-            getGTLoadConfigSnapshot(),
-            params.optimization,
-            getActiveImageLoader());
-        if (!inputs) {
-            return std::unexpected(inputs.error());
+        const auto cache_matches = [&camera, &gt_config, &opt_params](
+                                       const CameraMetricsInputCacheEntry& entry) {
+            return entry.camera_uid == camera.uid() &&
+                   entry.image_path == camera.image_path() &&
+                   entry.mask_path == camera.mask_path() &&
+                   entry.gt_config.resize_factor == gt_config.resize_factor &&
+                   entry.gt_config.max_width == gt_config.max_width &&
+                   entry.gt_config.undistort == gt_config.undistort &&
+                   entry.mask_mode == static_cast<int>(opt_params.mask_mode) &&
+                   entry.use_alpha_as_mask == opt_params.use_alpha_as_mask &&
+                   entry.invert_masks == opt_params.invert_masks &&
+                   entry.mask_threshold == opt_params.mask_threshold &&
+                   entry.undistort_prepared == camera.is_undistort_prepared() &&
+                   entry.gt_image.is_valid();
+        };
+
+        lfs::core::Tensor cached_gt_image;
+        lfs::core::Tensor cached_mask;
+        {
+            std::lock_guard lock(camera_metrics_input_cache_mutex_);
+            const auto entry = std::find_if(
+                camera_metrics_input_cache_.begin(),
+                camera_metrics_input_cache_.end(),
+                cache_matches);
+            if (entry != camera_metrics_input_cache_.end()) {
+                entry->last_used = ++camera_metrics_input_cache_clock_;
+                cached_gt_image = entry->gt_image;
+                cached_mask = entry->mask;
+            }
         }
 
-        auto gt_image = std::move(inputs->gt_image);
-        auto mask = std::move(inputs->mask);
+        if (!cached_gt_image.is_valid()) {
+            auto inputs = load_camera_metrics_inputs(
+                camera, gt_config, opt_params, image_loader);
+            if (!inputs) {
+                return std::unexpected(inputs.error());
+            }
+            cached_gt_image = inputs->gt_image;
+            cached_mask = inputs->mask;
+            std::lock_guard lock(camera_metrics_input_cache_mutex_);
+            camera_metrics_input_cache_.push_back(CameraMetricsInputCacheEntry{
+                .camera_uid = camera.uid(),
+                .image_path = camera.image_path(),
+                .mask_path = camera.mask_path(),
+                .gt_config = gt_config,
+                .mask_mode = static_cast<int>(opt_params.mask_mode),
+                .use_alpha_as_mask = opt_params.use_alpha_as_mask,
+                .invert_masks = opt_params.invert_masks,
+                .mask_threshold = opt_params.mask_threshold,
+                .undistort_prepared = camera.is_undistort_prepared(),
+                .gt_image = cached_gt_image,
+                .mask = cached_mask,
+                .last_used = ++camera_metrics_input_cache_clock_});
+            while (camera_metrics_input_cache_.size() > 4) {
+                const auto lru = std::min_element(
+                    camera_metrics_input_cache_.begin(),
+                    camera_metrics_input_cache_.end(),
+                    [](const auto& lhs, const auto& rhs) {
+                        return lhs.last_used < rhs.last_used;
+                    });
+                camera_metrics_input_cache_.erase(lru);
+            }
+        }
+
+        auto gt_image = std::move(cached_gt_image);
+        auto mask = std::move(cached_mask);
 
         if (gt_image.device() != lfs::core::Device::CUDA) {
             gt_image = gt_image.to(lfs::core::Device::CUDA);

--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -33,6 +33,7 @@
 #include <filesystem>
 #include <functional>
 #include <istream>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -137,6 +138,21 @@ namespace lfs::training {
             float psnr = 0.0f;
             std::optional<float> ssim;
             bool used_mask = false;
+        };
+
+        struct CameraMetricsInputCacheEntry {
+            int camera_uid = -1;
+            std::filesystem::path image_path;
+            std::filesystem::path mask_path;
+            GTLoadConfigSnapshot gt_config{};
+            int mask_mode = 0;
+            bool use_alpha_as_mask = false;
+            bool invert_masks = false;
+            float mask_threshold = 0.0f;
+            bool undistort_prepared = false;
+            lfs::core::Tensor gt_image;
+            lfs::core::Tensor mask;
+            std::uint64_t last_used = 0;
         };
 
         struct ProjectSnapshotRuntimeMetrics {
@@ -897,6 +913,9 @@ namespace lfs::training {
         mutable std::mutex active_image_loader_mutex_;
         mutable std::mutex camera_loss_heatmap_mutex_;
         mutable std::mutex gt_load_config_mutex_;
+        mutable std::mutex camera_metrics_input_cache_mutex_;
+        std::list<CameraMetricsInputCacheEntry> camera_metrics_input_cache_;
+        std::uint64_t camera_metrics_input_cache_clock_ = 0;
 
         // Control flags for thread communication
         std::atomic<bool> pause_requested_{false};

--- a/src/visualizer/rendering/gt_comparison_cache_utils.hpp
+++ b/src/visualizer/rendering/gt_comparison_cache_utils.hpp
@@ -1,0 +1,131 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include "core/tensor.hpp"
+#include "rendering/image_layout.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <glm/glm.hpp>
+#include <memory>
+
+namespace lfs::vis::gt_comparison_detail {
+
+    inline constexpr std::uint64_t SPLIT_RIGHT_GENERATION_BIT = 1ULL << 62;
+
+    [[nodiscard]] inline std::size_t previewBytes(const glm::ivec2 size) {
+        if (size.x <= 0 || size.y <= 0) {
+            return 0;
+        }
+        return static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y) * 3;
+    }
+
+    [[nodiscard]] inline bool prefetchFits(const std::size_t cache_bytes,
+                                           const std::size_t current_bytes,
+                                           const std::size_t neighbor_bytes,
+                                           const std::size_t budget_bytes) {
+        return current_bytes <= budget_bytes &&
+               neighbor_bytes <= budget_bytes - current_bytes &&
+               cache_bytes <= budget_bytes - current_bytes - neighbor_bytes;
+    }
+
+    inline void updateSplitImageGeneration(const void* const source,
+                                           const glm::ivec2 size,
+                                           const void* const known_static_source,
+                                           const glm::ivec2 known_static_size,
+                                           const std::uint64_t frame_generation,
+                                           std::uint64_t& generation) {
+        if (source != nullptr && source == known_static_source && size == known_static_size) {
+            generation |= SPLIT_RIGHT_GENERATION_BIT;
+            return;
+        }
+        generation = frame_generation;
+    }
+
+    [[nodiscard]] inline std::shared_ptr<lfs::core::Tensor> convertDisplayTensorToUInt8(
+        const std::shared_ptr<lfs::core::Tensor>& image) {
+        if (!image || !image->is_valid() || image->ndim() != 3) {
+            return {};
+        }
+        const auto layout = lfs::rendering::detectImageLayout(*image);
+        if (layout == lfs::rendering::ImageLayout::Unknown) {
+            return {};
+        }
+        lfs::core::Tensor src = *image;
+        if (src.device() == lfs::core::Device::CUDA) {
+            // The conversion below deliberately uses host-side loops. Tensor
+            // dtype conversion and layout materialization on CPU are not a
+            // reliable synchronization boundary for an asynchronously
+            // produced CUDA tensor, whereas cpu() without an explicit stream
+            // completes its device-to-host copy before returning.
+            src = src.cpu();
+        }
+        if (src.dtype() == lfs::core::DataType::UInt8 &&
+            layout == lfs::rendering::ImageLayout::CHW) {
+            return image;
+        }
+        if (src.dtype() != lfs::core::DataType::Float32 &&
+            src.dtype() != lfs::core::DataType::UInt8) {
+            return {};
+        }
+        const int channels = lfs::rendering::imageChannels(src, layout);
+        const int height = lfs::rendering::imageHeight(src, layout);
+        const int width = lfs::rendering::imageWidth(src, layout);
+        if (channels < 3 || height <= 0 || width <= 0) {
+            return {};
+        }
+
+        const std::size_t plane = static_cast<std::size_t>(height) * width;
+        auto result = lfs::core::Tensor::empty(
+            {3, static_cast<std::size_t>(height), static_cast<std::size_t>(width)},
+            lfs::core::Device::CPU,
+            lfs::core::DataType::UInt8);
+        auto* const output = result.ptr<std::uint8_t>();
+
+        const auto source_index = [&](const int channel,
+                                      const int row,
+                                      const int column) {
+            if (layout == lfs::rendering::ImageLayout::CHW) {
+                return static_cast<std::size_t>(channel) * src.stride(0) +
+                       static_cast<std::size_t>(row) * src.stride(1) +
+                       static_cast<std::size_t>(column) * src.stride(2);
+            }
+            return static_cast<std::size_t>(row) * src.stride(0) +
+                   static_cast<std::size_t>(column) * src.stride(1) +
+                   static_cast<std::size_t>(channel) * src.stride(2);
+        };
+
+        if (src.dtype() == lfs::core::DataType::Float32) {
+            const float* const input = src.ptr<float>();
+            for (int channel = 0; channel < 3; ++channel) {
+                for (int row = 0; row < height; ++row) {
+                    for (int column = 0; column < width; ++column) {
+                        const float value = std::clamp(
+                            input[source_index(channel, row, column)], 0.0f, 1.0f);
+                        output[static_cast<std::size_t>(channel) * plane +
+                               static_cast<std::size_t>(row) * width +
+                               static_cast<std::size_t>(column)] =
+                            static_cast<std::uint8_t>(value * 255.0f + 0.5f);
+                    }
+                }
+            }
+        } else {
+            const std::uint8_t* const input = src.ptr<std::uint8_t>();
+            for (int channel = 0; channel < 3; ++channel) {
+                for (int row = 0; row < height; ++row) {
+                    for (int column = 0; column < width; ++column) {
+                        output[static_cast<std::size_t>(channel) * plane +
+                               static_cast<std::size_t>(row) * width +
+                               static_cast<std::size_t>(column)] =
+                            input[source_index(channel, row, column)];
+                    }
+                }
+            }
+        }
+        return std::make_shared<lfs::core::Tensor>(std::move(result));
+    }
+
+} // namespace lfs::vis::gt_comparison_detail

--- a/src/visualizer/rendering/gt_comparison_cache_utils.hpp
+++ b/src/visualizer/rendering/gt_comparison_cache_utils.hpp
@@ -63,7 +63,8 @@ namespace lfs::vis::gt_comparison_detail {
             // completes its device-to-host copy before returning.
             src = src.cpu();
         }
-        if (src.dtype() == lfs::core::DataType::UInt8 &&
+        if (image->device() == lfs::core::Device::CPU &&
+            src.dtype() == lfs::core::DataType::UInt8 &&
             layout == lfs::rendering::ImageLayout::CHW) {
             return image;
         }

--- a/src/visualizer/rendering/rendering_manager.cpp
+++ b/src/visualizer/rendering/rendering_manager.cpp
@@ -628,7 +628,7 @@ namespace lfs::vis {
     void RenderingManager::advanceSplitOffset() {
         std::lock_guard<std::mutex> lock(settings_mutex_);
         split_view_service_.advanceSplitOffset(settings_);
-        markDirty(DirtyFlag::SPLIT_VIEW | DirtyFlag::SPLATS);
+        markDirty(DirtyFlag::SPLIT_VIEW);
     }
 
     SplitViewInfo RenderingManager::getSplitViewInfo() const {
@@ -749,39 +749,67 @@ namespace lfs::vis {
                    ppispOverridesEqual(lhs.settings.ppisp_overrides, rhs.settings.ppisp_overrides);
         };
 
+        std::optional<AppStore::CameraMetrics> cached_app_metrics;
         {
             std::lock_guard<std::mutex> lock(camera_metrics_mutex_);
-
-            const bool missing_metrics = !latest_camera_metrics_.has_value();
-            const bool wrong_camera = latest_camera_metrics_ &&
-                                      latest_camera_metrics_->camera_id != current_camera_id;
-            const bool stale_iteration = latest_camera_metrics_ &&
-                                         latest_camera_metrics_->camera_id == current_camera_id &&
-                                         latest_camera_metrics_->iteration != current_iteration;
-            const bool missing_ssim = include_ssim && latest_camera_metrics_ &&
-                                      latest_camera_metrics_->camera_id == current_camera_id &&
-                                      !latest_camera_metrics_->ssim.has_value();
-            const bool immediate_refresh = missing_metrics || wrong_camera || missing_ssim;
-            const bool refresh_interval_elapsed =
-                last_camera_metrics_refresh_time_.time_since_epoch().count() == 0 ||
-                (now - last_camera_metrics_refresh_time_) >= CAMERA_METRICS_REFRESH_INTERVAL;
-            const bool same_as_pending =
-                pending_camera_metrics_request_ &&
-                request_matches(*pending_camera_metrics_request_, request);
-            const bool same_as_active =
-                active_camera_metrics_request_ &&
-                request_matches(*active_camera_metrics_request_, request);
-
-            if ((immediate_refresh || (stale_iteration && refresh_interval_elapsed)) &&
-                !same_as_pending &&
-                !same_as_active) {
-                request.generation = ++camera_metrics_request_generation_;
-                pending_camera_metrics_request_ = request;
+            const auto cached = std::find_if(
+                camera_metrics_cache_.begin(), camera_metrics_cache_.end(),
+                [&request_matches, &request](const auto& entry) {
+                    return request_matches(entry.request, request);
+                });
+            if (cached != camera_metrics_cache_.end()) {
+                const auto& cached_metrics = cached->metrics;
+                const bool metrics_changed =
+                    !latest_camera_metrics_ ||
+                    latest_camera_metrics_->camera_id != cached_metrics.camera_id ||
+                    latest_camera_metrics_->iteration != cached_metrics.iteration ||
+                    latest_camera_metrics_->psnr != cached_metrics.psnr ||
+                    latest_camera_metrics_->ssim != cached_metrics.ssim ||
+                    latest_camera_metrics_->used_mask != cached_metrics.used_mask;
+                latest_camera_metrics_ = cached->metrics;
+                if (metrics_changed) {
+                    cached_app_metrics = toAppCameraMetrics(cached_metrics);
+                }
                 last_camera_metrics_refresh_time_ = now;
-                should_queue = true;
+                cached->request = request;
+            } else {
+
+                const bool missing_metrics = !latest_camera_metrics_.has_value();
+                const bool wrong_camera = latest_camera_metrics_ &&
+                                          latest_camera_metrics_->camera_id != current_camera_id;
+                const bool stale_iteration = latest_camera_metrics_ &&
+                                             latest_camera_metrics_->camera_id == current_camera_id &&
+                                             latest_camera_metrics_->iteration != current_iteration;
+                const bool missing_ssim = include_ssim && latest_camera_metrics_ &&
+                                          latest_camera_metrics_->camera_id == current_camera_id &&
+                                          !latest_camera_metrics_->ssim.has_value();
+                const bool immediate_refresh = missing_metrics || wrong_camera || missing_ssim;
+                const bool refresh_interval_elapsed =
+                    last_camera_metrics_refresh_time_.time_since_epoch().count() == 0 ||
+                    (now - last_camera_metrics_refresh_time_) >= CAMERA_METRICS_REFRESH_INTERVAL;
+                const bool same_as_pending =
+                    pending_camera_metrics_request_ &&
+                    request_matches(*pending_camera_metrics_request_, request);
+                const bool same_as_active =
+                    active_camera_metrics_request_ &&
+                    request_matches(*active_camera_metrics_request_, request);
+
+                if ((immediate_refresh || (stale_iteration && refresh_interval_elapsed)) &&
+                    !same_as_pending &&
+                    !same_as_active) {
+                    request.generation = ++camera_metrics_request_generation_;
+                    pending_camera_metrics_request_ = request;
+                    last_camera_metrics_refresh_time_ = now;
+                    should_queue = true;
+                }
             }
         }
 
+        if (cached_app_metrics) {
+            app_store().camera_metrics.set(std::move(cached_app_metrics));
+            markDirty(DirtyFlag::OVERLAY);
+            return;
+        }
         if (!should_queue) {
             return;
         }
@@ -824,6 +852,29 @@ namespace lfs::vis {
                 if (request.generation == camera_metrics_request_generation_) {
                     if (metrics) {
                         latest_camera_metrics_ = *metrics;
+                        const auto same_cached_request = [&](const auto& entry) {
+                            return entry.request.trainer_manager == request.trainer_manager &&
+                                   entry.request.camera_id == request.camera_id &&
+                                   entry.request.iteration == request.iteration &&
+                                   entry.request.settings.camera_metrics_mode == request.settings.camera_metrics_mode &&
+                                   entry.request.settings.apply_appearance_correction == request.settings.apply_appearance_correction &&
+                                   entry.request.settings.ppisp_mode == request.settings.ppisp_mode &&
+                                   ppispOverridesEqual(entry.request.settings.ppisp_overrides,
+                                                       request.settings.ppisp_overrides);
+                        };
+                        auto cached = std::find_if(
+                            camera_metrics_cache_.begin(), camera_metrics_cache_.end(),
+                            same_cached_request);
+                        if (cached == camera_metrics_cache_.end()) {
+                            camera_metrics_cache_.push_back(
+                                {.request = request, .metrics = *metrics});
+                        } else {
+                            cached->metrics = *metrics;
+                            cached->request = request;
+                        }
+                        while (camera_metrics_cache_.size() > 4) {
+                            camera_metrics_cache_.pop_front();
+                        }
                         app_metrics = toAppCameraMetrics(*metrics);
                     } else {
                         latest_camera_metrics_.reset();

--- a/src/visualizer/rendering/rendering_manager.hpp
+++ b/src/visualizer/rendering/rendering_manager.hpp
@@ -43,11 +43,14 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 #include <vulkan/vulkan.h>
 
 namespace lfs::core {
+    class Camera;
+    class Scene;
     class SplatData;
     class Tensor;
 } // namespace lfs::core
@@ -112,6 +115,7 @@ namespace lfs::vis {
             // (rideshares the existing scene-image interop). When this is set, the
             // gui-side split interop slot uploads it in parallel to the left panel.
             std::shared_ptr<const lfs::core::Tensor> split_right_image{};
+            std::uint64_t split_right_image_generation = 0;
             glm::ivec2 split_right_size{0, 0};
             bool split_right_flip_y = false;
         };
@@ -696,11 +700,16 @@ namespace lfs::vis {
         struct GTComparisonImageJobRequest {
             uint64_t generation = 0;
             int camera_uid = -1;
+            GTComparisonMode mode = GTComparisonMode::RGB;
             std::filesystem::path image_path;
             int preview_max_dimension = 0;
             glm::ivec2 image_size{0, 0};
             bool undistort_requested = false;
             lfs::core::UndistortParams undistort_params{};
+            lfs::rendering::DepthVisualizationMode depth_visualization_mode =
+                lfs::rendering::DepthVisualizationMode::Palette;
+            glm::vec3 background_color{0.0f};
+            std::shared_ptr<lfs::core::Camera> camera;
             std::shared_ptr<lfs::io::PipelinedImageLoader> image_loader;
             std::chrono::steady_clock::time_point queued_at{};
         };
@@ -801,10 +810,17 @@ namespace lfs::vis {
         static constexpr std::uint64_t SPLIT_LEFT_GENERATION_BIT = 1ULL << 63;
         std::uint64_t split_view_image_generation_ = 0;
         std::uint64_t split_left_image_generation_ = 0;
+        std::uint64_t split_right_image_generation_ = 0;
         const lfs::core::Tensor* split_left_source_ = nullptr;
         glm::ivec2 split_left_source_size_{0, 0};
         int split_left_source_camera_uid_ = -1;
         bool split_left_source_undistorted_ = false;
+        glm::ivec2 split_right_source_size_{0, 0};
+        cudaStream_t gt_comparison_worker_stream_ = nullptr;
+        const lfs::core::Scene* gt_camera_index_scene_ = nullptr;
+        std::uint64_t gt_camera_index_generation_ = 0;
+        std::vector<std::shared_ptr<lfs::core::Camera>> gt_camera_index_cameras_;
+        std::unordered_map<int, std::size_t> gt_camera_index_by_uid_;
         std::shared_ptr<lfs::core::Tensor> gt_comparison_cuda_image_;
         const lfs::core::Tensor* gt_comparison_cuda_source_ = nullptr;
         std::uint64_t gt_comparison_cuda_generation_ = 0;
@@ -824,9 +840,13 @@ namespace lfs::vis {
         glm::ivec2 vulkan_gt_comparison_content_size_{0, 0};
         struct GTComparisonImageCacheEntry {
             int camera_uid = -1;
+            GTComparisonMode mode = GTComparisonMode::RGB;
             bool undistort_requested = false;
             std::filesystem::path image_path;
             glm::ivec2 image_size{0, 0};
+            lfs::rendering::DepthVisualizationMode depth_visualization_mode =
+                lfs::rendering::DepthVisualizationMode::Palette;
+            glm::vec3 background_color{0.0f};
             std::shared_ptr<lfs::core::Tensor> image;
             std::string error;
             std::chrono::steady_clock::time_point failure_time{};
@@ -886,6 +906,11 @@ namespace lfs::vis {
         std::optional<CameraMetricsOverlayState> latest_camera_metrics_;
         std::optional<CameraMetricsJobRequest> pending_camera_metrics_request_;
         std::optional<CameraMetricsJobRequest> active_camera_metrics_request_;
+        struct CameraMetricsCacheEntry {
+            CameraMetricsJobRequest request;
+            CameraMetricsOverlayState metrics;
+        };
+        std::list<CameraMetricsCacheEntry> camera_metrics_cache_;
         std::condition_variable_any camera_metrics_cv_;
         std::jthread camera_metrics_worker_;
         uint64_t camera_metrics_request_generation_ = 0;

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -2620,7 +2620,12 @@ namespace lfs::vis {
                 gt_camera_index_generation_ = scene.cameraListGeneration();
             }
             if (!camera && !gt_camera_index_cameras_.empty()) {
-                camera = gt_camera_index_cameras_.front();
+                for (const auto& candidate : gt_camera_index_cameras_) {
+                    if (candidate) {
+                        camera = candidate;
+                        break;
+                    }
+                }
             }
 
             if (camera) {

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -9,7 +9,9 @@
 #include "core/memory_pressure.hpp"
 #include "core/splat_data.hpp"
 #include "core/tensor.hpp"
+#include "core/tensor/internal/memory_pool.hpp"
 #include "diagnostics/vram_profiler.hpp"
+#include "gt_comparison_cache_utils.hpp"
 #include "io/pipelined_image_loader.hpp"
 #include "model_renderability.hpp"
 #include "point_cloud_vulkan_renderer.hpp"
@@ -29,6 +31,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <expected>
 #include <filesystem>
 #include <format>
@@ -226,7 +229,8 @@ namespace lfs::vis {
 
         [[nodiscard]] std::shared_ptr<lfs::core::Tensor> makeDepthDisplayTensor(
             const lfs::core::Tensor& depth,
-            const RenderSettings& settings) {
+            const lfs::rendering::DepthVisualizationMode depth_visualization_mode,
+            const glm::vec3& background_color) {
             if (!depth.is_valid() || depth.ndim() != 2) {
                 return {};
             }
@@ -249,10 +253,10 @@ namespace lfs::vis {
             const float range_span = range_hi - range_lo;
 
             const bool grayscale =
-                settings.depth_visualization_mode == lfs::rendering::DepthVisualizationMode::Grayscale;
+                depth_visualization_mode == lfs::rendering::DepthVisualizationMode::Grayscale;
             for (std::size_t idx = 0; idx < pixel_count; ++idx) {
                 const float d = src[idx];
-                glm::vec3 color = settings.background_color;
+                glm::vec3 color = background_color;
                 if (std::isfinite(d) && d > 0.0f && d < 1.0e9f && range_span > 1.0e-6f) {
                     const float depth_t = std::clamp((d - range_lo) / range_span, 0.0f, 1.0f);
                     const float near_t = 1.0f - depth_t;
@@ -268,6 +272,13 @@ namespace lfs::vis {
                 {std::size_t{3}, static_cast<std::size_t>(height), static_cast<std::size_t>(width)},
                 lfs::core::Device::CPU);
             return std::make_shared<lfs::core::Tensor>(std::move(tensor));
+        }
+
+        [[nodiscard]] std::shared_ptr<lfs::core::Tensor> makeDepthDisplayTensor(
+            const lfs::core::Tensor& depth,
+            const RenderSettings& settings) {
+            return makeDepthDisplayTensor(
+                depth, settings.depth_visualization_mode, settings.background_color);
         }
 
         [[nodiscard]] std::shared_ptr<lfs::core::Tensor> makeNormalDisplayTensor(
@@ -1016,17 +1027,23 @@ namespace lfs::vis {
     bool RenderingManager::gtRequestMatches(const GTComparisonImageJobRequest& lhs,
                                             const GTComparisonImageJobRequest& rhs) {
         return lhs.camera_uid == rhs.camera_uid &&
+               lhs.mode == rhs.mode &&
                lhs.image_path == rhs.image_path &&
                lhs.image_size == rhs.image_size &&
-               lhs.undistort_requested == rhs.undistort_requested;
+               lhs.undistort_requested == rhs.undistort_requested &&
+               lhs.depth_visualization_mode == rhs.depth_visualization_mode &&
+               lhs.background_color == rhs.background_color;
     }
 
     bool RenderingManager::gtCacheEntryMatches(const GTComparisonImageCacheEntry& entry,
                                                const GTComparisonImageJobRequest& request) {
         return entry.camera_uid == request.camera_uid &&
+               entry.mode == request.mode &&
                entry.image_path == request.image_path &&
                entry.image_size == request.image_size &&
-               entry.undistort_requested == request.undistort_requested;
+               entry.undistort_requested == request.undistort_requested &&
+               entry.depth_visualization_mode == request.depth_visualization_mode &&
+               entry.background_color == request.background_color;
     }
 
     void RenderingManager::insertGTComparisonImageCacheEntry(
@@ -1049,18 +1066,24 @@ namespace lfs::vis {
                                                     : 0;
             *entry = {
                 .camera_uid = request.camera_uid,
+                .mode = request.mode,
                 .undistort_requested = request.undistort_requested,
                 .image_path = request.image_path,
                 .image_size = request.image_size,
+                .depth_visualization_mode = request.depth_visualization_mode,
+                .background_color = request.background_color,
                 .image = std::move(image),
                 .error = std::move(error),
                 .failure_time = image_valid ? std::chrono::steady_clock::time_point{} : now,
                 .last_used = now};
         } else {
             gt_comparison_image_cache_.push_back({.camera_uid = request.camera_uid,
+                                                  .mode = request.mode,
                                                   .undistort_requested = request.undistort_requested,
                                                   .image_path = request.image_path,
                                                   .image_size = request.image_size,
+                                                  .depth_visualization_mode = request.depth_visualization_mode,
+                                                  .background_color = request.background_color,
                                                   .image = std::move(image),
                                                   .error = std::move(error),
                                                   .failure_time = image_valid ? std::chrono::steady_clock::time_point{} : now,
@@ -1247,6 +1270,24 @@ namespace lfs::vis {
         bool queued = false;
         {
             std::lock_guard lock(gt_comparison_image_mutex_);
+            if (request.image_size.x <= 0 || request.image_size.y <= 0) {
+                return;
+            }
+            const std::size_t request_bytes = gt_comparison_detail::previewBytes(request.image_size);
+            // Keep at least the current request and one neighbor resident. A pending
+            // current request is not in the cache yet, so reserve its final uint8 size
+            // while deciding whether to enqueue this prefetch.
+            std::size_t reserved_current_bytes = 0;
+            if (pending_gt_comparison_image_request_) {
+                const auto& current = *pending_gt_comparison_image_request_;
+                reserved_current_bytes = gt_comparison_detail::previewBytes(current.image_size);
+            }
+            if (!gt_comparison_detail::prefetchFits(gt_comparison_image_cache_bytes_,
+                                                    reserved_current_bytes,
+                                                    request_bytes,
+                                                    GT_COMPARISON_IMAGE_CACHE_MAX_BYTES)) {
+                return;
+            }
             const auto cache_hit = std::find_if(
                 gt_comparison_image_cache_.begin(),
                 gt_comparison_image_cache_.end(),
@@ -1301,11 +1342,33 @@ namespace lfs::vis {
         split_left_source_camera_uid_ = -1;
         split_left_source_undistorted_ = false;
         split_left_image_generation_ = 0;
+        split_right_source_size_ = {0, 0};
+        split_right_image_generation_ = 0;
         gt_comparison_loading_placeholder_.reset();
         gt_comparison_failed_placeholder_.reset();
     }
 
     void RenderingManager::gtComparisonImageWorkerLoop(const std::stop_token stop_token) {
+        if (const cudaError_t err = cudaStreamCreateWithFlags(
+                &gt_comparison_worker_stream_, cudaStreamNonBlocking);
+            err != cudaSuccess) {
+            LOG_ERROR("GT comparison worker stream creation failed ({}); GT image worker disabled",
+                      cudaGetErrorString(err));
+            return;
+        }
+        const cudaStream_t worker_stream = gt_comparison_worker_stream_;
+        std::optional<lfs::core::CUDAStreamGuard> worker_stream_guard;
+        if (worker_stream) {
+            worker_stream_guard.emplace(worker_stream);
+        }
+        const auto release_worker_stream = [this]() {
+            if (gt_comparison_worker_stream_) {
+                (void)cudaStreamSynchronize(gt_comparison_worker_stream_);
+                lfs::core::CudaMemoryPool::instance().release_stream(gt_comparison_worker_stream_);
+                (void)cudaStreamDestroy(gt_comparison_worker_stream_);
+                gt_comparison_worker_stream_ = nullptr;
+            }
+        };
         while (true) {
             GTComparisonImageJobRequest request;
             bool is_prefetch = false;
@@ -1320,6 +1383,8 @@ namespace lfs::vis {
                     prefetch_gt_comparison_image_requests_.clear();
                     active_gt_comparison_image_request_.reset();
                     active_gt_comparison_image_is_prefetch_ = false;
+                    worker_stream_guard.reset();
+                    release_worker_stream();
                     return;
                 }
 
@@ -1339,52 +1404,118 @@ namespace lfs::vis {
             std::string error;
             try {
                 lfs::core::Tensor gt_tensor;
-                if (request.image_loader) {
-                    // The training loader's byte cache is bounded and keyed by plain
-                    // path (original bytes training reuses), so writing it is fine;
-                    // skip_blob_cache below guards only CacheLoader's unbounded
-                    // per-preview-size re-encode caches.
-                    lfs::io::LoadParams params;
-                    params.resize_factor = -1;
-                    params.max_width = request.preview_max_dimension;
-                    params.cuda_stream = nullptr;
-                    params.output_uint8 = false;
-                    gt_tensor = request.image_loader->load_image_immediate(request.image_path, params);
-                } else {
-                    gt_tensor = lfs::core::load_image_cached({.path = request.image_path,
-                                                              .resize_factor = -1,
-                                                              .max_width = request.preview_max_dimension,
-                                                              .stream = nullptr,
-                                                              .output_uint8 = false,
-                                                              .skip_blob_cache = true});
-                }
-                if (gt_tensor.is_valid() && gt_tensor.ndim() == 3) {
-                    const auto gt_layout = lfs::rendering::detectImageLayout(gt_tensor);
-                    if (gt_layout != lfs::rendering::ImageLayout::Unknown) {
-                        const bool undistort_gt =
-                            gt_layout == lfs::rendering::ImageLayout::CHW &&
-                            request.undistort_requested;
-                        if (undistort_gt) {
-                            if (gt_tensor.device() != lfs::core::Device::CUDA) {
-                                gt_tensor = gt_tensor.to(lfs::core::Device::CUDA);
-                            }
-                            const auto scaled = lfs::core::scale_undistort_params(
-                                request.undistort_params,
-                                lfs::rendering::imageWidth(gt_tensor, gt_layout),
-                                lfs::rendering::imageHeight(gt_tensor, gt_layout));
-                            gt_tensor = lfs::core::undistort_image(gt_tensor, scaled, nullptr);
-                        }
-                        gt_tensor = lfs::rendering::flipImageVertical(gt_tensor, gt_layout);
-                        // Static GT display images must be decoupled from the CUDA pool
-                        // while training can recycle device buffers mid-frame.
-                        gt_tensor = gt_tensor.cpu();
-                        image = std::make_shared<lfs::core::Tensor>(std::move(gt_tensor));
-                        image = resizeChwDisplayTensor(image, request.image_size);
+                if (request.mode == GTComparisonMode::RGB) {
+                    if (request.image_loader) {
+                        // The training loader's byte cache is bounded and keyed by plain
+                        // path (original bytes training reuses), so writing it is fine;
+                        // skip_blob_cache below guards only CacheLoader's unbounded
+                        // per-preview-size re-encode caches.
+                        lfs::io::LoadParams params;
+                        params.resize_factor = -1;
+                        params.max_width = request.preview_max_dimension;
+                        params.cuda_stream = worker_stream;
+                        params.output_uint8 = true;
+                        gt_tensor = request.image_loader->load_image_immediate(request.image_path, params);
+                    } else {
+                        gt_tensor = lfs::core::load_image_cached({.path = request.image_path,
+                                                                  .resize_factor = -1,
+                                                                  .max_width = request.preview_max_dimension,
+                                                                  .stream = worker_stream,
+                                                                  .output_uint8 = true,
+                                                                  .skip_blob_cache = true});
                     }
                 }
+                if (request.mode == GTComparisonMode::RGB) {
+                    if (gt_tensor.is_valid() && gt_tensor.ndim() == 3) {
+                        const auto gt_layout = lfs::rendering::detectImageLayout(gt_tensor);
+                        if (gt_layout != lfs::rendering::ImageLayout::Unknown) {
+                            const bool undistort_gt =
+                                gt_layout == lfs::rendering::ImageLayout::CHW &&
+                                request.undistort_requested;
+                            if (undistort_gt) {
+                                if (gt_tensor.device() != lfs::core::Device::CUDA) {
+                                    gt_tensor = gt_tensor.to(lfs::core::Device::CUDA, worker_stream);
+                                }
+                                if (gt_tensor.dtype() == lfs::core::DataType::UInt8) {
+                                    gt_tensor = gt_tensor.to(lfs::core::DataType::Float32) / 255.0f;
+                                    if (worker_stream) {
+                                        gt_tensor.set_stream(worker_stream);
+                                    }
+                                }
+                                const auto scaled = lfs::core::scale_undistort_params(
+                                    request.undistort_params,
+                                    lfs::rendering::imageWidth(gt_tensor, gt_layout),
+                                    lfs::rendering::imageHeight(gt_tensor, gt_layout));
+                                gt_tensor = lfs::core::undistort_image(gt_tensor, scaled, worker_stream);
+                            }
+                            gt_tensor = lfs::rendering::flipImageVertical(gt_tensor, gt_layout);
+                            // Static GT display images must be decoupled from the CUDA pool
+                            // while training can recycle device buffers mid-frame.
+                            gt_tensor = gt_tensor.cpu();
+                            image = std::make_shared<lfs::core::Tensor>(std::move(gt_tensor));
+                            image = resizeChwDisplayTensor(image, request.image_size);
+                        }
+                    }
+                } else if (request.camera) {
+                    if (request.mode == GTComparisonMode::Depth) {
+                        auto depth = request.camera->load_and_get_depth(
+                            -1, request.preview_max_dimension);
+                        if (depth.is_valid() && depth.ndim() == 2) {
+                            if (request.undistort_requested) {
+                                const auto scaled = lfs::core::scale_undistort_params(
+                                    request.undistort_params,
+                                    static_cast<int>(depth.shape()[1]),
+                                    static_cast<int>(depth.shape()[0]));
+                                depth = lfs::core::undistort_mask(depth, scaled, worker_stream);
+                            }
+                            image = makeDepthDisplayTensor(
+                                depth, request.depth_visualization_mode, request.background_color);
+                            image = resizeChwDisplayTensor(image, request.image_size);
+                            if (image) {
+                                auto flipped = lfs::rendering::flipImageVertical(
+                                    *image, lfs::rendering::ImageLayout::CHW);
+                                image = std::make_shared<lfs::core::Tensor>(std::move(flipped));
+                            }
+                        }
+                    } else {
+                        auto normal = request.camera->load_and_get_normal(
+                            -1, request.preview_max_dimension, lfs::core::Camera::NormalPriorDecode{});
+                        if (normal.is_valid() && normal.ndim() == 3) {
+                            const auto normal_layout = lfs::rendering::detectImageLayout(normal);
+                            if (request.undistort_requested &&
+                                normal_layout != lfs::rendering::ImageLayout::Unknown) {
+                                const auto scaled = lfs::core::scale_undistort_params(
+                                    request.undistort_params,
+                                    lfs::rendering::imageWidth(normal, normal_layout),
+                                    lfs::rendering::imageHeight(normal, normal_layout));
+                                normal = lfs::core::undistort_image(normal, scaled, worker_stream);
+                            }
+                            image = makeNormalDisplayTensor(normal);
+                            image = resizeChwDisplayTensor(image, request.image_size);
+                            if (image) {
+                                auto flipped = lfs::rendering::flipImageVertical(
+                                    *image, lfs::rendering::ImageLayout::CHW);
+                                image = std::make_shared<lfs::core::Tensor>(std::move(flipped));
+                            }
+                        }
+                    }
+                }
+                if (worker_stream) {
+                    if (const cudaError_t err = cudaStreamSynchronize(worker_stream);
+                        err != cudaSuccess) {
+                        throw std::runtime_error(
+                            std::string("GT comparison worker CUDA sync failed: ") +
+                            cudaGetErrorString(err));
+                    }
+                }
+                image = gt_comparison_detail::convertDisplayTensorToUInt8(image);
                 if (!image || !image->is_valid()) {
                     image.reset();
-                    error = "RGB GT comparison could not load the source image";
+                    error = request.mode == GTComparisonMode::RGB
+                                ? "RGB GT comparison could not load the source image"
+                            : request.mode == GTComparisonMode::Depth
+                                ? "Depth GT comparison could not load the camera depth map"
+                                : "Normal GT comparison could not load the camera normal map";
                 }
             } catch (const std::exception& e) {
                 image.reset();
@@ -2469,23 +2600,27 @@ namespace lfs::vis {
 
         if (splitViewUsesGTComparison(frame_settings.split_view_mode) && scene_manager &&
             (has_visible_gaussian_model || has_point_cloud)) {
+            auto& scene = scene_manager->getScene();
             std::shared_ptr<lfs::core::Camera> camera;
-            const auto cameras = scene_manager->getScene().getAllCameras();
             if (frame_ctx.current_camera_id >= 0) {
-                for (const auto& candidate : cameras) {
-                    if (candidate && candidate->uid() == frame_ctx.current_camera_id) {
-                        camera = candidate;
-                        break;
-                    }
-                }
+                camera = scene.getCameraByUid(frame_ctx.current_camera_id);
             }
-            if (!camera && !cameras.empty()) {
-                for (const auto& candidate : cameras) {
-                    if (candidate) {
-                        camera = candidate;
-                        break;
+            if (scene.cameraListGeneration() != gt_camera_index_generation_ ||
+                gt_camera_index_scene_ != &scene) {
+                gt_camera_index_cameras_ = scene.getAllCameras();
+                gt_camera_index_by_uid_.clear();
+                gt_camera_index_by_uid_.reserve(gt_camera_index_cameras_.size());
+                for (std::size_t index = 0; index < gt_camera_index_cameras_.size(); ++index) {
+                    if (gt_camera_index_cameras_[index]) {
+                        gt_camera_index_by_uid_.emplace(
+                            gt_camera_index_cameras_[index]->uid(), index);
                     }
                 }
+                gt_camera_index_scene_ = &scene;
+                gt_camera_index_generation_ = scene.cameraListGeneration();
+            }
+            if (!camera && !gt_camera_index_cameras_.empty()) {
+                camera = gt_camera_index_cameras_.front();
             }
 
             if (camera) {
@@ -2514,6 +2649,7 @@ namespace lfs::vis {
                             // transient size on the shared camera; training uses image dimensions
                             // as its raster target and may be running concurrently.
                             const auto lookup = getOrQueueGTComparisonImage({.camera_uid = camera->uid(),
+                                                                             .mode = gt_mode,
                                                                              .image_path = camera->image_path(),
                                                                              .preview_max_dimension = preview_max_dimension,
                                                                              .image_size = preview_gt_size,
@@ -2521,6 +2657,9 @@ namespace lfs::vis {
                                                                              .undistort_params = undistort_requested
                                                                                                      ? camera->undistort_params()
                                                                                                      : lfs::core::UndistortParams{},
+                                                                             .depth_visualization_mode = frame_settings.depth_visualization_mode,
+                                                                             .background_color = frame_settings.background_color,
+                                                                             .camera = camera,
                                                                              .image_loader = image_loader});
                             gt_image = lookup.image;
                             if (lookup.status == GTComparisonImageStatus::Loading) {
@@ -2536,21 +2675,20 @@ namespace lfs::vis {
                                                : lookup.error;
                             }
 
-                            const auto current_camera_it = std::find_if(
-                                cameras.begin(), cameras.end(), [&camera](const auto& candidate) {
-                                    return candidate && candidate->uid() == camera->uid();
-                                });
-                            if (current_camera_it != cameras.end() && !cameras.empty()) {
-                                const auto current_index =
-                                    static_cast<std::size_t>(current_camera_it - cameras.begin());
+                            const auto current_camera_it = gt_camera_index_by_uid_.find(camera->uid());
+                            if (current_camera_it != gt_camera_index_by_uid_.end() &&
+                                !gt_camera_index_cameras_.empty()) {
+                                const auto current_index = current_camera_it->second;
                                 const auto queue_neighbor = [&](const int direction) {
-                                    for (std::size_t offset = 1; offset <= cameras.size(); ++offset) {
+                                    for (std::size_t offset = 1;
+                                         offset <= gt_camera_index_cameras_.size();
+                                         ++offset) {
                                         const auto delta = direction * static_cast<int>(offset);
                                         const auto index = static_cast<std::size_t>(
                                             (static_cast<int>(current_index) + delta +
-                                             static_cast<int>(cameras.size()) * 2) %
-                                            static_cast<int>(cameras.size()));
-                                        const auto& neighbor = cameras[index];
+                                             static_cast<int>(gt_camera_index_cameras_.size()) * 2) %
+                                            static_cast<int>(gt_camera_index_cameras_.size()));
+                                        const auto& neighbor = gt_camera_index_cameras_[index];
                                         if (!neighbor || neighbor->uid() == camera->uid() ||
                                             neighbor->image_path().empty()) {
                                             continue;
@@ -2562,6 +2700,7 @@ namespace lfs::vis {
                                                 lfs::core::CameraModelType::EQUIRECTANGULAR &&
                                             neighbor->is_undistort_precomputed();
                                         queueGTComparisonImagePrefetch({.camera_uid = neighbor->uid(),
+                                                                        .mode = gt_mode,
                                                                         .image_path = neighbor->image_path(),
                                                                         .preview_max_dimension =
                                                                             std::max(neighbor_size.x, neighbor_size.y),
@@ -2570,6 +2709,9 @@ namespace lfs::vis {
                                                                         .undistort_params = neighbor_undistort
                                                                                                 ? neighbor->undistort_params()
                                                                                                 : lfs::core::UndistortParams{},
+                                                                        .depth_visualization_mode = frame_settings.depth_visualization_mode,
+                                                                        .background_color = frame_settings.background_color,
+                                                                        .camera = neighbor,
                                                                         .image_loader = image_loader});
                                         break;
                                     }
@@ -2582,62 +2724,66 @@ namespace lfs::vis {
                         if (!camera->has_depth()) {
                             gt_error = "Depth GT comparison requires a depth map for the selected camera";
                         } else {
-                            auto depth = camera->load_and_get_depth(-1, preview_max_dimension);
-                            if (depth.is_valid() && depth.ndim() == 2 &&
+                            const bool undistort_requested =
                                 camera->camera_model_type() != lfs::core::CameraModelType::EQUIRECTANGULAR &&
-                                camera->is_undistort_precomputed() &&
-                                !camera->is_undistort_prepared()) {
-                                const auto scaled = lfs::core::scale_undistort_params(
-                                    camera->undistort_params(),
-                                    static_cast<int>(depth.shape()[1]),
-                                    static_cast<int>(depth.shape()[0]));
-                                depth = lfs::core::undistort_mask(depth, scaled, nullptr);
-                            }
-                            gt_image = makeDepthDisplayTensor(depth, frame_settings);
-                            if (gt_image) {
-                                gt_image = resizeChwDisplayTensor(gt_image, preview_gt_size);
-                            }
-                            if (gt_image) {
-                                auto flipped = lfs::rendering::flipImageVertical(
-                                    *gt_image,
-                                    lfs::rendering::ImageLayout::CHW);
-                                gt_image = std::make_shared<lfs::core::Tensor>(std::move(flipped));
-                            } else {
-                                gt_error = "Depth GT comparison could not load the camera depth map";
+                                camera->is_undistort_precomputed() && !camera->is_undistort_prepared();
+                            const auto lookup = getOrQueueGTComparisonImage({.camera_uid = camera->uid(),
+                                                                             .mode = gt_mode,
+                                                                             .image_path = camera->depth_path(),
+                                                                             .preview_max_dimension = preview_max_dimension,
+                                                                             .image_size = preview_gt_size,
+                                                                             .undistort_requested = undistort_requested,
+                                                                             .undistort_params = undistort_requested
+                                                                                                     ? camera->undistort_params()
+                                                                                                     : lfs::core::UndistortParams{},
+                                                                             .depth_visualization_mode = frame_settings.depth_visualization_mode,
+                                                                             .background_color = frame_settings.background_color,
+                                                                             .camera = camera,
+                                                                             .image_loader = {}});
+                            gt_image = lookup.image;
+                            if (lookup.status == GTComparisonImageStatus::Loading) {
+                                markDirty(DirtyFlag::SPLIT_VIEW);
+                                gt_loading = true;
+                                if (lookup.stale_image && !lookup.grace_elapsed) {
+                                    gt_image = lookup.stale_image;
+                                    gt_loading = false;
+                                }
+                            } else if (lookup.status == GTComparisonImageStatus::Failed) {
+                                gt_error = lookup.error.empty()
+                                               ? "Depth GT comparison could not load the camera depth map"
+                                               : lookup.error;
                             }
                         }
                     } else {
                         if (!camera->has_normal()) {
                             gt_error = "Normal GT comparison requires a normal map for the selected camera";
                         } else {
-                            auto normal = camera->load_and_get_normal(
-                                -1,
-                                preview_max_dimension,
-                                lfs::core::Camera::NormalPriorDecode{});
-                            if (normal.is_valid() && normal.ndim() == 3 &&
+                            const bool undistort_requested =
                                 camera->camera_model_type() != lfs::core::CameraModelType::EQUIRECTANGULAR &&
-                                camera->is_undistort_precomputed() &&
-                                !camera->is_undistort_prepared()) {
-                                const auto normal_layout = lfs::rendering::detectImageLayout(normal);
-                                if (normal_layout != lfs::rendering::ImageLayout::Unknown) {
-                                    const auto scaled = lfs::core::scale_undistort_params(
-                                        camera->undistort_params(),
-                                        lfs::rendering::imageWidth(normal, normal_layout),
-                                        lfs::rendering::imageHeight(normal, normal_layout));
-                                    normal = lfs::core::undistort_image(normal, scaled, nullptr);
+                                camera->is_undistort_precomputed() && !camera->is_undistort_prepared();
+                            const auto lookup = getOrQueueGTComparisonImage({.camera_uid = camera->uid(),
+                                                                             .mode = gt_mode,
+                                                                             .image_path = camera->normal_path(),
+                                                                             .preview_max_dimension = preview_max_dimension,
+                                                                             .image_size = preview_gt_size,
+                                                                             .undistort_requested = undistort_requested,
+                                                                             .undistort_params = undistort_requested
+                                                                                                     ? camera->undistort_params()
+                                                                                                     : lfs::core::UndistortParams{},
+                                                                             .camera = camera,
+                                                                             .image_loader = {}});
+                            gt_image = lookup.image;
+                            if (lookup.status == GTComparisonImageStatus::Loading) {
+                                markDirty(DirtyFlag::SPLIT_VIEW);
+                                gt_loading = true;
+                                if (lookup.stale_image && !lookup.grace_elapsed) {
+                                    gt_image = lookup.stale_image;
+                                    gt_loading = false;
                                 }
-                            }
-                            gt_image = makeNormalDisplayTensor(normal);
-                            if (gt_image) {
-                                gt_image = resizeChwDisplayTensor(gt_image, preview_gt_size);
-                            }
-                            if (gt_image) {
-                                auto flipped = lfs::rendering::flipImageVertical(
-                                    *gt_image,
-                                    lfs::rendering::ImageLayout::CHW);
-                                gt_image = std::make_shared<lfs::core::Tensor>(std::move(flipped));
-                            } else {
-                                gt_error = "Normal GT comparison could not load the camera normal map";
+                            } else if (lookup.status == GTComparisonImageStatus::Failed) {
+                                gt_error = lookup.error.empty()
+                                               ? "Normal GT comparison could not load the camera normal map"
+                                               : lookup.error;
                             }
                         }
                     }
@@ -2668,12 +2814,21 @@ namespace lfs::vis {
                             const glm::ivec2 gt_size{
                                 lfs::rendering::imageWidth(*gt_image, gt_layout),
                                 lfs::rendering::imageHeight(*gt_image, gt_layout)};
+                            const glm::ivec2 render_gt_size{
+                                std::max(static_cast<int>(std::lround(
+                                             static_cast<float>(gt_size.x) * scale /
+                                             std::max(gt_comparison_scale, 1.0e-6f))),
+                                         1),
+                                std::max(static_cast<int>(std::lround(
+                                             static_cast<float>(gt_size.y) * scale /
+                                             std::max(gt_comparison_scale, 1.0e-6f))),
+                                         1)};
 
-                            auto request = buildViewportRenderRequest(frame_ctx, gt_size);
+                            auto request = buildViewportRenderRequest(frame_ctx, render_gt_size);
                             const glm::mat4 scene_transform =
                                 detail::currentSceneTransform(scene_manager, camera->uid());
                             const auto render_camera =
-                                detail::buildGTRenderCamera(*camera, gt_size, scene_transform);
+                                detail::buildGTRenderCamera(*camera, render_gt_size, scene_transform);
                             if (render_camera) {
                                 request.frame_view.rotation = render_camera->rotation;
                                 request.frame_view.translation = render_camera->translation;
@@ -2740,6 +2895,9 @@ namespace lfs::vis {
                                                 : "Normal GT comparison could not derive rendered normals");
                                     }
                                     gt_async_held_display_ = std::move(display);
+                                    split_right_image_generation_ =
+                                        (split_right_image_generation_ + 1) |
+                                        gt_comparison_detail::SPLIT_RIGHT_GENERATION_BIT;
                                     gt_async_held_flip_y_ = gt_async_ticket_flip_y_;
                                     gt_async_held_metadata_ = gt_async_ticket_metadata_;
                                     clear_gt_async_ticket();
@@ -2774,8 +2932,8 @@ namespace lfs::vis {
                                     if (compare_error.empty() && gt_async_depth_ticket_ != 0 &&
                                         (gt_async_ticket_mode_ != gt_mode ||
                                          !gt_async_depth_dest_.is_valid() ||
-                                         static_cast<int>(gt_async_depth_dest_.size(0)) != gt_size.y ||
-                                         static_cast<int>(gt_async_depth_dest_.size(1)) != gt_size.x)) {
+                                         static_cast<int>(gt_async_depth_dest_.size(0)) != render_gt_size.y ||
+                                         static_cast<int>(gt_async_depth_dest_.size(1)) != render_gt_size.x)) {
                                         if (const auto waited =
                                                 vksplat_viewport_renderer_->waitReadbackTicket(gt_async_depth_ticket_);
                                             !waited) {
@@ -2785,8 +2943,8 @@ namespace lfs::vis {
                                             // waitReadbackTicket already delivered into dest.
                                             const bool dest_matches_panel =
                                                 gt_async_depth_dest_.is_valid() &&
-                                                static_cast<int>(gt_async_depth_dest_.size(0)) == gt_size.y &&
-                                                static_cast<int>(gt_async_depth_dest_.size(1)) == gt_size.x;
+                                                static_cast<int>(gt_async_depth_dest_.size(0)) == render_gt_size.y &&
+                                                static_cast<int>(gt_async_depth_dest_.size(1)) == render_gt_size.x;
                                             if (dest_matches_panel) {
                                                 auto display =
                                                     gt_async_ticket_mode_ == GTComparisonMode::Depth
@@ -2798,6 +2956,9 @@ namespace lfs::vis {
                                                                : std::shared_ptr<lfs::core::Tensor>{});
                                                 if (display && display->is_valid()) {
                                                     gt_async_held_display_ = std::move(display);
+                                                    split_right_image_generation_ =
+                                                        (split_right_image_generation_ + 1) |
+                                                        gt_comparison_detail::SPLIT_RIGHT_GENERATION_BIT;
                                                     gt_async_held_flip_y_ = gt_async_ticket_flip_y_;
                                                     gt_async_held_metadata_ = gt_async_ticket_metadata_;
                                                 }
@@ -2822,7 +2983,7 @@ namespace lfs::vis {
 
                                         auto rendered = render_panel_image(
                                             context.viewport,
-                                            gt_size,
+                                            render_gt_size,
                                             std::nullopt,
                                             std::nullopt,
                                             nullptr,
@@ -2833,8 +2994,8 @@ namespace lfs::vis {
                                             compare_error = rendered.error();
                                         } else {
                                             gt_async_depth_dest_ = lfs::core::Tensor::empty(
-                                                {static_cast<std::size_t>(gt_size.y),
-                                                 static_cast<std::size_t>(gt_size.x)},
+                                                {static_cast<std::size_t>(render_gt_size.y),
+                                                 static_cast<std::size_t>(render_gt_size.x)},
                                                 lfs::core::Device::CPU,
                                                 lfs::core::DataType::Float32);
                                             if (!gt_async_depth_dest_.is_valid()) {
@@ -2867,7 +3028,7 @@ namespace lfs::vis {
                                         compare_panel.flip_y = gt_async_held_flip_y_;
                                         compare_panel.external_image_view = VK_NULL_HANDLE;
                                         compare_panel.external_image_generation = 0;
-                                        compare_panel.size = gt_size;
+                                        compare_panel.size = render_gt_size;
                                     }
 
                                     LOG_PERF(
@@ -2891,7 +3052,7 @@ namespace lfs::vis {
                                     frame_settings.point_cloud_mode || !has_visible_gaussian_model;
                                 if (use_point_cloud_compare && has_visible_gaussian_model) {
                                     auto point_request = buildPointCloudRenderRequest(
-                                        frame_ctx, gt_size, frame_ctx.scene_state.model_transforms);
+                                        frame_ctx, render_gt_size, frame_ctx.scene_state.model_transforms);
                                     point_request.frame_view = request.frame_view;
                                     if (auto auxiliary_engine = ensure_auxiliary_rendering_engine(); auxiliary_engine) {
                                         auto rendered = (*auxiliary_engine)->renderPointCloudImage(*model, point_request);
@@ -2911,7 +3072,7 @@ namespace lfs::vis {
                                     const std::vector<glm::mat4> point_cloud_transforms = {
                                         frame_ctx.scene_state.point_cloud_transform};
                                     auto point_request = buildPointCloudRenderRequest(
-                                        frame_ctx, gt_size, point_cloud_transforms);
+                                        frame_ctx, render_gt_size, point_cloud_transforms);
                                     point_request.frame_view = request.frame_view;
                                     if (auto auxiliary_engine = ensure_auxiliary_rendering_engine(); auxiliary_engine) {
                                         auto rendered = (*auxiliary_engine)->renderPointCloudImage(*frame_ctx.scene_state.point_cloud, point_request);
@@ -2930,7 +3091,7 @@ namespace lfs::vis {
                                 } else if (has_visible_gaussian_model) {
                                     auto rendered = render_panel_image(
                                         context.viewport,
-                                        gt_size,
+                                        render_gt_size,
                                         std::nullopt,
                                         std::nullopt,
                                         nullptr,
@@ -4132,9 +4293,28 @@ namespace lfs::vis {
                 }
                 if (auto right_tensor = pending_split_view.right.image) {
                     const auto sz = tensor_size(*right_tensor);
+                    gt_comparison_detail::updateSplitImageGeneration(
+                        right_tensor.get(),
+                        sz,
+                        gt_async_held_display_.get(),
+                        split_right_source_size_,
+                        result.image_generation,
+                        split_right_image_generation_);
+                    split_right_source_size_ = sz;
                     result.split_right_image = std::move(right_tensor);
+                    result.split_right_image_generation = split_right_image_generation_;
                     result.split_right_size = sz;
                     result.split_right_flip_y = pending_split_view.right.flip_y;
+                } else {
+                    gt_comparison_detail::updateSplitImageGeneration(
+                        nullptr,
+                        {0, 0},
+                        gt_async_held_display_.get(),
+                        split_right_source_size_,
+                        result.image_generation,
+                        split_right_image_generation_);
+                    split_right_source_size_ = {0, 0};
+                    result.split_right_image_generation = split_right_image_generation_;
                 }
             }
             if (!pending_split_view.enabled) {

--- a/src/visualizer/rendering/split_view_composition.cpp
+++ b/src/visualizer/rendering/split_view_composition.cpp
@@ -120,8 +120,7 @@ namespace lfs::vis {
 
             std::string gt_label = LOC(lichtfeld::Strings::StatusBar::GROUND_TRUTH);
             if (ctx.scene_manager && ctx.current_camera_id >= 0) {
-                const auto disabled_uids = ctx.scene_manager->getScene().getTrainingDisabledCameraUids();
-                if (disabled_uids.count(ctx.current_camera_id) > 0) {
+                if (!ctx.scene_manager->getScene().isCameraTrainingEnabled(ctx.current_camera_id)) {
                     gt_label = LOC(lichtfeld::Strings::StatusBar::GROUND_TRUTH_EXCLUDED);
                 }
             }

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -2471,7 +2471,7 @@ namespace lfs::vis {
                         vulkan_frame.split_right_image,
                         vulkan_frame.split_right_size,
                         vulkan_frame.split_right_flip_y,
-                        vulkan_frame.image_generation);
+                        vulkan_frame.split_right_image_generation);
                 } else {
                     interop.clearSplitRightImage();
                 }

--- a/tests/test_pipelined_loader.cpp
+++ b/tests/test_pipelined_loader.cpp
@@ -142,6 +142,22 @@ TEST_F(PipelinedImageLoaderTest, LoadsRealImageAndMaskWithExpectedContract) {
     EXPECT_LE(ready.mask->max().item<float>(), 1.0f);
 }
 
+TEST_F(PipelinedImageLoaderTest, PngMaxWidthUsesOneDecode) {
+    PipelinedImageLoader loader(config());
+    const auto before = loader.get_stats().cpu_decode_calls;
+
+    LoadParams params;
+    params.max_width = 16;
+    params.output_uint8 = true;
+    const auto tensor = loader.load_image_immediate(mask_path_, params);
+
+    const auto after = loader.get_stats().cpu_decode_calls;
+    EXPECT_EQ(after - before, 1U);
+    ASSERT_TRUE(tensor.is_valid());
+    ASSERT_EQ(tensor.shape().rank(), 3U);
+    EXPECT_LE(std::max(tensor.shape()[1], tensor.shape()[2]), 16U);
+}
+
 TEST_F(PipelinedImageLoaderTest, ResizeAndMaxWidthKeepImageAndMaskAligned) {
     PipelinedImageLoader loader(config());
     loader.prefetch({request(1, 256)});

--- a/tests/test_rendering_refactor_services.cpp
+++ b/tests/test_rendering_refactor_services.cpp
@@ -31,6 +31,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <cuda_runtime.h>
 #include <filesystem>
 #include <glm/gtc/matrix_transform.hpp>
 #include <gtest/gtest.h>
@@ -138,6 +139,11 @@ namespace lfs::vis {
                      .output_uint8 = p.output_uint8});
             });
             initialized = true;
+        }
+
+        bool has_cuda_device() {
+            int device_count = 0;
+            return cudaGetDeviceCount(&device_count) == cudaSuccess && device_count > 0;
         }
     } // namespace
 
@@ -266,6 +272,31 @@ namespace lfs::vis {
                               chw_bytes.data(),
                               chw_bytes.size()),
                   0);
+    }
+
+    TEST(GTComparisonCache, DisplayConversionCopiesCudaUInt8ChwToCpu) {
+        if (!has_cuda_device()) {
+            GTEST_SKIP() << "CUDA device required";
+        }
+
+        using lfs::core::DataType;
+        using lfs::core::Device;
+        using lfs::core::Tensor;
+
+        const std::array<std::uint8_t, 12> chw_bytes{
+            0, 128, 255, 64,
+            255, 64, 128, 0,
+            191, 0, 64, 255};
+        auto cpu_uint8_chw = std::make_shared<Tensor>(Tensor::empty(
+            {size_t{3}, size_t{2}, size_t{2}}, Device::CPU, DataType::UInt8));
+        std::memcpy(cpu_uint8_chw->ptr<std::uint8_t>(), chw_bytes.data(), chw_bytes.size());
+        const auto cuda_uint8_chw = std::make_shared<Tensor>(cpu_uint8_chw->cuda());
+
+        const auto preview = gt_comparison_detail::convertDisplayTensorToUInt8(cuda_uint8_chw);
+        ASSERT_TRUE(preview);
+        EXPECT_EQ(preview->device(), Device::CPU);
+        EXPECT_NE(preview.get(), cuda_uint8_chw.get());
+        EXPECT_EQ(std::memcmp(preview->ptr<std::uint8_t>(), chw_bytes.data(), chw_bytes.size()), 0);
     }
 
     TEST(GTComparisonCache, RightImageGenerationUsesFrameGenerationForRecycledTarget) {

--- a/tests/test_rendering_refactor_services.cpp
+++ b/tests/test_rendering_refactor_services.cpp
@@ -9,12 +9,14 @@
 #include "core/image_io.hpp"
 #include "core/image_loader.hpp"
 #include "core/point_cloud.hpp"
+#include "core/scene.hpp"
 #include "core/services.hpp"
 #include "core/tensor.hpp"
 #include "io/cache_image_loader.hpp"
 #include "operation/undo_history.hpp"
 #include "rendering/coordinate_conventions.hpp"
 #include "visualizer/gui_capabilities.hpp"
+#include "visualizer/rendering/gt_comparison_cache_utils.hpp"
 #include "visualizer/rendering/render_pass.hpp"
 #include "visualizer/rendering/rendering_manager.hpp"
 #include "visualizer/rendering/split_view_composition.hpp"
@@ -24,9 +26,11 @@
 #include "visualizer/rendering/viewport_request_builder.hpp"
 #include "visualizer/scene/scene_manager.hpp"
 
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <glm/gtc/matrix_transform.hpp>
 #include <gtest/gtest.h>
@@ -188,6 +192,108 @@ namespace lfs::vis {
         EXPECT_TRUE(*disable.restore_equirectangular);
         EXPECT_TRUE(settings.equirectangular);
         EXPECT_EQ(settings.split_view_mode, SplitViewMode::Disabled);
+    }
+
+    TEST(GTComparisonCache, UInt8PreviewAccountingKeepsCurrentAndNeighbor) {
+        constexpr std::size_t budget = 128ULL * 1024ULL * 1024ULL;
+        const auto current = gt_comparison_detail::previewBytes({3840, 2160});
+        const auto neighbor = gt_comparison_detail::previewBytes({3840, 2160});
+        EXPECT_EQ(current, 3840ULL * 2160ULL * 3ULL);
+        EXPECT_TRUE(gt_comparison_detail::prefetchFits(0, current, neighbor, budget));
+        EXPECT_FALSE(gt_comparison_detail::prefetchFits(0, 80ULL, 40ULL, 100ULL));
+    }
+
+    TEST(GTComparisonCache, DisplayConversionMatchesFloatChwAndUInt8Hwc) {
+        using lfs::core::DataType;
+        using lfs::core::Device;
+        using lfs::core::Tensor;
+
+        constexpr std::size_t plane = 2 * 2;
+        const std::array<std::uint8_t, 12> hwc_bytes{
+            0, 255, 191,
+            128, 64, 0,
+            255, 128, 64,
+            64, 0, 255};
+        std::vector<float> float_chw_values(3 * plane);
+        for (std::size_t pixel = 0; pixel < plane; ++pixel) {
+            for (std::size_t channel = 0; channel < 3; ++channel) {
+                float_chw_values[channel * plane + pixel] =
+                    static_cast<float>(hwc_bytes[pixel * 3 + channel]) / 255.0f;
+            }
+        }
+        const auto float_chw = std::make_shared<Tensor>(Tensor::from_vector(
+            float_chw_values,
+            {size_t{3}, size_t{2}, size_t{2}}, Device::CPU));
+        const auto uint8_hwc = std::make_shared<Tensor>(Tensor::empty(
+            {size_t{2}, size_t{2}, size_t{3}}, Device::CPU, DataType::UInt8));
+        std::memcpy(uint8_hwc->ptr<std::uint8_t>(), hwc_bytes.data(), hwc_bytes.size());
+
+        const auto float_preview = gt_comparison_detail::convertDisplayTensorToUInt8(float_chw);
+        const auto uint8_preview = gt_comparison_detail::convertDisplayTensorToUInt8(uint8_hwc);
+        ASSERT_TRUE(float_preview);
+        ASSERT_TRUE(uint8_preview);
+        ASSERT_EQ(float_preview->shape(), uint8_preview->shape());
+        const auto* const float_preview_bytes = float_preview->ptr<std::uint8_t>();
+        const auto* const uint8_preview_bytes = uint8_preview->ptr<std::uint8_t>();
+        std::size_t first_mismatch = float_preview->bytes();
+        for (std::size_t index = 0; index < float_preview->bytes(); ++index) {
+            if (float_preview_bytes[index] != uint8_preview_bytes[index]) {
+                first_mismatch = index;
+                break;
+            }
+        }
+        const auto float_value = first_mismatch < float_preview->bytes()
+                                     ? float_preview_bytes[first_mismatch]
+                                     : std::uint8_t{0};
+        const auto uint8_value = first_mismatch < uint8_preview->bytes()
+                                     ? uint8_preview_bytes[first_mismatch]
+                                     : std::uint8_t{0};
+        EXPECT_EQ(first_mismatch, float_preview->bytes())
+            << "first mismatching index=" << first_mismatch
+            << ", float byte=" << static_cast<unsigned int>(float_value)
+            << ", uint8 byte=" << static_cast<unsigned int>(uint8_value);
+
+        const auto uint8_chw = std::make_shared<Tensor>(Tensor::empty(
+            {size_t{3}, size_t{2}, size_t{2}}, Device::CPU, DataType::UInt8));
+        const std::array<std::uint8_t, 12> chw_bytes{
+            0, 128, 255, 64,
+            255, 64, 128, 0,
+            191, 0, 64, 255};
+        std::memcpy(uint8_chw->ptr<std::uint8_t>(), chw_bytes.data(), chw_bytes.size());
+        const auto uint8_chw_preview = gt_comparison_detail::convertDisplayTensorToUInt8(uint8_chw);
+        ASSERT_EQ(uint8_chw_preview.get(), uint8_chw.get());
+        EXPECT_EQ(std::memcmp(uint8_chw_preview->ptr<std::uint8_t>(),
+                              chw_bytes.data(),
+                              chw_bytes.size()),
+                  0);
+    }
+
+    TEST(GTComparisonCache, RightImageGenerationUsesFrameGenerationForRecycledTarget) {
+        constexpr glm::ivec2 size{640, 480};
+        constexpr auto stable_bit = gt_comparison_detail::SPLIT_RIGHT_GENERATION_BIT;
+        const int recycled_address = 1;
+        const int held_display = 2;
+        std::uint64_t generation = 7;
+
+        gt_comparison_detail::updateSplitImageGeneration(
+            &recycled_address, size, nullptr, size, 11, generation);
+        EXPECT_EQ(generation, 11U);
+        // A new ordinary tensor may reuse the same address; it still carries
+        // the current frame generation and must not inherit the old upload key.
+        gt_comparison_detail::updateSplitImageGeneration(
+            &recycled_address, size, nullptr, size, 12, generation);
+        EXPECT_EQ(generation, 12U);
+        gt_comparison_detail::updateSplitImageGeneration(
+            &held_display, size, &held_display, size, 13, generation);
+        EXPECT_EQ(generation, 12U | stable_bit);
+        gt_comparison_detail::updateSplitImageGeneration(
+            &held_display, {800, 600}, &held_display, size, 14, generation);
+        EXPECT_EQ(generation, 14U);
+    }
+
+    TEST(SceneCameraTraining, UnknownUidIsEnabled) {
+        const lfs::core::Scene scene;
+        EXPECT_TRUE(scene.isCameraTrainingEnabled(123456));
     }
 
     TEST(SplitViewServiceTest, UpdateInfoClearsStaleSplitViewLabels) {


### PR DESCRIPTION
Ground-truth comparison now does much less work per frame and per camera switch, and depth/normal comparison no longer stalls the render thread.

What was slow:
- The rendered half of the split view was drawn at the base render scale, ignoring the upscaler and the interactive/VRAM-pressure reductions, so GT compare could cost 4x the pixels of the normal view.
- Depth and normal ground truth were converted, resized and flipped on the render thread on every dirty frame, with no cache. RGB previews were cached as float32, so at 4K the cache held a single image and the neighbour prefetch evicted it on every switch.
- The image loader issued a device-wide CUDA sync from worker threads (stalling the viewport and the trainer) and decoded PNG/TIFF files twice when a preview size was requested.
- Pressing Tab forced a full splat re-upload, the right split image was re-uploaded to Vulkan every frame even when unchanged, several per-frame walks over all cameras ran on every frame, and the PSNR/SSIM overlay re-read the ground-truth image and mask from disk every refresh.

What changed: the splat panel renders at the effective viewer scale while the reference image keeps its stable preview size; RGB, depth and normal previews all go through the existing background worker and a keyed uint8 cache with the same stale/placeholder fallback; the loader syncs only its own stream and decodes once; Tab only invalidates the composition; the held right image keeps a stable upload generation; camera lookups are by uid; metrics inputs are cached per camera.

Verification: 177 GT-compare / split-view / image-loader tests pass (new tests for cache accounting, upload generations, single decode, display conversion). GT-compare screen captures on a COLMAP dataset match master on the reference half (max 5/255).
