### PR TITLE
Fix recent Windows compile and test-link regressions

### DIFF
--- a/src/visualizer/gui/selection_cursor.hpp
+++ b/src/visualizer/gui/selection_cursor.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/export.hpp"
 #include "rendering/rendering_types.hpp"
 #include <cstdint>
 #include <span>
@@ -48,11 +49,11 @@ namespace lfs::vis::gui {
         return 256;
     }
 
-    [[nodiscard]] bool useHardwareSelectionRing(bool preview_active,
-                                                SelectionPreviewMode mode,
-                                                int radius_px);
+    [[nodiscard]] LFS_VIS_API bool useHardwareSelectionRing(bool preview_active,
+                                                            SelectionPreviewMode mode,
+                                                            int radius_px);
 
-    [[nodiscard]] SelectionCursorImage makeSelectionCursorImage(
+    [[nodiscard]] LFS_VIS_API SelectionCursorImage makeSelectionCursorImage(
         int radius_px,
         SelectionCursorColor color,
         std::span<const uint8_t> badge_rgba = {},

--- a/src/visualizer/selection/selection_service.hpp
+++ b/src/visualizer/selection/selection_service.hpp
@@ -6,6 +6,7 @@
 #include "core/export.hpp"
 #include "core/scene.hpp"
 #include "core/tensor.hpp"
+#include "operation/undo_entry.hpp"
 #include "rendering/rendering_types.hpp"
 #include <array>
 #include <cstdint>
@@ -26,10 +27,6 @@ namespace lfs::rendering {
 class Viewport;
 
 namespace lfs::vis {
-
-    namespace op {
-        class SceneSnapshot;
-    }
 
     class SceneManager;
     class RenderingManager;


### PR DESCRIPTION
## What this fixes

This PR resolves two independent Windows regressions introduced by recent selection changes.

### 1. Incomplete `SceneSnapshot` ownership type

`SelectionService::PendingSelectionCounts` owns an `op::SceneSnapshot` through `std::unique_ptr`, but `selection_service.hpp` exposed only a forward declaration. MSVC instantiated `std::default_delete` while compiling consumers of the header and failed with C2027/C2338.

The ownership site now includes `operation/undo_entry.hpp`, and the redundant forward declaration is removed. The asynchronous selection-count behavior is unchanged.

### 2. Selection cursor helpers missing from the DLL interface

`lichtfeld_tests` calls `useHardwareSelectionRing` and `makeSelectionCursorImage`, both implemented in `lfs_visualizer`. Their declarations were missing `LFS_VIS_API`, so the test sources compiled but the Windows linker could not resolve them from the visualizer import library, producing LNK2019/LNK1120.

Only those two cross-DLL helper functions are now exported. Cursor behavior is unchanged.

## Validation

- Full local Windows build, including the `lichtfeld_tests.exe` link, completed successfully after both fixes (contributor-reported).
- `git diff --check` passes.
- The Error Debt gate reports no new violations.
- GitHub Windows and Ubuntu CI will re-run on the updated branch.

## Scope

- Based directly on `upstream/master` at `bd5361c22`.
- Two focused commits touching two headers only.
- No runtime behavior or selection semantics changed.

The regressions follow the changes merged in #1992 and #2004. The separate Windows `min`/`max` logger collision was already addressed on `master` by #2000 and is intentionally not duplicated here.