### PR TITLE
Windows: selection pending-count struct destroys SceneSnapshot where it is complete

### DIFF
--- a/src/visualizer/selection/selection_service.cpp
+++ b/src/visualizer/selection/selection_service.cpp
@@ -856,6 +856,12 @@ namespace lfs::vis {
 
     } // namespace
 
+    SelectionService::PendingSelectionCounts::PendingSelectionCounts() = default;
+    SelectionService::PendingSelectionCounts::~PendingSelectionCounts() = default;
+    SelectionService::PendingSelectionCounts::PendingSelectionCounts(PendingSelectionCounts&&) noexcept = default;
+    SelectionService::PendingSelectionCounts&
+    SelectionService::PendingSelectionCounts::operator=(PendingSelectionCounts&&) noexcept = default;
+
     SelectionService::SelectionService(SceneManager* scene_manager, RenderingManager* rendering_manager)
         : scene_manager_(scene_manager),
           rendering_manager_(rendering_manager) {

--- a/src/visualizer/selection/selection_service.hpp
+++ b/src/visualizer/selection/selection_service.hpp
@@ -161,6 +161,11 @@ namespace lfs::vis {
 
     private:
         struct PendingSelectionCounts {
+            PendingSelectionCounts();
+            ~PendingSelectionCounts();
+            PendingSelectionCounts(PendingSelectionCounts&&) noexcept;
+            PendingSelectionCounts& operator=(PendingSelectionCounts&&) noexcept;
+
             std::shared_ptr<core::Tensor> mask;
             std::unique_ptr<op::SceneSnapshot> undo_entry;
             core::Tensor scratch;


### PR DESCRIPTION
Windows Release CI is red since #1992: MSVC instantiates the implicit destructor of `SelectionService::PendingSelectionCounts` in every TU that includes `selection_service.hpp`, where `op::SceneSnapshot` is only forward-declared, and rejects deleting the incomplete type through `unique_ptr` (C2027/C2338 in visualizer.cpp, data_loading_service.cpp, editor_context.cpp).

Fix: declare the struct's constructor, destructor and move operations in the header and default them in `selection_service.cpp`, where the type is complete. No behavior change. Linux build and the 117 Selection tests pass; Windows is only verifiable by CI.

The same commit is on the dev sync PR #2006.