### PR TITLE
Fix logger.cpp compilation on MSVC

### DIFF
--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -4,6 +4,7 @@
 
 #include "core/logger.hpp"
 #include "diagnostics/vram_profiler.hpp"
+#include <algorithm>
 #include <array>
 #include <cstdio>
 #include <cstdlib>
@@ -16,6 +17,12 @@
 #include <regex>
 #include <vector>
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #else
 #include <unistd.h>


### PR DESCRIPTION
Similar fix as in mapped_file.cpp: The file now defines NOMINMAX and WIN32_LEAN_AND_MEAN before including <windows.h>.