### PR TITLE
Scene tree: lock before eye so eye and bin stay together

### DIFF
--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
@@ -722,14 +722,6 @@ namespace lfs::vis::gui {
             actions->SetClass("row-actions", true);
             auto* actions_el = slot.content->AppendChild(std::move(actions));
 
-            auto visibility_slot = doc->CreateElement("span");
-            visibility_slot->SetClass("row-action-slot", true);
-            auto* visibility_slot_el = actions_el->AppendChild(std::move(visibility_slot));
-            auto vis_icon = doc->CreateElement("img");
-            vis_icon->SetClass("row-icon", true);
-            vis_icon->SetAttribute("data-action", "toggle-vis");
-            slot.vis_icon = visibility_slot_el->AppendChild(std::move(vis_icon));
-
             auto training_slot = doc->CreateElement("span");
             training_slot->SetClass("row-action-slot", true);
             training_slot->SetClass("training-action-slot", true);
@@ -744,6 +736,14 @@ namespace lfs::vis::gui {
             auto mixed_mark = doc->CreateElement("span");
             mixed_mark->SetClass("training-mixed-mark", true);
             slot.training_mixed_mark = training_slot_el->AppendChild(std::move(mixed_mark));
+
+            auto visibility_slot = doc->CreateElement("span");
+            visibility_slot->SetClass("row-action-slot", true);
+            auto* visibility_slot_el = actions_el->AppendChild(std::move(visibility_slot));
+            auto vis_icon = doc->CreateElement("img");
+            vis_icon->SetClass("row-icon", true);
+            vis_icon->SetAttribute("data-action", "toggle-vis");
+            slot.vis_icon = visibility_slot_el->AppendChild(std::move(vis_icon));
 
             auto delete_slot = doc->CreateElement("span");
             delete_slot->SetClass("row-action-slot", true);

--- a/src/visualizer/gui/rmlui/resources/scene_tree.rml
+++ b/src/visualizer/gui/rmlui/resources/scene_tree.rml
@@ -40,10 +40,10 @@
             <button id="selection-clear" class="selection-action-button" type="button"
                     data-tooltip="scene.clear_selection"><img id="selection-clear-icon" /></button>
             <span class="selection-action-spacer"></span>
-            <button id="selection-visibility" class="selection-action-button" type="button"
-                    data-tooltip="scene.hide_selected"><img id="selection-visibility-icon" /></button>
             <button id="selection-training" class="selection-action-button" type="button"
                     data-tooltip="scene.disable_for_training"><img id="selection-training-icon" /></button>
+            <button id="selection-visibility" class="selection-action-button" type="button"
+                    data-tooltip="scene.hide_selected"><img id="selection-visibility-icon" /></button>
             <button id="selection-delete" class="selection-action-button selection-action-delete" type="button"
                     data-tooltip="scene.delete"><img id="selection-delete-icon" /></button>
         </div>

--- a/tests/python/test_menubar_resources.py
+++ b/tests/python/test_menubar_resources.py
@@ -514,7 +514,8 @@ def test_scene_tree_multi_selection_actions_are_fixed_below_the_scroll_view():
     spacer_pos = scene_rml.index('class="selection-action-spacer"')
     training_pos = scene_rml.index('id="selection-training"')
     visibility_pos = scene_rml.index('id="selection-visibility"')
-    assert count_pos < clear_pos < spacer_pos < training_pos < visibility_pos
+    delete_pos = scene_rml.index('id="selection-delete"')
+    assert count_pos < clear_pos < spacer_pos < training_pos < visibility_pos < delete_pos
     action_rule = _rule_body(scene_rcss, ".selection-action-bar")
     assert "flex-shrink: 0;" in action_rule
     assert "height: 27dp;" in action_rule

--- a/tests/python/test_menubar_resources.py
+++ b/tests/python/test_menubar_resources.py
@@ -275,7 +275,7 @@ def test_scene_tree_aligns_hierarchy_and_keeps_row_actions_trailing():
         'training_toggle_icon->SetAttribute("data-action", "toggle-training")'
     )
     delete = scene_graph_cpp.index('trash_icon->SetAttribute("data-action", "delete")')
-    assert checkbox < expand < name < visibility < training_toggle < delete
+    assert checkbox < expand < name < training_toggle < visibility < delete
     assert 'actions->SetClass("row-actions", true)' in scene_graph_cpp
     assert scene_graph_cpp.count('SetClass("row-action-slot", true)') == 3
     row_actions_rule = _rule_body(scene_rcss, ".row-actions")
@@ -512,8 +512,9 @@ def test_scene_tree_multi_selection_actions_are_fixed_below_the_scroll_view():
     count_pos = scene_rml.index('id="selection-action-count"')
     clear_pos = scene_rml.index('id="selection-clear"')
     spacer_pos = scene_rml.index('class="selection-action-spacer"')
+    training_pos = scene_rml.index('id="selection-training"')
     visibility_pos = scene_rml.index('id="selection-visibility"')
-    assert count_pos < clear_pos < spacer_pos < visibility_pos
+    assert count_pos < clear_pos < spacer_pos < training_pos < visibility_pos
     action_rule = _rule_body(scene_rcss, ".selection-action-bar")
     assert "flex-shrink: 0;" in action_rule
     assert "height: 27dp;" in action_rule


### PR DESCRIPTION
In the scene tree the eye and the bin are almost always there, while the lock only shows for trainable nodes. With the lock in the middle, rows without a lock left a gap and the eye sat in a different place than in the footer bar.

The order is now lock, eye, bin in both the rows and the footer bar.

Checked: scene tree resource tests, on screen with a loaded PLY.