### PR TITLE
Refresh the committed keymap stub from the generator

### DIFF
--- a/src/python/stubs/lichtfeld/keymap.pyi
+++ b/src/python/stubs/lichtfeld/keymap.pyi
@@ -27,6 +27,8 @@ class Action(enum.Enum):
 
     CAMERA_MOVE_DOWN = 10
 
+    CAMERA_RESET_HOME = 70
+
     CAMERA_SET_HOME = 11
 
     CAMERA_FOCUS_SELECTION = 12
@@ -71,6 +73,10 @@ class Action(enum.Enum):
 
     COPY_SELECTION = 32
 
+    CUT_SELECTION = 76
+
+    TOGGLE_PERFORMANCE_HUD = 77
+
     PASTE_SELECTION = 33
 
     DEPTH_ADJUST_FAR = 34
@@ -97,6 +103,8 @@ class Action(enum.Enum):
 
     SELECTION_REMOVE = 46
 
+    SELECTION_INTERSECT = 73
+
     SELECT_MODE_CENTERS = 47
 
     SELECT_MODE_RECTANGLE = 48
@@ -108,6 +116,10 @@ class Action(enum.Enum):
     SELECT_MODE_RINGS = 51
 
     SELECT_MODE_COLOR = 52
+
+    SELECT_MODE_BOX = 74
+
+    SELECT_MODE_SPHERE = 75
 
     APPLY_CROP_BOX = 53
 
@@ -141,21 +153,9 @@ class Action(enum.Enum):
 
     DEPTH_ADJUST_NEAR = 69
 
-    CAMERA_RESET_HOME = 70
-
     HISTOGRAM_ZOOM_MARKED = 71
 
     TOGGLE_CAMERA_FRUSTUMS = 72
-
-    SELECTION_INTERSECT = 73
-
-    SELECT_MODE_BOX = 74
-
-    SELECT_MODE_SPHERE = 75
-
-    CUT_SELECTION = 76
-
-    TOGGLE_PERFORMANCE_HUD = 77
 
     OPEN_PREFERENCES = 78
 
@@ -173,12 +173,11 @@ class Action(enum.Enum):
 
     DEPTH_ADJUST_SIZE = 85
 
-    DEPTH_WINDOW_DRAG = 86
-
     GROUP_SELECTED_SCENE_NODES = 87
 
     UNGROUP_SELECTED_SCENE_NODE = 88
 
+    DEPTH_WINDOW_DRAG = 86
 
 class ToolMode(enum.Enum):
     GLOBAL = 0


### PR DESCRIPTION
The master-into-dev sync (#2006) ordered the Action members of `keymap.pyi` by hand; the generator emits a different order, so `python_stub_check` fails on dev's default build target. Regenerated with `refresh_python_stubs`; enum values are unchanged.