### PR TITLE
Hidden panels no longer keep the frame loop awake

### DIFF
--- a/src/python/lfs/rml_python_panel_adapter.cpp
+++ b/src/python/lfs/rml_python_panel_adapter.cpp
@@ -562,23 +562,40 @@ namespace lfs::vis::gui {
 
     bool RmlPythonPanelAdapter::poll(const PanelDrawContext& ctx) {
         (void)ctx;
-        if (!has_poll_)
+        if (!has_poll_) {
+            poll_visible_ = true;
             return true;
-        if (!lfs::python::can_acquire_gil())
+        }
+        if (!lfs::python::can_acquire_gil()) {
+            poll_visible_ = false;
             return false;
+        }
         if (lfs::python::bridge().prepare_ui)
             lfs::python::bridge().prepare_ui();
 
         const lfs::python::GilAcquire gil;
         try {
-            return nb::cast<bool>(panel_instance_.attr("poll")(lfs::python::get_app_context()));
+            const bool result =
+                nb::cast<bool>(panel_instance_.attr("poll")(lfs::python::get_app_context()));
+            poll_visible_ = result;
+            return result;
         } catch (const std::exception& e) {
             LOG_ERROR("Panel poll error: {}", e.what());
+            poll_visible_ = false;
             return false;
         }
     }
 
+    void RmlPythonPanelAdapter::setPollVisibility(const bool visible) {
+        poll_visible_ = visible;
+    }
+
+    bool RmlPythonPanelAdapter::isVisibleForAnimation() const {
+        return enabled_visible_ && poll_visible_;
+    }
+
     void RmlPythonPanelAdapter::on_visibility_changed(const bool visible) {
+        enabled_visible_ = visible;
         if (visible)
             content_dirty_ = true;
     }
@@ -670,8 +687,9 @@ namespace lfs::vis::gui {
         const auto& ops = lfs::python::get_rml_panel_host_ops();
         if (ops.get_document) {
             auto* doc = static_cast<Rml::ElementDocument*>(ops.get_document(host_));
-            if (lfs::python::is_document_dirty(doc) ||
-                lfs::python::is_document_update_requested(doc))
+            if (isVisibleForAnimation() &&
+                (lfs::python::is_document_dirty(doc) ||
+                 lfs::python::is_document_update_requested(doc)))
                 return true;
         }
 
@@ -682,8 +700,39 @@ namespace lfs::vis::gui {
         std::string result = dirty_driven_updates_
                                  ? "policy=dirty"
                                  : std::format("policy=interval,{}ms", update_interval_ms_);
+
+        const auto append_reason = [&result](const char* reason) {
+            result += ',';
+            result += reason;
+        };
+        if (content_dirty_)
+            append_reason("content_dirty");
+
         if (host_) {
             const auto& ops = lfs::python::get_rml_panel_host_ops();
+            const auto language_generation =
+                lfs::event::LocalizationManager::getInstance().getCurrentLanguageGeneration();
+            if (language_generation != last_language_generation_)
+                append_reason("language");
+
+            if (!dirty_driven_updates_) {
+                const auto now = std::chrono::steady_clock::now();
+                if (next_update_at_ == std::chrono::steady_clock::time_point{} ||
+                    now >= next_update_at_)
+                    append_reason("interval");
+            }
+
+            if (ops.get_document) {
+                auto* doc = static_cast<Rml::ElementDocument*>(ops.get_document(host_));
+                if (lfs::python::is_document_dirty(doc))
+                    append_reason("doc_dirty");
+                if (lfs::python::is_document_update_requested(doc))
+                    append_reason("update_requested");
+            }
+
+            if (ops.needs_animation && ops.needs_animation(host_))
+                append_reason("rml_animation");
+
             if (ops.animation_demand_description) {
                 const auto document = ops.animation_demand_description(host_);
                 if (!document.empty()) {

--- a/src/python/lfs/rml_python_panel_adapter.hpp
+++ b/src/python/lfs/rml_python_panel_adapter.hpp
@@ -33,6 +33,8 @@ namespace lfs::vis::gui {
 
         void draw(const PanelDrawContext& ctx) override;
         bool poll(const PanelDrawContext& ctx) override;
+        void setPollVisibility(bool visible) override;
+        bool isVisibleForAnimation() const override;
         void on_visibility_changed(bool visible) override;
         void preload(const PanelDrawContext& ctx) override;
         PanelRenderCapabilities renderCapabilities() const override {
@@ -99,6 +101,8 @@ namespace lfs::vis::gui {
         int height_mode_ = 0;
         bool foreground_ = false;
         bool floating_ = false;
+        bool poll_visible_ = true;
+        bool enabled_visible_ = true;
         uint64_t last_scene_gen_ = 0;
         uint64_t last_prepare_frame_ = 0;
         bool content_dirty_ = false;

--- a/src/python/lfs_plugins/selection_groups.py
+++ b/src/python/lfs_plugins/selection_groups.py
@@ -111,14 +111,18 @@ class SelectionGroupsPanel(Panel):
             RuntimeState.selection_generation,
             RuntimeState.active_tool,
         )
-        self._reactive_binding.set_handle(self._handle).watch(*native_signals)
+        self._reactive_binding.set_handle(self._handle).watch(
+            *native_signals,
+            refresh=self._refresh_reactive_state,
+        )
 
     def _unsubscribe_reactive_state(self):
         self._reactive_binding.close()
 
-    def _request_reactive_update(self):
-        if self._handle:
-            rml_widgets.request_model_update(self._handle)
+    def _refresh_reactive_state(self):
+        if self.doc is None:
+            return None
+        return self._sync_panel_state(self.doc, force=False)
 
     def on_update(self, doc):
         return self._sync_panel_state(doc, force=False)
@@ -126,11 +130,12 @@ class SelectionGroupsPanel(Panel):
     def _sync_panel_state(self, doc, force=False):
         dirty = False
         visible = lf.ui.get_active_tool() == "builtin.select" and lf.get_scene() is not None
+        visibility_changed = force or visible != self._last_visible
         wrap = doc.get_element_by_id("content-wrap")
-        if wrap:
+        if wrap and visibility_changed:
             wrap.set_class("hidden", not visible)
-            if force or visible != self._last_visible:
-                dirty = True
+        if visibility_changed:
+            dirty = True
         self._last_visible = visible
         if not visible:
             return dirty
@@ -157,15 +162,14 @@ class SelectionGroupsPanel(Panel):
         )
         self._last_scene_generation = scene_generation
         self._last_selection_generation = selection_generation
-        self._rebuild_groups(recompute_counts=recompute_counts)
-        return True
+        groups_changed = self._rebuild_groups(recompute_counts=recompute_counts)
+        return dirty or groups_changed
 
     def on_scene_changed(self, doc):
         del doc
         self._prev_group_hash = None
         self._last_scene_generation = None
         self._last_selection_generation = None
-        self._request_reactive_update()
         return True
 
     def on_unmount(self, doc):
@@ -219,13 +223,13 @@ class SelectionGroupsPanel(Panel):
     def _rebuild_groups(self, recompute_counts=True):
         scene = lf.get_scene()
         if not scene or not self._handle:
-            return
+            return False
 
         if recompute_counts:
             scene.update_selection_group_counts()
         group_hash = self._compute_group_hash(scene)
         if group_hash == self._prev_group_hash:
-            return
+            return False
         self._prev_group_hash = group_hash
 
         groups = scene.selection_groups()
@@ -244,6 +248,7 @@ class SelectionGroupsPanel(Panel):
             })
 
         self._handle.update_record_list("groups", records)
+        return True
 
     def _find_action_element(self, element):
         while element is not None:

--- a/src/python/lfs_plugins/ui/store.py
+++ b/src/python/lfs_plugins/ui/store.py
@@ -203,22 +203,41 @@ class PanelStateBinding:
     def watch(
         self,
         *signals: StateSignal[object] | Signal[object] | ComputedSignal[object],
-        refresh: Callable[[], None] | None = None,
+        refresh: Callable[[], bool | None] | None = None,
         dirty: DirtySpec = None,
         immediate: bool = False,
     ) -> PanelStateBinding:
-        """Refresh and invalidate the panel when any runtime-state signal changes."""
+        """Refresh and invalidate on signal changes unless refresh returns False."""
 
-        def on_change(_value: object) -> None:
-            if refresh is not None:
-                refresh()
-            invalidate_panel(self._handle, dirty)
+        def make_on_change():
+            last_value = None
+            has_last_value = False
+
+            def on_change(value: object) -> None:
+                nonlocal has_last_value, last_value
+                if has_last_value and value == last_value:
+                    return
+                has_last_value = True
+                last_value = value
+
+                refresh_result = None
+                if refresh is not None:
+                    refresh_result = refresh()
+                if refresh_result is False:
+                    return
+                invalidate_panel(self._handle, dirty)
+
+            return on_change
 
         for signal in signals:
-            self._unsubscribers.append(signal.subscribe(on_change))
+            self._unsubscribers.append(signal.subscribe(make_on_change()))
 
         if immediate:
-            on_change(None)
+            refresh_result = None
+            if refresh is not None:
+                refresh_result = refresh()
+            if refresh_result is not False:
+                invalidate_panel(self._handle, dirty)
 
         return self
 

--- a/src/visualizer/gui/panel_registry.cpp
+++ b/src/visualizer/gui/panel_registry.cpp
@@ -548,8 +548,11 @@ apply_registered_chrome:
 
     bool PanelRegistry::check_poll(const PanelSnapshot& snap, const PanelDrawContext& ctx) {
         assert(snap.panel);
-        if (snap.is_native)
-            return snap.panel->poll(ctx);
+        if (snap.is_native) {
+            const bool result = snap.panel->poll(ctx);
+            snap.panel->setPollVisibility(result);
+            return result;
+        }
 
         const uint64_t gen = ctx.scene_generation;
         const bool has_sel = ctx.has_selection;
@@ -567,12 +570,15 @@ apply_registered_chrome:
                     valid &= (e.has_selection == has_sel);
                 if ((snap.poll_dependencies & PollDependency::TRAINING) != PollDependency::NONE)
                     valid &= (e.is_training == training);
-                if (valid)
+                if (valid) {
+                    snap.panel->setPollVisibility(e.result);
                     return e.result;
+                }
             }
         }
 
         const bool result = snap.panel->poll(ctx);
+        snap.panel->setPollVisibility(result);
 
         {
             std::lock_guard poll_lock(poll_mutex_);
@@ -1844,6 +1850,9 @@ apply_registered_chrome:
         // Must stay in lockstep: a mismatch causes either pinned frames or stalled wakes.
         [[nodiscard]] bool isPanelVisibleForAnimation(
             const PanelInfo& p, const PanelAnimationVisibility& visibility) {
+            if (!p.panel->isVisibleForAnimation())
+                return false;
+
             if (!p.parent_id.empty()) {
                 return visibility.right_panel_visible &&
                        std::string_view(p.parent_id) == visibility.active_main_tab;

--- a/src/visualizer/gui/panel_registry.hpp
+++ b/src/visualizer/gui/panel_registry.hpp
@@ -167,6 +167,11 @@ namespace lfs::vis::gui {
             (void)ctx;
             return true;
         }
+        // Poll-gated panels can publish whether their last poll allows them to
+        // participate in animation demand. The registry updates this for both
+        // fresh and cached poll results.
+        virtual void setPollVisibility(bool visible) { (void)visible; }
+        virtual bool isVisibleForAnimation() const { return true; }
         virtual void on_visibility_changed(bool visible) { (void)visible; }
         virtual void preload(const PanelDrawContext& ctx) { (void)ctx; }
         virtual PanelRenderCapabilities renderCapabilities() const { return {}; }

--- a/tests/python/test_selection_groups_panel.py
+++ b/tests/python/test_selection_groups_panel.py
@@ -191,10 +191,11 @@ def test_selection_groups_on_update_skips_unchanged_count_poll(selection_groups_
     selection_groups_module.lf = _make_panel_lf(scene)
 
     doc = _DocStub()
-    panel.on_update(doc)
-    panel.on_update(doc)
+    assert panel.on_update(doc) is True
+    assert panel.on_update(doc) is False
 
     assert count_updates == 1
+    assert doc.content_wrap.classes == [("hidden", False)]
 
     selection_groups_module.RuntimeState.selection_generation.value += 1
     panel.on_update(doc)
@@ -213,6 +214,37 @@ def test_selection_groups_store_update_invalidates_dirty_panel(selection_groups_
         assert "__update__" in panel._handle.dirty_fields
     finally:
         panel._unsubscribe_reactive_state()
+
+
+def test_selection_groups_reactive_refresh_skips_unchanged_groups(selection_groups_module):
+    panel = selection_groups_module.SelectionGroupsPanel()
+    panel._handle = _HandleStub()
+
+    groups = [_make_group(1, "Foreground", 5, False, (1.0, 0.0, 0.0))]
+    scene = SimpleNamespace(
+        active_selection_group=1,
+        selection_groups=lambda: groups,
+        update_selection_group_counts=lambda: None,
+    )
+    selection_groups_module.lf = _make_panel_lf(scene)
+    panel.doc = _DocStub()
+    panel.on_update(panel.doc)
+    panel._subscribe_reactive_state()
+    try:
+        panel._handle.dirty_fields.clear()
+        selection_groups_module.RuntimeState.selection_generation.value += 1
+
+        assert "__update__" not in panel._handle.dirty_fields
+    finally:
+        panel._unsubscribe_reactive_state()
+
+
+def test_selection_groups_scene_change_does_not_enqueue_extra_update(selection_groups_module):
+    panel = selection_groups_module.SelectionGroupsPanel()
+    panel._handle = _HandleStub()
+
+    assert panel.on_scene_changed(None) is True
+    assert "__update__" not in panel._handle.dirty_fields
 
 
 def test_selection_groups_context_menu_uses_callback_without_poll(selection_groups_module):

--- a/tests/python/test_store.py
+++ b/tests/python/test_store.py
@@ -238,3 +238,25 @@ def test_panel_state_binding_can_dirty_specific_model_fields():
 
     assert handle.request_count == 0
     assert handle.dirty_fields == ["label", "tooltip"]
+
+
+def test_panel_state_binding_ignores_repeated_signal_payloads():
+    class EmittingSignal:
+        def __init__(self):
+            self.callback = None
+
+        def subscribe(self, callback):
+            self.callback = callback
+            return lambda: None
+
+        def emit(self, value):
+            self.callback(value)
+
+    signal = EmittingSignal()
+    handle = _PanelHandle()
+    PanelStateBinding(handle).watch(signal)
+
+    signal.emit(7)
+    signal.emit(7)
+
+    assert handle.request_count == 1

--- a/tests/test_panel_layout_render_demand.cpp
+++ b/tests/test_panel_layout_render_demand.cpp
@@ -69,6 +69,47 @@ namespace {
         float height_ = 0.0f;
     };
 
+    class PollGatedUpdatePanel final : public lfs::vis::gui::IPanel {
+    public:
+        void draw(const lfs::vis::gui::PanelDrawContext&) override {}
+
+        lfs::vis::gui::PanelRenderCapabilities renderCapabilities() const override {
+            return {.direct = true};
+        }
+
+        lfs::vis::gui::PanelDirectRenderResult renderDirect(
+            const lfs::vis::gui::PanelDirectRenderRequest& request,
+            const lfs::vis::gui::PanelDrawContext&) override {
+            if (request.mode == lfs::vis::gui::PanelDirectRenderMode::Draw)
+                pending_update = false;
+            return {.handled = true, .height = 24.0f};
+        }
+
+        bool poll(const lfs::vis::gui::PanelDrawContext&) override {
+            ++poll_count;
+            return poll_result;
+        }
+
+        void setPollVisibility(const bool visible) override {
+            poll_visible = visible;
+        }
+
+        bool isVisibleForAnimation() const override {
+            return poll_visible;
+        }
+
+        bool needsAnimationFrame() const override {
+            return pending_update;
+        }
+
+        void setPollResult(const bool result) { poll_result = result; }
+
+        bool poll_result = false;
+        bool poll_visible = true;
+        bool pending_update = true;
+        int poll_count = 0;
+    };
+
     class PanelLayoutRenderDemandTest : public ::testing::Test {
     protected:
         void SetUp() override {
@@ -424,4 +465,50 @@ TEST_F(PanelLayoutRenderDemandTest, SetPanelSpaceFloatingMasksSameFrame) {
 
     const float left_x = s.work_pos.x + 8.0f;
     EXPECT_FALSE(PanelRegistry::instance().isPositionOverFloatingPanel(left_x, band_y));
+}
+
+TEST_F(PanelLayoutRenderDemandTest,
+       PollHiddenPendingUpdateDoesNotDemandAnimationUntilVisible) {
+    using namespace lfs::vis::gui;
+
+    auto panel = std::make_shared<PollGatedUpdatePanel>();
+    PanelInfo info;
+    info.id = "test.poll_gated_update";
+    info.label = info.id;
+    info.space = PanelSpace::MainPanelTab;
+    info.is_native = false;
+    info.panel = panel;
+    ASSERT_TRUE(PanelRegistry::instance().register_panel(std::move(info)));
+
+    PanelDrawContext ctx;
+    const PanelRenderOptions preload{
+        .target = PanelRenderTarget::for_panel("test.poll_gated_update"),
+        .mode = PanelRenderMode::DirectPreload,
+        .width = 320.0f,
+        .height = 200.0f,
+    };
+    const PanelAnimationVisibility visibility{
+        .active_main_tab = "test.poll_gated_update",
+    };
+
+    PanelRegistry::instance().render_panels(preload, ctx);
+    EXPECT_FALSE(panel->poll_visible);
+    EXPECT_FALSE(PanelRegistry::instance().needsAnimationFrameForVisiblePanels(visibility));
+    EXPECT_TRUE(panel->pending_update);
+
+    panel->setPollResult(true);
+    PanelRegistry::instance().invalidate_poll_cache();
+    PanelRegistry::instance().render_panels(preload, ctx);
+    EXPECT_TRUE(panel->poll_visible);
+    EXPECT_TRUE(PanelRegistry::instance().needsAnimationFrameForVisiblePanels(visibility));
+
+    PanelRegistry::instance().render_panels({
+                                                .target = preload.target,
+                                                .mode = PanelRenderMode::Direct,
+                                                .width = preload.width,
+                                                .height = preload.height,
+                                            },
+                                            ctx);
+    EXPECT_FALSE(panel->pending_update);
+    EXPECT_FALSE(PanelRegistry::instance().needsAnimationFrameForVisiblePanels(visibility));
 }


### PR DESCRIPTION
After using the select tool and switching to another tool, the process stayed at 100 % CPU with no input. The Selection Groups panel had a pending document update request; its poll gate was false, so the adapter never ran the update that consumes the request, while needsAnimationFrame kept reporting it and the loop re-polled every iteration.

The adapter now tracks the panel's last poll result and reports no animation demand for a hidden panel; the pending request is applied on the first visible frame. The registry's visibility filter treats a poll-gated hidden panel the same way. The loop diagnostic now names the demand reason for each panel. The panel itself no longer re-requests an update from on_scene_changed after a rebuild that changed nothing, and unchanged reactive payloads are deduplicated.

Tool-switching scenario on a 3.3M-splat scene (every tool activated twice, then cleared), process CPU in the idle window afterwards:

| | Master | This PR |
|---|---|---|
| idle CPU | 100 % | 0.4 % |
| loop demand | selection_groups every frame | none |

Full suite, census and locale check pass; python regressions added for the panel and the reactive binding.