### PR TITLE
Let headless training start from an untrained .licht with embedded dataset via --data-path

### DIFF
--- a/docs/licht_format.md
+++ b/docs/licht_format.md
@@ -98,6 +98,13 @@ use `--headless --resume project.licht`; a complete autosave newer than the
 master head is recovered automatically. Ambiguous recovery candidates remain
 an error.
 
+A project saved before any training carries no checkpoint and is a dataset
+source instead: `--headless --data-path project.licht --output-path <dir>` trains
+it from scratch with the dataset options stored in `PRMS`, reading images from
+the dataset folder recorded in `REFS` or, when that folder is not reachable, from
+the embedded dataset copy extracted to the per-user cache. A project that already
+holds a checkpoint is rejected there and must be continued with `--resume`.
+
 The current grammar is **1.1** on this development branch. Version 1.1 makes CKPT history
 explicit: SCNG binds exactly one resumable checkpoint when a training node exists, while
 additional live CKPT chapters are historical and are copied by compaction. The existing

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -26,6 +26,7 @@
 #include "core/user_paths.hpp"
 #include "diagnostics/vram_profiler.hpp"
 #include "io/cache_image_loader.hpp"
+#include "io/embedded_dataset.hpp"
 #include "io/project_document.hpp"
 #include "io/project_recovery.hpp"
 #include "tcp/include/tcp_publisher.hpp"
@@ -114,6 +115,113 @@ namespace lfs::app {
                 .detail = std::move(detail),
                 .detection = source,
             });
+        }
+
+        // --data-path may name an untrained .licht. Resolve its dataset, the
+        // external folder recorded in REFS or else the embedded copy extracted
+        // to the per-user cache, and continue as a plain dataset-folder run.
+        [[nodiscard]] lfs::Result<void> adoptDatasetProject(
+            core::param::TrainingParameters& params) {
+            const auto path = *params.dataset_project;
+            auto document = io::project::ProjectDocument::open(
+                path,
+                io::project::ProjectDocumentOpenOptions{
+                    .reader = {},
+                    .geometry = {},
+                    .defer_geometry_payloads = true,
+                });
+            if (!document) {
+                return lfs::Status::failure(
+                    std::move(document).error().with_context(
+                        "open training project",
+                        LFS_SOURCE_SITE_CURRENT()));
+            }
+
+            auto checkpoint_uuid = document->bound_checkpoint_uuid();
+            if (!checkpoint_uuid) {
+                return lfs::Status::failure(
+                    std::move(checkpoint_uuid).error());
+            }
+            // Check whether there's a checkpoint, hence being trained before.
+            if (*checkpoint_uuid) {
+                return lfs::Status::failure(training_project_error(
+                    lfs::ErrorCode::FailedPrecondition,
+                    "The project already has a training checkpoint; pass it "
+                    "to --resume to continue training",
+                    LFS_SOURCE_SITE_CURRENT()));
+            }
+
+            auto snapshot = document->parameters().snapshot();
+            if (!snapshot) {
+                return lfs::Status::failure(
+                    std::move(snapshot).error().with_context(
+                        "read training project parameters",
+                        LFS_SOURCE_SITE_CURRENT()));
+            }
+
+            // Prefer the original dataset folder recorded in REFS when it is
+            // still reachable, so nothing has to be unpacked.
+            std::optional<std::filesystem::path> dataset_root;
+            std::string images_folder = snapshot->dataset.images;
+            if (const auto dataset_ref =
+                    document->project().dataset_reference();
+                dataset_ref && *dataset_ref) {
+                auto external = io::project::resolve_path_reference(
+                    document->references(), path.parent_path(),
+                    **dataset_ref);
+                if (external && std::filesystem::is_directory(*external)) {
+                    dataset_root = std::move(*external);
+                }
+            }
+            // Otherwise unpack the embedded DSRC chunks into the per-user cache.
+            // Files already present with a matching hash are reused.
+            if (!dataset_root) {
+                auto cache_dir =
+                    io::project::embedded_dataset_cache_dir(*document);
+                if (!cache_dir) {
+                    return lfs::Status::failure(
+                        std::move(cache_dir).error());
+                }
+                auto extracted = io::project::extract_embedded_dataset(
+                    *document, *cache_dir);
+                if (!extracted) {
+                    return lfs::Status::failure(
+                        std::move(extracted).error());
+                }
+                if (*extracted) {
+                    dataset_root = std::move(**extracted);
+                    // The manifest records which images folder was embedded.
+                    if (const auto manifest =
+                            document->parameters().embedded_dataset();
+                        manifest && *manifest) {
+                        images_folder = (*manifest)->images_folder;
+                    }
+                }
+            }
+            if (!dataset_root) {
+                return lfs::Status::failure(training_project_error(
+                    lfs::ErrorCode::NotFound,
+                    "The project's dataset is neither reachable nor embedded",
+                    LFS_SOURCE_SITE_CURRENT()));
+            }
+
+            // Adopt the stored dataset options; machine-specific paths and
+            // loading resources stay with the command line.
+            auto dataset = std::move(snapshot->dataset);
+            dataset.data_path = std::move(*dataset_root);
+            dataset.images = std::move(images_folder);
+            dataset.output_path = params.dataset.output_path;
+            dataset.output_path_explicit = params.dataset.output_path_explicit;
+            dataset.output_name = params.dataset.output_name;
+            dataset.loading_params = params.dataset.loading_params;
+            params.dataset = std::move(dataset);
+            // From here on this is an ordinary --data-path run.
+            params.dataset_project.reset();
+            LOG_INFO(
+                "Training from project {}; dataset resolved to {}",
+                core::path_to_utf8(path),
+                core::path_to_utf8(params.dataset.data_path));
+            return {};
         }
 
         std::expected<core::param::TrainingParameters, std::string> loadCheckpointParams(const core::param::TrainingParameters& params, core::Scene& scene) {
@@ -291,7 +399,8 @@ namespace lfs::app {
             if (!*checkpoint_uuid) {
                 return training_project_error(
                     lfs::ErrorCode::FailedPrecondition,
-                    "Training project has no SCNG-bound CKPT instance",
+                    "Training project has no checkpoint to resume; pass an "
+                    "untrained project to --data-path instead",
                     LFS_SOURCE_SITE_CURRENT());
             }
             const auto bound_checkpoint_uuid = **checkpoint_uuid;
@@ -1428,6 +1537,18 @@ namespace lfs::app {
                 core::teardown_gpu_before_exit();
             }
             return result;
+        }
+
+        if (params->dataset_project) {
+            if (!params->optimization.headless) {
+                LOG_ERROR("--data-path project.licht requires --headless; use -v to open a project");
+                return 1;
+            }
+            if (const auto adopted = adoptDatasetProject(*params); !adopted) {
+                LOG_ERROR("Failed to load training project: {}",
+                          lfs::format_for_developer(adopted.error()));
+                return 1;
+            }
         }
 
         if (params->optimization.headless && params->server.tcp_connection) {

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -205,16 +205,9 @@ namespace lfs::app {
                     LFS_SOURCE_SITE_CURRENT()));
             }
 
-            // Adopt the stored dataset options; machine-specific paths and
-            // loading resources stay with the command line.
-            auto dataset = std::move(snapshot->dataset);
-            dataset.data_path = std::move(*dataset_root);
-            dataset.images = std::move(images_folder);
-            dataset.output_path = params.dataset.output_path;
-            dataset.output_path_explicit = params.dataset.output_path_explicit;
-            dataset.output_name = params.dataset.output_name;
-            dataset.loading_params = params.dataset.loading_params;
-            params.dataset = std::move(dataset);
+            io::project::adopt_project_training_parameters(
+                params, std::move(*snapshot), std::move(*dataset_root),
+                std::move(images_folder));
             // From here on this is an ordinary --data-path run.
             params.dataset_project.reset();
             LOG_INFO(

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -91,6 +91,8 @@ namespace lfs::app {
                 const HeadlessPluginSignalGuard&) = delete;
         };
 
+        // Headless runs train into the project they were started from unless
+        // -o redirects the result to a fresh project.licht.
         [[nodiscard]] std::filesystem::path headless_project_save_destination(
             const core::param::TrainingParameters& cli_params,
             const std::filesystem::path& source) {
@@ -98,9 +100,18 @@ namespace lfs::app {
                 return source;
 
             const auto destination = cli_params.dataset.output_path / "project.licht";
-            LOG_INFO("Headless resume project destination: {}",
+            LOG_INFO("Headless project destination: {}",
                      core::path_to_utf8(destination));
             return destination;
+        }
+
+        // Empty for a plain dataset-folder run, which keeps the default
+        // output_path/project.licht destination.
+        [[nodiscard]] std::filesystem::path headless_dataset_project_destination(
+            const core::param::TrainingParameters& params) {
+            if (!params.dataset_project)
+                return {};
+            return headless_project_save_destination(params, *params.dataset_project);
         }
 
         [[nodiscard]] lfs::Error training_project_error(
@@ -119,7 +130,8 @@ namespace lfs::app {
 
         // --data-path may name an untrained .licht. Resolve its dataset, the
         // external folder recorded in REFS or else the embedded copy extracted
-        // to the per-user cache, and continue as a plain dataset-folder run.
+        // to the per-user cache, and continue as a dataset-folder run that
+        // trains into the project unless -o redirects the result.
         [[nodiscard]] lfs::Result<void> adoptDatasetProject(
             core::param::TrainingParameters& params) {
             const auto path = *params.dataset_project;
@@ -205,11 +217,14 @@ namespace lfs::app {
                     LFS_SOURCE_SITE_CURRENT()));
             }
 
+            // Without -o, exports land beside the project.
+            if (!params.dataset.output_path_explicit)
+                params.dataset.output_path = path.parent_path();
             io::project::adopt_project_training_parameters(
                 params, std::move(*snapshot), std::move(*dataset_root),
                 std::move(images_folder));
-            // From here on this is an ordinary --data-path run.
-            params.dataset_project.reset();
+            // dataset_project stays set: it is the save destination unless
+            // -o redirects the result, exactly like --resume.
             LOG_INFO(
                 "Training from project {}; dataset resolved to {}",
                 core::path_to_utf8(path),
@@ -640,7 +655,8 @@ namespace lfs::app {
                         }
                         trainer->setParams(effective_params);
                         training::grant_headless_project_saves(
-                            *trainer, effective_params);
+                            *trainer, effective_params,
+                            headless_dataset_project_destination(effective_params));
                         manager->setTrainer(std::move(trainer));
                     }
                 }
@@ -950,7 +966,8 @@ namespace lfs::app {
                         return 1;
                     }
                     training::grant_headless_project_saves(
-                        *trainer, *params);
+                        *trainer, *params,
+                        headless_dataset_project_destination(*params));
 
                     core::Tensor::trim_memory_pool();
 

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -487,7 +487,7 @@ namespace {
             // =============================================================================
             ::args::Group paths_sep(parser, " ");
             ::args::Group paths_group(parser, "TRAINING PATHS:");
-            ::args::ValueFlag<std::string> data_path(paths_group, "data_path", "Path to training data", {'d', "data-path"});
+            ::args::ValueFlag<std::string> data_path(paths_group, "data_path", "Path to training data: a dataset folder or an untrained .licht project", {'d', "data-path"});
             ::args::ValueFlag<std::string> output_path(paths_group, "output_path", "Directory for project.licht and --export files", {'o', "output-path"});
             ::args::ValueFlag<std::string> output_name(paths_group, "output_name", "Output filename (replaces default splat_ITER.ply stem)", {"output-name"});
             ::args::ValueFlag<std::string> config_file(paths_group, "config_file", "LichtFeldStudio config file (json)", {"config"});
@@ -996,6 +996,23 @@ namespace {
             if (has_data_path && has_output_path) {
                 params.dataset.data_path = lfs::core::utf8_to_path(::args::get(data_path));
                 params.dataset.output_path = lfs::core::utf8_to_path(::args::get(output_path));
+
+                // An untrained .licht is a dataset source.
+                auto data_extension = params.dataset.data_path.extension().string();
+                std::ranges::transform(
+                    data_extension, data_extension.begin(),
+                    [](const unsigned char character) {
+                        return static_cast<char>(std::tolower(character));
+                    });
+                if (data_extension == ".licht") {
+                    if (!lfs::io::project::isPublishedLichtPath(params.dataset.data_path)) {
+                        return std::unexpected(
+                            lfs::io::project::unpublishedLichtUserMessage(
+                                params.dataset.data_path));
+                    }
+                    params.dataset_project = std::move(params.dataset.data_path);
+                    params.dataset.data_path.clear();
+                }
 
                 // Create output directory
                 std::error_code ec;

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -991,36 +991,44 @@ namespace {
                     parser.Help()));
             }
 
-            // Training/resume mode requires both data-path and output-path
-            // Exception: resume mode can work without explicit paths (extracted from checkpoint)
-            if (has_data_path && has_output_path) {
-                params.dataset.data_path = lfs::core::utf8_to_path(::args::get(data_path));
-                params.dataset.output_path = lfs::core::utf8_to_path(::args::get(output_path));
+            // An untrained .licht on --data-path is a dataset source and, unless
+            // --output-path redirects the result, also the project the run trains into.
+            const auto data_path_value = has_data_path
+                                             ? lfs::core::utf8_to_path(::args::get(data_path))
+                                             : std::filesystem::path{};
+            auto data_extension = data_path_value.extension().string();
+            std::ranges::transform(
+                data_extension, data_extension.begin(),
+                [](const unsigned char character) {
+                    return static_cast<char>(std::tolower(character));
+                });
+            const bool data_path_is_project = data_extension == ".licht";
 
-                // An untrained .licht is a dataset source.
-                auto data_extension = params.dataset.data_path.extension().string();
-                std::ranges::transform(
-                    data_extension, data_extension.begin(),
-                    [](const unsigned char character) {
-                        return static_cast<char>(std::tolower(character));
-                    });
-                if (data_extension == ".licht") {
-                    if (!lfs::io::project::isPublishedLichtPath(params.dataset.data_path)) {
+            // Training mode requires both data-path and output-path.
+            // Exceptions: a .licht carries its own destination, and resume mode
+            // can work without explicit paths (extracted from checkpoint).
+            if (has_data_path && (has_output_path || data_path_is_project)) {
+                if (data_path_is_project) {
+                    if (!lfs::io::project::isPublishedLichtPath(data_path_value)) {
                         return std::unexpected(
-                            lfs::io::project::unpublishedLichtUserMessage(
-                                params.dataset.data_path));
+                            lfs::io::project::unpublishedLichtUserMessage(data_path_value));
                     }
-                    params.dataset_project = std::move(params.dataset.data_path);
-                    params.dataset.data_path.clear();
+                    params.dataset_project = data_path_value;
+                } else {
+                    params.dataset.data_path = data_path_value;
                 }
 
-                // Create output directory
-                std::error_code ec;
-                std::filesystem::create_directories(params.dataset.output_path, ec);
-                if (ec) {
-                    return std::unexpected(std::format(
-                        "Failed to create output directory '{}': {}",
-                        lfs::core::path_to_utf8(params.dataset.output_path), ec.message()));
+                if (has_output_path) {
+                    params.dataset.output_path = lfs::core::utf8_to_path(::args::get(output_path));
+
+                    // Create output directory
+                    std::error_code ec;
+                    std::filesystem::create_directories(params.dataset.output_path, ec);
+                    if (ec) {
+                        return std::unexpected(std::format(
+                            "Failed to create output directory '{}': {}",
+                            lfs::core::path_to_utf8(params.dataset.output_path), ec.message()));
+                    }
                 }
             } else if (has_data_path != has_output_path && !has_resume) {
                 // Only require both if not in resume mode

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -442,6 +442,10 @@ namespace lfs::core {
             // train() is allowed to start.
             std::optional<std::filesystem::path> resume_project = std::nullopt;
 
+            // Untrained .licht passed to --data-path. Its REFS dataset folder,
+            // or the embedded dataset copy, becomes the training data source.
+            std::optional<std::filesystem::path> dataset_project = std::nullopt;
+
             // Headless/integration-test trigger for the production training
             // snapshot path. Empty unless the user passed --save-project-path;
             // the trainer then falls back to the bound project destination.

--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -560,6 +560,10 @@ namespace lfs::core {
                 (resume_checkpoint || resume_project)) {
                 return "A project path and --resume are mutually exclusive";
             }
+            if (dataset_project &&
+                (resume_checkpoint || resume_project)) {
+                return "--data-path project.licht and --resume are mutually exclusive";
+            }
             if (project_path) {
                 auto extension = project_path->extension().string();
                 std::ranges::transform(

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -323,6 +323,7 @@ add_library(lfs_io STATIC
         project/scene_chapter_adapter.cpp
         project/geometry_payload.cpp
         project/selection_chapter.cpp
+        project/embedded_dataset.cpp
 
 )
 

--- a/src/io/include/io/embedded_dataset.hpp
+++ b/src/io/include/io/embedded_dataset.hpp
@@ -1,0 +1,45 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "core/error.hpp"
+#include "core/export.hpp"
+#include "io/project_chapters.hpp"
+#include "io/project_document.hpp"
+
+#include <filesystem>
+#include <functional>
+#include <optional>
+
+namespace lfs::io::project {
+
+    // Digest of one dataset file, matching EmbeddedDatasetEntry::xxh3_128.
+    [[nodiscard]] LFS_IO_API lfs::Result<Hash128>
+    hash_dataset_file(const std::filesystem::path& path);
+
+    // Per-user cache folder that receives this project's extracted dataset.
+    [[nodiscard]] LFS_IO_API lfs::Result<std::filesystem::path>
+    embedded_dataset_cache_dir(const ProjectDocument& document);
+
+    // Unpack the complete embedded dataset into cache_dir and publish a
+    // ".complete" marker. Files already present with a matching hash are kept.
+    // Returns nullopt when the document carries no complete embedded dataset.
+    // progress may return false to cancel.
+    [[nodiscard]] LFS_IO_API lfs::Result<std::optional<std::filesystem::path>>
+    extract_embedded_dataset(const ProjectDocument& document,
+                             const std::filesystem::path& cache_dir,
+                             const std::function<bool(float)>& progress = {});
+
+    // Extract into the per-user cache unless the external dataset folder
+    // recorded in REFS still exists, then unpacking is not necessary and images
+    // can be read from REFS. Returns the extracted root, or nullopt when nothing
+    // needed extracting.
+    [[nodiscard]] LFS_IO_API lfs::Result<std::optional<std::filesystem::path>>
+    extract_embedded_dataset_if_needed(
+        const ProjectDocument& document,
+        const std::function<bool(float)>& progress = {});
+
+} // namespace lfs::io::project

--- a/src/io/include/io/project_chapters.hpp
+++ b/src/io/include/io/project_chapters.hpp
@@ -479,7 +479,31 @@ namespace lfs::io::project {
         ReferenceBindings mrnf_current_references;
         ReferenceBindings igs_current_references;
         lfs::core::param::DatasetConfig dataset;
+
+        // The pending parameters of the strategy selected in the project.
+        [[nodiscard]] const lfs::core::param::OptimizationParameters&
+        active_optimization() const noexcept {
+            const auto strategy =
+                lfs::core::param::canonical_strategy_name(active_strategy);
+            if (strategy == lfs::core::param::kStrategyMCMC)
+                return mcmc_current;
+            if (strategy == lfs::core::param::kStrategyIGSPlus)
+                return igs_current;
+            return mrnf_current;
+        }
     };
+
+    // Merge an untrained project's PRMS snapshot into the launch parameters
+    // of a headless run. Stored dataset and active-strategy optimization
+    // values replace the CLI defaults, the headless/auto_train/no_splash
+    // process flags stay with the command line, and explicit CLI flags win
+    // over stored values, as on --resume. dataset_root and images_folder
+    // are the resolved locations that replace the project's logical dataset.
+    LFS_IO_API void adopt_project_training_parameters(
+        lfs::core::param::TrainingParameters& params,
+        ParameterManagerSnapshot snapshot,
+        std::filesystem::path dataset_root,
+        std::string images_folder);
 
     class LFS_IO_API ParametersChapter {
     public:

--- a/src/io/project/embedded_dataset.cpp
+++ b/src/io/project/embedded_dataset.cpp
@@ -1,0 +1,309 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "io/embedded_dataset.hpp"
+
+#include "core/logger.hpp"
+#include "core/path_utils.hpp"
+#include "core/user_paths.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <fstream>
+#include <ios>
+#include <istream>
+#include <ranges>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace lfs::io::project {
+
+    namespace {
+
+        [[nodiscard]] lfs::Error embed_error(
+            const lfs::ErrorCode code,
+            std::string message,
+            std::string detail) {
+            lfs::SmallFields fields;
+            fields.add("field", "project.dataset_embed");
+            return lfs::make_error(lfs::ErrorInit{
+                .code = code,
+                .domain = lfs::ErrorDomain::IO,
+                .severity = lfs::Severity::Error,
+                .retryability = lfs::Retryability::NotRetryable,
+                .operation_id = {},
+                .user_message = std::move(message),
+                .detail = std::move(detail),
+                .detection = LFS_SOURCE_SITE_CURRENT(),
+                .fields = std::move(fields),
+                .native = std::nullopt,
+            });
+        }
+
+        [[nodiscard]] std::filesystem::path project_root_for(
+            const ProjectDocument& document) {
+            if (const auto source = document.source_path();
+                source && !source->empty()) {
+                return source->parent_path();
+            }
+            return {};
+        }
+
+    } // namespace
+
+    lfs::Result<Hash128> hash_dataset_file(const std::filesystem::path& path) {
+        std::ifstream input(path, std::ios::binary);
+        if (!input) {
+            return embed_error(
+                lfs::ErrorCode::PermissionDenied,
+                "A dataset file could not be opened.", lfs::core::path_to_utf8(path));
+        }
+        Hash128Stream hasher;
+        std::vector<char> buffer(1024 * 1024);
+        while (input) {
+            input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+            const auto count = input.gcount();
+            if (count <= 0) {
+                break;
+            }
+            if (!hasher.update(std::span<const std::byte>(
+                    reinterpret_cast<const std::byte*>(buffer.data()),
+                    static_cast<std::size_t>(count)))) {
+                return embed_error(
+                    lfs::ErrorCode::DataLoss,
+                    "A dataset file could not be hashed.", lfs::core::path_to_utf8(path));
+            }
+        }
+        if (!input.eof() || !hasher.valid()) {
+            return embed_error(
+                lfs::ErrorCode::DataLoss,
+                "A dataset file could not be hashed.", lfs::core::path_to_utf8(path));
+        }
+        return hasher.digest();
+    }
+
+    lfs::Result<std::filesystem::path>
+    embedded_dataset_cache_dir(const ProjectDocument& document) {
+        const auto paths = lfs::core::UserPaths::resolve();
+        if (!paths) {
+            return std::move(paths).error();
+        }
+        return paths->rootDir() / "cache" / "embedded_datasets" /
+               document.project_uuid().to_string();
+    }
+
+    lfs::Result<std::optional<std::filesystem::path>>
+    extract_embedded_dataset(const ProjectDocument& document,
+                             const std::filesystem::path& cache,
+                             const std::function<bool(float)>& progress) {
+        auto manifest = document.parameters().embedded_dataset();
+        if (!manifest) {
+            return std::move(manifest).error();
+        }
+        if (!*manifest || !(*manifest)->complete || (*manifest)->entries.empty()) {
+            return std::optional<std::filesystem::path>{};
+        }
+        std::error_code error;
+        std::filesystem::create_directories(cache, error);
+        if (error) {
+            return embed_error(lfs::ErrorCode::PermissionDenied,
+                               "The embedded dataset cache could not be created.",
+                               error.message());
+        }
+        const auto marker = cache / ".complete";
+        std::filesystem::remove(marker, error);
+        const auto total_bytes = std::ranges::fold_left(
+            (*manifest)->entries, std::uint64_t{0},
+            [](const std::uint64_t total, const auto& entry) {
+                return total + entry.bytes;
+            });
+        LOG_INFO(
+            "Embedded dataset extraction started: {} files, {} bytes, cache {}",
+            (*manifest)->entries.size(), total_bytes,
+            lfs::core::path_to_utf8(cache));
+        std::uint64_t completed_bytes = 0;
+        std::size_t reused_files = 0;
+        std::size_t extracted_files = 0;
+        for (const auto& entry : (*manifest)->entries) {
+            if (progress && !progress(
+                                total_bytes == 0
+                                    ? 0.0F
+                                    : static_cast<float>(completed_bytes) /
+                                          static_cast<float>(total_bytes))) {
+                return embed_error(
+                    lfs::ErrorCode::Cancelled,
+                    "Embedded dataset extraction was canceled.",
+                    "The caller requested cancellation");
+            }
+            const auto relative = lfs::core::utf8_to_path(entry.rel_path);
+            if (relative.empty() || relative.is_absolute() ||
+                relative.lexically_normal() != relative) {
+                return embed_error(
+                    lfs::ErrorCode::DataLoss,
+                    "The embedded dataset manifest contains an unsafe path.",
+                    entry.rel_path);
+            }
+            const auto destination = (cache / relative).lexically_normal();
+            const auto source = document.find_dataset_source(entry.chunk_uuid);
+            if (!source) {
+                return embed_error(
+                    lfs::ErrorCode::DataLoss,
+                    "The embedded dataset chunk is missing.",
+                    entry.chunk_uuid.to_string());
+            }
+            if (source->size() != entry.bytes) {
+                return embed_error(
+                    lfs::ErrorCode::DataLoss,
+                    "The embedded dataset chunk size does not match its manifest.",
+                    std::format("{} has {} bytes, manifest expected {}",
+                                entry.chunk_uuid.to_string(), source->size(),
+                                entry.bytes));
+            }
+            bool valid_existing = false;
+            if (std::filesystem::is_regular_file(destination)) {
+                std::error_code size_error;
+                valid_existing = std::filesystem::file_size(destination, size_error) ==
+                                     entry.bytes &&
+                                 !size_error;
+                if (valid_existing) {
+                    auto hash = hash_dataset_file(destination);
+                    valid_existing = hash && *hash == entry.xxh3_128;
+                }
+            }
+            if (valid_existing) {
+                completed_bytes += entry.bytes;
+                ++reused_files;
+                continue;
+            }
+            std::filesystem::create_directories(destination.parent_path(), error);
+            if (error) {
+                return embed_error(
+                    lfs::ErrorCode::PermissionDenied,
+                    "The embedded dataset cache could not be created.",
+                    error.message());
+            }
+            auto temporary = destination;
+            temporary += ".part";
+            std::ofstream output;
+            lfs::core::open_file_for_write(
+                temporary, std::ios::binary | std::ios::trunc, output);
+            if (!output) {
+                return embed_error(
+                    lfs::ErrorCode::PermissionDenied,
+                    "An embedded dataset file could not be extracted.",
+                    lfs::core::path_to_utf8(destination));
+            }
+            Hash128Stream hasher;
+            auto copied = source->visit_stream(
+                [&](std::istream& input, const std::uint64_t size) -> lfs::Result<void> {
+                    std::vector<char> buffer(1024 * 1024);
+                    std::uint64_t copied_bytes = 0;
+                    while (input && copied_bytes < size) {
+                        const auto remaining = size - copied_bytes;
+                        const auto request = static_cast<std::streamsize>(
+                            std::min<std::uint64_t>(remaining, buffer.size()));
+                        input.read(buffer.data(), request);
+                        const auto count = input.gcount();
+                        if (count <= 0)
+                            break;
+                        const auto bytes = std::span<const std::byte>(
+                            reinterpret_cast<const std::byte*>(buffer.data()),
+                            static_cast<std::size_t>(count));
+                        if (!hasher.update(bytes)) {
+                            return lfs::Result<void>::failure(embed_error(
+                                lfs::ErrorCode::DataLoss,
+                                "An embedded dataset file could not be extracted.",
+                                lfs::core::path_to_utf8(destination)));
+                        }
+                        output.write(buffer.data(), count);
+                        copied_bytes += static_cast<std::uint64_t>(count);
+                    }
+                    if (!output || copied_bytes != size) {
+                        return lfs::Result<void>::failure(embed_error(
+                            lfs::ErrorCode::DataLoss,
+                            "An embedded dataset file could not be extracted.",
+                            lfs::core::path_to_utf8(destination)));
+                    }
+                    return {};
+                });
+            output.close();
+            if (!copied || !hasher.valid() || hasher.digest() != entry.xxh3_128) {
+                std::filesystem::remove(temporary, error);
+                return copied ? embed_error(
+                                    lfs::ErrorCode::DataLoss,
+                                    "The embedded dataset file failed hash verification.",
+                                    lfs::core::path_to_utf8(destination))
+                              : std::move(copied).error();
+            }
+            std::filesystem::rename(temporary, destination, error);
+            if (error) {
+                std::filesystem::remove(temporary);
+                return embed_error(
+                    lfs::ErrorCode::PermissionDenied,
+                    "The embedded dataset file could not be published.",
+                    error.message());
+            }
+            completed_bytes += entry.bytes;
+            ++extracted_files;
+        }
+        if (progress && !progress(1.0F)) {
+            return embed_error(
+                lfs::ErrorCode::Cancelled,
+                "Embedded dataset extraction was canceled.",
+                "The caller requested cancellation");
+        }
+        std::ofstream complete_marker(marker,
+                                      std::ios::binary | std::ios::trunc);
+        if (!complete_marker) {
+            return embed_error(
+                lfs::ErrorCode::PermissionDenied,
+                "The embedded dataset cache could not be finalized.",
+                lfs::core::path_to_utf8(marker));
+        }
+        LOG_INFO(
+            "Embedded dataset extraction completed: {} files extracted, {} files reused, cache {}",
+            extracted_files, reused_files,
+            lfs::core::path_to_utf8(cache));
+        return std::optional<std::filesystem::path>{cache};
+    }
+
+    lfs::Result<std::optional<std::filesystem::path>>
+    extract_embedded_dataset_if_needed(
+        const ProjectDocument& document,
+        const std::function<bool(float)>& progress) {
+        auto manifest = document.parameters().embedded_dataset();
+        if (!manifest) {
+            return std::move(manifest).error();
+        }
+        if (!*manifest || !(*manifest)->complete || (*manifest)->entries.empty()) {
+            return std::optional<std::filesystem::path>{};
+        }
+        const auto dataset_ref = document.project().dataset_reference();
+        if (!dataset_ref) {
+            return std::move(dataset_ref).error();
+        }
+        if (!*dataset_ref) {
+            return std::optional<std::filesystem::path>{};
+        }
+        const auto external = resolve_path_reference(
+            document.references(), project_root_for(document), **dataset_ref, {});
+        if (external && std::filesystem::exists(*external)) {
+            return std::optional<std::filesystem::path>{};
+        }
+        // Resolve cache dir path from UserPaths
+        const auto cache = embedded_dataset_cache_dir(document);
+        if (!cache) {
+            return std::move(cache).error();
+        }
+        return extract_embedded_dataset(document, *cache, progress);
+    }
+
+} // namespace lfs::io::project

--- a/src/io/project/project_chapters.cpp
+++ b/src/io/project/project_chapters.cpp
@@ -3702,4 +3702,31 @@ namespace lfs::io::project {
             std::move(*result), parameters);
     }
 
+    void adopt_project_training_parameters(
+        lfs::core::param::TrainingParameters& params,
+        ParameterManagerSnapshot snapshot,
+        std::filesystem::path dataset_root,
+        std::string images_folder) {
+
+        // Take the stored options and supply the resolved and command-line locations.
+        auto dataset = std::move(snapshot.dataset);
+        dataset.data_path = std::move(dataset_root);
+        dataset.images = std::move(images_folder);
+        dataset.output_path = params.dataset.output_path;
+        dataset.output_path_explicit = params.dataset.output_path_explicit;
+        dataset.output_name = params.dataset.output_name;
+        params.dataset = std::move(dataset);
+
+        // The pending block of the active strategy is what the GUI would
+        // train with next. The three process flags describe this launch,
+        // not the project, so they always come from the command line.
+        auto optimization = snapshot.active_optimization();
+        optimization.headless = params.optimization.headless;
+        optimization.auto_train = params.optimization.auto_train;
+        optimization.no_splash = params.optimization.no_splash;
+        params.optimization = std::move(optimization);
+
+        lfs::core::param::apply_explicit_training_overrides(params, params.overrides);
+    }
+
 } // namespace lfs::io::project

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -22,6 +22,7 @@
 #include "gui/gui_manager.hpp"
 #include "gui/string_keys.hpp"
 #include "gui/utils/native_file_dialog.hpp"
+#include "io/embedded_dataset.hpp"
 #include "io/filesystem_utils.hpp"
 #include "io/loader.hpp"
 #include "io/loaders/missing_dataset_images.hpp"
@@ -417,41 +418,6 @@ namespace lfs::vis::project {
             return *resolved;
         }
 
-        lfs::Result<lfs::io::project::Hash128>
-        hashDatasetFile(const std::filesystem::path& path) {
-            std::ifstream input(path, std::ios::binary);
-            if (!input) {
-                return lifecycleError(
-                    lfs::ErrorCode::PermissionDenied,
-                    "A dataset file could not be opened.", lfs::core::path_to_utf8(path),
-                    "project.dataset_embed");
-            }
-            lfs::io::project::Hash128Stream hasher;
-            std::vector<char> buffer(1024 * 1024);
-            while (input) {
-                input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
-                const auto count = input.gcount();
-                if (count <= 0) {
-                    break;
-                }
-                if (!hasher.update(std::span<const std::byte>(
-                        reinterpret_cast<const std::byte*>(buffer.data()),
-                        static_cast<std::size_t>(count)))) {
-                    return lifecycleError(
-                        lfs::ErrorCode::DataLoss,
-                        "A dataset file could not be hashed.", lfs::core::path_to_utf8(path),
-                        "project.dataset_embed");
-                }
-            }
-            if (!input.eof() || !hasher.valid()) {
-                return lifecycleError(
-                    lfs::ErrorCode::DataLoss,
-                    "A dataset file could not be hashed.", lfs::core::path_to_utf8(path),
-                    "project.dataset_embed");
-            }
-            return hasher.digest();
-        }
-
         std::vector<std::pair<std::filesystem::path, std::string>>
         datasetFiles(const std::filesystem::path& directory,
                      const std::string_view kind) {
@@ -471,8 +437,19 @@ namespace lfs::vis::project {
 
         std::vector<std::pair<std::filesystem::path, std::string>>
         discoverDatasetFiles(const std::filesystem::path& root,
+                             const std::string& configured_images,
                              std::string& images_folder) {
-            const auto info = lfs::io::detect_dataset_info(root);
+            auto info = lfs::io::detect_dataset_info(root);
+            // Embed the images folder the project was loaded with (e.g. images_2).
+            // Detection alone would take the first well-known folder, usually the
+            // full-resolution "images", even when training used a downscaled one.
+            if (!configured_images.empty() && configured_images != ".") {
+                const auto configured =
+                    root / lfs::core::utf8_to_path(configured_images);
+                if (std::filesystem::is_directory(configured)) {
+                    info.images_path = configured;
+                }
+            }
             images_folder = lfs::core::path_to_generic_utf8(info.images_path.lexically_relative(root));
             std::vector<std::pair<std::filesystem::path, std::string>> result;
             const auto append = [&](const auto& directory, const std::string_view kind) {
@@ -505,202 +482,6 @@ namespace lfs::vis::project {
                 return lfs::core::path_to_generic_utf8(item.first.lexically_relative(root));
             });
             return result;
-        }
-
-        lfs::Result<std::optional<std::filesystem::path>>
-        extractEmbeddedDatasetIfNeeded(
-            const ProjectDocument& document,
-            const std::function<bool(float)>& progress = {}) {
-            auto manifest = document.parameters().embedded_dataset();
-            if (!manifest) {
-                return std::move(manifest).error();
-            }
-            if (!*manifest || !(*manifest)->complete || (*manifest)->entries.empty()) {
-                return std::optional<std::filesystem::path>{};
-            }
-            const auto dataset_ref = document.project().dataset_reference();
-            if (!dataset_ref) {
-                return std::move(dataset_ref).error();
-            }
-            if (!*dataset_ref) {
-                return std::optional<std::filesystem::path>{};
-            }
-            const auto external = lfs::io::project::resolve_path_reference(
-                document.references(), projectRootFor(document), **dataset_ref, {});
-            if (external && std::filesystem::exists(*external)) {
-                return std::optional<std::filesystem::path>{};
-            }
-            const auto paths = lfs::core::UserPaths::resolve();
-            if (!paths) {
-                return std::move(paths).error();
-            }
-            const auto cache = paths->rootDir() / "cache" / "embedded_datasets" /
-                               document.project_uuid().to_string();
-            std::error_code error;
-            std::filesystem::create_directories(cache, error);
-            if (error) {
-                return lifecycleError(lfs::ErrorCode::PermissionDenied,
-                                      "The embedded dataset cache could not be created.",
-                                      error.message(), "project.dataset_embed");
-            }
-            const auto marker = cache / ".complete";
-            std::filesystem::remove(marker, error);
-            const auto total_bytes = std::ranges::fold_left(
-                (*manifest)->entries, std::uint64_t{0},
-                [](const std::uint64_t total, const auto& entry) {
-                    return total + entry.bytes;
-                });
-            LOG_INFO(
-                "Embedded dataset extraction started: {} files, {} bytes, cache {}",
-                (*manifest)->entries.size(), total_bytes,
-                lfs::core::path_to_utf8(cache));
-            std::uint64_t completed_bytes = 0;
-            std::size_t reused_files = 0;
-            std::size_t extracted_files = 0;
-            for (const auto& entry : (*manifest)->entries) {
-                if (progress && !progress(
-                                    total_bytes == 0
-                                        ? 0.0F
-                                        : static_cast<float>(completed_bytes) /
-                                              static_cast<float>(total_bytes))) {
-                    return lifecycleError(
-                        lfs::ErrorCode::Cancelled,
-                        "Embedded dataset extraction was canceled.",
-                        "The project-open job requested cancellation",
-                        "project.dataset_embed");
-                }
-                const auto relative = lfs::core::utf8_to_path(entry.rel_path);
-                if (relative.empty() || relative.is_absolute() ||
-                    relative.lexically_normal() != relative) {
-                    return lifecycleError(
-                        lfs::ErrorCode::DataLoss,
-                        "The embedded dataset manifest contains an unsafe path.",
-                        entry.rel_path, "project.dataset_embed");
-                }
-                const auto destination = (cache / relative).lexically_normal();
-                const auto source = document.find_dataset_source(entry.chunk_uuid);
-                if (!source) {
-                    return lifecycleError(
-                        lfs::ErrorCode::DataLoss,
-                        "The embedded dataset chunk is missing.",
-                        entry.chunk_uuid.to_string(), "project.dataset_embed");
-                }
-                if (source->size() != entry.bytes) {
-                    return lifecycleError(
-                        lfs::ErrorCode::DataLoss,
-                        "The embedded dataset chunk size does not match its manifest.",
-                        std::format("{} has {} bytes, manifest expected {}",
-                                    entry.chunk_uuid.to_string(), source->size(),
-                                    entry.bytes),
-                        "project.dataset_embed");
-                }
-                bool valid_existing = false;
-                if (std::filesystem::is_regular_file(destination)) {
-                    std::error_code size_error;
-                    valid_existing = std::filesystem::file_size(destination, size_error) ==
-                                         entry.bytes &&
-                                     !size_error;
-                    if (valid_existing) {
-                        auto hash = hashDatasetFile(destination);
-                        valid_existing = hash && *hash == entry.xxh3_128;
-                    }
-                }
-                if (valid_existing) {
-                    completed_bytes += entry.bytes;
-                    ++reused_files;
-                    continue;
-                }
-                std::filesystem::create_directories(destination.parent_path(), error);
-                if (error) {
-                    return lifecycleError(
-                        lfs::ErrorCode::PermissionDenied,
-                        "The embedded dataset cache could not be created.",
-                        error.message(), "project.dataset_embed");
-                }
-                auto temporary = destination;
-                temporary += ".part";
-                std::ofstream output;
-                lfs::core::open_file_for_write(
-                    temporary, std::ios::binary | std::ios::trunc, output);
-                if (!output) {
-                    return lifecycleError(
-                        lfs::ErrorCode::PermissionDenied,
-                        "An embedded dataset file could not be extracted.",
-                        lfs::core::path_to_utf8(destination), "project.dataset_embed");
-                }
-                lfs::io::project::Hash128Stream hasher;
-                auto copied = source->visit_stream(
-                    [&](std::istream& input, const std::uint64_t size) -> lfs::Result<void> {
-                        std::vector<char> buffer(1024 * 1024);
-                        std::uint64_t copied_bytes = 0;
-                        while (input && copied_bytes < size) {
-                            const auto remaining = size - copied_bytes;
-                            const auto request = static_cast<std::streamsize>(
-                                std::min<std::uint64_t>(remaining, buffer.size()));
-                            input.read(buffer.data(), request);
-                            const auto count = input.gcount();
-                            if (count <= 0)
-                                break;
-                            const auto bytes = std::span<const std::byte>(
-                                reinterpret_cast<const std::byte*>(buffer.data()),
-                                static_cast<std::size_t>(count));
-                            if (!hasher.update(bytes)) {
-                                return lfs::Result<void>::failure(lifecycleError(
-                                    lfs::ErrorCode::DataLoss,
-                                    "An embedded dataset file could not be extracted.",
-                                    lfs::core::path_to_utf8(destination), "project.dataset_embed"));
-                            }
-                            output.write(buffer.data(), count);
-                            copied_bytes += static_cast<std::uint64_t>(count);
-                        }
-                        if (!output || copied_bytes != size) {
-                            return lfs::Result<void>::failure(lifecycleError(
-                                lfs::ErrorCode::DataLoss,
-                                "An embedded dataset file could not be extracted.",
-                                lfs::core::path_to_utf8(destination), "project.dataset_embed"));
-                        }
-                        return {};
-                    });
-                output.close();
-                if (!copied || !hasher.valid() || hasher.digest() != entry.xxh3_128) {
-                    std::filesystem::remove(temporary, error);
-                    return copied ? lifecycleError(
-                                        lfs::ErrorCode::DataLoss,
-                                        "The embedded dataset file failed hash verification.",
-                                        lfs::core::path_to_utf8(destination), "project.dataset_embed")
-                                  : std::move(copied).error();
-                }
-                std::filesystem::rename(temporary, destination, error);
-                if (error) {
-                    std::filesystem::remove(temporary);
-                    return lifecycleError(
-                        lfs::ErrorCode::PermissionDenied,
-                        "The embedded dataset file could not be published.",
-                        error.message(), "project.dataset_embed");
-                }
-                completed_bytes += entry.bytes;
-                ++extracted_files;
-            }
-            if (progress && !progress(1.0F)) {
-                return lifecycleError(
-                    lfs::ErrorCode::Cancelled,
-                    "Embedded dataset extraction was canceled.",
-                    "The project-open job requested cancellation",
-                    "project.dataset_embed");
-            }
-            std::ofstream complete_marker(marker,
-                                          std::ios::binary | std::ios::trunc);
-            if (!complete_marker) {
-                return lifecycleError(
-                    lfs::ErrorCode::PermissionDenied,
-                    "The embedded dataset cache could not be finalized.",
-                    lfs::core::path_to_utf8(marker), "project.dataset_embed");
-            }
-            LOG_INFO(
-                "Embedded dataset extraction completed: {} files extracted, {} files reused, cache {}",
-                extracted_files, reused_files,
-                lfs::core::path_to_utf8(cache));
-            return std::optional<std::filesystem::path>{cache};
         }
 
         struct PersistedDatasetScene {
@@ -3957,6 +3738,10 @@ namespace lfs::vis::project {
             document = document_;
         }
         const auto root = resolveExternalDatasetRoot(*document);
+        std::string configured_images;
+        if (const auto snapshot = document->parameters().snapshot(); snapshot) {
+            configured_images = snapshot->dataset.images;
+        }
         if (!root || root->empty() || !std::filesystem::is_directory(*root)) {
             return reportDatasetEmbedStartFailure(fail<void>(
                 lfs::ErrorCode::NotFound,
@@ -3987,6 +3772,7 @@ namespace lfs::vis::project {
         try {
             project_write_thread_ = std::jthread(
                 [this, document = std::move(document), root = *root,
+                 configured_images = std::move(configured_images),
                  destination, handle = *handle](const std::stop_token stop) mutable {
                     auto& jobs = viewer_.jobs();
                     jobs.work(handle);
@@ -4000,7 +3786,8 @@ namespace lfs::vis::project {
                         queueProjectWriteSettlement(handle);
                     };
                     std::string images_folder;
-                    const auto discovered = discoverDatasetFiles(root, images_folder);
+                    const auto discovered =
+                        discoverDatasetFiles(root, configured_images, images_folder);
                     EmbeddedDatasetManifest final_manifest{
                         .schema_version = 1,
                         .images_folder = std::move(images_folder),
@@ -4025,7 +3812,7 @@ namespace lfs::vis::project {
                                 "project.dataset_embed"));
                             return;
                         }
-                        auto hash = hashDatasetFile(path);
+                        auto hash = lfs::io::project::hash_dataset_file(path);
                         if (!hash) {
                             fail_worker(hash.error());
                             return;
@@ -7923,7 +7710,7 @@ namespace lfs::vis::project {
                             *project_open_job, 0.06F,
                             LOC("status.dataset_embed_extracting"));
                     }
-                    auto extracted = extractEmbeddedDatasetIfNeeded(
+                    auto extracted = lfs::io::project::extract_embedded_dataset_if_needed(
                         *opened_source,
                         [this, project_open_job, &stop](
                             const float progress) {

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -91,22 +91,6 @@ namespace lfs::vis::project {
         using lfs::io::project::ProjectSessionChapters;
         using lfs::io::project::TrainingFinishReason;
 
-        [[nodiscard]] const lfs::core::param::OptimizationParameters&
-        currentOptimizationParams(
-            const lfs::io::project::ParameterManagerSnapshot&
-                snapshot) {
-            const auto strategy =
-                lfs::core::param::canonical_strategy_name(
-                    snapshot.active_strategy);
-            if (strategy == lfs::core::param::kStrategyMCMC) {
-                return snapshot.mcmc_current;
-            }
-            if (strategy == lfs::core::param::kStrategyIGSPlus) {
-                return snapshot.igs_current;
-            }
-            return snapshot.mrnf_current;
-        }
-
         [[nodiscard]] bool storedSessionCompleted(
             const int iteration,
             const int max_iterations,
@@ -1039,8 +1023,7 @@ namespace lfs::vis::project {
             training_session_error_.clear();
         }
         const auto fill_facts = [&] {
-            const auto& params = currentOptimizationParams(
-                report.pending_parameters);
+            const auto& params = report.pending_parameters.active_optimization();
             std::string strategy(
                 lfs::core::param::canonical_strategy_name(
                     report.pending_parameters.active_strategy));

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -35,6 +35,31 @@ namespace {
 
 } // namespace
 
+// An untrained .licht on --data-path is its own destination, so
+// --output-path is optional and the project stays bound for the run.
+TEST(ArgumentParserTest, DataPathLichtWithoutOutputPathBindsProject) {
+    const auto directory =
+        make_test_path("lfs_arg_parser_dataset_project");
+    const auto project =
+        std::filesystem::path(directory) / "project.licht";
+    std::ofstream(project).put('\n');
+    const auto project_text = project.string();
+
+    const char* argv[] = {
+        "LichtFeld-Studio",
+        "--headless",
+        "-d",
+        project_text.c_str(),
+    };
+    auto parsed = lfs::core::args::parse_args_and_params(
+        static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed) << parsed.error();
+    EXPECT_EQ((*parsed)->dataset_project, project);
+    EXPECT_TRUE((*parsed)->dataset.data_path.empty());
+    EXPECT_TRUE((*parsed)->dataset.output_path.empty());
+    EXPECT_FALSE((*parsed)->dataset.output_path_explicit);
+}
+
 TEST(ArgumentParserTest,
      GuiProjectAndResumeLichtSelectProjectOpenFlow) {
     const auto directory =

--- a/tests/test_project_chapters.cpp
+++ b/tests/test_project_chapters.cpp
@@ -779,4 +779,46 @@ namespace {
         EXPECT_TRUE((*found)->camera->has_image);
     }
 
+    // Headless training from an untrained .licht has no checkpoint to restore
+    // from, so the run is assembled from the PRMS snapshot and the command
+    // line. This pins the three merge rules: stored values (active strategy,
+    // its iterations, loading settings) replace the CLI defaults; the process
+    // flags describe this launch and stay with the CLI; and flags the user
+    // typed explicitly, recorded as overrides, beat the stored values. The
+    // resolved dataset location and the CLI output location must survive
+    // because PRMS never stores paths.
+    TEST(ProjectChapterTest, AdoptProjectTrainingParametersMergesSnapshotAndCliFlags) {
+        using lfs::core::param::OptimizationParameters;
+        ParameterManagerSnapshot snapshot;
+        snapshot.active_strategy = "mcmc";
+        snapshot.mcmc_current = OptimizationParameters::mcmc_defaults();
+        snapshot.mcmc_current.iterations = 1234;
+        snapshot.dataset.images = "images_4";
+        snapshot.dataset.test_every = 8;
+        snapshot.dataset.loading_params.use_cpu_memory = false;
+
+        // As parsed from: --headless -o out --images images --test-every 4
+        lfs::core::param::TrainingParameters params;
+        params.optimization.headless = true;
+        params.dataset.output_path = "out";
+        params.dataset.output_path_explicit = true;
+        params.overrides.dataset_json = R"({"images":"images","test_every":4})";
+
+        adopt_project_training_parameters(params, snapshot, "/data/scene", "images_4");
+
+        // Stored strategy, iterations and loading settings win over CLI defaults.
+        EXPECT_EQ(params.optimization.strategy, "mcmc");
+        EXPECT_EQ(params.optimization.iterations, 1234u);
+        EXPECT_FALSE(params.dataset.loading_params.use_cpu_memory);
+        // Process flags stay with the command line.
+        EXPECT_TRUE(params.optimization.headless);
+        // Explicit CLI dataset flags win over stored values.
+        EXPECT_EQ(params.dataset.images, "images");
+        EXPECT_EQ(params.dataset.test_every, 4);
+        // Resolved dataset location and CLI output location are kept.
+        EXPECT_EQ(params.dataset.data_path, std::filesystem::path("/data/scene"));
+        EXPECT_EQ(params.dataset.output_path, std::filesystem::path("out"));
+        EXPECT_TRUE(params.dataset.output_path_explicit);
+    }
+
 } // namespace

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -5,6 +5,7 @@
 
 #include "app/headless_recovery_document.hpp"
 #include "core/image_io.hpp"
+#include "io/embedded_dataset.hpp"
 #include "io/loaders/loader_utils.hpp"
 #include "io/project/project_container_internal.hpp"
 #include "io/project/span_streambuf.hpp"
@@ -6081,6 +6082,103 @@ namespace {
             EXPECT_EQ(require_result(compacted_reader.read_chunk(*row)),
                       read_file_bytes(dataset / entry.rel_path));
         }
+    }
+
+    // Covers lfs::io::project::extract_embedded_dataset, the headless side of
+    // dataset embedding: DSRC chunks are written back to disk byte-for-byte,
+    // guarded by the manifest hash, into a caller-chosen cache folder.
+    TEST(ProjectDocumentTest, ExtractEmbeddedDatasetRestoresFilesIntoCache) {
+        TemporaryDirectory temporary;
+        // A minimal dataset with a downscaled images folder, so the test also
+        // exercises a non-default images_folder in the manifest.
+        const auto dataset = temporary.path / "dataset";
+        const auto image = dataset / "images_2" / "frame.bin";
+        const auto sparse = dataset / "sparse" / "0" / "cameras.bin";
+        std::filesystem::create_directories(image.parent_path());
+        std::filesystem::create_directories(sparse.parent_path());
+        const std::vector<std::byte> image_bytes{
+            std::byte{0x10}, std::byte{0x20}, std::byte{0x30}};
+        const std::vector<std::byte> sparse_bytes{std::byte{0x01}, std::byte{0x03}};
+        write_file_bytes(image, image_bytes);
+        write_file_bytes(sparse, sparse_bytes);
+
+        // The project references the dataset folder like a GUI save would.
+        auto document = require_result_ptr(ProjectDocument::create(
+            fixed_uuid(2501), 100));
+        bind_dataset(*document, dataset);
+        const auto project_path = temporary.path / "extract.licht";
+        (void)require_result(document->save(project_path, save_options(2502, 200)));
+
+        const auto entry_for = [](const fs::path& path,
+                                  const std::string& rel,
+                                  const std::string& kind,
+                                  const Uuid& uuid) {
+            const auto bytes = read_file_bytes(path);
+            return EmbeddedDatasetEntry{
+                .rel_path = rel,
+                .kind = kind,
+                .chunk_uuid = uuid,
+                .bytes = bytes.size(),
+                .xxh3_128 = xxh3_128(bytes),
+            };
+        };
+        const auto image_entry = entry_for(
+            image, "images_2/frame.bin", "image", fixed_uuid(2503));
+        const auto sparse_entry = entry_for(
+            sparse, "sparse/0/cameras.bin", "sparse", fixed_uuid(2504));
+        const std::array sources{
+            DatasetEmbedSource{.entry = image_entry, .source_path = image},
+            DatasetEmbedSource{.entry = sparse_entry, .source_path = sparse},
+        };
+        const auto cache = temporary.path / "cache";
+
+        // Embed only the image first. Extraction must refuse a manifest that is
+        // not marked complete and leave the cache without a ".complete" marker.
+        const EmbeddedDatasetManifest partial_manifest{
+            .schema_version = 1,
+            .images_folder = "images_2",
+            .complete = false,
+            .entries = {image_entry},
+        };
+        (void)require_result(document->embed_dataset_batch(
+            partial_manifest, std::span(sources).first(1),
+            save_options(2505, 300)));
+        EXPECT_FALSE(require_result(lfs::io::project::extract_embedded_dataset(
+                                        *document, cache))
+                         .has_value());
+        EXPECT_FALSE(fs::exists(cache / ".complete"));
+
+        const EmbeddedDatasetManifest manifest{
+            .schema_version = 1,
+            .images_folder = "images_2",
+            .complete = true,
+            .entries = {image_entry, sparse_entry},
+        };
+        (void)require_result(document->embed_dataset_batch(
+            manifest, std::span(sources).subspan(1),
+            save_options(2506, 400)));
+
+        // Reopen from disk so the DSRC chunks are read as lazy file-backed
+        // sources, the way headless training sees them.
+        auto reopened = require_result_ptr(ProjectDocument::open(project_path));
+        const auto extracted = require_result(
+            lfs::io::project::extract_embedded_dataset(*reopened, cache));
+        ASSERT_TRUE(extracted);
+        EXPECT_EQ(*extracted, cache);
+        EXPECT_TRUE(fs::is_regular_file(cache / ".complete"));
+        EXPECT_EQ(read_file_bytes(cache / "images_2" / "frame.bin"), image_bytes);
+        EXPECT_EQ(read_file_bytes(cache / "sparse" / "0" / "cameras.bin"),
+                  sparse_bytes);
+        EXPECT_EQ(require_result(lfs::io::project::hash_dataset_file(
+                      cache / "images_2" / "frame.bin")),
+                  image_entry.xxh3_128);
+
+        // Extraction is idempotent: a cached file that no longer matches its
+        // manifest hash is rewritten, while matching files would be reused.
+        write_file_bytes(cache / "images_2" / "frame.bin", sparse_bytes);
+        (void)require_result(
+            lfs::io::project::extract_embedded_dataset(*reopened, cache));
+        EXPECT_EQ(read_file_bytes(cache / "images_2" / "frame.bin"), image_bytes);
     }
 
 } // namespace


### PR DESCRIPTION
### Summary
Let headless training start from an untrained .licht with embedded dataset via `--data-path`.

Headless mode could not use either: `--resume` required a bound checkpoint and the embedded-dataset extraction lived only in the visualizer.

- Move the extraction into `lfs_io` (io/embedded_dataset.hpp) so headless and the GUI share it. The function body is unchanged.
- Accept an untrained .licht on `--data-path`. application.cpp resolves its dataset from the REFS folder or the embedded copy, applies the PRMS dataset options, and continues as an ordinary dataset run. Projects with a checkpoint are rejected with a hint to use `--resume`.
- Embed the images folder the project was loaded with instead of the first detected one, so downscaled datasets round-trip correctly.

### Future Work
- As mentioned in the second point above, if a project already contains checkpoints from a previous training run, an error is printed that `--resume` should be used. Instead, it could automatically just resume training.
- Starting training from .licht projects that don't have images embedded does not work yet.