### PR TITLE
Frame pacing: wait for the frame slot before reading input

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -5441,13 +5441,13 @@ namespace lfs::vis::gui {
         return guard_active && !ui_resize_ready;
     }
 
-    void GuiManager::render() {
+    bool GuiManager::render() {
         auto* window_manager = viewer_ ? viewer_->getWindowManager() : nullptr;
 
         auto* vulkan_context = (vulkan_gui_ && window_manager) ? window_manager->getVulkanContext() : nullptr;
         if (vulkan_gui_ && !vulkan_context) {
             updateInteractiveTransitionGuard();
-            return;
+            return false;
         }
 
         if (first_render_completed_ && deferred_startup_work_pending_) {
@@ -5464,6 +5464,7 @@ namespace lfs::vis::gui {
         }
 
         std::optional<::lfs::core::ScopedTimer> cpu_ui_before_vulkan_timer;
+        bool presented = false;
         if (vulkan_gui_) {
             cpu_ui_before_vulkan_timer.emplace("gui_render.cpu_ui_before_vulkan_begin",
                                                ::lfs::core::LogLevel::Performance,
@@ -6920,7 +6921,8 @@ namespace lfs::vis::gui {
                 // the active frame before returning its readback.
                 if (vulkan_context->hasActiveFrame()) {
                     LOG_TIMER("frame_pacing.vulkan_endFrame_present");
-                    if (!vulkan_context->endFrame()) {
+                    presented = vulkan_context->endFrame();
+                    if (!presented) {
                         LOG_WARN("Vulkan GUI frame present failed: {}", vulkan_context->lastError());
                     }
                 }
@@ -6950,7 +6952,7 @@ namespace lfs::vis::gui {
                 if (auto* const rendering = viewer_ ? viewer_->getRenderingManager() : nullptr)
                     rendering->markDirty(DirtyFlag::OVERLAY);
             }
-            return;
+            return presented;
         }
 
         if (!vulkan_gui_ && viewer_) {
@@ -6962,6 +6964,7 @@ namespace lfs::vis::gui {
             if (auto* const rendering = viewer_ ? viewer_->getRenderingManager() : nullptr)
                 rendering->markDirty(DirtyFlag::OVERLAY);
         }
+        return false;
     }
 
     void GuiManager::renderSelectionOverlays(const UIContext& ctx) {

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -105,7 +105,7 @@ namespace lfs::vis {
             // Drop viewport-pass GPU objects (descriptor sets that sample external
             // scene image views) while the Vulkan context is still alive.
             void shutdownVulkanViewportPass();
-            void render();
+            [[nodiscard]] bool render();
             void updateInteractiveTransitions();
             [[nodiscard]] bool isInteractiveTransitionSettling() const;
             void syncVisiblePanelsBeforeSceneRender();

--- a/src/visualizer/gui/rmlui/rml_panel_host.cpp
+++ b/src/visualizer/gui/rmlui/rml_panel_host.cpp
@@ -977,8 +977,8 @@ namespace lfs::vis::gui {
         if (clip_x2 <= clip_x1 || clip_y2 <= clip_y1)
             return;
 
-        const float screen_x = x - input_->screen_x - padding;
-        const float screen_y = y - input_->screen_y - padding;
+        const float screen_x = std::round(x - input_->screen_x - padding);
+        const float screen_y = std::round(y - input_->screen_y - padding);
         const float screen_clip_x1 = clip_x1 - input_->screen_x;
         const float screen_clip_y1 = clip_y1 - input_->screen_y;
         const float screen_clip_x2 = clip_x2 - input_->screen_x;

--- a/src/visualizer/input/frame_input_buffer.hpp
+++ b/src/visualizer/input/frame_input_buffer.hpp
@@ -9,6 +9,7 @@
 #include <SDL3/SDL_mouse.h>
 #include <SDL3/SDL_video.h>
 #include <cassert>
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -48,6 +49,7 @@ namespace lfs::vis {
         SDL_Keymod key_mods = SDL_KMOD_NONE;
         int window_w = 0;
         int window_h = 0;
+        std::chrono::steady_clock::time_point poll_time{};
 
         void beginFrame() {
             mouse_clicked[0] = mouse_clicked[1] = mouse_clicked[2] = false;
@@ -134,6 +136,7 @@ namespace lfs::vis {
 
         void finalize(SDL_Window* window) {
             assert(window);
+            poll_time = std::chrono::steady_clock::now();
             const SDL_MouseButtonFlags buttons = SDL_GetMouseState(&mouse_x, &mouse_y);
             mouse_down[0] = (buttons & SDL_BUTTON_LMASK) != 0;
             mouse_down[1] = (buttons & SDL_BUTTON_RMASK) != 0;

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -2608,15 +2608,16 @@ namespace lfs::vis {
                       frame_demand.render_work,
                       frame_demand.store_dirty);
         }
+        bool presented_gui_frame = false;
         if (gui_manager_) {
             LOG_TIMER("VisualizerImpl::render.gui_frame_total_with_swapchain_wait");
             window_manager_->updateWindowSize("pre_gui_render");
-            gui_manager_->render();
+            presented_gui_frame = gui_manager_->render();
             window_manager_->refreshResizeCursor();
             // Count presented frames (GUI-only included). Scene FPS still comes
             // from framerate_controller_ inside renderVulkanFrame; this is
             // measurement-only and does not affect pacing.
-            if (rendering_manager_) {
+            if (presented_gui_frame && rendering_manager_) {
                 rendering_manager_->notePresentedFrame();
             }
         } else {
@@ -2677,8 +2678,15 @@ namespace lfs::vis {
 
         const auto py_redraw_due = python::seconds_until_scheduled_redraw();
         const double py_redraw_due_in = py_redraw_due ? *py_redraw_due : -1.0;
+        const auto poll_time = window_manager_->frameInput().poll_time;
+        const double input_age_ms =
+            poll_time == std::chrono::steady_clock::time_point{}
+                ? 0.0
+                : std::chrono::duration<double, std::milli>(
+                      std::chrono::steady_clock::now() - poll_time)
+                      .count();
 
-        LOG_PERF("loop_end needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} window_resize_paint_pending={} viewport_resize_deferring={} viewport_resize_settle_ready={} gui_only_throttle={} py_redraw_due_in={:.4f} gui_anim_sources={} wake_reason={} wake_timeout_source={}",
+        LOG_PERF("loop_end needs_render={} continuous_input={} py_anim={} py_overlay={} py_redraw={} gui_anim={} input_event={} posted_work={} render_work={} store_dirty={} swapchain_resize_pending={} swapchain_resize_ready={} window_resize_paint_pending={} viewport_resize_deferring={} viewport_resize_settle_ready={} gui_only_throttle={} py_redraw_due_in={:.4f} gui_anim_sources={} wake_reason={} wake_timeout_source={} input_age_ms={:.2f}",
                  next_demand.scene_dirty,
                  next_demand.continuous_input,
                  next_demand.python_animation,
@@ -2698,13 +2706,18 @@ namespace lfs::vis {
                  py_redraw_due_in,
                  gui_manager_ ? gui_manager_->describeAnimationDemand() : std::string{"none"},
                  last_wake_reason_,
-                 last_wake_timeout_source_);
+                 last_wake_timeout_source_,
+                 input_age_ms);
 
         if (next_demand.needsContinuousLoop()) {
             if (gui_only_animation) {
                 // GUI-only animation must not free-run against a MAILBOX swapchain.
                 // Cap at the display interval; waitEvents still wakes instantly on input.
                 const double gui_animation_frame_interval = guiAnimationFrameInterval();
+                if (presented_gui_frame) {
+                    if (auto* const vulkan_context = window_manager_->getVulkanContext())
+                        static_cast<void>(vulkan_context->waitForNextFrameSlot());
+                }
                 const double elapsed = std::chrono::duration<double>(
                                            std::chrono::high_resolution_clock::now() - last_frame_time_)
                                            .count();
@@ -2720,6 +2733,10 @@ namespace lfs::vis {
                                                     : "gui_animation_paced";
                 }
             } else {
+                if (presented_gui_frame) {
+                    if (auto* const vulkan_context = window_manager_->getVulkanContext())
+                        static_cast<void>(vulkan_context->waitForNextFrameSlot());
+                }
                 window_manager_->pollEvents();
                 last_wake_reason_ = window_manager_->frameInput().had_event ? "event" : "poll";
                 last_wake_timeout_source_ = "none";
@@ -2727,6 +2744,10 @@ namespace lfs::vis {
         } else {
             // Idle: wait to minimize CPU/GPU work. Mouse-motion-only viewport wakes
             // are filtered at the top of the next loop without presenting a GUI frame.
+            if (presented_gui_frame) {
+                if (auto* const vulkan_context = window_manager_->getVulkanContext())
+                    static_cast<void>(vulkan_context->waitForNextFrameSlot());
+            }
             waitForNextEvent(is_training);
         }
     }

--- a/src/visualizer/window/vulkan_context.cpp
+++ b/src/visualizer/window/vulkan_context.cpp
@@ -1897,6 +1897,31 @@ namespace lfs::vis {
         return capture;
     }
 
+    bool VulkanContext::waitForNextFrameSlot() {
+        if (device_ == VK_NULL_HANDLE || swapchain_ == VK_NULL_HANDLE ||
+            framebuffer_width_ <= 0 || framebuffer_height_ <= 0 || hasPendingSwapchainResize()) {
+            return true;
+        }
+
+        const std::size_t next_frame = frame_index_;
+        if (next_frame >= in_flight_.size() || next_frame >= frame_submit_serials_.size())
+            return true;
+
+        VkFence frame_fence = in_flight_[next_frame];
+        if (frame_fence == VK_NULL_HANDLE || frame_submit_serials_[next_frame] == 0)
+            return true;
+
+        LOG_TIMER_THRESHOLD("frame_pacing.vulkan_frame_slot_prewait", 0.25);
+        auto outcome = lfs::rendering::wait_fence_bounded(
+            device_, frame_fence, std::stop_token{}, lfs::rendering::VulkanWaitPolicy{},
+            makeWaitContext("vulkan.context.frame_fence"));
+        return mapWaitOutcome(
+            std::move(outcome),
+            std::format("next frame fence (slot {}, last_submit_id={})",
+                        next_frame,
+                        frame_submit_serials_[next_frame]));
+    }
+
     bool VulkanContext::waitForCurrentFrameSlot() {
         if (device_ == VK_NULL_HANDLE) {
             return fail("Cannot wait for Vulkan frame slot before device initialization");

--- a/src/visualizer/window/vulkan_context.hpp
+++ b/src/visualizer/window/vulkan_context.hpp
@@ -275,6 +275,7 @@ namespace lfs::vis {
         [[nodiscard]] bool endFrame();
         [[nodiscard]] bool hasActiveFrame() const noexcept { return frame_active_; }
         [[nodiscard]] LFS_VIS_API std::expected<WindowCapture, std::string> captureAndEndActiveFrameRgba();
+        [[nodiscard]] bool waitForNextFrameSlot();
         [[nodiscard]] bool waitForCurrentFrameSlot();
         [[nodiscard]] bool waitForSubmittedFrames();
         // Serial of the most recent graphics frame submission attempt (pre-incremented


### PR DESCRIPTION
Dragging a floating panel or moving the selection brush trailed the pointer.

The loop polled input, ran all UI logic, and only then blocked about 15 ms on the Vulkan frame fence inside beginFrame. Every frame was built from input that was already a frame old before the GPU started.

Now the loop waits for the next frame slot before it polls input. UI logic runs on fresh input and beginFrame finds its fence signaled. Frame rate is unchanged (still vblank paced) and idle stays idle.

A perf-level probe `input_age_ms` on the loop_end line shows the age of the input snapshot at present time.
