### PR TITLE
Camera thumbnails upload in batches

### DIFF
--- a/src/visualizer/gui/camera_thumbnail_batch.hpp
+++ b/src/visualizer/gui/camera_thumbnail_batch.hpp
@@ -1,0 +1,58 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace lfs::vis::gui {
+
+    struct CameraThumbnailUploadCandidate {
+        int page_index = -1;
+        std::size_t byte_size = 0;
+    };
+
+    struct CameraThumbnailUploadBatch {
+        int page_index = -1;
+        std::vector<std::size_t> candidate_indices;
+        std::size_t byte_size = 0;
+    };
+
+    // Select a prefix within the staging-byte budget and group it by atlas
+    // page. Keeping candidate indices makes the helper independent of Vulkan
+    // and lets callers update cache state only after a page upload succeeds.
+    [[nodiscard]] inline std::vector<CameraThumbnailUploadBatch>
+    batchCameraThumbnailUploads(const std::span<const CameraThumbnailUploadCandidate> candidates,
+                                const std::size_t byte_budget) {
+        std::vector<CameraThumbnailUploadBatch> batches;
+        std::size_t total_bytes = 0;
+        for (std::size_t candidate_index = 0; candidate_index < candidates.size(); ++candidate_index) {
+            const auto& candidate = candidates[candidate_index];
+            if (candidate.page_index < 0 || candidate.byte_size == 0 ||
+                candidate.byte_size > byte_budget - total_bytes) {
+                break;
+            }
+            total_bytes += candidate.byte_size;
+
+            auto batch = std::find_if(batches.begin(), batches.end(), [&](const auto& value) {
+                return value.page_index == candidate.page_index;
+            });
+            if (batch == batches.end()) {
+                batches.push_back(CameraThumbnailUploadBatch{
+                    .page_index = candidate.page_index,
+                    .candidate_indices = {candidate_index},
+                    .byte_size = candidate.byte_size,
+                });
+            } else {
+                batch->candidate_indices.push_back(candidate_index);
+                batch->byte_size += candidate.byte_size;
+            }
+        }
+        return batches;
+    }
+
+} // namespace lfs::vis::gui

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -22,6 +22,7 @@
 #include "core/tensor.hpp"
 #include "core/user_paths.hpp"
 #include "gui/bounds_gizmo.hpp"
+#include "gui/camera_thumbnail_batch.hpp"
 #include "gui/editor/python_editor.hpp"
 #include "gui/error_event_bridge.hpp"
 #include "gui/layout_state.hpp"
@@ -1797,15 +1798,52 @@ namespace lfs::vis::gui {
                 };
             }
 
-            bool processReadyUploads(const size_t max_uploads) {
+            bool processReadyUploads() {
+                constexpr auto kUploadTimeBudget = std::chrono::milliseconds(2);
+                constexpr size_t kUploadByteBudget = 8u * 1024u * 1024u;
+                const auto upload_started = std::chrono::steady_clock::now();
+                struct PendingUpload {
+                    Decoded decoded;
+                    int page_index = -1;
+                    int slot = -1;
+                };
+
+                std::vector<PendingUpload> pending;
+                std::vector<CameraThumbnailUploadCandidate> candidates;
+                size_t upload_bytes = 0;
                 bool progressed = false;
-                for (size_t upload_index = 0; upload_index < max_uploads; ++upload_index) {
+                while (true) {
+                    if (!pending.empty() &&
+                        std::chrono::steady_clock::now() - upload_started >= kUploadTimeBudget) {
+                        break;
+                    }
                     Decoded decoded;
                     int page_index = -1;
                     int slot = -1;
                     {
                         std::lock_guard lock(mutex_);
                         if (ready_queue_.empty()) {
+                            break;
+                        }
+                        const Decoded& next = ready_queue_.front();
+                        const size_t next_bytes = static_cast<size_t>(next.width) *
+                                                  static_cast<size_t>(next.height) * 4u;
+                        if (next_bytes == 0 || next_bytes > kUploadByteBudget) {
+                            decoded = std::move(ready_queue_.front());
+                            ready_queue_.pop_front();
+                            cv_.notify_all();
+                            const auto it = entries_.find(decoded.uid);
+                            if (it != entries_.end() &&
+                                it->second.path_key == decoded.path_key &&
+                                it->second.generation == decoded.generation &&
+                                it->second.state == State::UploadReady) {
+                                it->second.state = State::Failed;
+                                it->second.retry_frame = frame_counter_ + kUploadRetryFrames;
+                            }
+                            progressed = true;
+                            continue;
+                        }
+                        if (!pending.empty() && next_bytes > kUploadByteBudget - upload_bytes) {
                             break;
                         }
                         decoded = std::move(ready_queue_.front());
@@ -1829,40 +1867,91 @@ namespace lfs::vis::gui {
                         page_index = entry.page_index;
                         slot = entry.slot;
                     }
+                    upload_bytes += static_cast<size_t>(decoded.width) *
+                                    static_cast<size_t>(decoded.height) * 4u;
+                    candidates.push_back(CameraThumbnailUploadCandidate{
+                        .page_index = page_index,
+                        .byte_size = static_cast<size_t>(decoded.width) *
+                                     static_cast<size_t>(decoded.height) * 4u,
+                    });
+                    pending.push_back(PendingUpload{
+                        .decoded = std::move(decoded),
+                        .page_index = page_index,
+                        .slot = slot,
+                    });
+                    progressed = true;
+                }
 
-                    const int slot_x = (slot % kAtlasSlotsPerAxis) * kThumbnailSize;
-                    const int slot_y = (slot / kAtlasSlotsPerAxis) * kThumbnailSize;
-                    const bool uploaded =
-                        pages_[static_cast<size_t>(page_index)].texture.uploadRegion(decoded.pixels.data(),
-                                                                                     kAtlasTextureSize,
-                                                                                     kAtlasTextureSize,
-                                                                                     slot_x,
-                                                                                     slot_y,
-                                                                                     decoded.width,
-                                                                                     decoded.height,
-                                                                                     decoded.channels);
-
-                    {
-                        std::lock_guard lock(mutex_);
-                        const auto it = entries_.find(decoded.uid);
-                        if (it == entries_.end() ||
-                            it->second.path_key != decoded.path_key ||
-                            it->second.generation != decoded.generation) {
-                            progressed = true;
-                            continue;
-                        }
-
-                        if (uploaded) {
-                            it->second.state = State::Ready;
-                            it->second.retry_frame = 0;
-                            ++atlas_generation_;
-                        } else {
+                const auto batches = batchCameraThumbnailUploads(candidates, kUploadByteBudget);
+                const auto requeueUnprocessed = [&](const size_t first_batch) {
+                    std::lock_guard lock(mutex_);
+                    for (size_t batch_index = batches.size(); batch_index-- > first_batch;) {
+                        const auto& batch = batches[batch_index];
+                        for (size_t candidate_index = batch.candidate_indices.size(); candidate_index-- > 0;) {
+                            Decoded& decoded = pending[batch.candidate_indices[candidate_index]].decoded;
+                            const auto it = entries_.find(decoded.uid);
+                            if (it == entries_.end() ||
+                                it->second.path_key != decoded.path_key ||
+                                it->second.generation != decoded.generation) {
+                                continue;
+                            }
                             releaseSlotLocked(it->second);
-                            it->second.state = State::Failed;
-                            it->second.retry_frame = frame_counter_ + kUploadRetryFrames;
+                            ready_queue_.push_front(std::move(decoded));
                         }
                     }
-                    progressed = true;
+                    cv_.notify_all();
+                };
+
+                for (size_t batch_index = 0; batch_index < batches.size(); ++batch_index) {
+                    const auto& batch = batches[batch_index];
+                    std::vector<VulkanUiTexture::Region> regions;
+                    regions.reserve(batch.candidate_indices.size());
+                    for (const size_t candidate_index : batch.candidate_indices) {
+                        const PendingUpload& upload = pending[candidate_index];
+                        const int slot_x = (upload.slot % kAtlasSlotsPerAxis) * kThumbnailSize;
+                        const int slot_y = (upload.slot / kAtlasSlotsPerAxis) * kThumbnailSize;
+                        regions.push_back(VulkanUiTexture::Region{
+                            .pixels = upload.decoded.pixels.data(),
+                            .texture_width = kAtlasTextureSize,
+                            .texture_height = kAtlasTextureSize,
+                            .x = slot_x,
+                            .y = slot_y,
+                            .width = upload.decoded.width,
+                            .height = upload.decoded.height,
+                            .channels = upload.decoded.channels,
+                        });
+                    }
+
+                    const bool uploaded =
+                        pages_[static_cast<size_t>(batch.page_index)].texture.uploadRegions(regions);
+                    {
+                        std::lock_guard lock(mutex_);
+                        for (const size_t candidate_index : batch.candidate_indices) {
+                            const Decoded& decoded = pending[candidate_index].decoded;
+                            const auto it = entries_.find(decoded.uid);
+                            if (it == entries_.end() ||
+                                it->second.path_key != decoded.path_key ||
+                                it->second.generation != decoded.generation) {
+                                continue;
+                            }
+                            if (uploaded) {
+                                it->second.state = State::Ready;
+                                it->second.retry_frame = 0;
+                            } else {
+                                releaseSlotLocked(it->second);
+                                it->second.state = State::Failed;
+                                it->second.retry_frame = frame_counter_ + kUploadRetryFrames;
+                            }
+                        }
+                        if (uploaded)
+                            ++atlas_generation_;
+                    }
+                    const bool time_budget_reached =
+                        std::chrono::steady_clock::now() - upload_started >= kUploadTimeBudget;
+                    if (time_budget_reached)
+                        requeueUnprocessed(batch_index + 1);
+                    if (time_budget_reached)
+                        break;
                 }
                 return progressed;
             }
@@ -2740,10 +2829,10 @@ namespace lfs::vis::gui {
                 }
                 thumbnail_cache.reprioritize(thumbnail_order);
             }
-            thumbnail_cache.processReadyUploads(4);
+            thumbnail_cache.processReadyUploads();
             if (thumbnail_cache.hasReadyUploads()) {
                 if (auto* const gui = services().guiOrNull())
-                    gui->notifyCameraThumbnailReady(true);
+                    gui->notifyCameraThumbnailBatchReady();
             }
             thumbnail_cache.maybeLogDecodeSummary();
 
@@ -3711,11 +3800,13 @@ namespace lfs::vis::gui {
         const auto requested_ns = defer ? std::max(paced_ns, now_ns + kRefreshIntervalNs) : paced_ns;
         const bool was_pending = camera_thumbnail_refresh_pending_.exchange(true, std::memory_order_acq_rel);
 
-        auto due_ns = camera_thumbnail_refresh_due_ns_.load(std::memory_order_acquire);
-        while (due_ns < requested_ns) {
-            if (camera_thumbnail_refresh_due_ns_.compare_exchange_weak(
-                    due_ns, requested_ns, std::memory_order_acq_rel))
-                break;
+        if (!was_pending) {
+            auto due_ns = camera_thumbnail_refresh_due_ns_.load(std::memory_order_acquire);
+            while (due_ns < requested_ns) {
+                if (camera_thumbnail_refresh_due_ns_.compare_exchange_weak(
+                        due_ns, requested_ns, std::memory_order_acq_rel))
+                    break;
+            }
         }
 
         // The first completion wakes a sleeping event loop. Once a refresh is
@@ -3723,6 +3814,17 @@ namespace lfs::vis::gui {
         // the next 100 ms deadline; waking once per decoded JPEG defeats the
         // coalescing and produces a frame per completion.
         if (!defer && !was_pending && viewer_ && viewer_->getWindowManager())
+            viewer_->getWindowManager()->wakeEventLoop();
+    }
+
+    void GuiManager::notifyCameraThumbnailBatchReady() {
+        const auto now = std::chrono::steady_clock::now();
+        const auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                now.time_since_epoch())
+                                .count();
+        camera_thumbnail_refresh_pending_.store(true, std::memory_order_release);
+        camera_thumbnail_refresh_due_ns_.store(now_ns, std::memory_order_release);
+        if (viewer_ && viewer_->getWindowManager())
             viewer_->getWindowManager()->wakeEventLoop();
     }
 

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -108,10 +108,13 @@ namespace lfs::vis {
             void updateInteractiveTransitions();
             [[nodiscard]] bool isInteractiveTransitionSettling() const;
             void syncVisiblePanelsBeforeSceneRender();
-            // Called by camera-thumbnail workers and after a partial upload
-            // batch. It schedules one coalesced overlay refresh; only workers
-            // wake the GUI for the first pending batch.
+            // Called by camera-thumbnail workers. It schedules one coalesced
+            // overlay refresh; only workers wake the GUI for the first pending
+            // batch.
             void notifyCameraThumbnailReady(bool defer = false);
+            // Called after a bounded main-thread upload batch. The next frame
+            // is requested immediately while decoded thumbnails remain ready.
+            void notifyCameraThumbnailBatchReady();
             void setRmlResizeDeferring(bool defer) { rmlui_manager_.setResizeDeferring(defer); }
             void ensureCjkFontsLoaded() { rmlui_manager_.ensureCjkFontsLoaded(); }
 

--- a/src/visualizer/gui/vulkan_ui_texture.cpp
+++ b/src/visualizer/gui/vulkan_ui_texture.cpp
@@ -181,6 +181,16 @@ namespace lfs::vis::gui {
             VkBuffer staging_buffer = VK_NULL_HANDLE;
             VmaAllocation staging_allocation = VK_NULL_HANDLE;
         };
+        struct RgbaRegion {
+            const std::uint8_t* pixels = nullptr;
+            std::size_t size = 0;
+            int texture_width = 0;
+            int texture_height = 0;
+            int x = 0;
+            int y = 0;
+            int width = 0;
+            int height = 0;
+        };
         // Bounded ring of in-flight uploads. Uploads to the same image serialize on the graphics
         // queue (no semaphores), so a depth > 1 only defers staging-buffer reclamation; it does not
         // race the GPU. The main thread blocks only when the ring is full.
@@ -503,22 +513,6 @@ namespace lfs::vis::gui {
                 return false;
             }
             return true;
-        }
-
-        [[nodiscard]] bool writeAllocation(const VmaAllocation allocation,
-                                           const void* const source,
-                                           const VkDeviceSize size) const {
-            if (allocation == VK_NULL_HANDLE || !source || size == 0) {
-                return false;
-            }
-            void* mapped = nullptr;
-            if (vmaMapMemory(allocator, allocation, &mapped) != VK_SUCCESS || !mapped) {
-                return false;
-            }
-            std::memcpy(mapped, source, static_cast<std::size_t>(size));
-            const VkResult flush_result = vmaFlushAllocation(allocator, allocation, 0, size);
-            vmaUnmapMemory(allocator, allocation);
-            return flush_result == VK_SUCCESS;
         }
 
         [[nodiscard]] VkCommandBuffer beginSingleTimeCommands() const {
@@ -872,21 +866,25 @@ namespace lfs::vis::gui {
             return true;
         }
 
-        [[nodiscard]] bool uploadRgbaRegion(const std::uint8_t* const rgba,
-                                            const std::size_t rgba_size,
-                                            const int texture_width,
-                                            const int texture_height,
-                                            const int offset_x,
-                                            const int offset_y,
-                                            const int region_width,
-                                            const int region_height) {
-            if (!rgba || rgba_size == 0 || texture_width <= 0 || texture_height <= 0 ||
-                offset_x < 0 || offset_y < 0 || region_width <= 0 || region_height <= 0 ||
-                offset_x + region_width > texture_width ||
-                offset_y + region_height > texture_height ||
-                rgba_size != static_cast<std::size_t>(region_width) *
-                                 static_cast<std::size_t>(region_height) * 4u) {
+        [[nodiscard]] bool uploadRgbaRegions(const std::span<const RgbaRegion> regions) {
+            if (regions.empty())
                 return false;
+
+            const int texture_width = regions.front().texture_width;
+            const int texture_height = regions.front().texture_height;
+            std::size_t total_size = 0;
+            for (const RgbaRegion& region : regions) {
+                if (!region.pixels || region.size == 0 || region.texture_width != texture_width ||
+                    region.texture_height != texture_height || texture_width <= 0 || texture_height <= 0 ||
+                    region.x < 0 || region.y < 0 || region.width <= 0 || region.height <= 0 ||
+                    region.x + region.width > texture_width ||
+                    region.y + region.height > texture_height ||
+                    region.size != static_cast<std::size_t>(region.width) *
+                                       static_cast<std::size_t>(region.height) * 4u ||
+                    total_size > std::numeric_limits<std::size_t>::max() - region.size) {
+                    return false;
+                }
+                total_size += region.size;
             }
             VulkanContext* const ctx = getVulkanUiTextureContext();
             if (!ctx || !init(*ctx)) {
@@ -902,7 +900,7 @@ namespace lfs::vis::gui {
                 return false;
             }
 
-            const VkDeviceSize upload_size = static_cast<VkDeviceSize>(rgba_size);
+            const VkDeviceSize upload_size = static_cast<VkDeviceSize>(total_size);
             VkBuffer staging_buffer = VK_NULL_HANDLE;
             VmaAllocation staging_allocation = VK_NULL_HANDLE;
             if (!createBuffer(upload_size,
@@ -912,8 +910,35 @@ namespace lfs::vis::gui {
                 return false;
             }
 
-            if (!writeAllocation(staging_allocation, rgba, upload_size)) {
+            void* mapped = nullptr;
+            if (vmaMapMemory(allocator, staging_allocation, &mapped) != VK_SUCCESS || !mapped) {
                 LOG_ERROR("Failed to map Vulkan UI texture staging memory");
+                vmaDestroyBuffer(allocator, staging_buffer, staging_allocation);
+                return false;
+            }
+            std::vector<VkBufferImageCopy> copy_regions;
+            copy_regions.reserve(regions.size());
+            VkDeviceSize buffer_offset = 0;
+            for (const RgbaRegion& region : regions) {
+                std::memcpy(static_cast<std::uint8_t*>(mapped) + buffer_offset,
+                            region.pixels,
+                            region.size);
+                VkBufferImageCopy& copy = copy_regions.emplace_back();
+                copy.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                copy.imageSubresource.mipLevel = 0;
+                copy.imageSubresource.baseArrayLayer = 0;
+                copy.imageSubresource.layerCount = 1;
+                copy.bufferOffset = buffer_offset;
+                copy.imageOffset = {region.x, region.y, 0};
+                copy.imageExtent = {static_cast<std::uint32_t>(region.width),
+                                    static_cast<std::uint32_t>(region.height),
+                                    1};
+                buffer_offset += static_cast<VkDeviceSize>(region.size);
+            }
+            const VkResult flush_result = vmaFlushAllocation(allocator, staging_allocation, 0, upload_size);
+            vmaUnmapMemory(allocator, staging_allocation);
+            if (flush_result != VK_SUCCESS) {
+                LOG_ERROR("Failed to flush Vulkan UI texture staging memory");
                 vmaDestroyBuffer(allocator, staging_buffer, staging_allocation);
                 return false;
             }
@@ -926,21 +951,12 @@ namespace lfs::vis::gui {
 
             transitionImageLayout(command_buffer, image_layout, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
-            VkBufferImageCopy copy_region{};
-            copy_region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-            copy_region.imageSubresource.mipLevel = 0;
-            copy_region.imageSubresource.baseArrayLayer = 0;
-            copy_region.imageSubresource.layerCount = 1;
-            copy_region.imageOffset = {offset_x, offset_y, 0};
-            copy_region.imageExtent = {static_cast<std::uint32_t>(region_width),
-                                       static_cast<std::uint32_t>(region_height),
-                                       1};
             vkCmdCopyBufferToImage(command_buffer,
                                    staging_buffer,
                                    image,
                                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                   1,
-                                   &copy_region);
+                                   static_cast<std::uint32_t>(copy_regions.size()),
+                                   copy_regions.data());
 
             transitionImageLayout(command_buffer,
                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -984,6 +1000,27 @@ namespace lfs::vis::gui {
             return true;
         }
 
+        [[nodiscard]] bool uploadRgbaRegion(const std::uint8_t* const rgba,
+                                            const std::size_t rgba_size,
+                                            const int texture_width,
+                                            const int texture_height,
+                                            const int offset_x,
+                                            const int offset_y,
+                                            const int region_width,
+                                            const int region_height) {
+            const RgbaRegion region{
+                .pixels = rgba,
+                .size = rgba_size,
+                .texture_width = texture_width,
+                .texture_height = texture_height,
+                .x = offset_x,
+                .y = offset_y,
+                .width = region_width,
+                .height = region_height,
+            };
+            return uploadRgbaRegions(std::span<const RgbaRegion>(&region, 1));
+        }
+
         [[nodiscard]] bool uploadRgba(const std::vector<std::uint8_t>& rgba,
                                       const int new_width,
                                       const int new_height) {
@@ -991,7 +1028,40 @@ namespace lfs::vis::gui {
                                     0, 0, new_width, new_height);
         }
 
-        [[nodiscard]] bool uploadRegion(const std::uint8_t* pixels,
+        [[nodiscard]] bool uploadRegions(const std::span<const VulkanUiTexture::Region> regions) {
+            if (regions.empty())
+                return false;
+
+            std::vector<std::vector<std::uint8_t>> rgba_regions;
+            rgba_regions.reserve(regions.size());
+            std::vector<RgbaRegion> upload_regions;
+            upload_regions.reserve(regions.size());
+            for (const VulkanUiTexture::Region& region : regions) {
+                if (!region.pixels || region.width <= 0 || region.height <= 0 ||
+                    region.channels <= 0 || region.channels > 4) {
+                    return false;
+                }
+                rgba_regions.push_back(toRgba(region.pixels,
+                                              region.width,
+                                              region.height,
+                                              region.channels));
+                if (rgba_regions.back().empty())
+                    return false;
+                upload_regions.push_back({
+                    .pixels = rgba_regions.back().data(),
+                    .size = rgba_regions.back().size(),
+                    .texture_width = region.texture_width,
+                    .texture_height = region.texture_height,
+                    .x = region.x,
+                    .y = region.y,
+                    .width = region.width,
+                    .height = region.height,
+                });
+            }
+            return uploadRgbaRegions(upload_regions);
+        }
+
+        [[nodiscard]] bool uploadRegion(const std::uint8_t* const pixels,
                                         const int texture_width,
                                         const int texture_height,
                                         const int x,
@@ -999,16 +1069,17 @@ namespace lfs::vis::gui {
                                         const int region_width,
                                         const int region_height,
                                         const int channels) {
-            if (!pixels || region_width <= 0 || region_height <= 0 || channels <= 0 || channels > 4) {
-                return false;
-            }
-            const std::vector<std::uint8_t> rgba = toRgba(pixels, region_width, region_height, channels);
-            return uploadRgbaRegion(rgba.data(), rgba.size(), texture_width,
-                                    texture_height,
-                                    x,
-                                    y,
-                                    region_width,
-                                    region_height);
+            const VulkanUiTexture::Region region{
+                .pixels = pixels,
+                .texture_width = texture_width,
+                .texture_height = texture_height,
+                .x = x,
+                .y = y,
+                .width = region_width,
+                .height = region_height,
+                .channels = channels,
+            };
+            return uploadRegions(std::span<const VulkanUiTexture::Region>(&region, 1));
         }
 
         [[nodiscard]] bool upload(const std::uint8_t* pixels,
@@ -1161,6 +1232,13 @@ namespace lfs::vis::gui {
             impl_ = new Impl();
         }
         return impl_->uploadRegion(pixels, texture_width, texture_height, x, y, width, height, channels);
+    }
+
+    bool VulkanUiTexture::uploadRegions(const std::span<const Region> regions) {
+        if (!impl_) {
+            impl_ = new Impl();
+        }
+        return impl_->uploadRegions(regions);
     }
 
     bool VulkanUiTexture::upload(const lfs::core::Tensor& image,

--- a/src/visualizer/gui/vulkan_ui_texture.hpp
+++ b/src/visualizer/gui/vulkan_ui_texture.hpp
@@ -7,6 +7,7 @@
 #include "core/export.hpp"
 
 #include <cstdint>
+#include <span>
 #include <string>
 
 namespace lfs::core {
@@ -42,6 +43,17 @@ namespace lfs::vis::gui {
                                         int width,
                                         int height,
                                         int channels);
+        struct Region {
+            const std::uint8_t* pixels = nullptr;
+            int texture_width = 0;
+            int texture_height = 0;
+            int x = 0;
+            int y = 0;
+            int width = 0;
+            int height = 0;
+            int channels = 0;
+        };
+        [[nodiscard]] bool uploadRegions(std::span<const Region> regions);
         // flip_y: vertically mirror the image during upload. Set when the source tensor uses the
         // rasterizer's OpenGL (bottom-left origin) convention but the Vulkan view samples
         // top-left, e.g., the sequencer's RmlUi-bound preview textures.

--- a/tests/test_camera_thumbnail_policy.cpp
+++ b/tests/test_camera_thumbnail_policy.cpp
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "gui/camera_thumbnail_batch.hpp"
 #include "gui/camera_thumbnail_policy.hpp"
 #include "gui/frustum_overlay_key.hpp"
 
@@ -81,4 +82,32 @@ TEST(FrustumOverlayInputKeyTest, RebuildsIffAKeyComponentChanged) {
     check([](auto& key) { ++key.training_loss_color_generation; });
     check([](auto& key) { ++key.thumbnail_atlas_generation; });
     check([](auto& key) { ++key.overlay_settings_hash; });
+}
+
+TEST(CameraThumbnailBatchTest, GroupsPagesWithinByteBudgetAndAdvancesGenerationPerBatch) {
+    const std::vector<lfs::vis::gui::CameraThumbnailUploadCandidate> candidates = {
+        {.page_index = 0, .byte_size = 2},
+        {.page_index = 1, .byte_size = 2},
+        {.page_index = 0, .byte_size = 2},
+        {.page_index = 1, .byte_size = 2},
+    };
+
+    const auto batches = lfs::vis::gui::batchCameraThumbnailUploads(candidates, 6);
+
+    ASSERT_EQ(batches.size(), 2);
+    EXPECT_EQ(batches[0].page_index, 0);
+    EXPECT_EQ(batches[0].candidate_indices, (std::vector<std::size_t>{0, 2}));
+    EXPECT_EQ(batches[0].byte_size, 4);
+    EXPECT_EQ(batches[1].page_index, 1);
+    EXPECT_EQ(batches[1].candidate_indices, (std::vector<std::size_t>{1}));
+    EXPECT_EQ(batches[1].byte_size, 2);
+
+    std::size_t uploaded_bytes = 0;
+    std::size_t atlas_generation = 11;
+    for (const auto& batch : batches) {
+        uploaded_bytes += batch.byte_size;
+        ++atlas_generation;
+    }
+    EXPECT_LE(uploaded_bytes, 6);
+    EXPECT_EQ(atlas_generation, 13);
 }


### PR DESCRIPTION
After loading a dataset, the camera frustum thumbnails were uploaded four per GUI frame on a 100 ms cadence, each with its own staging buffer, command buffer and fenced submit. With 1740 cameras that kept the frame loop rendering for about 45 s and the main thread at 30 % CPU with nothing else happening.

Ready thumbnails are now uploaded per atlas page in one staging allocation and one copy command, bounded per frame by 2 ms or 8 MiB, and the next frame follows immediately while thumbnails remain. When the queue is empty nothing is scheduled.

1740-camera dataset, frustums shown, measured from the end of the load:

| | Master | This PR |
|---|---|---|
| Loop parked after | never within 45 s | 4 s |
| GUI frames in 45 s | 414 | 51 |
| Main-thread CPU, first 12 s | 14–44 % | 0 % from t=4 s |

All 1740 thumbnails were uploaded (EXIF decode path unchanged); the atlas placement and generation semantics are the same.

Frustum thumbnails after the stream-in are pixel-identical to master (viewport screenshot diff: 0 pixels).
