### PR TITLE
Panels update on events, not on a timer

### DIFF
--- a/src/python/lfs_plugins/marketplace.py
+++ b/src/python/lfs_plugins/marketplace.py
@@ -34,7 +34,9 @@ except Exception:
     pass
 
 GITHUB_TIMEOUT_SEC = 10
+CATALOG_CACHE_TTL_SEC = 300
 REFRESH_RETRY_COOLDOWN_SEC = 30
+REFRESH_RETRY_MAX_COOLDOWN_SEC = 300
 GITHUB_API_URL = "https://api.github.com/repos"
 
 CURATED_PLUGIN_URLS: Tuple[str, ...] = (
@@ -65,6 +67,21 @@ class MarketplacePluginEntry:
     error: str = ""
 
 
+@dataclass(frozen=True)
+class _CatalogCache:
+    entries: Tuple[MarketplacePluginEntry, ...]
+    registry_loaded: bool
+    github_enriched: bool
+    stored_at: float
+    next_retry_at: float = 0.0
+    failure_count: int = 0
+
+
+_catalog_cache_lock = threading.Lock()
+_catalog_cache: Optional[_CatalogCache] = None
+_catalog_refresh_inflight = False
+
+
 class PluginMarketplaceCatalog:
     """Dual-source catalog: registry entries merged with curated URL list."""
 
@@ -74,8 +91,8 @@ class PluginMarketplaceCatalog:
         self._loading = False
         self._registry_loaded = False
         self._github_enriched = False
-        self._last_attempt: float = 0.0
         self._on_change: Optional[Callable[[], None]] = None
+        self._restore_cached_catalog(time.monotonic())
 
     def set_on_change(self, callback: Optional[Callable[[], None]]) -> None:
         with self._lock:
@@ -91,44 +108,97 @@ class PluginMarketplaceCatalog:
         except Exception:
             _log.debug("Plugin marketplace change callback failed", exc_info=True)
 
+    def _restore_cached_catalog(self, now: float) -> None:
+        with _catalog_cache_lock:
+            cache = _catalog_cache
+            if cache is None:
+                return
+            if cache.registry_loaded:
+                usable = now - cache.stored_at < CATALOG_CACHE_TTL_SEC
+            else:
+                usable = now < cache.next_retry_at
+            if not usable:
+                return
+
+        with self._lock:
+            self._entries = list(cache.entries)
+            self._registry_loaded = cache.registry_loaded
+            self._github_enriched = cache.github_enriched
+
+    @staticmethod
+    def _cache_can_serve(
+        cache: Optional[_CatalogCache],
+        now: float,
+        require_github_enrichment: bool,
+    ) -> bool:
+        if cache is None:
+            return False
+        if now < cache.next_retry_at:
+            return True
+        if not cache.registry_loaded or now - cache.stored_at >= CATALOG_CACHE_TTL_SEC:
+            return False
+        return not require_github_enrichment or cache.github_enriched
+
     def refresh_async(self, force: bool = False, require_github_enrichment: bool = False) -> None:
         """Fetch registry entries, optionally enriching curated entries with GitHub metadata."""
+        global _catalog_refresh_inflight
+
+        now = time.monotonic()
+        with _catalog_cache_lock:
+            cache = _catalog_cache
+            cache_can_serve = self._cache_can_serve(
+                cache, now, require_github_enrichment
+            )
+            if _catalog_refresh_inflight:
+                return
         with self._lock:
             if self._loading:
                 return
-            needs_github_upgrade = require_github_enrichment and not self._github_enriched
-            if self._registry_loaded and not needs_github_upgrade and not force:
+            needs_github_upgrade = (
+                require_github_enrichment
+                and not self._github_enriched
+                and not (cache and cache.github_enriched)
+            )
+            if not force and cache_can_serve and not needs_github_upgrade:
                 return
-            now = time.monotonic()
-            if (
-                not force
-                and not needs_github_upgrade
-                and self._last_attempt > 0
-                and (now - self._last_attempt) < REFRESH_RETRY_COOLDOWN_SEC
-            ):
+            if not force and cache is not None and now < cache.next_retry_at:
                 return
             self._loading = True
-            self._last_attempt = now
+        with _catalog_cache_lock:
+            if _catalog_refresh_inflight:
+                with self._lock:
+                    self._loading = False
+                return
+            _catalog_refresh_inflight = True
         self._notify_change()
 
         def worker():
-            from .manager import PluginManager
+            global _catalog_refresh_inflight, _catalog_cache
 
-            mgr = PluginManager.instance()
             registry_entries: List[MarketplacePluginEntry] = []
             registry_ok = False
+            registry_error = None
+            github_enrichment_succeeded = False
             try:
+                from .manager import PluginManager
+
+                mgr = PluginManager.instance()
                 for info in mgr.search(""):
                     registry_entries.append(_from_registry(info))
                 registry_ok = True
             except Exception as exc:
-                _log.debug("Registry search failed: %s", exc)
+                registry_error = exc
 
-            curated_entries = (
-                _resolve_curated_from_github()
-                if require_github_enrichment
-                else _build_curated_fallback()
-            )
+            try:
+                curated_entries = (
+                    _resolve_curated_from_github()
+                    if require_github_enrichment
+                    else _build_curated_fallback()
+                )
+                github_enrichment_succeeded = require_github_enrichment
+            except Exception as exc:
+                curated_entries = _build_curated_fallback()
+                registry_error = registry_error or exc
             merged = _merge_entries(registry_entries, curated_entries)
             if registry_ok:
                 _log.info(
@@ -136,17 +206,43 @@ class PluginMarketplaceCatalog:
                     len(registry_entries),
                     len(merged),
                 )
-            else:
-                _log.info(
-                    "Plugin marketplace registry unavailable, using fallback catalog: %d fallback entries, %d total catalog entries",
-                    len(curated_entries),
-                    len(merged),
-                )
             with self._lock:
                 self._entries = merged
                 self._loading = False
                 self._registry_loaded = registry_ok
-                self._github_enriched = self._github_enriched or require_github_enrichment
+                self._github_enriched = (
+                    self._github_enriched or github_enrichment_succeeded
+                )
+
+            with _catalog_cache_lock:
+                previous_failures = (
+                    _catalog_cache.failure_count
+                    if _catalog_cache is not None and not registry_ok
+                    else 0
+                )
+                failure_count = previous_failures + 1 if not registry_ok else 0
+                if failure_count:
+                    backoff = min(
+                        REFRESH_RETRY_COOLDOWN_SEC * 2 ** (failure_count - 1),
+                        REFRESH_RETRY_MAX_COOLDOWN_SEC,
+                    )
+                    next_retry_at = time.monotonic() + backoff
+                else:
+                    next_retry_at = 0.0
+                _catalog_cache = _CatalogCache(
+                    entries=tuple(merged),
+                    registry_loaded=registry_ok,
+                    github_enriched=self._github_enriched,
+                    stored_at=time.monotonic(),
+                    next_retry_at=next_retry_at,
+                    failure_count=failure_count,
+                )
+                _catalog_refresh_inflight = False
+            if registry_error is not None:
+                _log.warning(
+                    "Plugin marketplace refresh failed; retrying after backoff: %s",
+                    registry_error,
+                )
             self._notify_change()
 
         threading.Thread(target=worker, daemon=True).start()

--- a/src/python/lfs_plugins/marketplace.py
+++ b/src/python/lfs_plugins/marketplace.py
@@ -179,71 +179,83 @@ class PluginMarketplaceCatalog:
             registry_ok = False
             registry_error = None
             github_enrichment_succeeded = False
+            backoff = None
             try:
-                from .manager import PluginManager
+                try:
+                    from .manager import PluginManager
 
-                mgr = PluginManager.instance()
-                for info in mgr.search(""):
-                    registry_entries.append(_from_registry(info))
-                registry_ok = True
-            except Exception as exc:
-                registry_error = exc
+                    mgr = PluginManager.instance()
+                    for info in mgr.search(""):
+                        registry_entries.append(_from_registry(info))
+                    registry_ok = True
+                except Exception as exc:
+                    registry_error = exc
 
-            try:
-                curated_entries = (
-                    _resolve_curated_from_github()
-                    if require_github_enrichment
-                    else _build_curated_fallback()
-                )
-                github_enrichment_succeeded = require_github_enrichment
-            except Exception as exc:
-                curated_entries = _build_curated_fallback()
-                registry_error = registry_error or exc
-            merged = _merge_entries(registry_entries, curated_entries)
-            if registry_ok:
-                _log.info(
-                    "Plugin marketplace registry loaded: %d registry entries, %d total catalog entries",
-                    len(registry_entries),
-                    len(merged),
-                )
-            with self._lock:
-                self._entries = merged
-                self._loading = False
-                self._registry_loaded = registry_ok
-                self._github_enriched = (
-                    self._github_enriched or github_enrichment_succeeded
-                )
-
-            with _catalog_cache_lock:
-                previous_failures = (
-                    _catalog_cache.failure_count
-                    if _catalog_cache is not None and not registry_ok
-                    else 0
-                )
-                failure_count = previous_failures + 1 if not registry_ok else 0
-                if failure_count:
-                    backoff = min(
-                        REFRESH_RETRY_COOLDOWN_SEC * 2 ** (failure_count - 1),
-                        REFRESH_RETRY_MAX_COOLDOWN_SEC,
+                try:
+                    curated_entries = (
+                        _resolve_curated_from_github()
+                        if require_github_enrichment
+                        else _build_curated_fallback()
                     )
-                    next_retry_at = time.monotonic() + backoff
-                else:
-                    next_retry_at = 0.0
-                _catalog_cache = _CatalogCache(
-                    entries=tuple(merged),
-                    registry_loaded=registry_ok,
-                    github_enriched=self._github_enriched,
-                    stored_at=time.monotonic(),
-                    next_retry_at=next_retry_at,
-                    failure_count=failure_count,
-                )
-                _catalog_refresh_inflight = False
-            if registry_error is not None:
-                _log.warning(
-                    "Plugin marketplace refresh failed; retrying after backoff: %s",
-                    registry_error,
-                )
-            self._notify_change()
+                    github_enrichment_succeeded = require_github_enrichment
+                except Exception as exc:
+                    curated_entries = _build_curated_fallback()
+                    registry_error = registry_error or exc
+                merged = _merge_entries(registry_entries, curated_entries)
+                if registry_ok:
+                    _log.info(
+                        "Plugin marketplace registry loaded: %d registry entries, %d total catalog entries",
+                        len(registry_entries),
+                        len(merged),
+                    )
+                with self._lock:
+                    self._entries = merged
+                    self._registry_loaded = registry_ok
+                    self._github_enriched = (
+                        self._github_enriched or github_enrichment_succeeded
+                    )
+
+                with _catalog_cache_lock:
+                    previous_failures = (
+                        _catalog_cache.failure_count
+                        if _catalog_cache is not None and not registry_ok
+                        else 0
+                    )
+                    failure_count = previous_failures + 1 if not registry_ok else 0
+                    if failure_count:
+                        backoff = min(
+                            REFRESH_RETRY_COOLDOWN_SEC * 2 ** (failure_count - 1),
+                            REFRESH_RETRY_MAX_COOLDOWN_SEC,
+                        )
+                        next_retry_at = time.monotonic() + backoff
+                    else:
+                        next_retry_at = 0.0
+                    _catalog_cache = _CatalogCache(
+                        entries=tuple(merged),
+                        registry_loaded=registry_ok,
+                        github_enriched=self._github_enriched,
+                        stored_at=time.monotonic(),
+                        next_retry_at=next_retry_at,
+                        failure_count=failure_count,
+                    )
+                if registry_error is not None:
+                    if backoff is not None:
+                        _log.warning(
+                            "Plugin marketplace refresh failed; retrying in %.0f s: %s",
+                            backoff,
+                            registry_error,
+                        )
+                    else:
+                        _log.warning(
+                            "Plugin marketplace GitHub enrichment failed: %s",
+                            registry_error,
+                        )
+            finally:
+                with _catalog_cache_lock:
+                    _catalog_refresh_inflight = False
+                with self._lock:
+                    self._loading = False
+                self._notify_change()
 
         threading.Thread(target=worker, daemon=True).start()
 

--- a/src/python/lfs_plugins/panels.py
+++ b/src/python/lfs_plugins/panels.py
@@ -48,6 +48,7 @@ PANEL_SPECS = {
     "about": _PanelSpec(
         "lfs_plugins.about_panel", "AboutPanel", "lfs.about", "About",
         "FLOATING", 100, "rmlui/about.rml", "CONTENT", (400, 0),
+        update_policy="dirty",
     ),
     "account": _PanelSpec(
         "lfs_plugins.account_panel", "AccountPanel", "lfs.account", "Account",
@@ -91,7 +92,7 @@ PANEL_SPECS = {
         "lfs_plugins.plugin_marketplace_panel", "PluginMarketplacePanel",
         "lfs.plugin_marketplace", "Plugin Marketplace", "FLOATING", 91,
         "rmlui/plugin_marketplace.rml", "FILL", (770, 560),
-        update_policy="interval", update_interval_ms=250,
+        update_policy="dirty",
     ),
     "asset_manager": _PanelSpec(
         "lfs_plugins.asset_manager_panel", "AssetManagerPanel", "lfs.asset_manager",

--- a/src/python/lfs_plugins/plugin_marketplace_panel.py
+++ b/src/python/lfs_plugins/plugin_marketplace_panel.py
@@ -172,6 +172,7 @@ class PluginMarketplacePanel(Panel):
             self._sort_idx = idx
             self._entries_dirty = True
             self._needs_resort = True
+            self._ensure_loaded()
             self._request_model_update()
 
     # ── Lifecycle ─────────────────────────────────────────────
@@ -217,6 +218,7 @@ class PluginMarketplacePanel(Panel):
             )
         self._sync_view_mode_controls(doc)
         self._subscribe_reactive_state()
+        self._ensure_loaded()
         self._request_model_update()
 
     def on_unmount(self, doc):
@@ -309,6 +311,9 @@ class PluginMarketplacePanel(Panel):
         from .manager import PluginManager
 
         mgr = PluginManager.instance()
+        # Dirty-driven updates are event-driven, so this guard handles a sort
+        # change that arrives while the initial catalog fetch is in flight
+        # without reintroducing an idle polling loop.
         self._ensure_loaded()
 
         current_lang = lf.ui.get_current_language()

--- a/tests/python/test_plugin_marketplace_panel.py
+++ b/tests/python/test_plugin_marketplace_panel.py
@@ -149,10 +149,9 @@ def test_plugin_marketplace_syncs_feedback_nodes(plugin_marketplace_module):
     assert doc.get_element_by_id("feedback-card-error").classes["hidden"] is True
 
 
-def test_plugin_marketplace_uses_interval_update_policy(plugin_marketplace_module):
+def test_plugin_marketplace_uses_dirty_update_policy(plugin_marketplace_module):
     module, _state = plugin_marketplace_module
-    assert module.PluginMarketplacePanel.update_policy == "interval"
-    assert module.PluginMarketplacePanel.update_interval_ms == 250
+    assert module.PluginMarketplacePanel.update_policy == "dirty"
 
 
 def test_plugin_marketplace_converts_grid_width_from_pixels_to_dp(plugin_marketplace_module):
@@ -208,6 +207,117 @@ def test_plugin_marketplace_requests_update_on_language_generation(plugin_market
     assert panel._handle.request_update_count == 1
 
     panel._unsubscribe_reactive_state()
+
+
+def test_plugin_marketplace_coalesces_catalogue_update_requests(
+    plugin_marketplace_module,
+    monkeypatch,
+):
+    module, _state = plugin_marketplace_module
+    callbacks = []
+    monkeypatch.setattr(
+        module.lf.ui,
+        "schedule_on_ui_thread",
+        callbacks.append,
+        raising=False,
+    )
+
+    panel = module.PluginMarketplacePanel()
+    panel._handle = _HandleStub()
+
+    panel._schedule_model_update()
+    panel._schedule_model_update()
+
+    assert len(callbacks) == 1
+    assert panel._handle.request_update_count == 0
+
+    callbacks[0]()
+
+    assert panel._handle.request_update_count == 1
+
+
+def test_plugin_marketplace_cache_ttl_and_retry_backoff(plugin_marketplace_module):
+    module, _state = plugin_marketplace_module
+    marketplace = __import__("lfs_plugins.marketplace", fromlist=["_CatalogCache"])
+    entry = module.MarketplacePluginEntry(
+        source_url="https://github.com/owner/repo",
+        github_url="https://github.com/owner/repo",
+        owner="owner",
+        repo="repo",
+        name="Sample Plugin",
+        description="",
+    )
+
+    cached = marketplace._CatalogCache(
+        entries=(entry,),
+        registry_loaded=True,
+        github_enriched=False,
+        stored_at=100.0,
+    )
+    assert marketplace.PluginMarketplaceCatalog._cache_can_serve(cached, 100.0, False)
+    assert not marketplace.PluginMarketplaceCatalog._cache_can_serve(
+        cached, 100.0, True
+    )
+    assert not marketplace.PluginMarketplaceCatalog._cache_can_serve(
+        cached, 100.0 + marketplace.CATALOG_CACHE_TTL_SEC, False
+    )
+
+    failed = marketplace._CatalogCache(
+        entries=(entry,),
+        registry_loaded=False,
+        github_enriched=False,
+        stored_at=100.0,
+        next_retry_at=130.0,
+        failure_count=1,
+    )
+    assert marketplace.PluginMarketplaceCatalog._cache_can_serve(failed, 129.9, True)
+    assert not marketplace.PluginMarketplaceCatalog._cache_can_serve(failed, 130.0, True)
+
+
+def test_plugin_marketplace_refresh_is_cached_across_catalog_instances(
+    plugin_marketplace_module,
+    monkeypatch,
+):
+    _module, _state = plugin_marketplace_module
+    marketplace = __import__(
+        "lfs_plugins.marketplace", fromlist=["PluginMarketplaceCatalog"]
+    )
+    calls = []
+
+    class _ManagerStub:
+        @classmethod
+        def instance(cls):
+            return cls()
+
+        def search(self, _query):
+            calls.append("search")
+            return []
+
+    manager_module = ModuleType("lfs_plugins.manager")
+    manager_module.PluginManager = _ManagerStub
+    monkeypatch.setitem(sys.modules, "lfs_plugins.manager", manager_module)
+    monkeypatch.setattr(marketplace, "_build_curated_fallback", lambda: [])
+    monkeypatch.setattr(marketplace, "_catalog_cache", None)
+    monkeypatch.setattr(marketplace, "_catalog_refresh_inflight", False)
+    monkeypatch.setattr(marketplace._log, "disabled", True)
+
+    class _ImmediateThread:
+        def __init__(self, target, daemon=False):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(marketplace.threading, "Thread", _ImmediateThread)
+
+    first = marketplace.PluginMarketplaceCatalog()
+    first.refresh_async()
+    second = marketplace.PluginMarketplaceCatalog()
+    second.refresh_async()
+
+    assert calls == ["search"]
+    assert first.snapshot()[2] is True
+    assert second.snapshot()[2] is True
 
 
 def test_plugin_marketplace_manual_success_clears_url(plugin_marketplace_module):

--- a/tests/python/test_plugin_marketplace_panel.py
+++ b/tests/python/test_plugin_marketplace_panel.py
@@ -320,6 +320,50 @@ def test_plugin_marketplace_refresh_is_cached_across_catalog_instances(
     assert second.snapshot()[2] is True
 
 
+def test_plugin_marketplace_refresh_exception_clears_inflight_and_loading(
+    plugin_marketplace_module,
+    monkeypatch,
+):
+    _module, _state = plugin_marketplace_module
+    marketplace = __import__(
+        "lfs_plugins.marketplace", fromlist=["PluginMarketplaceCatalog"]
+    )
+
+    class _ManagerStub:
+        @classmethod
+        def instance(cls):
+            return cls()
+
+        def search(self, _query):
+            return []
+
+    manager_module = ModuleType("lfs_plugins.manager")
+    manager_module.PluginManager = _ManagerStub
+    monkeypatch.setitem(sys.modules, "lfs_plugins.manager", manager_module)
+    monkeypatch.setattr(marketplace, "_build_curated_fallback", lambda: [])
+    monkeypatch.setattr(marketplace, "_merge_entries", lambda *_args: (_ for _ in ()).throw(
+        RuntimeError("worker failed")
+    ))
+    monkeypatch.setattr(marketplace, "_catalog_cache", None)
+    monkeypatch.setattr(marketplace, "_catalog_refresh_inflight", False)
+
+    class _ImmediateThread:
+        def __init__(self, target, daemon=False):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(marketplace.threading, "Thread", _ImmediateThread)
+
+    catalog = marketplace.PluginMarketplaceCatalog()
+    with pytest.raises(RuntimeError, match="worker failed"):
+        catalog.refresh_async()
+
+    assert marketplace._catalog_refresh_inflight is False
+    assert catalog.snapshot()[1] is False
+
+
 def test_plugin_marketplace_manual_success_clears_url(plugin_marketplace_module):
     module, _state = plugin_marketplace_module
     panel = module.PluginMarketplacePanel()

--- a/tests/python/test_rmlui_image_sources.py
+++ b/tests/python/test_rmlui_image_sources.py
@@ -197,6 +197,23 @@ def test_image_preview_uses_dirty_update_policy(panel_modules):
     assert image_preview.ImagePreviewPanel.update_policy == "dirty"
 
 
+def test_about_panel_is_dirty_driven_without_idle_redraw(panel_modules):
+    _image_preview, _getting_started = panel_modules
+    about = import_module("lfs_plugins.about_panel")
+    source = (
+        Path(__file__).parent.parent.parent
+        / "src"
+        / "python"
+        / "lfs_plugins"
+        / "about_panel.py"
+    ).read_text(encoding="utf-8")
+
+    assert about.AboutPanel.update_policy == "dirty"
+    assert "on_update" not in about.AboutPanel.__dict__
+    assert "def on_update" not in source
+    assert "request_redraw" not in source
+
+
 def test_image_preview_dirty_request_schedules_update(panel_modules):
     image_preview, _ = panel_modules
     panel = image_preview.ImagePreviewPanel()


### PR DESCRIPTION
The About and Plugin Marketplace panels kept the frame loop running while open: About inherited the panel registry's default 100 ms interval policy, and the marketplace polled every 250 ms and re-checked the catalogue on each tick.

Both now update on events only. The marketplace catalogue is fetched once per open, cached for five minutes, and a failed fetch backs off instead of retrying every tick.

Process CPU in the 10 s after opening the panel on a 3.3M-splat scene (the floor with any panel open is 3.2 %):

| Panel | Before | After |
|---|---|---|
| About | 21.4 % | 3.3 % |
| Plugin Marketplace | 13.5 % | 3.4 % |