### PR TITLE
Preferences opens without a first-use stall

### DIFF
--- a/src/python/lfs/rml_python_panel_adapter.cpp
+++ b/src/python/lfs/rml_python_panel_adapter.cpp
@@ -172,6 +172,7 @@ namespace lfs::vis::gui {
         assert(rml_ctx);
         try {
             auto py_ctx = lfs::python::PyRmlContext(rml_ctx);
+            LOG_TIMER_THRESHOLD(context_name_ + ".on_bind_model", 2.0);
             panel_instance_.attr("on_bind_model")(py_ctx);
             setLifecycleState(LifecycleState::ModelBound);
         } catch (const std::exception& e) {
@@ -205,6 +206,7 @@ namespace lfs::vis::gui {
         lfs::python::RmlDocumentRegistry::instance().register_document(context_name_, doc);
         try {
             auto py_doc = lfs::python::PyRmlDocument(doc);
+            LOG_TIMER_THRESHOLD(context_name_ + ".on_mount", 2.0);
             panel_instance_.attr("on_mount")(py_doc);
             content_dirty_ = true;
             setLifecycleState(LifecycleState::Mounted);
@@ -574,6 +576,11 @@ namespace lfs::vis::gui {
             LOG_ERROR("Panel poll error: {}", e.what());
             return false;
         }
+    }
+
+    void RmlPythonPanelAdapter::on_visibility_changed(const bool visible) {
+        if (visible)
+            content_dirty_ = true;
     }
 
     void RmlPythonPanelAdapter::preload(const PanelDrawContext& ctx) {

--- a/src/python/lfs/rml_python_panel_adapter.hpp
+++ b/src/python/lfs/rml_python_panel_adapter.hpp
@@ -33,6 +33,7 @@ namespace lfs::vis::gui {
 
         void draw(const PanelDrawContext& ctx) override;
         bool poll(const PanelDrawContext& ctx) override;
+        void on_visibility_changed(bool visible) override;
         void preload(const PanelDrawContext& ctx) override;
         PanelRenderCapabilities renderCapabilities() const override {
             return {.direct = true};

--- a/src/python/lfs_plugins/keymap_bindings.py
+++ b/src/python/lfs_plugins/keymap_bindings.py
@@ -145,6 +145,7 @@ class KeymapBindingsSection:
         self._last_lang = ""
         self._last_current_profile = ""
         self._last_capturing = None
+        self._rows_built = False
 
     # ── Data model ────────────────────────────────────────────
 
@@ -259,10 +260,11 @@ class KeymapBindingsSection:
         self._doc = doc
         self._last_lang = lf.ui.get_current_language()
         self._last_current_profile = lf.keymap.get_current_profile()
+        self._rows_built = False
+        self._last_state_key = None
 
         self._rebuild_profile_records()
         self._rebuild_mode_records()
-        self._rebuild_binding_rows(self.TOOL_MODES[self._selected_mode_idx])
 
         table_el = doc.get_element_by_id("bindings-table")
         if table_el:
@@ -272,6 +274,8 @@ class KeymapBindingsSection:
     def on_unmount(self):
         self._doc = None
         self._handle = None
+        self._rows_built = False
+        self._last_state_key = None
 
     def on_update(self, doc):
         self._doc = doc
@@ -283,54 +287,51 @@ class KeymapBindingsSection:
             self._rebuild_profile_records()
             self._dirty_model("profile_idx")
 
-        is_capturing = lf.keymap.is_capturing()
-        mode = self.TOOL_MODES[self._selected_mode_idx]
-
-        if self._rebinding_action is not None:
-            trigger = lf.keymap.get_captured_trigger()
-            if trigger is not None:
-                action = self._rebinding_action
-                mode = self._rebinding_mode
-                previous_trigger = self._previous_trigger
-                self._rebinding_action = None
-                self._rebinding_mode = None
-                self._previous_trigger = None
-                conflict = lf.keymap.find_conflict_for_action(mode, action)
-                if conflict is not None:
-                    self._pending_conflict = {
-                        "mode": mode,
-                        "action": action,
-                        "other_mode": lf.keymap.ToolMode(conflict["other_mode"]),
-                        "other_action": lf.keymap.Action(conflict["other_action"]),
-                        "previous_trigger": previous_trigger,
-                    }
-                    self._show_conflict_overlay(doc)
-                else:
-                    self._hide_conflict_overlay()
-                is_capturing = lf.keymap.is_capturing()
-            elif not is_capturing:
-                self._rebinding_action = None
-                self._rebinding_mode = None
-                self._previous_trigger = None
-
-        current_profile = lf.keymap.get_current_profile()
-        state_key = (
-            self._selected_mode_idx,
-            self._rebinding_action,
-            is_capturing,
-            current_profile,
-            current_lang,
-        )
-        if state_key != self._last_state_key:
-            self._last_state_key = state_key
-            self._rebuild_binding_rows(mode)
-            self._dirty_model("bindings_hint")
-
         if current_lang != self._last_lang:
             self._last_lang = current_lang
             self._rebuild_mode_records()
             self._rebuild_profile_records()
             self._dirty_model()
+
+        is_capturing = lf.keymap.is_capturing()
+        current_profile = lf.keymap.get_current_profile()
+        if self._rows_built:
+            mode = self.TOOL_MODES[self._selected_mode_idx]
+
+            if self._rebinding_action is not None:
+                trigger = lf.keymap.get_captured_trigger()
+                if trigger is not None:
+                    action = self._rebinding_action
+                    mode = self._rebinding_mode
+                    previous_trigger = self._previous_trigger
+                    self._rebinding_action = None
+                    self._rebinding_mode = None
+                    self._previous_trigger = None
+                    conflict = lf.keymap.find_conflict_for_action(mode, action)
+                    if conflict is not None:
+                        self._pending_conflict = {
+                            "mode": mode,
+                            "action": action,
+                            "other_mode": lf.keymap.ToolMode(conflict["other_mode"]),
+                            "other_action": lf.keymap.Action(conflict["other_action"]),
+                            "previous_trigger": previous_trigger,
+                        }
+                        self._show_conflict_overlay(doc)
+                    else:
+                        self._hide_conflict_overlay()
+                    is_capturing = lf.keymap.is_capturing()
+                elif not is_capturing:
+                    self._rebinding_action = None
+                    self._rebinding_mode = None
+                    self._previous_trigger = None
+
+            state_key = self._current_state_key(
+                is_capturing, current_profile, current_lang, mode
+            )
+            if state_key != self._last_state_key:
+                self._last_state_key = state_key
+                self._rebuild_binding_rows(mode)
+                self._dirty_model("bindings_hint")
 
         if current_profile != self._last_current_profile:
             self._last_current_profile = current_profile
@@ -423,6 +424,28 @@ class KeymapBindingsSection:
         })
         for action in actions:
             rows.append(self._binding_row_record(action, mode))
+
+    def _current_state_key(self, is_capturing, current_profile, current_lang, mode):
+        return (
+            self.TOOL_MODES.index(mode),
+            self._rebinding_action,
+            is_capturing,
+            current_profile,
+            current_lang,
+        )
+
+    def ensure_binding_rows(self):
+        if self._rows_built or not self._handle:
+            return
+        mode = self.TOOL_MODES[self._selected_mode_idx]
+        is_capturing = lf.keymap.is_capturing()
+        current_profile = lf.keymap.get_current_profile()
+        current_lang = lf.ui.get_current_language()
+        self._last_state_key = self._current_state_key(
+            is_capturing, current_profile, current_lang, mode
+        )
+        self._rows_built = True
+        self._rebuild_binding_rows(mode)
 
     def _rebuild_binding_rows(self, mode):
         if not self._handle:

--- a/src/python/lfs_plugins/preferences_panel.py
+++ b/src/python/lfs_plugins/preferences_panel.py
@@ -72,6 +72,12 @@ class PreferencesPanel(Panel):
         self._applied_project_location = ""
         self._document = None
         self._file_associations = []
+        self._mount_count = 0
+
+    @property
+    def mount_count(self):
+        """Number of RML document mounts; closing retains the current mount."""
+        return self._mount_count
 
     def on_bind_model(self, ctx):
         self._read_mcp_preferences()
@@ -181,6 +187,7 @@ class PreferencesPanel(Panel):
                 "click", lambda _ev: self._on_close(None, None, None)
             )
         self._document = doc
+        self._mount_count += 1
         self._expanded_sections = set(self.EXPANDABLE_SECTIONS)
         self._dirty_expanded_sections()
         self._rebuild_records()
@@ -189,6 +196,7 @@ class PreferencesPanel(Panel):
         self._last_state = self._state()
         self._refresh_selection()
         self._keymap.on_mount(doc)
+        self._ensure_keymap_rows_if_visible()
 
     def on_unmount(self, doc):
         self._keymap.on_unmount()
@@ -199,6 +207,7 @@ class PreferencesPanel(Panel):
     def on_update(self, doc):
         self._consume_section_request()
         self._sync_mcp_runtime()
+        self._ensure_keymap_rows_if_visible()
         state = self._state()
         if state != self._last_state:
             self._last_state = state
@@ -206,6 +215,10 @@ class PreferencesPanel(Panel):
             self._dirty_selection()
             self._dirty_mcp()
         self._keymap.on_update(doc)
+
+    def _ensure_keymap_rows_if_visible(self):
+        if self._section == "input" and "key_bindings" in self._expanded_sections:
+            self._keymap.ensure_binding_rows()
 
     def _state(self):
         return (
@@ -861,10 +874,14 @@ class PreferencesPanel(Panel):
     def _on_close(self, _handle, _event, _args):
         # The floating-window title bar is cancellation: discard an unconfirmed
         # port draft while preserving settings that were already applied live.
+        mcp_draft_changed = self._mcp_port != str(self._mcp_applied_port)
+        project_draft_changed = self._project_location != self._applied_project_location
         self._mcp_port = str(self._mcp_applied_port)
         self._project_location = self._applied_project_location
-        self._dirty_mcp()
-        self._dirty_project_location()
+        if mcp_draft_changed:
+            self._dirty_mcp()
+        if project_draft_changed:
+            self._dirty_project_location()
         lf.ui.set_panel_enabled(self.id, False)
 
     def _on_accept_and_close(self, _handle, _event, _args):
@@ -878,6 +895,7 @@ class PreferencesPanel(Panel):
         if self._section == section:
             return
         self._section = section
+        self._ensure_keymap_rows_if_visible()
         if self._handle:
             for name in (
                 "show_general",
@@ -904,6 +922,7 @@ class PreferencesPanel(Panel):
             self._expanded_sections.add(section)
         if self._handle:
             self._handle.dirty(f"{section}_expanded")
+        self._ensure_keymap_rows_if_visible()
 
     def _dirty_expanded_sections(self):
         if not self._handle:

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -5267,6 +5267,10 @@ namespace lfs::vis::gui {
             if (rml_modal_overlay_)
                 rml_modal_overlay_->preload();
             warmupNativeFileDialogBackend();
+            {
+                LOG_TIMER_THRESHOLD("gui_render.panel_setup.preferences_preload", 2.0);
+                PanelRegistry::instance().preload_panel("lfs.preferences");
+            }
         }
 
         std::optional<::lfs::core::ScopedTimer> cpu_ui_before_vulkan_timer;

--- a/src/visualizer/gui/panel_registry.cpp
+++ b/src/visualizer/gui/panel_registry.cpp
@@ -1650,8 +1650,20 @@ apply_registered_chrome:
 
         if (changed)
             lfs::vis::publish_viewport_toolbar_generation();
-        if (panel_to_notify)
-            panel_to_notify->on_visibility_changed(enabled);
+        if (panel_to_notify) {
+            try {
+                panel_to_notify->on_visibility_changed(enabled);
+            } catch (const std::exception& e) {
+                LOG_ERROR("Panel '{}' visibility change error: {}", id, e.what());
+                std::lock_guard lock(mutex_);
+                for (auto& panel : panels_) {
+                    if (panel.id == id) {
+                        panel.error_disabled = true;
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     bool PanelRegistry::bring_panel_to_front(const std::string& id) {
@@ -1690,7 +1702,18 @@ apply_registered_chrome:
             return;
 
         const auto ctx = cachedLayoutDrawContext();
-        panel->preload(ctx);
+        try {
+            panel->preload(ctx);
+        } catch (const std::exception& e) {
+            LOG_ERROR("Panel '{}' preload error: {}", id, e.what());
+            std::lock_guard lock(mutex_);
+            for (auto& panel_info : panels_) {
+                if (panel_info.id == id) {
+                    panel_info.error_disabled = true;
+                    break;
+                }
+            }
+        }
     }
 
     bool PanelRegistry::apply_floating_resize_cursor() const {

--- a/src/visualizer/gui/panel_registry.cpp
+++ b/src/visualizer/gui/panel_registry.cpp
@@ -1592,6 +1592,7 @@ apply_registered_chrome:
 
     void PanelRegistry::set_panel_enabled(const std::string& id, bool enabled) {
         bool changed = false;
+        std::shared_ptr<IPanel> panel_to_notify;
         {
             std::lock_guard lock(mutex_);
             for (auto& p : panels_) {
@@ -1605,6 +1606,7 @@ apply_registered_chrome:
                         break;
 
                     p.enabled = enabled;
+                    panel_to_notify = p.panel;
                     if (enabled && p.space == PanelSpace::Floating) {
                         auto& interaction = ensure_floating_interaction_locked(p);
                         if (const auto requested =
@@ -1648,6 +1650,8 @@ apply_registered_chrome:
 
         if (changed)
             lfs::vis::publish_viewport_toolbar_generation();
+        if (panel_to_notify)
+            panel_to_notify->on_visibility_changed(enabled);
     }
 
     bool PanelRegistry::bring_panel_to_front(const std::string& id) {
@@ -1668,6 +1672,25 @@ apply_registered_chrome:
                 return p.enabled;
         }
         return false;
+    }
+
+    void PanelRegistry::preload_panel(const std::string& id) {
+        std::shared_ptr<IPanel> panel;
+        {
+            std::lock_guard lock(mutex_);
+            const auto found = std::find_if(
+                panels_.begin(), panels_.end(),
+                [&id](const PanelInfo& info) { return info.id == id; });
+            if (found == panels_.end() || found->error_disabled)
+                return;
+            panel = found->panel;
+        }
+
+        if (!panel)
+            return;
+
+        const auto ctx = cachedLayoutDrawContext();
+        panel->preload(ctx);
     }
 
     bool PanelRegistry::apply_floating_resize_cursor() const {

--- a/src/visualizer/gui/panel_registry.hpp
+++ b/src/visualizer/gui/panel_registry.hpp
@@ -167,6 +167,7 @@ namespace lfs::vis::gui {
             (void)ctx;
             return true;
         }
+        virtual void on_visibility_changed(bool visible) { (void)visible; }
         virtual void preload(const PanelDrawContext& ctx) { (void)ctx; }
         virtual PanelRenderCapabilities renderCapabilities() const { return {}; }
         virtual PanelDirectRenderResult renderDirect(
@@ -393,6 +394,9 @@ namespace lfs::vis::gui {
         void set_panel_enabled(const std::string& id, bool enabled);
         bool bring_panel_to_front(const std::string& id);
         bool is_panel_enabled(const std::string& id) const;
+        // Prepare a registered panel without requiring it to be enabled or
+        // visible. Used for small, opt-in startup warmups.
+        void preload_panel(const std::string& id);
         bool apply_floating_resize_cursor() const;
         void rescale_floating_panels(float previous_scale, float new_scale);
         bool needsAnimationFrame() const;

--- a/src/visualizer/gui/rmlui/rml_panel_host.cpp
+++ b/src/visualizer/gui/rmlui/rml_panel_host.cpp
@@ -243,6 +243,7 @@ namespace lfs::vis::gui {
             // Sibling theme files are optional; missing ones should not produce startup noise.
         }
 
+        LOG_TIMER_THRESHOLD(context_name_ + ".rml_theme_apply", 2.0);
         rml_theme::applyTheme(document_, base_rcss_, panel_theme);
         content_dirty_ = true;
         direct_cache_dirty_ = true;
@@ -326,6 +327,7 @@ namespace lfs::vis::gui {
             const auto full_path = requested_path.is_absolute()
                                        ? requested_path
                                        : lfs::vis::getAssetPath(rml_path_);
+            LOG_TIMER_THRESHOLD(context_name_ + ".rml_document_load", 2.0);
             document_ = rml_documents::loadDocument(rml_context_, full_path);
             if (document_) {
                 syncThemeProperties();

--- a/tests/python/test_keymap_bindings.py
+++ b/tests/python/test_keymap_bindings.py
@@ -527,6 +527,26 @@ def test_keymap_builds_binding_rows_with_capture_state(keymap_bindings_module):
     assert pan_row["button_class"] == "btn--primary"
 
 
+def test_keymap_ensure_rows_does_not_rebuild_on_first_update(keymap_bindings_module):
+    prefs, _state = keymap_bindings_module
+    _panel, model = _bind_panel(prefs)
+    section = _panel._keymap
+    binding_rows_calls = []
+    original_update_record_list = model.handle.update_record_list
+
+    def update_record_list(name, rows):
+        if name == "binding_rows":
+            binding_rows_calls.append(rows)
+        original_update_record_list(name, rows)
+
+    model.handle.update_record_list = update_record_list
+
+    section.ensure_binding_rows()
+    section.on_update(_DocStub())
+
+    assert len(binding_rows_calls) == 1
+
+
 def test_keymap_marks_conflicting_binding_rows(keymap_bindings_module):
     prefs, state = keymap_bindings_module
     panel, _model = _bind_panel(prefs)
@@ -553,6 +573,7 @@ def test_keymap_capture_conflict_prompts_to_replace(keymap_bindings_module):
     panel, _model = _bind_panel(prefs)
     section = panel._keymap
     doc = _DocStub(with_conflict_overlay=True)
+    section.ensure_binding_rows()
 
     old_trigger = {"type": "drag", "button": 2, "modifiers": 0}
     state.triggers[(prefs.lf.keymap.ToolMode.GLOBAL, prefs.lf.keymap.Action.CAMERA_ORBIT)] = old_trigger
@@ -616,6 +637,7 @@ def test_keymap_language_change_rebuilds_and_dirties_all(keymap_bindings_module)
     prefs, state = keymap_bindings_module
     panel, _model = _bind_panel(prefs)
     section = panel._keymap
+    section.ensure_binding_rows()
     section._last_profiles = list(state.profiles)
     section._last_lang = "en"
     section._last_current_profile = "Default"

--- a/tests/python/test_preferences_panel.py
+++ b/tests/python/test_preferences_panel.py
@@ -830,3 +830,46 @@ def test_embed_dataset_default_is_exposed_and_settable(preferences_panel_module)
     panel._set_embed_dataset_by_default(True)
     assert state.embed_dataset_by_default is True
     assert module.lf.ui.get_embed_dataset_by_default() is True
+
+
+def test_preferences_close_retains_the_mounted_document(preferences_panel_module):
+    module, state = preferences_panel_module
+    panel = module.PreferencesPanel()
+
+    class Document:
+        def get_element_by_id(self, _element_id):
+            return None
+
+    document = Document()
+    panel._rebuild_records = lambda: None
+    panel._load_mcp_preferences = lambda: None
+    panel._consume_section_request = lambda: None
+    panel._refresh_selection = lambda: None
+    panel._state = lambda: None
+    panel._dirty_expanded_sections = lambda: None
+    panel._keymap.on_mount = lambda _doc: None
+    panel.on_mount(document)
+    panel._on_close(None, None, None)
+
+    assert panel.mount_count == 1
+    assert panel._document is document
+    assert state.panel_enabled_calls[-1] == ("lfs.preferences", False)
+
+
+def test_preferences_keymap_rows_are_created_when_expanded(preferences_panel_module):
+    module, _state = preferences_panel_module
+    panel = module.PreferencesPanel()
+    records = {}
+    panel._keymap._handle = SimpleNamespace(
+        update_record_list=lambda name, items: records.__setitem__(name, list(items)),
+    )
+    panel._section = "input"
+
+    assert "key_bindings" in panel._expanded_sections
+    assert panel._keymap._rows_built is False
+
+    panel._expanded_sections.discard("key_bindings")
+    panel._on_toggle_section(None, None, ["key_bindings"])
+
+    assert panel._keymap._rows_built is True
+    assert records["binding_rows"]


### PR DESCRIPTION
The first open of Preferences did everything inside one frame: load and parse the RML document, bind the data model, generate every key-binding row, and load the CJK fonts through the language list.

The document is now prepared in the deferred startup step after the first frame and stays mounted across close and open. Key-binding rows are generated only when the Input section is shown, and closing only invalidates bindings whose draft changed.

First open of Preferences on a 3.3M-splat scene: floating-panel render 148 ms → 40 ms. Re-open and close frames are at the idle floor, idle CPU with the panel open 0.4 %. Per-panel timers (document load, theme apply, on_bind_model, on_mount) are logged at debug level above 2 ms.