### PR TITLE
Scene panel unregisters its tree element on destruction, keymap stubs refreshed

### DIFF
--- a/src/python/stubs/lichtfeld/keymap.pyi
+++ b/src/python/stubs/lichtfeld/keymap.pyi
@@ -171,6 +171,10 @@ class Action(enum.Enum):
 
     TOGGLE_SCENE_SELECTION_TRAINING = 84
 
+    GROUP_SELECTED_SCENE_NODES = 85
+
+    UNGROUP_SELECTED_SCENE_NODE = 86
+
 class ToolMode(enum.Enum):
     GLOBAL = 0
 

--- a/src/visualizer/gui/scene_panel_native.cpp
+++ b/src/visualizer/gui/scene_panel_native.cpp
@@ -383,6 +383,10 @@ namespace lfs::vis::gui {
             owner->handleEvent(event);
     }
 
+    NativeScenePanel::~NativeScenePanel() {
+        clearElementCache();
+    }
+
     void NativeScenePanel::clearElementCache() {
         logging_rows_.clear();
         if (manager_)

--- a/src/visualizer/gui/scene_panel_native.hpp
+++ b/src/visualizer/gui/scene_panel_native.hpp
@@ -32,6 +32,7 @@ namespace lfs::vis::gui {
     class NativeScenePanel : public IPanel {
     public:
         explicit NativeScenePanel(RmlUIManager* manager);
+        ~NativeScenePanel() override;
 
         void draw(const PanelDrawContext& ctx) override;
         void preload(const PanelDrawContext& ctx) override;


### PR DESCRIPTION
Two small master fixes found while verifying the cursor work.

- The scene panel is destroyed before the RmlUi manager shuts down, but it never cleared the manager's pointer to its scene graph element. Shutdown then touched a freed element (free(): invalid pointer, seen as an abort on exit). The panel now unregisters in its destructor.
- The GROUP and UNGROUP scene actions from #1994 were added without refreshing the keymap Python stubs, which fails the stub check. Refreshed.