### PR TITLE
Windows: logger.cpp includes windows.h with NOMINMAX

### DIFF
--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -16,6 +16,9 @@
 #include <regex>
 #include <vector>
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #else
 #include <unistd.h>


### PR DESCRIPTION
Windows CI on master fails in logger.cpp: windows.h without NOMINMAX turns std::min into the min macro (C2589). Guard the include the way mapped_file.cpp does.