### PR TITLE
Add fast source and MSVC preflight gates for Windows builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -278,6 +278,13 @@ jobs:
             Start-Sleep -Seconds (15 * $attempt)
           }
 
+      - name: Generate shader headers for preflight
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set PATH=%CD%\%BUILD_DIR%\vcpkg_installed\x64-windows\bin;%PATH%
+          cmake --build %BUILD_DIR% --target lfs_shader_headers --config Release -j 4
+
       - name: Run configured MSVC preflight
         shell: cmd
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -174,8 +174,13 @@ jobs:
             echo "- Decision: ${REASON}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  build-windows:
+  windows-preflight:
     needs: precheck
+    if: github.repository == 'MrNeRF/LichtFeld-Studio' && needs.precheck.outputs.should_build == 'true'
+    uses: ./.github/workflows/windows-build-preflight.yml
+
+  build-windows:
+    needs: [precheck, windows-preflight]
     if: github.repository == 'MrNeRF/LichtFeld-Studio' && needs.precheck.outputs.should_build == 'true'
     runs-on: windows-2022
     env:
@@ -272,6 +277,14 @@ jobs:
             }
             Start-Sleep -Seconds (15 * $attempt)
           }
+
+      - name: Run configured MSVC preflight
+        shell: cmd
+        env:
+          LFS_PREFLIGHT_BASE: ${{ needs.precheck.outputs.previous_sha }}
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          python tools\windows_build_preflight.py --skip-source-checks --compile-commands %BUILD_DIR%\compile_commands.json --max-commands 128
 
       - name: Build
         shell: cmd

--- a/.github/workflows/windows-build-preflight.yml
+++ b/.github/workflows/windows-build-preflight.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Set up minimum supported Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: Test the preflight checker
         run: python3 -m unittest tests/python/test_windows_build_preflight.py
 

--- a/.github/workflows/windows-build-preflight.yml
+++ b/.github/workflows/windows-build-preflight.yml
@@ -1,0 +1,23 @@
+name: Windows Build Preflight
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  source-contracts:
+    name: source-contracts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Test the preflight checker
+        run: python3 -m unittest tests/python/test_windows_build_preflight.py
+
+      - name: Check Windows source contracts
+        run: python3 tools/windows_build_preflight.py --source-only

--- a/.github/workflows/windows-build-preflight.yml
+++ b/.github/workflows/windows-build-preflight.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.10'
 
       - name: Test the preflight checker
-        run: python3 -m unittest tests/python/test_windows_build_preflight.py
+        run: python3 -m unittest tests/python/test_windows_build_preflight.py tests/python/test_shader_header_target.py
 
       - name: Check Windows source contracts
         run: python3 tools/windows_build_preflight.py --source-only

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -150,6 +150,15 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake -B %BUILD_DIR% -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DLFS_FAST_COMPILE=ON -DBUILD_FORMAT_TESTS=ON -DBUILD_PYTHON_STUBS=OFF -DLFS_DEV_IMPORT_SOURCE_PYTHON=OFF -DLFS_DEV_IMPORT_SOURCE_RESOURCES=OFF -DLFS_ENABLE_CUDA_DEVICE_DEBUG=OFF
 
+      - name: Generate shader headers for preflight
+        shell: cmd
+        env:
+          VCPKG_RUNTIME_SUBDIR: ${{ matrix.build_type == 'Debug' && 'debug\bin' || 'bin' }}
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set PATH=%CD%\%BUILD_DIR%\vcpkg_installed\x64-windows\%VCPKG_RUNTIME_SUBDIR%;%PATH%
+          cmake --build %BUILD_DIR% --target lfs_shader_headers --config ${{ matrix.build_type }} -j 4
+
       - name: Run configured MSVC preflight
         shell: cmd
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Run configured MSVC preflight
         shell: cmd
         env:
-          LFS_PREFLIGHT_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          LFS_PREFLIGHT_BASE: ${{ github.event_name == 'pull_request' && 'HEAD^1' || github.event.before }}
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           python tools\windows_build_preflight.py --skip-source-checks --compile-commands %BUILD_DIR%\compile_commands.json --max-commands 128

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,10 @@ on:
   workflow_dispatch:
 
 jobs:
+  windows-preflight:
+    if: github.repository == 'MrNeRF/LichtFeld-Studio' || github.event.pull_request.base.repo.full_name == 'MrNeRF/LichtFeld-Studio'
+    uses: ./.github/workflows/windows-build-preflight.yml
+
   test-plugin-venv:
     if: github.repository == 'MrNeRF/LichtFeld-Studio' || github.event.pull_request.base.repo.full_name == 'MrNeRF/LichtFeld-Studio'
     runs-on: windows-2022
@@ -85,6 +89,7 @@ jobs:
           Write-Host "PASS: uv sync resilient to wrong PYTHONHOME"
 
   build-windows:
+    needs: windows-preflight
     if: github.repository == 'MrNeRF/LichtFeld-Studio' || github.event.pull_request.base.repo.full_name == 'MrNeRF/LichtFeld-Studio'
     runs-on: windows-2022
     strategy:
@@ -144,6 +149,14 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake -B %BUILD_DIR% -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DLFS_FAST_COMPILE=ON -DBUILD_FORMAT_TESTS=ON -DBUILD_PYTHON_STUBS=OFF -DLFS_DEV_IMPORT_SOURCE_PYTHON=OFF -DLFS_DEV_IMPORT_SOURCE_RESOURCES=OFF -DLFS_ENABLE_CUDA_DEVICE_DEBUG=OFF
+
+      - name: Run configured MSVC preflight
+        shell: cmd
+        env:
+          LFS_PREFLIGHT_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          python tools\windows_build_preflight.py --skip-source-checks --compile-commands %BUILD_DIR%\compile_commands.json --max-commands 128
 
       - name: Build
         shell: cmd

--- a/cmake/CompileShaders.cmake
+++ b/cmake/CompileShaders.cmake
@@ -40,5 +40,11 @@ function(compile_shader target source output symbol)
 
     add_custom_target("${_shader_target}" DEPENDS "${_output}")
     add_dependencies("${target}" "${_shader_target}")
+    # Expose the existing code-generation graph to syntax-only callers without
+    # building the visualizer. Keep target knowledge in CMake, not in the checker.
+    if(NOT TARGET lfs_shader_headers)
+        add_custom_target(lfs_shader_headers)
+    endif()
+    add_dependencies(lfs_shader_headers "${_shader_target}")
     target_sources("${target}" PRIVATE "${_output}")
 endfunction()

--- a/docs/docs/development/build.md
+++ b/docs/docs/development/build.md
@@ -138,3 +138,8 @@ Tests remain opt-in, keeping test-only package restore and target generation
 out of the normal application loop without changing any shipped feature. The
 canonical [source build guide](../../building_and_distribution.md#tests)
 documents the test build targets, CTest tiers, and required real-data layout.
+
+Before a complete MSVC build, use the
+[Windows build preflight](windows-build-preflight) to check Windows-specific
+source contracts and replay affected configured C/C++ translation units without
+code generation or linking.

--- a/docs/docs/development/build.md
+++ b/docs/docs/development/build.md
@@ -147,6 +147,10 @@ cmake --list-presets=all
 cmake -P tests/cmake/test_vcpkg_profiles.cmake
 ```
 
+With `BUILD_TESTS=ON`, these checks are also registered as
+`lichtfeld.cmake.vcpkg_profiles` and run with `ctest --test-dir build -L fast`.
+They do not need application binaries or a vcpkg installation.
+
 For build validation, build and launch both profiles on the target OS, then
 switch back without deleting either directory. Check the vcpkg install log for
 reuse; exercise Python imports and Vulkan validation in the RelWithDebInfo

--- a/docs/docs/development/index.md
+++ b/docs/docs/development/index.md
@@ -10,5 +10,6 @@ Development docs in this section are organized around execution workflows rather
 - [RmlUI Styling](rmlui-styling)
 - [UI design language and window patterns](ui-design-language)
 - [Developer flags and diagnostics](flags)
+- [Windows build preflight](windows-build-preflight)
 - [Preferences and user storage](preferences-and-user-storage)
 - [Scene reconstruction](scene-reconstruction)

--- a/docs/docs/development/windows-build-preflight.md
+++ b/docs/docs/development/windows-build-preflight.md
@@ -10,7 +10,8 @@ replacement for building and testing the application.
 
 ## Source checks
 
-The dependency-free check runs on Windows or Linux and requires only Python:
+The dependency-free check and its self-tests run on Windows or Linux with
+Python 3.10 or newer:
 
 ```sh
 python tools/windows_build_preflight.py --source-only
@@ -24,6 +25,12 @@ present in the DLL import library.
 The rule is intentionally conservative. It ignores broad `using namespace`
 imports, class methods, inline functions, and `constexpr` helpers rather than
 guessing at C++ semantics.
+
+In particular, `tests/test_project_lifecycle.cpp` and
+`tests/test_p5_session_chapters.cpp` use unqualified calls after nested
+`using namespace` directives. Removing `LFS_VIS_API` from
+`capturePanelCameraProjectState` is not detected by this source-only rule.
+The Windows link step is still needed to catch that missing export.
 
 Run the checker self-tests after changing its matching rules:
 
@@ -43,7 +50,7 @@ python tools/windows_build_preflight.py `
   --changed-since upstream/master
 ```
 
-The tool follows project-local quoted includes from each changed header to the
+The tool follows project-local quoted and angle-bracket includes from each changed header to the
 affected C and C++ translation units. It then replays their existing commands
 with MSVC's `/Zs` option. The Microsoft compiler therefore parses the same
 sources with the configured defines and include paths, but does not generate
@@ -51,24 +58,17 @@ object files or link targets. Compiler-specific failures such as invalid use of
 an incomplete type belong to this authoritative configured check, not to a
 lexical Python rule.
 
-Before invoking MSVC, the tool prepares `lfs_core_abi_stamp` if that target is
-present in the configured build tree. This generates the ABI header needed by
-the app, core, and tests even on a clean build where no C++ target has run yet.
-Older configurations that generate this header during CMake configuration do
-not need this preparation step. The tool uses the CMake executable recorded in
-the cache and builds only the header target; it does not request an application
-or test build. CMake may regenerate its build files as part of that command.
-The preflight then reloads the compile database before selecting commands again.
-If preparation fails, it stops before invoking MSVC.
+Keep `compile_commands.json` in its original configured build directory. The
+include index also considers headers under that directory's `include/`, so the
+generated `config.h` does not alias Vulkan's private header of the same name.
+Only project and generated headers are resolved; system headers are excluded.
+Deleted headers and both sides of a rename participate in change discovery.
 
-Keep `compile_commands.json` in its original configured build directory,
-alongside `CMakeCache.txt` and `CMakeFiles/TargetDirectories.txt`. The latter is
-CMake's generated target inventory, which lets the preflight detect the ABI
-target without requiring it in older build trees. With Ninja, preparation uses
-`CMAKE_BUILD_TYPE`, including `RelWithDebInfo` and Release-only vcpkg presets.
-With [Ninja Multi-Config](https://cmake.org/cmake/help/latest/generator/Ninja%20Multi-Config.html),
-it prepares the separate ABI header for each configured configuration because
-the compile database can contain commands for all of them.
+Configuration must already have generated headers needed by the selected
+commands, including the ABI stamp for each configuration. The preflight reads
+the compile database and existing headers; it does not configure CMake or run
+build targets. Syntax-only replay bypasses `sccache` and removes `/showIncludes`,
+`/Yc`, `/Yu`, and `/Fp` (including PCH filenames). It does not require a PCH build.
 
 Build-system-only changes do not replay every translation unit automatically:
 that would duplicate most of a full build and defeat the purpose of a fast
@@ -77,9 +77,16 @@ definitions genuinely requires a complete configured syntax pass.
 
 Use `--max-commands N` to impose a finite work budget. If a broad header change
 exceeds that budget, the configured replay is skipped explicitly and the
-normal full build remains authoritative. This prevents the preflight from
+normal full build remains authoritative. GitHub Actions also receives a
+`::warning::` annotation so a green step does not hide the skipped replay.
+This prevents the preflight from
 adding an almost complete second compilation pass. Runs are unlimited by
-default.
+default. `--all-commands` covers C/C++ sources under `src/`, `include/`, and
+`tests/`; vendored, generated, `_deps`, and vcpkg sources are excluded.
+
+In Windows PR CI, the default merge checkout is compared with `HEAD^1`, the
+current target-branch parent. This excludes changes that arrived independently
+on master. Push builds use the event's previous commit.
 
 Before invoking MSVC, the configured pass lists every selected source using a
 repository-relative path. The headline count refers to compile-database
@@ -96,8 +103,8 @@ python tools/windows_build_preflight.py `
   --changed-since upstream/master
 ```
 
-Use `--dry-run` to inspect the selected translation units without generating
-headers or invoking the compiler, or `--all-commands` when a complete configured
+Use `--dry-run` to inspect the selected translation units without invoking the
+compiler, or `--all-commands` when a complete configured
 C/C++ syntax pass is needed:
 
 ```powershell
@@ -111,11 +118,6 @@ python tools/windows_build_preflight.py `
   --all-commands
 ```
 
-Header preparation is also skipped for `--source-only`, when no affected
-commands are selected, or when the selected commands exceed `--max-commands`.
-The same preparation is used by local runs and the Windows and nightly CI jobs;
-no extra manual header-generation command is needed.
-
 ## Coverage boundaries
 
 The preflight does not compile CUDA translation units, perform general linker
@@ -123,6 +125,10 @@ resolution, generate optimized machine code, validate packaging, or exercise
 runtime behavior. The DLL source rule catches the common missing-export case,
 but it cannot prove that every library and executable will link. A successful
 full Windows build and the relevant tests remain authoritative.
+
+Include discovery is a lexical approximation: macro-generated includes and
+ambiguous suffix matches are not resolved, and conditional branches are not
+evaluated. Use the full build for definitive dependency coverage.
 
 When no changed source or project header is reachable from the configured C/C++
 graph, the tool reports that no affected translation unit was found. Use the

--- a/docs/docs/development/windows-build-preflight.md
+++ b/docs/docs/development/windows-build-preflight.md
@@ -32,19 +32,24 @@ In particular, `tests/test_project_lifecycle.cpp` and
 `capturePanelCameraProjectState` is not detected by this source-only rule.
 The Windows link step is still needed to catch that missing export.
 
-Run the checker self-tests after changing its matching rules:
+Run the checker self-tests after changing its matching rules. The shader-target
+regression fixture additionally needs CMake and Ninja. It
+uses a project with no enabled compiler languages and a simulated header
+generator; it does not build LichtFeld or compile C++, CUDA, or GLSL.
 
 ```sh
-python -m unittest tests/python/test_windows_build_preflight.py
+python -m unittest tests/python/test_windows_build_preflight.py tests/python/test_shader_header_target.py
 ```
 
 ## Configured MSVC check
 
 For compiler-level coverage, first configure the normal Ninja/MSVC build so
 that `compile_commands.json` exists. From the same Visual Studio developer
-environment used for the build, run:
+environment used for the build, prepare the generated shader headers and then
+run the checker:
 
 ```powershell
+cmake --build build --target lfs_shader_headers --config Release -j 4
 python tools/windows_build_preflight.py `
   --compile-commands build/compile_commands.json `
   --changed-since upstream/master
@@ -63,11 +68,23 @@ include index also considers headers under that directory's `include/`, so the
 generated `config.h` does not alias Vulkan's private header of the same name.
 Only project and generated headers are resolved; system headers are excluded.
 Deleted headers and both sides of a rename participate in change discovery.
+Changed paths are limited to `src/`, `include/`, and `tests/`, and the selected
+compile database's build directory is excluded, even if it is named `b/` or
+located under a source directory. Generated files remain available to resolve
+includes but do not count as source edits.
 
-Configuration must already have generated headers needed by the selected
-commands, including the ABI stamp for each configuration. The preflight reads
-the compile database and existing headers; it does not configure CMake or run
-build targets. Syntax-only replay bypasses `sccache` and removes `/showIncludes`,
+Configuration provides the ABI stamp and configuration headers. Shader headers
+such as `viewport/frustum.vert.spv.h` are build outputs: `lfs_shader_headers`
+runs their existing CMake dependencies, including the shader compiler helper,
+without building the visualizer or application. Use the configuration matching
+the compile database; for a multi-config database, prepare each configuration
+that will be replayed. The normal Windows and nightly CI workflows run this
+prerequisite before the configured preflight and stop if generation fails.
+An unchanged header is reused by the subsequent full build.
+
+The Python checker itself reads the compile database and existing headers; it
+does not configure CMake, parse its cache, or run build targets. Syntax-only
+replay bypasses `sccache` and removes `/showIncludes`,
 `/Yc`, `/Yu`, and `/Fp` (including PCH filenames). It does not require a PCH build.
 
 Build-system-only changes do not replay every translation unit automatically:
@@ -98,6 +115,7 @@ paths.
 Use the portable build directory to check portable compile definitions:
 
 ```powershell
+cmake --build build-portable --target lfs_shader_headers --config Release -j 4
 python tools/windows_build_preflight.py `
   --compile-commands build-portable/compile_commands.json `
   --changed-since upstream/master

--- a/docs/docs/development/windows-build-preflight.md
+++ b/docs/docs/development/windows-build-preflight.md
@@ -62,6 +62,13 @@ normal full build remains authoritative. This prevents the preflight from
 adding an almost complete second compilation pass. Runs are unlimited by
 default.
 
+Before invoking MSVC, the configured pass lists every selected source using a
+repository-relative path. The headline count refers to compile-database
+commands; if the same source has more than one entry, the source list groups it
+once and annotates the number of commands. This makes unexpectedly broad
+selection visible without printing compiler command lines or machine-specific
+paths.
+
 Use the portable build directory to check portable compile definitions:
 
 ```powershell

--- a/docs/docs/development/windows-build-preflight.md
+++ b/docs/docs/development/windows-build-preflight.md
@@ -51,6 +51,25 @@ object files or link targets. Compiler-specific failures such as invalid use of
 an incomplete type belong to this authoritative configured check, not to a
 lexical Python rule.
 
+Before invoking MSVC, the tool prepares `lfs_core_abi_stamp` if that target is
+present in the configured build tree. This generates the ABI header needed by
+the app, core, and tests even on a clean build where no C++ target has run yet.
+Older configurations that generate this header during CMake configuration do
+not need this preparation step. The tool uses the CMake executable recorded in
+the cache and builds only the header target; it does not request an application
+or test build. CMake may regenerate its build files as part of that command.
+The preflight then reloads the compile database before selecting commands again.
+If preparation fails, it stops before invoking MSVC.
+
+Keep `compile_commands.json` in its original configured build directory,
+alongside `CMakeCache.txt` and `CMakeFiles/TargetDirectories.txt`. The latter is
+CMake's generated target inventory, which lets the preflight detect the ABI
+target without requiring it in older build trees. With Ninja, preparation uses
+`CMAKE_BUILD_TYPE`, including `RelWithDebInfo` and Release-only vcpkg presets.
+With [Ninja Multi-Config](https://cmake.org/cmake/help/latest/generator/Ninja%20Multi-Config.html),
+it prepares the separate ABI header for each configured configuration because
+the compile database can contain commands for all of them.
+
 Build-system-only changes do not replay every translation unit automatically:
 that would duplicate most of a full build and defeat the purpose of a fast
 preflight. Add `--all-commands` when a change to CMake options or compile
@@ -77,9 +96,9 @@ python tools/windows_build_preflight.py `
   --changed-since upstream/master
 ```
 
-Use `--dry-run` to inspect the selected translation units without invoking the
-compiler, or `--all-commands` when a complete configured C/C++ syntax pass is
-needed:
+Use `--dry-run` to inspect the selected translation units without generating
+headers or invoking the compiler, or `--all-commands` when a complete configured
+C/C++ syntax pass is needed:
 
 ```powershell
 python tools/windows_build_preflight.py `
@@ -91,6 +110,11 @@ python tools/windows_build_preflight.py `
   --compile-commands build/compile_commands.json `
   --all-commands
 ```
+
+Header preparation is also skipped for `--source-only`, when no affected
+commands are selected, or when the selected commands exceed `--max-commands`.
+The same preparation is used by local runs and the Windows and nightly CI jobs;
+no extra manual header-generation command is needed.
 
 ## Coverage boundaries
 

--- a/docs/docs/development/windows-build-preflight.md
+++ b/docs/docs/development/windows-build-preflight.md
@@ -1,0 +1,99 @@
+---
+sidebar_position: 5
+---
+
+# Windows build preflight
+
+The Windows build preflight catches selected MSVC and DLL-boundary regressions
+before a complete Windows build. It is a fast diagnostic layer, not a
+replacement for building and testing the application.
+
+## Source checks
+
+The dependency-free check runs on Windows or Linux and requires only Python:
+
+```sh
+python tools/windows_build_preflight.py --source-only
+```
+
+It checks a source contract that otherwise tends to fail only when the Windows
+test executable is linked: a non-inline visualizer free function explicitly
+imported or fully qualified by a test must declare `LFS_VIS_API` so it is
+present in the DLL import library.
+
+The rule is intentionally conservative. It ignores broad `using namespace`
+imports, class methods, inline functions, and `constexpr` helpers rather than
+guessing at C++ semantics.
+
+Run the checker self-tests after changing its matching rules:
+
+```sh
+python -m unittest tests/python/test_windows_build_preflight.py
+```
+
+## Configured MSVC check
+
+For compiler-level coverage, first configure the normal Ninja/MSVC build so
+that `compile_commands.json` exists. From the same Visual Studio developer
+environment used for the build, run:
+
+```powershell
+python tools/windows_build_preflight.py `
+  --compile-commands build/compile_commands.json `
+  --changed-since upstream/master
+```
+
+The tool follows project-local quoted includes from each changed header to the
+affected C and C++ translation units. It then replays their existing commands
+with MSVC's `/Zs` option. The Microsoft compiler therefore parses the same
+sources with the configured defines and include paths, but does not generate
+object files or link targets. Compiler-specific failures such as invalid use of
+an incomplete type belong to this authoritative configured check, not to a
+lexical Python rule.
+
+Build-system-only changes do not replay every translation unit automatically:
+that would duplicate most of a full build and defeat the purpose of a fast
+preflight. Add `--all-commands` when a change to CMake options or compile
+definitions genuinely requires a complete configured syntax pass.
+
+Use `--max-commands N` to impose a finite work budget. If a broad header change
+exceeds that budget, the configured replay is skipped explicitly and the
+normal full build remains authoritative. This prevents the preflight from
+adding an almost complete second compilation pass. Runs are unlimited by
+default.
+
+Use the portable build directory to check portable compile definitions:
+
+```powershell
+python tools/windows_build_preflight.py `
+  --compile-commands build-portable/compile_commands.json `
+  --changed-since upstream/master
+```
+
+Use `--dry-run` to inspect the selected translation units without invoking the
+compiler, or `--all-commands` when a complete configured C/C++ syntax pass is
+needed:
+
+```powershell
+python tools/windows_build_preflight.py `
+  --compile-commands build/compile_commands.json `
+  --changed-since upstream/master `
+  --dry-run
+
+python tools/windows_build_preflight.py `
+  --compile-commands build/compile_commands.json `
+  --all-commands
+```
+
+## Coverage boundaries
+
+The preflight does not compile CUDA translation units, perform general linker
+resolution, generate optimized machine code, validate packaging, or exercise
+runtime behavior. The DLL source rule catches the common missing-export case,
+but it cannot prove that every library and executable will link. A successful
+full Windows build and the relevant tests remain authoritative.
+
+When no changed source or project header is reachable from the configured C/C++
+graph, the tool reports that no affected translation unit was found. Use the
+build directory for the configuration being validated, especially when
+checking portable-only or optional code paths.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -923,6 +923,7 @@ set(LFS_PYTHON_FAST_TESTS
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_scripts_panel.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_selection_controls_panel.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_selection_groups_panel.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/test_shader_header_target.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_splat_lod_hierarchy.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_store.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_store_subscriptions.py
@@ -985,6 +986,7 @@ set_tests_properties(lichtfeld.python.fast PROPERTIES
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     LABELS "fast"
     TIMEOUT 60
+    ENVIRONMENT_MODIFICATION "CMAKE_COMMAND=set:${CMAKE_COMMAND}"
 )
 
 add_test(NAME lichtfeld.python.slow

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -983,6 +983,15 @@ set(LFS_PYTHON_NIGHTLY_TESTS
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_unicode_path_bindings.py
 )
 
+add_test(NAME lichtfeld.cmake.vcpkg_profiles
+    COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_vcpkg_profiles.cmake"
+)
+set_tests_properties(lichtfeld.cmake.vcpkg_profiles PROPERTIES
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    LABELS "fast"
+    TIMEOUT 60
+)
+
 add_test(NAME lichtfeld.python.fast
     COMMAND ${Python_EXECUTABLE} -m pytest -q
         -m "not gpu and not slow and not integration"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -935,6 +935,7 @@ set(LFS_PYTHON_FAST_TESTS
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_transform_controls_panel.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_undo.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_viewport_overlay_hooks.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/test_windows_build_preflight.py
 )
 
 set(LFS_PYTHON_SLOW_TESTS

--- a/tests/python/test_shader_header_target.py
+++ b/tests/python/test_shader_header_target.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Exercise the shader dependency graph using a compiler-free CMake fixture."""
+
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CMAKE = os.environ.get("CMAKE_COMMAND") or shutil.which("cmake")
+NINJA = shutil.which("ninja")
+
+
+@unittest.skipUnless(CMAKE and NINJA, "CMake and Ninja are required for the codegen fixture")
+class ShaderHeaderTargetTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="lfs shader fixture ")
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name).resolve()
+        self.build = self.root / "b"
+        self.outputs = [self.build / "generated/first.spv.h",
+                        self.build / "generated/second.spv.h"]
+        self.calls = self.root / "calls.txt"
+        # An imported Python wrapper stands in for lfs_shader_compiler. No C++,
+        # CUDA, or GLSL compiler is configured or invoked by this fixture.
+        script = self.root / "fake_shader.py"
+        script.write_text(
+            "import argparse\nfrom pathlib import Path\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--input'); p.add_argument('--output'); p.add_argument('--symbol')\n"
+            "a = p.parse_args()\n"
+            "source = Path(a.input)\n"
+            "if source.read_text(encoding='utf-8') == 'FAIL':\n"
+            "    raise SystemExit(42)\n"
+            "output = Path(a.output)\noutput.parent.mkdir(parents=True, exist_ok=True)\n"
+            "output.write_text(a.symbol + '\\n', encoding='utf-8')\n"
+            f"with Path({str(self.calls)!r}).open('a', encoding='utf-8') as calls:\n"
+            "    calls.write(a.symbol + '\\n')\n",
+            encoding="utf-8",
+        )
+        if os.name == "nt":
+            compiler = self.root / "fake shader.cmd"
+            compiler.write_text(
+                f'@echo off\n"{sys.executable}" -B "{script}" %*\nexit /b %errorlevel%\n',
+                encoding="utf-8",
+            )
+        else:
+            compiler = self.root / "fake shader"
+            compiler.write_text(
+                f"#!/bin/sh\nexec {shlex.quote(sys.executable)} -B "
+                f'{shlex.quote(str(script))} "$@"\n',
+                encoding="utf-8",
+            )
+            compiler.chmod(0o755)
+        for name in ("first", "second"):
+            (self.root / f"{name}.vert").write_text("fixture", encoding="utf-8")
+        (self.root / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.20)\n"
+            "project(ShaderHeaderFixture LANGUAGES NONE)\n"
+            "add_executable(lfs_shader_compiler IMPORTED GLOBAL)\n"
+            "set_target_properties(lfs_shader_compiler PROPERTIES "
+            f'IMPORTED_LOCATION "{compiler.as_posix()}")\n'
+            'add_custom_target(lfs_visualizer ALL COMMAND "${CMAKE_COMMAND}" -E touch '
+            '"${CMAKE_BINARY_DIR}/consumer-ran")\n'
+            f'include("{ROOT.as_posix()}/cmake/CompileShaders.cmake")\n'
+            'compile_shader(lfs_visualizer first.vert "${CMAKE_BINARY_DIR}/generated/first.spv.h" First)\n'
+            'compile_shader(lfs_visualizer second.vert "${CMAKE_BINARY_DIR}/generated/second.spv.h" Second)\n',
+            encoding="utf-8",
+        )
+        configured = self.command(
+            "-S", str(self.root), "-B", str(self.build), "-G", "Ninja",
+            f"-DCMAKE_MAKE_PROGRAM={Path(NINJA).as_posix()}",
+        )
+        self.assertEqual(0, configured.returncode, configured.stdout + configured.stderr)
+
+    def command(self, *arguments):
+        return subprocess.run(
+            [CMAKE, *arguments], capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+        )
+
+    def generate(self):
+        return self.command("--build", str(self.build), "--target", "lfs_shader_headers")
+
+    def test_header_target_generates_missing_outputs_without_building_consumer(self):
+        self.assertFalse(any(path.exists() for path in self.outputs))
+        result = self.generate()
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(["First", "Second"], sorted(self.calls.read_text().splitlines()))
+        self.assertTrue(all(path.is_file() for path in self.outputs))
+        self.assertFalse((self.build / "consumer-ran").exists())
+        # No-op builds reuse outputs; deleting one header regenerates only it.
+        result = self.generate()
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(2, len(self.calls.read_text().splitlines()))
+        self.outputs[0].unlink()
+        result = self.generate()
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(["First", "First", "Second"], sorted(self.calls.read_text().splitlines()))
+        self.assertFalse((self.build / "consumer-ran").exists())
+
+    def test_failed_generation_fails_the_prerequisite_target(self):
+        (self.root / "first.vert").write_text("FAIL", encoding="utf-8")
+        result = self.generate()
+        self.assertNotEqual(0, result.returncode)
+        self.assertFalse(self.outputs[0].exists())
+        self.assertFalse((self.build / "consumer-ran").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_windows_build_preflight.py
+++ b/tests/python/test_windows_build_preflight.py
@@ -4,11 +4,12 @@
 
 from __future__ import annotations
 
-from contextlib import ExitStack, redirect_stderr, redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 import json
 from pathlib import Path
 import tempfile
+import subprocess
 import unittest
 from unittest import mock
 
@@ -205,6 +206,33 @@ class WindowsBuildPreflightTests(unittest.TestCase):
         self.assertNotIn("showincludes", syntax_command.lower())
         self.assertTrue(syntax_command.endswith("/Zs"))
 
+    def test_syntax_command_removes_pch_options_without_changing_other_arguments(self):
+        prefix = '"C:/Program Files/VS/cl.exe" /DNAME="hello world" /I"C:/my includes"'
+        for pch in (
+            '/Yc"pch header.hpp" /Fp"C:/build dir/cache.pch"',
+            '/Yu "pch header.hpp" /Fp "C:/build dir/cache.pch"',
+            '/Ycpch.hpp /Yupch.hpp /Fpcache.pch',
+            '/Yc /Yu /Fp',
+            '"/Yupch header.hpp" "/FpC:/build dir/cache.pch"',
+        ):
+            with self.subTest(pch=pch):
+                command = f'{prefix} {pch} /Fo"C:/out dir/file.obj" /c "src/my file.cpp"'
+                self.assertEqual(
+                    f'{prefix} /Fo"C:/out dir/file.obj" /c "src/my file.cpp" /Zs',
+                    preflight._msvc_syntax_command(command),
+                )
+
+    def test_syntax_command_preserves_escaped_quotes_and_trailing_backslashes(self):
+        arguments = [
+            "C:/Program Files/VS/cl.exe", r'-DNAME="C:\source\src\python"',
+            '-DMESSAGE="hello /Yu /showIncludes world"',
+            "-I" + "C:\\include with spaces\\", "-I" + "C:\\no-spaces\\",
+            "/c", "src/my source.cpp",
+        ]
+        command = subprocess.list2cmdline(arguments)
+        self.assertEqual(len(arguments), len(preflight._windows_command_tokens(command)))
+        self.assertEqual(command + " /Zs", preflight._msvc_syntax_command(command))
+
     def test_header_change_selects_transitive_translation_unit(self) -> None:
         header = self.write("src/visualizer/detail.hpp", "#pragma once\n")
         self.write(
@@ -257,6 +285,74 @@ class WindowsBuildPreflightTests(unittest.TestCase):
         )
         self.assertEqual([source.resolve()], [item.file for item in selected])
 
+    def test_all_commands_excludes_generated_and_dependency_sources(self):
+        paths = ["src/core/real.cpp", "tests/real.cpp", "external/vendor.cpp",
+                 "build/vcpkg_installed/x64-windows/src/nanobind.cpp",
+                 "build/_deps/dependency-src/vendor.cpp", "_deps/vendor.cpp",
+                 "build-release/generated.cpp", "build/generated.cpp"]
+        commands = [preflight.CompileCommand(self.write(path, "").resolve(),
+                                             self.root, "cl.exe /c file.cpp")
+                    for path in paths]
+        selected = preflight.select_compile_commands(self.root, commands, set(), True)
+        self.assertEqual(commands[:2], selected)
+
+    def test_generated_config_does_not_alias_vulkan_config(self):
+        build = self.root / "custom build"
+        generated = self.write("custom build/include/config.h", "#pragma once\n")
+        vulkan = self.write("src/rendering/vulkan/config.h", "#pragma once\n")
+        actual = self.write("src/rendering/vulkan/renderer.cpp", '#include "config.h"\n')
+        unrelated = self.write("src/visualizer/widget.cpp", '#include "config.h"\n')
+        commands = [preflight.CompileCommand(path.resolve(), build, "cl.exe /c file.cpp")
+                    for path in (actual, unrelated)]
+        self.assertEqual([commands[0]], preflight.select_compile_commands(
+            self.root, commands, {vulkan.resolve()}, False, build))
+        self.assertEqual([commands[1]], preflight.select_compile_commands(
+            self.root, commands, {generated.resolve()}, False, build))
+
+    def test_generated_headers_in_build_outside_checkout(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            build = Path(temporary).resolve()
+            (build / "include").mkdir()
+            (build / "include/config.h").write_text("", encoding="utf-8")
+            vulkan = self.write("src/rendering/vulkan/config.h", "")
+            source = self.write("src/visualizer/widget.cpp", '#include "config.h"\n')
+            command = preflight.CompileCommand(source.resolve(), build, "cl.exe /c widget.cpp")
+            self.assertEqual([], preflight.select_compile_commands(
+                self.root, [command], {vulkan.resolve()}, False, build))
+
+    def test_budget_skip_emits_github_warning_without_replay(self):
+        source = self.write("src/core/sample.cpp", "int sample;\n")
+        database = self.write("build/compile_commands.json", json.dumps([
+            {"file": str(source), "directory": str(self.root), "command": "cl.exe /c sample.cpp"}
+        ] * 2))
+        output = StringIO()
+        with mock.patch.dict(preflight.os.environ, {"GITHUB_ACTIONS": "true"}), \
+                mock.patch.object(preflight, "run_msvc_syntax_checks") as replay, \
+                redirect_stdout(output):
+            result = preflight.main(["--root", str(self.root), "--skip-source-checks",
+                                     "--compile-commands", str(database),
+                                     "--all-commands", "--max-commands", "1"])
+        self.assertEqual(0, result)
+        self.assertIn("::warning::MSVC preflight: configured replay skipped", output.getvalue())
+        replay.assert_not_called()
+
+    def test_replay_uses_database_without_cmake_metadata_or_build_commands(self):
+        source = self.write("src/core/sample.cpp", "int sample;\n")
+        database = self.write("build/compile_commands.json", json.dumps([
+            {"file": str(source), "directory": str(self.root), "command": "cl.exe /c sample.cpp"}
+        ]))
+        host = mock.Mock(wraps=preflight.os)
+        host.name = "nt"
+        with mock.patch.object(preflight, "os", host), \
+                mock.patch.object(preflight.subprocess, "run") as native, \
+                mock.patch.object(preflight, "run_msvc_syntax_checks", return_value=[]) as replay, \
+                redirect_stdout(StringIO()):
+            result = preflight.main(["--root", str(self.root), "--skip-source-checks",
+                                     "--compile-commands", str(database), "--all-commands"])
+        self.assertEqual(0, result)
+        replay.assert_called_once()
+        native.assert_not_called()
+
     def test_build_graph_only_change_does_not_replay_every_source(self) -> None:
         source = self.write("src/visualizer/widget.cpp", "void widget() {}\n")
         cmake = self.write("CMakeLists.txt", "project(sample)\n")
@@ -294,220 +390,92 @@ class WindowsBuildPreflightTests(unittest.TestCase):
         self.assertNotIn(self.root.as_posix(), output.getvalue())
 
 
-class GeneratedHeaderPreflightTests(unittest.TestCase):
-    def setUp(self) -> None:
-        self.temporary_directory = tempfile.TemporaryDirectory()
-        self.addCleanup(self.temporary_directory.cleanup)
-        self.root = Path(self.temporary_directory.name).resolve()
-        (self.root / ".git").mkdir()
-        self.build = self.root / "build with spaces"
-        (self.build / "CMakeFiles").mkdir(parents=True)
-        self.source = self.root / "src" / "core" / "abi.cpp"
-        self.source.parent.mkdir(parents=True)
-        self.source.write_text('#include "lfs_core_abi_stamp.h"\n', encoding="utf-8")
-        self.database = self.build / "compile_commands.json"
-        self.entries = [{
-            "directory": str(self.build),
-            "command": '"C:/VS/cl.exe" /c abi.cpp',
-            "file": str(self.source),
-        }]
-        self.write_database()
-        self.cmake = str(self.root / "CMake with spaces" / "cmake.exe")
-        self.write_metadata()
-        # Mock the module's OS facade, not os.name globally: changing the latter
-        # makes pathlib choose WindowsPath even on the Linux source-check job.
-        host = mock.Mock(wraps=preflight.os)
-        host.name = "nt"
-        patches = self.enterContext(ExitStack())
-        patches.enter_context(mock.patch.object(preflight, "os", host))
-        self.native = patches.enter_context(mock.patch.object(preflight.subprocess, "run"))
-        self.native.return_value.returncode = 0
-        self.syntax = patches.enter_context(
-            mock.patch.object(preflight, "run_msvc_syntax_checks", return_value=[])
-        )
-        self.output = StringIO()
+class GitDiscoveryTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name).resolve()
+        environment = mock.patch.dict(preflight.os.environ,
+                                      {"GITHUB_ACTIONS": "false", "LFS_PREFLIGHT_BASE": ""})
+        environment.start()
+        self.addCleanup(environment.stop)
+        self.git("init", "--initial-branch=master")
+        self.header = self.write("src/core/include/core/internal/detail.hpp", "#pragma once\n")
+        self.write("src/core/include/core/tensor.hpp", "#include <core/internal/detail.hpp>\n")
+        self.source = self.write("src/app/sample.cpp", '#include <vector>\n#include "core/tensor.hpp"\n')
+        self.commands = [preflight.CompileCommand(self.source, self.root, "cl.exe /c sample.cpp")]
+        self.commit("baseline")
 
-    def write_database(self) -> None:
-        self.database.write_text(json.dumps(self.entries), encoding="utf-8")
+    def git(self, *arguments):
+        result = subprocess.run([
+            "git", "-c", "user.name=Preflight Test", "-c", "user.email=preflight@example.invalid",
+            "-c", "commit.gpgsign=false", "-c", f"core.hooksPath={self.root / 'no-hooks'}",
+            "-C", str(self.root), *arguments,
+        ], capture_output=True, text=True, encoding="utf-8")
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        return result.stdout.strip()
 
-    def write_metadata(
-        self, *, target: bool = True, generator: str = "Ninja",
-        build_type: str = "Release", configurations: str = "Debug;Release;RelWithDebInfo",
-        source_root: Path | None = None,
-    ) -> None:
-        (self.build / "CMakeCache.txt").write_text(
-            f"CMAKE_HOME_DIRECTORY:INTERNAL={source_root or self.root}\n"
-            f"CMAKE_COMMAND:INTERNAL={self.cmake}\n"
-            f"CMAKE_GENERATOR:INTERNAL={generator}\n"
-            f"CMAKE_BUILD_TYPE:STRING={build_type}\n"
-            f"CMAKE_CONFIGURATION_TYPES:STRING={configurations}\n",
-            encoding="utf-8",
-        )
-        targets = ["lfs_git_version", "LichtFeld-Studio"]
-        if target:
-            targets.append("lfs_core_abi_stamp")
-        (self.build / "CMakeFiles" / "TargetDirectories.txt").write_text(
-            "".join(f"{self.build.as_posix()}/CMakeFiles/{name}.dir\n" for name in targets),
-            encoding="utf-8",
-        )
+    def write(self, relative, contents):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+        return path.resolve()
 
-    def run_preflight(self, *extra: str, all_commands: bool = True) -> int:
-        arguments = ["--root", str(self.root), "--skip-source-checks",
-                     "--compile-commands", str(self.database)]
-        if all_commands:
-            arguments.append("--all-commands")
-        with redirect_stdout(self.output), redirect_stderr(self.output):
-            return preflight.main([*arguments, *extra])
+    def commit(self, message):
+        self.git("add", ".")
+        self.git("commit", "-m", message)
 
-    def test_clean_tree_generates_abi_header_before_msvc(self) -> None:
-        header = self.build / "include" / "Release" / "lfs_core_abi_stamp.h"
-        events = []
+    def assert_header_change_reaches_consumer(self):
+        changed, force_all = preflight.discover_changed_files(self.root, None)
+        self.assertFalse(force_all)
+        self.assertIn(self.header, changed)
+        self.assertEqual(self.commands, preflight.select_compile_commands(
+            self.root, self.commands, changed, force_all))
+        return changed
 
-        def generate(command, **kwargs):
-            self.assertEqual([
-                self.cmake, "--build", str(self.build), "--target",
-                "lfs_core_abi_stamp", "--config", "Release",
-            ], command)
-            header.parent.mkdir(parents=True)
-            header.write_text("#define LFS_CORE_ABI_STAMP \"fixture\"\n", encoding="utf-8")
-            events.append("generate")
-            return mock.Mock(returncode=0)
+    def test_staged_header_deletion(self):
+        self.git("rm", self.header.relative_to(self.root).as_posix())
+        self.assert_header_change_reaches_consumer()
 
-        def check(commands, jobs):
-            self.assertTrue(header.is_file())
-            self.assertEqual(self.source, commands[0].file)
-            events.append("syntax")
-            return []
+    def test_unstaged_header_deletion(self):
+        self.header.unlink()
+        self.assert_header_change_reaches_consumer()
 
-        self.native.side_effect = generate
-        self.syntax.side_effect = check
-        self.assertEqual(0, self.run_preflight())
-        self.assertEqual(["generate", "syntax"], events)
-        self.native.assert_called_once()
+    def test_git_mv_reports_old_and_new_header(self):
+        renamed = self.header.with_name("renamed.hpp")
+        self.git("mv", str(self.header), str(renamed))
+        self.assertIn(renamed, self.assert_header_change_reaches_consumer())
 
-    def test_legacy_configure_time_header_needs_no_build_target(self) -> None:
-        self.write_metadata(target=False)
-        self.assertEqual(0, self.run_preflight())
-        self.native.assert_not_called()
-        self.syntax.assert_called_once()
+    def test_angle_include_transitive_graph_in_git_and_source_archive(self):
+        self.header.write_text("// changed\n", encoding="utf-8")
+        self.assert_header_change_reaches_consumer()
+        # Both the accelerated git-grep and source-archive fallback must agree.
+        with mock.patch.object(preflight, "_git", return_value=mock.Mock(returncode=128)):
+            self.assertEqual(self.commands, preflight.select_compile_commands(
+                self.root, self.commands, {self.header}, False))
+        graph = preflight.build_reverse_include_graph(self.root)
+        self.assertTrue(all(path.is_relative_to(self.root) for path in graph))
+        self.assertFalse(any(path.name == "vector" for path in graph))
 
-    def test_ninja_uses_build_type_despite_cached_configuration_types(self) -> None:
-        for configuration in ("Debug", "Release", "RelWithDebInfo", "MinSizeRel", ""):
-            with self.subTest(configuration=configuration):
-                self.write_metadata(build_type=configuration)
-                commands = preflight.generated_header_build_commands(self.root, self.database)
-                expected = [
-                    self.cmake, "--build", str(self.build), "--target", "lfs_core_abi_stamp"
-                ]
-                if configuration:
-                    expected.extend(["--config", configuration])
-                self.assertEqual([expected], commands)
-
-    def test_multi_config_prepares_each_configuration_once(self) -> None:
-        self.write_metadata(
-            generator="Ninja Multi-Config", configurations="Debug;Release;RelWithDebInfo;Debug"
-        )
-        self.assertEqual(0, self.run_preflight())
-        self.assertEqual(
-            ["Debug", "Release", "RelWithDebInfo"],
-            [call.args[0][-1] for call in self.native.call_args_list],
-        )
-        self.syntax.assert_called_once()
-
-    def test_empty_multi_config_is_an_actionable_error(self) -> None:
-        self.write_metadata(generator="Ninja Multi-Config", configurations="")
-        self.assertEqual(1, self.run_preflight())
-        self.assertIn("no configurations", self.output.getvalue())
-        self.native.assert_not_called()
-        self.syntax.assert_not_called()
-
-    def test_preparation_failure_prevents_msvc(self) -> None:
-        self.native.return_value.returncode = 7
-        self.assertEqual(1, self.run_preflight())
-        self.assertIn("preparation failed (exit 7)", self.output.getvalue())
-        self.syntax.assert_not_called()
-
-    def test_missing_cmake_prevents_msvc_with_a_clear_error(self) -> None:
-        self.native.side_effect = FileNotFoundError("cmake fixture missing")
-        self.assertEqual(1, self.run_preflight())
-        self.assertIn("cannot prepare generated headers", self.output.getvalue())
-        self.syntax.assert_not_called()
-
-    def test_missing_metadata_does_not_silently_skip_preparation(self) -> None:
-        (self.build / "CMakeFiles" / "TargetDirectories.txt").unlink()
-        self.assertEqual(1, self.run_preflight())
-        self.assertIn("original build directory", self.output.getvalue())
-        self.native.assert_not_called()
-        self.syntax.assert_not_called()
-
-    def test_another_source_tree_is_not_built(self) -> None:
-        self.write_metadata(source_root=self.root / "other checkout")
-        self.assertEqual(1, self.run_preflight())
-        self.assertIn("different CMake source tree", self.output.getvalue())
-        self.native.assert_not_called()
-        self.syntax.assert_not_called()
-
-    def test_dry_run_never_prepares_headers_or_invokes_msvc(self) -> None:
-        self.assertEqual(0, self.run_preflight("--dry-run"))
-        self.native.assert_not_called()
-        self.syntax.assert_not_called()
-
-    def test_source_only_never_prepares_headers_or_invokes_msvc(self) -> None:
-        with redirect_stdout(self.output):
-            self.assertEqual(0, preflight.main(["--root", str(self.root), "--source-only"]))
-        self.native.assert_not_called()
-        self.syntax.assert_not_called()
-
-    def test_no_affected_commands_never_prepares_headers(self) -> None:
-        with mock.patch.object(
-            preflight, "discover_changed_files", return_value=(set(), False)
-        ):
-            self.assertEqual(0, self.run_preflight(all_commands=False))
-        self.native.assert_not_called()
-        self.syntax.assert_not_called()
-
-    def test_over_budget_never_prepares_headers(self) -> None:
-        self.entries *= 2
-        self.write_database()
-        self.assertEqual(0, self.run_preflight("--max-commands", "1"))
-        self.native.assert_not_called()
-        self.syntax.assert_not_called()
-
-    def test_non_windows_host_never_prepares_headers(self) -> None:
-        preflight.os.name = "posix"
-        self.assertEqual(2, self.run_preflight())
-        self.native.assert_not_called()
-        self.syntax.assert_not_called()
-
-    def test_no_msvc_commands_never_prepares_headers(self) -> None:
-        self.entries[0]["command"] = "g++ -c abi.cpp"
-        self.write_database()
-        self.assertEqual(2, self.run_preflight())
-        self.native.assert_not_called()
-        self.syntax.assert_not_called()
-
-    def test_regenerated_compile_commands_are_reloaded_before_msvc(self) -> None:
-        def regenerate(command, **kwargs):
-            self.entries[0]["command"] += " /DREFRESHED=1"
-            self.write_database()
-            return mock.Mock(returncode=0)
-
-        self.native.side_effect = regenerate
-        self.assertEqual(0, self.run_preflight())
-        self.assertIn("/DREFRESHED=1", self.syntax.call_args.args[0][0].command)
-        self.native.assert_called_once()
-
-    def test_regeneration_rechecks_the_command_budget(self) -> None:
-        def regenerate(command, **kwargs):
-            self.entries *= 2
-            self.write_database()
-            return mock.Mock(returncode=0)
-
-        self.native.side_effect = regenerate
-        self.assertEqual(0, self.run_preflight("--max-commands", "1"))
-        self.assertIn("exceed the 1-command budget", self.output.getvalue())
-        self.native.assert_called_once()
-        self.syntax.assert_not_called()
+    def test_pr_merge_base_does_not_replay_new_master_sources(self):
+        old_base = self.git("rev-parse", "HEAD")
+        self.git("checkout", "-b", "feature")
+        cmake = self.write("CMakeLists.txt", "# PR changes only build files\n")
+        self.commit("feature build change")
+        self.git("checkout", "master")
+        self.source.write_text("int added_on_master;\n", encoding="utf-8")
+        self.commit("new master source change")
+        self.git("merge", "--no-ff", "feature", "-m", "simulated PR merge checkout")
+        # The old event base incorrectly included the master's C++ changes.
+        old_changed, _ = preflight.discover_changed_files(self.root, old_base)
+        self.assertIn(self.source, old_changed)
+        with mock.patch.dict(preflight.os.environ,
+                             {"GITHUB_ACTIONS": "true", "LFS_PREFLIGHT_BASE": "HEAD^1"}):
+            changed, forced = preflight.discover_changed_files(self.root, None)
+        self.assertFalse(forced)
+        self.assertEqual({cmake}, changed)
+        self.assertEqual([], preflight.select_compile_commands(
+            self.root, self.commands, changed, forced))
 
 
 if __name__ == "__main__":

--- a/tests/python/test_windows_build_preflight.py
+++ b/tests/python/test_windows_build_preflight.py
@@ -460,7 +460,7 @@ class GitDiscoveryTests(unittest.TestCase):
     def test_pr_merge_base_does_not_replay_new_master_sources(self):
         old_base = self.git("rev-parse", "HEAD")
         self.git("checkout", "-b", "feature")
-        cmake = self.write("CMakeLists.txt", "# PR changes only build files\n")
+        self.write("CMakeLists.txt", "# PR changes only build files\n")
         self.commit("feature build change")
         self.git("checkout", "master")
         self.source.write_text("int added_on_master;\n", encoding="utf-8")
@@ -473,9 +473,101 @@ class GitDiscoveryTests(unittest.TestCase):
                              {"GITHUB_ACTIONS": "true", "LFS_PREFLIGHT_BASE": "HEAD^1"}):
             changed, forced = preflight.discover_changed_files(self.root, None)
         self.assertFalse(forced)
-        self.assertEqual({cmake}, changed)
+        self.assertEqual(set(), changed)
         self.assertEqual([], preflight.select_compile_commands(
             self.root, self.commands, changed, forced))
+
+    def test_ci_build_outputs_do_not_select_unchanged_shader_consumer(self):
+        self.source.write_text(
+            '#include "config.h"\n#include "viewport/frustum.vert.spv.h"\n',
+            encoding="utf-8",
+        )
+        self.commit("unchanged shader consumer")
+        self.git("checkout", "-b", "feature")
+        self.write("CMakeLists.txt", "# PR only changes build files\n")
+        self.commit("build-only PR")
+        self.git("checkout", "master")
+        self.git("merge", "--no-ff", "feature", "-m", "PR merge checkout")
+        # Reproduce the CI binary directory, which is not excluded by build*/.
+        build = self.root / "b"
+        self.write("b/include/config.h", "#define CONFIGURED 1\n")
+        self.write("b/include/git_version.h", "#define VERSION 1\n")
+        self.write("b/include/lfs_core_abi_stamp.h", "#define ABI 1\n")
+        self.write("other-output/include/config.h", "// another build\n")
+        database = self.write("b/compile_commands.json", json.dumps([{
+            "file": str(self.source), "directory": str(build),
+            "command": "cl.exe /c sample.cpp",
+        }]))
+        output = StringIO()
+        with redirect_stdout(output), mock.patch.object(
+            preflight, "run_msvc_syntax_checks"
+        ) as replay:
+            result = preflight.main([
+                "--root", str(self.root), "--skip-source-checks",
+                "--compile-commands", str(database), "--changed-since", "HEAD^1",
+            ])
+        self.assertEqual(0, result)
+        self.assertIn("no affected configured", output.getvalue())
+        replay.assert_not_called()
+
+    def test_untracked_project_sources_survive_build_output_filter(self):
+        added_header = self.write("src/core/include/core/new.hpp", "// new\n")
+        added_source = self.write("src/app/new.cpp", '#include "core/new.hpp"\n')
+        added_test = self.write("tests/new.cpp", '#include "core/new.hpp"\n')
+        self.write("scratch/include/config.h", "// generated\n")
+        changed, forced = preflight.discover_changed_files(
+            self.root, "HEAD", self.root / "scratch"
+        )
+        self.assertFalse(forced)
+        self.assertEqual({added_header, added_source, added_test}, changed)
+        commands = [preflight.CompileCommand(path, self.root, "cl.exe /c file.cpp")
+                    for path in (added_source, added_test)]
+        self.assertEqual(commands, preflight.select_compile_commands(
+            self.root, commands, changed, forced, self.root / "scratch"))
+
+    def test_tracked_changes_outside_project_roots_are_excluded(self):
+        paths = [self.write(path, "// baseline\n") for path in
+                 ("cmake/template.h", "docs/example.hpp", "external/vendor.hpp")]
+        self.commit("tracked non-project headers")
+        for path in paths:
+            path.write_text("// changed\n", encoding="utf-8")
+        self.header.write_text("// project edit\n", encoding="utf-8")
+        changed, forced = preflight.discover_changed_files(self.root, "HEAD", self.root / "b")
+        self.assertFalse(forced)
+        self.assertEqual({self.header}, changed)
+
+    def test_tracked_and_untracked_outputs_under_src_are_excluded(self):
+        build = self.root / "src/configured"
+        generated = self.write("src/configured/include/config.h", "// old\n")
+        self.commit("fixture tracked output")
+        generated.write_text("// new\n", encoding="utf-8")
+        generated_source = self.write("src/configured/generated.cpp", "int generated;\n")
+        self.header.write_text("// real header edit\n", encoding="utf-8")
+        changed, forced = preflight.discover_changed_files(self.root, "HEAD", build)
+        self.assertFalse(forced)
+        self.assertEqual({self.header}, changed)
+        self.assertEqual(self.commands, preflight.select_compile_commands(
+            self.root, self.commands, changed, forced, build))
+        commands = [*self.commands, preflight.CompileCommand(
+            generated_source, build, "cl.exe /c generated.cpp")]
+        self.assertEqual(self.commands, preflight.select_compile_commands(
+            self.root, commands, set(), True, build))
+
+    def test_binary_directory_equal_to_root_does_not_hide_source_edits(self):
+        self.header.write_text("// edit\n", encoding="utf-8")
+        changed, forced = preflight.discover_changed_files(self.root, "HEAD", self.root)
+        self.assertFalse(forced)
+        self.assertEqual({self.header}, changed)
+
+    def test_real_source_edit_is_selected_alongside_fresh_generated_headers(self):
+        build = self.root / "b"
+        self.write("b/include/config.h", "// configured\n")
+        self.source.write_text('#include "config.h"\nint changed;\n', encoding="utf-8")
+        changed, forced = preflight.discover_changed_files(self.root, "HEAD", build)
+        self.assertFalse(forced)
+        self.assertEqual({self.source}, changed)
+        self.assertEqual(self.commands, preflight.select_compile_commands(
+            self.root, self.commands, changed, forced, build))
 
 
 if __name__ == "__main__":

--- a/tests/python/test_windows_build_preflight.py
+++ b/tests/python/test_windows_build_preflight.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from contextlib import redirect_stdout
+from io import StringIO
 import json
 from pathlib import Path
 import tempfile
@@ -264,6 +266,31 @@ class WindowsBuildPreflightTests(unittest.TestCase):
             self.root, commands, {cmake.resolve()}, False
         )
         self.assertEqual([], selected)
+
+    def test_selected_command_report_is_relative_sorted_and_counts_duplicates(
+        self,
+    ) -> None:
+        alpha = self.write("src/visualizer/alpha.cpp", "void alpha() {}\n")
+        beta = self.write("src/visualizer/beta.cpp", "void beta() {}\n")
+        commands = [
+            preflight.CompileCommand(beta.resolve(), self.root, "cl.exe /c beta.cpp"),
+            preflight.CompileCommand(alpha.resolve(), self.root, "cl.exe /c alpha.cpp"),
+            preflight.CompileCommand(beta.resolve(), self.root, "cl.exe /c beta.cpp"),
+        ]
+        output = StringIO()
+
+        with redirect_stdout(output):
+            preflight._print_selected_compile_commands(self.root, commands)
+
+        self.assertEqual(
+            [
+                "MSVC preflight: selected 2 source file(s) for 3 compile command(s):",
+                "  - src/visualizer/alpha.cpp",
+                "  - src/visualizer/beta.cpp (2 compile commands)",
+            ],
+            output.getvalue().splitlines(),
+        )
+        self.assertNotIn(self.root.as_posix(), output.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/python/test_windows_build_preflight.py
+++ b/tests/python/test_windows_build_preflight.py
@@ -4,12 +4,13 @@
 
 from __future__ import annotations
 
-from contextlib import redirect_stdout
+from contextlib import ExitStack, redirect_stderr, redirect_stdout
 from io import StringIO
 import json
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
 
 try:
     import windows_build_preflight as preflight
@@ -291,6 +292,222 @@ class WindowsBuildPreflightTests(unittest.TestCase):
             output.getvalue().splitlines(),
         )
         self.assertNotIn(self.root.as_posix(), output.getvalue())
+
+
+class GeneratedHeaderPreflightTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.root = Path(self.temporary_directory.name).resolve()
+        (self.root / ".git").mkdir()
+        self.build = self.root / "build with spaces"
+        (self.build / "CMakeFiles").mkdir(parents=True)
+        self.source = self.root / "src" / "core" / "abi.cpp"
+        self.source.parent.mkdir(parents=True)
+        self.source.write_text('#include "lfs_core_abi_stamp.h"\n', encoding="utf-8")
+        self.database = self.build / "compile_commands.json"
+        self.entries = [{
+            "directory": str(self.build),
+            "command": '"C:/VS/cl.exe" /c abi.cpp',
+            "file": str(self.source),
+        }]
+        self.write_database()
+        self.cmake = str(self.root / "CMake with spaces" / "cmake.exe")
+        self.write_metadata()
+        # Mock the module's OS facade, not os.name globally: changing the latter
+        # makes pathlib choose WindowsPath even on the Linux source-check job.
+        host = mock.Mock(wraps=preflight.os)
+        host.name = "nt"
+        patches = self.enterContext(ExitStack())
+        patches.enter_context(mock.patch.object(preflight, "os", host))
+        self.native = patches.enter_context(mock.patch.object(preflight.subprocess, "run"))
+        self.native.return_value.returncode = 0
+        self.syntax = patches.enter_context(
+            mock.patch.object(preflight, "run_msvc_syntax_checks", return_value=[])
+        )
+        self.output = StringIO()
+
+    def write_database(self) -> None:
+        self.database.write_text(json.dumps(self.entries), encoding="utf-8")
+
+    def write_metadata(
+        self, *, target: bool = True, generator: str = "Ninja",
+        build_type: str = "Release", configurations: str = "Debug;Release;RelWithDebInfo",
+        source_root: Path | None = None,
+    ) -> None:
+        (self.build / "CMakeCache.txt").write_text(
+            f"CMAKE_HOME_DIRECTORY:INTERNAL={source_root or self.root}\n"
+            f"CMAKE_COMMAND:INTERNAL={self.cmake}\n"
+            f"CMAKE_GENERATOR:INTERNAL={generator}\n"
+            f"CMAKE_BUILD_TYPE:STRING={build_type}\n"
+            f"CMAKE_CONFIGURATION_TYPES:STRING={configurations}\n",
+            encoding="utf-8",
+        )
+        targets = ["lfs_git_version", "LichtFeld-Studio"]
+        if target:
+            targets.append("lfs_core_abi_stamp")
+        (self.build / "CMakeFiles" / "TargetDirectories.txt").write_text(
+            "".join(f"{self.build.as_posix()}/CMakeFiles/{name}.dir\n" for name in targets),
+            encoding="utf-8",
+        )
+
+    def run_preflight(self, *extra: str, all_commands: bool = True) -> int:
+        arguments = ["--root", str(self.root), "--skip-source-checks",
+                     "--compile-commands", str(self.database)]
+        if all_commands:
+            arguments.append("--all-commands")
+        with redirect_stdout(self.output), redirect_stderr(self.output):
+            return preflight.main([*arguments, *extra])
+
+    def test_clean_tree_generates_abi_header_before_msvc(self) -> None:
+        header = self.build / "include" / "Release" / "lfs_core_abi_stamp.h"
+        events = []
+
+        def generate(command, **kwargs):
+            self.assertEqual([
+                self.cmake, "--build", str(self.build), "--target",
+                "lfs_core_abi_stamp", "--config", "Release",
+            ], command)
+            header.parent.mkdir(parents=True)
+            header.write_text("#define LFS_CORE_ABI_STAMP \"fixture\"\n", encoding="utf-8")
+            events.append("generate")
+            return mock.Mock(returncode=0)
+
+        def check(commands, jobs):
+            self.assertTrue(header.is_file())
+            self.assertEqual(self.source, commands[0].file)
+            events.append("syntax")
+            return []
+
+        self.native.side_effect = generate
+        self.syntax.side_effect = check
+        self.assertEqual(0, self.run_preflight())
+        self.assertEqual(["generate", "syntax"], events)
+        self.native.assert_called_once()
+
+    def test_legacy_configure_time_header_needs_no_build_target(self) -> None:
+        self.write_metadata(target=False)
+        self.assertEqual(0, self.run_preflight())
+        self.native.assert_not_called()
+        self.syntax.assert_called_once()
+
+    def test_ninja_uses_build_type_despite_cached_configuration_types(self) -> None:
+        for configuration in ("Debug", "Release", "RelWithDebInfo", "MinSizeRel", ""):
+            with self.subTest(configuration=configuration):
+                self.write_metadata(build_type=configuration)
+                commands = preflight.generated_header_build_commands(self.root, self.database)
+                expected = [
+                    self.cmake, "--build", str(self.build), "--target", "lfs_core_abi_stamp"
+                ]
+                if configuration:
+                    expected.extend(["--config", configuration])
+                self.assertEqual([expected], commands)
+
+    def test_multi_config_prepares_each_configuration_once(self) -> None:
+        self.write_metadata(
+            generator="Ninja Multi-Config", configurations="Debug;Release;RelWithDebInfo;Debug"
+        )
+        self.assertEqual(0, self.run_preflight())
+        self.assertEqual(
+            ["Debug", "Release", "RelWithDebInfo"],
+            [call.args[0][-1] for call in self.native.call_args_list],
+        )
+        self.syntax.assert_called_once()
+
+    def test_empty_multi_config_is_an_actionable_error(self) -> None:
+        self.write_metadata(generator="Ninja Multi-Config", configurations="")
+        self.assertEqual(1, self.run_preflight())
+        self.assertIn("no configurations", self.output.getvalue())
+        self.native.assert_not_called()
+        self.syntax.assert_not_called()
+
+    def test_preparation_failure_prevents_msvc(self) -> None:
+        self.native.return_value.returncode = 7
+        self.assertEqual(1, self.run_preflight())
+        self.assertIn("preparation failed (exit 7)", self.output.getvalue())
+        self.syntax.assert_not_called()
+
+    def test_missing_cmake_prevents_msvc_with_a_clear_error(self) -> None:
+        self.native.side_effect = FileNotFoundError("cmake fixture missing")
+        self.assertEqual(1, self.run_preflight())
+        self.assertIn("cannot prepare generated headers", self.output.getvalue())
+        self.syntax.assert_not_called()
+
+    def test_missing_metadata_does_not_silently_skip_preparation(self) -> None:
+        (self.build / "CMakeFiles" / "TargetDirectories.txt").unlink()
+        self.assertEqual(1, self.run_preflight())
+        self.assertIn("original build directory", self.output.getvalue())
+        self.native.assert_not_called()
+        self.syntax.assert_not_called()
+
+    def test_another_source_tree_is_not_built(self) -> None:
+        self.write_metadata(source_root=self.root / "other checkout")
+        self.assertEqual(1, self.run_preflight())
+        self.assertIn("different CMake source tree", self.output.getvalue())
+        self.native.assert_not_called()
+        self.syntax.assert_not_called()
+
+    def test_dry_run_never_prepares_headers_or_invokes_msvc(self) -> None:
+        self.assertEqual(0, self.run_preflight("--dry-run"))
+        self.native.assert_not_called()
+        self.syntax.assert_not_called()
+
+    def test_source_only_never_prepares_headers_or_invokes_msvc(self) -> None:
+        with redirect_stdout(self.output):
+            self.assertEqual(0, preflight.main(["--root", str(self.root), "--source-only"]))
+        self.native.assert_not_called()
+        self.syntax.assert_not_called()
+
+    def test_no_affected_commands_never_prepares_headers(self) -> None:
+        with mock.patch.object(
+            preflight, "discover_changed_files", return_value=(set(), False)
+        ):
+            self.assertEqual(0, self.run_preflight(all_commands=False))
+        self.native.assert_not_called()
+        self.syntax.assert_not_called()
+
+    def test_over_budget_never_prepares_headers(self) -> None:
+        self.entries *= 2
+        self.write_database()
+        self.assertEqual(0, self.run_preflight("--max-commands", "1"))
+        self.native.assert_not_called()
+        self.syntax.assert_not_called()
+
+    def test_non_windows_host_never_prepares_headers(self) -> None:
+        preflight.os.name = "posix"
+        self.assertEqual(2, self.run_preflight())
+        self.native.assert_not_called()
+        self.syntax.assert_not_called()
+
+    def test_no_msvc_commands_never_prepares_headers(self) -> None:
+        self.entries[0]["command"] = "g++ -c abi.cpp"
+        self.write_database()
+        self.assertEqual(2, self.run_preflight())
+        self.native.assert_not_called()
+        self.syntax.assert_not_called()
+
+    def test_regenerated_compile_commands_are_reloaded_before_msvc(self) -> None:
+        def regenerate(command, **kwargs):
+            self.entries[0]["command"] += " /DREFRESHED=1"
+            self.write_database()
+            return mock.Mock(returncode=0)
+
+        self.native.side_effect = regenerate
+        self.assertEqual(0, self.run_preflight())
+        self.assertIn("/DREFRESHED=1", self.syntax.call_args.args[0][0].command)
+        self.native.assert_called_once()
+
+    def test_regeneration_rechecks_the_command_budget(self) -> None:
+        def regenerate(command, **kwargs):
+            self.entries *= 2
+            self.write_database()
+            return mock.Mock(returncode=0)
+
+        self.native.side_effect = regenerate
+        self.assertEqual(0, self.run_preflight("--max-commands", "1"))
+        self.assertIn("exceed the 1-command budget", self.output.getvalue())
+        self.native.assert_called_once()
+        self.syntax.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/python/test_windows_build_preflight.py
+++ b/tests/python/test_windows_build_preflight.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Self-tests for the Windows build preflight."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+try:
+    import windows_build_preflight as preflight
+except ImportError:
+    from tools import windows_build_preflight as preflight
+
+
+class WindowsBuildPreflightTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        (self.root / ".git").mkdir()
+        (self.root / "src" / "visualizer" / "gui").mkdir(parents=True)
+        (self.root / "tests").mkdir()
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def write(self, relative_path: str, contents: str) -> Path:
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+        return path
+
+    def test_visualizer_test_function_requires_export(self) -> None:
+        self.write(
+            "src/visualizer/gui/widget.hpp",
+            "#pragma once\n"
+            "namespace lfs::vis::gui {\n"
+            "[[nodiscard]] bool makeWidget(int size);\n"
+            "}\n",
+        )
+        self.write(
+            "tests/test_widget.cpp",
+            '#include "gui/widget.hpp"\n'
+            "using lfs::vis::gui::makeWidget;\n"
+            "void test() { (void)makeWidget(3); }\n",
+        )
+        findings = preflight.check_visualizer_test_exports(self.root)
+        self.assertEqual(["visualizer-test-dll-export"], [item.rule for item in findings])
+        self.assertEqual(3, findings[0].line)
+
+    def test_exported_and_constexpr_functions_are_accepted(self) -> None:
+        self.write(
+            "src/visualizer/gui/widget.hpp",
+            "#pragma once\n"
+            "namespace lfs::vis::gui {\n"
+            "[[nodiscard]] LFS_VIS_API bool makeWidget(int size);\n"
+            "constexpr int widgetLimit() { return 4; }\n"
+            "}\n",
+        )
+        self.write(
+            "tests/test_widget.cpp",
+            '#include "gui/widget.hpp"\n'
+            "using lfs::vis::gui::makeWidget;\n"
+            "void test() { (void)makeWidget(widgetLimit()); }\n",
+        )
+        self.assertEqual([], preflight.check_visualizer_test_exports(self.root))
+
+    def test_methods_do_not_require_function_level_export(self) -> None:
+        self.write(
+            "src/visualizer/gui/widget.hpp",
+            "#pragma once\n"
+            "namespace lfs::vis::gui {\n"
+            "class LFS_VIS_API Widget {\n"
+            "public:\n"
+            "  bool valid() const;\n"
+            "};\n"
+            "}\n",
+        )
+        self.write(
+            "tests/test_widget.cpp",
+            '#include "gui/widget.hpp"\n'
+            "void test(Widget& widget) { (void)widget.valid(); }\n",
+        )
+        self.assertEqual([], preflight.check_visualizer_test_exports(self.root))
+
+    def test_unqualified_call_without_explicit_import_is_ignored(self) -> None:
+        self.write(
+            "src/visualizer/gui/widget.hpp",
+            "namespace lfs::vis::gui { bool makeWidget(int size); }\n",
+        )
+        self.write(
+            "tests/test_widget.cpp",
+            '#include "gui/widget.hpp"\n'
+            "using namespace lfs::vis::gui;\n"
+            "void test() { (void)makeWidget(3); }\n",
+        )
+        self.assertEqual([], preflight.check_visualizer_test_exports(self.root))
+
+    def test_fully_qualified_visualizer_call_requires_export(self) -> None:
+        self.write(
+            "src/visualizer/gui/widget.hpp",
+            "namespace lfs::vis::gui {\n"
+            "bool makeWidget(int size);\n"
+            "}\n",
+        )
+        self.write(
+            "tests/test_widget.cpp",
+            '#include "gui/widget.hpp"\n'
+            "void test() { (void)lfs::vis::gui::makeWidget(3); }\n",
+        )
+        findings = preflight.check_visualizer_test_exports(self.root)
+        self.assertEqual(["makeWidget"], [item.message.split()[2] for item in findings])
+
+    def test_header_body_calls_do_not_look_like_declarations(self) -> None:
+        self.write(
+            "src/visualizer/gui/widget.hpp",
+            "namespace lfs::vis::gui {\n"
+            "inline bool wrapper() { return Factory::makeWidget(); }\n"
+            "}\n",
+        )
+        self.write(
+            "tests/test_widget.cpp",
+            '#include "gui/widget.hpp"\n'
+            "using lfs::vis::gui::makeWidget;\n",
+        )
+        self.assertEqual([], preflight.check_visualizer_test_exports(self.root))
+
+    def test_inline_definition_is_available_without_dll_export(self) -> None:
+        self.write(
+            "src/visualizer/gui/widget.hpp",
+            "namespace lfs::vis::gui {\n"
+            "inline bool makeWidget(int size) { return size > 0; }\n"
+            "}\n",
+        )
+        self.write(
+            "tests/test_widget.cpp",
+            '#include "gui/widget.hpp"\n'
+            "using lfs::vis::gui::makeWidget;\n"
+            "void test() { (void)makeWidget(3); }\n",
+        )
+        self.assertEqual([], preflight.check_visualizer_test_exports(self.root))
+
+    def test_compile_database_validation(self) -> None:
+        database = self.write(
+            "compile_commands.json",
+            json.dumps(
+                [
+                    {
+                        "directory": str(self.root),
+                        "command": '"C:/VS/cl.exe" /c source.cpp',
+                        "file": str(self.root / "source.cpp"),
+                    }
+                ]
+            ),
+        )
+        commands = preflight.load_compile_commands(database)
+        self.assertEqual(1, len(commands))
+        self.assertEqual((self.root / "source.cpp").resolve(), commands[0].file)
+
+    def test_compile_database_accepts_arguments_array(self) -> None:
+        database = self.write(
+            "compile_commands.json",
+            json.dumps(
+                [
+                    {
+                        "directory": str(self.root),
+                        "arguments": ["C:/VS/cl.exe", "/c", "source.cpp"],
+                        "file": "source.cpp",
+                    }
+                ]
+            ),
+        )
+        commands = preflight.load_compile_commands(database)
+        self.assertEqual((self.root / "source.cpp").resolve(), commands[0].file)
+        self.assertTrue(preflight._is_msvc_command(commands[0]))
+
+    def test_msvc_detection_rejects_nvcc_host_compilation(self) -> None:
+        source = self.root / "source.cpp"
+        self.assertTrue(
+            preflight._is_msvc_command(
+                preflight.CompileCommand(source, self.root, '"C:/VS/cl.exe" /c source.cpp')
+            )
+        )
+        self.assertFalse(
+            preflight._is_msvc_command(
+                preflight.CompileCommand(
+                    source, self.root, 'nvcc.exe -ccbin "C:/VS/cl.exe" source.cu'
+                )
+            )
+        )
+
+    def test_syntax_command_bypasses_sccache_and_show_includes(self) -> None:
+        command = (
+            'sccache "C:/Program Files/VS/cl.exe" /nologo /showIncludes '
+            '/Iinclude /Foout.obj /c source.cpp'
+        )
+        syntax_command = preflight._msvc_syntax_command(command)
+        self.assertTrue(syntax_command.startswith('"C:/Program Files/VS/cl.exe"'))
+        self.assertNotIn("sccache", syntax_command.lower())
+        self.assertNotIn("showincludes", syntax_command.lower())
+        self.assertTrue(syntax_command.endswith("/Zs"))
+
+    def test_header_change_selects_transitive_translation_unit(self) -> None:
+        header = self.write("src/visualizer/detail.hpp", "#pragma once\n")
+        self.write(
+            "src/visualizer/wrapper.hpp",
+            '#include "detail.hpp"\n',
+        )
+        source = self.write(
+            "src/visualizer/widget.cpp",
+            '#include "wrapper.hpp"\n',
+        )
+        unrelated = self.write("src/visualizer/other.cpp", "void other() {}\n")
+        commands = [
+            preflight.CompileCommand(source.resolve(), self.root, "cl.exe /c widget.cpp"),
+            preflight.CompileCommand(
+                unrelated.resolve(), self.root, "cl.exe /c other.cpp"
+            ),
+        ]
+        selected = preflight.select_compile_commands(
+            self.root, commands, {header.resolve()}, False
+        )
+        self.assertEqual([source.resolve()], [item.file for item in selected])
+
+    def test_deleted_header_selects_its_consumer(self) -> None:
+        deleted = self.root / "src" / "visualizer" / "deleted.hpp"
+        source = self.write(
+            "src/visualizer/widget.cpp",
+            '#include "deleted.hpp"\n',
+        )
+        commands = [
+            preflight.CompileCommand(source.resolve(), self.root, "cl.exe /c widget.cpp")
+        ]
+        selected = preflight.select_compile_commands(
+            self.root, commands, {deleted.resolve()}, False
+        )
+        self.assertEqual([source.resolve()], [item.file for item in selected])
+
+    def test_force_all_selects_project_cxx_but_not_cuda_or_external(self) -> None:
+        source = self.write("src/visualizer/widget.cpp", "void widget() {}\n")
+        cuda = self.write("src/visualizer/widget.cu", "__global__ void widget() {}\n")
+        external = self.write("external/library.cpp", "void library() {}\n")
+        commands = [
+            preflight.CompileCommand(source.resolve(), self.root, "cl.exe /c widget.cpp"),
+            preflight.CompileCommand(cuda.resolve(), self.root, "nvcc widget.cu"),
+            preflight.CompileCommand(
+                external.resolve(), self.root, "cl.exe /c library.cpp"
+            ),
+        ]
+        selected = preflight.select_compile_commands(
+            self.root, commands, set(), True
+        )
+        self.assertEqual([source.resolve()], [item.file for item in selected])
+
+    def test_build_graph_only_change_does_not_replay_every_source(self) -> None:
+        source = self.write("src/visualizer/widget.cpp", "void widget() {}\n")
+        cmake = self.write("CMakeLists.txt", "project(sample)\n")
+        commands = [
+            preflight.CompileCommand(source.resolve(), self.root, "cl.exe /c widget.cpp")
+        ]
+        selected = preflight.select_compile_commands(
+            self.root, commands, {cmake.resolve()}, False
+        )
+        self.assertEqual([], selected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/windows_build_preflight.py
+++ b/tools/windows_build_preflight.py
@@ -48,7 +48,7 @@ SKIPPED_COMPONENTS = frozenset(
         "node_modules",
     }
 )
-INCLUDE_RE = re.compile(r'^\s*#\s*include\s*"([^"]+)"', re.MULTILINE)
+INCLUDE_RE = re.compile(r'^\s*#\s*include\s*["<]([^">]+)[">]', re.MULTILINE)
 TYPE_DEFINITION_RE = re.compile(
     r"\b(?:class|struct)\s+(?:LFS_[A-Z_]+_API\s+)?"
     r"(?P<name>[A-Za-z_]\w*)[^;{}]*\{"
@@ -382,18 +382,19 @@ def discover_changed_files(root: Path, base: str | None) -> tuple[set[Path], boo
 
     changed: set[Path] = set()
     if not force_all:
-        diff = _git(root, "diff", "--name-only", "--diff-filter=ACMRT", diff_base, "--")
+        # Treat renames as delete/add so old include spellings remain reachable.
+        diff = _git(root, "diff", "--name-only", "-z", "--no-renames", diff_base, "--")
         if diff.returncode != 0:
             force_all = True
         else:
-            for line in diff.stdout.splitlines():
-                if line.strip():
-                    changed.add((root / line.strip()).resolve())
-            untracked = _git(root, "ls-files", "--others", "--exclude-standard")
+            for path in diff.stdout.split("\0"):
+                if path:
+                    changed.add((root / path).resolve())
+            untracked = _git(root, "ls-files", "-z", "--others", "--exclude-standard")
             if untracked.returncode == 0:
-                for line in untracked.stdout.splitlines():
-                    if line.strip():
-                        changed.add((root / line.strip()).resolve())
+                for path in untracked.stdout.split("\0"):
+                    if path:
+                        changed.add((root / path).resolve())
     return changed, force_all
 
 
@@ -405,7 +406,7 @@ def _lexical_absolute(path: Path, base: Path | None = None) -> Path:
 
 def _iter_local_includes(
     root: Path, project_files: Iterable[Path]
-) -> Iterable[tuple[Path, str]]:
+) -> Iterable[tuple[Path, str, bool]]:
     grep = _git(
         root,
         "grep",
@@ -413,7 +414,7 @@ def _iter_local_includes(
         "-n",
         "-I",
         "-E",
-        r'^[[:space:]]*#[[:space:]]*include[[:space:]]*"[^"]+"',
+        r'^[[:space:]]*#[[:space:]]*include[[:space:]]*["<][^">]+[">]',
         "--",
         "src",
         "include",
@@ -427,33 +428,49 @@ def _iter_local_includes(
             source = (root / parts[0]).resolve()
             match = INCLUDE_RE.search(parts[2])
             if match is not None:
-                yield source, match.group(1)
+                yield source, match.group(1), match.group(0).endswith('"')
         return
 
     # Source archives and unit-test fixtures may have no usable Git index.
     for source in project_files:
         raw = source.read_text(encoding="utf-8", errors="replace")
-        for include in INCLUDE_RE.findall(raw):
-            yield source, include
+        for match in INCLUDE_RE.finditer(raw):
+            yield source, match.group(1), match.group(0).endswith('"')
 
 
 def build_reverse_include_graph(
-    root: Path, extra_dependencies: Iterable[Path] = ()
+    root: Path, extra_dependencies: Iterable[Path] = (), build_dir: Path | None = None
 ) -> dict[Path, set[Path]]:
     project_files = set(_iter_project_files(root, PROJECT_SOURCE_SUFFIXES))
-    dependency_files = project_files | {path.resolve() for path in extra_dependencies}
+    generated_root = (build_dir or root / "build") / "include"
+    generated_files = {
+        path.resolve() for path in generated_root.rglob("*")
+        if path.is_file() and path.suffix.lower() in HEADER_SUFFIXES
+    }
+    dependency_files = project_files | generated_files | {
+        path.resolve() for path in extra_dependencies
+    }
     suffix_index: dict[str, list[Path]] = defaultdict(list)
     for path in dependency_files:
-        relative = path.relative_to(root).as_posix().lower()
+        try:
+            relative = path.relative_to(root).as_posix().lower()
+        except ValueError:
+            # The selected build directory can live outside the checkout.
+            relative = path.relative_to(generated_root).as_posix().lower()
         parts = relative.split("/")
         for index in range(len(parts)):
             suffix_index["/".join(parts[index:])].append(path)
 
     reverse: dict[Path, set[Path]] = defaultdict(set)
-    for source, include in _iter_local_includes(root, project_files):
+    for source, include, quoted in _iter_local_includes(root, project_files):
         include_path = Path(include.replace("\\", "/"))
         direct = _lexical_absolute(source.parent / include_path)
-        resolved: Path | None = direct if direct in dependency_files else None
+        resolved: Path | None = direct if quoted and direct in dependency_files else None
+        # config.h from build/include must not alias Vulkan's private config.h.
+        # Prefer the configured header after a quoted include's local directory.
+        generated = _lexical_absolute(generated_root / include_path)
+        if resolved is None and generated in generated_files:
+            resolved = generated
         if resolved is None:
             matches = suffix_index.get(include.replace("\\", "/").lower(), [])
             if len(matches) == 1:
@@ -468,7 +485,7 @@ def _is_project_compile_command(root: Path, command: CompileCommand) -> bool:
         relative = command.file.relative_to(root)
     except ValueError:
         return False
-    return bool(relative.parts) and relative.parts[0] != "external"
+    return bool(relative.parts) and relative.parts[0] in {"src", "include", "tests"}
 
 
 def select_compile_commands(
@@ -476,6 +493,7 @@ def select_compile_commands(
     commands: Sequence[CompileCommand],
     changed: set[Path],
     force_all: bool,
+    build_dir: Path | None = None,
 ) -> list[CompileCommand]:
     cxx_commands = [
         command
@@ -490,7 +508,7 @@ def select_compile_commands(
     selected_files = {path for path in changed if path in command_files}
     changed_headers = {path for path in changed if path.suffix.lower() in HEADER_SUFFIXES}
     if changed_headers:
-        reverse = build_reverse_include_graph(root, changed_headers)
+        reverse = build_reverse_include_graph(root, changed_headers, build_dir)
         queue = deque(changed_headers)
         visited = set(changed_headers)
         while queue:
@@ -539,6 +557,25 @@ def _is_msvc_command(command: CompileCommand) -> bool:
     )
 
 
+def _windows_command_tokens(command: str) -> list[str]:
+    """Split at unquoted whitespace without unescaping CMake's Windows arguments."""
+    tokens = []
+    start = 0
+    quoted = False
+    backslashes = 0
+    for index, character in enumerate(command):
+        if character == '"' and backslashes % 2 == 0:
+            quoted = not quoted
+        if character.isspace() and not quoted:
+            if start < index:
+                tokens.append(command[start:index])
+            start = index + 1
+        backslashes = backslashes + 1 if character == "\\" else 0
+    if start < len(command):
+        tokens.append(command[start:])
+    return tokens
+
+
 def _msvc_syntax_command(command: str) -> str:
     # A syntax-only invocation creates no object for a compiler cache to store.
     # Bypass a direct sccache launcher and suppress the dependency-list stream,
@@ -551,10 +588,23 @@ def _msvc_syntax_command(command: str) -> str:
         count=1,
         flags=re.IGNORECASE,
     )
-    without_includes = re.sub(
-        r"(?i)(?<!\S)/showIncludes(?=\s|$)", "", without_launcher
-    )
-    return f"{without_includes.rstrip()} /Zs"
+    # Preserve command spelling/quoting. PCH switches can carry an attached or
+    # separate (possibly quoted) filename; a bare switch must not eat /c or /I.
+    kept = []
+    skip_argument = False
+    for argument in _windows_command_tokens(without_launcher):
+        option = argument[1:-1] if argument.startswith('"') and argument.endswith('"') else argument
+        if skip_argument:
+            skip_argument = False
+            if not option.startswith(("/", "-")):
+                continue
+        if option.lower() == "/showincludes":
+            continue
+        if re.match(r"^[-/](?:Yc|Yu|Fp)", option):
+            skip_argument = len(option) == 3
+            continue
+        kept.append(argument)
+    return " ".join([*kept, "/Zs"])
 
 
 def _run_one_syntax_check(command: CompileCommand) -> tuple[CompileCommand, int, str]:
@@ -587,86 +637,6 @@ def run_msvc_syntax_checks(
             if returncode != 0:
                 failures.append((command, returncode, output))
     return sorted(failures, key=lambda item: item[0].file.as_posix().lower())
-
-
-def generated_header_build_commands(root: Path, database: Path) -> list[list[str]]:
-    """Prepare only known header targets present in this configured CMake tree.
-
-    Older trees generate the ABI header at configure time and have no such
-    target. Use CMake's generated target inventory, not the current source, so
-    the command matches the build tree that supplied the compile database.
-    """
-
-    build_dir = database.parent
-    try:
-        cache_text = (build_dir / "CMakeCache.txt").read_text(encoding="utf-8")
-        target_text = (build_dir / "CMakeFiles" / "TargetDirectories.txt").read_text(
-            encoding="utf-8"
-        )
-    except OSError as error:
-        raise ValueError(
-            "cannot read configured CMake metadata; use compile_commands.json "
-            f"in its original build directory and configure it first: {error}"
-        ) from error
-
-    cache = dict(re.findall(r"^([^#/:\n][^:\n]*):[^=\n]+=(.*)$", cache_text, re.MULTILINE))
-    source_dir = cache.get("CMAKE_HOME_DIRECTORY")
-    if not source_dir or Path(source_dir).resolve() != root.resolve():
-        raise ValueError("compile database belongs to a different CMake source tree")
-
-    targets = {
-        line.strip().replace("\\", "/").rsplit("/", 1)[-1]
-        for line in target_text.splitlines()
-    }
-    if "lfs_core_abi_stamp.dir" not in targets:
-        return []
-
-    cmake = cache.get("CMAKE_COMMAND")
-    generator = cache.get("CMAKE_GENERATOR")
-    if not cmake or not generator:
-        raise ValueError(
-            "CMake cache lacks CMAKE_COMMAND or CMAKE_GENERATOR; configure it again"
-        )
-    if generator == "Ninja Multi-Config":
-        # Its compile database can contain every configuration. Generate each
-        # separate ABI header before replaying any of those commands.
-        configurations = list(dict.fromkeys(
-            value for value in cache.get("CMAKE_CONFIGURATION_TYPES", "").split(";")
-            if value
-        ))
-        if not configurations:
-            raise ValueError(
-                "Ninja Multi-Config cache has no configurations; configure it again"
-            )
-    else:
-        # Dependencies can populate CMAKE_CONFIGURATION_TYPES even with Ninja.
-        configurations = [cache.get("CMAKE_BUILD_TYPE", "")]
-
-    result = []
-    for configuration in configurations:
-        command = [cmake, "--build", str(build_dir), "--target", "lfs_core_abi_stamp"]
-        if configuration:
-            command.extend(["--config", configuration])
-        result.append(command)
-    return result
-
-
-def prepare_generated_headers(commands: Sequence[Sequence[str]]) -> None:
-    for command in commands:
-        print(
-            "MSVC preflight: preparing generated headers: "
-            f"{subprocess.list2cmdline(command)}",
-            flush=True,
-        )
-        try:
-            result = subprocess.run(command, check=False)
-        except OSError as error:
-            raise ValueError(f"cannot prepare generated headers: {error}") from error
-        if result.returncode != 0:
-            raise ValueError(
-                f"generated-header preparation failed (exit {result.returncode}); "
-                "MSVC was not run"
-            )
 
 
 def _print_source_result(findings: Sequence[Finding]) -> None:
@@ -767,49 +737,35 @@ def main(argv: Sequence[str] | None = None) -> int:
         changed, forced_all = discover_changed_files(root, arguments.changed_since)
 
     database = arguments.compile_commands.resolve()
-    headers_prepared = False
-    while True:
-        try:
-            commands = load_compile_commands(database)
-        except ValueError as error:
-            print(f"error: {error}", file=sys.stderr)
-            return 2
-        selected = select_compile_commands(root, commands, changed, forced_all)
+    try:
+        commands = load_compile_commands(database)
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    selected = select_compile_commands(root, commands, changed, forced_all, database.parent)
 
-        if not selected:
-            print("MSVC preflight: no affected configured C/C++ translation units")
-            return 0
-        if arguments.dry_run:
-            _print_selected_compile_commands(root, selected)
-            return 0
-        if arguments.max_commands and len(selected) > arguments.max_commands:
-            print(
-                "MSVC preflight: configured replay skipped because "
-                f"{len(selected)} commands exceed the {arguments.max_commands}-command "
-                "budget; the full build remains authoritative"
-            )
-            return 0
-        if os.name != "nt":
-            print("error: configured MSVC checks require Windows", file=sys.stderr)
-            return 2
+    if not selected:
+        print("MSVC preflight: no affected configured C/C++ translation units")
+        return 0
+    if arguments.dry_run:
+        _print_selected_compile_commands(root, selected)
+        return 0
+    if arguments.max_commands and len(selected) > arguments.max_commands:
+        annotation = "::warning::" if os.environ.get("GITHUB_ACTIONS") == "true" else "warning: "
+        print(
+            annotation + "MSVC preflight: configured replay skipped because "
+            f"{len(selected)} commands exceed the {arguments.max_commands}-command "
+            "budget; the full build remains authoritative"
+        )
+        return 0
+    if os.name != "nt":
+        print("error: configured MSVC checks require Windows", file=sys.stderr)
+        return 2
 
-        supported = [command for command in selected if _is_msvc_command(command)]
-        if not supported:
-            print("error: no selected compile command invokes MSVC cl.exe", file=sys.stderr)
-            return 2
-        if headers_prepared:
-            break
-        try:
-            header_commands = generated_header_build_commands(root, database)
-            if not header_commands:
-                break
-            prepare_generated_headers(header_commands)
-        except ValueError as error:
-            print(f"error: {error}", file=sys.stderr)
-            return 1
-        # The native build tool may have regenerated CMake. Reload and reselect
-        # commands (including the work budget) before invoking the compiler.
-        headers_prepared = True
+    supported = [command for command in selected if _is_msvc_command(command)]
+    if not supported:
+        print("error: no selected compile command invokes MSVC cl.exe", file=sys.stderr)
+        return 2
 
     for command in selected:
         if not _is_msvc_command(command):

--- a/tools/windows_build_preflight.py
+++ b/tools/windows_build_preflight.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Fail early on Windows build-contract regressions.
+
+The source checks are dependency-free and run on every host.  The configured
+check is Windows-only: it replays affected MSVC compile-database entries with
+``/Zs`` so the real Microsoft frontend performs parsing and semantic checks
+without creating object files.
+
+This is deliberately not a replacement for a full build.  CUDA compilation,
+general linker resolution, code generation, and runtime behavior remain the
+responsibility of the normal build and test jobs.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict, deque
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+import json
+import locale
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Iterable, Sequence
+
+try:
+    from error_debt_census import mask_source
+except ImportError:  # Imported as tools.windows_build_preflight in self-tests.
+    from tools.error_debt_census import mask_source
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HEADER_SUFFIXES = frozenset({".h", ".hh", ".hpp", ".hxx", ".cuh"})
+CXX_SUFFIXES = frozenset({".c", ".cc", ".cpp", ".cxx"})
+PROJECT_SOURCE_SUFFIXES = HEADER_SUFFIXES | CXX_SUFFIXES | frozenset({".cu"})
+SKIPPED_COMPONENTS = frozenset(
+    {
+        ".git",
+        ".pytest_cache",
+        "build",
+        "build-debug",
+        "external",
+        "node_modules",
+    }
+)
+INCLUDE_RE = re.compile(r'^\s*#\s*include\s*"([^"]+)"', re.MULTILINE)
+TYPE_DEFINITION_RE = re.compile(
+    r"\b(?:class|struct)\s+(?:LFS_[A-Z_]+_API\s+)?"
+    r"(?P<name>[A-Za-z_]\w*)[^;{}]*\{"
+)
+VISUALIZER_USING_RE = re.compile(
+    r"\busing\s+(?P<qualified>lfs\s*::\s*vis"
+    r"(?:\s*::\s*[A-Za-z_]\w*)+)\s*;"
+)
+VISUALIZER_QUALIFIED_CALL_RE = re.compile(
+    r"\b(?P<qualified>lfs\s*::\s*vis"
+    r"(?:\s*::\s*[A-Za-z_]\w*)+)\s*\("
+)
+EXPORT_EXEMPT_TOKENS = frozenset(
+    {"constexpr", "friend", "inline", "static", "template", "typedef", "using"}
+)
+
+
+@dataclass(frozen=True, order=True)
+class Finding:
+    path: str
+    line: int
+    rule: str
+    message: str
+
+    def render(self) -> str:
+        return f"{self.path}:{self.line}: {self.rule}: {self.message}"
+
+
+@dataclass(frozen=True)
+class TypeBlock:
+    name: str
+    open_brace: int
+    close_brace: int
+    body_depth: int
+
+
+@dataclass(frozen=True)
+class CompileCommand:
+    file: Path
+    directory: Path
+    command: str
+
+
+def _line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _depths(text: str, opening: str, closing: str) -> list[int]:
+    result = [0] * (len(text) + 1)
+    depth = 0
+    for index, character in enumerate(text):
+        result[index] = depth
+        if character == opening:
+            depth += 1
+        elif character == closing:
+            depth = max(depth - 1, 0)
+    result[len(text)] = depth
+    return result
+
+
+def _matching_delimiter(
+    text: str, start: int, opening: str, closing: str
+) -> int | None:
+    depth = 0
+    for index in range(start, len(text)):
+        character = text[index]
+        if character == opening:
+            depth += 1
+        elif character == closing:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _type_blocks(masked: str) -> list[TypeBlock]:
+    brace_depth = _depths(masked, "{", "}")
+    blocks: list[TypeBlock] = []
+    for match in TYPE_DEFINITION_RE.finditer(masked):
+        open_brace = masked.find("{", match.start(), match.end())
+        close_brace = _matching_delimiter(masked, open_brace, "{", "}")
+        if close_brace is None:
+            continue
+        blocks.append(
+            TypeBlock(
+                name=match.group("name"),
+                open_brace=open_brace,
+                close_brace=close_brace,
+                body_depth=brace_depth[open_brace] + 1,
+            )
+        )
+    return blocks
+
+
+def _iter_project_files(root: Path, suffixes: frozenset[str]) -> Iterable[Path]:
+    tracked = _git(
+        root,
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "--",
+        "src",
+        "include",
+        "tests",
+    )
+    if tracked.returncode == 0:
+        for relative_name in tracked.stdout.splitlines():
+            path = root / relative_name
+            if path.suffix.lower() not in suffixes or not path.is_file():
+                continue
+            if any(component in SKIPPED_COMPONENTS for component in path.parts):
+                continue
+            yield path.resolve()
+        return
+
+    # Unit-test fixtures need no real Git repository. Keep a filesystem
+    # fallback for those and for source archives without Git metadata.
+    for base in (root / "src", root / "include", root / "tests"):
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file() or path.suffix.lower() not in suffixes:
+                continue
+            if any(component in SKIPPED_COMPONENTS for component in path.parts):
+                continue
+            yield path.resolve()
+
+
+def _inside_type(position: int, blocks: Sequence[TypeBlock]) -> bool:
+    return any(block.open_brace < position < block.close_brace for block in blocks)
+
+
+def _resolve_visualizer_header(root: Path, include: str) -> Path | None:
+    normalized = Path(include.replace("\\", "/"))
+    candidates = (
+        root / "src" / "visualizer" / normalized,
+        root / "src" / "visualizer" / "include" / normalized,
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    return None
+
+
+def _function_segment(masked: str, name_offset: int) -> tuple[int, str] | None:
+    open_paren = masked.find("(", name_offset)
+    if open_paren < 0:
+        return None
+    close_paren = _matching_delimiter(masked, open_paren, "(", ")")
+    if close_paren is None:
+        return None
+    boundaries = [
+        (masked.find(character, close_paren), character)
+        for character in (";", "{", "}")
+    ]
+    boundary, character = min(
+        (item for item in boundaries if item[0] >= 0),
+        default=(-1, ""),
+    )
+    if boundary < 0 or character == "}":
+        return None
+    start = max(
+        masked.rfind(";", 0, name_offset),
+        masked.rfind("{", 0, name_offset),
+        masked.rfind("}", 0, name_offset),
+    ) + 1
+    return start, masked[start : boundary + 1]
+
+
+def _explicit_visualizer_symbols(masked_test: str) -> set[str]:
+    """Return functions that a test explicitly reaches across the DLL boundary.
+
+    Deliberately ignore unqualified calls and broad ``using namespace`` imports:
+    a lexical checker cannot reliably distinguish those from methods and local
+    helpers.  The configured MSVC pass remains authoritative for C++ semantics.
+    """
+
+    qualified = {
+        match.group("qualified")
+        for pattern in (VISUALIZER_USING_RE, VISUALIZER_QUALIFIED_CALL_RE)
+        for match in pattern.finditer(masked_test)
+    }
+    return {re.sub(r"\s+", "", symbol).split("::")[-1] for symbol in qualified}
+
+
+def check_visualizer_test_exports(root: Path) -> list[Finding]:
+    """Require exports for explicitly referenced visualizer free functions."""
+
+    findings: set[Finding] = set()
+    tests_root = root / "tests"
+    if not tests_root.exists():
+        return []
+
+    for test_path in tests_root.rglob("*.cpp"):
+        raw_test = test_path.read_text(encoding="utf-8", errors="replace")
+        referenced_names = _explicit_visualizer_symbols(mask_source(raw_test))
+        if not referenced_names:
+            continue
+        headers = {
+            header
+            for include in INCLUDE_RE.findall(raw_test)
+            if (header := _resolve_visualizer_header(root, include)) is not None
+        }
+        for header in headers:
+            raw_header = header.read_text(encoding="utf-8", errors="replace")
+            masked_header = mask_source(raw_header)
+            blocks = _type_blocks(masked_header)
+            for name in referenced_names:
+                pattern = re.compile(rf"\b{re.escape(name)}\s*\(")
+                unexported: list[re.Match[str]] = []
+                header_available = False
+                for match in pattern.finditer(masked_header):
+                    if _inside_type(match.start(), blocks):
+                        continue
+                    prefix = masked_header[max(0, match.start() - 2) : match.start()]
+                    if prefix.endswith("::") or prefix.endswith("->"):
+                        continue
+                    function = _function_segment(masked_header, match.start())
+                    if function is None:
+                        continue
+                    _start, segment = function
+                    tokens = set(re.findall(r"\b[A-Za-z_]\w*\b", segment))
+                    if (
+                        tokens & EXPORT_EXEMPT_TOKENS
+                        or "operator" in tokens
+                        or "LFS_VIS_API" in tokens
+                    ):
+                        header_available = True
+                        break
+                    unexported.append(match)
+
+                if header_available or not unexported:
+                    continue
+                match = unexported[0]
+                relative = header.relative_to(root).as_posix()
+                findings.add(
+                    Finding(
+                        path=relative,
+                        line=_line_number(raw_header, match.start()),
+                        rule="visualizer-test-dll-export",
+                        message=(
+                            f"free function {name} is called by "
+                            f"{test_path.relative_to(root).as_posix()} but its "
+                            "declaration lacks LFS_VIS_API"
+                        ),
+                    )
+                )
+    return sorted(findings)
+
+
+def run_source_checks(root: Path) -> list[Finding]:
+    return check_visualizer_test_exports(root)
+
+
+def load_compile_commands(path: Path) -> list[CompileCommand]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read compile database {path}: {error}") from error
+    if not isinstance(payload, list):
+        raise ValueError(f"compile database {path} must contain a JSON array")
+
+    commands: list[CompileCommand] = []
+    for index, entry in enumerate(payload):
+        if not isinstance(entry, dict):
+            raise ValueError(f"compile database entry {index} is not an object")
+        command = entry.get("command")
+        arguments = entry.get("arguments")
+        file_value = entry.get("file")
+        directory = entry.get("directory")
+        if command is None and isinstance(arguments, list) and all(
+            isinstance(value, str) for value in arguments
+        ):
+            command = subprocess.list2cmdline(arguments)
+        if not all(
+            isinstance(value, str) and value
+            for value in (command, file_value, directory)
+        ):
+            raise ValueError(
+                f"compile database entry {index} requires file and directory strings "
+                "plus a command string or arguments array"
+            )
+        directory_path = _lexical_absolute(Path(directory))
+        commands.append(
+            CompileCommand(
+                file=_lexical_absolute(Path(file_value), directory_path),
+                directory=directory_path,
+                command=command,
+            )
+        )
+    return commands
+
+
+def _git(root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _valid_base(root: Path, candidate: str | None) -> str | None:
+    if not candidate or set(candidate) == {"0"}:
+        return None
+    result = _git(root, "rev-parse", "--verify", f"{candidate}^{{commit}}")
+    return candidate if result.returncode == 0 else None
+
+
+def discover_changed_files(root: Path, base: str | None) -> tuple[set[Path], bool]:
+    """Return changed paths and whether missing base forced full coverage."""
+
+    requested_base = base or os.environ.get("LFS_PREFLIGHT_BASE")
+    valid_base = _valid_base(root, requested_base)
+    force_all = bool(requested_base and valid_base is None)
+    if valid_base is not None:
+        merge_base = _git(root, "merge-base", valid_base, "HEAD")
+        if merge_base.returncode != 0:
+            force_all = True
+            valid_base = None
+        else:
+            diff_base = merge_base.stdout.strip()
+    else:
+        diff_base = "HEAD"
+        if os.environ.get("GITHUB_ACTIONS") == "true" and not requested_base:
+            force_all = True
+
+    changed: set[Path] = set()
+    if not force_all:
+        diff = _git(root, "diff", "--name-only", "--diff-filter=ACMRT", diff_base, "--")
+        if diff.returncode != 0:
+            force_all = True
+        else:
+            for line in diff.stdout.splitlines():
+                if line.strip():
+                    changed.add((root / line.strip()).resolve())
+            untracked = _git(root, "ls-files", "--others", "--exclude-standard")
+            if untracked.returncode == 0:
+                for line in untracked.stdout.splitlines():
+                    if line.strip():
+                        changed.add((root / line.strip()).resolve())
+    return changed, force_all
+
+
+def _lexical_absolute(path: Path, base: Path | None = None) -> Path:
+    if not path.is_absolute():
+        path = (base or Path.cwd()) / path
+    return Path(os.path.abspath(os.path.normpath(path)))
+
+
+def _iter_local_includes(
+    root: Path, project_files: Iterable[Path]
+) -> Iterable[tuple[Path, str]]:
+    grep = _git(
+        root,
+        "grep",
+        "--untracked",
+        "-n",
+        "-I",
+        "-E",
+        r'^[[:space:]]*#[[:space:]]*include[[:space:]]*"[^"]+"',
+        "--",
+        "src",
+        "include",
+        "tests",
+    )
+    if grep.returncode in (0, 1):
+        for line in grep.stdout.splitlines():
+            parts = line.split(":", 2)
+            if len(parts) != 3:
+                continue
+            source = (root / parts[0]).resolve()
+            match = INCLUDE_RE.search(parts[2])
+            if match is not None:
+                yield source, match.group(1)
+        return
+
+    # Source archives and unit-test fixtures may have no usable Git index.
+    for source in project_files:
+        raw = source.read_text(encoding="utf-8", errors="replace")
+        for include in INCLUDE_RE.findall(raw):
+            yield source, include
+
+
+def build_reverse_include_graph(
+    root: Path, extra_dependencies: Iterable[Path] = ()
+) -> dict[Path, set[Path]]:
+    project_files = set(_iter_project_files(root, PROJECT_SOURCE_SUFFIXES))
+    dependency_files = project_files | {path.resolve() for path in extra_dependencies}
+    suffix_index: dict[str, list[Path]] = defaultdict(list)
+    for path in dependency_files:
+        relative = path.relative_to(root).as_posix().lower()
+        parts = relative.split("/")
+        for index in range(len(parts)):
+            suffix_index["/".join(parts[index:])].append(path)
+
+    reverse: dict[Path, set[Path]] = defaultdict(set)
+    for source, include in _iter_local_includes(root, project_files):
+        include_path = Path(include.replace("\\", "/"))
+        direct = _lexical_absolute(source.parent / include_path)
+        resolved: Path | None = direct if direct in dependency_files else None
+        if resolved is None:
+            matches = suffix_index.get(include.replace("\\", "/").lower(), [])
+            if len(matches) == 1:
+                resolved = matches[0]
+        if resolved is not None and resolved in dependency_files:
+            reverse[resolved].add(source)
+    return reverse
+
+
+def _is_project_compile_command(root: Path, command: CompileCommand) -> bool:
+    try:
+        relative = command.file.relative_to(root)
+    except ValueError:
+        return False
+    return bool(relative.parts) and relative.parts[0] != "external"
+
+
+def select_compile_commands(
+    root: Path,
+    commands: Sequence[CompileCommand],
+    changed: set[Path],
+    force_all: bool,
+) -> list[CompileCommand]:
+    cxx_commands = [
+        command
+        for command in commands
+        if command.file.suffix.lower() in CXX_SUFFIXES
+        and _is_project_compile_command(root, command)
+    ]
+    if force_all:
+        return cxx_commands
+
+    command_files = {command.file for command in cxx_commands}
+    selected_files = {path for path in changed if path in command_files}
+    changed_headers = {path for path in changed if path.suffix.lower() in HEADER_SUFFIXES}
+    if changed_headers:
+        reverse = build_reverse_include_graph(root, changed_headers)
+        queue = deque(changed_headers)
+        visited = set(changed_headers)
+        while queue:
+            dependency = queue.popleft()
+            for consumer in reverse.get(dependency, ()):
+                if consumer in visited:
+                    continue
+                visited.add(consumer)
+                queue.append(consumer)
+                if consumer in command_files:
+                    selected_files.add(consumer)
+
+    selected = [command for command in cxx_commands if command.file in selected_files]
+    return selected
+
+
+def _is_msvc_command(command: CompileCommand) -> bool:
+    lowered = command.command.lower()
+    return (
+        re.search(r'(?:^|[\\/"\s])cl(?:\.exe)?(?=["\s]|$)', lowered)
+        is not None
+        and "nvcc" not in lowered
+    )
+
+
+def _msvc_syntax_command(command: str) -> str:
+    # A syntax-only invocation creates no object for a compiler cache to store.
+    # Bypass a direct sccache launcher and suppress the dependency-list stream,
+    # while preserving the exact compiler, defines, and include paths selected
+    # by CMake.
+    without_launcher = re.sub(
+        r'^\s*(?:"[^"]*sccache(?:\.exe)?"|[^\s"]*sccache(?:\.exe)?)\s+',
+        "",
+        command,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    without_includes = re.sub(
+        r"(?i)(?<!\S)/showIncludes(?=\s|$)", "", without_launcher
+    )
+    return f"{without_includes.rstrip()} /Zs"
+
+
+def _run_one_syntax_check(command: CompileCommand) -> tuple[CompileCommand, int, str]:
+    encoding = locale.getpreferredencoding(False) or "utf-8"
+    result = subprocess.run(
+        _msvc_syntax_command(command.command),
+        cwd=command.directory,
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding=encoding,
+        errors="replace",
+    )
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
+    return command, result.returncode, output
+
+
+def run_msvc_syntax_checks(
+    commands: Sequence[CompileCommand], jobs: int
+) -> list[tuple[CompileCommand, int, str]]:
+    failures: list[tuple[CompileCommand, int, str]] = []
+    with ThreadPoolExecutor(max_workers=max(1, jobs)) as executor:
+        futures = {
+            executor.submit(_run_one_syntax_check, command): command
+            for command in commands
+        }
+        for future in as_completed(futures):
+            command, returncode, output = future.result()
+            if returncode != 0:
+                failures.append((command, returncode, output))
+    return sorted(failures, key=lambda item: item[0].file.as_posix().lower())
+
+
+def _print_source_result(findings: Sequence[Finding]) -> None:
+    if findings:
+        print("Windows build source preflight failed:", file=sys.stderr)
+        for finding in findings:
+            print(f"  {finding.render()}", file=sys.stderr)
+        return
+    print("Windows build source preflight passed")
+
+
+def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="repository root (default: inferred from this script)",
+    )
+    parser.add_argument(
+        "--source-only",
+        action="store_true",
+        help="run dependency-free source contract checks only",
+    )
+    parser.add_argument(
+        "--skip-source-checks",
+        action="store_true",
+        help="skip source checks already performed by an earlier CI gate",
+    )
+    parser.add_argument(
+        "--compile-commands",
+        type=Path,
+        help="compile_commands.json used for configured MSVC /Zs checks",
+    )
+    parser.add_argument(
+        "--changed-since",
+        help="Git revision used to select affected translation units",
+    )
+    parser.add_argument(
+        "--all-commands",
+        action="store_true",
+        help="check every MSVC C/C++ entry in the compile database",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print selected translation units without invoking MSVC",
+    )
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=min(os.cpu_count() or 1, 4),
+        help="maximum parallel MSVC syntax checks (default: up to 4)",
+    )
+    parser.add_argument(
+        "--max-commands",
+        type=int,
+        default=0,
+        help=(
+            "skip configured replay when more commands are affected; "
+            "zero means unlimited (default: 0)"
+        ),
+    )
+    arguments = parser.parse_args(argv)
+    if arguments.source_only and arguments.compile_commands is not None:
+        parser.error("--source-only cannot be combined with --compile-commands")
+    if arguments.source_only and arguments.skip_source_checks:
+        parser.error("--source-only cannot be combined with --skip-source-checks")
+    if arguments.all_commands and arguments.compile_commands is None:
+        parser.error("--all-commands requires --compile-commands")
+    if arguments.dry_run and arguments.compile_commands is None:
+        parser.error("--dry-run requires --compile-commands")
+    if arguments.jobs < 1:
+        parser.error("--jobs must be at least 1")
+    if arguments.max_commands < 0:
+        parser.error("--max-commands cannot be negative")
+    return arguments
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = parse_arguments(argv)
+    root = arguments.root.resolve()
+    if not (root / ".git").exists():
+        print(f"error: repository root does not contain .git: {root}", file=sys.stderr)
+        return 2
+
+    if not arguments.skip_source_checks:
+        findings = run_source_checks(root)
+        _print_source_result(findings)
+        if findings:
+            return 1
+    if arguments.source_only or arguments.compile_commands is None:
+        return 0
+
+    try:
+        commands = load_compile_commands(arguments.compile_commands.resolve())
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    if arguments.all_commands:
+        selected = select_compile_commands(root, commands, set(), True)
+        forced_all = True
+    else:
+        changed, forced_all = discover_changed_files(root, arguments.changed_since)
+        selected = select_compile_commands(root, commands, changed, forced_all)
+
+    if forced_all:
+        print("MSVC preflight: checking all configured C/C++ translation units")
+    elif selected:
+        print(f"MSVC preflight: checking {len(selected)} affected compile command(s)")
+    else:
+        print("MSVC preflight: no affected configured C/C++ translation units")
+        return 0
+
+    if arguments.dry_run:
+        for command in selected:
+            print(command.file.as_posix())
+        return 0
+    if arguments.max_commands and len(selected) > arguments.max_commands:
+        print(
+            "MSVC preflight: configured replay skipped because "
+            f"{len(selected)} commands exceed the {arguments.max_commands}-command "
+            "budget; the full build remains authoritative"
+        )
+        return 0
+    if os.name != "nt":
+        print("error: configured MSVC checks require Windows", file=sys.stderr)
+        return 2
+
+    unsupported = [command for command in selected if not _is_msvc_command(command)]
+    for command in unsupported:
+        print(
+            f"warning: skipping non-MSVC compile command for {command.file.as_posix()}",
+            file=sys.stderr,
+        )
+    supported = [command for command in selected if _is_msvc_command(command)]
+    if not supported:
+        print("error: no selected compile command invokes MSVC cl.exe", file=sys.stderr)
+        return 2
+
+    failures = run_msvc_syntax_checks(supported, arguments.jobs)
+    if failures:
+        print("MSVC configured preflight failed:", file=sys.stderr)
+        for command, returncode, output in failures:
+            print(
+                f"\n--- {command.file.as_posix()} (exit {returncode}) ---",
+                file=sys.stderr,
+            )
+            if output:
+                print(output, file=sys.stderr)
+        return 1
+    print(f"MSVC configured preflight passed ({len(supported)} command(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/windows_build_preflight.py
+++ b/tools/windows_build_preflight.py
@@ -16,7 +16,7 @@ responsibility of the normal build and test jobs.
 from __future__ import annotations
 
 import argparse
-from collections import defaultdict, deque
+from collections import Counter, defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 import json
@@ -507,6 +507,29 @@ def select_compile_commands(
     return selected
 
 
+def _display_source_path(root: Path, source: Path) -> str:
+    try:
+        return source.relative_to(root).as_posix()
+    except ValueError:
+        return source.as_posix()
+
+
+def _print_selected_compile_commands(
+    root: Path, commands: Sequence[CompileCommand]
+) -> None:
+    source_counts = Counter(
+        _display_source_path(root, command.file) for command in commands
+    )
+    print(
+        "MSVC preflight: selected "
+        f"{len(source_counts)} source file(s) for {len(commands)} compile command(s):"
+    )
+    for source in sorted(source_counts, key=lambda path: (path.lower(), path)):
+        count = source_counts[source]
+        duplicate_note = f" ({count} compile commands)" if count > 1 else ""
+        print(f"  - {source}{duplicate_note}")
+
+
 def _is_msvc_command(command: CompileCommand) -> bool:
     lowered = command.command.lower()
     return (
@@ -680,8 +703,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     if arguments.dry_run:
-        for command in selected:
-            print(command.file.as_posix())
+        _print_selected_compile_commands(root, selected)
         return 0
     if arguments.max_commands and len(selected) > arguments.max_commands:
         print(
@@ -697,7 +719,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     unsupported = [command for command in selected if not _is_msvc_command(command)]
     for command in unsupported:
         print(
-            f"warning: skipping non-MSVC compile command for {command.file.as_posix()}",
+            "warning: skipping non-MSVC compile command for "
+            f"{_display_source_path(root, command.file)}",
             file=sys.stderr,
         )
     supported = [command for command in selected if _is_msvc_command(command)]
@@ -705,12 +728,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("error: no selected compile command invokes MSVC cl.exe", file=sys.stderr)
         return 2
 
+    _print_selected_compile_commands(root, supported)
     failures = run_msvc_syntax_checks(supported, arguments.jobs)
     if failures:
         print("MSVC configured preflight failed:", file=sys.stderr)
         for command, returncode, output in failures:
             print(
-                f"\n--- {command.file.as_posix()} (exit {returncode}) ---",
+                "\n--- "
+                f"{_display_source_path(root, command.file)} (exit {returncode}) ---",
                 file=sys.stderr,
             )
             if output:

--- a/tools/windows_build_preflight.py
+++ b/tools/windows_build_preflight.py
@@ -589,6 +589,86 @@ def run_msvc_syntax_checks(
     return sorted(failures, key=lambda item: item[0].file.as_posix().lower())
 
 
+def generated_header_build_commands(root: Path, database: Path) -> list[list[str]]:
+    """Prepare only known header targets present in this configured CMake tree.
+
+    Older trees generate the ABI header at configure time and have no such
+    target. Use CMake's generated target inventory, not the current source, so
+    the command matches the build tree that supplied the compile database.
+    """
+
+    build_dir = database.parent
+    try:
+        cache_text = (build_dir / "CMakeCache.txt").read_text(encoding="utf-8")
+        target_text = (build_dir / "CMakeFiles" / "TargetDirectories.txt").read_text(
+            encoding="utf-8"
+        )
+    except OSError as error:
+        raise ValueError(
+            "cannot read configured CMake metadata; use compile_commands.json "
+            f"in its original build directory and configure it first: {error}"
+        ) from error
+
+    cache = dict(re.findall(r"^([^#/:\n][^:\n]*):[^=\n]+=(.*)$", cache_text, re.MULTILINE))
+    source_dir = cache.get("CMAKE_HOME_DIRECTORY")
+    if not source_dir or Path(source_dir).resolve() != root.resolve():
+        raise ValueError("compile database belongs to a different CMake source tree")
+
+    targets = {
+        line.strip().replace("\\", "/").rsplit("/", 1)[-1]
+        for line in target_text.splitlines()
+    }
+    if "lfs_core_abi_stamp.dir" not in targets:
+        return []
+
+    cmake = cache.get("CMAKE_COMMAND")
+    generator = cache.get("CMAKE_GENERATOR")
+    if not cmake or not generator:
+        raise ValueError(
+            "CMake cache lacks CMAKE_COMMAND or CMAKE_GENERATOR; configure it again"
+        )
+    if generator == "Ninja Multi-Config":
+        # Its compile database can contain every configuration. Generate each
+        # separate ABI header before replaying any of those commands.
+        configurations = list(dict.fromkeys(
+            value for value in cache.get("CMAKE_CONFIGURATION_TYPES", "").split(";")
+            if value
+        ))
+        if not configurations:
+            raise ValueError(
+                "Ninja Multi-Config cache has no configurations; configure it again"
+            )
+    else:
+        # Dependencies can populate CMAKE_CONFIGURATION_TYPES even with Ninja.
+        configurations = [cache.get("CMAKE_BUILD_TYPE", "")]
+
+    result = []
+    for configuration in configurations:
+        command = [cmake, "--build", str(build_dir), "--target", "lfs_core_abi_stamp"]
+        if configuration:
+            command.extend(["--config", configuration])
+        result.append(command)
+    return result
+
+
+def prepare_generated_headers(commands: Sequence[Sequence[str]]) -> None:
+    for command in commands:
+        print(
+            "MSVC preflight: preparing generated headers: "
+            f"{subprocess.list2cmdline(command)}",
+            flush=True,
+        )
+        try:
+            result = subprocess.run(command, check=False)
+        except OSError as error:
+            raise ValueError(f"cannot prepare generated headers: {error}") from error
+        if result.returncode != 0:
+            raise ValueError(
+                f"generated-header preparation failed (exit {result.returncode}); "
+                "MSVC was not run"
+            )
+
+
 def _print_source_result(findings: Sequence[Finding]) -> None:
     if findings:
         print("Windows build source preflight failed:", file=sys.stderr)
@@ -681,53 +761,67 @@ def main(argv: Sequence[str] | None = None) -> int:
     if arguments.source_only or arguments.compile_commands is None:
         return 0
 
-    try:
-        commands = load_compile_commands(arguments.compile_commands.resolve())
-    except ValueError as error:
-        print(f"error: {error}", file=sys.stderr)
-        return 2
-
     if arguments.all_commands:
-        selected = select_compile_commands(root, commands, set(), True)
-        forced_all = True
+        changed, forced_all = set(), True
     else:
         changed, forced_all = discover_changed_files(root, arguments.changed_since)
+
+    database = arguments.compile_commands.resolve()
+    headers_prepared = False
+    while True:
+        try:
+            commands = load_compile_commands(database)
+        except ValueError as error:
+            print(f"error: {error}", file=sys.stderr)
+            return 2
         selected = select_compile_commands(root, commands, changed, forced_all)
 
+        if not selected:
+            print("MSVC preflight: no affected configured C/C++ translation units")
+            return 0
+        if arguments.dry_run:
+            _print_selected_compile_commands(root, selected)
+            return 0
+        if arguments.max_commands and len(selected) > arguments.max_commands:
+            print(
+                "MSVC preflight: configured replay skipped because "
+                f"{len(selected)} commands exceed the {arguments.max_commands}-command "
+                "budget; the full build remains authoritative"
+            )
+            return 0
+        if os.name != "nt":
+            print("error: configured MSVC checks require Windows", file=sys.stderr)
+            return 2
+
+        supported = [command for command in selected if _is_msvc_command(command)]
+        if not supported:
+            print("error: no selected compile command invokes MSVC cl.exe", file=sys.stderr)
+            return 2
+        if headers_prepared:
+            break
+        try:
+            header_commands = generated_header_build_commands(root, database)
+            if not header_commands:
+                break
+            prepare_generated_headers(header_commands)
+        except ValueError as error:
+            print(f"error: {error}", file=sys.stderr)
+            return 1
+        # The native build tool may have regenerated CMake. Reload and reselect
+        # commands (including the work budget) before invoking the compiler.
+        headers_prepared = True
+
+    for command in selected:
+        if not _is_msvc_command(command):
+            print(
+                "warning: skipping non-MSVC compile command for "
+                f"{_display_source_path(root, command.file)}",
+                file=sys.stderr,
+            )
     if forced_all:
         print("MSVC preflight: checking all configured C/C++ translation units")
-    elif selected:
-        print(f"MSVC preflight: checking {len(selected)} affected compile command(s)")
     else:
-        print("MSVC preflight: no affected configured C/C++ translation units")
-        return 0
-
-    if arguments.dry_run:
-        _print_selected_compile_commands(root, selected)
-        return 0
-    if arguments.max_commands and len(selected) > arguments.max_commands:
-        print(
-            "MSVC preflight: configured replay skipped because "
-            f"{len(selected)} commands exceed the {arguments.max_commands}-command "
-            "budget; the full build remains authoritative"
-        )
-        return 0
-    if os.name != "nt":
-        print("error: configured MSVC checks require Windows", file=sys.stderr)
-        return 2
-
-    unsupported = [command for command in selected if not _is_msvc_command(command)]
-    for command in unsupported:
-        print(
-            "warning: skipping non-MSVC compile command for "
-            f"{_display_source_path(root, command.file)}",
-            file=sys.stderr,
-        )
-    supported = [command for command in selected if _is_msvc_command(command)]
-    if not supported:
-        print("error: no selected compile command invokes MSVC cl.exe", file=sys.stderr)
-        return 2
-
+        print(f"MSVC preflight: checking {len(selected)} affected compile command(s)")
     _print_selected_compile_commands(root, supported)
     failures = run_msvc_syntax_checks(supported, arguments.jobs)
     if failures:

--- a/tools/windows_build_preflight.py
+++ b/tools/windows_build_preflight.py
@@ -362,7 +362,23 @@ def _valid_base(root: Path, candidate: str | None) -> str | None:
     return candidate if result.returncode == 0 else None
 
 
-def discover_changed_files(root: Path, base: str | None) -> tuple[set[Path], bool]:
+def _is_project_path(root: Path, path: Path) -> bool:
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return False
+    return bool(relative.parts) and relative.parts[0] in {"src", "include", "tests"}
+
+
+def _is_build_output(path: Path, root: Path, build_dir: Path | None) -> bool:
+    # Never discard the whole checkout if a caller passes its root as the
+    # compile-database directory (for example, in a source-only test fixture).
+    return build_dir is not None and build_dir != root and path.is_relative_to(build_dir)
+
+
+def discover_changed_files(
+    root: Path, base: str | None, build_dir: Path | None = None
+) -> tuple[set[Path], bool]:
     """Return changed paths and whether missing base forced full coverage."""
 
     requested_base = base or os.environ.get("LFS_PREFLIGHT_BASE")
@@ -390,12 +406,21 @@ def discover_changed_files(root: Path, base: str | None) -> tuple[set[Path], boo
             for path in diff.stdout.split("\0"):
                 if path:
                     changed.add((root / path).resolve())
-            untracked = _git(root, "ls-files", "-z", "--others", "--exclude-standard")
+            # Build directories can have arbitrary names (CI uses b/). Only
+            # untracked project sources are edits; configured/generated files
+            # are dependency-index inputs, not reasons to replay their users.
+            untracked = _git(
+                root, "ls-files", "-z", "--others", "--exclude-standard",
+                "--", "src", "include", "tests",
+            )
             if untracked.returncode == 0:
                 for path in untracked.stdout.split("\0"):
                     if path:
                         changed.add((root / path).resolve())
-    return changed, force_all
+    return {
+        path for path in changed
+        if _is_project_path(root, path) and not _is_build_output(path, root, build_dir)
+    }, force_all
 
 
 def _lexical_absolute(path: Path, base: Path | None = None) -> Path:
@@ -426,6 +451,8 @@ def _iter_local_includes(
             if len(parts) != 3:
                 continue
             source = (root / parts[0]).resolve()
+            if source not in project_files:
+                continue
             match = INCLUDE_RE.search(parts[2])
             if match is not None:
                 yield source, match.group(1), match.group(0).endswith('"')
@@ -441,7 +468,10 @@ def _iter_local_includes(
 def build_reverse_include_graph(
     root: Path, extra_dependencies: Iterable[Path] = (), build_dir: Path | None = None
 ) -> dict[Path, set[Path]]:
-    project_files = set(_iter_project_files(root, PROJECT_SOURCE_SUFFIXES))
+    project_files = {
+        path for path in _iter_project_files(root, PROJECT_SOURCE_SUFFIXES)
+        if not _is_build_output(path, root, build_dir)
+    }
     generated_root = (build_dir or root / "build") / "include"
     generated_files = {
         path.resolve() for path in generated_root.rglob("*")
@@ -480,12 +510,13 @@ def build_reverse_include_graph(
     return reverse
 
 
-def _is_project_compile_command(root: Path, command: CompileCommand) -> bool:
-    try:
-        relative = command.file.relative_to(root)
-    except ValueError:
-        return False
-    return bool(relative.parts) and relative.parts[0] in {"src", "include", "tests"}
+def _is_project_compile_command(
+    root: Path, command: CompileCommand, build_dir: Path | None = None
+) -> bool:
+    return (
+        _is_project_path(root, command.file)
+        and not _is_build_output(command.file, root, build_dir)
+    )
 
 
 def select_compile_commands(
@@ -499,7 +530,7 @@ def select_compile_commands(
         command
         for command in commands
         if command.file.suffix.lower() in CXX_SUFFIXES
-        and _is_project_compile_command(root, command)
+        and _is_project_compile_command(root, command, build_dir)
     ]
     if force_all:
         return cxx_commands
@@ -731,12 +762,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     if arguments.source_only or arguments.compile_commands is None:
         return 0
 
+    database = arguments.compile_commands.resolve()
     if arguments.all_commands:
         changed, forced_all = set(), True
     else:
-        changed, forced_all = discover_changed_files(root, arguments.changed_since)
+        changed, forced_all = discover_changed_files(
+            root, arguments.changed_since, database.parent
+        )
 
-    database = arguments.compile_commands.resolve()
     try:
         commands = load_compile_commands(database)
     except ValueError as error:


### PR DESCRIPTION
Changes to project headers can fail late in the Windows build, while an overly broad preflight repeats unrelated compilation. This adds a portable DLL-export source check and a bounded replay of affected compile-database entries through MSVC `/Zs`.

The configured pass:

- follows quoted and angle-bracket project includes, including deleted headers and both sides of renames;
- compares PR merge checkouts with `HEAD^1`, excluding independent master changes, while push builds use the previous event commit;
- restricts changed paths and compilation entries to `src/`, `include/`, and `tests/`, excluding the selected build directory even when named `b/` or nested under a source root;
- retains generated headers for include resolution without treating newly generated configuration or ABI headers as source edits;
- bypasses sccache and removes dependency-reporting/PCH switches while preserving MSVC quoting, defines, and include arguments;
- limits concurrency to four processes and emits a GitHub warning when the 128-command CI budget skips replay.

Build-only changes do not request a complete replay unless `--all-commands` is supplied. CUDA, vendored, generated, vcpkg, and `_deps` compilation entries are excluded. Source lists show repository-relative filenames and duplicate command counts.

Windows Release/Debug CI and nightly portable packaging first build the `lfs_shader_headers` prerequisite, which exposes the existing CMake shader-generation graph. This prepares headers such as `viewport/frustum.vert.spv.h` before syntax-only replay, propagates generation failures, and lets the subsequent full build reuse the outputs. The prerequisite builds the shader compiler helper and headers without building the visualizer or application. The Python checker itself does not configure CMake, parse its cache, or invoke build targets. ABI headers are seeded at configuration by the now-merged #2018.

The branch includes upstream/master `dc266db24`, containing #2018 and #2028. As requested in the approved #2028 review, its existing profile checks are registered as `lichtfeld.cmake.vcpkg_profiles` with the `fast` CTest label. Documentation covers this registration, local prerequisite generation, configuration selection, and concrete DLL-export checking limitations.

Validation:

- All 40 targeted preflight, shader-dependency, and ABI-stamp tests pass on Python 3.10 after the upstream merge. The 36 preflight/shader tests also passed on Python 3.11.
- Real-Git regressions reproduce the build-only PR with fresh `b/` headers and verify that no unchanged shader consumer is replayed, while genuine source edits remain selected.
- A temporary CMake/Ninja fixture with `LANGUAGES NONE` and a Python header generator verifies generation, incremental reuse, missing-output regeneration, failure propagation, and consumer isolation.
- The actual vcpkg test registration was exercised in a temporary compiler-free CMake fixture: CTest discovery confirms the command, label and timeout, and all 30 Windows/Linux profile cases pass through CTest.
- Source-only contracts, workflow parsing/step ordering, and `git diff --check` pass.

No LichtFeld configuration, native C++/CUDA/GLSL compilation, or runtime execution was performed locally. Include discovery remains lexical; macro includes, ambiguous suffix matches, and linker/runtime behavior still require the full build and tests.