### PR TITLE
Getting Started opens with the overview video

### DIFF
--- a/src/visualizer/gui/resources/locales/de.json
+++ b/src/visualizer/gui/resources/locales/de.json
@@ -74,12 +74,12 @@
     "title": "Erste Schritte",
     "description": "Erfahren Sie, wie Sie Datensätze vorbereiten und mit LichtFeld Studio beginnen:",
     "wiki_section": "WIKI & FAQ",
+    "video_overview": "Alles, was LichtFeld Studio heute kann",
     "video_automotive": "3dgs for automotive marketing",
     "video_intro": "Training mit 360° Equirectangular-Bildern",
     "video_latest": "LichtFeld v0.3.0 Funktionsübersicht",
     "video_reality_scan": "Reality Scan Datensatz",
     "video_colmap": "COLMAP Tutorial",
-    "video_lichtfeld": "LichtFeld Tutorial",
     "video_masks": "Masken Tutorial"
   },
   "about": {

--- a/src/visualizer/gui/resources/locales/en.json
+++ b/src/visualizer/gui/resources/locales/en.json
@@ -74,12 +74,12 @@
     "title": "Getting Started",
     "description": "Learn how to prepare datasets and get started with LichtFeld Studio:",
     "wiki_section": "WIKI & FAQ",
+    "video_overview": "Everything LichtFeld Studio can do today",
     "video_automotive": "3dgs for automotive marketing",
     "video_intro": "Training on 360 Equirectangular Images",
     "video_latest": "LichtFeld v0.3.0 Feature Overview",
     "video_reality_scan": "Reality Scan Dataset",
     "video_colmap": "COLMAP Tutorial",
-    "video_lichtfeld": "LichtFeld Tutorial",
     "video_masks": "Masks Tutorial"
   },
   "about": {

--- a/src/visualizer/gui/resources/locales/es.json
+++ b/src/visualizer/gui/resources/locales/es.json
@@ -74,12 +74,12 @@
     "title": "Primeros Pasos",
     "description": "Aprenda a preparar datasets y comenzar con LichtFeld Studio:",
     "wiki_section": "WIKI & PREGUNTAS FRECUENTES",
+    "video_overview": "Todo lo que LichtFeld Studio puede hacer hoy",
     "video_automotive": "3dgs for automotive marketing",
     "video_intro": "Entrenamiento con Imágenes Equirectangulares 360",
     "video_latest": "LichtFeld v0.3.0 Resumen de Funciones",
     "video_reality_scan": "Dataset Reality Scan",
     "video_colmap": "Tutorial COLMAP",
-    "video_lichtfeld": "Tutorial LichtFeld",
     "video_masks": "Tutorial de Máscaras"
   },
   "about": {

--- a/src/visualizer/gui/resources/locales/fr.json
+++ b/src/visualizer/gui/resources/locales/fr.json
@@ -74,12 +74,12 @@
     "title": "Démarrage",
     "description": "Apprenez à préparer les datasets et à démarrer avec LichtFeld Studio :",
     "wiki_section": "WIKI & FAQ",
+    "video_overview": "Tout ce que LichtFeld Studio peut faire aujourd'hui",
     "video_automotive": "3dgs for automotive marketing",
     "video_intro": "Entraînement sur Images Équirectangulaires 360",
     "video_latest": "LichtFeld v0.3.0 Aperçu des Fonctionnalités",
     "video_reality_scan": "Dataset Reality Scan",
     "video_colmap": "Tutoriel COLMAP",
-    "video_lichtfeld": "Tutoriel LichtFeld",
     "video_masks": "Tutoriel Masques"
   },
   "about": {

--- a/src/visualizer/gui/resources/locales/it.json
+++ b/src/visualizer/gui/resources/locales/it.json
@@ -74,12 +74,12 @@
     "title": "Inizia",
     "description": "Impara a preparare i dataset e iniziare con LichtFeld Studio:",
     "wiki_section": "WIKI & FAQ",
+    "video_overview": "Tutto ciò che LichtFeld Studio può fare oggi",
     "video_automotive": "3dgs for automotive marketing",
     "video_intro": "Training su Immagini Equirettangolari 360",
     "video_latest": "LichtFeld v0.3.0 Panoramica Funzionalità",
     "video_reality_scan": "Dataset Reality Scan",
     "video_colmap": "Tutorial COLMAP",
-    "video_lichtfeld": "Tutorial LichtFeld",
     "video_masks": "Tutorial Maschere"
   },
   "about": {

--- a/src/visualizer/gui/resources/locales/ja.json
+++ b/src/visualizer/gui/resources/locales/ja.json
@@ -74,12 +74,12 @@
     "title": "はじめに",
     "description": "データセットの準備方法とLichtFeld Studioの使い方を学びましょう:",
     "wiki_section": "Wiki & よくある質問",
+    "video_overview": "LichtFeld Studioで現在できることのすべて",
     "video_automotive": "自動車マーケティング向け 3DGS",
     "video_intro": "360°正距円筒図法画像でのトレーニング",
     "video_latest": "LichtFeld v0.3.0 機能概要",
     "video_reality_scan": "Reality Scanデータセット",
     "video_colmap": "COLMAPチュートリアル",
-    "video_lichtfeld": "LichtFeldチュートリアル",
     "video_masks": "マスクチュートリアル"
   },
   "about": {

--- a/src/visualizer/gui/resources/locales/ko.json
+++ b/src/visualizer/gui/resources/locales/ko.json
@@ -74,12 +74,12 @@
     "title": "시작하기",
     "description": "데이터셋 준비 방법과 LichtFeld Studio 사용법을 배워보세요:",
     "wiki_section": "위키 & 자주 묻는 질문",
+    "video_overview": "오늘날 LichtFeld Studio로 할 수 있는 모든 것",
     "video_automotive": "자동차 마케팅용 3DGS",
     "video_intro": "360 정방형 이미지 트레이닝",
     "video_latest": "LichtFeld v0.3.0 기능 개요",
     "video_reality_scan": "Reality Scan 데이터셋",
     "video_colmap": "COLMAP 튜토리얼",
-    "video_lichtfeld": "LichtFeld 튜토리얼",
     "video_masks": "마스크 튜토리얼"
   },
   "about": {

--- a/src/visualizer/gui/resources/locales/nl.json
+++ b/src/visualizer/gui/resources/locales/nl.json
@@ -74,12 +74,12 @@
     "title": "Aan de Slag",
     "description": "Leer hoe je datasets voorbereidt en aan de slag gaat met LichtFeld Studio:",
     "wiki_section": "WIKI & FAQ",
+    "video_overview": "Alles wat LichtFeld Studio vandaag kan doen",
     "video_automotive": "3dgs for automotive marketing",
     "video_intro": "Training op 360 Equirectangulaire Afbeeldingen",
     "video_latest": "LichtFeld v0.3.0 Functie Overzicht",
     "video_reality_scan": "Reality Scan Dataset",
     "video_colmap": "COLMAP Tutorial",
-    "video_lichtfeld": "LichtFeld Tutorial",
     "video_masks": "Maskers Tutorial"
   },
   "about": {

--- a/src/visualizer/gui/resources/locales/pl.json
+++ b/src/visualizer/gui/resources/locales/pl.json
@@ -74,12 +74,12 @@
     "title": "Wprowadzenie",
     "description": "Dowiedz się, jak przygotować zbiory danych i rozpocząć pracę z LichtFeld Studio:",
     "wiki_section": "WIKI & FAQ",
+    "video_overview": "Wszystko, co LichtFeld Studio potrafi dziś",
     "video_automotive": "3DGS dla marketingu motoryzacyjnego",
     "video_intro": "Trening na Obrazach Equirectangular 360",
     "video_latest": "LichtFeld v0.3.0 Przegląd Funkcji",
     "video_reality_scan": "Zbiór Danych Reality Scan",
     "video_colmap": "Samouczek COLMAP",
-    "video_lichtfeld": "Samouczek LichtFeld",
     "video_masks": "Samouczek Masek"
   },
   "about": {

--- a/src/visualizer/gui/resources/locales/zh.json
+++ b/src/visualizer/gui/resources/locales/zh.json
@@ -74,12 +74,12 @@
     "title": "入门指南",
     "description": "学习如何准备数据集并开始使用LichtFeld Studio：",
     "wiki_section": "维基 & 常见问题",
+    "video_overview": "LichtFeld Studio 当前的全部功能",
     "video_automotive": "面向汽车营销的 3DGS",
     "video_intro": "360度等距柱状投影图像训练",
     "video_latest": "LichtFeld v0.3.0 功能概览",
     "video_reality_scan": "Reality Scan数据集",
     "video_colmap": "COLMAP教程",
-    "video_lichtfeld": "LichtFeld教程",
     "video_masks": "蒙版教程"
   },
   "about": {

--- a/src/visualizer/gui/rmlui/resources/getting_started.rml
+++ b/src/visualizer/gui/rmlui/resources/getting_started.rml
@@ -11,6 +11,14 @@
   <p class="description">@tr:getting_started.description</p>
 
   <div class="video-grid">
+    <div class="video-card" id="card-overview"
+         data-url="https://www.youtube.com/watch?v=i-04z4_eqiU"
+         data-event-click="open_url">
+      <div class="card-body">
+        <span class="play-icon">&#x25B6;</span>
+      </div>
+      <span class="card-title">@tr:getting_started.video_overview</span>
+    </div>
     <div class="video-card" id="card-automotive"
          data-url="https://www.youtube.com/watch?v=FqYTKeI5K6I"
          data-event-click="open_url">
@@ -58,14 +66,6 @@
         <span class="play-icon">&#x25B6;</span>
       </div>
       <span class="card-title">@tr:getting_started.video_colmap</span>
-    </div>
-    <div class="video-card" id="card-lichtfeld"
-         data-url="https://www.youtube.com/watch?v=aX8MTlr9Ypc"
-         data-event-click="open_url">
-      <div class="card-body">
-        <span class="play-icon">&#x25B6;</span>
-      </div>
-      <span class="card-title">@tr:getting_started.video_lichtfeld</span>
     </div>
   </div>
 


### PR DESCRIPTION
The Getting Started panel in the Help menu now leads with the new overview video, "Everything LichtFeld Studio can do today", and drops the Pixel Reconstruct tutorial, which was recorded on an old version.

All ten locales carry the new label. The panel code needed no change: it picks up the cards and their thumbnails from the markup.

Checked: localization contract and RML image-source tests pass, all locale files parse.