### PR TITLE
Drops from Wayland-native apps arrive as files again

### DIFF
--- a/src/visualizer/gui/utils/drag_drop_native.cpp
+++ b/src/visualizer/gui/utils/drag_drop_native.cpp
@@ -15,6 +15,7 @@
 #include <SDL3/SDL.h>
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
+#include <utility>
 #else
 #include <SDL3/SDL.h>
 #endif
@@ -223,9 +224,61 @@ namespace lfs::vis::gui {
         Atom xdnd_finished = 0;
         Atom xdnd_selection = 0;
         Atom xdnd_type_list = 0;
+        Atom text_uri_list = 0;
 
         Window source_window = 0;
     };
+
+    namespace {
+
+        constexpr long kXdndEnterUseTypeList = 1;
+
+        // SDL 3.4.2 takes the first XDND target it recognises. mutter forwards a
+        // GTK4 (Nautilus) drag with text/plain;charset=utf-8 listed ahead of
+        // text/uri-list, so the drop arrives as SDL_EVENT_DROP_TEXT holding a
+        // bare path instead of SDL_EVENT_DROP_FILE. Rewrite XdndEnter so
+        // text/uri-list is the first offered type whenever the source has it
+        // (upstream fix: SDL commit 1df279a04, after 3.4.2).
+        void preferUriListTarget(Display* const dpy, XClientMessageEvent& msg, const Atom type_list_atom,
+                                 const Atom uri_list) {
+            long* const l = msg.data.l;
+            if ((l[1] & kXdndEnterUseTypeList) == 0) {
+                for (int i = 3; i <= 4; ++i) {
+                    if (static_cast<Atom>(l[i]) == uri_list) {
+                        std::swap(l[2], l[i]);
+                        break;
+                    }
+                }
+                return;
+            }
+
+            Atom actual_type = None;
+            int actual_format = 0;
+            unsigned long count = 0;
+            unsigned long bytes_after = 0;
+            unsigned char* data = nullptr;
+            if (XGetWindowProperty(dpy, static_cast<Window>(l[0]), type_list_atom, 0, 4096, False, XA_ATOM,
+                                   &actual_type, &actual_format, &count, &bytes_after, &data) != Success ||
+                !data) {
+                return;
+            }
+            bool has_uri_list = false;
+            if (actual_type == XA_ATOM && actual_format == 32) {
+                const Atom* const atoms = reinterpret_cast<const Atom*>(data);
+                for (unsigned long i = 0; i < count && !has_uri_list; ++i)
+                    has_uri_list = atoms[i] == uri_list;
+            }
+            XFree(data);
+            if (!has_uri_list)
+                return;
+
+            l[1] &= ~kXdndEnterUseTypeList;
+            l[2] = static_cast<long>(uri_list);
+            l[3] = 0;
+            l[4] = 0;
+        }
+
+    } // namespace
 
     bool NativeDragDrop::init(SDL_Window* window) {
         if (initialized_)
@@ -256,6 +309,12 @@ namespace lfs::vis::gui {
         platform_data_->xdnd_finished = XInternAtom(dpy, "XdndFinished", False);
         platform_data_->xdnd_selection = XInternAtom(dpy, "XdndSelection", False);
         platform_data_->xdnd_type_list = XInternAtom(dpy, "XdndTypeList", False);
+        platform_data_->text_uri_list = XInternAtom(dpy, "text/uri-list", False);
+
+        // Observe XDnD traffic inside SDL's own pump. Dequeuing ClientMessages
+        // ourselves (XCheckTypedEvent + XPutBackEvent) reordered them ahead of
+        // the SelectionNotify SDL waits for after XdndDrop.
+        SDL_SetX11EventHook(&NativeDragDrop::x11EventHook, this);
 
         initialized_ = true;
         LOG_DEBUG("Native drag-drop initialized (X11 XDnD)");
@@ -266,6 +325,7 @@ namespace lfs::vis::gui {
         if (!initialized_)
             return;
 
+        SDL_SetX11EventHook(nullptr, nullptr);
         if (platform_data_) {
             delete platform_data_;
             platform_data_ = nullptr;
@@ -276,34 +336,31 @@ namespace lfs::vis::gui {
     }
 
     void NativeDragDrop::pollEvents() {
-        if (!initialized_ || !platform_data_)
-            return;
+        // XDnD state is tracked from SDL's event hook, nothing to poll.
+    }
 
-        Display* const dpy = platform_data_->display;
-        if (XPending(dpy) <= 0)
-            return;
-
-        // Extract all ClientMessage events to find XDnD state changes.
-        // XPeekEvent only checks the first event; XDnD messages may be
-        // buried behind mouse/keyboard/expose events in the queue.
-        XEvent event;
-        std::vector<XEvent> extracted;
-        while (XCheckTypedEvent(dpy, ClientMessage, &event)) {
-            const Atom msg_type = event.xclient.message_type;
-            if (msg_type == platform_data_->xdnd_enter && !drag_hovering_) {
-                platform_data_->source_window = static_cast<Window>(event.xclient.data.l[0]);
-                setDragHovering(true);
-            } else if ((msg_type == platform_data_->xdnd_leave || msg_type == platform_data_->xdnd_drop) && drag_hovering_) {
-                setDragHovering(false);
-                platform_data_->source_window = 0;
-            }
-            extracted.push_back(event);
+    bool NativeDragDrop::x11EventHook(void* userdata, XEvent* xevent) {
+        auto* const self = static_cast<NativeDragDrop*>(userdata);
+        if (!self || !self->platform_data_ || xevent->type != ClientMessage ||
+            xevent->xclient.window != self->platform_data_->xwindow) {
+            return true;
         }
 
-        // Restore events for SDL to process (reverse order preserves queue ordering)
-        for (auto it = extracted.rbegin(); it != extracted.rend(); ++it) {
-            XPutBackEvent(dpy, &*it);
+        PlatformData& pd = *self->platform_data_;
+        XClientMessageEvent& msg = xevent->xclient;
+        if (msg.message_type == pd.xdnd_enter) {
+            LOG_DEBUG("XDnD enter: source=0x{:x} version={} type_list={}", static_cast<unsigned long>(msg.data.l[0]),
+                      msg.data.l[1] >> 24, (msg.data.l[1] & kXdndEnterUseTypeList) != 0);
+            preferUriListTarget(pd.display, msg, pd.xdnd_type_list, pd.text_uri_list);
+            pd.source_window = static_cast<Window>(msg.data.l[0]);
+            self->setDragHovering(true);
+        } else if (msg.message_type == pd.xdnd_drop || msg.message_type == pd.xdnd_leave) {
+            LOG_DEBUG("XDnD {}: source=0x{:x}", msg.message_type == pd.xdnd_drop ? "drop" : "leave",
+                      static_cast<unsigned long>(msg.data.l[0]));
+            self->setDragHovering(false);
+            pd.source_window = 0;
         }
+        return true;
     }
 
 // ============================================================================

--- a/src/visualizer/gui/utils/drag_drop_native.hpp
+++ b/src/visualizer/gui/utils/drag_drop_native.hpp
@@ -9,6 +9,9 @@
 #include <vector>
 
 struct SDL_Window;
+#ifdef __linux__
+union _XEvent;
+#endif
 
 namespace lfs::vis::gui {
 
@@ -45,7 +48,7 @@ namespace lfs::vis::gui {
         // Force-reset hovering state (called when file drop is confirmed via SDL callback)
         void resetHovering() { setDragHovering(false); }
 
-        // Poll for X11 events (call each frame on Linux)
+        // Per-frame hook for platforms that need polling (no-op on X11 and Windows)
         void pollEvents();
 
     private:
@@ -61,6 +64,9 @@ namespace lfs::vis::gui {
 
         void setDragHovering(bool hovering);
         void handleFileDrop(const std::vector<std::string>& paths);
+#ifdef __linux__
+        static bool x11EventHook(void* userdata, union _XEvent* xevent);
+#endif
     };
 
 } // namespace lfs::vis::gui

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -1142,6 +1142,8 @@ namespace lfs::vis {
         }
 
         case SDL_EVENT_DROP_FILE:
+            LOG_DEBUG("SDL drop file: window={} data={}", event.drop.windowID,
+                      event.drop.data ? event.drop.data : "(null)");
             if (!eventTargetsWindow(event, main_window_id))
                 break;
             if (event.drop.data) {
@@ -1149,7 +1151,20 @@ namespace lfs::vis {
             }
             break;
 
+        case SDL_EVENT_DROP_TEXT:
+            // A file drag that reached us as text (e.g. an X11 source offering
+            // text/plain ahead of text/uri-list) carries no usable file list.
+            LOG_DEBUG("SDL drop text ignored: window={} text={}", event.drop.windowID,
+                      event.drop.data ? event.drop.data : "(null)");
+            break;
+
+        case SDL_EVENT_DROP_BEGIN:
+            LOG_DEBUG("SDL drop begin: window={}", event.drop.windowID);
+            break;
+
         case SDL_EVENT_DROP_COMPLETE:
+            LOG_DEBUG("SDL drop complete: window={} pending_files={}", event.drop.windowID,
+                      pending_drop_files_.size());
             if (!eventTargetsWindow(event, main_window_id))
                 break;
             if (input_controller_ && !pending_drop_files_.empty()) {


### PR DESCRIPTION
Dropping a folder or file from Nautilus onto the app on a GNOME Wayland desktop (the app runs on Xwayland) did nothing.

mutter's Xwayland drag proxy lists the source's mime types in the order the Wayland client offers them, and GTK 4 puts `text/plain;charset=utf-8` ahead of `text/uri-list`. SDL 3.4.2 picks the first accepted type, so the drop reached the app as a DROP_TEXT event carrying a bare path, which the app ignores. SDL fixed the target choice upstream after 3.4.2; vcpkg still ships 3.4.2.

The native drag tracker now hooks SDL's X11 event stream instead of pulling ClientMessages off SDL's queue every frame: it tracks hover from XdndEnter/Leave/Drop inside SDL's pump (so it also works while the frame loop is parked), and rewrites XdndEnter to offer `text/uri-list` first when the source has it, so SDL requests the uri list and delivers DROP_FILE. Harmless once SDL is upgraded.

Reproduced on the Xvfb rig with a mutter-style XDND source (GTK-ordered type list, XdndLeave right after XdndDrop, asynchronous selection reply): before, `drop complete` with no file; after, `Processing 1 dropped file(s)`. Verified by the maintainer on the GNOME Wayland desktop with Nautilus.