### PR TITLE
Modal dialogs no longer keep the frame loop awake

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -7098,7 +7098,14 @@ namespace lfs::vis::gui {
         add(isViewportExportLocked(), "viewport_export");
         add(static_cast<bool>(rmlui_manager_.dragPayload()), "drag_payload");
         add(startup_overlay_.needsAnimationFrame(), "startup_overlay");
-        add(rml_modal_overlay_ && rml_modal_overlay_->needsAnimationFrame(), "modal_overlay");
+        if (rml_modal_overlay_) {
+            if (const auto modal_demand = rml_modal_overlay_->animationDemandDescription();
+                !modal_demand.empty()) {
+                if (!result.empty())
+                    result += ',';
+                result += modal_demand;
+            }
+        }
         add(rml_toast_overlay_ && rml_toast_overlay_->needsAnimationFrame(), "toast_overlay");
         add(global_context_menu_ && global_context_menu_->needsAnimationFrame(), "context_menu");
         add(video_widget_ && video_widget_->isVideoPlaying(), "video");

--- a/src/visualizer/gui/rml_modal_overlay.cpp
+++ b/src/visualizer/gui/rml_modal_overlay.cpp
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <cmath>
 #include <format>
+#include <limits>
 #include <string_view>
 
 namespace lfs::vis::gui {
@@ -168,7 +169,23 @@ namespace lfs::vis::gui {
     }
 
     bool RmlModalOverlay::needsAnimationFrame() const {
-        return hasPendingRequest();
+        // A queued request is rendered after the current modal is dismissed.
+        // While a modal is already visible, the queue must not be treated as
+        // an animation source: doing so spins the frame loop for a static
+        // modal until the user makes that choice.
+        return !active_.has_value() && hasPendingRequest();
+    }
+
+    std::string RmlModalOverlay::animationDemandDescription() const {
+        if (!needsAnimationFrame())
+            return {};
+
+        const double next_update_delay = rml_context_
+                                             ? rml_context_->GetNextUpdateDelay()
+                                             : std::numeric_limits<double>::infinity();
+        return std::format(
+            "modal_overlay(pending_request=true,active={},render_needed={},rml_delay={})",
+            active_.has_value(), render_needed_, next_update_delay);
     }
 
     void RmlModalOverlay::initContext() {

--- a/src/visualizer/gui/rml_modal_overlay.hpp
+++ b/src/visualizer/gui/rml_modal_overlay.hpp
@@ -40,6 +40,7 @@ namespace lfs::vis {
     class VisualizerImplResetTest_StartupSweepsEmptyScratchAndDoesNotOffer_Test;
     class VisualizerImplResetTest_RecoverTempWithSidecarThenDiscardExitLeavesNoTempFiles_Test;
     class VisualizerImplResetTest_RecoverLegacyScratchThenSaveAsRemovesLegacyFile_Test;
+    class VisualizerImplResetTest_ModalOverlayQueuedRequestDoesNotAnimateActiveModal_Test;
 } // namespace lfs::vis
 namespace lfs::vis::gui {
 
@@ -78,6 +79,7 @@ namespace lfs::vis::gui {
         [[nodiscard]] bool hasPendingRequest() const;
         [[nodiscard]] bool hasPendingRenderWork() const;
         [[nodiscard]] bool needsAnimationFrame() const;
+        [[nodiscard]] std::string animationDemandDescription() const;
 
     private:
         friend class lfs::vis::VisualizerImplResetTest_RecoveryDeclineKeepsSidecarSuppressesRepeatAndExplicitSaveDeletesIt_Test;
@@ -96,6 +98,7 @@ namespace lfs::vis::gui {
         friend class lfs::vis::VisualizerImplResetTest_StartupSweepsEmptyScratchAndDoesNotOffer_Test;
         friend class lfs::vis::VisualizerImplResetTest_RecoverTempWithSidecarThenDiscardExitLeavesNoTempFiles_Test;
         friend class lfs::vis::VisualizerImplResetTest_RecoverLegacyScratchThenSaveAsRemovesLegacyFile_Test;
+        friend class lfs::vis::VisualizerImplResetTest_ModalOverlayQueuedRequestDoesNotAnimateActiveModal_Test;
         void initContext();
         bool syncTheme();
         void cacheElements();

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -1892,6 +1892,31 @@ namespace lfs::vis {
     }
 
     TEST_F(VisualizerImplResetTest,
+           ModalOverlayQueuedRequestDoesNotAnimateActiveModal) {
+        VisualizerImpl viewer(projectOptions());
+        auto* const gui = viewer.getGuiManager();
+        ASSERT_NE(gui, nullptr);
+        auto* const overlay = gui->modalOverlay();
+        ASSERT_NE(overlay, nullptr);
+
+        lfs::core::ModalRequest queued;
+        queued.title = "Queued";
+        queued.buttons = {{"OK", "primary"}};
+        overlay->enqueue(std::move(queued));
+
+        // Model the state after the first request has been shown. The second
+        // request must wait for input instead of driving a continuous loop.
+        overlay->active_.emplace();
+        EXPECT_FALSE(overlay->needsAnimationFrame());
+        EXPECT_TRUE(overlay->animationDemandDescription().empty());
+
+        overlay->active_.reset();
+        EXPECT_TRUE(overlay->needsAnimationFrame());
+        EXPECT_NE(overlay->animationDemandDescription().find("pending_request=true"),
+                  std::string::npos);
+    }
+
+    TEST_F(VisualizerImplResetTest,
            RecoveryDeclineKeepsSidecarSuppressesRepeatAndExplicitSaveDeletesIt) {
         const auto& temporary = temporary_.path;
         const auto project_path =


### PR DESCRIPTION
A modal dialog no longer keeps the app rendering at full speed while it is on screen.

What was wrong: when a second modal request was queued behind a visible one (for example after stopping training, when the "training stopped" prompt is up), the modal overlay reported "needs a frame" on every loop iteration, so the app rendered ~18 frames a second and used a full CPU core for as long as the dialog stayed open.

What changed: a queued modal only requests a frame once no modal is active; the queued follow-up is shown on the next input-driven frame after the current one is dismissed. The frame-loop diagnostic now names the modal overlay's demand source.

Measured on this machine: idle CPU with a modal shown after stopping training 101% → 0.8%. Tests: GUI/panel/modal/visualizer suites pass except the two that need a fixture missing from this checkout and fail on master.
