### PR TITLE
Add the overview video to the docs Getting Started page

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,3 +3,23 @@ sidebar_position: 1
 ---
 
 # Getting Started
+
+New here? Start with the overview video. It walks through what LichtFeld Studio can do today, from loading a dataset and training to viewing, editing and exporting splats.
+
+<iframe
+  width="100%"
+  height="480"
+  src="https://www.youtube-nocookie.com/embed/i-04z4_eqiU"
+  title="Everything LichtFeld Studio can do today"
+  frameBorder="0"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+[Watch on YouTube](https://youtu.be/i-04z4_eqiU) if the player does not load here.
+
+Then:
+
+- [Install LichtFeld Studio](installation/index.md), as a Windows build or from source.
+- Read the [FAQ](faq.md) for the questions that come up most often.
+- Join the [Discord](https://discord.gg/TbxJST2BbC) if you get stuck.


### PR DESCRIPTION
The Getting Started page of the docs site was empty.

It now opens with the overview video, the same one the README shows, and points to Installation, the FAQ and Discord as the next steps.

Checked: `pnpm build` compiles the page and resolves its links. The docs build as a whole still stops on four broken links in the development and installation pages that predate this change and are not touched here.