### PR TITLE
Import dialogs open again after lazy panel registration

### DIFF
--- a/src/python/lfs/py_ui.cpp
+++ b/src/python/lfs/py_ui.cpp
@@ -43,6 +43,7 @@
 #include "rendering/render_constants.hpp"
 #include "rendering/scene_upscaler_registry.hpp"
 #include "rendering/screen_overlay_renderer.hpp"
+#include "rml_python_panel_adapter.hpp"
 #include "visualizer/app_store.hpp"
 #include "visualizer/core/editor_context.hpp"
 #include "visualizer/gui/gui_manager.hpp"
@@ -2755,6 +2756,25 @@ namespace lfs::python {
         register_ui_operators(m);
         register_ui_modals(m);
         register_rml_bindings(m);
+
+        m.def(
+            "get_panel_object",
+            [](const std::string& panel_id) {
+                return invoke_on_viewer(
+                    [panel_id]() -> nb::object {
+                        const nb::gil_scoped_acquire acquire;
+                        const auto panel = vis::gui::PanelRegistry::instance().get_panel_instance(panel_id);
+                        const auto retained_panel =
+                            std::dynamic_pointer_cast<vis::gui::RmlPythonPanelAdapter>(panel);
+                        if (!retained_panel)
+                            return nb::none();
+
+                        return retained_panel->panelInstance();
+                    },
+                    nb::none());
+            },
+            nb::arg("panel_id"),
+            "Get the Python object for a retained Python panel, or None if unavailable");
 
         m.def(
             "begin_drag_payload",

--- a/src/python/lfs/rml_python_panel_adapter.hpp
+++ b/src/python/lfs/rml_python_panel_adapter.hpp
@@ -50,6 +50,7 @@ namespace lfs::vis::gui {
         [[nodiscard]] std::string captureChromeJson() const override;
         void applyChromeJson(std::string_view json) override;
         void setForeground(bool fg);
+        [[nodiscard]] nb::object panelInstance() const { return panel_instance_; }
 
     private:
         enum class LifecycleState : uint8_t {

--- a/src/python/lfs_plugins/image_preview_panel.py
+++ b/src/python/lfs_plugins/image_preview_panel.py
@@ -1218,8 +1218,13 @@ def open_image_preview(image_paths: list[Path], mask_paths: list[Path],
     global _pending_open
     _pending_open = (image_paths, mask_paths, start_index, camera_uids)
     lf.ui.set_panel_enabled("lfs.image_preview", True)
-    if _instance and _pending_open is not None:
-        _instance.open(*_pending_open)
+    panel = _instance
+    if panel is None:
+        get_panel_object = getattr(lf.ui, "get_panel_object", None)
+        if get_panel_object is not None:
+            panel = get_panel_object("lfs.image_preview")
+    if panel and _pending_open is not None:
+        panel.open(*_pending_open)
         _pending_open = None
 
 

--- a/src/python/lfs_plugins/import_panels.py
+++ b/src/python/lfs_plugins/import_panels.py
@@ -23,15 +23,17 @@ __lfs_panel_ids__ = ["lfs.new_project", "lfs.resume_checkpoint"]
 
 
 def open_new_project_panel(source_path: str = "") -> bool:
-    if _new_project_panel is None:
+    panel = _new_project_panel or lf.ui.get_panel_object("lfs.new_project")
+    if panel is None:
         return False
-    return _new_project_panel.show(source_path)
+    return panel.show(source_path)
 
 
 def open_resume_checkpoint_panel(checkpoint_path: str) -> bool:
-    if _resume_checkpoint_panel is None:
+    panel = _resume_checkpoint_panel or lf.ui.get_panel_object("lfs.resume_checkpoint")
+    if panel is None:
         return False
-    return _resume_checkpoint_panel.show(checkpoint_path)
+    return panel.show(checkpoint_path)
 
 
 def _directory_has_colmap_file(path: str) -> bool:

--- a/src/python/stubs/lichtfeld/ui/__init__.pyi
+++ b/src/python/stubs/lichtfeld/ui/__init__.pyi
@@ -416,6 +416,9 @@ def set_bottom_dock_active_tab(panel_id: str) -> None:
 def get_panel(panel_id: str) -> PanelInfo | None:
     """Get typed panel info by id (None if not found)"""
 
+def get_panel_object(panel_id: str) -> object | None:
+    """Get the Python object for a retained Python panel, or None if unavailable"""
+
 def set_panel_label(panel_id: str, label: str) -> bool:
     """Set the display label for a panel"""
 

--- a/src/visualizer/gui/panel_registry.cpp
+++ b/src/visualizer/gui/panel_registry.cpp
@@ -1412,6 +1412,15 @@ apply_registered_chrome:
         return std::nullopt;
     }
 
+    std::shared_ptr<IPanel> PanelRegistry::get_panel_instance(const std::string& id) const {
+        std::lock_guard lock(mutex_);
+        for (const auto& panel : panels_) {
+            if (panel.id == id)
+                return panel.panel;
+        }
+        return nullptr;
+    }
+
     std::vector<PanelProjectState>
     PanelRegistry::capture_project_state() const {
         std::lock_guard lock(mutex_);

--- a/src/visualizer/gui/panel_registry.hpp
+++ b/src/visualizer/gui/panel_registry.hpp
@@ -381,6 +381,7 @@ namespace lfs::vis::gui {
             PanelSpace space, const PanelDrawContext& ctx, bool check_poll);
         std::vector<std::string> get_panel_names(PanelSpace space) const;
         std::optional<PanelDetails> get_panel(const std::string& id);
+        std::shared_ptr<IPanel> get_panel_instance(const std::string& id) const;
         [[nodiscard]] std::vector<PanelProjectState>
         capture_project_state() const;
         void apply_project_state(

--- a/tests/python/test_new_project_panel.py
+++ b/tests/python/test_new_project_panel.py
@@ -57,6 +57,8 @@ def new_project_module(monkeypatch, tmp_path):
         embed_default=False,
         scheduled=[],
         scheduled_event=threading.Event(),
+        registered_classes=[],
+        registered_panels={},
     )
 
     def schedule_on_ui_thread(callback):
@@ -68,6 +70,7 @@ def new_project_module(monkeypatch, tmp_path):
 
     lf_stub = ModuleType("lichtfeld")
     lf_stub.ui = SimpleNamespace(
+        Panel=type("Panel", (), {}),
         PanelSpace=SimpleNamespace(FLOATING="FLOATING"),
         PanelHeightMode=SimpleNamespace(CONTENT="CONTENT"),
         PanelOption=SimpleNamespace(DEFAULT_CLOSED="DEFAULT_CLOSED"),
@@ -81,7 +84,13 @@ def new_project_module(monkeypatch, tmp_path):
         open_ply_file_dialog=lambda _start="": str(splat),
         get_embed_dataset_by_default=lambda: state.embed_default,
         schedule_on_ui_thread=schedule_on_ui_thread,
+        get_panel_object=lambda panel_id: state.registered_panels.get(panel_id),
     )
+    def register_class(cls):
+        state.registered_classes.append(cls)
+        state.registered_panels[cls.id] = cls()
+
+    lf_stub.register_class = register_class
     lf_stub.is_dataset_path = lambda path: str(path) == str(dataset)
     lf_stub.detect_dataset_info = lambda _path: info
     lf_stub.optimization_params = lambda: None
@@ -92,6 +101,7 @@ def new_project_module(monkeypatch, tmp_path):
     lf_stub.load_file = lambda *args, **kwargs: state.calls.append(("load", args, kwargs))
     lf_stub.project_embed_dataset = lambda: state.calls.append(("embed", (), {}))
     monkeypatch.setitem(sys.modules, "lichtfeld", lf_stub)
+    state.lf = lf_stub
     return import_module("lfs_plugins.import_panels"), state
 
 
@@ -114,6 +124,37 @@ def _run_scheduled(state, timeout=2.0):
             return
         state.scheduled_event.wait(max(0.0, deadline - time.monotonic()))
     raise AssertionError("worker did not schedule a UI callback")
+
+
+def _register_lazy_panel(state, name):
+    panels = import_module("lfs_plugins.panels")
+    panels._register_lazy_panel(state.lf, name)
+
+
+def test_open_new_project_panel_loads_lazy_proxy(new_project_module):
+    module, state = new_project_module
+    _register_lazy_panel(state, "new_project")
+
+    assert len(state.registered_classes) == 1
+    assert module._new_project_panel is None
+    assert module.open_new_project_panel("/tmp/x") is True
+    assert module._new_project_panel._source_path == "/tmp/x"
+
+
+def test_open_resume_checkpoint_panel_loads_lazy_proxy(new_project_module):
+    module, state = new_project_module
+    module.lf.read_checkpoint_header = lambda _path: SimpleNamespace(
+        iteration=12, num_gaussians=34
+    )
+    module.lf.read_checkpoint_params = lambda _path: SimpleNamespace(
+        dataset_path=state.dataset, output_path=state.location / "resumed.licht"
+    )
+    _register_lazy_panel(state, "resume_checkpoint")
+
+    assert len(state.registered_classes) == 1
+    assert module._resume_checkpoint_panel is None
+    assert module.open_resume_checkpoint_panel("/tmp/checkpoint.ckpt") is True
+    assert module._resume_checkpoint_panel._checkpoint_path == "/tmp/checkpoint.ckpt"
 
 
 def test_dataset_create_emits_project_before_load_without_output_path(new_project_module):


### PR DESCRIPTION
Since #1965 the Python panels are registered as lazy proxies and the real panel classes are only instantiated on first use. The helpers that open the New Project and Resume Checkpoint dialogs read a module global that only the real constructor sets, so a COLMAP folder (or any dataset) dropped onto the window before the dialog had ever been opened did nothing, and the File menu import raised "dataset import dialog is unavailable". A dropped `.resume` file and the image preview had the same shape; the video extractor's frame import ends in the same dialog.

`lf.ui.get_panel_object(panel_id)` now returns the registered panel instance, the helpers resolve the panel through it, and calling `show()` on the lazy proxy loads the implementation.

Verified live on a dev build: the drop callback with a COLMAP folder now opens New Project with the source prefilled (it did nothing on master). Python tier passes; regression tests cover the lazy proxy for both dialogs and the pending image-preview request.

To verify: on a fresh start, drop a COLMAP folder onto the viewport, drop a `.resume` file, and drop a video and import frames from the extractor.