### PR TITLE
UI: no more idle CPU spin, display-rate animations, exact click replay

### DIFF
--- a/src/core/event_bridge/localization_manager.cpp
+++ b/src/core/event_bridge/localization_manager.cpp
@@ -79,6 +79,7 @@ namespace lfs::event {
             return false;
 
         current_language_ = initial_language;
+        language_generation_.fetch_add(1, std::memory_order_release);
         LOG_INFO("Language set to: {}", initial_language);
         return true;
     }
@@ -93,6 +94,7 @@ namespace lfs::event {
         available_languages_.clear();
         language_names_.clear();
         overrides_.clear();
+        language_generation_.fetch_add(1, std::memory_order_release);
     }
 
     const char* LocalizationManager::get(std::string_view key) const {
@@ -204,6 +206,7 @@ namespace lfs::event {
             return false;
 
         current_language_ = language_code;
+        language_generation_.fetch_add(1, std::memory_order_release);
         LOG_INFO("Language set to: {}", language_code);
         return true;
     }

--- a/src/core/event_bridge/localization_manager.hpp
+++ b/src/core/event_bridge/localization_manager.hpp
@@ -6,6 +6,8 @@
 #include "event_bridge.hpp"
 
 #include <array>
+#include <atomic>
+#include <cstdint>
 #include <format>
 #include <mutex>
 #include <string>
@@ -34,6 +36,9 @@ namespace lfs::event {
         std::vector<std::string> getAvailableLanguageNames() const;
         bool setLanguage(const std::string& language_code);
         std::string getCurrentLanguage() const;
+        [[nodiscard]] std::uint64_t getCurrentLanguageGeneration() const noexcept {
+            return language_generation_.load(std::memory_order_acquire);
+        }
         std::string getCurrentLanguageName() const;
         bool reload();
 
@@ -61,6 +66,7 @@ namespace lfs::event {
         std::vector<std::string> available_languages_;
         std::unordered_map<std::string, std::string> language_names_;
         mutable std::unordered_map<std::string, std::string> overrides_;
+        std::atomic<std::uint64_t> language_generation_{0};
     };
 
     template <typename... Args>

--- a/src/core/include/core/logger.hpp
+++ b/src/core/include/core/logger.hpp
@@ -213,18 +213,19 @@ namespace lfs::core {
     // Scoped timer for performance measurement
     class LFS_LOGGER_API ScopedTimer {
     public:
-        explicit ScopedTimer(std::string name, LogLevel level, SourceSite loc);
-        ScopedTimer(std::string name, double min_log_ms,
+        explicit ScopedTimer(std::string_view name, LogLevel level, SourceSite loc);
+        ScopedTimer(std::string_view name, double min_log_ms,
                     LogLevel level, SourceSite loc);
         ~ScopedTimer();
 
     private:
-        std::chrono::high_resolution_clock::time_point start_;
+        std::chrono::high_resolution_clock::time_point start_{};
         std::string name_;
         double min_log_ms_ = 0.0;
         LogLevel level_;
         SourceSite loc_;
         bool diagnostics_scope_active_ = false;
+        bool disabled_ = false;
     };
 
 } // namespace lfs::core

--- a/src/core/include/core/scene.hpp
+++ b/src/core/include/core/scene.hpp
@@ -426,6 +426,8 @@ namespace lfs::core {
 
         [[nodiscard]] std::shared_ptr<lfs::core::Tensor> getVisibleSelectionIndices() const;
         [[nodiscard]] std::shared_ptr<lfs::core::Tensor> getVisibleSelectionMask() const;
+        [[nodiscard]] uint64_t renderGeneration() const noexcept { return render_generation_; }
+        [[nodiscard]] uint64_t selectionGeneration() const noexcept { return selection_generation_; }
 
         enum class MergeStorageMode {
             Clone,
@@ -561,8 +563,13 @@ namespace lfs::core {
             transform_cache_valid_.store(false, std::memory_order_release);
             cached_transform_indices_.reset();
             cached_visible_selection_indices_.reset();
+            invalidateVisibleSelectionMaskCache();
+            ++render_generation_;
         }
-        void invalidateTransformCache() { transform_cache_valid_.store(false, std::memory_order_release); }
+        void invalidateTransformCache() {
+            transform_cache_valid_.store(false, std::memory_order_release);
+            ++render_generation_;
+        }
         void markDirty() { invalidateCache(); }
         void markTransformDirty(NodeId node);
 
@@ -622,6 +629,12 @@ namespace lfs::core {
         mutable std::shared_ptr<lfs::core::SplatData> cached_combined_;
         mutable std::shared_ptr<lfs::core::Tensor> cached_transform_indices_;
         mutable std::shared_ptr<lfs::core::Tensor> cached_visible_selection_indices_;
+        mutable std::shared_ptr<lfs::core::Tensor> cached_visible_selection_mask_;
+        mutable const lfs::core::Tensor* cached_visible_selection_mask_source_ = nullptr;
+        mutable const lfs::core::SplatData* cached_visible_selection_mask_model_ = nullptr;
+        mutable const lfs::core::Tensor* cached_visible_selection_mask_indices_ = nullptr;
+        mutable uint64_t cached_visible_selection_mask_selection_generation_ = 0;
+        mutable uint64_t cached_visible_selection_mask_visibility_generation_ = 0;
         mutable std::atomic<bool> model_cache_valid_{false};
         mutable const lfs::core::SplatData* single_node_model_ = nullptr;
 
@@ -637,6 +650,8 @@ namespace lfs::core {
         mutable bool consolidated_ = false;
         mutable std::vector<ConsolidatedNodeSlot> consolidated_node_slots_;
         mutable uint64_t consolidated_generation_ = 0;
+        mutable uint64_t render_generation_ = 0;
+        mutable uint64_t selection_generation_ = 0;
 
         mutable std::shared_mutex selection_mutex_;
         mutable std::shared_ptr<lfs::core::Tensor> selection_mask_;
@@ -651,6 +666,15 @@ namespace lfs::core {
         bool selection_group_counts_dirty_ = true;
 
         void rebuildCacheIfNeeded() const;
+        void invalidateVisibleSelectionMaskCache() const {
+            cached_visible_selection_mask_.reset();
+            cached_visible_selection_mask_source_ = nullptr;
+            cached_visible_selection_mask_model_ = nullptr;
+            cached_visible_selection_mask_indices_ = nullptr;
+            cached_visible_selection_mask_selection_generation_ = 0;
+            cached_visible_selection_mask_visibility_generation_ = 0;
+        }
+
         void rebuildModelCacheIfNeeded() const;
         void rebuildModelCacheIfNeeded(bool include_hidden_splats) const;
         void rebuildTransformCacheIfNeeded() const;

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -691,28 +691,41 @@ namespace lfs::core {
         return impl_->memory_sink ? impl_->memory_sink->text() : std::string{};
     }
 
-    ScopedTimer::ScopedTimer(std::string name, const LogLevel level, const SourceSite loc)
-        : start_(std::chrono::high_resolution_clock::now()),
-          name_(std::move(name)),
-          level_(level),
+    ScopedTimer::ScopedTimer(const std::string_view name, const LogLevel level,
+                             const SourceSite loc)
+        : level_(level),
           loc_(loc) {
+        const bool log_enabled = Logger::get().is_enabled(level_);
         try {
             diagnostics_scope_active_ = lfs::diagnostics::VramProfiler::instance().enabled();
-            if (diagnostics_scope_active_) {
-                lfs::diagnostics::VramProfiler::instance().pushTimerScope(name_);
-            }
         } catch (...) {
             diagnostics_scope_active_ = false;
         }
+
+        disabled_ = !log_enabled && !diagnostics_scope_active_;
+        if (disabled_)
+            return;
+
+        start_ = std::chrono::high_resolution_clock::now();
+        name_ = name;
+        if (diagnostics_scope_active_) {
+            try {
+                lfs::diagnostics::VramProfiler::instance().pushTimerScope(name_);
+            } catch (...) {
+                diagnostics_scope_active_ = false;
+            }
+        }
     }
 
-    ScopedTimer::ScopedTimer(std::string name, const double min_log_ms,
+    ScopedTimer::ScopedTimer(const std::string_view name, const double min_log_ms,
                              const LogLevel level, const SourceSite loc)
-        : ScopedTimer(std::move(name), level, loc) {
+        : ScopedTimer(name, level, loc) {
         min_log_ms_ = min_log_ms;
     }
 
     ScopedTimer::~ScopedTimer() {
+        if (disabled_)
+            return;
         const auto duration = std::chrono::high_resolution_clock::now() - start_;
         const auto ms = std::chrono::duration<double, std::milli>(duration).count();
         if (diagnostics_scope_active_) {
@@ -723,7 +736,8 @@ namespace lfs::core {
         }
         if (ms < min_log_ms_)
             return;
-        Logger::get().log(level_, loc_, std::format("{} took {:.2f}ms", name_, ms));
+        if (Logger::get().is_enabled(level_))
+            Logger::get().log(level_, loc_, std::format("{} took {:.2f}ms", name_, ms));
     }
 
 } // namespace lfs::core

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -137,6 +137,7 @@ namespace lfs::core {
                 invalidateCache();
             break;
         case MutationType::SELECTION_CHANGED:
+            ++selection_generation_;
             break;
         default:
             invalidateCache();
@@ -571,6 +572,7 @@ namespace lfs::core {
         auto* node = getNodeById(id);
         if (node) {
             node->local_transform.set(transform, false);
+            invalidateTransformCache();
         }
     }
 
@@ -594,6 +596,7 @@ namespace lfs::core {
         cached_combined_.reset();
         cached_transform_indices_.reset();
         cached_visible_selection_indices_.reset();
+        invalidateVisibleSelectionMaskCache();
         cached_transforms_.clear();
         model_cache_valid_.store(false, std::memory_order_release);
         transform_cache_valid_.store(false, std::memory_order_release);
@@ -693,6 +696,7 @@ namespace lfs::core {
         single_node_model_ = nullptr;
         cached_transform_indices_.reset();
         cached_visible_selection_indices_.reset();
+        invalidateVisibleSelectionMaskCache();
         rebuildModelCacheIfNeeded(/*include_hidden_splats=*/true);
 
         if (single_node_model_ || !cached_combined_) {
@@ -808,6 +812,7 @@ namespace lfs::core {
         ++consolidated_generation_;
         cached_transform_indices_.reset();
         cached_visible_selection_indices_.reset();
+        invalidateVisibleSelectionMaskCache();
         model_cache_valid_.store(false, std::memory_order_release);
         transform_cache_valid_.store(false, std::memory_order_release);
     }
@@ -1037,6 +1042,7 @@ namespace lfs::core {
 
         cached_transform_indices_.reset();
         cached_visible_selection_indices_.reset();
+        invalidateVisibleSelectionMaskCache();
         model_cache_valid_.store(false, std::memory_order_release);
         transform_cache_valid_.store(false, std::memory_order_release);
         return true;
@@ -1649,6 +1655,7 @@ namespace lfs::core {
 
         if (!include_hidden_splats && consolidated_ && cached_combined_) {
             cached_visible_selection_indices_.reset();
+            invalidateVisibleSelectionMaskCache();
             rebuildConsolidatedTransformIndices();
             model_cache_valid_.store(true, std::memory_order_release);
             return;
@@ -1685,6 +1692,7 @@ namespace lfs::core {
             cached_combined_.reset();
             cached_transform_indices_.reset();
             cached_visible_selection_indices_.reset();
+            invalidateVisibleSelectionMaskCache();
             model_cache_valid_.store(true, std::memory_order_release);
             transform_cache_valid_.store(false, std::memory_order_release);
             return;
@@ -1703,11 +1711,13 @@ namespace lfs::core {
                 lfs::core::Tensor::zeros({n}, lfs::core::Device::CUDA, lfs::core::DataType::Int32));
             if (n == full_selection_count && visible_selection_offsets[0] == 0) {
                 cached_visible_selection_indices_.reset();
+                invalidateVisibleSelectionMaskCache();
             } else {
                 std::vector<int> visible_indices(n);
                 for (size_t i = 0; i < n; ++i) {
                     visible_indices[i] = static_cast<int>(visible_selection_offsets[0] + i);
                 }
+                invalidateVisibleSelectionMaskCache();
                 cached_visible_selection_indices_ = std::make_shared<lfs::core::Tensor>(
                     lfs::core::Tensor::from_vector(
                         visible_indices, {n}, lfs::core::Device::CPU)
@@ -1859,6 +1869,7 @@ namespace lfs::core {
             Tensor::from_vector(transform_indices_data, {stats.total_gaussians}, lfs::core::Device::CPU).cuda());
         if (stats.total_gaussians == full_selection_count) {
             cached_visible_selection_indices_.reset();
+            invalidateVisibleSelectionMaskCache();
         } else {
             std::vector<int> visible_indices(stats.total_gaussians);
             size_t visible_offset = 0;
@@ -1870,6 +1881,7 @@ namespace lfs::core {
                 }
                 visible_offset += size;
             }
+            invalidateVisibleSelectionMaskCache();
             cached_visible_selection_indices_ = std::make_shared<Tensor>(
                 Tensor::from_vector(visible_indices, {stats.total_gaussians}, lfs::core::Device::CPU).cuda());
         }
@@ -1967,7 +1979,25 @@ namespace lfs::core {
             visible_indices->numel() != static_cast<size_t>(model->size())) {
             return nullptr;
         }
-        return std::make_shared<lfs::core::Tensor>(selection->index_select(0, *visible_indices).contiguous());
+
+        const auto selection_generation = selection_generation_;
+        const auto visibility_generation = render_generation_;
+        if (cached_visible_selection_mask_ &&
+            cached_visible_selection_mask_source_ == selection.get() &&
+            cached_visible_selection_mask_model_ == model &&
+            cached_visible_selection_mask_indices_ == visible_indices.get() &&
+            cached_visible_selection_mask_selection_generation_ == selection_generation &&
+            cached_visible_selection_mask_visibility_generation_ == visibility_generation)
+            return cached_visible_selection_mask_;
+
+        cached_visible_selection_mask_ = std::make_shared<lfs::core::Tensor>(
+            selection->index_select(0, *visible_indices).contiguous());
+        cached_visible_selection_mask_source_ = selection.get();
+        cached_visible_selection_mask_model_ = model;
+        cached_visible_selection_mask_indices_ = visible_indices.get();
+        cached_visible_selection_mask_selection_generation_ = selection_generation;
+        cached_visible_selection_mask_visibility_generation_ = visibility_generation;
+        return cached_visible_selection_mask_;
     }
 
     int Scene::getVisibleNodeIndex(const std::string& name) const {
@@ -3233,6 +3263,7 @@ namespace lfs::core {
         has_selection_ = staged->has_selection_;
         has_point_cloud_selection_ =
             staged->has_point_cloud_selection_;
+        ++selection_generation_;
         selection_group_counts_dirty_ =
             staged->selection_group_counts_dirty_;
 

--- a/src/python/_lfs_panel_contract.py
+++ b/src/python/_lfs_panel_contract.py
@@ -23,7 +23,7 @@ class Panel:
     style: str = ''
     height_mode: PanelHeightMode = DEFAULT_HEIGHT_MODE
     update_interval_ms: int = 100
-    update_policy: str = 'interval'
+    update_policy: str = 'dirty'
 
     @classmethod
     def _class_id(cls) -> str:

--- a/src/python/lfs/rml_python_panel_adapter.cpp
+++ b/src/python/lfs/rml_python_panel_adapter.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <format>
 #include <nanobind/stl/string.h>
 
 namespace lfs::vis::gui {
@@ -233,6 +234,8 @@ namespace lfs::vis::gui {
 
         if (isMounted() && last_language_.empty())
             last_language_ = lfs::event::LocalizationManager::getInstance().getCurrentLanguage();
+        last_language_generation_ =
+            lfs::event::LocalizationManager::getInstance().getCurrentLanguageGeneration();
 
         return doc;
     }
@@ -381,7 +384,8 @@ namespace lfs::vis::gui {
         if (frame_serial != 0 && last_prepare_frame_ == frame_serial)
             return doc;
 
-        bool pending_dirty = content_dirty_ || lfs::python::consume_document_dirty(doc);
+        const bool was_content_dirty = content_dirty_;
+        bool pending_dirty = was_content_dirty || lfs::python::consume_document_dirty(doc);
         bool update_requested = lfs::python::consume_document_update_request(doc);
         const bool scene_changed = ctx && ctx->scene && ctx->scene_generation != last_scene_gen_;
         const auto now = std::chrono::steady_clock::now();
@@ -433,7 +437,14 @@ namespace lfs::vis::gui {
         if (pending_dirty && ops.mark_content_dirty)
             ops.mark_content_dirty(host_);
 
-        drawImmediateLayout(doc, ctx);
+        // A retained panel is clean when neither its host nor its Python model
+        // requested work in this frame. In that state the cached Rml surface is
+        // already authoritative, so avoid reacquiring the GIL and calling draw().
+        const bool draw_required = was_content_dirty || pending_dirty ||
+                                   update_requested || should_run_update ||
+                                   last_prepare_frame_ == 0;
+        if (draw_required)
+            drawImmediateLayout(doc, ctx);
 
         if (frame_serial != 0)
             last_prepare_frame_ = frame_serial;
@@ -636,9 +647,9 @@ namespace lfs::vis::gui {
         if (!host_)
             return false;
 
-        const std::string current_language =
-            lfs::event::LocalizationManager::getInstance().getCurrentLanguage();
-        if (!current_language.empty() && current_language != last_language_)
+        const auto language_generation =
+            lfs::event::LocalizationManager::getInstance().getCurrentLanguageGeneration();
+        if (language_generation != last_language_generation_)
             return true;
 
         if (!dirty_driven_updates_) {
@@ -658,6 +669,30 @@ namespace lfs::vis::gui {
         }
 
         return ops.needs_animation ? ops.needs_animation(host_) : false;
+    }
+
+    std::string RmlPythonPanelAdapter::animationDemandDescription() const {
+        std::string result = dirty_driven_updates_
+                                 ? "policy=dirty"
+                                 : std::format("policy=interval,{}ms", update_interval_ms_);
+        if (host_) {
+            const auto& ops = lfs::python::get_rml_panel_host_ops();
+            if (ops.animation_demand_description) {
+                const auto document = ops.animation_demand_description(host_);
+                if (!document.empty()) {
+                    result += ',';
+                    result += document;
+                }
+            }
+        }
+        return result;
+    }
+
+    bool RmlPythonPanelAdapter::needsImmediateAnimationFrame() const {
+        if (!host_)
+            return false;
+        const auto& ops = lfs::python::get_rml_panel_host_ops();
+        return ops.needs_immediate_animation && ops.needs_immediate_animation(host_);
     }
 
     std::optional<double> RmlPythonPanelAdapter::nextScheduledAnimationDelay() const {

--- a/src/python/lfs/rml_python_panel_adapter.hpp
+++ b/src/python/lfs/rml_python_panel_adapter.hpp
@@ -40,6 +40,8 @@ namespace lfs::vis::gui {
         PanelDirectRenderResult renderDirect(const PanelDirectRenderRequest& request,
                                              const PanelDrawContext& ctx) override;
         bool needsAnimationFrame() const override;
+        bool needsImmediateAnimationFrame() const override;
+        std::string animationDemandDescription() const override;
         std::optional<double> nextScheduledAnimationDelay() const override;
         void reloadRmlResources() override;
         [[nodiscard]] std::string captureChromeJson() const override;
@@ -106,6 +108,7 @@ namespace lfs::vis::gui {
         int update_interval_ms_ = 100;
         std::chrono::steady_clock::time_point next_update_at_{};
         std::string last_language_;
+        std::uint64_t last_language_generation_ = 0;
         lfs::python::RmlImModeLayout layout_;
         std::optional<PanelInputState> current_input_;
         float prev_mouse_x_ = 0.0f;

--- a/src/python/lfs_plugins/asset_manager_panel.py
+++ b/src/python/lfs_plugins/asset_manager_panel.py
@@ -86,8 +86,7 @@ class AssetManagerPanel(Panel):
     height_mode = lf.ui.PanelHeightMode.FILL
     size = (980, 620)
     options = {lf.ui.PanelOption.DEFAULT_CLOSED}
-    update_policy = "interval"
-    update_interval_ms = 250
+    update_policy = "dirty"
 
     STORAGE_PATH: Optional[Path] = None
 

--- a/src/python/lfs_plugins/overlays/__init__.py
+++ b/src/python/lfs_plugins/overlays/__init__.py
@@ -36,9 +36,13 @@ _GAP_LENGTH = 8.0
 _BORDER_THICKNESS = 2.0
 _ICON_SIZE = 48.0
 _ANIM_SPEED = 30.0
-_EMPTY_STATE_REDRAW_INTERVAL = 1.0 / 15.0  # marching-ants pacing; ~2px/frame at _ANIM_SPEED=30
+_EMPTY_STATE_REDRAW_INTERVAL = 1.0 / 60.0
+_EMPTY_STATE_ANIMATION_IDLE_TIMEOUT = 3.0
 _MIN_VIEWPORT_SIZE = 200.0
 _AUTO_DISMISS_DELAY = 3.0
+
+_empty_state_animation_until = 0.0
+_empty_state_last_mouse_pos = None
 
 _OVERLAY_FLAGS = (
     lf.ui.UILayout.WindowFlags.NoTitleBar
@@ -328,10 +332,16 @@ class _OverlayDocumentController:
 
 
 def _draw_empty_state_overlay(layout):
+    global _empty_state_animation_until, _empty_state_last_mouse_pos
+
     if not lf.ui.is_scene_empty() or lf.ui.is_drag_hovering() or lf.ui.is_startup_visible():
+        _empty_state_animation_until = 0.0
+        _empty_state_last_mouse_pos = None
         return
     import_state = _get_import_state()
     if import_state.get("active", False) or import_state.get("show_completion", False):
+        _empty_state_animation_until = 0.0
+        _empty_state_last_mouse_pos = None
         return
 
     vp_x, vp_y = layout.get_viewport_pos()
@@ -360,7 +370,15 @@ def _draw_empty_state_overlay(layout):
     zone_max_x = vp_x + vp_w - _ZONE_PADDING
     zone_max_y = vp_y + vp_h - _viewport_bottom_inset(layout, _ZONE_PADDING)
 
-    dash_offset = (lf.ui.get_time() * _ANIM_SPEED) % (_DASH_LENGTH + _GAP_LENGTH)
+    now = lf.ui.get_time()
+    mouse_pos = lf.ui.get_mouse_screen_pos()
+    if (_empty_state_last_mouse_pos is not None and
+            (abs(mouse_pos[0] - _empty_state_last_mouse_pos[0]) > 0.5 or
+             abs(mouse_pos[1] - _empty_state_last_mouse_pos[1]) > 0.5)):
+        _empty_state_animation_until = now + _EMPTY_STATE_ANIMATION_IDLE_TIMEOUT
+    _empty_state_last_mouse_pos = mouse_pos
+    animating = now < _empty_state_animation_until
+    dash_offset = (now * _ANIM_SPEED) % (_DASH_LENGTH + _GAP_LENGTH) if animating else 0.0
 
     def draw_dashed_line(start_x, start_y, end_x, end_y):
         dx = end_x - start_x
@@ -436,7 +454,8 @@ def _draw_empty_state_overlay(layout):
     layout.draw_window_text(center_x - hint_w * 0.5, center_y + 70.0, hint, hint_color)
 
     layout.end_window()
-    lf.ui.request_redraw(delay=_EMPTY_STATE_REDRAW_INTERVAL)
+    if animating:
+        lf.ui.request_redraw(delay=_EMPTY_STATE_REDRAW_INTERVAL)
 
 
 def _draw_drag_drop_overlay(layout):

--- a/src/python/lfs_plugins/preferences_panel.py
+++ b/src/python/lfs_plugins/preferences_panel.py
@@ -22,8 +22,7 @@ class PreferencesPanel(Panel):
     height_mode = lf.ui.PanelHeightMode.FILL
     size = (780, 440)
     options = {lf.ui.PanelOption.DEFAULT_CLOSED}
-    update_policy = "interval"
-    update_interval_ms = 50
+    update_policy = "dirty"
 
     SCALE_OPTIONS = (
         (0.0, "menu.view.ui_scale.auto"),

--- a/src/python/python_runtime.hpp
+++ b/src/python/python_runtime.hpp
@@ -706,6 +706,8 @@ namespace lfs::python {
         void (*set_input)(void* host, const void* input);
         void (*set_forced_height)(void* host, float h);
         bool (*needs_animation)(void* host);
+        bool (*needs_immediate_animation)(void* host);
+        std::string (*animation_demand_description)(void* host);
         // Returns true and writes delay when the host has a finite scheduled
         // update delay > 0 seconds; false for continuous demand or idle.
         bool (*next_scheduled_update_delay)(void* host, double* out_seconds);

--- a/src/python/stubs/lichtfeld/ui/__init__.pyi
+++ b/src/python/stubs/lichtfeld/ui/__init__.pyi
@@ -306,7 +306,7 @@ class Panel:
 
     update_interval_ms: int = 100
 
-    update_policy: str = 'interval'
+    update_policy: str = 'dirty'
 
     @classmethod
     def poll(cls, context) -> bool: ...

--- a/src/visualizer/core/editor_context.cpp
+++ b/src/visualizer/core/editor_context.cpp
@@ -40,6 +40,35 @@ namespace lfs::vis {
     } // namespace
 
     void EditorContext::update(const SceneManager* scene_manager, const TrainerManager* trainer_manager) {
+        const auto scene_generation = app_store().scene_generation.get();
+        const auto selection_generation = app_store().selection_generation.get();
+        const bool has_scene_manager = scene_manager != nullptr;
+        const bool has_trainer_manager = trainer_manager != nullptr;
+        const bool trainer_running = trainer_manager && trainer_manager->isRunning();
+        const bool trainer_paused = trainer_manager && trainer_manager->isPaused();
+        const bool trainer_finished = trainer_manager && trainer_manager->isFinished();
+        const std::size_t scene_node_count = scene_manager ? scene_manager->getScene().getNodeCount() : 0;
+        if (state_initialized_ &&
+            scene_generation == last_scene_generation_ &&
+            selection_generation == last_selection_generation_ &&
+            has_scene_manager == last_has_scene_manager_ &&
+            has_trainer_manager == last_has_trainer_manager_ &&
+            trainer_running == last_trainer_running_ &&
+            trainer_paused == last_trainer_paused_ &&
+            trainer_finished == last_trainer_finished_ &&
+            scene_node_count == last_scene_node_count_)
+            return;
+
+        last_scene_generation_ = scene_generation;
+        last_selection_generation_ = selection_generation;
+        last_has_scene_manager_ = has_scene_manager;
+        last_has_trainer_manager_ = has_trainer_manager;
+        last_trainer_running_ = trainer_running;
+        last_trainer_paused_ = trainer_paused;
+        last_trainer_finished_ = trainer_finished;
+        last_scene_node_count_ = scene_node_count;
+        state_initialized_ = true;
+
         if (!scene_manager) {
             mode_ = EditorMode::EMPTY;
             has_selection_ = false;
@@ -80,8 +109,8 @@ namespace lfs::vis {
         }
 
         // Update selection state
-        const auto selected_node_names = scene_manager->getSelectedNodeNames();
-        has_selection_ = !selected_node_names.empty();
+        const auto selected_node_ids = scene_manager->getSelectedNodeIds();
+        has_selection_ = !selected_node_ids.empty();
         has_editable_transform_selection_ = false;
         has_splat_selection_ = false;
         has_editable_splat_selection_ = false;
@@ -95,8 +124,8 @@ namespace lfs::vis {
             bool has_editable_transform_target = false;
             bool selected_type_initialized = false;
 
-            for (const auto& name : selected_node_names) {
-                const auto* const node = scene.getNode(name);
+            for (const auto id : selected_node_ids) {
+                const auto* const node = scene.getNodeById(id);
                 if (!node)
                     continue;
 

--- a/src/visualizer/core/editor_context.hpp
+++ b/src/visualizer/core/editor_context.hpp
@@ -134,6 +134,15 @@ namespace lfs::vis {
         bool dispatchModalEvent(const ModalEvent& evt) const override { return modal_event_cb_ ? modal_event_cb_(evt) : false; }
 
     private:
+        std::uint64_t last_scene_generation_ = 0;
+        std::uint64_t last_selection_generation_ = 0;
+        bool last_has_scene_manager_ = false;
+        bool last_has_trainer_manager_ = false;
+        bool last_trainer_running_ = false;
+        bool last_trainer_paused_ = false;
+        bool last_trainer_finished_ = false;
+        std::size_t last_scene_node_count_ = 0;
+        bool state_initialized_ = false;
         EditorMode mode_ = EditorMode::EMPTY;
         core::NodeType selected_node_type_ = core::NodeType::SPLAT;
         ToolType active_tool_ = ToolType::None;

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -2847,6 +2847,8 @@ namespace lfs::vis::gui {
             for (auto& value : input.mouse_released)
                 value = false;
             input.mouse_wheel = 0.0f;
+            input.mouse_wheel_x = 0.0f;
+            input.mouse_button_events.clear();
             input.key_ctrl = false;
             input.key_shift = false;
             input.key_alt = false;
@@ -3578,6 +3580,12 @@ namespace lfs::vis::gui {
         };
         ops.needs_animation = [](void* host) -> bool {
             return static_cast<RmlPanelHost*>(host)->needsAnimationFrame();
+        };
+        ops.needs_immediate_animation = [](void* host) -> bool {
+            return static_cast<RmlPanelHost*>(host)->needsImmediateAnimationFrame();
+        };
+        ops.animation_demand_description = [](void* host) {
+            return static_cast<RmlPanelHost*>(host)->animationDemandDescription();
         };
         ops.next_scheduled_update_delay = [](void* host, double* out_seconds) -> bool {
             const auto delay =
@@ -5152,6 +5160,8 @@ namespace lfs::vis::gui {
                 for (auto& v : masked_input.mouse_down)
                     v = false;
                 masked_input.mouse_wheel = 0;
+                masked_input.mouse_wheel_x = 0;
+                masked_input.mouse_button_events.clear();
                 rml_right_panel_.processInput(rp_layout, masked_input);
             } else {
                 rml_right_panel_.processInput(rp_layout, panel_input);
@@ -7043,6 +7053,69 @@ namespace lfs::vis::gui {
         return false;
     }
 
+    std::string GuiManager::describeAnimationDemand() const {
+        if (!lfs::core::Logger::get().is_enabled(lfs::core::LogLevel::Performance))
+            return {};
+
+        const auto now = std::chrono::steady_clock::now();
+        if (last_animation_demand_description_at_ != std::chrono::steady_clock::time_point{} &&
+            now - last_animation_demand_description_at_ < std::chrono::seconds(1))
+            return animation_demand_description_cache_;
+
+        std::string result;
+        const auto add = [&result](const bool active, const std::string_view source) {
+            if (!active)
+                return;
+            if (!result.empty())
+                result += ',';
+            result += source;
+        };
+
+        add(ui_toggle_pending_ && now >= ui_toggle_next_allowed_at_, "ui_toggle");
+        add(fullscreen_toggle_pending_ && now >= fullscreen_toggle_next_allowed_at_,
+            "fullscreen_toggle");
+        add(interactive_transition_resume_training_ || now < interactive_transition_guard_until_,
+            "interactive_transition");
+        add(isViewportExportLocked(), "viewport_export");
+        add(static_cast<bool>(rmlui_manager_.dragPayload()), "drag_payload");
+        add(startup_overlay_.needsAnimationFrame(), "startup_overlay");
+        add(rml_modal_overlay_ && rml_modal_overlay_->needsAnimationFrame(), "modal_overlay");
+        add(rml_toast_overlay_ && rml_toast_overlay_->needsAnimationFrame(), "toast_overlay");
+        add(global_context_menu_ && global_context_menu_->needsAnimationFrame(), "context_menu");
+        add(video_widget_ && video_widget_->isVideoPlaying(), "video");
+        add(ui_layout_settle_frames_ > 0, "layout_settle");
+        add(isVramHudPublishDue(now), "vram_hud");
+        add(rml_viewport_overlay_.needsAnimationFrame(), "viewport_overlay");
+        add(rml_menu_bar_.needsAnimationFrame(), "menu_bar");
+        if (const auto right_panel_demand = rml_right_panel_.animationDemandDescription();
+            !right_panel_demand.empty()) {
+            if (!result.empty())
+                result += ',';
+            result += right_panel_demand;
+        }
+        add(rml_status_bar_.animationFrameDue(now), "status_bar");
+
+        if (!python::is_plugin_preload_running()) {
+            const auto panel_sources = PanelRegistry::instance().describeAnimationDemand(
+                panelAnimationVisibility());
+            if (!panel_sources.empty()) {
+                if (!result.empty())
+                    result += ',';
+                result += "panels=";
+                result += panel_sources;
+            }
+        }
+
+        last_animation_demand_description_at_ = now;
+        animation_demand_description_cache_ = result.empty() ? "none" : std::move(result);
+        return animation_demand_description_cache_;
+    }
+
+    bool GuiManager::needsImmediateAnimationFrame() const {
+        return PanelRegistry::instance().needsImmediateAnimationFrameForVisiblePanels(
+            panelAnimationVisibility());
+    }
+
     PanelAnimationVisibility GuiManager::panelAnimationVisibility() const {
         return {
             .active_main_tab = panel_layout_.getActiveTab(),
@@ -7053,13 +7126,26 @@ namespace lfs::vis::gui {
         };
     }
 
-    std::optional<double> GuiManager::secondsUntilNextAnimationFrame() const {
-        auto min_delay = [](std::optional<double> a, std::optional<double> b) -> std::optional<double> {
-            if (!a)
+    std::optional<double> GuiManager::secondsUntilNextAnimationFrame(const char** source) const {
+        if (source)
+            *source = nullptr;
+
+        auto min_delay = [source](std::optional<double> a,
+                                  std::optional<double> b,
+                                  const char* b_source) -> std::optional<double> {
+            if (!a) {
+                if (source)
+                    *source = b_source;
                 return b;
+            }
             if (!b)
                 return a;
-            return std::min(*a, *b);
+            if (*b < *a) {
+                if (source)
+                    *source = b_source;
+                return b;
+            }
+            return a;
         };
 
         std::optional<double> result;
@@ -7068,11 +7154,14 @@ namespace lfs::vis::gui {
         if (!python::is_plugin_preload_running()) {
             result = min_delay(result,
                                PanelRegistry::instance().nextScheduledAnimationDelayForVisiblePanels(
-                                   panelAnimationVisibility()));
+                                   panelAnimationVisibility()),
+                               "panels");
         }
 
-        result = min_delay(result, rml_viewport_overlay_.nextScheduledUpdateDelay());
-        result = min_delay(result, rml_status_bar_.secondsUntilAnimationFrame(now));
+        result = min_delay(result, rml_viewport_overlay_.nextScheduledUpdateDelay(),
+                           "viewport_overlay");
+        result = min_delay(result, rml_status_bar_.secondsUntilAnimationFrame(now),
+                           "status_bar");
 
         // VRAM HUD cadence: when armed and not yet due, wake at the publish deadline.
         if (isVramHudOverlayVisible()) {
@@ -7081,7 +7170,7 @@ namespace lfs::vis::gui {
                 const double remaining =
                     std::chrono::duration<double>(next_vram_hud_publish_ - now).count();
                 if (remaining > 0.0)
-                    result = min_delay(result, remaining);
+                    result = min_delay(result, remaining, "vram_hud");
             }
         }
 

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -126,9 +126,12 @@ namespace lfs::vis {
 
             // State queries
             bool needsAnimationFrame() const;
+            [[nodiscard]] std::string describeAnimationDemand() const;
+            [[nodiscard]] bool needsImmediateAnimationFrame() const;
             // Min finite scheduled GUI animation/update delay (seconds). Used by the
             // idle wait path so CSS transitions / timers wake on time without spinning.
-            [[nodiscard]] std::optional<double> secondsUntilNextAnimationFrame() const;
+            [[nodiscard]] std::optional<double> secondsUntilNextAnimationFrame(
+                const char** source = nullptr) const;
             [[nodiscard]] bool isViewportExportLocked() const;
 
             // Window visibility
@@ -429,6 +432,8 @@ namespace lfs::vis {
             bool last_ui_layout_python_console_visible_ = false;
             bool last_ui_layout_bottom_dock_visible_ = false;
             bool last_ui_layout_left_dock_visible_ = false;
+            mutable std::chrono::steady_clock::time_point last_animation_demand_description_at_{};
+            mutable std::string animation_demand_description_cache_;
             enum class RightPanelPointerRegion : uint8_t {
                 None,
                 Resize,

--- a/src/visualizer/gui/panel_input_utils.hpp
+++ b/src/visualizer/gui/panel_input_utils.hpp
@@ -22,6 +22,8 @@ namespace lfs::vis::gui {
             input.mouse_released[i] = buf.mouse_released[i];
         }
         input.mouse_wheel = buf.mouse_wheel;
+        input.mouse_wheel_x = buf.mouse_wheel_x;
+        input.mouse_button_events = buf.mouse_button_events;
         input.screen_w = buf.window_w;
         input.screen_h = buf.window_h;
         input.key_ctrl = (buf.key_mods & SDL_KMOD_CTRL) != 0;

--- a/src/visualizer/gui/panel_layout.cpp
+++ b/src/visualizer/gui/panel_layout.cpp
@@ -150,6 +150,8 @@ namespace lfs::vis::gui {
             for (auto& v : masked.mouse_down)
                 v = false;
             masked.mouse_wheel = 0.0f;
+            masked.mouse_wheel_x = 0.0f;
+            masked.mouse_button_events.clear();
             return masked;
         };
         const PanelInputState masked_panel_input =
@@ -562,6 +564,8 @@ namespace lfs::vis::gui {
             for (auto& v : masked.mouse_down)
                 v = false;
             masked.mouse_wheel = 0.0f;
+            masked.mouse_wheel_x = 0.0f;
+            masked.mouse_button_events.clear();
             return masked;
         };
 
@@ -731,6 +735,8 @@ namespace lfs::vis::gui {
             for (auto& v : masked.mouse_down)
                 v = false;
             masked.mouse_wheel = 0.0f;
+            masked.mouse_wheel_x = 0.0f;
+            masked.mouse_button_events.clear();
             return masked;
         };
 

--- a/src/visualizer/gui/panel_layout.hpp
+++ b/src/visualizer/gui/panel_layout.hpp
@@ -8,6 +8,7 @@
 #include "gui/layout_state.hpp"
 #include "gui/panel_registry.hpp"
 #include "gui/ui_context.hpp"
+#include "input/frame_input_buffer.hpp"
 #include <cstdint>
 #include <glm/glm.hpp>
 #include <string>
@@ -42,6 +43,8 @@ namespace lfs::vis::gui {
         int screen_w = 0;
         int screen_h = 0;
         float mouse_wheel = 0;
+        float mouse_wheel_x = 0;
+        std::vector<FrameMouseButtonEvent> mouse_button_events;
         bool key_ctrl = false;
         bool key_shift = false;
         bool key_alt = false;

--- a/src/visualizer/gui/panel_registry.cpp
+++ b/src/visualizer/gui/panel_registry.cpp
@@ -48,7 +48,7 @@ namespace lfs::vis::gui {
             interaction.user_height = 0.0f;
         }
 
-        std::string panelDirectTimerName(const std::string& panel_id, const char* stage) {
+        std::string panelDirectTimerName(const std::string_view panel_id, const char* stage) {
             std::string name = "gui_render.panel_direct.";
             if (panel_id.empty()) {
                 name += "unknown";
@@ -331,6 +331,9 @@ namespace lfs::vis::gui {
             assert(info.panel);
             assert(!info.id.empty());
 
+            info.id_storage = std::make_shared<const std::string>(info.id);
+            info.label_storage = std::make_shared<const std::string>(info.label);
+
             if (!validatePanelContract(info, info.space))
                 return false;
 
@@ -547,7 +550,7 @@ apply_registered_chrome:
 
         {
             std::lock_guard poll_lock(poll_mutex_);
-            auto cache_it = poll_cache_.find(snap.id);
+            auto cache_it = poll_cache_.find(*snap.id_storage);
             if (cache_it != poll_cache_.end()) {
                 const auto& e = cache_it->second;
                 bool valid = true;
@@ -566,7 +569,8 @@ apply_registered_chrome:
 
         {
             std::lock_guard poll_lock(poll_mutex_);
-            poll_cache_[snap.id] = {result, gen, has_sel, training, snap.poll_dependencies};
+            poll_cache_[*snap.id_storage] = {result, gen, has_sel, training,
+                                             snap.poll_dependencies};
         }
         return result;
     }
@@ -576,8 +580,10 @@ apply_registered_chrome:
         PanelSnapshot snapshot{
             index,
             panel.panel.get(),
-            panel.label,
-            panel.id,
+            panel.label_storage ? *panel.label_storage : panel.label,
+            panel.id_storage ? *panel.id_storage : panel.id,
+            panel.label_storage,
+            panel.id_storage,
             panel.space,
             panel.options,
             panel.is_native,
@@ -722,8 +728,7 @@ apply_registered_chrome:
 
                     const bool stable_height =
                         prev_h > 0.0f && std::abs(drawn_h - prev_h) <= 1.0f;
-                    if (drawn_h > 0.0f && stable_height &&
-                        !snap.panel->needsAnimationFrame())
+                    if (drawn_h > 0.0f && stable_height)
                         break;
 
                     prev_h = drawn_h;
@@ -736,7 +741,7 @@ apply_registered_chrome:
                 std::lock_guard lock(mutex_);
                 if (snap.index < panels_.size() && panels_[snap.index].id == snap.id &&
                     panels_[snap.index].space == PanelSpace::Floating) {
-                    const auto interaction = floating_interactions_.find(snap.id);
+                    const auto interaction = floating_interactions_.find(*snap.id_storage);
                     if (interaction != floating_interactions_.end() &&
                         interaction->second.user_height > 0) {
                         h = interaction->second.user_height;
@@ -767,7 +772,7 @@ apply_registered_chrome:
                 std::lock_guard lock(mutex_);
                 if (snap.index < panels_.size() && panels_[snap.index].id == snap.id &&
                     panels_[snap.index].space == PanelSpace::Floating) {
-                    if (const auto interaction = floating_interactions_.find(snap.id);
+                    if (const auto interaction = floating_interactions_.find(*snap.id_storage);
                         interaction != floating_interactions_.end()) {
                         auto_center = interaction->second.auto_center;
                     }
@@ -1842,6 +1847,39 @@ apply_registered_chrome:
         return animationDemandForVisiblePanels(visibility).any();
     }
 
+    std::string PanelRegistry::describeAnimationDemand(
+        const PanelAnimationVisibility visibility) const {
+        std::string result;
+        std::lock_guard lock(mutex_);
+        for (const auto& p : panels_) {
+            if (!p.enabled || p.error_disabled || !p.panel ||
+                !isPanelVisibleForAnimation(p, visibility) ||
+                !p.panel->needsAnimationFrame())
+                continue;
+
+            if (!result.empty())
+                result += ',';
+            result += p.id;
+            const auto detail = p.panel->animationDemandDescription();
+            if (!detail.empty()) {
+                result += '(';
+                result += detail;
+                result += ')';
+            }
+        }
+        return result;
+    }
+
+    bool PanelRegistry::needsImmediateAnimationFrameForVisiblePanels(
+        const PanelAnimationVisibility visibility) const {
+        std::lock_guard lock(mutex_);
+        return std::any_of(panels_.begin(), panels_.end(), [&](const auto& p) {
+            return p.enabled && !p.error_disabled && p.panel &&
+                   isPanelVisibleForAnimation(p, visibility) &&
+                   p.panel->needsImmediateAnimationFrame();
+        });
+    }
+
     std::optional<double> PanelRegistry::nextScheduledAnimationDelayForVisiblePanels(
         const PanelAnimationVisibility visibility) const {
         std::optional<double> min_delay;
@@ -1861,6 +1899,7 @@ apply_registered_chrome:
         for (auto& p : panels_) {
             if (p.id == id) {
                 p.label = new_label;
+                p.label_storage = std::make_shared<const std::string>(p.label);
                 return true;
             }
         }

--- a/src/visualizer/gui/panel_registry.hpp
+++ b/src/visualizer/gui/panel_registry.hpp
@@ -187,6 +187,8 @@ namespace lfs::vis::gui {
             return {};
         }
         virtual bool needsAnimationFrame() const { return false; }
+        virtual bool needsImmediateAnimationFrame() const { return false; }
+        virtual std::string animationDemandDescription() const { return {}; }
         // Finite scheduled animation/update delay in seconds (> 0). nullopt means
         // no scheduled wake (either continuous demand via needsAnimationFrame or idle).
         virtual std::optional<double> nextScheduledAnimationDelay() const { return std::nullopt; }
@@ -220,6 +222,8 @@ namespace lfs::vis::gui {
         PanelSpace default_space = PanelSpace::Floating;
         int default_order = 100;
         bool default_enabled = true;
+        std::shared_ptr<const std::string> label_storage;
+        std::shared_ptr<const std::string> id_storage;
         static constexpr int MAX_CONSECUTIVE_ERRORS = 3;
 
         bool has_option(PanelOption opt) const {
@@ -325,8 +329,10 @@ namespace lfs::vis::gui {
     struct PanelSnapshot {
         size_t index;
         IPanel* panel;
-        std::string label;
-        std::string id;
+        std::string_view label;
+        std::string_view id;
+        std::shared_ptr<const std::string> label_storage;
+        std::shared_ptr<const std::string> id_storage;
         PanelSpace space;
         uint32_t options;
         bool is_native;
@@ -393,6 +399,10 @@ namespace lfs::vis::gui {
         PanelAnimationDemand animationDemandForVisiblePanels(
             PanelAnimationVisibility visibility) const;
         bool needsAnimationFrameForVisiblePanels(PanelAnimationVisibility visibility) const;
+        [[nodiscard]] std::string describeAnimationDemand(
+            PanelAnimationVisibility visibility) const;
+        [[nodiscard]] bool needsImmediateAnimationFrameForVisiblePanels(
+            PanelAnimationVisibility visibility) const;
         // Min finite scheduled delay across visible panels (same visibility rules as
         // needsAnimationFrameForVisiblePanels). nullopt if none are scheduled.
         std::optional<double> nextScheduledAnimationDelayForVisiblePanels(

--- a/src/visualizer/gui/rml_right_panel.cpp
+++ b/src/visualizer/gui/rml_right_panel.cpp
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <cmath>
 #include <format>
+#include <limits>
 
 namespace lfs::vis::gui {
 
@@ -122,6 +123,8 @@ namespace lfs::vis::gui {
         tabs_overflow_ = false;
         can_scroll_tabs_left_ = false;
         can_scroll_tabs_right_ = false;
+        last_blurred_focus_ = nullptr;
+        last_hover_element_ = nullptr;
     }
 
     void RmlRightPanel::reloadResources() {
@@ -158,6 +161,8 @@ namespace lfs::vis::gui {
         last_over_interactive_ = false;
         last_over_resize_handle_ = false;
         rml_pointer_inside_ = false;
+        last_blurred_focus_ = nullptr;
+        last_hover_element_ = nullptr;
 
         try {
             const auto rml_path = lfs::vis::getAssetPath("rmlui/right_panel.rml");
@@ -375,16 +380,40 @@ namespace lfs::vis::gui {
             return;
 
         auto* const focused = rml_context_->GetFocusElement();
-        if (!focused)
+        if (!focused) {
+            last_blurred_focus_ = nullptr;
             return;
+        }
+
+        // Frame-input capture is applied after the right-panel render. RmlUi can
+        // retain the same focus element until its next Update(), so repeatedly
+        // marking this flag here would keep needsAnimationFrame() true forever.
+        if (focused == last_blurred_focus_) {
+            wants_keyboard_ = false;
+            return;
+        }
 
         focused->Blur();
+        last_blurred_focus_ = focused;
         wants_keyboard_ = false;
         input_dirty_ = true;
     }
 
     bool RmlRightPanel::needsAnimationFrame() const {
         return render_needed_ || input_dirty_ || splitter_dragging_ || resize_dragging_;
+    }
+
+    std::string RmlRightPanel::animationDemandDescription() const {
+        if (!needsAnimationFrame())
+            return {};
+
+        const double next_update_delay = rml_context_
+                                             ? rml_context_->GetNextUpdateDelay()
+                                             : std::numeric_limits<double>::infinity();
+        return std::format(
+            "right_panel(render_needed={},input_dirty={},splitter_dragging={},resize_dragging={},rml_delay={})",
+            render_needed_, input_dirty_, splitter_dragging_, resize_dragging_,
+            next_update_delay);
     }
 
     void RmlRightPanel::processInput(const RightPanelLayout& layout, const PanelInputState& input) {
@@ -420,6 +449,8 @@ namespace lfs::vis::gui {
             !input.keys_repeated.empty() || !input.text_codepoints.empty() ||
             !input.text_inputs.empty() || input.has_text_editing;
         auto* const focused_before = rml_context_->GetFocusElement();
+        if (pointer_event || keyboard_event)
+            last_blurred_focus_ = nullptr;
         const bool viewport_focus_blurs_panel = input.viewport_keyboard_focus && focused_before;
         const bool layout_changed =
             static_cast<int>(layout.size.x) != last_fbo_w_ ||
@@ -487,9 +518,10 @@ namespace lfs::vis::gui {
         if (over_interactive != last_over_interactive_) {
             input_dirty_ = true;
             last_over_interactive_ = over_interactive;
-        } else if (mouse_moved && over_interactive) {
+        } else if (mouse_moved && over_interactive && hover != last_hover_element_) {
             input_dirty_ = true;
         }
+        last_hover_element_ = hover;
 
         if (resize_dragging_) {
             wants_input_ = true;
@@ -556,14 +588,11 @@ namespace lfs::vis::gui {
                     rml_context_->ProcessMouseButtonUp(0, mods);
             }
         } else if (input.mouse_clicked[0]) {
-            if (auto* focused = rml_context_->GetFocusElement())
-                focused->Blur();
+            blurFocus();
         }
 
-        if (input.viewport_keyboard_focus) {
-            if (auto* focused = rml_context_->GetFocusElement())
-                focused->Blur();
-        }
+        if (input.viewport_keyboard_focus)
+            blurFocus();
 
         if (rml_input::hasFocusedKeyboardTarget(rml_context_->GetFocusElement()) &&
             !input.viewport_keyboard_focus) {

--- a/src/visualizer/gui/rml_right_panel.hpp
+++ b/src/visualizer/gui/rml_right_panel.hpp
@@ -60,6 +60,7 @@ namespace lfs::vis::gui {
         bool wantsInput() const { return wants_input_; }
         bool wantsKeyboard() const { return wants_keyboard_; }
         bool needsAnimationFrame() const;
+        [[nodiscard]] std::string animationDemandDescription() const;
         CursorRequest getCursorRequest() const;
         [[nodiscard]] float tabStripScroll() const { return tab_scroll_left_; }
         void setTabStripScroll(float value);
@@ -107,6 +108,8 @@ namespace lfs::vis::gui {
 
         bool resize_dragging_ = false;
         bool last_over_resize_handle_ = false;
+        Rml::Element* last_blurred_focus_ = nullptr;
+        Rml::Element* last_hover_element_ = nullptr;
 
         CursorRequest cursor_request_{};
         float prev_mouse_x_ = 0;

--- a/src/visualizer/gui/rml_status_bar.cpp
+++ b/src/visualizer/gui/rml_status_bar.cpp
@@ -485,12 +485,14 @@ namespace lfs::vis::gui {
         if (!speed_events_initialized_) {
             lfs::core::events::ui::SpeedChanged::when([this](const auto& e) {
                 speed_state_.showWasd(e.current_speed);
+                model_animation_active_ = true;
                 animation_active_ = true;
                 next_refresh_at_ = {};
                 markModelDirty();
             });
             lfs::core::events::ui::ZoomSpeedChanged::when([this](const auto& e) {
                 speed_state_.showZoom(e.zoom_speed);
+                model_animation_active_ = true;
                 animation_active_ = true;
                 next_refresh_at_ = {};
                 markModelDirty();
@@ -519,6 +521,9 @@ namespace lfs::vis::gui {
             rml_manager_->destroyContext("status_bar");
         rml_context_ = nullptr;
         document_ = nullptr;
+        model_animation_active_ = false;
+        rml_animation_active_ = false;
+        animation_active_ = false;
         delete git_commit_listener_;
         git_commit_listener_ = nullptr;
         delete gpu_icon_listener_;
@@ -554,6 +559,8 @@ namespace lfs::vis::gui {
         mining_scene_ = {};
         progress_style_checked_at_ = {};
         model_dirty_ = true;
+        model_animation_active_ = false;
+        rml_animation_active_ = false;
         animation_active_ = true;
         fit_level_ = 0;
         last_dp_ratio_ = 0.0f;
@@ -1626,15 +1633,19 @@ namespace lfs::vis::gui {
             (model_.show_gpu_model ? uint32_t{1} << 7 : 0) |
             (model_.account_show_tier ? uint32_t{1} << 8 : 0);
 
-        const bool miner_visible = progress_miner_pref_ && show_training;
-        animation_active_ = wasd_visible || zoom_visible || status_msg.visible ||
-                            miner_visible;
+        // A paused trainer has a static progress display. Keep the miner's
+        // periodic refresh armed only while its particles actually advance.
+        const bool miner_visible = progress_miner_pref_ && show_training &&
+                                   training_state == TrainingState::Running;
+        model_animation_active_ = wasd_visible || zoom_visible || status_msg.visible ||
+                                  miner_visible;
+        animation_active_ = model_animation_active_ || rml_animation_active_;
         next_refresh_at_ = now + (miner_visible && training_state == TrainingState::Running
                                       ? kBusyRefreshInterval
-                                  : miner_visible     ? kMiningRefreshInterval
-                                  : animation_active_ ? kAnimatedRefreshInterval
-                                  : ctx.is_training   ? kBusyRefreshInterval
-                                                      : kIdleRefreshInterval);
+                                  : miner_visible           ? kMiningRefreshInterval
+                                  : model_animation_active_ ? kAnimatedRefreshInterval
+                                  : ctx.is_training         ? kBusyRefreshInterval
+                                                            : kIdleRefreshInterval);
         return model_dirty_;
     }
 
@@ -1804,11 +1815,17 @@ namespace lfs::vis::gui {
     void RmlStatusBar::render(const PanelDrawContext& ctx, const float x, const float y,
                               const float w_px, const float h_px,
                               const int screen_w, const int screen_h) {
-        if (!rml_context_ || !document_)
+        if (!rml_context_ || !document_) {
+            rml_animation_active_ = false;
+            animation_active_ = model_animation_active_;
             return;
+        }
 
-        if (w_px <= 0.0f || h_px <= 0.0f || screen_w <= 0 || screen_h <= 0)
+        if (w_px <= 0.0f || h_px <= 0.0f || screen_w <= 0 || screen_h <= 0) {
+            rml_animation_active_ = false;
+            animation_active_ = model_animation_active_;
             return;
+        }
 
         const float overlay_height = overlayHeight();
         const int render_w = static_cast<int>(w_px);
@@ -1828,8 +1845,11 @@ namespace lfs::vis::gui {
         const bool needs_render = size_changed || dp_changed || theme_changed || had_pending_model_dirty ||
                                   content_changed ||
                                   (animation_active_ && refresh_due);
-        if (!rml_manager_ || !rml_manager_->getVulkanRenderInterface())
+        if (!rml_manager_ || !rml_manager_->getVulkanRenderInterface()) {
+            rml_animation_active_ = false;
+            animation_active_ = model_animation_active_;
             return;
+        }
 
         if (needs_render) {
             rml_context_->SetDimensions(Rml::Vector2i(render_w, render_h));
@@ -1840,7 +1860,10 @@ namespace lfs::vis::gui {
             rml_context_->Update();
             fitToAvailableWidth(size_changed || dp_changed || theme_changed || section_signature_changed);
 
-            animation_active_ = animation_active_ || (rml_context_->GetNextUpdateDelay() == 0);
+            rml_animation_active_ = rml_context_->GetNextUpdateDelay() == 0;
+            animation_active_ = model_animation_active_ || rml_animation_active_;
+            if (rml_animation_active_)
+                next_refresh_at_ = now;
             last_dp_ratio_ = dp_ratio;
             last_section_signature_ = section_signature_;
             last_render_w_ = render_w;

--- a/src/visualizer/gui/rml_status_bar.hpp
+++ b/src/visualizer/gui/rml_status_bar.hpp
@@ -281,6 +281,8 @@ namespace lfs::vis::gui {
         std::chrono::steady_clock::time_point next_refresh_at_{};
         std::chrono::steady_clock::time_point next_gpu_refresh_at_{};
         bool model_dirty_ = true;
+        bool model_animation_active_ = false;
+        bool rml_animation_active_ = false;
         bool animation_active_ = false;
         bool reactive_fps_available_ = false;
         float reactive_fps_value_ = 0.0f;

--- a/src/visualizer/gui/rml_viewport_overlay.cpp
+++ b/src/visualizer/gui/rml_viewport_overlay.cpp
@@ -798,6 +798,18 @@ namespace lfs::vis::gui {
                                               static_cast<float>(rml_my)))
                                         : nullptr;
         const bool point_interactive = viewportOverlayHoverRoot(point_element) != nullptr;
+        const bool has_interactive_button_event = std::any_of(
+            input.mouse_button_events.begin(), input.mouse_button_events.end(), [&](const auto& event) {
+                if (event.button >= 3)
+                    return false;
+                const float event_x = event.x - vp_pos_.x;
+                const float event_y = event.y - vp_pos_.y;
+                if (event_x < 0.0f || event_y < 0.0f ||
+                    event_x >= vp_size_.x || event_y >= vp_size_.y)
+                    return false;
+                return viewportOverlayHoverRoot(rml_context_->GetElementAtPoint(
+                           Rml::Vector2f(event_x, event_y))) != nullptr;
+            });
         const bool hover_target_changed = point_element != last_hover_element_;
         if (focused_text_target &&
             mouse_clicked &&
@@ -807,7 +819,7 @@ namespace lfs::vis::gui {
             markRenderNeeded(RenderReason::Keyboard);
         }
         if (external_mouse_capture && !point_interactive && !hovered_interactive_ &&
-            !vram_drag_capture) {
+            !vram_drag_capture && !has_interactive_button_event) {
             tooltip_.setHover({}, nullptr);
             return;
         }
@@ -853,29 +865,56 @@ namespace lfs::vis::gui {
         const bool over_interactive = is_inside && hover_root != nullptr;
         hovered_interactive_ = over_interactive;
 
-        if (over_interactive || vram_drag_capture) {
+        bool replayed_button_events = false;
+        for (const auto& event : input.mouse_button_events) {
+            if (event.button >= 3)
+                continue;
+            const float event_x = event.x - vp_pos_.x;
+            const float event_y = event.y - vp_pos_.y;
+            const bool event_inside = event_x >= 0.0f && event_x < vp_size_.x &&
+                                      event_y >= 0.0f && event_y < vp_size_.y;
+            const auto* const event_element = event_inside
+                                                  ? rml_context_->GetElementAtPoint(
+                                                        Rml::Vector2f(event_x, event_y))
+                                                  : nullptr;
+            if (!vram_drag_capture && viewportOverlayHoverRoot(event_element) == nullptr)
+                continue;
+            rml_context_->ProcessMouseMove(static_cast<int>(event_x),
+                                           static_cast<int>(event_y), mods);
+            markRenderNeeded(RenderReason::PointerButton);
+            if (event.down)
+                rml_context_->ProcessMouseButtonDown(event.button, mods);
+            else
+                rml_context_->ProcessMouseButtonUp(event.button, mods);
+            replayed_button_events = true;
+        }
+
+        if (over_interactive || vram_drag_capture || replayed_button_events) {
             wants_input_ = true;
             guiFocusState().want_capture_mouse = true;
 
-            if (input.mouse_clicked[0]) {
-                markRenderNeeded(RenderReason::PointerButton);
-                rml_context_->ProcessMouseButtonDown(0, mods);
-            }
-            if (input.mouse_released[0]) {
-                markRenderNeeded(RenderReason::PointerButton);
-                rml_context_->ProcessMouseButtonUp(0, mods);
-            }
-            if (input.mouse_clicked[1]) {
-                markRenderNeeded(RenderReason::PointerButton);
-                rml_context_->ProcessMouseButtonDown(1, mods);
-            }
-            if (input.mouse_released[1]) {
-                markRenderNeeded(RenderReason::PointerButton);
-                rml_context_->ProcessMouseButtonUp(1, mods);
+            if (!replayed_button_events && (over_interactive || vram_drag_capture)) {
+                if (input.mouse_clicked[0]) {
+                    markRenderNeeded(RenderReason::PointerButton);
+                    rml_context_->ProcessMouseButtonDown(0, mods);
+                }
+                if (input.mouse_released[0]) {
+                    markRenderNeeded(RenderReason::PointerButton);
+                    rml_context_->ProcessMouseButtonUp(0, mods);
+                }
+                if (input.mouse_clicked[1]) {
+                    markRenderNeeded(RenderReason::PointerButton);
+                    rml_context_->ProcessMouseButtonDown(1, mods);
+                }
+                if (input.mouse_released[1]) {
+                    markRenderNeeded(RenderReason::PointerButton);
+                    rml_context_->ProcessMouseButtonUp(1, mods);
+                }
             }
             if (input.mouse_wheel != 0.0f) {
                 markRenderNeeded(RenderReason::PointerWheel);
-                rml_context_->ProcessMouseWheel(Rml::Vector2f(0.0f, -input.mouse_wheel), mods);
+                rml_context_->ProcessMouseWheel(
+                    Rml::Vector2f(-input.mouse_wheel_x, -input.mouse_wheel), mods);
             }
 
             if (hover)

--- a/src/visualizer/gui/rmlui/rml_panel_host.cpp
+++ b/src/visualizer/gui/rmlui/rml_panel_host.cpp
@@ -517,6 +517,7 @@ namespace lfs::vis::gui {
             (pw != last_measure_w_ || ph != last_layout_h_ || content_dirty_ ||
              last_content_height_ <= 0.0f);
         const float saved_scroll = scroll_el_ ? scroll_el_->GetScrollTop() : 0.0f;
+        float converged_content_h = last_content_height_;
 
         if (need_content_measure) {
             last_measure_w_ = pw;
@@ -532,7 +533,9 @@ namespace lfs::vis::gui {
             layout_h = std::clamp(layout_h, 1, kMaxFboSize);
 
             float content_h = 0.0f;
-            for (int pass = 0; pass < 3; ++pass) {
+            float previous_content_h = -1.0f;
+            bool content_height_settled = false;
+            for (int pass = 0; pass < 8; ++pass) {
                 const bool dims_changed =
                     pw != last_layout_w_ || layout_h != last_layout_h_ ||
                     padding != last_layout_padding_;
@@ -549,13 +552,17 @@ namespace lfs::vis::gui {
 
                 const int measured = std::clamp(
                     static_cast<int>(std::ceil(content_h)), 1, kMaxFboSize);
-                if (measured <= layout_h || layout_h == kMaxFboSize)
+                content_height_settled = previous_content_h >= 0.0f &&
+                                         std::abs(content_h - previous_content_h) <= 2.0f;
+                if (content_height_settled || layout_h == kMaxFboSize)
                     break;
 
+                previous_content_h = content_h;
                 layout_h = measured;
             }
 
             last_content_height_ = content_h;
+            converged_content_h = content_h;
             if (content_el_)
                 last_content_el_height_ = content_el_->GetOffsetHeight();
             const int measured = std::clamp(
@@ -597,30 +604,31 @@ namespace lfs::vis::gui {
         render_needed_ = false;
 
         if (height_mode_ == PanelHeightMode::Content) {
-            const float prev_content_h = last_content_height_;
             const float actual_content_h = computeContentHeight();
             last_content_height_ = actual_content_h;
 
             if (content_el_)
                 last_content_el_height_ = content_el_->GetOffsetHeight();
 
-            if (std::abs(actual_content_h - prev_content_h) > 2.0f) {
+            if (std::abs(actual_content_h - converged_content_h) > 2.0f) {
                 ++content_height_rearm_count_;
                 if (content_height_rearm_count_ > 8) {
                     if (!content_height_rearm_warned_) {
                         content_height_rearm_warned_ = true;
                         LOG_WARN("RmlPanelHost '{}': content-height settle exceeded 8 re-arms "
                                  "(pw={}, ph={}, prev_h={:.1f}, actual_h={:.1f}); skipping re-arm",
-                                 context_name_, pw, ph, prev_content_h, actual_content_h);
+                                 context_name_, pw, ph, converged_content_h, actual_content_h);
                     }
                 } else {
                     content_dirty_ = true;
                     direct_cache_dirty_ = true;
                     last_measure_w_ = 0;
+                    content_height_settling_ = true;
                 }
             } else {
                 content_height_rearm_count_ = 0;
                 content_height_rearm_warned_ = false;
+                content_height_settling_ = false;
             }
         }
     }
@@ -629,6 +637,15 @@ namespace lfs::vis::gui {
         if (std::isfinite(next_update_delay_) && next_update_delay_ > 0.0)
             return next_update_delay_;
         return std::nullopt;
+    }
+
+    std::string RmlPanelHost::animationDemandDescription() const {
+        if (!document_ || !needsAnimationFrame())
+            return {};
+        return std::format(
+            "document={},content_dirty={},render_needed={},animation_active={},tooltip_due={},rml_delay={}",
+            rml_path_, content_dirty_, render_needed_, animation_active_,
+            tooltip_.revealDue(), next_update_delay_);
     }
 
     void RmlPanelHost::draw(const PanelDrawContext& ctx) {
@@ -1209,6 +1226,37 @@ namespace lfs::vis::gui {
             had_input = true;
         };
 
+        // SDL can deliver multiple button transitions before the next frame.
+        // Replay each transition at its recorded position so a fast double click
+        // is not collapsed onto the final cursor position.
+        const auto replay_button_events = [&]() {
+            bool replayed = false;
+            for (const auto& event : input.mouse_button_events) {
+                if (event.button >= 3)
+                    continue;
+
+                const float event_x = event.x - panel_x + last_fbo_padding_;
+                const float event_y = event.y - panel_y + last_fbo_padding_;
+                const bool event_hovered = hitTestPanelShape(
+                    event_x, event_y, logical_w, logical_h);
+                if (!event_hovered && !mouse_captured_[event.button])
+                    continue;
+
+                rml_context_->ProcessMouseMove(static_cast<int>(event_x),
+                                               static_cast<int>(event_y), mods);
+                if (event.down)
+                    deliver_button_down(event.button);
+                else
+                    deliver_button_up(event.button);
+                had_input = true;
+                replayed = true;
+            }
+            return replayed;
+        };
+
+        const bool replayed_button_events =
+            !manual_dropdown_option_route && replay_button_events();
+
         if (manual_dropdown_option_route) {
             if (input.mouse_clicked[0]) {
                 manual_dropdown_mouse_captured_ = true;
@@ -1229,12 +1277,13 @@ namespace lfs::vis::gui {
                 had_input = true;
             }
         } else if (hovered) {
-            if (input.mouse_clicked[0])
+            if (!replayed_button_events && input.mouse_clicked[0])
                 deliver_button_down(0);
-            if (input.mouse_clicked[1])
+            if (!replayed_button_events && input.mouse_clicked[1])
                 deliver_button_down(1);
             if (input.mouse_wheel != 0.0f) {
-                rml_context_->ProcessMouseWheel(Rml::Vector2f(0, -input.mouse_wheel), mods);
+                rml_context_->ProcessMouseWheel(
+                    Rml::Vector2f(-input.mouse_wheel_x, -input.mouse_wheel), mods);
                 // Re-resolve hover against the new scroll offset so row text
                 // doesn't render against a stale layout for one frame.
                 rml_context_->ProcessMouseMove(rml_mx, rml_my, mods);

--- a/src/visualizer/gui/rmlui/rml_panel_host.hpp
+++ b/src/visualizer/gui/rmlui/rml_panel_host.hpp
@@ -75,6 +75,10 @@ namespace lfs::vis::gui {
         bool needsAnimationFrame() const {
             return render_needed_ || content_dirty_ || animation_active_ || tooltip_.revealDue();
         }
+        [[nodiscard]] bool needsImmediateAnimationFrame() const {
+            return content_height_settling_;
+        }
+        [[nodiscard]] std::string animationDemandDescription() const;
         // Finite RmlUi scheduled update delay (seconds) when > 0; nullopt for
         // continuous demand (0, use needsAnimationFrame) or idle (infinity).
         [[nodiscard]] std::optional<double> nextScheduledUpdateDelay() const;
@@ -143,6 +147,7 @@ namespace lfs::vis::gui {
         double next_update_delay_ = std::numeric_limits<double>::infinity();
         int content_height_rearm_count_ = 0;
         bool content_height_rearm_warned_ = false;
+        bool content_height_settling_ = false;
         std::uint64_t localized_language_generation_ = std::numeric_limits<std::uint64_t>::max();
         bool direct_cache_dirty_ = true;
         CachedVulkanContextRender direct_cache_;

--- a/src/visualizer/gui/startup_overlay.cpp
+++ b/src/visualizer/gui/startup_overlay.cpp
@@ -592,10 +592,30 @@ namespace lfs::vis::gui {
 
         const bool hovered = local_x >= 0 && local_y >= 0 &&
                              local_x < overlay_w && local_y < overlay_h;
+        const int mods = sdlModsToRml(input.key_ctrl, input.key_shift,
+                                      input.key_alt, input.key_super);
+        bool replayed_button_events = false;
+        for (const auto& event : input.mouse_button_events) {
+            if (event.button >= 3)
+                continue;
+            const float event_x = event.x - overlay_x;
+            const float event_y = event.y - overlay_y;
+            if (event_x < 0.0f || event_y < 0.0f ||
+                event_x >= overlay_w || event_y >= overlay_h)
+                continue;
+            if (event.down && isLanguageSelectHit(event_x, event_y))
+                ensureLanguageDropdownFontsLoaded();
+            rml_context_->ProcessMouseMove(static_cast<int>(event_x),
+                                           static_cast<int>(event_y), mods);
+            if (event.down)
+                rml_context_->ProcessMouseButtonDown(event.button, mods);
+            else
+                rml_context_->ProcessMouseButtonUp(event.button, mods);
+            replayed_button_events = true;
+            result.event_forwarded = true;
+        }
 
         if (hovered) {
-            const int mods = sdlModsToRml(input.key_ctrl, input.key_shift,
-                                          input.key_alt, input.key_super);
             const bool opening_language_select =
                 input.mouse_clicked[0] && isLanguageSelectHit(local_x, local_y);
             if (isLanguageSelectOpen() || opening_language_select)
@@ -604,17 +624,18 @@ namespace lfs::vis::gui {
                                            static_cast<int>(local_y), mods);
             result.event_forwarded = true;
 
-            if (input.mouse_clicked[0]) {
+            if (!replayed_button_events && input.mouse_clicked[0]) {
                 rml_context_->ProcessMouseButtonDown(0, mods);
                 result.event_forwarded = true;
             }
-            if (input.mouse_released[0]) {
+            if (!replayed_button_events && input.mouse_released[0]) {
                 rml_context_->ProcessMouseButtonUp(0, mods);
                 result.event_forwarded = true;
             }
 
             if (input.mouse_wheel != 0.0f) {
-                rml_context_->ProcessMouseWheel(Rml::Vector2f(0.0f, -input.mouse_wheel), mods);
+                rml_context_->ProcessMouseWheel(
+                    Rml::Vector2f(-input.mouse_wheel_x, -input.mouse_wheel), mods);
                 result.event_forwarded = true;
             }
         }

--- a/src/visualizer/gui/vulkan_ui_texture.cpp
+++ b/src/visualizer/gui/vulkan_ui_texture.cpp
@@ -187,6 +187,18 @@ namespace lfs::vis::gui {
         static constexpr std::size_t kMaxPendingUploads = 3;
         std::vector<PendingUpload> pending_uploads;
 
+        struct RetiredImage {
+            VkImage image = VK_NULL_HANDLE;
+            VkImageView image_view = VK_NULL_HANDLE;
+            VmaAllocation allocation = VK_NULL_HANDLE;
+            std::uint64_t retire_serial = 0;
+            std::uint64_t generation = 0;
+            std::string vram_label;
+            std::vector<PendingUpload> pending_uploads;
+        };
+        static constexpr std::size_t kMaxRetiredImages = 8;
+        std::vector<RetiredImage> retired_images;
+
         int width = 0;
         int height = 0;
 
@@ -263,6 +275,105 @@ namespace lfs::vis::gui {
                 }
             }
             pending_uploads.erase(write, pending_uploads.end());
+        }
+
+        [[nodiscard]] bool releaseRetiredUploads(RetiredImage& retired, const bool wait) {
+            auto write = retired.pending_uploads.begin();
+            bool all_ready = true;
+            for (auto read = retired.pending_uploads.begin();
+                 read != retired.pending_uploads.end(); ++read) {
+                bool ready = read->fence == VK_NULL_HANDLE;
+                if (!ready && wait) {
+                    lfs::rendering::WaitContext wait_ctx;
+                    wait_ctx.fingerprint = "ui_texture.retired_upload.wait";
+                    const auto wait_outcome = lfs::rendering::wait_fence_bounded(
+                        device,
+                        read->fence,
+                        std::stop_token{},
+                        lfs::rendering::VulkanWaitPolicy{},
+                        wait_ctx);
+                    ready = wait_outcome.has_value() &&
+                            *wait_outcome == lfs::rendering::WaitOutcome::Ready;
+                } else if (!ready) {
+                    ready = vkGetFenceStatus(device, read->fence) == VK_SUCCESS;
+                }
+
+                if (ready) {
+                    destroyPendingUpload(*read);
+                } else {
+                    all_ready = false;
+                    if (write != read)
+                        *write = *read;
+                    ++write;
+                }
+            }
+            retired.pending_uploads.erase(write, retired.pending_uploads.end());
+            return all_ready;
+        }
+
+        void releaseRetiredImages(const bool wait) {
+            if (wait && context) {
+                const auto serial = context->lastSuccessfulFrameSubmitSerial();
+                if (serial != 0 && !context->waitForRetiredFrameSubmitSerial(serial))
+                    LOG_WARN("Vulkan UI texture could not retire frame serial {}: {}",
+                             serial,
+                             context->lastError());
+            }
+            const auto retired_serial = context ? context->retiredFrameSubmitSerial()
+                                                : std::numeric_limits<std::uint64_t>::max();
+            auto write = retired_images.begin();
+            for (auto read = retired_images.begin(); read != retired_images.end(); ++read) {
+                const bool uploads_ready = releaseRetiredUploads(*read, wait);
+                if (read->retire_serial <= retired_serial && uploads_ready) {
+                    image_barriers.forgetImage(read->image, read->generation);
+                    if (read->image_view != VK_NULL_HANDLE)
+                        vkDestroyImageView(device, read->image_view, nullptr);
+                    if (read->image != VK_NULL_HANDLE)
+                        vmaDestroyImage(allocator, read->image, read->allocation);
+                    if (!read->vram_label.empty()) {
+                        lfs::diagnostics::VramProfiler::instance().recordCurrentBytes(
+                            "vulkan.ui_texture.image", read->vram_label, 0);
+                    }
+                    continue;
+                }
+                if (write != read)
+                    *write = std::move(*read);
+                ++write;
+            }
+            retired_images.erase(write, retired_images.end());
+        }
+
+        void retireCurrentImage() {
+            if (image == VK_NULL_HANDLE)
+                return;
+            tryReleasePendingUpload();
+            const std::uint64_t serial = context ? context->lastSuccessfulFrameSubmitSerial() : 0;
+            if (serial == 0) {
+                image_barriers.forgetImage(image, image_generation_);
+                if (image_view != VK_NULL_HANDLE)
+                    vkDestroyImageView(device, image_view, nullptr);
+                vmaDestroyImage(allocator, image, image_allocation);
+                image = VK_NULL_HANDLE;
+                image_view = VK_NULL_HANDLE;
+                image_allocation = VK_NULL_HANDLE;
+                return;
+            }
+            if (retired_images.size() >= kMaxRetiredImages)
+                releaseRetiredImages(true);
+            retired_images.push_back({
+                .image = image,
+                .image_view = image_view,
+                .allocation = image_allocation,
+                .retire_serial = serial,
+                .generation = image_generation_,
+                .vram_label = std::move(image_vram_label),
+                .pending_uploads = std::move(pending_uploads),
+            });
+            pending_uploads.clear();
+            image = VK_NULL_HANDLE;
+            image_view = VK_NULL_HANDLE;
+            image_allocation = VK_NULL_HANDLE;
+            image_vram_label.clear();
         }
 
         // Block only when the ring is full: wait on the oldest entry to free a slot.
@@ -522,31 +633,8 @@ namespace lfs::vis::gui {
             }
 
             if (image != VK_NULL_HANDLE) {
-                waitAndReleasePendingUpload();
-                // Descriptor updates and image destruction are only legal once
-                // every submitted RmlUI draw that can reference the old view has
-                // retired. Resize is already a cold path; pay the bounded fence
-                // wait here instead of retaining every historical image forever.
-                if (context != nullptr && !context->waitForSubmittedFrames()) {
-                    LOG_ERROR("Vulkan UI texture resize could not drain submitted frames: {}",
-                              context->lastError());
-                    return false;
-                }
-                if (!image_vram_label.empty()) {
-                    lfs::diagnostics::VramProfiler::instance().recordCurrentBytes(
-                        "vulkan.ui_texture.image",
-                        image_vram_label,
-                        0);
-                }
-                image_barriers.forgetImage(image, image_generation_);
-                if (image_view != VK_NULL_HANDLE) {
-                    vkDestroyImageView(device, image_view, nullptr);
-                }
-                vmaDestroyImage(allocator, image, image_allocation);
-                image = VK_NULL_HANDLE;
-                image_view = VK_NULL_HANDLE;
-                image_allocation = VK_NULL_HANDLE;
-                image_vram_label.clear();
+                releaseRetiredImages(false);
+                retireCurrentImage();
             }
             width = new_width;
             height = new_height;
@@ -941,6 +1029,7 @@ namespace lfs::vis::gui {
 
         void destroyImage() {
             waitAndReleasePendingUpload();
+            releaseRetiredImages(true);
             const bool has_interop_resources =
                 mode == Mode::CudaInterop || interop.valid() ||
                 interop_image.image != VK_NULL_HANDLE ||

--- a/src/visualizer/input/frame_input_buffer.hpp
+++ b/src/visualizer/input/frame_input_buffer.hpp
@@ -14,6 +14,15 @@
 
 namespace lfs::vis {
 
+    struct FrameMouseButtonEvent {
+        uint8_t button = 0;
+        bool down = false;
+        float x = 0.0f;
+        float y = 0.0f;
+        uint64_t timestamp = 0;
+        uint8_t clicks = 0;
+    };
+
     struct FrameInputBuffer {
         float mouse_x = 0;
         float mouse_y = 0;
@@ -21,6 +30,8 @@ namespace lfs::vis {
         bool mouse_clicked[3] = {};
         bool mouse_released[3] = {};
         float mouse_wheel = 0;
+        float mouse_wheel_x = 0;
+        std::vector<FrameMouseButtonEvent> mouse_button_events;
         std::vector<SDL_Scancode> keys_pressed;
         std::vector<SDL_Scancode> keys_repeated;
         std::vector<SDL_Scancode> keys_released;
@@ -42,6 +53,8 @@ namespace lfs::vis {
             mouse_clicked[0] = mouse_clicked[1] = mouse_clicked[2] = false;
             mouse_released[0] = mouse_released[1] = mouse_released[2] = false;
             mouse_wheel = 0;
+            mouse_wheel_x = 0;
+            mouse_button_events.clear();
             keys_pressed.clear();
             keys_repeated.clear();
             keys_released.clear();
@@ -75,6 +88,14 @@ namespace lfs::vis {
             case SDL_EVENT_MOUSE_BUTTON_UP: {
                 const int idx = buttonIndex(event.button.button);
                 if (idx >= 0) {
+                    mouse_button_events.push_back({
+                        .button = static_cast<uint8_t>(idx),
+                        .down = event.type == SDL_EVENT_MOUSE_BUTTON_DOWN,
+                        .x = event.button.x,
+                        .y = event.button.y,
+                        .timestamp = event.button.timestamp,
+                        .clicks = event.button.clicks,
+                    });
                     if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
                         mouse_clicked[idx] = true;
                     else
@@ -84,6 +105,7 @@ namespace lfs::vis {
             }
             case SDL_EVENT_MOUSE_WHEEL:
                 mouse_wheel += event.wheel.y;
+                mouse_wheel_x += event.wheel.x;
                 break;
             case SDL_EVENT_KEY_DOWN:
                 if (event.key.repeat)

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -3215,6 +3215,28 @@ namespace lfs::vis {
     SceneRenderState SceneManager::buildRenderState() const {
         std::lock_guard<std::mutex> lock(state_mutex_);
 
+        const auto scene_generation = app_store().scene_generation.get();
+        const auto selection_generation = static_cast<std::uint64_t>(selection_.generation());
+        const auto gaussian_selection_generation = scene_.selectionGeneration();
+        const auto local_scene_generation = scene_.renderGeneration();
+        const auto* current_model = content_type_ == ContentType::Dataset
+                                        ? scene_.getTrainingModel()
+                                        : scene_.getCombinedModel();
+        // PointCloud tensors are public and can be edited in place without a Scene mutation
+        // notification. Keep the small node scan, but do not reuse a state that owns a merged
+        // point cloud unless those tensors acquire an explicit generation in the future.
+        const auto visible_point_cloud_nodes = collectVisiblePointCloudNodes(scene_);
+        const bool point_cloud_fallback = !hasRenderableGaussians(current_model) &&
+                                          !visible_point_cloud_nodes.empty();
+        if (!point_cloud_fallback && cached_render_state_ &&
+            cached_render_scene_generation_ == scene_generation &&
+            cached_render_selection_generation_ == selection_generation &&
+            cached_render_gaussian_selection_generation_ == gaussian_selection_generation &&
+            cached_render_scene_generation_local_ == local_scene_generation &&
+            cached_render_model_ == current_model &&
+            cached_render_content_type_ == content_type_)
+            return *cached_render_state_;
+
         SceneRenderState state;
 
         // Get combined model or point cloud
@@ -3231,7 +3253,6 @@ namespace lfs::vis {
         // Fall back to the visible point cloud whenever the active splat model is absent or empty.
         // This keeps dataset "ready" scenes renderable before training has produced gaussians.
         if (!hasRenderableGaussians(state.combined_model)) {
-            const auto visible_point_cloud_nodes = collectVisiblePointCloudNodes(scene_);
             if (visible_point_cloud_nodes.size() > 1) {
                 state.owned_point_cloud = buildMergedVisiblePointCloud(scene_, visible_point_cloud_nodes);
                 state.point_cloud = state.owned_point_cloud.get();
@@ -3342,7 +3363,14 @@ namespace lfs::vis {
         // getNodeMask() may promote shared→exclusive internally, call outside shared_lock
         state.selected_node_mask = selection_.getNodeMask(scene_);
 
-        return state;
+        cached_render_state_ = std::make_shared<const SceneRenderState>(std::move(state));
+        cached_render_scene_generation_ = scene_generation;
+        cached_render_selection_generation_ = selection_generation;
+        cached_render_gaussian_selection_generation_ = gaussian_selection_generation;
+        cached_render_scene_generation_local_ = local_scene_generation;
+        cached_render_model_ = current_model;
+        cached_render_content_type_ = content_type_;
+        return *cached_render_state_;
     }
 
     SceneManager::SceneInfo SceneManager::getSceneInfo() const {

--- a/src/visualizer/scene/scene_manager.hpp
+++ b/src/visualizer/scene/scene_manager.hpp
@@ -414,6 +414,14 @@ namespace lfs::vis {
         std::jthread consolidated_compaction_thread_;
         bool consolidated_compaction_running_ = false;
         bool consolidated_compaction_pending_ = false;
+
+        mutable std::shared_ptr<const SceneRenderState> cached_render_state_;
+        mutable std::uint64_t cached_render_scene_generation_ = 0;
+        mutable std::uint64_t cached_render_selection_generation_ = 0;
+        mutable std::uint64_t cached_render_gaussian_selection_generation_ = 0;
+        mutable std::uint64_t cached_render_scene_generation_local_ = 0;
+        mutable const lfs::core::SplatData* cached_render_model_ = nullptr;
+        mutable ContentType cached_render_content_type_ = ContentType::Empty;
     };
 
 } // namespace lfs::vis

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -50,6 +50,7 @@
 #include "window/vulkan_context.hpp"
 #include <SDL3/SDL_events.h>
 #include <SDL3/SDL_messagebox.h>
+#include <SDL3/SDL_video.h>
 #include <algorithm>
 #include <cassert>
 #include <chrono>
@@ -148,7 +149,6 @@ namespace lfs::vis {
         constexpr double kGuiScheduledUpdateMinWaitSeconds = 0.001;
         // Backstop cap for GUI-only continuous demand (python_redraw / gui_animation only).
         // MAILBOX presents never block, so free-running would pin the GPU at full GUI cost.
-        constexpr double kGuiAnimationFrameInterval = 1.0 / 30.0;
 #if defined(__linux__)
         constexpr auto kWindowResizePaintDemandWindow = std::chrono::milliseconds(160);
 #endif
@@ -2028,6 +2028,10 @@ namespace lfs::vis {
         update_work_processed_ = false;
         window_manager_->updateWindowSize();
 
+        motion_only_wake_skipped_ = isMotionOnlyWake();
+        if (motion_only_wake_skipped_)
+            return;
+
         if (fully_initialized_ && gui_frame_rendered_ && !startup_plugin_preload_started_) {
             startup_plugin_preload_started_ = true;
             LOG_TIMER("startup.python.preload_plugins_async");
@@ -2168,9 +2172,44 @@ namespace lfs::vis {
         processing_render_work_ = false;
     }
 
-    bool VisualizerImpl::hasPendingRenderWork() {
+    bool VisualizerImpl::hasPendingRenderWork() const {
         std::lock_guard lock(work_queue_mutex_);
         return !render_work_queue_.empty();
+    }
+
+    bool VisualizerImpl::hasPendingWork() const {
+        std::lock_guard lock(work_queue_mutex_);
+        return !work_queue_.empty();
+    }
+
+    bool VisualizerImpl::isMotionOnlyWake() const {
+        if (!window_manager_ || !gui_manager_ ||
+            python::is_plugin_preload_running() || !has_last_frame_demand_ ||
+            last_frame_demand_.needsContinuousLoop() || hasPendingWork() ||
+            hasPendingRenderWork() || app_store().store().has_dirty() ||
+            python::has_redraw_request())
+            return false;
+
+        // pollDirtyState() does not consume the dirty mask. Checking it before
+        // the shortcut prevents a scene/model change arriving between frames
+        // from being skipped on every subsequent mouse-only wake.
+        if (rendering_manager_ && rendering_manager_->pollDirtyState())
+            return false;
+
+        if (gui_manager_->needsAnimationFrame() ||
+            gui_manager_->secondsUntilTooltipReveal())
+            return false;
+
+        const auto& input = window_manager_->frameInput();
+        if (!input.had_event || !input.mouse_moved || input.window_event ||
+            input.mouse_wheel != 0.0f || input.mouse_down[0] || input.mouse_down[1] ||
+            input.mouse_down[2] || !input.mouse_button_events.empty() ||
+            !input.keys_pressed.empty() || !input.keys_repeated.empty() ||
+            !input.keys_released.empty() || !input.text_codepoints.empty() ||
+            !input.text_inputs.empty() || input.has_text_editing)
+            return false;
+
+        return !gui_manager_->passiveMouseMoveNeedsRender(input.mouse_x, input.mouse_y);
     }
 
     bool VisualizerImpl::inputFrameRequestsRender() const {
@@ -2256,15 +2295,42 @@ namespace lfs::vis {
         return demand;
     }
 
+    double VisualizerImpl::guiAnimationFrameInterval() const {
+        const auto now = std::chrono::steady_clock::now();
+        if (display_refresh_queried_at_ != std::chrono::steady_clock::time_point{} &&
+            now - display_refresh_queried_at_ < std::chrono::seconds(1))
+            return gui_animation_frame_interval_;
+
+        display_refresh_queried_at_ = now;
+        float refresh_rate = 60.0f;
+        if (window_manager_ && window_manager_->getWindow()) {
+            const SDL_DisplayID display_id = SDL_GetDisplayForWindow(window_manager_->getWindow());
+            if (const SDL_DisplayMode* const mode = SDL_GetCurrentDisplayMode(display_id);
+                mode && mode->refresh_rate > 0.0f)
+                refresh_rate = mode->refresh_rate;
+        }
+        refresh_rate = std::clamp(refresh_rate, 30.0f, 240.0f);
+        gui_animation_frame_interval_ = 1.0 / static_cast<double>(refresh_rate);
+        return gui_animation_frame_interval_;
+    }
+
     void VisualizerImpl::waitForNextEvent(const bool is_training) {
         if (!window_manager_)
             return;
 
         auto wait_seconds = is_training ? 0.1 : 0.5;
+        std::string timeout_source = is_training ? "training_default" : "idle_default";
+        const auto consider_timeout = [&wait_seconds, &timeout_source](
+                                          const double candidate,
+                                          const char* source) {
+            if (candidate < wait_seconds) {
+                wait_seconds = candidate;
+                timeout_source = source;
+            }
+        };
         if (rendering_manager_ && rendering_manager_->hasPendingViewportResizeSettle()) {
             const double settle_wait = rendering_manager_->secondsUntilViewportResizeSettleReady();
-            wait_seconds = std::min(wait_seconds,
-                                    std::max(kResizeSettleMinWaitSeconds, settle_wait));
+            consider_timeout(std::max(kResizeSettleMinWaitSeconds, settle_wait), "resize_settle");
         }
 
         // Wake exactly when a pending tooltip is due so the reveal costs a single
@@ -2273,22 +2339,34 @@ namespace lfs::vis {
         // so finite-delay panels wake on time without gui_animation spin.
         if (gui_manager_) {
             if (const auto tooltip_wait = gui_manager_->secondsUntilTooltipReveal())
-                wait_seconds = std::min(wait_seconds,
-                                        std::max(kTooltipRevealMinWaitSeconds, *tooltip_wait));
-            if (const auto anim_wait = gui_manager_->secondsUntilNextAnimationFrame())
-                wait_seconds = std::min(wait_seconds,
-                                        std::max(kGuiScheduledUpdateMinWaitSeconds, *anim_wait));
+                consider_timeout(std::max(kTooltipRevealMinWaitSeconds, *tooltip_wait),
+                                 "tooltip_reveal");
+            const char* gui_source = nullptr;
+            const auto anim_wait = gui_manager_->secondsUntilNextAnimationFrame(&gui_source);
+            const std::string gui_timeout_source = gui_source ? std::format("gui.{}", gui_source)
+                                                              : "gui_animation";
+            if (anim_wait)
+                consider_timeout(std::max(kGuiScheduledUpdateMinWaitSeconds, *anim_wait),
+                                 gui_timeout_source.c_str());
         }
 
         // Wake no later than a Python-scheduled redraw deadline (paced overlay animation).
         if (const auto redraw_wait = python::seconds_until_scheduled_redraw())
-            wait_seconds = std::min(wait_seconds,
-                                    std::max(kScheduledRedrawMinWaitSeconds, *redraw_wait));
+            consider_timeout(std::max(kScheduledRedrawMinWaitSeconds, *redraw_wait),
+                             "python_scheduled_redraw");
 
         window_manager_->waitEvents(wait_seconds);
+        last_wake_reason_ = window_manager_->frameInput().had_event ? "event" : "timeout";
+        last_wake_timeout_source_ = window_manager_->frameInput().had_event ? "none" : timeout_source;
     }
 
     void VisualizerImpl::render() {
+
+        if (motion_only_wake_skipped_) {
+            motion_only_wake_skipped_ = false;
+            window_manager_->pollEvents();
+            return;
+        }
 
         auto now = std::chrono::high_resolution_clock::now();
         float delta_time = std::chrono::duration<float>(now - last_frame_time_).count();
@@ -2403,7 +2481,7 @@ namespace lfs::vis {
         const bool is_training = trainer_manager_ && trainer_manager_->isRunning();
         const FrameDemand frame_demand = collectFrameDemand(viewport_export_locked, store_dirty);
         if (gui_frame_rendered_ && !frame_demand.shouldRenderFrame()) {
-            LOG_PERF("loop_idle skip_gui_render=true needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} window_resize_paint_pending={} viewport_resize_deferring={} viewport_resize_settle_ready={}",
+            LOG_PERF("loop_idle skip_gui_render=true needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} window_resize_paint_pending={} viewport_resize_deferring={} viewport_resize_settle_ready={} wake_reason={} wake_timeout_source={}",
                      frame_demand.scene_dirty,
                      frame_demand.continuous_input,
                      frame_demand.python_animation,
@@ -2418,7 +2496,9 @@ namespace lfs::vis {
                      frame_demand.swapchain_resize_ready,
                      frame_demand.window_resize_paint_pending,
                      frame_demand.viewport_resize_deferring,
-                     frame_demand.viewport_resize_settle_ready);
+                     frame_demand.viewport_resize_settle_ready,
+                     last_wake_reason_,
+                     last_wake_timeout_source_);
             if (!python::is_plugin_preload_running()) {
                 python::flush_signals();
             }
@@ -2535,12 +2615,22 @@ namespace lfs::vis {
         update_work_processed_ = false;
 
         // Render-on-demand: VSync handles frame pacing, waitEvents saves CPU when idle
-        const FrameDemand next_demand = collectFrameDemand(viewport_export_locked, false, false);
+        // The demand walk is the expensive part of the frame loop (notably the
+        // visible Python panel traversal). Reuse the demand collected before the
+        // render and refresh only the cheap flags that can be created by the
+        // just-finished presentation.
+        FrameDemand next_demand = frame_demand;
+        next_demand.python_redraw = python::has_redraw_request();
+        next_demand.render_work = hasPendingRenderWork();
+        next_demand.store_dirty = app_store().store().has_dirty();
+        last_frame_demand_ = next_demand;
+        has_last_frame_demand_ = true;
 
         // Continuous demand that is only python_redraw and/or gui_animation — pace it
         // so GUI-only animation does not free-run against a MAILBOX swapchain.
         const bool gui_only_animation =
             next_demand.needsContinuousLoop() &&
+            !(gui_manager_ && gui_manager_->needsImmediateAnimationFrame()) &&
             !python::is_plugin_preload_running() &&
             !next_demand.scene_dirty && !next_demand.continuous_input &&
             !next_demand.python_animation && !next_demand.python_overlay &&
@@ -2553,7 +2643,7 @@ namespace lfs::vis {
         const auto py_redraw_due = python::seconds_until_scheduled_redraw();
         const double py_redraw_due_in = py_redraw_due ? *py_redraw_due : -1.0;
 
-        LOG_PERF("loop_end needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} window_resize_paint_pending={} viewport_resize_deferring={} viewport_resize_settle_ready={} gui_only_throttle={} py_redraw_due_in={:.4f}",
+        LOG_PERF("loop_end needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} window_resize_paint_pending={} viewport_resize_deferring={} viewport_resize_settle_ready={} gui_only_throttle={} py_redraw_due_in={:.4f} gui_anim_sources={} wake_reason={} wake_timeout_source={}",
                  next_demand.scene_dirty,
                  next_demand.continuous_input,
                  next_demand.python_animation,
@@ -2570,22 +2660,34 @@ namespace lfs::vis {
                  next_demand.viewport_resize_deferring,
                  next_demand.viewport_resize_settle_ready,
                  gui_only_animation,
-                 py_redraw_due_in);
+                 py_redraw_due_in,
+                 gui_manager_ ? gui_manager_->describeAnimationDemand() : std::string{"none"},
+                 last_wake_reason_,
+                 last_wake_timeout_source_);
 
         if (next_demand.needsContinuousLoop()) {
             if (gui_only_animation) {
                 // GUI-only animation must not free-run against a MAILBOX swapchain.
-                // Cap at kGuiAnimationFrameInterval; waitEvents still wakes instantly on input.
+                // Cap at the display interval; waitEvents still wakes instantly on input.
+                const double gui_animation_frame_interval = guiAnimationFrameInterval();
                 const double elapsed = std::chrono::duration<double>(
                                            std::chrono::high_resolution_clock::now() - last_frame_time_)
                                            .count();
-                if (elapsed >= kGuiAnimationFrameInterval) {
+                if (elapsed >= gui_animation_frame_interval) {
                     window_manager_->pollEvents();
+                    last_wake_reason_ = window_manager_->frameInput().had_event ? "event" : "poll";
+                    last_wake_timeout_source_ = "none";
                 } else {
-                    window_manager_->waitEvents(kGuiAnimationFrameInterval - elapsed);
+                    window_manager_->waitEvents(gui_animation_frame_interval - elapsed);
+                    last_wake_reason_ = window_manager_->frameInput().had_event ? "event" : "timeout";
+                    last_wake_timeout_source_ = window_manager_->frameInput().had_event
+                                                    ? "none"
+                                                    : "gui_animation_paced";
                 }
             } else {
                 window_manager_->pollEvents();
+                last_wake_reason_ = window_manager_->frameInput().had_event ? "event" : "poll";
+                last_wake_timeout_source_ = "none";
             }
         } else {
             // Idle: wait to minimize CPU/GPU work. Mouse-motion-only viewport wakes

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -514,7 +514,8 @@ namespace lfs::vis {
         void setupViewContextBridge();
         void beginShutdown(std::string_view reason = "Viewer is shutting down");
         void processRenderWorkQueue();
-        [[nodiscard]] bool hasPendingRenderWork();
+        [[nodiscard]] bool hasPendingWork() const;
+        [[nodiscard]] bool hasPendingRenderWork() const;
         [[nodiscard]] bool inputFrameRequestsRender() const;
 
         struct FrameDemand {
@@ -559,6 +560,8 @@ namespace lfs::vis {
         [[nodiscard]] FrameDemand collectFrameDemand(bool viewport_export_locked,
                                                      bool drained_store_dirty = false,
                                                      bool consume_python_redraw = true);
+        [[nodiscard]] bool isMotionOnlyWake() const;
+        [[nodiscard]] double guiAnimationFrameInterval() const;
         void waitForNextEvent(bool is_training);
 
         class CallbackCleanup {
@@ -620,6 +623,8 @@ namespace lfs::vis {
         // State tracking
         bool fully_initialized_ = false;
         bool window_initialized_ = false;
+        mutable std::chrono::steady_clock::time_point display_refresh_queried_at_{};
+        mutable double gui_animation_frame_interval_ = 1.0 / 60.0;
         bool gui_initialized_ = false;
         bool tools_initialized_ = false;
         bool view_context_bridge_initialized_ = false;
@@ -650,6 +655,11 @@ namespace lfs::vis {
             pending_load_files_;
         int pending_training_completion_refresh_frames_ = 0;
         bool gui_frame_rendered_ = false;
+        bool motion_only_wake_skipped_ = false;
+        std::string last_wake_reason_ = "startup";
+        std::string last_wake_timeout_source_ = "none";
+        FrameDemand last_frame_demand_{};
+        bool has_last_frame_demand_ = false;
         bool startup_plugin_preload_started_ = false;
         bool startup_project_open_attempted_ = false;
         bool close_save_notice_posted_ = false;

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -1474,6 +1474,8 @@ namespace lfs::vis {
         frame_input_.mouse_released[1] = false;
         frame_input_.mouse_released[2] = false;
         frame_input_.mouse_wheel = 0.0f;
+        frame_input_.mouse_wheel_x = 0.0f;
+        frame_input_.mouse_button_events.clear();
         frame_input_.mouse_moved = false;
     }
 

--- a/tests/python/test_asset_manager_panel.py
+++ b/tests/python/test_asset_manager_panel.py
@@ -333,8 +333,8 @@ def _scan_result(**overrides):
 
 def test_panel_contract_polls_preference_and_remains_left_dock(panel_module):
     panel_type = panel_module.AssetManagerPanel
-    assert panel_type.update_policy == "interval"
-    assert panel_type.update_interval_ms == 250
+    assert panel_type.update_policy == "dirty"
+    assert "update_interval_ms" not in panel_type.__dict__
     assert panel_type.space == panel_module.lf.ui.PanelSpace.LEFT_DOCK
     assert panel_type.order == 20
 

--- a/tests/python/test_localization_contracts.py
+++ b/tests/python/test_localization_contracts.py
@@ -422,7 +422,7 @@ def test_operator_property_registration_preserves_localization_keys():
 def test_cached_python_panels_request_a_frame_on_language_change():
     source = (ROOT / "src" / "python" / "lfs" / "rml_python_panel_adapter.cpp").read_text(encoding="utf-8")
     needs_frame = source[source.index("bool RmlPythonPanelAdapter::needsAnimationFrame() const"):]
-    assert "current_language != last_language_" in needs_frame
+    assert "getCurrentLanguageGeneration()" in needs_frame
     assert "return true;" in needs_frame.split("if (!dirty_driven_updates_)", 1)[0]
 
 

--- a/tests/python/test_startup_recent_panel.py
+++ b/tests/python/test_startup_recent_panel.py
@@ -43,7 +43,7 @@ def _install_lf_stub(monkeypatch, tmp_path, *, recent_paths=None, dispositions=N
         template = ""
         height_mode = panel_height_mode.CONTENT
         size = None
-        update_policy = "interval"
+        update_policy = "dirty"
 
         def on_bind_model(self, ctx):
             del ctx

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -121,6 +121,29 @@ TEST(LoggerTest, ScopedTimerThresholdKeepsZeroThresholdCompatible) {
     EXPECT_NE(messages.front().find("logger.threshold.compat took"), std::string::npos);
 }
 
+TEST(LoggerTest, ScopedTimerDisabledPathDoesNotEmit) {
+    auto& logger = lfs::core::Logger::get();
+    const auto previous_level = logger.level();
+    logger.set_level(lfs::core::LogLevel::Info);
+
+    std::vector<std::string> messages;
+    LogHandlerGuard guard([&messages](lfs::core::LogLevel level,
+                                      const lfs::core::SourceSite&,
+                                      std::string_view message) {
+        if (level == lfs::core::LogLevel::Performance)
+            messages.emplace_back(message);
+    });
+
+    {
+        lfs::core::ScopedTimer timer(
+            "logger.disabled", lfs::core::LogLevel::Performance,
+            LFS_SOURCE_SITE_CURRENT());
+    }
+
+    logger.set_level(previous_level);
+    EXPECT_TRUE(messages.empty());
+}
+
 TEST(LoggerTest, DefaultLogFilePathResolvesUnderPerUserDirectory) {
     const std::filesystem::path resolved(lfs::core::Logger::default_log_file_path());
 

--- a/tests/test_rendering_refactor_services.cpp
+++ b/tests/test_rendering_refactor_services.cpp
@@ -539,6 +539,23 @@ namespace lfs::vis {
         EXPECT_EQ(manager.getModelForRendering(), state.combined_model);
     }
 
+    TEST_F(SceneManagerRenderStateTest, VisibleSelectionMaskIsCachedForUnchangedGenerations) {
+        SceneManager manager;
+        auto& scene = manager.getScene();
+
+        scene.addSplat("Visible", makeTwoPointTestSplat(0.0f, 1.0f));
+        scene.addSplat("Hidden", makeTestSplat(2.0f));
+        scene.setNodeVisibility("Hidden", false);
+        scene.setSelection({0});
+
+        const auto first = scene.getVisibleSelectionMask();
+        const auto second = scene.getVisibleSelectionMask();
+
+        ASSERT_NE(first, nullptr);
+        ASSERT_NE(second, nullptr);
+        EXPECT_EQ(first.get(), second.get());
+    }
+
     TEST_F(SceneManagerRenderStateTest, PointCloudTransformIsTrackedSeparatelyFromModelTransforms) {
         SceneManager manager;
         auto& scene = manager.getScene();

--- a/tests/test_sdl_rml_key_mapping.cpp
+++ b/tests/test_sdl_rml_key_mapping.cpp
@@ -114,6 +114,53 @@ namespace {
         EXPECT_FALSE(buffer.mouse_moved);
     }
 
+    TEST(FrameInputBufferTest, PreservesOrderedMouseButtonsAndHorizontalWheel) {
+        lfs::vis::FrameInputBuffer buffer;
+        buffer.beginFrame();
+
+        SDL_Event first_down{};
+        first_down.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+        first_down.button.windowID = 11;
+        first_down.button.button = SDL_BUTTON_LEFT;
+        first_down.button.x = 10.0f;
+        first_down.button.y = 20.0f;
+        first_down.button.timestamp = 100;
+        first_down.button.clicks = 1;
+        buffer.processEvent(first_down, 11);
+
+        SDL_Event first_up = first_down;
+        first_up.type = SDL_EVENT_MOUSE_BUTTON_UP;
+        first_up.button.timestamp = 101;
+        buffer.processEvent(first_up, 11);
+
+        SDL_Event second_down = first_down;
+        second_down.button.x = 30.0f;
+        second_down.button.y = 40.0f;
+        second_down.button.timestamp = 102;
+        second_down.button.clicks = 2;
+        buffer.processEvent(second_down, 11);
+
+        SDL_Event wheel{};
+        wheel.type = SDL_EVENT_MOUSE_WHEEL;
+        wheel.wheel.windowID = 11;
+        wheel.wheel.x = 2.0f;
+        wheel.wheel.y = -3.0f;
+        buffer.processEvent(wheel, 11);
+
+        ASSERT_EQ(buffer.mouse_button_events.size(), 3u);
+        EXPECT_TRUE(buffer.mouse_button_events[0].down);
+        EXPECT_FALSE(buffer.mouse_button_events[1].down);
+        EXPECT_TRUE(buffer.mouse_button_events[2].down);
+        EXPECT_FLOAT_EQ(buffer.mouse_button_events[0].x, 10.0f);
+        EXPECT_FLOAT_EQ(buffer.mouse_button_events[2].x, 30.0f);
+        EXPECT_EQ(buffer.mouse_button_events[0].timestamp, 100u);
+        EXPECT_EQ(buffer.mouse_button_events[2].clicks, 2u);
+        EXPECT_FLOAT_EQ(buffer.mouse_wheel, -3.0f);
+        EXPECT_FLOAT_EQ(buffer.mouse_wheel_x, 2.0f);
+        EXPECT_TRUE(buffer.mouse_clicked[0]);
+        EXPECT_TRUE(buffer.mouse_released[0]);
+    }
+
     TEST(FrameInputBufferTest, TracksMouseWindowAndWakeEventsForRenderDemand) {
         lfs::vis::FrameInputBuffer buffer;
         buffer.beginFrame();


### PR DESCRIPTION
The app no longer burns a CPU core while idle, and the UI reacts at the display's refresh rate.

What was wrong: once the right dock had been shown, a trainer existed or GT compare was on, the frame loop never parked again: it rendered a GUI frame about 35 times a second forever. A focus-blur call re-armed the right panel's "needs a frame" flag every frame, and the status bar turned any one-off animation into a permanent refresh timer. Measured idle CPU with Preferences open: 75% before, 0.6% after; Asset Manager 75% → 0.5%; paused trainer 78% → 0.4%; GT compare 78% → 0.6%.

What else changed: GUI animations run at the display rate instead of a fixed 30 fps; panels that resize to their content settle in one frame instead of up to eight; mouse clicks are replayed at their own coordinates so fast double clicks are no longer lost; horizontal scrolling reaches panels; mouse motion that changes nothing no longer runs the full update path; Python panels update when something changes rather than on a timer; several per-frame recomputations (editor context, selection mask, render state, panel snapshots, timers with logging off) are cached or skipped.

Verification: new tests for the input records, timer fast path, selection-mask cache and language generation; input/panel/GUI/scene suites pass except two failures that already fail on master; Python fast tier passes. Idle CPU measured in six UI states on the same machine.
