### PR TITLE
Build the multi-node combined model off the main thread

### DIFF
--- a/src/core/include/core/scene.hpp
+++ b/src/core/include/core/scene.hpp
@@ -111,6 +111,7 @@ namespace lfs::core {
     };
 
     class Scene;
+    struct CombinedModelBuildLifetimeRegistry;
 
     // Project payload hydration is tracked at the chapter/node boundary. A
     // geometry node may exist in the interactive scene shell before its heavy
@@ -693,6 +694,8 @@ namespace lfs::core {
         mutable std::optional<CombinedModelBuild> completed_combined_model_build_;
         mutable std::mutex combined_model_build_mutex_;
         mutable std::atomic<bool> combined_model_build_running_{false};
+        mutable std::shared_ptr<CombinedModelBuildLifetimeRegistry>
+            combined_model_lifetime_;
 
         /// Points at Trainer::render_mutex_ while a trainer owns this scene.
         /// Null when idle / headless without a live GUI trainer.
@@ -737,6 +740,11 @@ namespace lfs::core {
         void rebuildModelCacheIfNeeded(bool include_hidden_splats) const;
         void pollCombinedModelBuild() const;
         void requestCombinedModelBuildIfNeeded(bool include_hidden_splats = false) const;
+        [[nodiscard]] std::shared_ptr<const lfs::core::SplatData>
+        borrowCombinedModel(const lfs::core::SplatData* model) const;
+        [[nodiscard]] std::unique_ptr<lfs::core::SplatData>
+        retireCombinedModelIfInFlight(
+            std::unique_ptr<lfs::core::SplatData> model) const;
         void rebuildTransformCacheIfNeeded() const;
         void updateWorldTransform(const SceneNode& node) const;
         void removeNodeInternal(NodeId id, bool keep_children);

--- a/src/core/include/core/scene.hpp
+++ b/src/core/include/core/scene.hpp
@@ -22,6 +22,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -264,7 +265,7 @@ namespace lfs::core {
         };
 
         Scene();
-        ~Scene() = default;
+        ~Scene();
 
         Scene(const Scene&) = delete;
         Scene& operator=(const Scene&) = delete;
@@ -389,6 +390,44 @@ namespace lfs::core {
 
         const lfs::core::SplatData* getCombinedModel() const;
 
+        struct CombinedModelBuildInput {
+            std::shared_ptr<const lfs::core::SplatData> model;
+            bool visible = true;
+            size_t selection_offset = 0;
+        };
+
+        struct CombinedModelBuild {
+            std::vector<CombinedModelBuildInput> inputs;
+            size_t full_selection_count = 0;
+            SplatTensorAllocator allocator;
+            std::shared_ptr<lfs::core::SplatData> model;
+            std::shared_ptr<lfs::core::Tensor> transform_indices;
+            std::shared_ptr<lfs::core::Tensor> visible_selection_indices;
+            // The worker records this after all output tensors have been ordered
+            // onto worker_stream. The consumer synchronizes it before install.
+            std::shared_ptr<void> ready_event;
+            cudaStream_t worker_stream = nullptr;
+            uint64_t generation = 0;
+            bool includes_hidden_splats = false;
+        };
+
+        // The inputs are captured without copying model tensors. The caller must
+        // keep the source models alive until buildCombinedModelCache returns.
+        [[nodiscard]] CombinedModelBuild captureCombinedModelBuild(
+            bool include_hidden_splats = false) const;
+        [[nodiscard]] static CombinedModelBuild buildCombinedModelCache(
+            std::vector<CombinedModelBuildInput> inputs,
+            size_t full_selection_count,
+            SplatTensorAllocator allocator = {},
+            uint64_t generation = 0,
+            bool include_hidden_splats = false);
+        [[nodiscard]] bool installCombinedModelCache(CombinedModelBuild build) const;
+        [[nodiscard]] bool installCombinedModelCache(
+            std::shared_ptr<lfs::core::SplatData> model,
+            uint64_t generation) const;
+        void requestCombinedModelBuild(bool include_hidden_splats = false) const;
+        [[nodiscard]] bool combinedModelBuildPending() const;
+
         void setCombinedModelAllocator(SplatTensorAllocator allocator);
 
         size_t consolidateNodeModels();
@@ -426,7 +465,9 @@ namespace lfs::core {
 
         [[nodiscard]] std::shared_ptr<lfs::core::Tensor> getVisibleSelectionIndices() const;
         [[nodiscard]] std::shared_ptr<lfs::core::Tensor> getVisibleSelectionMask() const;
-        [[nodiscard]] uint64_t renderGeneration() const noexcept { return render_generation_; }
+        [[nodiscard]] uint64_t renderGeneration() const noexcept {
+            return render_generation_.load(std::memory_order_acquire);
+        }
         [[nodiscard]] uint64_t selectionGeneration() const noexcept { return selection_generation_; }
 
         enum class MergeStorageMode {
@@ -569,11 +610,11 @@ namespace lfs::core {
             cached_transform_indices_.reset();
             cached_visible_selection_indices_.reset();
             invalidateVisibleSelectionMaskCache();
-            ++render_generation_;
+            render_generation_.fetch_add(1, std::memory_order_acq_rel);
         }
         void invalidateTransformCache() {
             transform_cache_valid_.store(false, std::memory_order_release);
-            ++render_generation_;
+            render_generation_.fetch_add(1, std::memory_order_acq_rel);
         }
         void markDirty() { invalidateCache(); }
         void markTransformDirty(NodeId node);
@@ -633,6 +674,7 @@ namespace lfs::core {
             std::unique_ptr<SceneNode> node,
             bool allow_duplicate_name = false);
         mutable std::shared_ptr<lfs::core::SplatData> cached_combined_;
+        mutable bool cached_combined_includes_hidden_ = false;
         mutable std::shared_ptr<lfs::core::Tensor> cached_transform_indices_;
         mutable std::shared_ptr<lfs::core::Tensor> cached_visible_selection_indices_;
         mutable std::shared_ptr<lfs::core::Tensor> cached_visible_selection_mask_;
@@ -643,9 +685,14 @@ namespace lfs::core {
         mutable uint64_t cached_visible_selection_mask_visibility_generation_ = 0;
         mutable std::atomic<bool> model_cache_valid_{false};
         mutable const lfs::core::SplatData* single_node_model_ = nullptr;
+        mutable size_t single_node_selection_offset_ = 0;
+        mutable size_t single_node_full_selection_count_ = 0;
 
         mutable std::mutex combined_model_mutex_;
         SplatTensorAllocator combined_model_allocator_;
+        mutable std::optional<CombinedModelBuild> completed_combined_model_build_;
+        mutable std::mutex combined_model_build_mutex_;
+        mutable std::atomic<bool> combined_model_build_running_{false};
 
         /// Points at Trainer::render_mutex_ while a trainer owns this scene.
         /// Null when idle / headless without a live GUI trainer.
@@ -656,7 +703,7 @@ namespace lfs::core {
         mutable bool consolidated_ = false;
         mutable std::vector<ConsolidatedNodeSlot> consolidated_node_slots_;
         mutable uint64_t consolidated_generation_ = 0;
-        mutable uint64_t render_generation_ = 0;
+        mutable std::atomic<uint64_t> render_generation_{0};
         mutable uint64_t selection_generation_ = 0;
 
         mutable std::shared_mutex selection_mutex_;
@@ -671,6 +718,11 @@ namespace lfs::core {
         uint8_t next_group_id_ = 1;
         bool selection_group_counts_dirty_ = true;
 
+        // Must be declared last: its destructor joins before any member touched
+        // by the worker is destroyed. ~Scene also performs this join explicitly
+        // so the completion event and result are drained in a documented order.
+        mutable std::optional<std::jthread> combined_model_build_thread_;
+
         void rebuildCacheIfNeeded() const;
         void invalidateVisibleSelectionMaskCache() const {
             cached_visible_selection_mask_.reset();
@@ -683,6 +735,8 @@ namespace lfs::core {
 
         void rebuildModelCacheIfNeeded() const;
         void rebuildModelCacheIfNeeded(bool include_hidden_splats) const;
+        void pollCombinedModelBuild() const;
+        void requestCombinedModelBuildIfNeeded(bool include_hidden_splats = false) const;
         void rebuildTransformCacheIfNeeded() const;
         void updateWorldTransform(const SceneNode& node) const;
         void removeNodeInternal(NodeId id, bool keep_children);

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -32,6 +32,67 @@
 
 namespace lfs::core {
 
+    struct CombinedModelBuildLifetimeRegistry {
+        void retain(const SplatData* model) {
+            std::lock_guard<std::mutex> lock(mutex);
+            ++in_flight_models[model];
+            retired_release_enabled = false;
+        }
+
+        void release(const SplatData* model) {
+            std::vector<std::unique_ptr<SplatData>> retired;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                const auto it = in_flight_models.find(model);
+                assert(it != in_flight_models.end());
+                if (it != in_flight_models.end()) {
+                    if (--it->second == 0) {
+                        in_flight_models.erase(it);
+                    }
+                }
+                releaseRetiredIfIdleLocked(retired);
+            }
+            retired.clear();
+        }
+
+        [[nodiscard]] std::unique_ptr<SplatData> retire(
+            std::unique_ptr<SplatData> model) {
+            if (!model) {
+                return model;
+            }
+
+            std::lock_guard<std::mutex> lock(mutex);
+            if (!in_flight_models.contains(model.get())) {
+                return model;
+            }
+            retired_models.push_back(std::move(model));
+            return nullptr;
+        }
+
+        void releaseRetiredAfterJoin() {
+            std::vector<std::unique_ptr<SplatData>> retired;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                retired_release_enabled = true;
+                releaseRetiredIfIdleLocked(retired);
+            }
+            retired.clear();
+        }
+
+    private:
+        void releaseRetiredIfIdleLocked(
+            std::vector<std::unique_ptr<SplatData>>& retired) {
+            if (retired_release_enabled && in_flight_models.empty()) {
+                retired.swap(retired_models);
+            }
+        }
+
+        std::mutex mutex;
+        std::unordered_map<const SplatData*, size_t> in_flight_models;
+        std::vector<std::unique_ptr<SplatData>> retired_models;
+        bool retired_release_enabled = false;
+    };
+
     std::string makeUniqueNodeName(const std::unordered_set<std::string>& existing_names,
                                    const std::string_view base_name) {
         std::string unique_name(base_name);
@@ -161,7 +222,9 @@ namespace lfs::core {
         });
     }
 
-    Scene::Scene() {
+    Scene::Scene()
+        : combined_model_lifetime_(
+              std::make_shared<CombinedModelBuildLifetimeRegistry>()) {
         addSelectionGroup("Group 1", glm::vec3(0.0f));
     }
 
@@ -173,10 +236,20 @@ namespace lfs::core {
             combined_model_build_thread_->join();
         }
         pollCombinedModelBuild();
+        if (combined_model_lifetime_) {
+            for (auto& node : nodes_) {
+                if (node && node->model) {
+                    (void)retireCombinedModelIfInFlight(std::move(node->model));
+                }
+            }
+            combined_model_lifetime_->releaseRetiredAfterJoin();
+        }
     }
 
     Scene::Scene(RestoreStageTag, Scene& target) noexcept
-        : restore_target_(&target),
+        : combined_model_lifetime_(
+              std::make_shared<CombinedModelBuildLifetimeRegistry>()),
+          restore_target_(&target),
           restore_staging_(true) {}
 
     void Scene::notifyMutation(MutationType type) {
@@ -420,7 +493,10 @@ namespace lfs::core {
             }
 
             if (node->model) {
-                detached.push_back(std::move(node->model));
+                if (auto model = retireCombinedModelIfInFlight(
+                        std::move(node->model))) {
+                    detached.push_back(std::move(model));
+                }
             }
 
             if (!keep_children) {
@@ -476,6 +552,11 @@ namespace lfs::core {
             return;
         const size_t removed_index = idx_it->second;
         node = nodes_[removed_index].get();
+
+        // A worker may still be reading this model through a captured alias.
+        // Keep it owned by the Scene until pollCombinedModelBuild() has joined
+        // the worker and drained its input aliases.
+        (void)retireCombinedModelIfInFlight(std::move(node->model));
 
         const std::string name_copy = node->name;
         const Uuid uuid_copy = node->uuid;
@@ -562,7 +643,11 @@ namespace lfs::core {
                       name,
                       node->gaussian_count.load(std::memory_order_acquire),
                       gaussian_count);
+            auto previous = retireCombinedModelIfInFlight(std::move(node->model));
             node->model = std::move(model);
+            // `previous` is empty when it was parked for an in-flight worker;
+            // otherwise its normal scope lifetime releases it here.
+            previous.reset();
             node->gaussian_count.store(gaussian_count, std::memory_order_release);
             node->centroid = centroid;
             node->payload_hydration = PayloadHydrationState::Loaded;
@@ -582,7 +667,7 @@ namespace lfs::core {
 
         const size_t gaussian_count = model ? static_cast<size_t>(model->size()) : 0;
         const glm::vec3 centroid = model ? computeCentroid(model.get()) : node->centroid;
-        auto previous = std::move(node->model);
+        auto previous = retireCombinedModelIfInFlight(std::move(node->model));
         node->model = std::move(model);
         node->gaussian_count.store(gaussian_count, std::memory_order_release);
         node->centroid = centroid;
@@ -657,6 +742,11 @@ namespace lfs::core {
     void Scene::clear() {
         Transaction txn(*this);
 
+        for (auto& node : nodes_) {
+            if (node && node->model) {
+                (void)retireCombinedModelIfInFlight(std::move(node->model));
+            }
+        }
         nodes_.clear();
         id_to_index_.clear();
         name_to_id_.clear();
@@ -787,8 +877,7 @@ namespace lfs::core {
                                          ? static_cast<size_t>(node->model->size())
                                          : node->gaussian_count.load(std::memory_order_acquire);
             if (node->model) {
-                build.inputs.push_back({std::shared_ptr<const lfs::core::SplatData>(
-                                            node->model.get(), [](const lfs::core::SplatData*) {}),
+                build.inputs.push_back({borrowCombinedModel(node->model.get()),
                                         isNodeEffectivelyVisible(node->id),
                                         selection_offset});
             }
@@ -800,6 +889,29 @@ namespace lfs::core {
             build.allocator = combined_model_allocator_;
         }
         return build;
+    }
+
+    std::shared_ptr<const lfs::core::SplatData> Scene::borrowCombinedModel(
+        const lfs::core::SplatData* model) const {
+        assert(model);
+        const auto registry = combined_model_lifetime_;
+        registry->retain(model);
+        try {
+            return std::shared_ptr<const lfs::core::SplatData>(
+                model,
+                [registry](const lfs::core::SplatData* input) {
+                    registry->release(input);
+                });
+        } catch (...) {
+            registry->release(model);
+            throw;
+        }
+    }
+
+    std::unique_ptr<lfs::core::SplatData>
+    Scene::retireCombinedModelIfInFlight(
+        std::unique_ptr<lfs::core::SplatData> model) const {
+        return combined_model_lifetime_->retire(std::move(model));
     }
 
     Scene::CombinedModelBuild Scene::buildCombinedModelCache(
@@ -1042,7 +1154,14 @@ namespace lfs::core {
     }
 
     void Scene::pollCombinedModelBuild() const {
-        if (!combined_model_build_thread_ || combined_model_build_running_.load(std::memory_order_acquire)) {
+        if (!combined_model_lifetime_) {
+            return;
+        }
+        if (!combined_model_build_thread_) {
+            combined_model_lifetime_->releaseRetiredAfterJoin();
+            return;
+        }
+        if (combined_model_build_running_.load(std::memory_order_acquire)) {
             return;
         }
 
@@ -1056,24 +1175,29 @@ namespace lfs::core {
             combined_model_build_thread_->join();
         }
         combined_model_build_thread_.reset();
-        if (completed) {
-            if (completed->ready_event) {
-                const auto status = cudaEventSynchronize(
-                    reinterpret_cast<cudaEvent_t>(completed->ready_event.get()));
-                if (status != cudaSuccess) {
-                    LOG_ERROR("Combined model worker result dropped: event wait failed: {} ({})",
-                              cudaGetErrorName(status), cudaGetErrorString(status));
-                    return;
+        {
+            if (completed) {
+                if (completed->ready_event) {
+                    const auto status = cudaEventSynchronize(
+                        reinterpret_cast<cudaEvent_t>(completed->ready_event.get()));
+                    if (status != cudaSuccess) {
+                        LOG_ERROR("Combined model worker result dropped: event wait failed: {} ({})",
+                                  cudaGetErrorName(status), cudaGetErrorString(status));
+                    } else if (!completed->model) {
+                        LOG_ERROR("Combined model worker result dropped: no model was produced");
+                    } else if (!installCombinedModelCache(std::move(*completed))) {
+                        LOG_DEBUG("Combined model worker result dropped: cache generation is stale");
+                    }
+                } else if (!completed->model) {
+                    LOG_ERROR("Combined model worker result dropped: no model was produced");
+                } else if (!installCombinedModelCache(std::move(*completed))) {
+                    LOG_DEBUG("Combined model worker result dropped: cache generation is stale");
                 }
             }
-            if (!completed->model) {
-                LOG_ERROR("Combined model worker result dropped: no model was produced");
-                return;
-            }
-            if (!installCombinedModelCache(std::move(*completed))) {
-                LOG_DEBUG("Combined model worker result dropped: cache generation is stale");
-            }
         }
+        // The scope above destroys the completed build, releasing its input
+        // aliases. Only now may models parked by a mutation be destroyed.
+        combined_model_lifetime_->releaseRetiredAfterJoin();
     }
 
     void Scene::requestCombinedModelBuild(bool include_hidden_splats) const {
@@ -1180,7 +1304,7 @@ namespace lfs::core {
                 consolidated_node_slots_.push_back({.id = node->id,
                                                     .gaussian_count = gaussian_count});
                 consolidated_gaussians += gaussian_count;
-                node->model.reset();
+                (void)retireCombinedModelIfInFlight(std::move(node->model));
                 ++consolidated;
             }
         }
@@ -2210,8 +2334,7 @@ namespace lfs::core {
                                          ? static_cast<size_t>(node->model->size())
                                          : node->gaussian_count.load(std::memory_order_acquire);
             if (node->model) {
-                inputs.push_back({std::shared_ptr<const SplatData>(
-                                      node->model.get(), [](const SplatData*) {}),
+                inputs.push_back({borrowCombinedModel(node->model.get()),
                                   include_hidden_splats || isNodeEffectivelyVisible(node->id),
                                   selection_offset});
             }
@@ -3577,6 +3700,11 @@ namespace lfs::core {
         assert(!restore_staging_);
         assert(transaction_depth_ == 0);
 
+        // The restore swaps the entire node graph. Join the worker before the
+        // old graph moves into the returned Scene, so a later destruction of
+        // that graph cannot race reads from the target's captured inputs.
+        pollCombinedModelBuild();
+
         nodes_.swap(staged->nodes_);
         id_to_index_.swap(staged->id_to_index_);
         name_to_id_.swap(staged->name_to_id_);
@@ -3665,6 +3793,8 @@ namespace lfs::core {
                 has_payload = static_cast<bool>(
                     staged_node->model);
                 if (has_payload) {
+                    (void)retireCombinedModelIfInFlight(
+                        std::move(live->model));
                     live->model =
                         std::move(staged_node->model);
                     live->gaussian_count.store(

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -11,6 +11,8 @@
 #include "core/path_utils.hpp"
 #include "core/sh_value_quant.hpp"
 #include "core/splat_data_transform.hpp"
+#include "core/tensor/internal/cuda_event_pool.hpp"
+#include "core/tensor/internal/cuda_stream_context.hpp"
 
 #include <algorithm>
 #include <array>
@@ -41,6 +43,22 @@ namespace lfs::core {
     }
 
     namespace {
+        std::mutex combined_model_allocator_mutex;
+
+        [[nodiscard]] SplatTensorAllocator serialize_combined_model_allocator(
+            SplatTensorAllocator allocator) {
+            if (!allocator) {
+                return {};
+            }
+            return [allocator = std::move(allocator)](TensorShape shape,
+                                                      const size_t capacity,
+                                                      const DataType dtype,
+                                                      const std::string_view name) {
+                std::lock_guard<std::mutex> lock(combined_model_allocator_mutex);
+                return allocator(std::move(shape), capacity, dtype, name);
+            };
+        }
+
         std::string makeUniqueNodeName(const std::unordered_map<std::string, NodeId>& existing_names,
                                        const std::string& base_name) {
             std::string unique_name = base_name;
@@ -51,24 +69,6 @@ namespace lfs::core {
             return unique_name;
         }
 
-        [[nodiscard]] bool tensor_uses_vulkan_external_storage(const Tensor& tensor) {
-            if (!tensor.is_valid() || tensor.numel() == 0)
-                return true;
-            return tensor.is_external_storage() &&
-                   tensor.external_storage_kind() == "vulkan_external_buffer";
-        }
-
-        [[nodiscard]] bool splat_uses_vulkan_external_storage(const SplatData& model) {
-            return tensor_uses_vulkan_external_storage(model.means_raw()) &&
-                   tensor_uses_vulkan_external_storage(model.sh0_raw()) &&
-                   tensor_uses_vulkan_external_storage(model.scaling_raw()) &&
-                   tensor_uses_vulkan_external_storage(model.rotation_raw()) &&
-                   tensor_uses_vulkan_external_storage(model.opacity_raw()) &&
-                   tensor_uses_vulkan_external_storage(model.shN_raw()) &&
-                   (!model.shN_value_quantized() ||
-                    tensor_uses_vulkan_external_storage(model.shN_value_bounds()));
-        }
-
         void commit_combined_model_q16(SplatData& model, const SplatTensorAllocator& alloc) {
             model.set_tensor_allocator(alloc);
             if (!alloc || !sh_value_quant::enabled()) {
@@ -76,6 +76,55 @@ namespace lfs::core {
             }
             if (model.apply_shN_value_quant()) {
                 Tensor::trim_memory_pool();
+            }
+        }
+
+        void order_combined_build_outputs(Scene::CombinedModelBuild& build) {
+            build.worker_stream = getCurrentCUDAStream();
+            const auto order = [stream = build.worker_stream](const Tensor& tensor) {
+                if (tensor.is_valid() && tensor.device() == Device::CUDA) {
+                    tensor.sync_to_stream(stream);
+                }
+            };
+            if (build.model) {
+                order(build.model->means_raw());
+                order(build.model->sh0_raw());
+                order(build.model->shN_raw());
+                order(build.model->scaling_raw());
+                order(build.model->rotation_raw());
+                order(build.model->opacity_raw());
+                if (build.model->has_deleted_mask()) {
+                    order(build.model->deleted());
+                }
+            }
+            if (build.transform_indices) {
+                order(*build.transform_indices);
+            }
+            if (build.visible_selection_indices) {
+                order(*build.visible_selection_indices);
+            }
+
+            cudaEvent_t ready = CudaEventPool::instance().acquire();
+            if (ready && cudaEventRecord(ready, build.worker_stream) == cudaSuccess) {
+                build.ready_event = std::shared_ptr<void>(
+                    reinterpret_cast<void*>(ready),
+                    [](void* event) {
+                        CudaEventPool::instance().release(
+                            reinterpret_cast<cudaEvent_t>(event));
+                    });
+                return;
+            }
+            if (ready) {
+                (void)cudaGetLastError();
+                CudaEventPool::instance().release(ready);
+            }
+            // Event creation/recording is allowed to fail in headless or
+            // teardown-adjacent environments; preserve correctness with a
+            // one-off host fence before publishing the result.
+            const cudaError_t sync_status = cudaDeviceSynchronize();
+            if (sync_status != cudaSuccess) {
+                LOG_ERROR("Combined model worker stream fence failed: {} ({})",
+                          cudaGetErrorName(sync_status), cudaGetErrorString(sync_status));
             }
         }
     } // namespace
@@ -114,6 +163,16 @@ namespace lfs::core {
 
     Scene::Scene() {
         addSelectionGroup("Group 1", glm::vec3(0.0f));
+    }
+
+    Scene::~Scene() {
+        // The worker only captures source-model handles and publishes through
+        // the build mutex, but its completion/result still refer to members of
+        // this Scene. Join and drain it before member destruction begins.
+        if (combined_model_build_thread_ && combined_model_build_thread_->joinable()) {
+            combined_model_build_thread_->join();
+        }
+        pollCombinedModelBuild();
     }
 
     Scene::Scene(RestoreStageTag, Scene& target) noexcept
@@ -246,6 +305,7 @@ namespace lfs::core {
             consolidated_node_slots_.clear();
             ++consolidated_generation_;
             cached_combined_.reset();
+            cached_combined_includes_hidden_ = false;
             single_node_model_ = nullptr;
         }
 
@@ -447,6 +507,7 @@ namespace lfs::core {
         single_node_model_ = nullptr;
         if (!consolidated_) {
             cached_combined_.reset();
+            cached_combined_includes_hidden_ = false;
         }
 
         for (auto& [node_id, index] : id_to_index_) {
@@ -492,6 +553,7 @@ namespace lfs::core {
                 ++consolidated_generation_;
             }
             cached_combined_.reset();
+            cached_combined_includes_hidden_ = false;
             single_node_model_ = nullptr;
 
             const size_t gaussian_count = static_cast<size_t>(model->size());
@@ -601,6 +663,7 @@ namespace lfs::core {
         uuid_to_id_.clear();
 
         cached_combined_.reset();
+        cached_combined_includes_hidden_ = false;
         cached_transform_indices_.reset();
         cached_visible_selection_indices_.reset();
         invalidateVisibleSelectionMaskCache();
@@ -684,11 +747,405 @@ namespace lfs::core {
     }
 
     const lfs::core::SplatData* Scene::getCombinedModel() const {
-        rebuildCacheIfNeeded();
+        pollCombinedModelBuild();
+        if (!model_cache_valid_.load(std::memory_order_acquire)) {
+            requestCombinedModelBuildIfNeeded();
+            size_t visible_count = 0;
+            size_t visible_node_count = 0;
+            for (const auto& node : nodes_) {
+                if (node->type == NodeType::SPLAT && node->model &&
+                    isNodeEffectivelyVisible(node->id)) {
+                    visible_count += static_cast<size_t>(node->model->size());
+                    ++visible_node_count;
+                }
+            }
+            if (visible_node_count > 1 && visible_count > 1'000'000) {
+                // A large invalidated multi-node cache is rebuilt by the worker.
+                // Keep the previous renderable cache (or the previous single
+                // node alias) until its replacement lands; on the first-ever
+                // load both are null, so this intentionally returns null rather
+                // than rebuilding synchronously on the render thread.
+                return single_node_model_ ? single_node_model_ : cached_combined_.get();
+            }
+        }
+        rebuildModelCacheIfNeeded();
         return single_node_model_ ? single_node_model_ : cached_combined_.get();
     }
 
+    Scene::CombinedModelBuild Scene::captureCombinedModelBuild(
+        const bool include_hidden_splats) const {
+        CombinedModelBuild build;
+        build.generation = render_generation_.load(std::memory_order_acquire);
+        build.includes_hidden_splats = include_hidden_splats;
+
+        size_t selection_offset = 0;
+        for (const auto& node : nodes_) {
+            if (node->type != NodeType::SPLAT) {
+                continue;
+            }
+            const size_t node_size = node->model
+                                         ? static_cast<size_t>(node->model->size())
+                                         : node->gaussian_count.load(std::memory_order_acquire);
+            if (node->model) {
+                build.inputs.push_back({std::shared_ptr<const lfs::core::SplatData>(
+                                            node->model.get(), [](const lfs::core::SplatData*) {}),
+                                        isNodeEffectivelyVisible(node->id),
+                                        selection_offset});
+            }
+            selection_offset += node_size;
+        }
+        build.full_selection_count = selection_offset;
+        {
+            std::lock_guard<std::mutex> lock(combined_model_mutex_);
+            build.allocator = combined_model_allocator_;
+        }
+        return build;
+    }
+
+    Scene::CombinedModelBuild Scene::buildCombinedModelCache(
+        std::vector<CombinedModelBuildInput> inputs,
+        const size_t full_selection_count,
+        SplatTensorAllocator allocator,
+        const uint64_t generation,
+        const bool include_hidden_splats) {
+        CombinedModelBuild result;
+        result.full_selection_count = full_selection_count;
+        allocator = serialize_combined_model_allocator(std::move(allocator));
+        result.allocator = allocator;
+        result.generation = generation;
+        result.includes_hidden_splats = include_hidden_splats;
+
+        // This is deliberately a tensor-only concatenation. The source models
+        // are shared by the snapshot and remain owned by the caller's Scene;
+        // making a staging Scene here would clone every input before making the
+        // same concatenated tensors again.
+        struct ModelStats {
+            size_t total_gaussians = 0;
+            int max_sh_degree = 0;
+            int max_active_sh_degree = 0;
+            float total_scene_scale = 0.0f;
+        };
+
+        std::vector<const CombinedModelBuildInput*> selected_inputs;
+        selected_inputs.reserve(inputs.size());
+        for (const auto& input : inputs) {
+            if (input.model && (include_hidden_splats || input.visible)) {
+                selected_inputs.push_back(&input);
+            }
+        }
+        if (selected_inputs.empty()) {
+            result.inputs = std::move(inputs);
+            return result;
+        }
+
+        const cudaStream_t build_stream = getCurrentCUDAStream();
+        const auto order_input = [build_stream](const Tensor& tensor) {
+            if (tensor.is_valid() && tensor.device() == Device::CUDA) {
+                tensor.sync_to_stream(build_stream);
+            }
+        };
+
+        std::vector<size_t> cached_sizes;
+        cached_sizes.reserve(selected_inputs.size());
+        ModelStats stats{};
+        for (const auto* input : selected_inputs) {
+            const auto& model = *input->model;
+            order_input(model.means_raw());
+            order_input(model.sh0_raw());
+            order_input(model.shN_raw());
+            order_input(model.scaling_raw());
+            order_input(model.rotation_raw());
+            order_input(model.opacity_raw());
+
+            const size_t node_size = static_cast<size_t>(model.size());
+            cached_sizes.push_back(node_size);
+            stats.total_gaussians += node_size;
+            const auto& shN_tensor = model.shN_raw();
+            const auto model_layout_rest = model.max_sh_coeffs_rest();
+            if (shN_tensor.is_valid() && shN_tensor.numel() > 0 && model_layout_rest > 0) {
+                stats.max_sh_degree = std::max(stats.max_sh_degree, model.get_max_sh_degree());
+            }
+            stats.max_active_sh_degree = std::max(stats.max_active_sh_degree,
+                                                  model.get_active_sh_degree());
+            stats.total_scene_scale += model.get_scene_scale();
+        }
+
+        const Device device = selected_inputs[0]->model->means_raw().device();
+        constexpr int SH0_COEFFS = 1;
+        const auto dst_layout_rest = sh_rest_coefficients_for_degree(stats.max_sh_degree);
+        const size_t shN_swizzled_floats =
+            sh_swizzled_float_count(stats.total_gaussians, dst_layout_rest);
+        const size_t total = stats.total_gaussians;
+        const auto alloc_param = [&allocator, device](TensorShape shape,
+                                                      const size_t rows,
+                                                      const std::string_view name) -> Tensor {
+            return allocator ? allocator(std::move(shape), rows, DataType::Float32, name)
+                             : Tensor::empty(std::move(shape), device);
+        };
+
+        Tensor means = alloc_param(TensorShape({total, 3}), total, "SplatData.means");
+        Tensor sh0 = alloc_param(
+            TensorShape({total, static_cast<size_t>(SH0_COEFFS), 3}),
+            total,
+            "SplatData.sh0");
+        Tensor shN;
+        if (shN_swizzled_floats > 0) {
+            const bool q16_float_workspace =
+                static_cast<bool>(allocator) && sh_value_quant::enabled();
+            if (allocator && !q16_float_workspace) {
+                shN = allocator(TensorShape({shN_swizzled_floats}),
+                                shN_swizzled_floats,
+                                DataType::Float32,
+                                "SplatData.shN");
+                shN.zero_();
+            } else {
+                shN = Tensor::zeros_direct(TensorShape({shN_swizzled_floats}),
+                                           shN_swizzled_floats,
+                                           Device::CUDA);
+            }
+        } else {
+            shN = Tensor::zeros({0}, Device::CUDA);
+        }
+        Tensor opacity = alloc_param(TensorShape({total, 1}), total, "SplatData.opacity");
+        Tensor scaling = alloc_param(TensorShape({total, 3}), total, "SplatData.scaling");
+        Tensor rotation = alloc_param(TensorShape({total, 4}), total, "SplatData.rotation");
+
+        const bool has_any_deleted = std::any_of(
+            selected_inputs.begin(), selected_inputs.end(),
+            [](const CombinedModelBuildInput* input) {
+                return input->model->has_deleted_mask();
+            });
+        Tensor deleted = has_any_deleted
+                             ? Tensor::zeros({total}, device, DataType::Bool)
+                             : Tensor();
+        std::vector<int> transform_indices_data(total);
+
+        size_t offset = 0;
+        for (size_t i = 0; i < selected_inputs.size(); ++i) {
+            const auto& input = *selected_inputs[i];
+            const auto& model = *input.model;
+            const size_t size = cached_sizes[i];
+            std::fill(transform_indices_data.begin() + offset,
+                      transform_indices_data.begin() + offset + size,
+                      static_cast<int>(i));
+
+            means.slice(0, offset, offset + size) = model.means_raw();
+            scaling.slice(0, offset, offset + size) = model.scaling_raw();
+            rotation.slice(0, offset, offset + size) = model.rotation_raw();
+            sh0.slice(0, offset, offset + size) = model.sh0_raw();
+            opacity.slice(0, offset, offset + size) = model.opacity_raw();
+
+            if (stats.max_sh_degree > 0 && model.shN_raw().is_valid() &&
+                model.shN_raw().numel() > 0) {
+                const auto model_layout_rest =
+                    static_cast<std::uint32_t>(model.max_sh_coeffs_rest());
+                if (model_layout_rest > 0) {
+                    if (model.shN_raw().dtype() != DataType::Float32 ||
+                        model.shN_value_quantized() || model.shN_ieee_f16()) {
+                        auto float_piece = std::make_unique<SplatData>(
+                            model.get_max_sh_degree(),
+                            model.means_raw(),
+                            model.sh0_raw(),
+                            model.shN_canonical(),
+                            model.scaling_raw(),
+                            model.rotation_raw(),
+                            model.opacity_raw(),
+                            model.get_scene_scale(),
+                            SplatData::ShNLayout::Canonical);
+                        float_piece->set_active_sh_degree(model.get_active_sh_degree());
+                        shN_swizzled_copy_contiguous(
+                            float_piece->shN_raw().ptr<float>(),
+                            shN.ptr<float>(),
+                            size,
+                            offset,
+                            static_cast<std::uint32_t>(float_piece->max_sh_coeffs_rest()),
+                            dst_layout_rest,
+                            shN.stream());
+                    } else {
+                        shN_swizzled_copy_contiguous(model.shN_raw().ptr<float>(),
+                                                     shN.ptr<float>(),
+                                                     size,
+                                                     offset,
+                                                     model_layout_rest,
+                                                     dst_layout_rest,
+                                                     shN.stream());
+                    }
+                }
+            }
+
+            if (has_any_deleted && model.has_deleted_mask()) {
+                deleted.slice(0, offset, offset + size) = model.deleted();
+            }
+            offset += size;
+        }
+
+        result.transform_indices = std::make_shared<Tensor>(
+            Tensor::from_vector(transform_indices_data, {total}, Device::CPU).cuda());
+        if (total != full_selection_count) {
+            std::vector<int> visible_indices(total);
+            size_t visible_offset = 0;
+            for (const auto* input : selected_inputs) {
+                const size_t size = static_cast<size_t>(input->model->size());
+                for (size_t j = 0; j < size; ++j) {
+                    visible_indices[visible_offset + j] =
+                        static_cast<int>(input->selection_offset + j);
+                }
+                visible_offset += size;
+            }
+            result.visible_selection_indices = std::make_shared<Tensor>(
+                Tensor::from_vector(visible_indices, {total}, Device::CPU).cuda());
+        }
+
+        result.model = std::make_shared<SplatData>(
+            stats.max_sh_degree,
+            std::move(means),
+            std::move(sh0),
+            std::move(shN),
+            std::move(scaling),
+            std::move(rotation),
+            std::move(opacity),
+            stats.total_scene_scale / selected_inputs.size(),
+            SplatData::ShNLayout::Swizzled);
+        result.model->set_active_sh_degree(stats.max_active_sh_degree);
+        commit_combined_model_q16(*result.model, allocator);
+        if (has_any_deleted) {
+            result.model->deleted() = std::move(deleted);
+        }
+        result.inputs = std::move(inputs);
+        return result;
+    }
+
+    bool Scene::installCombinedModelCache(CombinedModelBuild build) const {
+        std::lock_guard<std::mutex> lock(combined_model_mutex_);
+        if (!build.model ||
+            build.generation != render_generation_.load(std::memory_order_acquire)) {
+            return false;
+        }
+        cached_combined_ = std::move(build.model);
+        cached_combined_includes_hidden_ = build.includes_hidden_splats;
+        cached_transform_indices_ = std::move(build.transform_indices);
+        cached_visible_selection_indices_ = std::move(build.visible_selection_indices);
+        single_node_model_ = nullptr;
+        model_cache_valid_.store(true, std::memory_order_release);
+        transform_cache_valid_.store(false, std::memory_order_release);
+        invalidateVisibleSelectionMaskCache();
+        return true;
+    }
+
+    bool Scene::installCombinedModelCache(
+        std::shared_ptr<lfs::core::SplatData> model,
+        const uint64_t generation) const {
+        CombinedModelBuild build;
+        build.model = std::move(model);
+        build.generation = generation;
+        return installCombinedModelCache(std::move(build));
+    }
+
+    void Scene::pollCombinedModelBuild() const {
+        if (!combined_model_build_thread_ || combined_model_build_running_.load(std::memory_order_acquire)) {
+            return;
+        }
+
+        std::optional<CombinedModelBuild> completed;
+        {
+            std::lock_guard<std::mutex> lock(combined_model_build_mutex_);
+            completed = std::move(completed_combined_model_build_);
+            completed_combined_model_build_.reset();
+        }
+        if (combined_model_build_thread_->joinable()) {
+            combined_model_build_thread_->join();
+        }
+        combined_model_build_thread_.reset();
+        if (completed) {
+            if (completed->ready_event) {
+                const auto status = cudaEventSynchronize(
+                    reinterpret_cast<cudaEvent_t>(completed->ready_event.get()));
+                if (status != cudaSuccess) {
+                    LOG_ERROR("Combined model worker result dropped: event wait failed: {} ({})",
+                              cudaGetErrorName(status), cudaGetErrorString(status));
+                    return;
+                }
+            }
+            if (!completed->model) {
+                LOG_ERROR("Combined model worker result dropped: no model was produced");
+                return;
+            }
+            if (!installCombinedModelCache(std::move(*completed))) {
+                LOG_DEBUG("Combined model worker result dropped: cache generation is stale");
+            }
+        }
+    }
+
+    void Scene::requestCombinedModelBuild(bool include_hidden_splats) const {
+        pollCombinedModelBuild();
+        requestCombinedModelBuildIfNeeded(include_hidden_splats);
+    }
+
+    bool Scene::combinedModelBuildPending() const {
+        if (combined_model_build_running_.load(std::memory_order_acquire)) {
+            return true;
+        }
+        std::lock_guard<std::mutex> lock(combined_model_build_mutex_);
+        return completed_combined_model_build_.has_value();
+    }
+
+    void Scene::requestCombinedModelBuildIfNeeded(const bool include_hidden_splats) const {
+        if (combined_model_build_running_.load(std::memory_order_acquire)) {
+            return;
+        }
+
+        auto snapshot = captureCombinedModelBuild(include_hidden_splats);
+        const size_t selected_nodes = std::count_if(
+            snapshot.inputs.begin(), snapshot.inputs.end(),
+            [include_hidden_splats](const CombinedModelBuildInput& input) {
+                return include_hidden_splats || input.visible;
+            });
+        size_t selected_gaussians = 0;
+        for (const auto& input : snapshot.inputs) {
+            if ((include_hidden_splats || input.visible) && input.model) {
+                selected_gaussians += static_cast<size_t>(input.model->size());
+            }
+        }
+        if (selected_nodes < 2) {
+            return;
+        }
+        if (!include_hidden_splats && selected_gaussians <= 1'000'000) {
+            return;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(combined_model_build_mutex_);
+            completed_combined_model_build_.reset();
+        }
+        combined_model_build_running_.store(true, std::memory_order_release);
+        combined_model_build_thread_.emplace(
+            [this, include_hidden_splats, snapshot = std::move(snapshot)]() mutable {
+                CombinedModelBuild built;
+                try {
+                    built = buildCombinedModelCache(
+                        std::move(snapshot.inputs),
+                        snapshot.full_selection_count,
+                        snapshot.allocator,
+                        snapshot.generation,
+                        include_hidden_splats);
+                    order_combined_build_outputs(built);
+                } catch (const std::exception& error) {
+                    LOG_ERROR("Combined model worker failed: {}", error.what());
+                    built = {};
+                } catch (...) {
+                    LOG_ERROR("Combined model worker failed with an unknown exception");
+                    built = {};
+                }
+                {
+                    std::lock_guard<std::mutex> lock(combined_model_build_mutex_);
+                    completed_combined_model_build_ = std::move(built);
+                }
+                combined_model_build_running_.store(false, std::memory_order_release);
+            });
+    }
+
     size_t Scene::consolidateNodeModels() {
+        pollCombinedModelBuild();
         const size_t loaded_splat_count = std::count_if(
             nodes_.begin(), nodes_.end(),
             [](const std::unique_ptr<SceneNode>& node) {
@@ -698,13 +1155,17 @@ namespace lfs::core {
             return 0;
         }
 
-        model_cache_valid_.store(false, std::memory_order_release);
-        cached_combined_.reset();
-        single_node_model_ = nullptr;
-        cached_transform_indices_.reset();
-        cached_visible_selection_indices_.reset();
-        invalidateVisibleSelectionMaskCache();
-        rebuildModelCacheIfNeeded(/*include_hidden_splats=*/true);
+        if (!(cached_combined_includes_hidden_ && cached_combined_ &&
+              model_cache_valid_.load(std::memory_order_acquire))) {
+            model_cache_valid_.store(false, std::memory_order_release);
+            cached_combined_.reset();
+            cached_combined_includes_hidden_ = false;
+            single_node_model_ = nullptr;
+            cached_transform_indices_.reset();
+            cached_visible_selection_indices_.reset();
+            invalidateVisibleSelectionMaskCache();
+            rebuildModelCacheIfNeeded(/*include_hidden_splats=*/true);
+        }
 
         if (single_node_model_ || !cached_combined_) {
             return 0;
@@ -1038,10 +1499,12 @@ namespace lfs::core {
 
         if (!model || slots.empty()) {
             cached_combined_.reset();
+            cached_combined_includes_hidden_ = false;
             consolidated_node_slots_.clear();
             consolidated_ = false;
         } else {
             cached_combined_ = model;
+            cached_combined_includes_hidden_ = true;
             consolidated_node_slots_ = std::move(slots);
             consolidated_ = true;
         }
@@ -1621,6 +2084,7 @@ namespace lfs::core {
         std::lock_guard<std::mutex> lock(combined_model_mutex_);
         combined_model_allocator_ = std::move(allocator);
         model_cache_valid_.store(false, std::memory_order_release);
+        render_generation_.fetch_add(1, std::memory_order_acq_rel);
     }
 
     void Scene::rebuildModelCacheIfNeeded() const {
@@ -1644,6 +2108,7 @@ namespace lfs::core {
             if (const auto* node = getNode(training_model_node_); node && node->model) {
                 single_node_model_ = node->model.get();
                 cached_combined_.reset();
+                cached_combined_includes_hidden_ = false;
                 model_cache_valid_.store(true, std::memory_order_release);
             }
             return;
@@ -1706,6 +2171,7 @@ namespace lfs::core {
 
         if (visible_nodes.empty()) {
             cached_combined_.reset();
+            cached_combined_includes_hidden_ = false;
             cached_transform_indices_.reset();
             cached_visible_selection_indices_.reset();
             invalidateVisibleSelectionMaskCache();
@@ -1714,31 +2180,18 @@ namespace lfs::core {
             return;
         }
 
-        if (visible_nodes.size() == 1 &&
-            (!combined_model_allocator_ ||
-             visible_nodes[0]->model->lod_tree ||
-             splat_uses_vulkan_external_storage(*visible_nodes[0]->model))) {
+        if (!include_hidden_splats && visible_nodes.size() == 1) {
             const auto* node = visible_nodes[0];
             single_node_model_ = node->model.get();
             cached_combined_.reset();
+            cached_combined_includes_hidden_ = false;
+            cached_transform_indices_.reset();
+            cached_visible_selection_indices_.reset();
+            single_node_selection_offset_ = visible_selection_offsets[0];
+            single_node_full_selection_count_ = full_selection_count;
 
             const size_t n = node->model->size();
-            cached_transform_indices_ = std::make_shared<lfs::core::Tensor>(
-                lfs::core::Tensor::zeros({n}, lfs::core::Device::CUDA, lfs::core::DataType::Int32));
-            if (n == full_selection_count && visible_selection_offsets[0] == 0) {
-                cached_visible_selection_indices_.reset();
-                invalidateVisibleSelectionMaskCache();
-            } else {
-                std::vector<int> visible_indices(n);
-                for (size_t i = 0; i < n; ++i) {
-                    visible_indices[i] = static_cast<int>(visible_selection_offsets[0] + i);
-                }
-                invalidateVisibleSelectionMaskCache();
-                cached_visible_selection_indices_ = std::make_shared<lfs::core::Tensor>(
-                    lfs::core::Tensor::from_vector(
-                        visible_indices, {n}, lfs::core::Device::CPU)
-                        .cuda());
-            }
+            invalidateVisibleSelectionMaskCache();
 
             LOG_DEBUG("Single node: {} ({} gaussians)", node->name, n);
             model_cache_valid_.store(true, std::memory_order_release);
@@ -1746,178 +2199,36 @@ namespace lfs::core {
             return;
         }
 
-        struct ModelStats {
-            size_t total_gaussians = 0;
-            int max_sh_degree = 0;
-            int max_active_sh_degree = 0;
-            float total_scene_scale = 0.0f;
-            bool has_shN = false;
-        };
-
-        std::vector<size_t> cached_sizes;
-        cached_sizes.reserve(visible_nodes.size());
-        ModelStats stats{};
-
-        for (const auto* node : visible_nodes) {
-            const auto* model = node->model.get();
-            const size_t node_size = model->size();
-            cached_sizes.push_back(node_size);
-            stats.total_gaussians += node_size;
-
-            const auto& shN_tensor = model->shN_raw();
-            const auto model_layout_rest = model->max_sh_coeffs_rest();
-            if (shN_tensor.is_valid() && shN_tensor.numel() > 0 && model_layout_rest > 0) {
-                stats.max_sh_degree = std::max(stats.max_sh_degree, model->get_max_sh_degree());
+        std::vector<CombinedModelBuildInput> inputs;
+        inputs.reserve(nodes_.size());
+        size_t selection_offset = 0;
+        for (const auto& node : nodes_) {
+            if (node->type != NodeType::SPLAT) {
+                continue;
             }
-            stats.max_active_sh_degree = std::max(stats.max_active_sh_degree, model->get_active_sh_degree());
-
-            stats.total_scene_scale += model->get_scene_scale();
-            stats.has_shN = stats.has_shN || (shN_tensor.numel() > 0 && model_layout_rest > 0);
+            const size_t node_size = node->model
+                                         ? static_cast<size_t>(node->model->size())
+                                         : node->gaussian_count.load(std::memory_order_acquire);
+            if (node->model) {
+                inputs.push_back({std::shared_ptr<const SplatData>(
+                                      node->model.get(), [](const SplatData*) {}),
+                                  include_hidden_splats || isNodeEffectivelyVisible(node->id),
+                                  selection_offset});
+            }
+            selection_offset += node_size;
         }
 
-        const lfs::core::Device device = visible_nodes[0]->model->means_raw().device();
-        constexpr int SH0_COEFFS = 1;
-        const auto dst_layout_rest = sh_rest_coefficients_for_degree(stats.max_sh_degree);
-        const size_t shN_swizzled_floats = lfs::core::sh_swizzled_float_count(stats.total_gaussians, dst_layout_rest);
-
-        using lfs::core::Tensor;
-        const size_t total = stats.total_gaussians;
-        const auto& alloc = combined_model_allocator_;
-        const auto alloc_param = [&](TensorShape shape, const size_t rows, const std::string_view name) -> Tensor {
-            return alloc ? alloc(std::move(shape), rows, lfs::core::DataType::Float32, name)
-                         : Tensor::empty(std::move(shape), device);
-        };
-        Tensor means = alloc_param(TensorShape({total, 3}), total, "SplatData.means");
-        Tensor sh0 = alloc_param(TensorShape({total, static_cast<size_t>(SH0_COEFFS), 3}), total, "SplatData.sh0");
-        // shN needs zeroing: copy_contiguous leaves the swizzled block-padding lanes untouched.
-        Tensor shN;
-        if (shN_swizzled_floats > 0) {
-            const bool q16_float_workspace =
-                static_cast<bool>(alloc) && sh_value_quant::enabled();
-            if (alloc && !q16_float_workspace) {
-                shN = alloc(TensorShape({shN_swizzled_floats}),
-                            shN_swizzled_floats,
-                            lfs::core::DataType::Float32,
-                            "SplatData.shN");
-                shN.zero_();
-            } else {
-                shN = Tensor::zeros_direct(TensorShape({shN_swizzled_floats}),
-                                           shN_swizzled_floats,
-                                           lfs::core::Device::CUDA);
-            }
-        } else {
-            shN = Tensor::zeros({0}, lfs::core::Device::CUDA);
-        }
-        Tensor opacity = alloc_param(TensorShape({total, 1}), total, "SplatData.opacity");
-        Tensor scaling = alloc_param(TensorShape({total, 3}), total, "SplatData.scaling");
-        Tensor rotation = alloc_param(TensorShape({total, 4}), total, "SplatData.rotation");
-
-        const bool has_any_deleted = std::any_of(visible_nodes.begin(), visible_nodes.end(),
-                                                 [](const SceneNode* node) { return node->model->has_deleted_mask(); });
-
-        Tensor deleted = has_any_deleted
-                             ? Tensor::zeros({static_cast<size_t>(stats.total_gaussians)}, device, lfs::core::DataType::Bool)
-                             : Tensor();
-
-        std::vector<int> transform_indices_data(stats.total_gaussians);
-
-        size_t offset = 0;
-        for (size_t i = 0; i < visible_nodes.size(); ++i) {
-            const auto* model = visible_nodes[i]->model.get();
-            const size_t size = cached_sizes[i];
-
-            std::fill(transform_indices_data.begin() + offset,
-                      transform_indices_data.begin() + offset + size,
-                      static_cast<int>(i));
-
-            means.slice(0, offset, offset + size) = model->means_raw();
-            scaling.slice(0, offset, offset + size) = model->scaling_raw();
-            rotation.slice(0, offset, offset + size) = model->rotation_raw();
-            sh0.slice(0, offset, offset + size) = model->sh0_raw();
-            opacity.slice(0, offset, offset + size) = model->opacity_raw();
-
-            if (stats.max_sh_degree > 0 && model->shN_raw().is_valid() && model->shN_raw().numel() > 0) {
-                const auto model_layout_rest = static_cast<std::uint32_t>(model->max_sh_coeffs_rest());
-                if (model_layout_rest > 0) {
-                    // Training cache merge must not ptr<float>() q16/ieee-f16 codes.
-                    if (model->shN_raw().dtype() != DataType::Float32 || model->shN_value_quantized() ||
-                        model->shN_ieee_f16()) {
-                        auto float_piece = std::make_unique<lfs::core::SplatData>(
-                            model->get_max_sh_degree(),
-                            model->means_raw(),
-                            model->sh0_raw(),
-                            model->shN_canonical(),
-                            model->scaling_raw(),
-                            model->rotation_raw(),
-                            model->opacity_raw(),
-                            model->get_scene_scale(),
-                            lfs::core::SplatData::ShNLayout::Canonical);
-                        float_piece->set_active_sh_degree(model->get_active_sh_degree());
-                        lfs::core::shN_swizzled_copy_contiguous(
-                            float_piece->shN_raw().ptr<float>(),
-                            shN.ptr<float>(),
-                            size,
-                            offset,
-                            static_cast<std::uint32_t>(float_piece->max_sh_coeffs_rest()),
-                            dst_layout_rest,
-                            shN.stream());
-                    } else {
-                        lfs::core::shN_swizzled_copy_contiguous(
-                            model->shN_raw().ptr<float>(),
-                            shN.ptr<float>(),
-                            size,
-                            offset,
-                            model_layout_rest,
-                            dst_layout_rest,
-                            shN.stream());
-                    }
-                }
-            }
-
-            if (has_any_deleted && model->has_deleted_mask()) {
-                deleted.slice(0, offset, offset + size) = model->deleted();
-            }
-
-            offset += size;
-        }
-
-        cached_transform_indices_ = std::make_shared<Tensor>(
-            Tensor::from_vector(transform_indices_data, {stats.total_gaussians}, lfs::core::Device::CPU).cuda());
-        if (stats.total_gaussians == full_selection_count) {
-            cached_visible_selection_indices_.reset();
-            invalidateVisibleSelectionMaskCache();
-        } else {
-            std::vector<int> visible_indices(stats.total_gaussians);
-            size_t visible_offset = 0;
-            for (size_t i = 0; i < visible_nodes.size(); ++i) {
-                const size_t global_offset = visible_selection_offsets[i];
-                const size_t size = cached_sizes[i];
-                for (size_t j = 0; j < size; ++j) {
-                    visible_indices[visible_offset + j] = static_cast<int>(global_offset + j);
-                }
-                visible_offset += size;
-            }
-            invalidateVisibleSelectionMaskCache();
-            cached_visible_selection_indices_ = std::make_shared<Tensor>(
-                Tensor::from_vector(visible_indices, {stats.total_gaussians}, lfs::core::Device::CPU).cuda());
-        }
-
-        cached_combined_ = std::make_shared<lfs::core::SplatData>(
-            stats.max_sh_degree,
-            std::move(means),
-            std::move(sh0),
-            std::move(shN),
-            std::move(scaling),
-            std::move(rotation),
-            std::move(opacity),
-            stats.total_scene_scale / visible_nodes.size(),
-            lfs::core::SplatData::ShNLayout::Swizzled);
-        cached_combined_->set_active_sh_degree(stats.max_active_sh_degree);
-        commit_combined_model_q16(*cached_combined_, combined_model_allocator_);
-
-        if (has_any_deleted) {
-            cached_combined_->deleted() = std::move(deleted);
-        }
+        // Rebuild the exact same tensor set as the worker. The single-node
+        // alias above remains the zero-copy fast path; only multi-node scenes
+        // reach this concatenation helper.
+        const auto built = buildCombinedModelCache(
+            std::move(inputs), full_selection_count, combined_model_allocator_,
+            render_generation_.load(std::memory_order_acquire), include_hidden_splats);
+        cached_combined_ = built.model;
+        cached_transform_indices_ = built.transform_indices;
+        cached_visible_selection_indices_ = built.visible_selection_indices;
+        cached_combined_includes_hidden_ = include_hidden_splats;
+        invalidateVisibleSelectionMaskCache();
 
         // Epoch fence: any CUDA copies from live training tensors must complete
         // before this function returns and drops live_model / combined locks.
@@ -1960,7 +2271,7 @@ namespace lfs::core {
     }
 
     void Scene::rebuildCacheIfNeeded() const {
-        rebuildModelCacheIfNeeded();
+        getCombinedModel();
         rebuildTransformCacheIfNeeded();
     }
 
@@ -1970,12 +2281,28 @@ namespace lfs::core {
     }
 
     std::shared_ptr<lfs::core::Tensor> Scene::getTransformIndices() const {
-        rebuildCacheIfNeeded();
+        getCombinedModel();
+        if (!cached_transform_indices_ && single_node_model_) {
+            const size_t n = static_cast<size_t>(single_node_model_->size());
+            cached_transform_indices_ = std::make_shared<lfs::core::Tensor>(
+                lfs::core::Tensor::zeros({n}, lfs::core::Device::CUDA, lfs::core::DataType::Int32));
+        }
+        rebuildTransformCacheIfNeeded();
         return cached_transform_indices_;
     }
 
     std::shared_ptr<lfs::core::Tensor> Scene::getVisibleSelectionIndices() const {
-        rebuildCacheIfNeeded();
+        getCombinedModel();
+        if (!cached_visible_selection_indices_ && single_node_model_ &&
+            single_node_full_selection_count_ != static_cast<size_t>(single_node_model_->size())) {
+            const size_t n = static_cast<size_t>(single_node_model_->size());
+            std::vector<int> visible_indices(n);
+            for (size_t i = 0; i < n; ++i) {
+                visible_indices[i] = static_cast<int>(single_node_selection_offset_ + i);
+            }
+            cached_visible_selection_indices_ = std::make_shared<lfs::core::Tensor>(
+                lfs::core::Tensor::from_vector(visible_indices, {n}, lfs::core::Device::CPU).cuda());
+        }
         return cached_visible_selection_indices_;
     }
 
@@ -1997,7 +2324,7 @@ namespace lfs::core {
         }
 
         const auto selection_generation = selection_generation_;
-        const auto visibility_generation = render_generation_;
+        const auto visibility_generation = render_generation_.load(std::memory_order_acquire);
         if (cached_visible_selection_mask_ &&
             cached_visible_selection_mask_source_ == selection.get() &&
             cached_visible_selection_mask_model_ == model &&
@@ -3391,6 +3718,7 @@ namespace lfs::core {
                 ++consolidated_generation_;
             }
             cached_combined_.reset();
+            cached_combined_includes_hidden_ = false;
             single_node_model_ = nullptr;
             invalidateCache();
         }

--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -944,6 +944,7 @@ namespace lfs::vis::gui {
             splat_load_state_.requests.clear();
             splat_load_state_.loaded_count = 0;
             splat_load_state_.failed_count = 0;
+            splat_load_state_.consolidation_pending = false;
             for (size_t index = 0; index < paths.size(); ++index) {
                 splat_load_state_.requests.push_back(SplatLoadRequest{
                     .path = std::move(paths[index]),
@@ -1077,12 +1078,6 @@ namespace lfs::vis::gui {
                          completion.stage_elapsed.count(),
                          attach_elapsed.count(),
                          completion.stage_elapsed.count() + attach_elapsed.count());
-                // Attachment invalidates the scene cache. Warm it before the
-                // next frame so getCombinedModel() never performs the cold
-                // six-tensor rebuild from inside the render callback.
-                jobs_.report(splat_load_state_.job, 0.95F,
-                             LOC(lichtfeld::Strings::Runtime::TASK_APPLYING));
-                static_cast<void>(scene_manager->getScene().getCombinedModel());
                 ++splat_load_state_.loaded_count;
             } catch (const std::exception& error) {
                 ++splat_load_state_.failed_count;
@@ -1116,10 +1111,23 @@ namespace lfs::vis::gui {
             return;
         }
 
-        if (scene_manager && splat_load_state_.loaded_count > 1) {
+        if (scene_manager && splat_load_state_.loaded_count > 1 &&
+            !splat_load_state_.consolidation_pending) {
             jobs_.report(splat_load_state_.job, 0.98F,
                          LOC(lichtfeld::Strings::Runtime::TASK_APPLYING));
+            scene_manager->getScene().requestCombinedModelBuild(true);
+            splat_load_state_.consolidation_pending = true;
+        }
+        if (scene_manager && splat_load_state_.consolidation_pending) {
+            // Polling getCombinedModel only swaps a completed worker cache;
+            // it never performs the large build on this thread.
+            static_cast<void>(scene_manager->getScene().getCombinedModel());
+            if (scene_manager->getScene().combinedModelBuildPending()) {
+                publishImportOverlayState();
+                return;
+            }
             scene_manager->consolidateNodeModels();
+            splat_load_state_.consolidation_pending = false;
         }
         const bool success = splat_load_state_.loaded_count > 0;
         {

--- a/src/visualizer/gui/async_task_manager.hpp
+++ b/src/visualizer/gui/async_task_manager.hpp
@@ -244,6 +244,7 @@ namespace lfs::vis {
                 std::vector<SplatLoadRequest> requests;
                 size_t loaded_count = 0;
                 size_t failed_count = 0;
+                bool consolidation_pending = false;
                 std::optional<std::jthread> thread;
             };
             SplatLoadState splat_load_state_;

--- a/tests/test_scene_consolidation.cpp
+++ b/tests/test_scene_consolidation.cpp
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "core/alloc_counter.hpp"
 #include "core/error.hpp"
 #include "core/scene.hpp"
 #include "core/splat_data.hpp"
@@ -15,11 +16,16 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
+#include <condition_variable>
 #include <cstddef>
 #include <filesystem>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -195,6 +201,167 @@ TEST_F(SceneConsolidationExtractTest, ExtractsEachNodeMatchingOriginals) {
     ASSERT_TRUE(hydrated) << lfs::format_for_developer(hydrated.error());
     ASSERT_NE(*hydrated, nullptr);
     EXPECT_EQ(static_cast<size_t>((*hydrated)->size()), built.full_n);
+}
+
+TEST_F(SceneConsolidationExtractTest, SingleVisibleNodeAliasesWithoutAllocatorUse) {
+    Scene scene;
+    const auto id = scene.addSplat("single", std::make_unique<SplatData>(bike_.clone()));
+    ASSERT_NE(id, lfs::core::NULL_NODE);
+
+    std::atomic<size_t> allocator_calls = 0;
+    scene.setCombinedModelAllocator(
+        [&allocator_calls](lfs::core::TensorShape shape,
+                           size_t,
+                           lfs::core::DataType dtype,
+                           std::string_view) {
+            ++allocator_calls;
+            return Tensor::empty(std::move(shape), Device::CUDA, dtype);
+        });
+
+    const auto* combined = scene.getCombinedModel();
+    ASSERT_NE(combined, nullptr);
+    const auto* node = scene.getNodeById(id);
+    ASSERT_NE(node, nullptr);
+    ASSERT_NE(node->model, nullptr);
+    EXPECT_EQ(combined, node->model.get());
+    EXPECT_EQ(combined->means_raw().data_ptr(), node->model->means_raw().data_ptr());
+    EXPECT_EQ(combined->sh0_raw().data_ptr(), node->model->sh0_raw().data_ptr());
+    EXPECT_EQ(combined->scaling_raw().data_ptr(), node->model->scaling_raw().data_ptr());
+    EXPECT_EQ(combined->rotation_raw().data_ptr(), node->model->rotation_raw().data_ptr());
+    EXPECT_EQ(combined->opacity_raw().data_ptr(), node->model->opacity_raw().data_ptr());
+    EXPECT_EQ(allocator_calls.load(), 0u);
+}
+
+TEST_F(SceneConsolidationExtractTest, WorkerBuildMatchesSynchronousCombinedModel) {
+    auto first = std::make_shared<SplatData>(bike_.clone());
+    auto second = std::make_shared<SplatData>(bike_.clone());
+    const size_t first_size = static_cast<size_t>(first->size());
+
+    std::vector<size_t> allocation_shape_rows;
+    std::vector<size_t> allocation_capacities;
+    std::vector<std::string> allocation_names;
+    const auto counting_allocator =
+        [&allocation_shape_rows, &allocation_capacities, &allocation_names](lfs::core::TensorShape shape,
+                                                                            const size_t capacity,
+                                                                            lfs::core::DataType dtype,
+                                                                            std::string_view name) {
+            allocation_shape_rows.push_back(shape[0]);
+            allocation_capacities.push_back(capacity);
+            allocation_names.emplace_back(name);
+            return Tensor::empty(std::move(shape), Device::CUDA, dtype);
+        };
+
+    Tensor::trim_memory_pool();
+    const auto allocation_snapshot = lfs::core::alloc_counter::snapshot();
+    std::optional<Scene::CombinedModelBuild> worker_build;
+    std::jthread worker([&] {
+        worker_build = Scene::buildCombinedModelCache(
+            {{first, true, 0}, {second, true, first_size}},
+            first_size + static_cast<size_t>(second->size()),
+            counting_allocator);
+    });
+    worker.join();
+    // The direct concatenator may allocate its six result fields, q16 companion
+    // storage, indices, and transient SH conversion workspaces. It must not add
+    // two full input-model clone sets to that budget.
+    EXPECT_LE(lfs::core::alloc_counter::delta_since(allocation_snapshot), 16u);
+    ASSERT_TRUE(worker_build.has_value());
+    ASSERT_NE(worker_build->model, nullptr);
+    ASSERT_GE(allocation_names.size(), 5u);
+    const size_t total_size = first_size + static_cast<size_t>(second->size());
+    EXPECT_TRUE(std::all_of(allocation_names.begin(), allocation_names.end(),
+                            [](const std::string& name) {
+                                return name == "SplatData.means" ||
+                                       name == "SplatData.sh0" ||
+                                       name == "SplatData.shN" ||
+                                       name == "SplatData.shN_value_bounds" ||
+                                       name == "SplatData.opacity" ||
+                                       name == "SplatData.scaling" ||
+                                       name == "SplatData.rotation";
+                            }));
+    for (size_t i = 0; i < allocation_names.size(); ++i) {
+        if (allocation_names[i] == "SplatData.means" ||
+            allocation_names[i] == "SplatData.sh0" ||
+            allocation_names[i] == "SplatData.opacity" ||
+            allocation_names[i] == "SplatData.scaling" ||
+            allocation_names[i] == "SplatData.rotation") {
+            EXPECT_EQ(allocation_capacities[i], total_size);
+        }
+    }
+    EXPECT_TRUE(std::any_of(allocation_shape_rows.begin(), allocation_shape_rows.end(),
+                            [total_size](const size_t rows) { return rows == total_size; }));
+
+    Scene synchronous;
+    ASSERT_NE(synchronous.addSplat("first", std::make_unique<SplatData>(first->clone())),
+              lfs::core::NULL_NODE);
+    ASSERT_NE(synchronous.addSplat("second", std::make_unique<SplatData>(second->clone())),
+              lfs::core::NULL_NODE);
+    const auto* expected = synchronous.getCombinedModel();
+    ASSERT_NE(expected, nullptr);
+
+    EXPECT_EQ(worker_build->model->means_raw().to_vector(), expected->means_raw().to_vector());
+    EXPECT_EQ(worker_build->model->sh0_raw().to_vector(), expected->sh0_raw().to_vector());
+    EXPECT_EQ(worker_build->model->scaling_raw().to_vector(), expected->scaling_raw().to_vector());
+    EXPECT_EQ(worker_build->model->rotation_raw().to_vector(), expected->rotation_raw().to_vector());
+    EXPECT_EQ(worker_build->model->opacity_raw().to_vector(), expected->opacity_raw().to_vector());
+    EXPECT_EQ(worker_build->model->shN_raw().to_vector(), expected->shN_raw().to_vector());
+}
+
+TEST_F(SceneConsolidationExtractTest, SceneDestructionJoinsCombinedModelWorker) {
+    std::mutex gate_mutex;
+    std::condition_variable gate_changed;
+    bool allocator_entered = false;
+    bool release_allocator = false;
+
+    std::thread releaser([&] {
+        std::unique_lock lock(gate_mutex);
+        gate_changed.wait(lock, [&] { return allocator_entered; });
+        release_allocator = true;
+        gate_changed.notify_all();
+    });
+
+    {
+        Scene scene;
+        EXPECT_NE(scene.addSplat("first", std::make_unique<SplatData>(bike_.clone())),
+                  lfs::core::NULL_NODE);
+        EXPECT_NE(scene.addSplat("second", std::make_unique<SplatData>(bike_.clone())),
+                  lfs::core::NULL_NODE);
+        scene.setCombinedModelAllocator(
+            [&](lfs::core::TensorShape shape,
+                size_t,
+                lfs::core::DataType dtype,
+                std::string_view) {
+                std::unique_lock lock(gate_mutex);
+                allocator_entered = true;
+                gate_changed.notify_all();
+                gate_changed.wait(lock, [&] { return release_allocator; });
+                return Tensor::empty(std::move(shape), Device::CUDA, dtype);
+            });
+        scene.requestCombinedModelBuild(true);
+    }
+    releaser.join();
+}
+
+TEST_F(SceneConsolidationExtractTest, StaleWorkerGenerationCannotReplaceNewestCache) {
+    Scene scene;
+    const auto first_id = scene.addSplat("first", std::make_unique<SplatData>(bike_.clone()));
+    const auto second_id = scene.addSplat("second", std::make_unique<SplatData>(bike_.clone()));
+    ASSERT_NE(first_id, lfs::core::NULL_NODE);
+    ASSERT_NE(second_id, lfs::core::NULL_NODE);
+
+    auto old_snapshot = scene.captureCombinedModelBuild();
+    auto old_build = Scene::buildCombinedModelCache(
+        old_snapshot.inputs, old_snapshot.full_selection_count,
+        old_snapshot.allocator, old_snapshot.generation);
+    scene.invalidateCache();
+    EXPECT_FALSE(scene.installCombinedModelCache(std::move(old_build)));
+
+    auto newest_snapshot = scene.captureCombinedModelBuild();
+    auto newest_build = Scene::buildCombinedModelCache(
+        std::move(newest_snapshot.inputs), newest_snapshot.full_selection_count,
+        newest_snapshot.allocator, newest_snapshot.generation);
+    EXPECT_TRUE(scene.installCombinedModelCache(std::move(newest_build)));
+    EXPECT_NE(scene.getCombinedModel(), nullptr);
 }
 
 TEST_F(SceneConsolidationExtractTest, OffsetWalksNullSlotAfterMiddleRemove) {

--- a/tests/test_scene_consolidation.cpp
+++ b/tests/test_scene_consolidation.cpp
@@ -342,6 +342,113 @@ TEST_F(SceneConsolidationExtractTest, SceneDestructionJoinsCombinedModelWorker) 
     releaser.join();
 }
 
+TEST_F(SceneConsolidationExtractTest, RemovingNodeRetiresModelUntilWorkerPoll) {
+    Scene scene;
+    const auto removed_id = scene.addSplat("removed", std::make_unique<SplatData>(bike_.clone()));
+    const auto remaining_id = scene.addSplat("remaining", std::make_unique<SplatData>(bike_.clone()));
+    ASSERT_NE(removed_id, lfs::core::NULL_NODE);
+    ASSERT_NE(remaining_id, lfs::core::NULL_NODE);
+
+    std::mutex gate_mutex;
+    std::condition_variable gate_changed;
+    bool allocator_entered = false;
+    bool release_allocator = false;
+    scene.setCombinedModelAllocator(
+        [&](lfs::core::TensorShape shape,
+            size_t,
+            lfs::core::DataType dtype,
+            std::string_view) {
+            std::unique_lock lock(gate_mutex);
+            allocator_entered = true;
+            gate_changed.notify_all();
+            gate_changed.wait(lock, [&] { return release_allocator; });
+            return Tensor::empty(std::move(shape), Device::CUDA, dtype);
+        });
+
+    scene.requestCombinedModelBuild(true);
+    {
+        std::unique_lock lock(gate_mutex);
+        gate_changed.wait(lock, [&] { return allocator_entered; });
+    }
+
+    const auto* removed_node = scene.getNodeById(removed_id);
+    ASSERT_NE(removed_node, nullptr);
+    ASSERT_NE(removed_node->model, nullptr);
+    const auto* retired_model = removed_node->model.get();
+    const size_t retired_size = retired_model->size();
+    scene.removeNodeById(removed_id);
+    EXPECT_EQ(scene.getNodeById(removed_id), nullptr);
+    // The pointer is no longer in a SceneNode, but the in-flight registry still
+    // owns it while the held worker can read it.
+    EXPECT_EQ(retired_model->size(), retired_size);
+
+    {
+        std::lock_guard lock(gate_mutex);
+        release_allocator = true;
+    }
+    gate_changed.notify_all();
+
+    const auto* remaining = scene.getNodeById(remaining_id);
+    ASSERT_NE(remaining, nullptr);
+    ASSERT_NE(remaining->model, nullptr);
+    EXPECT_EQ(scene.getCombinedModel(), remaining->model.get());
+}
+
+TEST_F(SceneConsolidationExtractTest, ReplacingNodeModelRetiresPreviousUntilWorkerPoll) {
+    Scene scene;
+    const auto first_id = scene.addSplat("first", std::make_unique<SplatData>(bike_.clone()));
+    const auto second_id = scene.addSplat("second", std::make_unique<SplatData>(bike_.clone()));
+    ASSERT_NE(first_id, lfs::core::NULL_NODE);
+    ASSERT_NE(second_id, lfs::core::NULL_NODE);
+
+    std::mutex gate_mutex;
+    std::condition_variable gate_changed;
+    bool allocator_entered = false;
+    bool release_allocator = false;
+    scene.setCombinedModelAllocator(
+        [&](lfs::core::TensorShape shape,
+            size_t,
+            lfs::core::DataType dtype,
+            std::string_view) {
+            std::unique_lock lock(gate_mutex);
+            allocator_entered = true;
+            gate_changed.notify_all();
+            gate_changed.wait(lock, [&] { return release_allocator; });
+            return Tensor::empty(std::move(shape), Device::CUDA, dtype);
+        });
+
+    scene.requestCombinedModelBuild(true);
+    {
+        std::unique_lock lock(gate_mutex);
+        gate_changed.wait(lock, [&] { return allocator_entered; });
+    }
+
+    const auto* first_node = scene.getNodeById(first_id);
+    ASSERT_NE(first_node, nullptr);
+    ASSERT_NE(first_node->model, nullptr);
+    const auto* previous_model = first_node->model.get();
+    const size_t previous_size = previous_model->size();
+    scene.replaceNodeModel("first", std::make_unique<SplatData>(bike_.clone()));
+    const auto* replaced = scene.getNodeById(first_id);
+    ASSERT_NE(replaced, nullptr);
+    ASSERT_NE(replaced->model, nullptr);
+    EXPECT_NE(replaced->model.get(), previous_model);
+    EXPECT_EQ(previous_model->size(), previous_size);
+
+    {
+        std::lock_guard lock(gate_mutex);
+        release_allocator = true;
+    }
+    gate_changed.notify_all();
+
+    // Leave one node so the post-poll cache rebuild is synchronous and avoids
+    // starting another worker while checking that the stale result was
+    // rejected.
+    scene.removeNodeById(second_id);
+    EXPECT_EQ(scene.getCombinedModel(), replaced->model.get());
+    EXPECT_FALSE(scene.combinedModelBuildPending());
+}
+
 TEST_F(SceneConsolidationExtractTest, StaleWorkerGenerationCannotReplaceNewestCache) {
     Scene scene;
     const auto first_id = scene.addSplat("first", std::make_unique<SplatData>(bike_.clone()));


### PR DESCRIPTION
Adding a second or third large splat file froze the window while the combined model was rebuilt inside the import poll on the main thread.

- Scenes above one million visible gaussians build the concatenated model on a worker while the previous cache keeps rendering; the result is published through a CUDA event and installed only if the scene generation still matches.
- A single visible node aliases its model instead of copying six tensors.
- Batch loading requests the worker build before consolidation and waits for it without blocking the poll.
- The scene joins the worker before its members are torn down.

Measured with three 3.3M-splat files added in sequence (PLY, SOG, SPZ): the import-poll block on the main thread went from 1.2 s / 2.0 s to under 30 ms. The two-node viewport render is pixel-identical to master. Tests: full suite (only the known missing-fixture failures), new coverage for aliasing, worker/synchronous byte equality, stale-generation rejection, allocation counts, and destruction with a worker in flight.