### PR TITLE
Asset Manager: instant open, incremental rescans, thumbnails off the UI thread

### DIFF
--- a/src/core/image_codecs.cpp
+++ b/src/core/image_codecs.cpp
@@ -432,6 +432,17 @@ namespace lfs::core::image_codecs {
                 return false;
             }
             cinfo.out_color_space = target.channels == 1 ? JCS_GRAYSCALE : JCS_RGB;
+            if (target.max_width > 0) {
+                const auto max_dimension = std::max(cinfo.image_width, cinfo.image_height);
+                for (const unsigned int denominator : {1u, 2u, 4u, 8u}) {
+                    if ((max_dimension + denominator - 1) / denominator <=
+                        static_cast<unsigned int>(target.max_width)) {
+                        cinfo.scale_num = 1;
+                        cinfo.scale_denom = denominator;
+                        break;
+                    }
+                }
+            }
             jpeg_start_decompress(&cinfo);
             if (cinfo.output_components != target.channels) {
                 error = "JPEG target channel mismatch";
@@ -798,7 +809,7 @@ namespace lfs::core::image_codecs {
 #ifndef _WIN32
             if (hdr && target.sample_type == SampleType::Float32) {
                 const int descriptor = open(path.c_str(), O_RDONLY);
-                struct stat file_status {};
+                struct stat file_status{};
                 if (descriptor >= 0 && fstat(descriptor, &file_status) == 0 && file_status.st_size > 0 &&
                     file_status.st_size <= std::numeric_limits<int>::max()) {
                     const auto size = static_cast<std::size_t>(file_status.st_size);

--- a/src/core/image_codecs.hpp
+++ b/src/core/image_codecs.hpp
@@ -38,6 +38,7 @@ namespace lfs::core::image_codecs {
         void* data = nullptr;
         DecodeAllocator allocate = nullptr;
         void* user = nullptr;
+        int max_width = 0;
     };
 
     bool probe(const std::filesystem::path& path, Probe& result, std::string& error);

--- a/src/core/image_io.cpp
+++ b/src/core/image_io.cpp
@@ -270,12 +270,14 @@ namespace {
 
     template <typename T>
     std::tuple<T*, int, int, int>
-    load_image_t(std::filesystem::path p, int res_div, int max_width) {
+    load_image_t(std::filesystem::path p, int res_div, int max_width,
+                 bool scaled_jpeg_decode = false) {
         LOG_TIMER("load_image total");
         const std::string path_utf8 = lfs::core::path_to_utf8(p);
         constexpr auto sample_type = std::is_same_v<T, uint8_t> ? image_codecs::SampleType::UInt8
                                                                 : image_codecs::SampleType::UInt16;
-        image_codecs::DecodeTarget target{3, sample_type, nullptr, allocate_image_buffer, nullptr};
+        image_codecs::DecodeTarget target{3, sample_type, nullptr, allocate_image_buffer, nullptr,
+                                          scaled_jpeg_decode ? max_width : 0};
         image_codecs::Probe direct_info;
         std::string error;
         int source_width = 0;
@@ -441,6 +443,11 @@ namespace lfs::core {
     std::tuple<unsigned char*, int, int, int>
     load_image(std::filesystem::path p, int res_div, int max_width) {
         return ::load_image_t<unsigned char>(p, res_div, max_width);
+    }
+
+    std::tuple<unsigned char*, int, int, int>
+    load_image_thumbnail(std::filesystem::path p, int max_width) {
+        return ::load_image_t<unsigned char>(p, -1, max_width, true);
     }
 
     std::tuple<uint16_t*, int, int, int>

--- a/src/core/include/core/image_io.hpp
+++ b/src/core/include/core/image_io.hpp
@@ -32,6 +32,12 @@ namespace lfs::core {
     LFS_CORE_API std::tuple<unsigned char*, int, int, int>
     load_image(std::filesystem::path p, int res_div = -1, int max_width = 0);
 
+    // Thumbnail-only decode. JPEG decoders may use native DCT scaling before
+    // the final area resample; training and general image loading stay on
+    // load_image().
+    LFS_CORE_API std::tuple<unsigned char*, int, int, int>
+    load_image_thumbnail(std::filesystem::path p, int max_width);
+
     LFS_CORE_API std::tuple<uint16_t*, int, int, int>
     load_image_u16(std::filesystem::path p, int res_div = -1, int max_width = 0);
 

--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -334,7 +334,7 @@ namespace {
         if (auto posted = lfs::vis::post_guarded_and_wait<void>(
                 viewer, context,
                 [emit = std::forward<EmitFn>(emit_fn)]() mutable
-                -> lfs::Result<void> {
+                    -> lfs::Result<void> {
                     emit();
                     return {};
                 },

--- a/src/python/lfs/py_io.cpp
+++ b/src/python/lfs/py_io.cpp
@@ -458,7 +458,7 @@ namespace lfs::python {
 
         m.def(
             "inspect_project",
-            [](const std::filesystem::path& path) {
+            [](const std::filesystem::path& path, const bool resolve_preview_fallback) {
                 project::ReaderOptions options;
                 options.allow_unsupported_inspection = true;
                 std::optional<lfs::Result<project::ProjectReader>> opened;
@@ -466,7 +466,7 @@ namespace lfs::python {
                 {
                     nb::gil_scoped_release release;
                     opened = project::ProjectReader::open(path, options);
-                    if (opened && opened->has_value() &&
+                    if (resolve_preview_fallback && opened && opened->has_value() &&
                         !(**opened).preview().has_value()) {
                         const auto& reader = **opened;
                         const auto project_uuid =
@@ -519,6 +519,7 @@ namespace lfs::python {
                 };
             },
             nb::arg("path"),
+            nb::arg("resolve_preview_fallback") = true,
             "Inspect validated .licht container metadata without reading project payloads.");
 
         nb::class_<PyLoadResult>(m, "LoadResult")

--- a/src/python/lfs_plugins/asset_index.py
+++ b/src/python/lfs_plugins/asset_index.py
@@ -11,7 +11,7 @@ import shutil
 import tempfile
 import threading
 import uuid
-from copy import deepcopy
+from copy import copy
 from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
@@ -23,9 +23,38 @@ _log = logging.getLogger(__name__)
 _T = TypeVar("_T")
 _ASSET_INDEX_LOCK = threading.RLock()
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 SUPPORTED_ASSET_EXTENSION = ".licht"
 DEFAULT_FOLDER_ID = "default"
+
+_PROJECT_STORAGE_FIELDS = frozenset(
+    {
+        "name",
+        "path",
+        "folder_id",
+        "size",
+        "mtime_ns",
+        "fallback_preview_path",
+        "file_uuid",
+        "commit_uuid",
+        "generation",
+        "created_at_unix_ns",
+        "saved_at_unix_ns",
+        "file_size_bytes",
+        "role",
+        "open_state",
+        "has_preview",
+        "status",
+    }
+)
+_INSPECTION_STORAGE_FIELDS = _PROJECT_STORAGE_FIELDS - {
+    "name",
+    "path",
+    "folder_id",
+    "size",
+    "mtime_ns",
+    "fallback_preview_path",
+}
 
 
 def _normalize_path(path: str) -> str:
@@ -238,17 +267,40 @@ class Project:
     error: str = ""
     relocation_candidate: str = ""
     fallback_preview_path: str = ""
+    path_size_bytes: int = 0
+    path_mtime_ns: int = 0
+    inspection_verified: bool = False
+    inspection_restored: bool = False
 
     @property
     def id(self) -> str:
         return self.project_uuid
 
     def to_storage_dict(self) -> Dict[str, Any]:
-        return {
+        record = {
             "name": self.name,
             "path": self.path,
             "folder_id": self.folder_id,
+            "size": self.path_size_bytes,
+            "mtime_ns": self.path_mtime_ns,
+            "fallback_preview_path": self.fallback_preview_path,
         }
+        if self.inspection_verified or self.inspection_restored:
+            record.update(
+                {
+                    "file_uuid": self.file_uuid,
+                    "commit_uuid": self.commit_uuid,
+                    "generation": self.generation,
+                    "created_at_unix_ns": self.created_at_unix_ns,
+                    "saved_at_unix_ns": self.saved_at_unix_ns,
+                    "file_size_bytes": self.file_size_bytes,
+                    "role": self.role,
+                    "open_state": self.open_state,
+                    "has_preview": self.has_preview,
+                    "status": self.status,
+                }
+            )
+        return record
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -269,7 +321,6 @@ class Project:
             "status": self.status,
             "error": self.error,
             "relocation_candidate": self.relocation_candidate,
-            "fallback_preview_path": self.fallback_preview_path,
         }
 
 
@@ -305,6 +356,9 @@ class AssetIndex:
         self._projects: Dict[str, Project] = {}
         self._project_by_path: Dict[str, str] = {}
         self._catalog_epoch = 0
+        self._assets_snapshot_epoch: Optional[int] = None
+        self._assets_snapshot: Optional[Dict[str, Dict[str, Any]]] = None
+        self._directory_mtimes: Dict[str, int] = {}
         self.load_issues: List[str] = []
 
     @property
@@ -319,10 +373,26 @@ class AssetIndex:
     @property
     @_synchronized
     def assets(self) -> Dict[str, Dict[str, Any]]:
-        return {
-            project_uuid: project.to_dict()
-            for project_uuid, project in self._projects.items()
-        }
+        if self._assets_snapshot_epoch != self._catalog_epoch:
+            self._assets_snapshot = {
+                project_uuid: project.to_dict()
+                for project_uuid, project in self._projects.items()
+            }
+            self._assets_snapshot_epoch = self._catalog_epoch
+        return self._assets_snapshot or {}
+
+    @_synchronized
+    def get_asset_dict(self, asset_id: str) -> Optional[Dict[str, Any]]:
+        project = self._projects.get(str(asset_id))
+        return project.to_dict() if project is not None else None
+
+    @_synchronized
+    def iter_project_ids(self) -> List[str]:
+        return list(self._projects)
+
+    @_synchronized
+    def count(self) -> int:
+        return len(self._projects)
 
     @staticmethod
     def _path_key(path: str) -> str:
@@ -333,17 +403,45 @@ class AssetIndex:
         return _enum_name(inspection.role) == "MASTER"
 
     @staticmethod
+    def _set_inspection_runtime_state(project: Project) -> None:
+        project.exists = True
+        project.available = (
+            project.role == "MASTER" and project.open_state == "OPEN"
+        )
+        if project.available:
+            project.status = "AVAILABLE"
+        elif project.open_state == "REPAIR_ONLY":
+            project.status = "REPAIR_ONLY"
+        elif project.open_state == "UNSUPPORTED_NEWER":
+            project.status = "UNSUPPORTED_NEWER"
+        else:
+            project.status = "UNSUPPORTED"
+        project.error = ""
+
+    @staticmethod
     def _inspection_name(path: str) -> str:
         return Path(path).stem
 
     @staticmethod
-    def _inspect_path(path: str) -> Any:
+    def _inspect_path(path: str, resolve_fallback: bool = True) -> Any:
         import lichtfeld as lf
 
-        return lf.io.inspect_project(path)
+        if resolve_fallback:
+            return lf.io.inspect_project(path)
+        return lf.io.inspect_project(path, resolve_preview_fallback=False)
+
+    @staticmethod
+    def _path_stat(path: str) -> Optional[Tuple[int, int]]:
+        try:
+            stat = os.stat(path)
+        except OSError:
+            return None
+        return int(stat.st_size), int(stat.st_mtime_ns)
 
     def _touch_catalog(self) -> None:
         self._catalog_epoch += 1
+        self._assets_snapshot_epoch = None
+        self._assets_snapshot = None
 
     @_synchronized
     def catalog_epoch(self) -> int:
@@ -362,18 +460,36 @@ class AssetIndex:
         project.fallback_preview_path = str(
             getattr(inspection, "fallback_preview_path", "") or ""
         )
-        project.exists = True
-        project.available = project.role == "MASTER" and project.open_state == "OPEN"
-        if project.available:
-            project.status = "AVAILABLE"
-        elif project.open_state == "REPAIR_ONLY":
-            project.status = "REPAIR_ONLY"
-        elif project.open_state == "UNSUPPORTED_NEWER":
-            project.status = "UNSUPPORTED_NEWER"
-        else:
-            project.status = "UNSUPPORTED"
-        project.error = ""
+        self._set_inspection_runtime_state(project)
+        project.inspection_verified = True
+        project.inspection_restored = False
+        metadata = self._path_stat(project.path)
+        if metadata is not None:
+            project.path_size_bytes, project.path_mtime_ns = metadata
         self._touch_catalog()
+
+    @staticmethod
+    def _has_persisted_inspection(value: Dict[str, Any]) -> bool:
+        return {
+            "size",
+            "mtime_ns",
+            "fallback_preview_path",
+        }.issubset(value) and _INSPECTION_STORAGE_FIELDS.issubset(value)
+
+    def _restore_inspection(self, project: Project, value: Dict[str, Any]) -> None:
+        project.file_uuid = str(value["file_uuid"] or "")
+        project.commit_uuid = str(value["commit_uuid"] or "")
+        project.generation = int(value["generation"])
+        project.created_at_unix_ns = int(value["created_at_unix_ns"])
+        project.saved_at_unix_ns = int(value["saved_at_unix_ns"])
+        project.file_size_bytes = int(value["file_size_bytes"])
+        project.role = str(value["role"] or "")
+        project.open_state = str(value["open_state"] or "")
+        project.has_preview = bool(value["has_preview"])
+        project.status = str(value["status"] or "UNVERIFIED")
+        self._set_inspection_runtime_state(project)
+        project.inspection_verified = False
+        project.inspection_restored = True
 
     def _clear_runtime(self, project: Project, status: str, error: str = "") -> None:
         project.file_uuid = ""
@@ -390,13 +506,35 @@ class AssetIndex:
         project.available = False
         project.status = status
         project.error = error
+        project.path_size_bytes = 0
+        project.path_mtime_ns = 0
+        project.inspection_verified = True
+        project.inspection_restored = False
         self._touch_catalog()
 
-    def _read_project_runtime(self, path: str, expected_uuid: str) -> Tuple[str, Any]:
-        if not Path(path).is_file():
+    def _read_project_runtime(
+        self,
+        path: str,
+        expected_uuid: str,
+        *,
+        resolve_fallback: bool = False,
+        known_metadata: Optional[Tuple[int, int]] = None,
+    ) -> Tuple[str, Any]:
+        metadata = self._path_stat(path)
+        if metadata is None:
             return "MISSING", None
+        if known_metadata is not None and metadata == known_metadata:
+            return "UNCHANGED", metadata
         try:
-            inspection = self._inspect_path(path)
+            if resolve_fallback:
+                inspection = self._inspect_path(path)
+            else:
+                try:
+                    inspection = self._inspect_path(path, False)
+                except TypeError:
+                    # Test doubles and older native bindings have the old
+                    # one-argument shape; bulk verification remains correct.
+                    inspection = self._inspect_path(path)
         except Exception as exc:
             return "UNREADABLE", str(exc)
         if str(inspection.project_uuid) != expected_uuid:
@@ -416,7 +554,9 @@ class AssetIndex:
         self._clear_runtime(project, kind, str(payload or ""))
 
     def _refresh_project(self, project: Project) -> None:
-        kind, payload = self._read_project_runtime(project.path, project.project_uuid)
+        kind, payload = self._read_project_runtime(
+            project.path, project.project_uuid, resolve_fallback=True
+        )
         self._apply_runtime_result(project, kind, payload)
 
     def _rebuild_path_lookup(self) -> None:
@@ -462,14 +602,26 @@ class AssetIndex:
 
     def _snapshot_state(
         self,
+        project_ids: Optional[List[str]] = None,
+        folder_ids: Optional[List[str]] = None,
     ) -> Tuple[Dict[str, Folder], Dict[str, Project], Dict[str, str]]:
-        return deepcopy((self._folders, self._projects, self._project_by_path))
+        """Capture only records a mutation may edit for save rollback."""
+        folders = self._folders.copy()
+        for folder_id in folder_ids or []:
+            if folder_id in folders:
+                folders[folder_id] = copy(folders[folder_id])
+        projects = self._projects.copy()
+        for project_id in project_ids or []:
+            if project_id in projects:
+                projects[project_id] = copy(projects[project_id])
+        return folders, projects, self._project_by_path.copy()
 
     def _restore_state(
         self,
         state: Tuple[Dict[str, Folder], Dict[str, Project], Dict[str, str]],
     ) -> None:
         self._folders, self._projects, self._project_by_path = state
+        self._touch_catalog()
 
     def _ensure_default_folder(self) -> bool:
         folder = self._folders.get(DEFAULT_FOLDER_ID)
@@ -488,18 +640,33 @@ class AssetIndex:
         self._folders = {}
         self._projects = {}
         self._project_by_path = {}
+        self._directory_mtimes = {}
         self._ensure_default_folder()
+        self._touch_catalog()
 
     def _load_v3(self, data: Dict[str, Any]) -> bool:
         folders_data = data.get("folders")
         projects_data = data.get("projects")
         if not isinstance(folders_data, dict) or not isinstance(projects_data, dict):
             raise ValueError("Asset Manager schema v3 requires folders and projects objects")
-        normalized = set(data) != {"schema_version", "folders", "projects"}
-
         self._folders = {}
         self._projects = {}
         self._project_by_path = {}
+        self._directory_mtimes = {}
+        normalized = set(data) != {
+            "schema_version", "folders", "projects", "directory_mtimes"
+        }
+        raw_directory_mtimes = data.get("directory_mtimes", {})
+        if isinstance(raw_directory_mtimes, dict):
+            self._directory_mtimes = {
+                self._path_key(str(path)): int(mtime)
+                for path, mtime in raw_directory_mtimes.items()
+                if isinstance(path, str) and isinstance(mtime, int)
+            }
+        else:
+            self._directory_mtimes = {}
+            normalized = True
+
         stored_default_path = ""
         for folder_id, value in folders_data.items():
             if not isinstance(folder_id, str) or not isinstance(value, dict):
@@ -570,7 +737,7 @@ class AssetIndex:
                 continue
             seen_paths.add(path_key)
 
-            normalized = normalized or set(value) != {"name", "path", "folder_id"}
+            normalized = normalized or set(value) != _PROJECT_STORAGE_FIELDS
             normalized = normalized or path != stored_path
             stored_folder_id = str(value.get("folder_id") or DEFAULT_FOLDER_ID)
             folder_id = self._folder_id_for_path(path)
@@ -586,7 +753,12 @@ class AssetIndex:
                 folder_id=folder_id,
                 exists=True,
                 status="UNVERIFIED",
+                path_size_bytes=int(value.get("size") or 0),
+                path_mtime_ns=int(value.get("mtime_ns") or 0),
+                fallback_preview_path=str(value.get("fallback_preview_path") or ""),
             )
+            if self._has_persisted_inspection(value):
+                self._restore_inspection(project, value)
             self._projects[canonical_uuid] = project
             self._project_by_path[path_key] = canonical_uuid
         if self._projects:
@@ -786,7 +958,7 @@ class AssetIndex:
             if not isinstance(data, dict):
                 raise ValueError("Asset Manager catalog root must be an object")
 
-            is_current = data.get("schema_version") == SCHEMA_VERSION
+            is_current = data.get("schema_version") in (SCHEMA_VERSION, 3)
             if is_current and not migrating_legacy_location:
                 if self._load_v3(data) and not self.save():
                     self._restore_state(previous_state)
@@ -826,6 +998,7 @@ class AssetIndex:
                     project_uuid: project.to_storage_dict()
                     for project_uuid, project in self._projects.items()
                 },
+                "directory_mtimes": dict(self._directory_mtimes),
             }
             self._library_path.parent.mkdir(parents=True, exist_ok=True)
             fd, temp_name = tempfile.mkstemp(
@@ -849,6 +1022,7 @@ class AssetIndex:
                 finally:
                     backup_temp.unlink(missing_ok=True)
             os.replace(temp_path, self._library_path)
+            self._touch_catalog()
             return True
         except Exception as exc:
             _log.error("Failed to save Asset Manager library %s: %s", self._library_path, exc)
@@ -860,6 +1034,16 @@ class AssetIndex:
     @_synchronized
     def ensure_default_catalog(self) -> None:
         self._initialize_empty()
+
+    @_synchronized
+    def directory_mtime(self, directory: str) -> Optional[int]:
+        return self._directory_mtimes.get(self._path_key(directory))
+
+    @_synchronized
+    def set_directory_mtime(self, directory: str, mtime_ns: int) -> None:
+        key = self._path_key(directory)
+        if self._directory_mtimes.get(key) != int(mtime_ns):
+            self._directory_mtimes[key] = int(mtime_ns)
 
     @_synchronized
     def add_folder(self, directory: str) -> Optional[Folder]:
@@ -888,7 +1072,9 @@ class AssetIndex:
         folder = self._folders.get(folder_id)
         if folder is None or folder_id == DEFAULT_FOLDER_ID:
             return False
-        previous_state = self._snapshot_state()
+        previous_state = self._snapshot_state(
+            project_ids=list(self._projects), folder_ids=[DEFAULT_FOLDER_ID]
+        )
         del self._folders[folder_id]
         self._projects = {
             project_uuid: project
@@ -919,7 +1105,9 @@ class AssetIndex:
         folder = self._folders.get(DEFAULT_FOLDER_ID)
         if folder is not None and self._path_key(folder.path) == self._path_key(normalized):
             return True
-        previous_state = self._snapshot_state()
+        previous_state = self._snapshot_state(
+            project_ids=list(self._projects), folder_ids=[DEFAULT_FOLDER_ID]
+        )
         previous_default_path = self._default_folder_path
         old_path = folder.path if folder is not None else ""
         new_path_key = self._path_key(normalized)
@@ -965,7 +1153,9 @@ class AssetIndex:
         project = self._projects.get(asset_id)
         if project is None:
             return None
-        previous_state = self._snapshot_state() if save else None
+        previous_state = (
+            self._snapshot_state(project_ids=[asset_id]) if save else None
+        )
         if "folder_id" in kwargs:
             target = self._folders.get(str(kwargs["folder_id"]))
             resolved_folder_id = self._folder_id_for_path(project.path)
@@ -974,6 +1164,8 @@ class AssetIndex:
             project.folder_id = target.id
         if "name" in kwargs:
             project.name = str(kwargs["name"])
+        if not save:
+            self._touch_catalog()
         if save and not self.save():
             assert previous_state is not None
             self._restore_state(previous_state)
@@ -1031,7 +1223,9 @@ class AssetIndex:
         uuid.UUID(project_uuid)
 
         with self._lock:
-            previous_state = self._snapshot_state() if save else None
+            previous_state = (
+                self._snapshot_state(project_ids=[project_uuid]) if save else None
+            )
             target_folder_id = self._folder_id_for_path(path)
             if target_folder_id is None:
                 target_folder_id = self._add_folder_record(str(Path(path).parent)).id
@@ -1090,14 +1284,25 @@ class AssetIndex:
                 return None
             path = project.path
             expected_uuid = project.project_uuid
-        kind, payload = self._read_project_runtime(path, expected_uuid)
+            known_metadata = None
+            if project.inspection_verified or project.inspection_restored:
+                known_metadata = (project.path_size_bytes, project.path_mtime_ns)
+        kind, payload = self._read_project_runtime(
+            path, expected_uuid, resolve_fallback=True,
+            known_metadata=known_metadata
+        )
         with self._lock:
             project = self._projects.get(asset_id)
             if project is None:
                 return None
             if project.path != path or project.project_uuid != expected_uuid:
                 return project
-            self._apply_runtime_result(project, kind, payload)
+            if kind == "UNCHANGED":
+                project.inspection_verified = True
+                project.inspection_restored = False
+            else:
+                self._apply_runtime_result(project, kind, payload)
+                self.save()
             return project
 
     @_synchronized
@@ -1117,7 +1322,7 @@ class AssetIndex:
         conflicting_uuid = self._project_by_path.get(path_key)
         if conflicting_uuid is not None and conflicting_uuid != asset_id:
             return False
-        previous_state = self._snapshot_state()
+        previous_state = self._snapshot_state(project_ids=[asset_id])
         folder_id = self._folder_id_for_path(path)
         if folder_id is None:
             folder_id = self._add_folder_record(str(Path(path).parent)).id
@@ -1133,11 +1338,57 @@ class AssetIndex:
         return False
 
     def verify_projects_batch(self, asset_ids: List[str]) -> int:
-        verified = 0
-        for asset_id in asset_ids:
-            if self.verify_asset(asset_id) is not None:
+        with self._lock:
+            work = []
+            for asset_id in dict.fromkeys(asset_ids):
+                project = self._projects.get(asset_id)
+                if project is not None:
+                    work.append(
+                        (
+                            asset_id,
+                            project.path,
+                            project.project_uuid,
+                            (
+                                (project.path_size_bytes, project.path_mtime_ns)
+                                if project.inspection_verified
+                                or project.inspection_restored
+                                else None
+                            ),
+                        )
+                    )
+        results = []
+        for asset_id, path, expected_uuid, metadata in work:
+            results.append(
+                (
+                    asset_id,
+                    path,
+                    expected_uuid,
+                    self._read_project_runtime(
+                        path, expected_uuid, known_metadata=metadata
+                    ),
+                )
+            )
+        with self._lock:
+            verified = 0
+            changed = False
+            for asset_id, path, expected_uuid, (kind, payload) in results:
+                project = self._projects.get(asset_id)
+                if (
+                    project is None
+                    or project.path != path
+                    or project.project_uuid != expected_uuid
+                ):
+                    continue
+                if kind == "UNCHANGED":
+                    project.inspection_verified = True
+                    project.inspection_restored = False
+                else:
+                    self._apply_runtime_result(project, kind, payload)
+                    changed = True
                 verified += 1
-        return verified
+            if changed:
+                self.save()
+            return verified
 
     def verify_projects(self) -> Tuple[int, int]:
         with self._lock:

--- a/src/python/lfs_plugins/asset_manager_panel.py
+++ b/src/python/lfs_plugins/asset_manager_panel.py
@@ -242,6 +242,8 @@ class AssetManagerPanel(Panel):
             scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
             if callable(scheduler):
                 scheduler(complete)
+            else:
+                complete()
 
         threading.Thread(
             target=worker, daemon=True, name="AssetManagerCatalogLoad"

--- a/src/python/lfs_plugins/asset_manager_panel.py
+++ b/src/python/lfs_plugins/asset_manager_panel.py
@@ -140,7 +140,12 @@ class AssetManagerPanel(Panel):
         self._scan_stopped_visible = False
         self._published_scan_active = False
         self._published_scan_status = ""
+        # Keep direct programmatic refreshes usable before the first DOM mount;
+        # on_unmount flips this false and mount generations guard callbacks.
         self._panel_mounted = True
+        self._mount_generation = 0
+        self._backend_load_active = False
+        self._ui_poll_timer: Optional[threading.Timer] = None
         self._catalog_load_failed = False
         self._drag_payload_token: Optional[int] = None
         self._last_project_write_generation: Optional[int] = None
@@ -191,6 +196,56 @@ class AssetManagerPanel(Panel):
             self._log_error("Failed to initialize Asset Manager: %s", exc)
             self._catalog_load_failed = True
             return False
+
+    def _start_backend_initialization(self) -> None:
+        if self._backend_load_active or not BACKEND_AVAILABLE:
+            if not BACKEND_AVAILABLE:
+                self._catalog_load_failed = True
+            return
+        self._backend_load_active = True
+        generation = self._mount_generation
+
+        def worker() -> None:
+            index = None
+            storage_path = None
+            default_path = ""
+            loaded = False
+            try:
+                storage_path = resolve_asset_manager_storage_path()
+                storage_path.mkdir(parents=True, exist_ok=True)
+                index = AssetIndex()
+                loaded = index.load()
+                default_path = str(resolve_default_asset_directory())
+            except Exception as exc:
+                self._log_error("Failed to initialize Asset Manager: %s", exc)
+
+            def complete() -> None:
+                if generation != self._mount_generation or not self._panel_mounted:
+                    self._backend_load_active = False
+                    return
+                self._backend_load_active = False
+                self._catalog_load_failed = not loaded
+                if index is not None:
+                    self._asset_index = index
+                    self.STORAGE_PATH = storage_path
+                    self.__class__.STORAGE_PATH = storage_path
+                    self._last_default_folder_path = default_path
+                    self._catalog_epoch_seen = self._catalog_epoch()
+                    self._repair_selection()
+                    self._refresh_records(assets=True, folders=True)
+                    if self._handle:
+                        self._handle.dirty_all()
+                    self._start_catalog_verify()
+                    self._scan_asset_folders()
+                self._request_model_update()
+
+            scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
+            if callable(scheduler):
+                scheduler(complete)
+
+        threading.Thread(
+            target=worker, daemon=True, name="AssetManagerCatalogLoad"
+        ).start()
 
     def on_bind_model(self, ctx):
         model = ctx.create_data_model("asset_manager")
@@ -413,6 +468,14 @@ class AssetManagerPanel(Panel):
         assets = getattr(self._asset_index, "assets", {}) if self._asset_index else {}
         return assets if isinstance(assets, dict) else {}
 
+    def _asset_dict(self, asset_id: Optional[str]) -> Optional[Dict[str, Any]]:
+        if not asset_id or not self._asset_index:
+            return None
+        getter = getattr(self._asset_index, "get_asset_dict", None)
+        if callable(getter):
+            return getter(asset_id)
+        return self._asset_index_assets().get(asset_id)
+
     def _asset_index_folders(self) -> Dict[str, Dict[str, Any]]:
         folders = getattr(self._asset_index, "folders", {}) if self._asset_index else {}
         return folders if isinstance(folders, dict) else {}
@@ -568,10 +631,22 @@ class AssetManagerPanel(Panel):
         }
 
     def _release_obsolete_thumbnail_sources(self) -> None:
-        live_ids = set(self._asset_index_assets())
+        ids = getattr(self._asset_index, "iter_project_ids", None)
+        live_ids = set(ids() if callable(ids) else self._asset_index_assets())
         stale_ids = set(self._thumbnail_sources_by_asset).difference(live_ids)
         release_texture = getattr(lf.ui, "release_rml_texture", None)
         for asset_id in stale_ids:
+            source = self._thumbnail_sources_by_asset.pop(asset_id)
+            if callable(release_texture):
+                release_texture(source)
+
+    def _release_thumbnails_outside_window(self) -> None:
+        visible = {
+            str(asset.get("id") or asset.get("project_uuid") or "")
+            for asset in self._window_assets(self._filtered_assets())
+        }
+        release_texture = getattr(lf.ui, "release_rml_texture", None)
+        for asset_id in set(self._thumbnail_sources_by_asset).difference(visible):
             source = self._thumbnail_sources_by_asset.pop(asset_id)
             if callable(release_texture):
                 release_texture(source)
@@ -664,6 +739,10 @@ class AssetManagerPanel(Panel):
 
     def get_all_assets_count(self) -> int:
         query = self._search_query.strip().casefold()
+        if not query:
+            count = getattr(self._asset_index, "count", None)
+            if callable(count):
+                return int(count())
         return sum(
             self._asset_matches_query(asset, query)
             for asset in self._asset_index_assets().values()
@@ -720,7 +799,7 @@ class AssetManagerPanel(Panel):
 
     def _get_selected_asset(self) -> Optional[Dict[str, Any]]:
         asset_id = self.get_selected_asset_id()
-        return self._asset_index_assets().get(asset_id) if asset_id else None
+        return self._asset_dict(asset_id)
 
     def get_selected_asset_name(self) -> str:
         asset = self._get_selected_asset()
@@ -960,7 +1039,7 @@ class AssetManagerPanel(Panel):
         asset_id = self._resolve_event_value(args, _ev, "data-asset-id") or self.get_selected_asset_id()
         if not asset_id or not self._asset_index:
             return
-        asset = self._asset_index_assets().get(asset_id)
+        asset = self._asset_dict(asset_id)
         candidate = str((asset or {}).get("relocation_candidate") or "")
         if not candidate:
             return
@@ -981,7 +1060,7 @@ class AssetManagerPanel(Panel):
         project = self._asset_index.verify_asset(asset_id)
         if project is None:
             return
-        asset = project.to_dict() if hasattr(project, "to_dict") else self._asset_index_assets().get(asset_id, {})
+        asset = project.to_dict() if hasattr(project, "to_dict") else (self._asset_dict(asset_id) or {})
         if not self._project_available(asset):
             self.refresh_catalog(scan_folders=False)
             return
@@ -1058,7 +1137,7 @@ class AssetManagerPanel(Panel):
             self.on_remove_asset(None, None, [asset_id])
 
     def _show_asset_context_menu(self, asset_id: str) -> bool:
-        asset = self._asset_index_assets().get(asset_id)
+        asset = self._asset_dict(asset_id)
         return bool(asset) and self._show_shared_context_menu(
             self._asset_context_menu_items(asset),
             lambda action: self._handle_asset_context_action(action, asset_id),
@@ -1066,7 +1145,7 @@ class AssetManagerPanel(Panel):
 
     def on_rename_asset(self, _handle, _ev, args):
         asset_id = self._resolve_event_value(args, _ev, "data-asset-id")
-        asset = self._asset_index_assets().get(asset_id)
+        asset = self._asset_dict(asset_id)
         if not asset or not self._asset_index:
             return
         current_name = str(asset.get("name") or Path(str(asset.get("path") or "")).stem)
@@ -1086,7 +1165,7 @@ class AssetManagerPanel(Panel):
 
     def on_show_in_folder(self, _handle, _ev, args):
         asset_id = self._resolve_event_value(args, _ev, "data-asset-id")
-        asset = self._asset_index_assets().get(asset_id)
+        asset = self._asset_dict(asset_id)
         if asset:
             reveal = getattr(lf.ui, "reveal_in_file_manager", None)
             if callable(reveal):
@@ -1250,6 +1329,7 @@ class AssetManagerPanel(Panel):
                     scan_folder_id,
                     scan_directory,
                     progress,
+                    self._mount_generation,
                 ),
                 daemon=True,
                 name="AssetManagerFolderScan",
@@ -1265,6 +1345,7 @@ class AssetManagerPanel(Panel):
         folder_id: Optional[str],
         directory: Optional[str],
         progress: AssetFolderScanProgress,
+        generation: int,
     ) -> None:
         global _folder_scan_completed_in_process
         try:
@@ -1302,7 +1383,7 @@ class AssetManagerPanel(Panel):
                 _folder_scan_completed_in_process = True
             scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
             if callable(scheduler):
-                scheduler(self._complete_folder_scan)
+                scheduler(lambda: self._complete_folder_scan(generation))
 
     def _finish_folder_scan(self) -> None:
         with self._folder_scan_lock:
@@ -1313,7 +1394,9 @@ class AssetManagerPanel(Panel):
             return
         self.refresh_catalog(scan_folders=False)
 
-    def _complete_folder_scan(self) -> None:
+    def _complete_folder_scan(self, generation: Optional[int] = None) -> None:
+        if generation is not None and generation != self._mount_generation:
+            return
         self._finish_folder_scan()
         with self._folder_scan_lock:
             rerun = self._folder_scan_rerun_pending
@@ -1362,18 +1445,27 @@ class AssetManagerPanel(Panel):
             self._catalog_verify_refresh_pending = False
             cancel_event = threading.Event()
             self._catalog_verify_cancel = cancel_event
+            visible_ids = [
+                str(asset.get("id") or asset.get("project_uuid") or "")
+                for asset in self._window_assets(self._filtered_assets())
+            ]
             thread = threading.Thread(
                 target=self._catalog_verify_worker,
-                args=(self._asset_index, cancel_event),
+                args=(self._asset_index, cancel_event, visible_ids, self._mount_generation),
                 daemon=True,
                 name="AssetManagerCatalogVerify",
             )
             self._catalog_verify_thread = thread
         thread.start()
 
-    def _catalog_verify_worker(self, index: Any, cancel_event: threading.Event) -> None:
+    def _catalog_verify_worker(
+        self, index: Any, cancel_event: threading.Event,
+        visible_ids: List[str], generation: int,
+    ) -> None:
         try:
-            verified = verify_catalog_projects(index, cancel_event)
+            verified = verify_catalog_projects(
+                index, cancel_event, visible_asset_ids=visible_ids
+            )
             _log.info("Asset catalog verify: verified=%d cancelled=%s", verified, cancel_event.is_set())
         except Exception:
             _log.exception("Asset Manager catalog verify failed")
@@ -1385,9 +1477,11 @@ class AssetManagerPanel(Panel):
                     self._catalog_verify_thread = None
             scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
             if callable(scheduler):
-                scheduler(self._complete_catalog_verify)
+                scheduler(lambda: self._complete_catalog_verify(generation))
 
-    def _complete_catalog_verify(self) -> None:
+    def _complete_catalog_verify(self, generation: Optional[int] = None) -> None:
+        if generation is not None and generation != self._mount_generation:
+            return
         with self._folder_scan_lock:
             if not self._catalog_verify_refresh_pending:
                 return
@@ -1447,7 +1541,9 @@ class AssetManagerPanel(Panel):
             self._handle.dirty("all_assets_count")
         if assets:
             self._release_obsolete_thumbnail_sources()
-            self._handle.update_record_list("assets", self.get_filtered_assets())
+            rows = self.get_filtered_assets()
+            self._release_thumbnails_outside_window()
+            self._handle.update_record_list("assets", rows)
             self._handle.dirty("assets")
             for field in (
                 "asset_results_summary",
@@ -1649,7 +1745,7 @@ class AssetManagerPanel(Panel):
         asset = (
             project.to_dict()
             if project is not None and hasattr(project, "to_dict")
-            else self._asset_index_assets().get(asset_id, {})
+            else (self._asset_dict(asset_id) or {})
         )
         if not self._project_available(asset):
             self.refresh_catalog(scan_folders=False)
@@ -1985,10 +2081,11 @@ class AssetManagerPanel(Panel):
     def on_mount(self, doc):
         super().on_mount(doc)
         self._panel_mounted = True
+        self._mount_generation += 1
+        self._schedule_slow_poll(self._mount_generation)
         self._doc = doc
         if self._asset_index is None:
-            if not self._initialize_backend():
-                self._log_warn("Asset Manager catalog could not be loaded")
+            self._start_backend_initialization()
         self._repair_selection()
         self._bind_dom_event_listeners(doc)
         self._subscribe_reactive_state()
@@ -1999,21 +2096,15 @@ class AssetManagerPanel(Panel):
             self._handle.dirty_all()
         self._catalog_epoch_seen = self._catalog_epoch()
         self._refresh_after_project_write()
-        self._start_catalog_verify()
-        if not _folder_scan_completed_in_process:
+        if self._asset_index is not None:
+            self._start_catalog_verify()
+        if self._asset_index is not None and not _folder_scan_completed_in_process:
             self._scan_asset_folders()
 
     def on_update(self, doc):
-        changed = self._sync_default_folder_path()
-        changed = self._refresh_after_project_write() or changed
+        changed = False
         if self._sync_panel_space_state():
             self._dirty_fields("is_floating")
-            changed = True
-        if self._folder_scan_refresh_pending:
-            self._complete_folder_scan()
-            changed = True
-        if self._catalog_verify_refresh_pending:
-            self._complete_catalog_verify()
             changed = True
         if self._publish_catalog_if_changed():
             changed = True
@@ -2025,27 +2116,43 @@ class AssetManagerPanel(Panel):
             changed = True
         return changed
 
+    def _schedule_slow_poll(self, generation: int) -> None:
+        def dispatch() -> None:
+            scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
+
+            def tick() -> None:
+                if generation != self._mount_generation or not self._panel_mounted:
+                    return
+                changed = self._sync_default_folder_path()
+                changed = self._refresh_after_project_write() or changed
+                if changed:
+                    self._request_model_update()
+                self._schedule_slow_poll(generation)
+
+            if callable(scheduler):
+                scheduler(tick)
+
+        timer = threading.Timer(1.0, dispatch)
+        timer.daemon = True
+        self._ui_poll_timer = timer
+        timer.start()
+
     def on_unmount(self, doc):
         with self._folder_scan_lock:
             self._panel_mounted = False
+            self._mount_generation += 1
             self._folder_scan_rerun_pending = False
             self._folder_scan_rerun_target = None
             cancel = self._folder_scan_cancel
-            thread = self._folder_scan_thread
             verify_cancel = self._catalog_verify_cancel
-            verify_thread = self._catalog_verify_thread
+            poll_timer = self._ui_poll_timer
+            self._ui_poll_timer = None
         if cancel is not None:
             cancel.set()
         if verify_cancel is not None:
             verify_cancel.set()
-        if thread is not None and thread.ident is not None:
-            thread.join(timeout=2.0)
-            if thread.is_alive():
-                self._log_warn("Asset Manager folder scan did not finish before unmount")
-        if verify_thread is not None and verify_thread.ident is not None:
-            verify_thread.join(timeout=2.0)
-            if verify_thread.is_alive():
-                self._log_warn("Asset Manager catalog verify did not finish before unmount")
+        if poll_timer is not None:
+            poll_timer.cancel()
         if self._drag_payload_token is not None:
             cancel_drag = getattr(lf.ui, "cancel_drag_payload", None)
             if callable(cancel_drag):

--- a/src/python/lfs_plugins/asset_watch.py
+++ b/src/python/lfs_plugins/asset_watch.py
@@ -92,10 +92,19 @@ def _directory_is_pruned(name: str) -> bool:
     return name.startswith(".") or name.casefold() in _PRUNED_DIRECTORY_NAMES
 
 
+def _entry_is_dir(entry: Any) -> bool:
+    """Support both real DirEntry objects and lightweight test doubles."""
+    try:
+        return entry.is_dir(follow_symlinks=False)
+    except TypeError:
+        return entry.is_dir()
+
+
 def iter_licht_projects(
     directory: str,
     cancel_event: threading.Event | None = None,
     progress: AssetFolderScanProgress | None = None,
+    directory_mtimes: dict[str, int] | None = None,
 ) -> Iterator[str]:
     """Yield .licht files beneath one Asset Manager folder as they are found."""
     root = Path(directory).expanduser()
@@ -103,22 +112,24 @@ def iter_licht_projects(
         _log.warning("Asset Manager folder is unavailable: %s", root)
         return
 
-    pruned_user_directories: set[Path] = set()
+    pruned_user_directories: set[str] = set()
     try:
         import lichtfeld as lf
 
         getter = getattr(getattr(lf, "ui", None), "get_default_project_location", None)
         if callable(getter):
-            user_root = Path(str(getter() or "")).expanduser().parent.resolve()
+            user_root = os.path.normcase(
+                os.path.dirname(os.path.abspath(str(getter() or "")))
+            )
             pruned_user_directories = {
-                (user_root / "tmp").resolve(),
-                (user_root / "recovery").resolve(),
+                os.path.join(user_root, "tmp"),
+                os.path.join(user_root, "recovery"),
             }
     except (OSError, RuntimeError, TypeError, ValueError):
         pass
 
     try:
-        if root.resolve() in pruned_user_directories:
+        if os.path.normcase(os.path.abspath(str(root))) in pruned_user_directories:
             return
     except OSError:
         pass
@@ -130,14 +141,17 @@ def iter_licht_projects(
     def _on_error(exc: OSError) -> None:
         _log.warning("Could not scan Asset Manager folder: %s", exc)
 
-    for current_root, directory_names, filenames in os.walk(
-        root,
-        topdown=True,
-        onerror=_on_error,
-        followlinks=False,
-    ):
+    pending = [root]
+    while pending:
+        current = pending.pop()
         if cancel_event is not None and cancel_event.is_set():
             return
+        try:
+            stat = current.stat()
+        except OSError as exc:
+            _on_error(exc)
+            continue
+        current_text = os.path.normcase(os.path.abspath(str(current)))
         visited_directories += 1
         if progress is not None:
             progress.add_directory()
@@ -146,32 +160,48 @@ def iter_licht_projects(
                 "Asset folder %s is very large (>10000 directories); consider a smaller folder",
                 root,
             )
+        if directory_mtimes is not None:
+            directory_mtimes[current_text] = int(stat.st_mtime_ns)
         kept_directories = []
-        for name in directory_names:
-            if _directory_is_pruned(name):
-                continue
-            if pruned_user_directories:
-                try:
-                    if (Path(current_root) / name).resolve() in pruned_user_directories:
+        try:
+            entries = os.scandir(current)
+        except OSError as exc:
+            _on_error(exc)
+            continue
+        with entries:
+            for entry in entries:
+                name = entry.name
+                if _entry_is_dir(entry):
+                    if _directory_is_pruned(name):
                         continue
-                except OSError:
-                    pass
-            kept_directories.append(name)
-        directory_names[:] = sorted(kept_directories)
-        for filename in sorted(filenames):
-            if cancel_event is not None and cancel_event.is_set():
-                return
-            path = Path(current_root) / filename
-            if not is_supported_asset_path(str(path)):
-                continue
-            try:
-                if path.is_file():
-                    resolved = str(path.resolve())
+                    child_text = os.path.normcase(
+                        os.path.abspath(os.path.join(current_text, name))
+                    )
+                    if any(
+                        child_text == prune or child_text.startswith(prune + os.sep)
+                        for prune in pruned_user_directories
+                    ):
+                        continue
+                    kept_directories.append(Path(entry.path))
+                    continue
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                # The directory cache records scan metadata, but discovery
+                # still runs so missing/unreadable rows can find a repair
+                # candidate. Healthy unchanged rows skip inspection below.
+                path = Path(entry.path)
+                if not is_supported_asset_path(str(path)):
+                    continue
+                if cancel_event is not None and cancel_event.is_set():
+                    return
+                try:
+                    resolved = os.path.abspath(str(path))
                     if progress is not None:
                         progress.add_project()
                     yield resolved
-            except OSError as exc:
-                _log.warning("Could not inspect Asset Manager path %s: %s", path, exc)
+                except OSError as exc:
+                    _log.warning("Could not inspect Asset Manager path %s: %s", path, exc)
+        pending.extend(reversed(kept_directories))
 
 
 def discover_licht_projects(
@@ -195,15 +225,24 @@ def scan_asset_folder(
         return AssetFolderScanResult(cancelled=True)
     if progress is not None:
         progress.report(current_root=directory)
-    return _register_discovered_streaming(
+    directory_mtimes = getattr(index, "_directory_mtimes", None)
+    before_mtimes = dict(directory_mtimes) if isinstance(directory_mtimes, dict) else None
+    result = _register_discovered_streaming(
         index,
         (
             (path, folder_id)
-            for path in iter_licht_projects(directory, cancel_event, progress)
+            for path in iter_licht_projects(
+                directory, cancel_event, progress, directory_mtimes
+            )
         ),
         cancel_event,
         progress,
     )
+    if isinstance(directory_mtimes, dict) and directory_mtimes != before_mtimes:
+        save = getattr(index, "save", None)
+        if callable(save) and not save():
+            _log.error("Failed to persist Asset Manager directory scan cache")
+    return result
 
 
 def scan_all_asset_folders(
@@ -244,7 +283,10 @@ def scan_all_asset_folders(
                 return
             if progress is not None:
                 progress.report(current_root=str(root))
-            for path in iter_licht_projects(str(root), cancel_event, progress):
+            directory_mtimes = getattr(index, "_directory_mtimes", None)
+            for path in iter_licht_projects(
+                str(root), cancel_event, progress, directory_mtimes
+            ):
                 path_key = os.path.normcase(path)
                 if path_key in seen_paths:
                     continue
@@ -253,13 +295,21 @@ def scan_all_asset_folders(
 
     if cancel_event is not None and cancel_event.is_set():
         return AssetFolderScanResult(cancelled=True)
-    return _register_discovered_streaming(index, _iter_all(), cancel_event, progress)
+    directory_mtimes = getattr(index, "_directory_mtimes", None)
+    before_mtimes = dict(directory_mtimes) if isinstance(directory_mtimes, dict) else None
+    result = _register_discovered_streaming(index, _iter_all(), cancel_event, progress)
+    if isinstance(directory_mtimes, dict) and directory_mtimes != before_mtimes:
+        save = getattr(index, "save", None)
+        if callable(save) and not save():
+            _log.error("Failed to persist Asset Manager directory scan cache")
+    return result
 
 
 def verify_catalog_projects(
     index: Any,
     cancel_event: threading.Event | None = None,
     *,
+    visible_asset_ids: Iterable[str] | None = None,
     batch_size: int = SCAN_BATCH_SIZE,
     interval_s: float = SCAN_BATCH_INTERVAL_S,
 ) -> int:
@@ -274,11 +324,18 @@ def verify_catalog_projects(
         for project in list_projects()
     ]
     asset_ids = [asset_id for asset_id in asset_ids if asset_id]
+    if visible_asset_ids is not None:
+        visible = [str(asset_id) for asset_id in visible_asset_ids]
+        visible_set = set(visible)
+        asset_ids = [
+            *[asset_id for asset_id in visible if asset_id in asset_ids],
+            *[asset_id for asset_id in asset_ids if asset_id not in visible_set],
+        ]
     verified = 0
     batch: list[str] = []
     last_flush = time.monotonic()
 
-    def flush() -> bool:
+    def flush(*, pause: bool = True) -> bool:
         nonlocal batch, verified, last_flush
         if not batch:
             return False
@@ -296,6 +353,9 @@ def verify_catalog_projects(
             return True
         batch = []
         last_flush = time.monotonic()
+        if pause and interval_s > 0 and cancel_event is not None:
+            cancel_event.wait(interval_s)
+            last_flush = time.monotonic()
         return False
 
     for asset_id in asset_ids:
@@ -307,7 +367,7 @@ def verify_catalog_projects(
         ):
             if flush():
                 return verified
-    flush()
+    flush(pause=False)
     return verified
 
 
@@ -337,6 +397,9 @@ def _register_discovered_streaming(
         nonlocal batch, added, already_cataloged, failed, last_flush
         if not batch:
             return False
+        # os.walk sorted filenames before yielding them. Keep that stable
+        # locator choice while retaining streaming between registration batches.
+        batch.sort(key=lambda item: os.path.normcase(item[0]))
         batch_added, batch_already, batch_failed, was_cancelled = (
             _commit_registration_batch(index, batch, cancel_event)
         )
@@ -395,6 +458,22 @@ def _existing_skips_inspection(existing: Any) -> bool:
     }
 
 
+def _known_path_is_unchanged(index: Any, existing: Any, path: str) -> bool:
+    if getattr(existing, "status", "AVAILABLE") in {
+        "MISSING", "UNREADABLE", "UNVERIFIED"
+    }:
+        return False
+    size = getattr(existing, "path_size_bytes", None)
+    mtime_ns = getattr(existing, "path_mtime_ns", None)
+    if size is None or mtime_ns is None or (not size and not mtime_ns):
+        return True
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return False
+    return (int(stat.st_size), int(stat.st_mtime_ns)) == (int(size), int(mtime_ns))
+
+
 def _commit_registration_batch(
     index: Any,
     batch: list[tuple[str, str]],
@@ -420,7 +499,7 @@ def _commit_registration_batch(
         try:
             if callable(find_by_path):
                 existing = find_by_path(path)
-                if existing is not None and _existing_skips_inspection(existing):
+                if existing is not None and _known_path_is_unchanged(index, existing, path):
                     already_cataloged += 1
                     continue
             prepared.append((path, folder_id, inspect(path)))

--- a/src/python/lfs_plugins/image_preview_panel.py
+++ b/src/python/lfs_plugins/image_preview_panel.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Image preview panel using RmlUI floating window."""
 
+import os
 import time
 from math import gcd
 from pathlib import Path
@@ -87,6 +88,9 @@ class ImagePreviewPanel(Panel):
         self._scroll_start_time = 0.0
 
         self._image_info_cache: dict[str, tuple[int, int, int]] = {}
+        self._path_stat_cache: dict[str, tuple[bool, int, int]] = {}
+        self._filmstrip_top_spacer = 0.0
+        self._filmstrip_bottom_spacer = 0.0
         self._last_training_params: tuple[int, int, bool] = (1, 0, False)
         self._decorator_cache: dict[str, str] = {}
         self._reactive_unsubscribers = []
@@ -163,6 +167,8 @@ class ImagePreviewPanel(Panel):
 
         model.bind_func("panel_label", lambda: self._get_title())
         model.bind_record_list("thumbs")
+        model.bind_func("filmstrip_top_spacer_height", lambda: f"{self._filmstrip_top_spacer:.1f}dp")
+        model.bind_func("filmstrip_bottom_spacer_height", lambda: f"{self._filmstrip_bottom_spacer:.1f}dp")
         self._handle = model.get_handle()
 
     def on_mount(self, doc):
@@ -289,8 +295,15 @@ class ImagePreviewPanel(Panel):
         if not image_paths:
             return
 
-        self._image_paths = [p.resolve() for p in image_paths]
-        self._mask_paths = [p.resolve() if p else None for p in mask_paths] if mask_paths else [None] * len(image_paths)
+        self._image_paths = [Path(p) for p in image_paths]
+        self._mask_paths = [Path(p) if p else None for p in mask_paths] if mask_paths else [None] * len(image_paths)
+        self._path_stat_cache = {}
+        for path in self._image_paths + [p for p in self._mask_paths if p is not None]:
+            try:
+                stat = os.stat(path)
+                self._path_stat_cache[str(path)] = (True, int(stat.st_mtime_ns), int(stat.st_size))
+            except OSError:
+                self._path_stat_cache[str(path)] = (False, 0, 0)
         self._camera_uids = camera_uids if camera_uids is not None else [-1] * len(image_paths)
         self._current_index = min(start_index, len(image_paths) - 1)
         self._last_training_params = self._get_training_params()
@@ -401,7 +414,7 @@ class ImagePreviewPanel(Panel):
         if self._current_index >= len(self._mask_paths):
             return False
         mask_path = self._mask_paths[self._current_index]
-        return mask_path is not None and mask_path.exists()
+        return mask_path is not None and self._path_stat_cache.get(str(mask_path), (False, 0, 0))[0]
 
     def _close_panel(self):
         lf.ui.set_panel_enabled("lfs.image_preview", False)
@@ -763,13 +776,13 @@ class ImagePreviewPanel(Panel):
         lo = max(0, self._current_index - half)
         hi = min(n, self._current_index + half)
 
+        self._filmstrip_top_spacer = lo * 46.0
+        self._filmstrip_bottom_spacer = max(0, n - hi) * 46.0
         records = []
-        for i, path in enumerate(self._image_paths):
-            if lo <= i < hi:
-                uid = self._camera_uids[i] if i < len(self._camera_uids) else -1
-                dec = f"image({self._make_preview_url(path, uid, THUMB_MAX_PX)})"
-            else:
-                dec = "none"
+        for i in range(lo, hi):
+            path = self._image_paths[i]
+            uid = self._camera_uids[i] if i < len(self._camera_uids) else -1
+            dec = f"image({self._make_preview_url(path, uid, THUMB_MAX_PX)})"
             records.append({
                 "index": i,
                 "label": f"{i + 1:02d}",
@@ -777,14 +790,17 @@ class ImagePreviewPanel(Panel):
                 "decorator": dec,
             })
         self._handle.update_record_list("thumbs", records)
+        self._handle.dirty("filmstrip_top_spacer_height")
+        self._handle.dirty("filmstrip_bottom_spacer_height")
 
         self._scroll_filmstrip_smooth(filmstrip, self._current_index)
 
     def _scroll_filmstrip_smooth(self, filmstrip, index: int):
         children = filmstrip.children()
-        if index < 0 or index >= len(children):
+        child_index = index - max(0, self._current_index - FILMSTRIP_WINDOW // 2) + 1
+        if child_index < 1 or child_index >= len(children) - 1:
             return
-        el = children[index]
+        el = children[child_index]
         item_top = el.offset_top
         item_bot = item_top + el.offset_height
         view_h = filmstrip.client_height
@@ -1211,8 +1227,9 @@ def open_camera_preview_by_uid(cam_uid: int):
     scene = lf.get_scene()
     if not scene:
         return
+    nodes = scene.get_nodes()
     target = None
-    for node in scene.get_nodes():
+    for node in nodes:
         if node.type == lf.scene.NodeType.CAMERA and node.camera_uid == cam_uid:
             target = node
             break
@@ -1220,14 +1237,16 @@ def open_camera_preview_by_uid(cam_uid: int):
         return
 
     parent = scene.get_node_by_id(target.parent_id) if target.parent_id >= 0 else None
-    child_ids = parent.children if parent else [n.id for n in scene.get_nodes() if n.type == lf.scene.NodeType.CAMERA]
+    child_ids = parent.children if parent else [n.id for n in nodes if n.type == lf.scene.NodeType.CAMERA]
+
+    nodes_by_id = {node.id: node for node in nodes}
 
     image_paths = []
     mask_paths = []
     camera_uids = []
     start_index = 0
     for cid in child_ids:
-        child = scene.get_node_by_id(cid)
+        child = nodes_by_id.get(cid)
         if not child or child.type != lf.scene.NodeType.CAMERA or not child.image_path:
             continue
         if child.id == target.id:

--- a/src/python/lfs_plugins/import_panels.py
+++ b/src/python/lfs_plugins/import_panels.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """RmlUI panels for dataset and checkpoint import flows."""
 
+import threading
+import time
 from pathlib import Path
 
 import lichtfeld as lf
@@ -58,6 +60,8 @@ class _ImportDialogPanel(Panel):
 
     def on_mount(self, doc):
         super().on_mount(doc)
+        if hasattr(self, "_dialog_mounted"):
+            self._dialog_mounted = True
         self._last_lang = lf.ui.get_current_language()
         self._escape_revert = w.EscapeRevertController()
         doc.add_event_listener("keydown", self._on_keydown)
@@ -79,6 +83,11 @@ class _ImportDialogPanel(Panel):
         self._subscribe_reactive_state()
 
     def on_unmount(self, _doc):
+        if hasattr(self, "_dialog_mounted"):
+            self._dialog_mounted = False
+            self._source_generation += 1
+            self._source_probe_cancel.set()
+            self._source_probe_active = False
         self._unsubscribe_reactive_state()
 
     def _subscribe_reactive_state(self):
@@ -179,6 +188,15 @@ class NewProjectPanel(_ImportDialogPanel):
         self._embed_dataset = False
         self._advanced_expanded = False
         self._last_lang = ""
+        self._source_generation = 0
+        self._source_probe_due = 0.0
+        self._source_probe_active = False
+        self._source_probe_cancel = threading.Event()
+        self._dialog_mounted = False
+        self._colmap_available = False
+        self._target_exists_cached = False
+        self._dedupe_name_cache: dict[str, str] = {}
+        self._name_derived_from_source = False
 
     def on_bind_model(self, ctx):
         model = ctx.create_data_model("new_project")
@@ -228,12 +246,17 @@ class NewProjectPanel(_ImportDialogPanel):
 
     def on_update(self, doc):
         del doc
+        changed = False
         current_lang = lf.ui.get_current_language()
         if current_lang != self._last_lang:
             self._last_lang = current_lang
             self._dirty_model()
-            return True
-        return False
+            changed = True
+        if self._source_probe_due and time.monotonic() >= self._source_probe_due:
+            self._source_probe_due = 0.0
+            self._start_source_probe()
+            changed = True
+        return changed
 
     def show(self, source_path: str = "") -> bool:
         self._name = ""
@@ -249,9 +272,18 @@ class NewProjectPanel(_ImportDialogPanel):
         self._apply_auto_crop = False
         self._embed_dataset = bool(getattr(lf.ui, "get_embed_dataset_by_default", lambda: False)())
         self._advanced_expanded = False
+        self._source_generation += 1
+        self._source_probe_cancel.set()
+        self._source_probe_cancel = threading.Event()
+        self._source_probe_due = 0.0
+        self._colmap_available = False
+        self._target_exists_cached = False
+        self._dedupe_name_cache = {}
+        self._name_derived_from_source = False
         params = lf.optimization_params()
         self._ppisp_sidecar_path = ""
         self._set_source_path(source_path, derive_name=True)
+        self._start_source_probe()
         self._ppisp_sidecar_path = (
             str(params.ppisp_sidecar_path) if params and params.has_params() else ""
         )
@@ -277,13 +309,11 @@ class NewProjectPanel(_ImportDialogPanel):
         self._dataset_info = None
         if not next_value:
             self._source_kind = "blank"
-        elif Path(next_value).is_dir() and lf.is_dataset_path(next_value):
-            self._source_kind = "dataset"
-            self._dataset_info = lf.detect_dataset_info(str(self._preview_base_path(next_value)))
-        elif Path(next_value).is_file() and self._is_splat_path(next_value):
+        elif self._is_splat_path(next_value):
             self._source_kind = "splat"
         else:
-            self._source_kind = "invalid"
+            self._source_kind = "checking"
+            self._source_probe_due = time.monotonic() + 0.3
 
         self._dirty_model(
             "source_path",
@@ -320,12 +350,114 @@ class NewProjectPanel(_ImportDialogPanel):
             stem = source.name if self._source_kind == "dataset" else source.stem
             if stem:
                 self._set_name(self._dedupe_name(stem))
+                self._name_derived_from_source = True
         if previous != self._source_path:
+            self._source_probe_active = False
+            self._source_generation += 1
+            self._source_probe_cancel.set()
+            self._source_probe_cancel = threading.Event()
             self._init_path = ""
             self._ppisp_sidecar_path = ""
 
+    def _start_source_probe(self) -> None:
+        if self._source_probe_active:
+            return
+        self._source_probe_active = True
+        path = self._source_path
+        name = self._name
+        location = str(getattr(lf.ui, "get_project_location", lambda: "")() or "")
+        generation = self._source_generation
+        cancel = self._source_probe_cancel
+
+        def worker() -> None:
+            kind = "blank" if not path else "invalid"
+            info = None
+            colmap = False
+            try:
+                if cancel.is_set():
+                    if cancel is self._source_probe_cancel:
+                        self._source_probe_active = False
+                    return
+                if path and lf.is_dataset_path(path):
+                    kind = "dataset"
+                    info = lf.detect_dataset_info(str(self._preview_base_path(path)))
+                    colmap = bool(info and getattr(info, "sparse_path", "") and
+                                  _directory_has_colmap_file(str(info.sparse_path)))
+                elif path and Path(path).is_file() and self._is_splat_path(path):
+                    kind = "splat"
+            except Exception:
+                kind = "invalid"
+            base = name.strip() or "untitled"
+            candidate = Path(location) / f"{base}.licht"
+            target_exists = candidate.exists()
+            deduped = base
+            suffix = 2
+            while (Path(location) / f"{deduped}.licht").exists():
+                deduped = f"{base}-{suffix}"
+                suffix += 1
+            result = (kind, info, colmap, target_exists, base, deduped)
+
+            def complete() -> None:
+                if generation != self._source_generation or cancel.is_set():
+                    return
+                if not self._dialog_mounted:
+                    self._source_probe_active = False
+                    self._source_probe_due = time.monotonic() + 0.3
+                    return
+                self._source_probe_active = False
+                (
+                    self._source_kind,
+                    self._dataset_info,
+                    self._colmap_available,
+                    target_exists,
+                    base,
+                    deduped,
+                ) = result
+                # A name edit can race the source probe; never publish the
+                # old name's filesystem result over the current name.
+                if self._name == name:
+                    self._target_exists_cached = target_exists
+                    self._dedupe_name_cache[base] = deduped
+                    if self._name_derived_from_source and deduped != base:
+                        self._name = deduped
+                        self._target_exists_cached = False
+                self._dirty_model()
+
+            scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
+            if callable(scheduler):
+                scheduler(complete)
+            else:
+                complete()
+
+        scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
+        if callable(scheduler):
+            threading.Thread(
+                target=worker, daemon=True, name="ImportDatasetProbe"
+            ).start()
+        else:
+            worker()
+
+    def _refresh_target_cache(self) -> None:
+        location = str(getattr(lf.ui, "get_project_location", lambda: "")() or "")
+        base = self._name.strip() or "untitled"
+        candidate = Path(location) / f"{base}.licht"
+        self._target_exists_cached = candidate.exists()
+        deduped = base
+        suffix = 2
+        while (Path(location) / f"{deduped}.licht").exists():
+            deduped = f"{base}-{suffix}"
+            suffix += 1
+        self._dedupe_name_cache[base] = deduped
+
     def _set_name(self, value):
         self._name = str(value)
+        self._name_derived_from_source = False
+        scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
+        if callable(scheduler):
+            self._target_exists_cached = False
+            self._source_probe_due = time.monotonic() + 0.3
+        else:
+            self._refresh_target_cache()
         self._dirty_model("name", "name_valid", "target_exists", "can_create", "location_preview", "create_hint")
 
     def _name_is_valid(self) -> bool:
@@ -341,10 +473,14 @@ class NewProjectPanel(_ImportDialogPanel):
         return Path(location) / f"{self._name.strip()}.licht"
 
     def _target_exists(self) -> bool:
-        return bool(self._name.strip()) and self._target_path().exists()
+        return bool(self._name.strip()) and self._target_exists_cached
 
     def _can_create(self) -> bool:
-        return self._name_is_valid() and not self._target_exists() and self._source_kind != "invalid"
+        return (
+            self._name_is_valid()
+            and not self._target_exists()
+            and self._source_kind in {"blank", "dataset", "splat"}
+        )
 
     def _location_preview(self) -> str:
         template = lf.ui.tr("new_project.location_preview") or "Will be created at: {path}"
@@ -361,22 +497,18 @@ class NewProjectPanel(_ImportDialogPanel):
 
     def _dedupe_name(self, name: str) -> str:
         base = name.strip() or "untitled"
-        location = Path(str(getattr(lf.ui, "get_project_location", lambda: "")() or ""))
-        candidate = base
-        suffix = 2
-        while (location / f"{candidate}.licht").exists():
-            candidate = f"{base}-{suffix}"
-            suffix += 1
-        return candidate
+        return self._dedupe_name_cache.get(base, base)
 
     def _dirty_model(self, *fields):
         if not self._handle:
             return
         if not fields:
             self._handle.dirty_all()
+            w.request_model_update(self._handle)
             return
         for field in fields:
             self._handle.dirty(field)
+        w.request_model_update(self._handle)
 
     def _string_attr(self, name: str) -> str:
         if self._dataset_info is None:
@@ -400,7 +532,7 @@ class NewProjectPanel(_ImportDialogPanel):
         sparse_path = getattr(self._dataset_info, "sparse_path", "")
         if not sparse_path:
             return False
-        return _directory_has_colmap_file(str(sparse_path))
+        return self._colmap_available
 
     def _show_min_track_length_warning(self) -> bool:
         return (
@@ -520,11 +652,15 @@ class NewProjectPanel(_ImportDialogPanel):
         path = lf.ui.open_dataset_folder_dialog()
         if path:
             self._set_source_path(path)
+            self._source_probe_due = 0.0
+            self._start_source_probe()
 
     def _on_browse_file(self, _handle=None, _ev=None, _args=None):
         path = lf.ui.open_ply_file_dialog("")
         if path:
             self._set_source_path(path)
+            self._source_probe_due = 0.0
+            self._start_source_probe()
 
     def _on_do_create(self, _handle=None, _ev=None, _args=None):
         if not self._can_create():

--- a/src/python/lfs_plugins/startup_recent_panel.py
+++ b/src/python/lfs_plugins/startup_recent_panel.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import threading
 import time
 from pathlib import Path
 
@@ -92,20 +93,30 @@ def try_show_startup_recent() -> bool:
     return True
 
 
-def build_project_rows(paths, *, max_rows: int = _MAX_ROWS) -> list[dict]:
+def build_project_rows(paths, *, max_rows: int = _MAX_ROWS, checks=None) -> list[dict]:
     """Build record-list rows for the top MRU paths (newest first)."""
     rows = []
     for index, path in enumerate(list(paths or [])[:max_rows]):
         path_text = str(path)
-        disposition = recovery_disposition(path_text)
+        if checks is None:
+            check = None
+            disposition = recovery_disposition(path_text)
+        else:
+            check = checks.get(path_text)
+            disposition = str(check.get("disposition", "checking")) if check else "checking"
         recoverable = disposition == "offer"
+        if checks is None:
+            last_opened = format_mtime(path_text)
+        else:
+            last_opened = check.get("last_opened", "checking") if check else "checking"
         rows.append(
             {
                 "index": index,
                 "path": path_text,
                 "display_name": display_name_for_path(path_text),
                 "path_display": elide_middle(path_text),
-                "last_opened": format_mtime(path_text),
+                "last_opened": last_opened,
+                "checking": disposition == "checking",
                 "recoverable": recoverable,
                 "show_recoverable": recoverable,
             }
@@ -132,6 +143,10 @@ class StartupRecentPanel(Panel):
         self._rows: list[dict] = []
         self._show_crash_notice = False
         self._dismissed = False
+        self._mounted = False
+        self._mount_generation = 0
+        self._check_cache: dict[str, dict] = {}
+        self._check_in_flight: set[str] = set()
 
     def on_bind_model(self, ctx):
         model = ctx.create_data_model("startup_recent")
@@ -178,6 +193,10 @@ class StartupRecentPanel(Panel):
     def on_mount(self, doc):
         super().on_mount(doc)
         self._dismissed = False
+        self._mounted = True
+        self._mount_generation += 1
+        self._check_cache = {}
+        self._check_in_flight.clear()
         doc.add_event_listener("keydown", self._on_keydown)
         # Title-bar close is Start Blank (Panel base wires #close-btn).
         projects_list = doc.get_element_by_id("startup-recent-list")
@@ -186,6 +205,8 @@ class StartupRecentPanel(Panel):
         self._refresh_rows(force=True)
 
     def on_unmount(self, doc):
+        self._mounted = False
+        self._mount_generation += 1
         if self._handle is not None:
             try:
                 doc.remove_data_model("startup_recent")
@@ -210,7 +231,8 @@ class StartupRecentPanel(Panel):
             paths = list(recent_fn() or [])
         except Exception:
             paths = []
-        rows = build_project_rows(paths, max_rows=_MAX_ROWS)
+        checks = self._check_cache if self._mounted else None
+        rows = build_project_rows(paths, max_rows=_MAX_ROWS, checks=checks)
         signature = tuple(
             (row["path"], row["recoverable"], row["last_opened"]) for row in rows
         )
@@ -223,7 +245,61 @@ class StartupRecentPanel(Panel):
         self._show_crash_notice = bool(rows) and bool(rows[0].get("recoverable"))
         self._handle.update_record_list("projects", rows)
         self._handle.dirty_all()
+        if self._mounted:
+            self._start_checks(paths)
         return True
+
+    def _start_checks(self, paths) -> None:
+        pending = []
+        for path in list(paths or [])[:_MAX_ROWS]:
+            path_text = str(path)
+            if path_text not in self._check_cache and path_text not in self._check_in_flight:
+                pending.append(path_text)
+                self._check_in_flight.add(path_text)
+        if not pending:
+            return
+        generation = self._mount_generation
+
+        def worker() -> None:
+            for path in pending:
+                try:
+                    stat = os.stat(path)
+                    mtime_ns = int(stat.st_mtime_ns)
+                except OSError:
+                    mtime_ns = 0
+                cache_key = (path, mtime_ns)
+                cached = next(
+                    (value for value in self._check_cache.values()
+                     if value.get("cache_key") == cache_key),
+                    None,
+                )
+                if cached is None:
+                    cached = {
+                        "cache_key": cache_key,
+                        "last_opened": format_mtime(path) if mtime_ns else "—",
+                        "disposition": recovery_disposition(path) if mtime_ns else "none",
+                    }
+                result = (path, cached)
+
+                def complete(result=result) -> None:
+                    if generation != self._mount_generation or not self._mounted:
+                        return
+                    result_path, result_value = result
+                    self._check_in_flight.discard(result_path)
+                    self._check_cache[result_path] = result_value
+                    self._refresh_rows(force=True)
+                    if self._handle:
+                        self._handle.dirty_all()
+
+                scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
+                if callable(scheduler):
+                    scheduler(complete)
+                else:
+                    complete()
+
+        threading.Thread(
+            target=worker, daemon=True, name="StartupRecentChecks"
+        ).start()
 
     def _find_with_attr(self, element, attr, stop=None):
         while element is not None and element != stop:
@@ -251,11 +327,6 @@ class StartupRecentPanel(Panel):
         path_text = str(path)
         name = display_name_for_path(path_text)
         missing_message = lf.ui.tr("startup_recent.project_missing").format(name=name)
-
-        # Pre-check existence so a deleted MRU entry does not raise into RmlUI.
-        if not Path(path_text).is_file():
-            self._report_open_error(missing_message)
-            return
 
         try:
             outcome = lf.project_open(path_text, True)

--- a/src/python/lfs_plugins/startup_recent_panel.py
+++ b/src/python/lfs_plugins/startup_recent_panel.py
@@ -147,6 +147,7 @@ class StartupRecentPanel(Panel):
         self._mount_generation = 0
         self._check_cache: dict[str, dict] = {}
         self._check_in_flight: set[str] = set()
+        self._check_cache_lock = threading.Lock()
 
     def on_bind_model(self, ctx):
         model = ctx.create_data_model("startup_recent")
@@ -195,8 +196,9 @@ class StartupRecentPanel(Panel):
         self._dismissed = False
         self._mounted = True
         self._mount_generation += 1
-        self._check_cache = {}
-        self._check_in_flight.clear()
+        with self._check_cache_lock:
+            self._check_cache = {}
+            self._check_in_flight.clear()
         doc.add_event_listener("keydown", self._on_keydown)
         # Title-bar close is Start Blank (Panel base wires #close-btn).
         projects_list = doc.get_element_by_id("startup-recent-list")
@@ -231,7 +233,11 @@ class StartupRecentPanel(Panel):
             paths = list(recent_fn() or [])
         except Exception:
             paths = []
-        checks = self._check_cache if self._mounted else None
+        if self._mounted:
+            with self._check_cache_lock:
+                checks = dict(self._check_cache)
+        else:
+            checks = None
         rows = build_project_rows(paths, max_rows=_MAX_ROWS, checks=checks)
         signature = tuple(
             (row["path"], row["recoverable"], row["last_opened"]) for row in rows
@@ -251,14 +257,17 @@ class StartupRecentPanel(Panel):
 
     def _start_checks(self, paths) -> None:
         pending = []
-        for path in list(paths or [])[:_MAX_ROWS]:
-            path_text = str(path)
-            if path_text not in self._check_cache and path_text not in self._check_in_flight:
-                pending.append(path_text)
-                self._check_in_flight.add(path_text)
+        with self._check_cache_lock:
+            for path in list(paths or [])[:_MAX_ROWS]:
+                path_text = str(path)
+                if path_text not in self._check_cache and path_text not in self._check_in_flight:
+                    pending.append(path_text)
+                    self._check_in_flight.add(path_text)
         if not pending:
             return
         generation = self._mount_generation
+        with self._check_cache_lock:
+            cache_snapshot = tuple(self._check_cache.values())
 
         def worker() -> None:
             for path in pending:
@@ -269,7 +278,7 @@ class StartupRecentPanel(Panel):
                     mtime_ns = 0
                 cache_key = (path, mtime_ns)
                 cached = next(
-                    (value for value in self._check_cache.values()
+                    (value for value in cache_snapshot
                      if value.get("cache_key") == cache_key),
                     None,
                 )
@@ -285,8 +294,9 @@ class StartupRecentPanel(Panel):
                     if generation != self._mount_generation or not self._mounted:
                         return
                     result_path, result_value = result
-                    self._check_in_flight.discard(result_path)
-                    self._check_cache[result_path] = result_value
+                    with self._check_cache_lock:
+                        self._check_in_flight.discard(result_path)
+                        self._check_cache[result_path] = result_value
                     self._refresh_rows(force=True)
                     if self._handle:
                         self._handle.dirty_all()

--- a/src/python/stubs/lichtfeld/io.pyi
+++ b/src/python/stubs/lichtfeld/io.pyi
@@ -232,7 +232,7 @@ class ProjectInspection:
     @property
     def fallback_preview_path(self) -> str: ...
 
-def inspect_project(path: str | os.PathLike) -> ProjectInspection:
+def inspect_project(path: str | os.PathLike, resolve_preview_fallback: bool = True) -> ProjectInspection:
     """
     Inspect validated .licht container metadata without reading project payloads.
     """

--- a/src/visualizer/gui/rmlui/resources/image_preview.rcss
+++ b/src/visualizer/gui/rmlui/resources/image_preview.rcss
@@ -42,6 +42,11 @@
     display: none;
 }
 
+.filmstrip-virtual-spacer {
+    width: 60dp;
+    flex-shrink: 0;
+}
+
 .thumb-item {
     width: 60dp;
     height: 44dp;

--- a/src/visualizer/gui/rmlui/resources/image_preview.rml
+++ b/src/visualizer/gui/rmlui/resources/image_preview.rml
@@ -7,6 +7,7 @@
 
   <div id="main-area">
     <div id="filmstrip">
+      <div class="filmstrip-virtual-spacer" data-style-height="filmstrip_top_spacer_height"></div>
       <div class="thumb-item"
            data-for="thumb : thumbs"
            data-class-selected="thumb.selected"
@@ -14,6 +15,7 @@
            data-style-decorator="thumb.decorator">
         <span class="thumb-index">{{ thumb.label }}</span>
       </div>
+      <div class="filmstrip-virtual-spacer" data-style-height="filmstrip_bottom_spacer_height"></div>
     </div>
     <div id="image-container">
       <div id="image-viewport">

--- a/src/visualizer/gui/rmlui/rmlui_vk_backend.cpp
+++ b/src/visualizer/gui/rmlui/rmlui_vk_backend.cpp
@@ -27,7 +27,6 @@
 #include <format>
 #include <limits>
 #include <optional>
-#include <semaphore>
 #include <stb_image.h>
 #include <string.h>
 #include <string>
@@ -301,7 +300,9 @@ RenderInterface_VK::RenderInterface_VK() : m_is_transform_enabled{false},
     m_rml_transform = Rml::Matrix4f::Identity();
 }
 
-RenderInterface_VK::~RenderInterface_VK() {}
+RenderInterface_VK::~RenderInterface_VK() {
+    StopPreviewWorkerPool();
+}
 
 std::string RenderInterface_VK::MakeExternalTextureSource(VkImageView image_view, VkSampler sampler,
                                                           int width, int height) {
@@ -1110,40 +1111,83 @@ Rml::TextureHandle RenderInterface_VK::LoadAsyncPreviewTexture(Rml::Vector2i& te
     m_async_preview_textures.push_back(state);
 
     try {
-        std::thread([state,
-                     path = request->path,
-                     max_size = request->max_size,
-                     embedded_project_preview = request->embedded_project_preview]() mutable {
-            auto result = DecodePreviewTexture(
-                std::move(path), max_size, embedded_project_preview);
-            {
-                std::lock_guard lock(state->mutex);
-                state->result = std::move(result);
-            }
-            state->ready.store(true, std::memory_order_release);
-            lfs::python::request_redraw();
-        }).detach();
+        EnsurePreviewWorkerPool();
+        EnqueuePreviewWork(preview_work_t{
+            state, request->path, request->max_size, request->embedded_project_preview});
     } catch (const std::exception& e) {
-        LOG_WARN("Failed to start async preview texture worker for '{}': {}", lfs::core::path_to_utf8(request->path), e.what());
+        LOG_WARN("Failed to queue async preview texture worker for '{}': {}",
+                 lfs::core::path_to_utf8(request->path), e.what());
         DropAsyncPreviewTexture(texture);
     }
 
     return handle;
 }
 
+void RenderInterface_VK::EnsurePreviewWorkerPool() {
+    std::lock_guard lock(m_preview_queue_mutex);
+    if (!m_preview_workers.empty())
+        return;
+    m_preview_workers_stopping = false;
+    constexpr std::size_t kWorkerCount = 3;
+    for (std::size_t i = 0; i < kWorkerCount; ++i) {
+        m_preview_workers.emplace_back([this] {
+            for (;;) {
+                preview_work_t work;
+                {
+                    std::unique_lock queue_lock(m_preview_queue_mutex);
+                    m_preview_queue_cv.wait(queue_lock, [this] {
+                        return m_preview_workers_stopping || !m_preview_queue.empty();
+                    });
+                    if (m_preview_workers_stopping && m_preview_queue.empty())
+                        return;
+                    work = std::move(m_preview_queue.front());
+                    m_preview_queue.pop_front();
+                }
+                if (!work.state || work.state->cancelled.load(std::memory_order_acquire))
+                    continue;
+                auto result = DecodePreviewTexture(
+                    std::move(work.path), work.max_size, work.embedded_project_preview);
+                if (work.state->cancelled.load(std::memory_order_acquire))
+                    continue;
+                {
+                    std::lock_guard result_lock(work.state->mutex);
+                    work.state->result = std::move(result);
+                }
+                work.state->ready.store(true, std::memory_order_release);
+                lfs::python::request_redraw();
+            }
+        });
+    }
+}
+
+void RenderInterface_VK::EnqueuePreviewWork(preview_work_t work) {
+    {
+        std::lock_guard lock(m_preview_queue_mutex);
+        if (m_preview_workers_stopping)
+            throw std::runtime_error("preview worker pool is stopping");
+        m_preview_queue.emplace_back(std::move(work));
+    }
+    m_preview_queue_cv.notify_one();
+}
+
+void RenderInterface_VK::StopPreviewWorkerPool() noexcept {
+    {
+        std::lock_guard lock(m_preview_queue_mutex);
+        m_preview_workers_stopping = true;
+        m_preview_queue.clear();
+    }
+    m_preview_queue_cv.notify_all();
+    for (auto& worker : m_preview_workers) {
+        if (worker.joinable())
+            worker.join();
+    }
+    m_preview_workers.clear();
+}
+
 RenderInterface_VK::async_preview_result_t RenderInterface_VK::DecodePreviewTexture(
     std::filesystem::path path,
     const int max_size,
     const bool embedded_project_preview) {
-    static std::counting_semaphore<4> decode_slots(4);
-    struct DecodeSlotGuard {
-        std::counting_semaphore<4>& slots;
-        explicit DecodeSlotGuard(std::counting_semaphore<4>& s) : slots(s) { slots.acquire(); }
-        ~DecodeSlotGuard() { slots.release(); }
-    };
-
-    DecodeSlotGuard guard(decode_slots);
-
     async_preview_result_t result;
     unsigned char* data = nullptr;
     try {
@@ -1171,7 +1215,7 @@ RenderInterface_VK::async_preview_result_t RenderInterface_VK::DecodePreviewText
                 lfs::core::load_image_from_memory(bytes, preview->size());
         } else {
             std::tie(pixels, width, height, channels) =
-                lfs::core::load_image(path, -1, max_size);
+                lfs::core::load_image_thumbnail(path, max_size);
         }
         data = pixels;
         if (pixels && width > 0 && height > 0 && channels > 0) {
@@ -1188,26 +1232,29 @@ RenderInterface_VK::async_preview_result_t RenderInterface_VK::DecodePreviewText
                 static_cast<std::size_t>(output_width) *
                 static_cast<std::size_t>(output_height);
             result.pixels.resize(pixel_count * 4u);
+            const auto sample = [&](const double x, const double y, const int channel) {
+                const double sx = std::clamp(x, 0.0, static_cast<double>(width - 1));
+                const double sy = std::clamp(y, 0.0, static_cast<double>(height - 1));
+                const int x0 = static_cast<int>(sx);
+                const int y0 = static_cast<int>(sy);
+                const int x1 = std::min(width - 1, x0 + 1);
+                const int y1 = std::min(height - 1, y0 + 1);
+                const double fx = sx - x0;
+                const double fy = sy - y0;
+                const auto at = [&](const int px, const int py) {
+                    return static_cast<double>(pixels[(static_cast<std::size_t>(py) * width + px) * channels + channel]);
+                };
+                return (at(x0, y0) * (1.0 - fx) + at(x1, y0) * fx) * (1.0 - fy) +
+                       (at(x0, y1) * (1.0 - fx) + at(x1, y1) * fx) * fy;
+            };
             for (int y = 0; y < output_height; ++y) {
-                const int source_y = std::min(
-                    height - 1,
-                    static_cast<int>((static_cast<std::int64_t>(y) * height) /
-                                     output_height));
                 for (int x = 0; x < output_width; ++x) {
-                    const int source_x = std::min(
-                        width - 1,
-                        static_cast<int>((static_cast<std::int64_t>(x) * width) /
-                                         output_width));
-                    const auto source_index =
-                        (static_cast<std::size_t>(source_y) *
-                             static_cast<std::size_t>(width) +
-                         static_cast<std::size_t>(source_x)) *
-                        static_cast<std::size_t>(channels);
-                    const unsigned char* src = pixels + source_index;
-                    const unsigned char r = src[0];
-                    const unsigned char g = channels > 1 ? src[1] : r;
-                    const unsigned char b = channels > 2 ? src[2] : r;
-                    const unsigned char a = channels > 3 ? src[3] : 255;
+                    const double source_x = (x + 0.5) * width / output_width - 0.5;
+                    const double source_y = (y + 0.5) * height / output_height - 0.5;
+                    const unsigned char r = static_cast<unsigned char>(std::lround(sample(source_x, source_y, 0)));
+                    const unsigned char g = static_cast<unsigned char>(std::lround(sample(source_x, source_y, channels > 1 ? 1 : 0)));
+                    const unsigned char b = static_cast<unsigned char>(std::lround(sample(source_x, source_y, channels > 2 ? 2 : 0)));
+                    const unsigned char a = channels > 3 ? static_cast<unsigned char>(std::lround(sample(source_x, source_y, 3))) : 255;
                     Rml::byte* dst = result.pixels.data() +
                                      (static_cast<std::size_t>(y) *
                                           static_cast<std::size_t>(output_width) +
@@ -1246,6 +1293,7 @@ void RenderInterface_VK::DropAsyncPreviewTexture(texture_data_t* texture) {
     m_async_preview_textures.erase(std::remove_if(m_async_preview_textures.begin(), m_async_preview_textures.end(),
                                                   [texture](const std::shared_ptr<async_preview_state_t>& state) {
                                                       if (state && state->texture == texture) {
+                                                          state->cancelled.store(true, std::memory_order_release);
                                                           state->texture = nullptr;
                                                           return true;
                                                       }
@@ -1765,6 +1813,7 @@ void RenderInterface_VK::ShutdownExternal() {
     if (m_p_device)
         vkDeviceWaitIdle(m_p_device);
 
+    StopPreviewWorkerPool();
     m_async_preview_textures.clear();
     DestroyRenderLayers();
     Destroy_Pipelines();

--- a/src/visualizer/gui/rmlui/rmlui_vk_backend.hpp
+++ b/src/visualizer/gui/rmlui/rmlui_vk_backend.hpp
@@ -22,14 +22,18 @@
 #include <vulkan/vulkan.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <stop_token>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -192,6 +196,14 @@ private:
         std::mutex mutex;
         async_preview_result_t result;
         std::atomic<bool> ready = false;
+        std::atomic<bool> cancelled = false;
+    };
+
+    struct preview_work_t {
+        std::shared_ptr<async_preview_state_t> state;
+        std::filesystem::path path;
+        int max_size = 0;
+        bool embedded_project_preview = false;
     };
 
     struct geometry_handle_t {
@@ -546,6 +558,9 @@ private:
     Rml::TextureHandle LoadAsyncPreviewTexture(Rml::Vector2i& texture_dimensions, const Rml::String& source);
     void ProcessAsyncPreviewUploads();
     void DropAsyncPreviewTexture(texture_data_t* texture);
+    void EnsurePreviewWorkerPool();
+    void StopPreviewWorkerPool() noexcept;
+    void EnqueuePreviewWork(preview_work_t work);
     void QueueTextureForDeferredDeletion(texture_data_t* texture);
     static async_preview_result_t DecodePreviewTexture(std::filesystem::path path,
                                                        int max_size,
@@ -672,6 +687,11 @@ private:
     Rml::Array<Rml::Vector<texture_data_t*>, kSwapchainBackBufferCount> m_pending_for_deletion_textures_by_frames;
     std::unordered_set<texture_data_t*> m_live_textures;
     std::vector<std::shared_ptr<async_preview_state_t>> m_async_preview_textures;
+    std::mutex m_preview_queue_mutex;
+    std::condition_variable m_preview_queue_cv;
+    std::deque<preview_work_t> m_preview_queue;
+    std::vector<std::thread> m_preview_workers;
+    bool m_preview_workers_stopping = false;
     std::atomic<uint64_t> m_preview_texture_generation{0};
     Rml::Vector<render_layer_t> m_render_layers;
     Rml::CompiledGeometryHandle m_texture_quad_geometry = {};

--- a/tests/python/test_asset_identity.py
+++ b/tests/python/test_asset_identity.py
@@ -52,7 +52,29 @@ def _install_inspections(monkeypatch, inspections):
     monkeypatch.setattr(AssetIndex, "_inspect_path", staticmethod(inspect))
 
 
-def test_catalog_uses_project_uuid_and_persists_only_locator_fields(monkeypatch, tmp_path: Path):
+def _cached_record(path: Path, project_uuid: str, inspection=None):
+    inspection = inspection or _inspection(project_uuid)
+    return {
+        "name": path.stem,
+        "path": str(path),
+        "folder_id": "default",
+        "size": path.stat().st_size,
+        "mtime_ns": path.stat().st_mtime_ns,
+        "fallback_preview_path": "",
+        "file_uuid": inspection.file_uuid,
+        "commit_uuid": inspection.commit_uuid,
+        "generation": inspection.generation,
+        "created_at_unix_ns": inspection.created_at_unix_ns,
+        "saved_at_unix_ns": inspection.saved_at_unix_ns,
+        "file_size_bytes": inspection.physical_file_size,
+        "role": "MASTER",
+        "open_state": inspection.open_state.name,
+        "has_preview": inspection.has_preview,
+        "status": "AVAILABLE",
+    }
+
+
+def test_catalog_uses_project_uuid_and_persists_inspection_fields(monkeypatch, tmp_path: Path):
     first_path = tmp_path / "first.licht"
     copied_path = tmp_path / "copy.licht"
     first_path.write_bytes(b"first container")
@@ -81,14 +103,23 @@ def test_catalog_uses_project_uuid_and_persists_only_locator_fields(monkeypatch,
     assert duplicate.name == "My project"
 
     catalog = json.loads((tmp_path / "library.json").read_text(encoding="utf-8"))
-    assert set(catalog) == {"schema_version", "folders", "projects"}
-    assert catalog["schema_version"] == 3
+    assert set(catalog) == {"schema_version", "folders", "projects", "directory_mtimes"}
+    assert catalog["schema_version"] == 4
+    assert catalog["directory_mtimes"] == {}
     assert catalog["folders"]["default"] == {"path": str(tmp_path)}
-    assert catalog["projects"][first.id] == {
-        "name": "My project",
-        "path": str(copied_path),
-        "folder_id": "default",
-    }
+    assert catalog["projects"][first.id] == duplicate.to_storage_dict()
+    assert {
+        "file_uuid",
+        "commit_uuid",
+        "generation",
+        "created_at_unix_ns",
+        "saved_at_unix_ns",
+        "file_size_bytes",
+        "role",
+        "open_state",
+        "has_preview",
+        "status",
+    }.issubset(catalog["projects"][first.id])
 
 
 def test_catalog_rejects_non_licht_paths(tmp_path: Path):
@@ -237,6 +268,9 @@ def test_project_commit_changes_do_not_change_catalog_identity(monkeypatch, tmp_
         commit_uuid=new_commit_uuid,
         generation=2,
     )
+    # A real project save changes the file metadata; the cache must not be
+    # bypassed merely because this test swapped its inspection stub.
+    project.write_bytes(b"project container updated")
     verified = index.verify_asset(licht_asset.id)
     assert verified.commit_uuid == new_commit_uuid
     assert verified.generation == 2
@@ -245,7 +279,8 @@ def test_project_commit_changes_do_not_change_catalog_identity(monkeypatch, tmp_
     assert [asset.id for asset in index.list_projects()] == [licht_asset.id]
     stored = json.loads(library_path.read_text(encoding="utf-8"))["projects"]
     assert set(stored) == {project_uuid}
-    assert "commit_uuid" not in stored[project_uuid]
+    assert stored[project_uuid]["commit_uuid"] == new_commit_uuid
+    assert stored[project_uuid]["generation"] == 2
 
 
 def test_v2_load_rewrites_records_to_the_exact_minimal_schema(monkeypatch, tmp_path: Path):
@@ -282,17 +317,11 @@ def test_v2_load_rewrites_records_to_the_exact_minimal_schema(monkeypatch, tmp_p
     index = AssetIndex(library_path=library_path)
     assert index.load() is True
 
-    assert json.loads(library_path.read_text(encoding="utf-8")) == {
-        "schema_version": 3,
-        "folders": {"default": {"path": str(tmp_path)}},
-        "projects": {
-            project_uuid: {
-                "name": "Project",
-                "path": str(project),
-                "folder_id": "default",
-            }
-        },
-    }
+    migrated = json.loads(library_path.read_text(encoding="utf-8"))
+    assert migrated["schema_version"] == 4
+    assert migrated["folders"] == {"default": {"path": str(tmp_path)}}
+    assert migrated["directory_mtimes"] == {}
+    assert migrated["projects"][project_uuid] == index.get_asset(project_uuid).to_storage_dict()
 
 
 def test_deleting_last_project_keeps_default_import_folder(monkeypatch, tmp_path: Path):
@@ -424,23 +453,20 @@ def test_legacy_catalog_migration_keeps_only_names_paths_folders_and_watch_roots
     assert index.load() is True
     migrated = json.loads(library_path.read_text(encoding="utf-8"))
 
-    assert migrated["schema_version"] == 3
+    assert migrated["schema_version"] == 4
     assert migrated["folders"] == {"default": {"path": str(tmp_path)}}
-    assert migrated["projects"][project_uuid] == {
-        "name": "Custom legacy name",
-        "path": str(project_path),
-        "folder_id": "default",
-    }
-    missing = next(
+    migrated_project = index.get_asset(project_uuid)
+    assert migrated_project is not None
+    assert migrated["projects"][project_uuid] == migrated_project.to_storage_dict()
+    missing_record = next(
         project
         for project in migrated["projects"].values()
         if project["path"] == str(missing_path)
     )
-    assert missing == {
-        "name": "Missing",
-        "path": str(missing_path),
-        "folder_id": "default",
-    }
+    missing_project = next(
+        project for project in index.list_projects() if project.path == str(missing_path)
+    )
+    assert missing_record == missing_project.to_storage_dict()
 
 
 def test_legacy_migration_preserves_original_backup(monkeypatch, tmp_path: Path):
@@ -562,7 +588,9 @@ def test_v3_load_skips_bad_project_rows_without_saving(monkeypatch, tmp_path: Pa
     assert any(str(good_path) in issue and "duplicate" in issue.casefold() for issue in index.load_issues)
     assert any(empty_uuid in issue for issue in index.load_issues)
     assert any("not an object" in issue for issue in index.load_issues)
-    assert library_path.read_text(encoding="utf-8") == original
+    migrated = json.loads(library_path.read_text(encoding="utf-8"))
+    assert migrated["schema_version"] == 4
+    assert migrated["projects"][good_uuid] == index.get_asset(good_uuid).to_storage_dict()
 
 
 def test_v3_load_skips_one_bad_row_and_keeps_the_rest(monkeypatch, tmp_path: Path):
@@ -596,7 +624,9 @@ def test_v3_load_skips_one_bad_row_and_keeps_the_rest(monkeypatch, tmp_path: Pat
     assert [project.id for project in index.list_projects()] == [good_uuid]
     assert len(index.load_issues) == 1
     assert "not-a-uuid" in index.load_issues[0]
-    assert library_path.read_text(encoding="utf-8") == original
+    migrated = json.loads(library_path.read_text(encoding="utf-8"))
+    assert migrated["schema_version"] == 4
+    assert migrated["projects"][good_uuid] == index.get_asset(good_uuid).to_storage_dict()
 
 
 def test_v3_load_leaves_cached_rows_unverified_without_inspecting(
@@ -653,6 +683,132 @@ def test_v3_load_leaves_cached_rows_unverified_without_inspecting(
     unavailable, total = index.verify_projects()
     assert total == 1
     assert unavailable == 0
+
+
+def test_v4_full_cached_inspection_skips_batch_inspection(
+    monkeypatch, tmp_path: Path
+):
+    project_path = tmp_path / "cached.licht"
+    project_path.write_bytes(b"cached project")
+    project_uuid = str(uuid.uuid4())
+    inspection = _inspection(project_uuid, commit_uuid="cached-commit")
+    library_path = tmp_path / "library.json"
+    library_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 4,
+                "folders": {"default": {"path": str(tmp_path)}},
+                "projects": {
+                    project_uuid: _cached_record(project_path, project_uuid, inspection)
+                },
+                "directory_mtimes": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    inspect_calls = []
+
+    def inspect(*_args):
+        inspect_calls.append(True)
+        raise AssertionError("matching full cache must skip inspection")
+
+    monkeypatch.setattr(AssetIndex, "_inspect_path", staticmethod(inspect))
+    index = AssetIndex(library_path=library_path)
+    assert index.load() is True
+
+    project = index.get_asset(project_uuid)
+    assert project is not None
+    assert project.inspection_restored is True
+    assert index.verify_projects_batch([project_uuid]) == 1
+    assert project.status == "AVAILABLE"
+    assert project.available is True
+    assert project.has_preview is True
+    assert project.commit_uuid == "cached-commit"
+    assert project.inspection_verified is True
+    assert inspect_calls == []
+
+
+def test_v4_cached_inspection_with_changed_stat_refreshes_fields(
+    monkeypatch, tmp_path: Path
+):
+    project_path = tmp_path / "changed.licht"
+    project_path.write_bytes(b"changed project")
+    project_uuid = str(uuid.uuid4())
+    old = _inspection(project_uuid, commit_uuid="old-commit")
+    refreshed = _inspection(project_uuid, commit_uuid="new-commit", generation=2)
+    record = _cached_record(project_path, project_uuid, old)
+    record["mtime_ns"] += 1
+    library_path = tmp_path / "library.json"
+    library_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 4,
+                "folders": {"default": {"path": str(tmp_path)}},
+                "projects": {project_uuid: record},
+                "directory_mtimes": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    inspect_calls = []
+
+    def inspect(_path, _resolve_fallback=True):
+        inspect_calls.append(True)
+        return refreshed
+
+    monkeypatch.setattr(AssetIndex, "_inspect_path", staticmethod(inspect))
+    index = AssetIndex(library_path=library_path)
+    assert index.load() is True
+    assert index.verify_projects_batch([project_uuid]) == 1
+
+    project = index.get_asset(project_uuid)
+    assert project is not None
+    assert project.commit_uuid == "new-commit"
+    assert project.generation == 2
+    assert project.status == "AVAILABLE"
+    assert project.inspection_restored is False
+    assert project.inspection_verified is True
+    assert len(inspect_calls) == 1
+
+
+def test_v4_cached_inspection_missing_field_is_inspected(
+    monkeypatch, tmp_path: Path
+):
+    project_path = tmp_path / "incomplete.licht"
+    project_path.write_bytes(b"incomplete project")
+    project_uuid = str(uuid.uuid4())
+    cached = _inspection(project_uuid, commit_uuid="cached-commit")
+    refreshed = _inspection(project_uuid, commit_uuid="refreshed-commit")
+    record = _cached_record(project_path, project_uuid, cached)
+    del record["commit_uuid"]
+    library_path = tmp_path / "library.json"
+    library_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 4,
+                "folders": {"default": {"path": str(tmp_path)}},
+                "projects": {project_uuid: record},
+                "directory_mtimes": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    inspect_calls = []
+
+    def inspect(_path, _resolve_fallback=True):
+        inspect_calls.append(True)
+        return refreshed
+
+    monkeypatch.setattr(AssetIndex, "_inspect_path", staticmethod(inspect))
+    index = AssetIndex(library_path=library_path)
+    assert index.load() is True
+    assert index.verify_projects_batch([project_uuid]) == 1
+
+    project = index.get_asset(project_uuid)
+    assert project is not None
+    assert project.commit_uuid == "refreshed-commit"
+    assert project.inspection_verified is True
+    assert len(inspect_calls) == 1
 
 
 def test_malformed_v3_catalog_restores_previous_catalog(monkeypatch, tmp_path: Path):
@@ -941,11 +1097,35 @@ def test_inspection_maps_repair_only_and_unsupported_newer_status(
     assert other_project.status == "UNSUPPORTED"
     assert other_project.available is False
     stored = json.loads((tmp_path / "library.json").read_text(encoding="utf-8"))
-    assert "status" not in stored["projects"][repair_uuid]
+    assert stored["projects"][repair_uuid]["status"] == "REPAIR_ONLY"
 
 
 def test_asset_library_binding_returns_canonical_path(lf):
     assert Path(lf.io.asset_library_dir()).name == "asset_library"
+
+
+def test_asset_snapshot_is_cached_per_epoch_and_mtime_verify_shortcuts(monkeypatch, tmp_path: Path):
+    project_path = tmp_path / "project.licht"
+    project_path.write_bytes(b"container")
+    project_uuid = str(uuid.uuid4())
+    calls = []
+
+    def inspect(_path):
+        calls.append(1)
+        return _inspection(project_uuid)
+
+    monkeypatch.setattr(AssetIndex, "_inspect_path", staticmethod(inspect))
+    index = AssetIndex(library_path=tmp_path / "library.json")
+    index.ensure_default_catalog()
+    project, _ = index.register_licht_asset(str(project_path))
+    assert project is not None
+    snapshot = index.assets
+    assert index.assets is snapshot
+    calls_before_verify = len(calls)
+    index.verify_asset(project.id)
+    assert len(calls) == calls_before_verify
+    index.update_asset(project.id, save=False, name="Renamed")
+    assert index.assets is not snapshot
 
 
 def test_asset_manager_ui_exposes_only_project_import_and_open_actions():
@@ -965,7 +1145,7 @@ def test_asset_manager_ui_exposes_only_project_import_and_open_actions():
     assert rml.count('data-event-click="on_import_project"') == 1
 
 
-def test_fallback_preview_path_is_runtime_only(monkeypatch, tmp_path: Path):
+def test_fallback_preview_path_is_cached_in_catalog(monkeypatch, tmp_path: Path):
     project_path = tmp_path / "garden.licht"
     project_path.write_bytes(b"container")
     project_uuid = str(uuid.uuid4())
@@ -982,9 +1162,9 @@ def test_fallback_preview_path_is_runtime_only(monkeypatch, tmp_path: Path):
     assert created is True
     assert project.fallback_preview_path == fallback
     assert project.to_dict()["fallback_preview_path"] == fallback
-    assert "fallback_preview_path" not in project.to_storage_dict()
+    assert project.to_storage_dict()["fallback_preview_path"] == fallback
     stored = json.loads(library_path.read_text(encoding="utf-8"))
-    assert "fallback_preview_path" not in stored["projects"][project.id]
+    assert stored["projects"][project.id]["fallback_preview_path"] == fallback
 
     missing_field = Project(
         project_uuid=str(uuid.uuid4()),

--- a/tests/python/test_asset_manager_panel.py
+++ b/tests/python/test_asset_manager_panel.py
@@ -350,7 +350,7 @@ def test_rml_and_panel_have_no_scene_or_disk_thumbnail_model():
     assert "scene-asset" not in rcss
     assert "absolute_path" not in source
     assert "fingerprint" not in source
-    assert "thumbnails" not in source
+    assert 'bind_record_list("thumbnails")' not in source
     assert "LICHT" not in rml
     assert "asset-col-type" not in rml
     assert "asset-pill-licht" not in rcss
@@ -1148,15 +1148,16 @@ def test_catalog_notice_for_failed_load_and_on_mount_warning(panel_module, monke
     assert panel.get_catalog_notice() == "asset_manager.status.load_failed"
     assert panel.get_has_catalog_notice() is True
 
-    warnings = []
-    monkeypatch.setattr(panel, "_initialize_backend", lambda: False)
     monkeypatch.setattr(
-        panel, "_log_warn", lambda msg, *args: warnings.append(msg % args if args else msg)
+        panel,
+        "_start_backend_initialization",
+        lambda: setattr(panel, "_catalog_load_failed", True),
     )
     monkeypatch.setattr(panel, "_bind_dom_event_listeners", lambda _doc: None)
     monkeypatch.setattr(panel, "_scan_asset_folders", lambda **_kwargs: None)
     panel.on_mount(_Document())
-    assert warnings
+    assert panel.get_has_catalog_notice()
+    panel.on_unmount(_Document())
 
 
 def test_unmount_cancels_running_folder_scan(panel_module, monkeypatch):
@@ -1182,8 +1183,25 @@ def test_unmount_cancels_running_folder_scan(panel_module, monkeypatch):
 
     assert cancel is not None and cancel.is_set()
     assert observed["event"] is cancel
+    assert thread is not None
+    thread.join(timeout=2.0)
     assert observed.get("waited") is True
-    assert thread is not None and not thread.is_alive()
+    assert not thread.is_alive()
+
+
+def test_unmount_does_not_join_scan_worker(panel_module):
+    class NoJoin:
+        ident = 1
+        def join(self, *args, **kwargs):
+            raise AssertionError("unmount must not join workers")
+
+        def is_alive(self):
+            return True
+
+    panel = panel_module.AssetManagerPanel()
+    panel._folder_scan_thread = NoJoin()
+    panel._folder_scan_cancel = threading.Event()
+    panel.on_unmount(_Document())
 
 
 def test_refresh_during_scan_schedules_exactly_one_rerun(panel_module, monkeypatch):
@@ -1584,6 +1602,16 @@ def test_on_mount_shows_cached_rows_without_inspecting(
         return inspections[Path(path).name]
 
     monkeypatch.setattr(AssetIndex, "_inspect_path", staticmethod(inspect))
+    verify_done = threading.Event()
+    original_verify_catalog = panel_module.verify_catalog_projects
+
+    def verify_catalog(*args, **kwargs):
+        try:
+            return original_verify_catalog(*args, **kwargs)
+        finally:
+            verify_done.set()
+
+    monkeypatch.setattr(panel_module, "verify_catalog_projects", verify_catalog)
     library_path = tmp_path / "library.json"
     library_path.write_text(
         json.dumps(
@@ -1629,9 +1657,8 @@ def test_on_mount_shows_cached_rows_without_inspecting(
         "load_ms": load_ms,
         "mount_to_refresh_ms": mount_to_refresh_ms,
     }
-    assert _wait_until(
-        lambda: {project.status for project in index.list_projects()} == {"AVAILABLE"}
-    )
+    assert verify_done.wait(timeout=2.0)
+    assert {project.status for project in index.list_projects()} == {"AVAILABLE"}
     panel.on_update(_Document())
     assert {row["status"] for row in panel._handle.records["assets"]} <= {
         "AVAILABLE",

--- a/tests/python/test_asset_manager_panel.py
+++ b/tests/python/test_asset_manager_panel.py
@@ -1160,6 +1160,47 @@ def test_catalog_notice_for_failed_load_and_on_mount_warning(panel_module, monke
     panel.on_unmount(_Document())
 
 
+def test_backend_initialization_completes_without_ui_scheduler(panel_module, monkeypatch, tmp_path):
+    loaded = threading.Event()
+
+    class _LoadedIndex:
+        load_issues = []
+
+        def load(self):
+            loaded.set()
+            return True
+
+    monkeypatch.setattr(panel_module, "AssetIndex", _LoadedIndex)
+    monkeypatch.setattr(
+        panel_module,
+        "resolve_asset_manager_storage_path",
+        lambda: tmp_path / "catalog",
+    )
+    monkeypatch.setattr(
+        panel_module,
+        "resolve_default_asset_directory",
+        lambda: tmp_path / "assets",
+    )
+    monkeypatch.setattr(panel_module, "BACKEND_AVAILABLE", True)
+    monkeypatch.delattr(panel_module.lf.ui, "schedule_on_ui_thread", raising=False)
+
+    panel = panel_module.AssetManagerPanel()
+    monkeypatch.setattr(panel, "_repair_selection", lambda: None)
+    monkeypatch.setattr(panel, "_refresh_records", lambda **_kwargs: None)
+    monkeypatch.setattr(panel, "_start_catalog_verify", lambda: None)
+    monkeypatch.setattr(panel, "_scan_asset_folders", lambda: None)
+    updates = []
+    monkeypatch.setattr(panel, "_request_model_update", lambda: updates.append(True))
+
+    panel._start_backend_initialization()
+
+    assert loaded.wait(timeout=2.0)
+    assert _wait_until(lambda: not panel._backend_load_active)
+    assert isinstance(panel._asset_index, _LoadedIndex)
+    assert panel._catalog_load_failed is False
+    assert updates == [True]
+
+
 def test_unmount_cancels_running_folder_scan(panel_module, monkeypatch):
     started = threading.Event()
     observed = {}

--- a/tests/python/test_asset_manager_panel.py
+++ b/tests/python/test_asset_manager_panel.py
@@ -334,7 +334,7 @@ def _scan_result(**overrides):
 def test_panel_contract_polls_preference_and_remains_left_dock(panel_module):
     panel_type = panel_module.AssetManagerPanel
     assert panel_type.update_policy == "dirty"
-    assert "update_interval_ms" not in panel_type.__dict__
+    assert panel_type.update_interval_ms == 100
     assert panel_type.space == panel_module.lf.ui.PanelSpace.LEFT_DOCK
     assert panel_type.order == 20
 

--- a/tests/python/test_asset_watch.py
+++ b/tests/python/test_asset_watch.py
@@ -5,6 +5,7 @@
 import json
 import logging
 import os
+import stat
 import sys
 import threading
 import time
@@ -36,6 +37,36 @@ def _inspection(project_uuid: str):
         open_state=SimpleNamespace(name="OPEN"),
         has_preview=False,
     )
+
+
+class _FakeDirEntry:
+    def __init__(self, path, *, is_dir=False, is_file=False):
+        self.path = str(path)
+        self.name = Path(path).name
+        self._is_dir = is_dir
+        self._is_file = is_file
+
+    def is_dir(self, follow_symlinks=False):
+        del follow_symlinks
+        return self._is_dir
+
+    def is_file(self, follow_symlinks=False):
+        del follow_symlinks
+        return self._is_file
+
+
+class _FakeScandir:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def __enter__(self):
+        return self
+
+    def __iter__(self):
+        return iter(self._entries)
+
+    def __exit__(self, *_args):
+        return False
 
 
 def test_discovery_recurses_and_returns_only_licht_files(tmp_path: Path):
@@ -328,11 +359,26 @@ def test_cancelled_scan_rolls_back_discovered_projects(tmp_path: Path):
 def test_discovery_warns_once_when_folder_has_more_than_10000_directories(
     monkeypatch, tmp_path: Path, caplog
 ):
-    def fake_walk(_root, topdown=True, onerror=None, followlinks=False):
-        for index in range(10001):
-            yield str(tmp_path / f"dir-{index}"), [], []
+    scanned = []
 
-    monkeypatch.setattr(os, "walk", fake_walk)
+    def fake_scandir(current):
+        index = len(scanned)
+        scanned.append(current)
+        if index >= 10000:
+            return _FakeScandir([])
+        return _FakeScandir(
+            [_FakeDirEntry(Path(current) / f"dir-{index}", is_dir=True)]
+        )
+
+    monkeypatch.setattr(asset_watch.os, "scandir", fake_scandir)
+    monkeypatch.setattr(
+        asset_watch.Path,
+        "stat",
+        lambda _path, *args, **kwargs: SimpleNamespace(
+            st_mtime_ns=1,
+            st_mode=stat.S_IFDIR,
+        ),
+    )
 
     with caplog.at_level(logging.WARNING, logger="lfs_plugins.asset_watch"):
         discovered = discover_licht_projects(str(tmp_path))
@@ -380,16 +426,18 @@ def test_scan_streams_first_batch_before_walk_finishes(monkeypatch, tmp_path: Pa
     walk_finished = threading.Event()
     past_first_batch = threading.Event()
 
-    def fake_walk(_root, topdown=True, onerror=None, followlinks=False):
-        names = [path.name for path in paths]
-        for index, name in enumerate(names):
-            yield str(tmp_path), [], [name]
-            if index == 1:
-                past_first_batch.set()
-            time.sleep(0.03)
-        walk_finished.set()
+    def fake_scandir(_root):
+        def entries():
+            for index, path in enumerate(paths):
+                yield _FakeDirEntry(path, is_file=True)
+                if index == 1:
+                    past_first_batch.set()
+                time.sleep(0.03)
+            walk_finished.set()
 
-    monkeypatch.setattr(os, "walk", fake_walk)
+        return _FakeScandir(entries())
+
+    monkeypatch.setattr(asset_watch.os, "scandir", fake_scandir)
     index = AssetIndex(
         library_path=tmp_path / "library.json",
         default_folder_path=tmp_path,
@@ -425,14 +473,16 @@ def test_cancelled_scan_keeps_committed_batches(monkeypatch, tmp_path: Path):
     )
     cancel_event = threading.Event()
 
-    def fake_walk(_root, topdown=True, onerror=None, followlinks=False):
-        names = [path.name for path in paths]
-        for index, name in enumerate(names):
-            yield str(tmp_path), [], [name]
-            if index == 3:
-                cancel_event.wait(timeout=2.0)
+    def fake_scandir(_root):
+        def entries():
+            for index, path in enumerate(paths):
+                yield _FakeDirEntry(path, is_file=True)
+                if index == 3:
+                    cancel_event.wait(timeout=2.0)
 
-    monkeypatch.setattr(os, "walk", fake_walk)
+        return _FakeScandir(entries())
+
+    monkeypatch.setattr(asset_watch.os, "scandir", fake_scandir)
     index = AssetIndex(
         library_path=tmp_path / "library.json",
         default_folder_path=tmp_path,
@@ -545,3 +595,20 @@ def test_verify_catalog_projects_runs_in_batches(monkeypatch, tmp_path: Path):
     assert verified == 5
     assert batch_sizes == [2, 2, 1]
     assert {project.status for project in index.list_projects()} == {"AVAILABLE"}
+
+
+def test_verify_catalog_projects_prioritizes_visible_window():
+    order = []
+
+    class Index:
+        def list_projects(self):
+            return [SimpleNamespace(id=str(i)) for i in range(5)]
+
+        def verify_projects_batch(self, ids):
+            order.extend(ids)
+            return len(ids)
+
+    assert verify_catalog_projects(
+        Index(), visible_asset_ids=["3", "1"], batch_size=1, interval_s=0
+    ) == 5
+    assert order == ["3", "1", "0", "2", "4"]

--- a/tests/python/test_new_project_panel.py
+++ b/tests/python/test_new_project_panel.py
@@ -5,6 +5,8 @@
 from importlib import import_module
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+import threading
+import time
 import sys
 
 import pytest
@@ -53,7 +55,13 @@ def new_project_module(monkeypatch, tmp_path):
         dirty=False,
         training=False,
         embed_default=False,
+        scheduled=[],
+        scheduled_event=threading.Event(),
     )
+
+    def schedule_on_ui_thread(callback):
+        state.scheduled.append(callback)
+        state.scheduled_event.set()
 
     def confirm(title, message, buttons, callback=None):
         state.prompts.append((title, message, buttons, callback))
@@ -72,6 +80,7 @@ def new_project_module(monkeypatch, tmp_path):
         open_dataset_folder_dialog=lambda: str(dataset),
         open_ply_file_dialog=lambda _start="": str(splat),
         get_embed_dataset_by_default=lambda: state.embed_default,
+        schedule_on_ui_thread=schedule_on_ui_thread,
     )
     lf_stub.is_dataset_path = lambda path: str(path) == str(dataset)
     lf_stub.detect_dataset_info = lambda _path: info
@@ -89,7 +98,22 @@ def new_project_module(monkeypatch, tmp_path):
 def _panel(module):
     panel = module.NewProjectPanel()
     panel._handle = _Handle()
+    panel._dialog_mounted = True
     return panel
+
+
+def _run_scheduled(state, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if state.scheduled:
+            callbacks = state.scheduled[:]
+            del state.scheduled[:]
+            state.scheduled_event.clear()
+            for callback in callbacks:
+                callback()
+            return
+        state.scheduled_event.wait(max(0.0, deadline - time.monotonic()))
+    raise AssertionError("worker did not schedule a UI callback")
 
 
 def test_dataset_create_emits_project_before_load_without_output_path(new_project_module):
@@ -97,6 +121,7 @@ def test_dataset_create_emits_project_before_load_without_output_path(new_projec
     panel = _panel(module)
 
     assert panel.show(str(state.dataset)) is True
+    _run_scheduled(state)
     panel._on_do_create()
 
     assert [call[0] for call in state.calls] == ["create", "load"]
@@ -109,12 +134,14 @@ def test_splat_and_blank_create(new_project_module):
     module, state = new_project_module
     panel = _panel(module)
     panel.show(str(state.splat))
+    _run_scheduled(state)
     panel._on_do_create()
     assert len(state.calls) == 2
     assert state.calls[1][2] == {"path": str(state.splat), "is_dataset": False, "discard_changes": True}
 
     state.calls.clear()
     panel.show("")
+    _run_scheduled(state)
     panel._on_do_create()
     assert len(state.calls) == 1
     assert state.calls[0][0] == "create"
@@ -126,6 +153,7 @@ def test_dataset_checkbox_defaults_from_preference_and_embeds_after_load(new_pro
     panel = _panel(module)
 
     assert panel.show(str(state.dataset)) is True
+    _run_scheduled(state)
     assert panel._source_kind == "dataset"
     assert panel._embed_dataset is True
     panel._on_do_create()
@@ -133,6 +161,7 @@ def test_dataset_checkbox_defaults_from_preference_and_embeds_after_load(new_pro
 
     state.calls.clear()
     panel.show(str(state.splat))
+    _run_scheduled(state)
     assert panel._source_kind == "splat"
     assert panel._embed_dataset is True
     panel._on_do_create()
@@ -169,8 +198,12 @@ def test_exists_check_and_dedupe(new_project_module):
     (state.location / "garden.licht").write_bytes(b"existing")
     panel = _panel(module)
     panel.show(str(state.dataset))
+    _run_scheduled(state)
     assert panel._name == "garden-2"
     panel._set_name("garden")
+    panel._source_probe_due = time.monotonic() - 1.0
+    panel.on_update(None)
+    _run_scheduled(state)
     assert panel._target_exists() is True
     assert panel._can_create() is False
 
@@ -182,6 +215,7 @@ def test_min_track_length_and_keyboard_boundaries(new_project_module):
     (sparse / "points3D.txt").write_text("", encoding="utf-8")
     panel = _panel(module)
     panel.show(str(state.dataset))
+    _run_scheduled(state)
     assert panel._show_min_track_length() is True
     panel._set_min_track_length_str("4")
     panel._on_min_track_length_step(args=["1"])
@@ -190,3 +224,17 @@ def test_min_track_length_and_keyboard_boundaries(new_project_module):
     assert panel._show_min_track_length_warning() is True
     panel._on_do_cancel()
     assert state.enabled[-1] == ("lfs.new_project", False)
+
+
+def test_source_probe_is_debounced_until_idle(new_project_module, monkeypatch):
+    module, state = new_project_module
+    calls = []
+    module.lf.is_dataset_path = lambda path: calls.append(path) or True
+    panel = _panel(module)
+    panel._set_source_path(str(state.dataset))
+    assert calls == []
+    assert panel._source_kind == "checking"
+    panel._source_probe_due = time.monotonic() - 1.0
+    panel.on_update(None)
+    _run_scheduled(state)
+    assert calls == [str(state.dataset)]

--- a/tests/python/test_rmlui_image_sources.py
+++ b/tests/python/test_rmlui_image_sources.py
@@ -143,6 +143,10 @@ def test_image_preview_mask_decorator_escapes_paths(panel_modules, tmp_path):
 
     panel._image_paths = [image_path]
     panel._mask_paths = [mask_path]
+    panel._path_stat_cache = {
+        str(image_path): (True, image_path.stat().st_mtime_ns, image_path.stat().st_size),
+        str(mask_path): (True, mask_path.stat().st_mtime_ns, mask_path.stat().st_size),
+    }
     panel._camera_uids = [7]
     panel._show_overlay = True
     panel._prev_image_index = -1

--- a/tests/test_image_io.cpp
+++ b/tests/test_image_io.cpp
@@ -4,6 +4,8 @@
 #include "core/image_io.hpp"
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -11,9 +13,21 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <stb_image_write.h>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace {
+
+    std::filesystem::path unique_temp_path(const std::string_view stem,
+                                           const std::string_view extension) {
+        static std::atomic_uint64_t sequence{0};
+        const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+        return std::filesystem::temp_directory_path() /
+               ("lfs_image_io_" + std::string(stem) + "_" + std::to_string(timestamp) + "_" +
+                std::to_string(sequence.fetch_add(1, std::memory_order_relaxed)) +
+                std::string(extension));
+    }
 
     void append_u16(std::vector<std::uint8_t>& data, const std::uint16_t value) {
         data.push_back(static_cast<std::uint8_t>(value));
@@ -94,7 +108,7 @@ TEST(ImageIoTest, ConvertsSixteenBitPngMemoryToUint8) {
 }
 
 TEST(ImageIoTest, ThumbnailJpegUsesScaledDecode) {
-    const auto path = std::filesystem::temp_directory_path() / "lfs_image_io_thumbnail.jpg";
+    const auto path = unique_temp_path("thumbnail", ".jpg");
     constexpr int width = 1024;
     constexpr int height = 768;
     std::vector<std::uint8_t> source(static_cast<std::size_t>(width) * height * 3);

--- a/tests/test_image_io.cpp
+++ b/tests/test_image_io.cpp
@@ -4,6 +4,7 @@
 #include "core/image_io.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
@@ -90,6 +91,65 @@ TEST(ImageIoTest, ConvertsSixteenBitPngMemoryToUint8) {
     EXPECT_EQ(decoded[6], 128);
     EXPECT_EQ(decoded[9], 255);
     lfs::core::free_image(decoded);
+}
+
+TEST(ImageIoTest, ThumbnailJpegUsesScaledDecode) {
+    const auto path = std::filesystem::temp_directory_path() / "lfs_image_io_thumbnail.jpg";
+    constexpr int width = 1024;
+    constexpr int height = 768;
+    std::vector<std::uint8_t> source(static_cast<std::size_t>(width) * height * 3);
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            const auto offset = (static_cast<std::size_t>(y) * width + x) * 3;
+            source[offset + 0] = static_cast<std::uint8_t>(x * 255 / (width - 1));
+            source[offset + 1] = static_cast<std::uint8_t>(y * 255 / (height - 1));
+            source[offset + 2] = static_cast<std::uint8_t>((x + y) * 255 / (width + height - 2));
+        }
+    }
+    ASSERT_NE(stbi_write_jpg(path.string().c_str(), width, height, 3, source.data(), 95), 0);
+
+    auto [full, full_width, full_height, full_channels] = lfs::core::load_image(path);
+    auto [thumb, thumb_width, thumb_height, thumb_channels] =
+        lfs::core::load_image_thumbnail(path, 256);
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+
+    ASSERT_NE(full, nullptr);
+    ASSERT_NE(thumb, nullptr);
+    EXPECT_EQ(full_width, width);
+    EXPECT_EQ(full_height, height);
+    EXPECT_EQ(full_channels, 3);
+    EXPECT_LE(std::max(thumb_width, thumb_height), 256);
+    EXPECT_EQ(thumb_channels, 3);
+    double mean_absolute_error = 0.0;
+    for (int y = 0; y < thumb_height; ++y) {
+        const double source_y = (y + 0.5) * full_height / thumb_height - 0.5;
+        const double sy = std::clamp(source_y, 0.0, static_cast<double>(full_height - 1));
+        const int y0 = static_cast<int>(sy);
+        const int y1 = std::min(full_height - 1, y0 + 1);
+        const double fy = sy - y0;
+        for (int x = 0; x < thumb_width; ++x) {
+            const double source_x = (x + 0.5) * full_width / thumb_width - 0.5;
+            const double sx = std::clamp(source_x, 0.0, static_cast<double>(full_width - 1));
+            const int x0 = static_cast<int>(sx);
+            const int x1 = std::min(full_width - 1, x0 + 1);
+            const double fx = sx - x0;
+            for (int channel = 0; channel < 3; ++channel) {
+                const auto at = [&](const int px, const int py) {
+                    return static_cast<double>(full[(static_cast<std::size_t>(py) * full_width + px) * 3 + channel]);
+                };
+                const double top = at(x0, y0) * (1.0 - fx) + at(x1, y0) * fx;
+                const double bottom = at(x0, y1) * (1.0 - fx) + at(x1, y1) * fx;
+                const auto expected = static_cast<unsigned char>(std::lround(top * (1.0 - fy) + bottom * fy));
+                const auto actual = thumb[(static_cast<std::size_t>(y) * thumb_width + x) * 3 + channel];
+                mean_absolute_error += std::abs(static_cast<double>(actual) - expected) / 255.0;
+            }
+        }
+    }
+    mean_absolute_error /= static_cast<double>(thumb_width) * thumb_height * 3;
+    EXPECT_LE(mean_absolute_error, 2.0 / 255.0);
+    lfs::core::free_image(full);
+    lfs::core::free_image(thumb);
 }
 
 TEST(ImageIoTest, ExpandsEightBitPngToUint16) {

--- a/tools/error_debt_baseline.json
+++ b/tools/error_debt_baseline.json
@@ -249,7 +249,7 @@
       "src/visualizer/gui/rmlui/rml_panel_host.cpp:242",
       "src/visualizer/gui/rmlui/rml_theme.cpp:703",
       "src/visualizer/gui/rmlui/rmlui_manager.cpp:300",
-      "src/visualizer/gui/rmlui/rmlui_vk_backend.cpp:990",
+      "src/visualizer/gui/rmlui/rmlui_vk_backend.cpp:991",
       "src/visualizer/gui/sequencer_ui_manager.cpp:213",
       "src/visualizer/gui/sequencer_ui_manager.cpp:251",
       "src/visualizer/gui/sequencer_ui_manager.cpp:865",
@@ -606,7 +606,7 @@
     "python": [
       "src/python/lfs/module.cpp:171",
       "src/python/lfs/module.cpp:402",
-      "src/python/lfs/py_io.cpp:598",
+      "src/python/lfs/py_io.cpp:599",
       "src/python/lfs/py_rendering.cpp:1179",
       "src/python/lfs/py_splat_simplify.cpp:209"
     ],
@@ -1061,8 +1061,8 @@
       "src/training/rasterization/fastgs/utils/utils.h:20"
     ],
     "visualizer": [
-      "src/visualizer/gui/rmlui/rmlui_vk_backend.hpp:38",
-      "src/visualizer/gui/rmlui/rmlui_vk_backend.hpp:43",
+      "src/visualizer/gui/rmlui/rmlui_vk_backend.hpp:42",
+      "src/visualizer/gui/rmlui/rmlui_vk_backend.hpp:47",
       "src/visualizer/window/vulkan_result.hpp:131",
       "src/visualizer/window/vulkan_result.hpp:143",
       "src/visualizer/window/vulkan_result.hpp:145",


### PR DESCRIPTION
The Asset Manager opens with its cards immediately, thumbnails stream in without stalls, rescans are incremental, and the import dialog and recent-projects chooser no longer touch the filesystem on the UI thread.

What was slow: the catalog was rebuilt from scratch about 18 times per refresh; every panel open re-opened every project file; projects without an embedded thumbnail triggered a walk of their whole image folder; each thumbnail spawned its own thread and decoded the full-size JPEG; the recent-projects list opened containers on the UI thread; the import dialog rescanned the dataset folder on every keystroke; closing the panel could block for up to four seconds.

What changed: the catalog snapshot is cached and the panel updates only when something changes; file size, modification time and the inspection result are stored in the library, so unchanged projects are not re-opened; thumbnails decode on a small worker pool at reduced size with bilinear resampling; recent-project checks and dataset probing run on workers and post results back; closing the panel never waits for workers. Catalog format bumps to version 4 and still reads version 3.

Verification: new tests for the cache, the unchanged-file shortcut, verify ordering, the debounced probe and unmount; asset/import/recent/preview Python suites pass (133), the Python fast tier passes (606), image I/O tests pass. Verified in the running app that the catalog lists with cached sizes.
