### PR TITLE
Panel layout test advances the scene generation before a poll flip

### DIFF
--- a/tests/test_panel_layout_render_demand.cpp
+++ b/tests/test_panel_layout_render_demand.cpp
@@ -193,6 +193,7 @@ TEST_F(PanelLayoutRenderDemandTest, PollFalsePanelIsNotVisibleAndPollFlipDoesNot
     ASSERT_EQ(layout.bottomDockTabs().size(), 1);
     EXPECT_EQ(layout.getBottomDockActiveTab(), "test.bottom.poll.first");
     hidden->setPollResult(true);
+    ++draw_ctx.scene_generation;
     layout.renderBottomDock(draw_ctx, true, false, input, screen());
 
     ASSERT_EQ(layout.bottomDockTabs().size(), 2);


### PR DESCRIPTION
The bottom-dock poll test failed on master after the panels it registers became non-native. Non-native panels answer polls from the registry cache, which is keyed on the scene generation, so flipping the poll result without a scene change kept returning the cached value.

The test now advances the draw context's scene generation before the second pass, the same way a real poll flip arrives with a scene change. No production code changed.

Checked: all 34 panel layout and registry gtests pass.