### PR TITLE
Viewport rail follows the bottom dock and re-flows instead of scrolling

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -6513,6 +6513,7 @@ namespace lfs::vis::gui {
         const float bottom_dock_edge_grab_h =
             std::max(PanelLayoutManager::SPLITTER_H * current_ui_scale_,
                      8.0f * current_ui_scale_);
+        const float bottom_dock_grip_h = PanelLayoutManager::DOCK_GRIP_H * current_ui_scale_;
         const bool pointer_over_bottom_dock =
             panel_layout_.isBottomDockVisible() &&
             pointInRect(panel_input.mouse_x, panel_input.mouse_y,
@@ -6523,7 +6524,7 @@ namespace lfs::vis::gui {
             panel_input.mouse_x >= bottom_dock_x &&
             panel_input.mouse_x < bottom_dock_x + bottom_dock_w &&
             panel_input.mouse_y >= bottom_dock_y - bottom_dock_edge_grab_h &&
-            panel_input.mouse_y <= bottom_dock_y + bottom_dock_edge_grab_h;
+            panel_input.mouse_y <= bottom_dock_y + bottom_dock_grip_h + 4.0f * current_ui_scale_;
         const bool pointer_targets_bottom_dock =
             pointer_over_bottom_dock || pointer_over_bottom_dock_edge;
         if (pointer_targets_bottom_dock &&
@@ -6544,6 +6545,7 @@ namespace lfs::vis::gui {
             BottomDockLayout bottom_dock_rml_layout;
             bottom_dock_rml_layout.pos = {bottom_dock_x, bottom_dock_y};
             bottom_dock_rml_layout.size = {bottom_dock_w, bottom_dock_h};
+            bottom_dock_rml_layout.grip_h = bottom_dock_grip_h;
             bottom_dock_rml_layout.tab_bar_h = PanelLayoutManager::TAB_BAR_H * current_ui_scale_;
             bottom_dock_rml_layout.separator_h = current_ui_scale_;
             rml_bottom_dock_.processInput(bottom_dock_rml_layout, panel_input);
@@ -6582,8 +6584,11 @@ namespace lfs::vis::gui {
             BottomDockLayout bottom_dock_rml_layout;
             bottom_dock_rml_layout.pos = {bottom_dock_x, bottom_dock_y};
             bottom_dock_rml_layout.size = {bottom_dock_w, bottom_dock_h};
+            bottom_dock_rml_layout.grip_h = bottom_dock_grip_h;
             bottom_dock_rml_layout.tab_bar_h = PanelLayoutManager::TAB_BAR_H * current_ui_scale_;
             bottom_dock_rml_layout.separator_h = current_ui_scale_;
+            bottom_dock_rml_layout.grip_hovered = panel_layout_.isBottomDockHoveringEdge();
+            bottom_dock_rml_layout.grip_active = panel_layout_.isBottomDockResizing();
             rml_bottom_dock_.render(bottom_dock_rml_layout, bottom_dock_tab_snaps,
                                     panel_layout_.getBottomDockActiveTab(),
                                     panel_input.screen_x, panel_input.screen_y,

--- a/src/visualizer/gui/panel_layout.cpp
+++ b/src/visualizer/gui/panel_layout.cpp
@@ -7,6 +7,7 @@
 #include "gui/panels/python_console_panel.hpp"
 #include "gui/rml_viewport_overlay.hpp"
 #include "python/python_runtime.hpp"
+#include "visualizer/app_store.hpp"
 #include "visualizer_impl.hpp"
 #include <algorithm>
 #include <cmath>
@@ -30,6 +31,20 @@ namespace lfs::vis::gui {
 
     PanelLayoutManager::PanelLayoutManager() = default;
 
+    void PanelLayoutManager::setBottomDockActiveTab(const std::string& id) {
+        if (bottom_dock_active_tab_id_ == id)
+            return;
+        bottom_dock_active_tab_id_ = id;
+        lfs::vis::publish_viewport_toolbar_generation();
+    }
+
+    void PanelLayoutManager::setShowSequencer(const bool visible) {
+        if (show_sequencer_ == visible)
+            return;
+        show_sequencer_ = visible;
+        lfs::vis::publish_viewport_toolbar_generation();
+    }
+
     void PanelLayoutManager::loadState() {
         // Legacy layout.json remains an import-only first-run reader. Project
         // panel geometry is authoritative in GUIL (right_panel_width,
@@ -38,7 +53,7 @@ namespace lfs::vis::gui {
         // layout.json so a later GUIL restore cannot fight stale user prefs.
         LayoutState state;
         state.load();
-        show_sequencer_ = false;
+        setShowSequencer(false);
         previous_bottom_docked_ids_.clear();
         bottom_dock_sync_seeded_ = false;
     }
@@ -74,9 +89,9 @@ namespace lfs::vis::gui {
         if (std::isfinite(state.left_dock_width) &&
             state.left_dock_width > 0.0f)
             left_dock_width_ = state.left_dock_width;
-        show_sequencer_ = state.show_sequencer;
+        setShowSequencer(state.show_sequencer);
         active_tab_id_ = state.active_tab_id;
-        bottom_dock_active_tab_id_ = state.bottom_dock_active_tab_id;
+        setBottomDockActiveTab(state.bottom_dock_active_tab_id);
         previous_bottom_docked_ids_.clear();
         bottom_dock_sync_seeded_ = false;
         tab_scroll_offset_ = std::isfinite(state.tab_scroll_offset)
@@ -546,7 +561,7 @@ namespace lfs::vis::gui {
         if (bottom_dock_sync_seeded_) {
             for (const auto& tab : docked_tabs) {
                 if (!previous_bottom_docked_ids_.contains(tab.id)) {
-                    bottom_dock_active_tab_id_ = tab.id;
+                    setBottomDockActiveTab(tab.id);
                     bottom_dock_active_tab_changed_ = true;
                 }
             }
@@ -564,7 +579,7 @@ namespace lfs::vis::gui {
                                                 ? std::string{}
                                                 : bottom_dock_tabs_.front().id;
             bottom_dock_active_tab_changed_ = bottom_dock_active_tab_id_ != next_active;
-            bottom_dock_active_tab_id_ = next_active;
+            setBottomDockActiveTab(next_active);
         }
         if (bottom_dock_tabs_.empty()) {
             bottom_dock_hovering_edge_ = false;

--- a/src/visualizer/gui/panel_layout.cpp
+++ b/src/visualizer/gui/panel_layout.cpp
@@ -645,6 +645,7 @@ namespace lfs::vis::gui {
             bottom_dock_resizing_ = false;
 
         const float edge_grab_h = std::max(SPLITTER_H * dpi, 8.0f * dpi);
+        const float grip_h = DOCK_GRIP_H * dpi;
         float panel_h = bottom_dock_height_;
         float panel_y = screen.work_pos.y + screen.work_size.y - panel_h;
 
@@ -653,7 +654,7 @@ namespace lfs::vis::gui {
             dock_input.mouse_x >= panel_x &&
             dock_input.mouse_x <= panel_x + panel_w &&
             dock_input.mouse_y >= panel_y - edge_grab_h &&
-            dock_input.mouse_y <= panel_y + edge_grab_h;
+            dock_input.mouse_y <= panel_y + grip_h + 4.0f * dpi;
 
         if (bottom_dock_resizing_) {
             bottom_dock_height_ = std::clamp(bottom_dock_height_ - delta_y, min_panel_h, max_panel_h);
@@ -669,11 +670,11 @@ namespace lfs::vis::gui {
 
         const float tab_bar_h = TAB_BAR_H * dpi;
         const float tab_separator_h = dpi;
-        const float content_y = panel_y + tab_bar_h + tab_separator_h;
-        const float content_h = std::max(0.0f, panel_h - tab_bar_h - tab_separator_h);
+        const float content_y = panel_y + grip_h + tab_bar_h + tab_separator_h;
+        const float content_h = std::max(0.0f, panel_h - grip_h - tab_bar_h - tab_separator_h);
         bottom_dock_tab_bar_rect_ = {
             .x = panel_x,
-            .y = panel_y,
+            .y = panel_y + grip_h,
             .width = panel_w,
             .height = tab_bar_h + tab_separator_h,
         };
@@ -754,13 +755,24 @@ namespace lfs::vis::gui {
 
         const float panel_h = bottom_dock_height_;
         const float panel_y = screen.work_pos.y + screen.work_size.y - panel_h;
+        const float grip_h = DOCK_GRIP_H * dpi;
+        const float edge_grab_h = std::max(SPLITTER_H * dpi, 8.0f * dpi);
+        const bool float_blocks_bottom_dock = reg.isPositionOverFloatingPanel(input.mouse_x, input.mouse_y);
+        bottom_dock_hovering_edge_ =
+            !float_blocks_bottom_dock &&
+            input.mouse_x >= panel_x &&
+            input.mouse_x <= panel_x + panel_w &&
+            input.mouse_y >= panel_y - edge_grab_h &&
+            input.mouse_y <= panel_y + grip_h + 4.0f * dpi;
+        if (bottom_dock_hovering_edge_ || bottom_dock_resizing_)
+            cursor_request_ = CursorRequest::ResizeNS;
         const float tab_bar_h = TAB_BAR_H * dpi;
         const float tab_separator_h = dpi;
-        const float content_y = panel_y + tab_bar_h + tab_separator_h;
-        const float content_h = std::max(0.0f, panel_h - tab_bar_h - tab_separator_h);
+        const float content_y = panel_y + grip_h + tab_bar_h + tab_separator_h;
+        const float content_h = std::max(0.0f, panel_h - grip_h - tab_bar_h - tab_separator_h);
         bottom_dock_tab_bar_rect_ = {
             .x = panel_x,
-            .y = panel_y,
+            .y = panel_y + grip_h,
             .width = panel_w,
             .height = tab_bar_h + tab_separator_h,
         };

--- a/src/visualizer/gui/panel_layout.hpp
+++ b/src/visualizer/gui/panel_layout.hpp
@@ -154,6 +154,8 @@ namespace lfs::vis::gui {
         float bottomDockTopY() const { return bottom_dock_top_y_; }
         const std::vector<PanelSummary>& bottomDockTabs() const { return bottom_dock_tabs_; }
         const std::string& getBottomDockActiveTab() const { return bottom_dock_active_tab_id_; }
+        bool isBottomDockHoveringEdge() const { return bottom_dock_hovering_edge_; }
+        bool isBottomDockResizing() const { return bottom_dock_resizing_; }
         void setBottomDockActiveTab(const std::string& id);
         bool bottomDockActiveTabChanged() const { return bottom_dock_active_tab_changed_; }
         PanelDrawBounds bottomDockTabBarRect() const { return bottom_dock_tab_bar_rect_; }
@@ -169,6 +171,7 @@ namespace lfs::vis::gui {
                            std::string& focus_panel_name);
 
         static constexpr float SPLITTER_H = 6.0f;
+        static constexpr float DOCK_GRIP_H = 8.0f;
         static constexpr float TAB_BAR_H = 28.0f;
         static constexpr float STATUS_BAR_HEIGHT = 22.0f;
         static constexpr float PANEL_GAP = 2.0f;

--- a/src/visualizer/gui/panel_layout.hpp
+++ b/src/visualizer/gui/panel_layout.hpp
@@ -154,14 +154,14 @@ namespace lfs::vis::gui {
         float bottomDockTopY() const { return bottom_dock_top_y_; }
         const std::vector<PanelSummary>& bottomDockTabs() const { return bottom_dock_tabs_; }
         const std::string& getBottomDockActiveTab() const { return bottom_dock_active_tab_id_; }
-        void setBottomDockActiveTab(const std::string& id) { bottom_dock_active_tab_id_ = id; }
+        void setBottomDockActiveTab(const std::string& id);
         bool bottomDockActiveTabChanged() const { return bottom_dock_active_tab_changed_; }
         PanelDrawBounds bottomDockTabBarRect() const { return bottom_dock_tab_bar_rect_; }
         float getLeftDockWidth() const { return left_dock_width_; }
         void setLeftDockWidth(float width);
         bool isLeftDockVisible() const { return left_dock_visible_; }
         bool isShowSequencer() const { return show_sequencer_; }
-        void setShowSequencer(bool v) { show_sequencer_ = v; }
+        void setShowSequencer(bool v);
 
         const std::string& getActiveTab() const { return active_tab_id_; }
         void setActiveTab(const std::string& id) { active_tab_id_ = id; }

--- a/src/visualizer/gui/rml_bottom_dock.cpp
+++ b/src/visualizer/gui/rml_bottom_dock.cpp
@@ -83,6 +83,7 @@ namespace lfs::vis::gui {
             LOG_ERROR("RmlBottomDock: resource not found: {}", e.what());
             return;
         }
+        dock_grip_el_ = document_->GetElementById("dock-grip");
         tab_bar_el_ = document_->GetElementById("tab-bar");
         tab_strip_viewport_el_ = document_->GetElementById("tab-strip-viewport");
         tab_separator_el_ = document_->GetElementById("tab-separator");
@@ -98,6 +99,7 @@ namespace lfs::vis::gui {
             rml_manager_->destroyContext("bottom_dock");
         rml_context_ = nullptr;
         document_ = nullptr;
+        dock_grip_el_ = nullptr;
         tab_bar_el_ = nullptr;
         tab_strip_viewport_el_ = nullptr;
         tab_separator_el_ = nullptr;
@@ -138,6 +140,7 @@ namespace lfs::vis::gui {
             rml_context_->Update();
         }
         document_ = nullptr;
+        dock_grip_el_ = nullptr;
         tab_bar_el_ = nullptr;
         tab_strip_viewport_el_ = nullptr;
         base_rcss_.clear();
@@ -158,9 +161,12 @@ namespace lfs::vis::gui {
             LOG_ERROR("RmlBottomDock: resource not found during reload: {}", e.what());
             return;
         }
+        dock_grip_el_ = document_->GetElementById("dock-grip");
         tab_bar_el_ = document_->GetElementById("tab-bar");
         tab_strip_viewport_el_ = document_->GetElementById("tab-strip-viewport");
         tab_separator_el_ = document_->GetElementById("tab-separator");
+        last_grip_hovered_ = false;
+        last_grip_active_ = false;
         tab_model_.DirtyVariable("tabs");
         tab_model_.DirtyVariable("active_tab");
         tab_model_.DirtyVariable("tabs_overflow");
@@ -276,8 +282,9 @@ namespace lfs::vis::gui {
         prev_mouse_x_ = mx;
         prev_mouse_y_ = my;
         const int mods = sdlModsToRml(input.key_ctrl, input.key_shift, input.key_alt, input.key_super);
-        const float chrome_h = layout.tab_bar_h + layout.separator_h;
-        const bool inside = mx >= 0 && mx < layout.size.x && my >= 0 && my < chrome_h;
+        const float chrome_h = layout.grip_h + layout.tab_bar_h + layout.separator_h;
+        const bool over_grip = mx >= 0 && mx < layout.size.x && my >= 0 && my < layout.grip_h;
+        const bool inside = mx >= 0 && mx < layout.size.x && my >= layout.grip_h && my < chrome_h;
         if (inside) {
             if (moved)
                 rml_context_->ProcessMouseMove(static_cast<int>(mx), static_cast<int>(my), mods);
@@ -316,7 +323,7 @@ namespace lfs::vis::gui {
             blurFocus();
         auto* focused = rml_context_->GetFocusElement();
         wants_keyboard_ = rml_input::hasFocusedKeyboardTarget(focused);
-        wants_input_ = wants_input_ || wants_keyboard_;
+        wants_input_ = wants_input_ || (wants_keyboard_ && !over_grip);
         if (rml_input::wantsTextInput(focused))
             guiFocusState().want_text_input = true;
         if (!moved && !input.mouse_clicked[0] && !input.mouse_released[0] && !input.mouse_wheel &&
@@ -338,17 +345,32 @@ namespace lfs::vis::gui {
                                             static_cast<int>(layout.pos.y - screen_y));
         const bool theme_changed = updateTheme();
         const int w = static_cast<int>(layout.size.x);
-        const int h = static_cast<int>(layout.tab_bar_h + layout.separator_h);
+        const int h = static_cast<int>(layout.grip_h + layout.tab_bar_h + layout.separator_h);
         const bool dims_changed = w != last_fbo_w_ || h != last_fbo_h_;
         const bool tabs_changed = syncTabData(tabs, active_tab);
+        const bool grip_state_changed = layout.grip_hovered != last_grip_hovered_ ||
+                                        layout.grip_active != last_grip_active_;
+        if (grip_state_changed) {
+            if (dock_grip_el_) {
+                dock_grip_el_->SetClass("hover", layout.grip_hovered);
+                dock_grip_el_->SetClass("active", layout.grip_active);
+            }
+            last_grip_hovered_ = layout.grip_hovered;
+            last_grip_active_ = layout.grip_active;
+            render_needed_ = true;
+        }
         const bool needs_render = render_needed_ || input_dirty_ || theme_changed || dims_changed || tabs_changed;
         if (needs_render) {
+            if (dock_grip_el_) {
+                dock_grip_el_->SetProperty("top", "0px");
+                dock_grip_el_->SetProperty("height", std::format("{:.0f}px", layout.grip_h));
+            }
             if (tab_bar_el_) {
-                tab_bar_el_->SetProperty("top", "0px");
+                tab_bar_el_->SetProperty("top", std::format("{:.0f}px", layout.grip_h));
                 tab_bar_el_->SetProperty("height", std::format("{:.0f}px", layout.tab_bar_h));
             }
             if (tab_separator_el_) {
-                tab_separator_el_->SetProperty("top", std::format("{:.0f}px", layout.tab_bar_h));
+                tab_separator_el_->SetProperty("top", std::format("{:.0f}px", layout.grip_h + layout.tab_bar_h));
                 tab_separator_el_->SetProperty("height", std::format("{:.0f}px", layout.separator_h));
             }
             rml_context_->SetDimensions(Rml::Vector2i(w, h));

--- a/src/visualizer/gui/rml_bottom_dock.hpp
+++ b/src/visualizer/gui/rml_bottom_dock.hpp
@@ -23,8 +23,11 @@ namespace lfs::vis::gui {
     struct BottomDockLayout {
         glm::vec2 pos{0, 0};
         glm::vec2 size{0, 0};
+        float grip_h = 0.0f;
         float tab_bar_h = 0.0f;
         float separator_h = 0.0f;
+        bool grip_hovered = false;
+        bool grip_active = false;
     };
 
     class RmlBottomDock {
@@ -59,6 +62,7 @@ namespace lfs::vis::gui {
         RmlUIManager* rml_manager_ = nullptr;
         Rml::Context* rml_context_ = nullptr;
         Rml::ElementDocument* document_ = nullptr;
+        Rml::Element* dock_grip_el_ = nullptr;
         Rml::Element* tab_bar_el_ = nullptr;
         Rml::Element* tab_strip_viewport_el_ = nullptr;
         Rml::Element* tab_separator_el_ = nullptr;
@@ -70,6 +74,8 @@ namespace lfs::vis::gui {
         bool tabs_overflow_ = false;
         bool can_scroll_tabs_left_ = false;
         bool can_scroll_tabs_right_ = false;
+        bool last_grip_hovered_ = false;
+        bool last_grip_active_ = false;
 
         std::size_t last_theme_signature_ = 0;
         bool has_theme_signature_ = false;

--- a/src/visualizer/gui/rml_viewport_overlay.cpp
+++ b/src/visualizer/gui/rml_viewport_overlay.cpp
@@ -329,8 +329,10 @@ namespace lfs::vis::gui {
         LOG_TIMER_THRESHOLD("gui_render.rml_viewport_overlay.render.builtin_document_sync", 0.25);
         const bool dirty = lfs::python::sync_viewport_overlay_document(document_);
         document_sync_dirty_ = false;
-        if (dirty)
+        if (dirty) {
+            toolbar_rail_layout_dirty_ = true;
             markRenderNeeded(RenderReason::DocumentSync);
+        }
         return dirty;
     }
 
@@ -347,6 +349,8 @@ namespace lfs::vis::gui {
             markRenderNeeded(RenderReason::ViewportResize);
         if (context_size_changed)
             toolbar_roots_dirty_ = true;
+        if (context_size_changed)
+            toolbar_rail_layout_dirty_ = true;
         vp_pos_ = pos;
         vp_size_ = size;
         screen_origin_ = screen_origin;
@@ -384,6 +388,7 @@ namespace lfs::vis::gui {
         secondary_toolbar_width_ = secondary_width;
         markRenderNeeded(RenderReason::ToolbarLayout);
         toolbar_roots_dirty_ = true;
+        toolbar_rail_layout_dirty_ = true;
         updateToolbarRoots();
     }
 
@@ -625,7 +630,80 @@ namespace lfs::vis::gui {
         applied_secondary_toolbar_x_ = secondary_toolbar_x_;
         applied_secondary_toolbar_width_ = secondary_toolbar_width_;
         toolbar_roots_dirty_ = false;
+        toolbar_rail_layout_dirty_ = true;
         return true;
+    }
+
+    bool RmlViewportOverlay::updateToolbarRailLayout() {
+        if (!document_ || !rml_context_ || !toolbar_rail_layout_dirty_)
+            return false;
+
+        const float dpi = std::max(rml_context_->GetDensityIndependentPixelRatio(), 0.01f);
+        const float available_height = std::max(0.0f, vp_size_.y - 24.0f * dpi);
+        auto* const primary_toolbar = document_->GetElementById("primary-utility-toolbar");
+        auto* const secondary_toolbar = document_->GetElementById("secondary-utility-toolbar");
+        auto* const primary_tools = document_->GetElementById("primary-rail-tools");
+        auto* const primary_panels = document_->GetElementById("primary-rail-panels");
+        auto* const secondary_tools = document_->GetElementById("secondary-rail-tools");
+        auto* const secondary_panels = document_->GetElementById("secondary-rail-panels");
+
+        auto* toolbar = primary_toolbar;
+        auto* tools = primary_tools;
+        auto* panels = primary_panels;
+        if (primary_toolbar_width_ <= 0.0f && show_secondary_toolbar_ && secondary_toolbar) {
+            toolbar = secondary_toolbar;
+            tools = secondary_tools;
+            panels = secondary_panels;
+        }
+        if (!toolbar || !tools || !panels)
+            return false;
+
+        const bool tools_empty = tools->GetNumChildren() == 0;
+        const bool panels_empty = panels->GetNumChildren() == 0;
+        const bool both_groups_non_empty = !tools_empty && !panels_empty;
+        bool changed = false;
+
+        const auto set_class_on_roots = [&](const char* class_name, const bool enabled) {
+            bool class_changed = false;
+            const auto set_class = [&](Rml::Element* element) {
+                if (!element || element->IsClassSet(class_name) == enabled)
+                    return;
+                element->SetClass(class_name, enabled);
+                changed = true;
+                class_changed = true;
+            };
+            set_class(primary_toolbar);
+            set_class(secondary_toolbar);
+            return class_changed;
+        };
+
+        bool classes_changed = false;
+        classes_changed |= set_class_on_roots("rail-tools-empty", tools_empty);
+        classes_changed |= set_class_on_roots("rail-panels-empty", panels_empty);
+        classes_changed |= set_class_on_roots("rail-two-column", false);
+        classes_changed |= set_class_on_roots("rail-compact", false);
+        if (classes_changed)
+            rml_context_->Update();
+
+        const auto natural_height = [&]() {
+            return toolbar->GetBox().GetSize(Rml::BoxArea::Border).y;
+        };
+        if (natural_height() > available_height + 0.5f) {
+            if (both_groups_non_empty) {
+                if (set_class_on_roots("rail-two-column", true))
+                    rml_context_->Update();
+                if (natural_height() > available_height + 0.5f) {
+                    if (set_class_on_roots("rail-compact", true))
+                        rml_context_->Update();
+                }
+            } else {
+                if (set_class_on_roots("rail-compact", true))
+                    rml_context_->Update();
+            }
+        }
+
+        toolbar_rail_layout_dirty_ = false;
+        return changed;
     }
 
     float RmlViewportOverlay::toolbarFreeGap(const float toolbar_height) const {
@@ -1430,6 +1508,10 @@ namespace lfs::vis::gui {
             return;
 
         const bool theme_changed = updateTheme();
+        const float toolbar_dpi = std::max(rml_context_->GetDensityIndependentPixelRatio(), 0.01f);
+        const bool dpi_changed = std::abs(last_toolbar_dpi_ - toolbar_dpi) > 0.001f;
+        if (theme_changed || dpi_changed)
+            toolbar_rail_layout_dirty_ = true;
         const int w = static_cast<int>(vp_size_.x);
         const int h = static_cast<int>(vp_size_.y);
         const bool size_changed = (w != last_render_w_ || h != last_render_h_);
@@ -1475,7 +1557,7 @@ namespace lfs::vis::gui {
         }
 
         const bool needs_render = render_needed_ || animation_active_ || document_dirty ||
-                                  theme_changed || size_changed || toolbar_changed ||
+                                  theme_changed || size_changed || dpi_changed || toolbar_changed ||
                                   tooltip_changed || had_data_model_binding_dirty;
         if (!needs_render) {
             queueCachedVulkanContext(direct_cache_.texture == 0 ||
@@ -1510,6 +1592,7 @@ namespace lfs::vis::gui {
                 LOG_TIMER_THRESHOLD("gui_render.rml_viewport_overlay.render.update.context_update", 0.25);
                 rml_context_->Update();
             }
+            updateToolbarRailLayout();
             if (viewport_toolbar_position_ == "free" && applyToolbarPosition()) {
                 LOG_TIMER_THRESHOLD("gui_render.rml_viewport_overlay.render.update.toolbar_position", 0.25);
                 rml_context_->Update();
@@ -1527,6 +1610,7 @@ namespace lfs::vis::gui {
         render_reason_bits_ = 0;
         last_render_w_ = w;
         last_render_h_ = h;
+        last_toolbar_dpi_ = toolbar_dpi;
     }
 
     std::optional<double> RmlViewportOverlay::nextScheduledUpdateDelay() const {

--- a/src/visualizer/gui/rml_viewport_overlay.hpp
+++ b/src/visualizer/gui/rml_viewport_overlay.hpp
@@ -128,6 +128,7 @@ namespace lfs::vis::gui {
         void markDocumentSyncDirty();
         bool syncBuiltinDocument(bool force);
         bool updateToolbarRoots();
+        bool updateToolbarRailLayout();
         bool applyToolbarPosition();
         void attachToolbarDragListeners();
         void resetToolbarDragListeners();
@@ -189,6 +190,8 @@ namespace lfs::vis::gui {
         float applied_secondary_toolbar_x_ = 0.0f;
         float applied_secondary_toolbar_width_ = -1.0f;
         bool toolbar_roots_dirty_ = true;
+        bool toolbar_rail_layout_dirty_ = true;
+        float last_toolbar_dpi_ = 0.0f;
         bool toolbar_position_preference_dirty_ = true;
         std::string viewport_toolbar_position_ = "centered";
         std::string applied_viewport_toolbar_position_;

--- a/src/visualizer/gui/rmlui/resources/bottom_dock.rcss
+++ b/src/visualizer/gui/rmlui/resources/bottom_dock.rcss
@@ -6,3 +6,21 @@ body {
     font-size: 12dp;
     nav: auto;
 }
+
+#dock-grip {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 8dp;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+}
+
+.dock-grip-bar {
+    width: 36dp;
+    height: 3dp;
+    border-radius: 2dp;
+}

--- a/src/visualizer/gui/rmlui/resources/bottom_dock.rml
+++ b/src/visualizer/gui/rmlui/resources/bottom_dock.rml
@@ -4,6 +4,9 @@
     <link type="text/rcss" href="panel_tabs.rcss"/>
 </head>
 <body id="bottom-dock-body" data-model="bottom_dock_tabs">
+    <div id="dock-grip">
+        <div class="dock-grip-bar"></div>
+    </div>
     <div id="tab-bar" data-class-with-scroll="tabs_overflow">
         <button id="tab-scroll-left" class="tab-nav"
                 data-class-hidden="!tabs_overflow"

--- a/src/visualizer/gui/rmlui/resources/bottom_dock.theme.rcss
+++ b/src/visualizer/gui/rmlui/resources/bottom_dock.theme.rcss
@@ -1,3 +1,12 @@
 #tab-bar {
     background-color: @{surface};
 }
+
+.dock-grip-bar {
+    background-color: @{alpha(text_dim,0.55)};
+}
+
+#dock-grip.hover .dock-grip-bar,
+#dock-grip.active .dock-grip-bar {
+    background-color: @{primary};
+}

--- a/src/visualizer/gui/rmlui/resources/histogram_panel.rcss
+++ b/src/visualizer/gui/rmlui/resources/histogram_panel.rcss
@@ -82,6 +82,9 @@
 }
 
 .histogram-panel-action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     min-width: 64dp;
 }
 
@@ -491,6 +494,9 @@
 }
 
 .range-reset {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     min-width: 56dp;
     margin-left: 4dp;
 }
@@ -798,6 +804,9 @@
 }
 
 .histogram-history-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 30dp;
     height: 30dp;
     min-width: 30dp;
@@ -809,7 +818,7 @@
     display: block;
     width: 16dp;
     height: 16dp;
-    margin: 6dp auto 0;
+    margin: 0;
     image-color: rgba(236, 241, 255, 235);
 }
 
@@ -818,6 +827,9 @@
 }
 
 .footer-text-action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     min-width: 78dp;
 }
 

--- a/src/visualizer/gui/rmlui/resources/histogram_panel.rcss
+++ b/src/visualizer/gui/rmlui/resources/histogram_panel.rcss
@@ -16,30 +16,6 @@
     min-height: 0;
 }
 
-.dock-drag-handle {
-    flex: 0 0 auto;
-    height: 8dp;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding-top: 3dp;
-}
-
-.dock-drag-handle-bar {
-    width: 36dp;
-    height: 3dp;
-    background-color: rgba(108, 112, 134, 160);
-    border-radius: 2dp;
-}
-
-.dock-drag-handle:hover .dock-drag-handle-bar {
-    background-color: rgba(137, 180, 250, 220);
-}
-
-.dock-drag-handle.hidden {
-    display: none;
-}
-
 #histogram-shell {
     flex: 1;
     padding: 8dp 10dp 12dp;

--- a/src/visualizer/gui/rmlui/resources/histogram_panel.rml
+++ b/src/visualizer/gui/rmlui/resources/histogram_panel.rml
@@ -12,9 +12,9 @@
       <span id="histogram-floating-title">{{ panel_label }}</span>
       <div class="histogram-panel-actions histogram-panel-actions--floating">
         <button class="btn btn--secondary histogram-panel-action"
-                data-event-click="toggle_dock_mode()">{{ dock_toggle_label }}</button>
+                data-event-click="toggle_dock_mode()"><span class="btn-label">{{ dock_toggle_label }}</span></button>
         <button class="btn btn--secondary histogram-panel-action"
-                data-event-click="close_panel()">{{ close_label }}</button>
+                data-event-click="close_panel()"><span class="btn-label">{{ close_label }}</span></button>
       </div>
     </div>
     <div id="histogram-hero">
@@ -76,7 +76,7 @@
           <div class="histogram-toolbar-item histogram-toolbar-item--action hidden"
                data-class-hidden="is_floating">
             <button class="btn btn--secondary histogram-panel-action"
-                    data-event-click="toggle_dock_mode()">{{ dock_toggle_label }}</button>
+                    data-event-click="toggle_dock_mode()"><span class="btn-label">{{ dock_toggle_label }}</span></button>
           </div>
         </div>
       </div>
@@ -185,7 +185,7 @@
           <input id="range-max-input" type="text" class="number-input range-input" data-value="range_max_str" />
           <button class="btn btn--secondary range-reset"
                   data-event-click="reset_range()"
-                  data-attrif-disabled="!has_custom_range">{{ reset_range_label }}</button>
+                  data-attrif-disabled="!has_custom_range"><span class="btn-label">{{ reset_range_label }}</span></button>
         </div>
 
         <div id="histogram-chart">
@@ -242,7 +242,7 @@
             <input id="compare-range-y-max-input" type="text" class="number-input range-input" data-value="compare_y_range_max_str" />
             <button class="btn btn--secondary range-reset"
                     data-event-click="reset_compare_range()"
-                    data-attrif-disabled="!compare_has_custom_range">{{ reset_range_label }}</button>
+                    data-attrif-disabled="!compare_has_custom_range"><span class="btn-label">{{ reset_range_label }}</span></button>
           </div>
 
           <div id="compare-chart-shell">
@@ -314,10 +314,10 @@
       <div class="footer-text-actions">
         <button class="btn btn--secondary footer-text-action"
                 data-event-click="clear_mark()"
-                data-attrif-disabled="!clear_enabled">{{ clear_label }}</button>
+                data-attrif-disabled="!clear_enabled"><span class="btn-label">{{ clear_label }}</span></button>
         <button class="btn btn--error footer-text-action"
                 data-event-click="delete_marked()"
-                data-attrif-disabled="!delete_enabled">{{ delete_label }}</button>
+                data-attrif-disabled="!delete_enabled"><span class="btn-label">{{ delete_label }}</span></button>
       </div>
     </div>
   </div>

--- a/src/visualizer/gui/rmlui/resources/histogram_panel.rml
+++ b/src/visualizer/gui/rmlui/resources/histogram_panel.rml
@@ -4,9 +4,6 @@
   <link type="text/rcss" href="histogram_panel.rcss"/>
 </head>
 <body template="docked-panel" data-model="histogram_panel">
-  <div class="dock-drag-handle" data-class-hidden="is_floating">
-    <div class="dock-drag-handle-bar"></div>
-  </div>
   <div id="histogram-shell" data-class-is-floating="is_floating">
     <div id="histogram-floating-header" class="hidden" data-class-hidden="!is_floating">
       <span id="histogram-floating-title">{{ panel_label }}</span>

--- a/src/visualizer/gui/rmlui/resources/viewport_overlay.rcss
+++ b/src/visualizer/gui/rmlui/resources/viewport_overlay.rcss
@@ -103,12 +103,11 @@ body {
     left: 0;
     width: 38dp;
     height: auto;
-    max-height: 90%;
     padding: 5dp 3dp;
     flex-direction: column;
     align-items: center;
     pointer-events: auto;
-    overflow-y: auto;
+    overflow: hidden;
 }
 
 .toolbar-position-top .toolbar-vertical {
@@ -167,6 +166,55 @@ body {
 .toolbar-vertical .icon-btn img {
     width: 20dp;
     height: 20dp;
+}
+
+.toolbar-vertical .rail-columns,
+.toolbar-vertical .rail-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.toolbar-vertical.rail-tools-empty .rail-group--tools,
+.toolbar-vertical.rail-panels-empty .rail-group--panels,
+.toolbar-vertical.rail-tools-empty .rail-columns > .toolbar-separator,
+.toolbar-vertical.rail-panels-empty .rail-columns > .toolbar-separator {
+    display: none;
+}
+
+.toolbar-vertical.rail-two-column {
+    width: auto;
+}
+
+.toolbar-vertical.rail-two-column .rail-columns {
+    flex-direction: row;
+    align-items: stretch;
+}
+
+.toolbar-vertical.rail-two-column .rail-columns > .toolbar-separator {
+    width: 1dp;
+    height: auto;
+    margin: 0 5dp;
+}
+
+.toolbar-vertical.rail-compact .icon-btn {
+    width: 26dp;
+    height: 26dp;
+    min-width: 26dp;
+    min-height: 26dp;
+    margin: 0;
+    padding: 2dp;
+}
+
+.toolbar-vertical.rail-compact .icon-btn img {
+    width: 18dp;
+    height: 18dp;
+}
+
+.toolbar-vertical.rail-compact .rail-columns > .toolbar-separator {
+    margin-top: 4dp;
+    margin-bottom: 3dp;
 }
 
 .viewport-gizmo-controls {

--- a/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
+++ b/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
@@ -21,93 +21,93 @@
                 <span class="toolbar-drag-line"></span>
             </div>
             <div class="rail-columns">
-            <div id="primary-rail-tools" class="rail-group rail-group--tools">
-            <div class="icon-btn"
-                 data-for="button : selection_group_buttons"
-                 data-class-selected="button.selected"
-                 data-attr-id="button.button_id"
-                 data-attr-data-action="button.action_id"
-                 data-attr-data-shortcut="button.shortcut_text"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            <div class="icon-btn"
-                 data-for="button : transform_group_buttons"
-                 data-class-selected="button.selected"
-                 data-attr-id="button.button_id"
-                 data-attr-data-action="button.action_id"
-                 data-attr-data-shortcut="button.shortcut_text"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            <div class="icon-btn"
-                 data-for="button : mirror_group_buttons"
-                 data-class-selected="button.selected"
-                 data-attr-id="button.button_id"
-                 data-attr-data-action="button.action_id"
-                 data-attr-data-shortcut="button.shortcut_text"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            <div class="icon-btn"
-                 data-for="button : crop_group_buttons"
-                 data-class-selected="button.selected"
-                 data-attr-id="button.button_id"
-                 data-attr-data-action="button.action_id"
-                 data-attr-data-shortcut="button.shortcut_text"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            <div class="icon-btn"
-                 data-for="button : gizmo_buttons"
-                 data-attr-id="button.button_id"
-                 data-class-selected="button.selected"
-                 data-attr-data-action="button.action_id"
-                 data-attr-data-shortcut="button.shortcut_text"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            </div>
-            <div class="toolbar-separator"></div>
-            <div id="primary-rail-panels" class="rail-group rail-group--panels">
-            <div class="icon-btn"
-                 data-for="button : utility_extra_buttons"
-                 data-attr-id="button.button_id"
-                 data-class-selected="button.selected"
-                 data-attr-data-action="button.action_id"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            <div class="icon-btn"
-                 data-for="button : utility_bottom_buttons"
-                 data-attr-id="button.button_id"
-                 data-class-selected="button.selected"
-                 data-attr-data-action="button.action_id"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            </div>
+                <div id="primary-rail-tools" class="rail-group rail-group--tools">
+                    <div class="icon-btn"
+                         data-for="button : selection_group_buttons"
+                         data-class-selected="button.selected"
+                         data-attr-id="button.button_id"
+                         data-attr-data-action="button.action_id"
+                         data-attr-data-shortcut="button.shortcut_text"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                    <div class="icon-btn"
+                         data-for="button : transform_group_buttons"
+                         data-class-selected="button.selected"
+                         data-attr-id="button.button_id"
+                         data-attr-data-action="button.action_id"
+                         data-attr-data-shortcut="button.shortcut_text"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                    <div class="icon-btn"
+                         data-for="button : mirror_group_buttons"
+                         data-class-selected="button.selected"
+                         data-attr-id="button.button_id"
+                         data-attr-data-action="button.action_id"
+                         data-attr-data-shortcut="button.shortcut_text"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                    <div class="icon-btn"
+                         data-for="button : crop_group_buttons"
+                         data-class-selected="button.selected"
+                         data-attr-id="button.button_id"
+                         data-attr-data-action="button.action_id"
+                         data-attr-data-shortcut="button.shortcut_text"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                    <div class="icon-btn"
+                         data-for="button : gizmo_buttons"
+                         data-attr-id="button.button_id"
+                         data-class-selected="button.selected"
+                         data-attr-data-action="button.action_id"
+                         data-attr-data-shortcut="button.shortcut_text"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                </div>
+                <div class="toolbar-separator"></div>
+                <div id="primary-rail-panels" class="rail-group rail-group--panels">
+                    <div class="icon-btn"
+                         data-for="button : utility_extra_buttons"
+                         data-attr-id="button.button_id"
+                         data-class-selected="button.selected"
+                         data-attr-data-action="button.action_id"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                    <div class="icon-btn"
+                         data-for="button : utility_bottom_buttons"
+                         data-attr-id="button.button_id"
+                         data-class-selected="button.selected"
+                         data-attr-data-action="button.action_id"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -276,93 +276,93 @@
                 <span class="toolbar-drag-line"></span>
             </div>
             <div class="rail-columns">
-            <div id="secondary-rail-tools" class="rail-group rail-group--tools">
-            <div class="icon-btn"
-                 data-for="button : selection_group_buttons"
-                 data-attr-id="button.button_id"
-                 data-class-selected="button.selected"
-                 data-attr-data-action="button.action_id"
-                 data-attr-data-shortcut="button.shortcut_text"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            <div class="icon-btn"
-                 data-for="button : transform_group_buttons"
-                 data-attr-id="button.button_id"
-                 data-class-selected="button.selected"
-                 data-attr-data-action="button.action_id"
-                 data-attr-data-shortcut="button.shortcut_text"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            <div class="icon-btn"
-                 data-for="button : mirror_group_buttons"
-                 data-attr-id="button.button_id"
-                 data-class-selected="button.selected"
-                 data-attr-data-action="button.action_id"
-                 data-attr-data-shortcut="button.shortcut_text"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            <div class="icon-btn"
-                 data-for="button : crop_group_buttons"
-                 data-attr-id="button.button_id"
-                 data-class-selected="button.selected"
-                 data-attr-data-action="button.action_id"
-                 data-attr-data-shortcut="button.shortcut_text"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            <div class="icon-btn"
-                 data-for="button : gizmo_buttons"
-                 data-attr-id="button.button_id"
-                 data-class-selected="button.selected"
-                 data-attr-data-action="button.action_id"
-                 data-attr-data-shortcut="button.shortcut_text"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            </div>
-            <div class="toolbar-separator"></div>
-            <div id="secondary-rail-panels" class="rail-group rail-group--panels">
-            <div class="icon-btn"
-                 data-for="button : utility_extra_buttons"
-                 data-attr-id="button.button_id"
-                 data-class-selected="button.selected"
-                 data-attr-data-action="button.action_id"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            <div class="icon-btn"
-                 data-for="button : utility_bottom_buttons"
-                 data-attr-id="button.button_id"
-                 data-class-selected="button.selected"
-                 data-attr-data-action="button.action_id"
-                 data-attr-title="button.tooltip_text"
-                 data-attrif-disabled="!button.enabled"
-                 data-class-disabled="!button.enabled"
-                 data-event-click="toolbar_action(button.action, button.value)">
-                <img data-attr-src="button.icon_src" />
-            </div>
-            </div>
+                <div id="secondary-rail-tools" class="rail-group rail-group--tools">
+                    <div class="icon-btn"
+                         data-for="button : selection_group_buttons"
+                         data-attr-id="button.button_id"
+                         data-class-selected="button.selected"
+                         data-attr-data-action="button.action_id"
+                         data-attr-data-shortcut="button.shortcut_text"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                    <div class="icon-btn"
+                         data-for="button : transform_group_buttons"
+                         data-attr-id="button.button_id"
+                         data-class-selected="button.selected"
+                         data-attr-data-action="button.action_id"
+                         data-attr-data-shortcut="button.shortcut_text"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                    <div class="icon-btn"
+                         data-for="button : mirror_group_buttons"
+                         data-attr-id="button.button_id"
+                         data-class-selected="button.selected"
+                         data-attr-data-action="button.action_id"
+                         data-attr-data-shortcut="button.shortcut_text"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                    <div class="icon-btn"
+                         data-for="button : crop_group_buttons"
+                         data-attr-id="button.button_id"
+                         data-class-selected="button.selected"
+                         data-attr-data-action="button.action_id"
+                         data-attr-data-shortcut="button.shortcut_text"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                    <div class="icon-btn"
+                         data-for="button : gizmo_buttons"
+                         data-attr-id="button.button_id"
+                         data-class-selected="button.selected"
+                         data-attr-data-action="button.action_id"
+                         data-attr-data-shortcut="button.shortcut_text"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                </div>
+                <div class="toolbar-separator"></div>
+                <div id="secondary-rail-panels" class="rail-group rail-group--panels">
+                    <div class="icon-btn"
+                         data-for="button : utility_extra_buttons"
+                         data-attr-id="button.button_id"
+                         data-class-selected="button.selected"
+                         data-attr-data-action="button.action_id"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                    <div class="icon-btn"
+                         data-for="button : utility_bottom_buttons"
+                         data-attr-id="button.button_id"
+                         data-class-selected="button.selected"
+                         data-attr-data-action="button.action_id"
+                         data-attr-title="button.tooltip_text"
+                         data-attrif-disabled="!button.enabled"
+                         data-class-disabled="!button.enabled"
+                         data-event-click="toolbar_action(button.action, button.value)">
+                        <img data-attr-src="button.icon_src" />
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
+++ b/src/visualizer/gui/rmlui/resources/viewport_overlay.rml
@@ -20,6 +20,8 @@
                 <span class="toolbar-drag-line"></span>
                 <span class="toolbar-drag-line"></span>
             </div>
+            <div class="rail-columns">
+            <div id="primary-rail-tools" class="rail-group rail-group--tools">
             <div class="icon-btn"
                  data-for="button : selection_group_buttons"
                  data-class-selected="button.selected"
@@ -80,7 +82,9 @@
                  data-event-click="toolbar_action(button.action, button.value)">
                 <img data-attr-src="button.icon_src" />
             </div>
+            </div>
             <div class="toolbar-separator"></div>
+            <div id="primary-rail-panels" class="rail-group rail-group--panels">
             <div class="icon-btn"
                  data-for="button : utility_extra_buttons"
                  data-attr-id="button.button_id"
@@ -102,6 +106,8 @@
                  data-class-disabled="!button.enabled"
                  data-event-click="toolbar_action(button.action, button.value)">
                 <img data-attr-src="button.icon_src" />
+            </div>
+            </div>
             </div>
         </div>
 
@@ -269,6 +275,8 @@
                 <span class="toolbar-drag-line"></span>
                 <span class="toolbar-drag-line"></span>
             </div>
+            <div class="rail-columns">
+            <div id="secondary-rail-tools" class="rail-group rail-group--tools">
             <div class="icon-btn"
                  data-for="button : selection_group_buttons"
                  data-attr-id="button.button_id"
@@ -329,7 +337,9 @@
                  data-event-click="toolbar_action(button.action, button.value)">
                 <img data-attr-src="button.icon_src" />
             </div>
+            </div>
             <div class="toolbar-separator"></div>
+            <div id="secondary-rail-panels" class="rail-group rail-group--panels">
             <div class="icon-btn"
                  data-for="button : utility_extra_buttons"
                  data-attr-id="button.button_id"
@@ -351,6 +361,8 @@
                  data-class-disabled="!button.enabled"
                  data-event-click="toolbar_action(button.action, button.value)">
                 <img data-attr-src="button.icon_src" />
+            </div>
+            </div>
             </div>
         </div>
 

--- a/tests/python/test_toolbar_hooks.py
+++ b/tests/python/test_toolbar_hooks.py
@@ -1591,8 +1591,8 @@ def test_viewport_toolbar_uses_theme_glass_without_backdrop_filter():
         "position: relative;",
         "width: 38dp;",
         "height: auto;",
-        "max-height: 90%;",
         "padding: 5dp 3dp;",
+        "overflow: hidden;",
     ):
         assert declaration in toolbar_rule
     assert "bottom:" not in toolbar_rule

--- a/tests/test_panel_layout_render_demand.cpp
+++ b/tests/test_panel_layout_render_demand.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <visualizer/app_store.hpp>
 #include <visualizer/gui/panel_layout.hpp>
 #include <visualizer/gui/panel_registry.hpp>
 
@@ -511,4 +512,26 @@ TEST_F(PanelLayoutRenderDemandTest,
                                             ctx);
     EXPECT_FALSE(panel->pending_update);
     EXPECT_FALSE(PanelRegistry::instance().needsAnimationFrameForVisiblePanels(visibility));
+}
+
+TEST_F(PanelLayoutRenderDemandTest, BottomDockAndSequencerChangesPublishToolbarGeneration) {
+    using namespace lfs::vis::gui;
+
+    PanelLayoutManager layout;
+    auto& generation = lfs::vis::app_store().viewport_toolbar_generation;
+    const auto initial = generation.get();
+
+    layout.setBottomDockActiveTab("test.bottom.first");
+    EXPECT_EQ(generation.get(), initial + 1);
+    layout.setBottomDockActiveTab("test.bottom.first");
+    EXPECT_EQ(generation.get(), initial + 1);
+    layout.setBottomDockActiveTab("test.bottom.second");
+    EXPECT_EQ(generation.get(), initial + 2);
+
+    layout.setShowSequencer(true);
+    EXPECT_EQ(generation.get(), initial + 3);
+    layout.setShowSequencer(true);
+    EXPECT_EQ(generation.get(), initial + 3);
+    layout.setShowSequencer(false);
+    EXPECT_EQ(generation.get(), initial + 4);
 }

--- a/tests/test_panel_layout_render_demand.cpp
+++ b/tests/test_panel_layout_render_demand.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <python/python_runtime.hpp>
 #include <visualizer/app_store.hpp>
 #include <visualizer/gui/panel_layout.hpp>
 #include <visualizer/gui/panel_registry.hpp>
@@ -176,8 +177,14 @@ TEST_F(PanelLayoutRenderDemandTest, BottomDockDrawsOnlyActivePanelAtFullContentH
     EXPECT_EQ(first->draw_count, 1);
     EXPECT_EQ(second->draw_count, 0);
     const auto bar = layout.bottomDockTabBarRect();
+    const float dpi = lfs::python::get_shared_dpi_scale();
+    EXPECT_FLOAT_EQ(bar.y, layout.bottomDockTopY() + PanelLayoutManager::DOCK_GRIP_H * dpi);
     EXPECT_FLOAT_EQ(first->last_draw_y, bar.y + bar.height);
-    EXPECT_FLOAT_EQ(first->last_draw_height, layout.getBottomDockHeight() - bar.height);
+    EXPECT_FLOAT_EQ(first->last_draw_y,
+                    layout.bottomDockTopY() +
+                        (PanelLayoutManager::DOCK_GRIP_H + PanelLayoutManager::TAB_BAR_H + 1.0f) * dpi);
+    EXPECT_FLOAT_EQ(first->last_draw_height,
+                    layout.getBottomDockHeight() - bar.height - PanelLayoutManager::DOCK_GRIP_H * dpi);
 }
 
 TEST_F(PanelLayoutRenderDemandTest, BottomDockEnablingPanelActivatesIt) {


### PR DESCRIPTION
Three viewport rail defects, all reproduced with real pointer input on a 1920x1168 window.

**Rail highlight out of sync with the bottom dock.** Clicking a dock tab, closing the active tab with its x, or hiding the sequencer while the histogram stays open left the rail highlighting the wrong panel. The rail is refreshed by the overlay document sync, which only runs on `viewport_toolbar_generation` (published by `set_panel_enabled`) or a forced size/theme sync. `PanelLayoutManager::setBottomDockActiveTab`, the auto-activation in `renderBottomDock`, and `setShowSequencer` never published anything, so the perf log showed the tab click rendering with `document_dirty=false`. Closing the last tab only looked right because the viewport resize forced a sync. The setters now publish on real change (no-op calls stay silent), with a gtest covering both.

**Rail scrolled and clipped buttons at short viewport heights.** `.toolbar-vertical` had `max-height: 90%; overflow-y: auto`, so a tall dock or a small window produced a scrollbar and a half-visible last button. The rail now re-flows instead: single column when it fits; two columns (editing tools | panel toggles, split by group with a vertical separator) when it does not; compact 26dp buttons with 18dp icons when even that does not fit; overflow hidden below roughly 200dp of viewport height. The tier is measured in `RmlViewportOverlay::updateToolbarRailLayout` after the context update against `viewport height - 24dp`, only when viewport size, DPI, toolbar roots, or toolbar records change. Both toolbar roots (primary and split-view secondary) get the same treatment.

**Histogram button labels sat at the top of their boxes.** `Undock` and friends were inline-block buttons with a taller min-height. They are now flex-centered; because RmlUi drops bare text inside a flex container, the bound labels are wrapped in `span.btn-label`, the same pattern the asset manager uses.

Verified: `lfs-build-guard` build, `*PanelLayout*:*BottomDock*:*ViewportOverlay*` gtests (16), toolbar/overlay/localization/panel pytest (55), and an xdotool session on `--view 3k.ply`: tab click, active-tab close, sequencer close, last-tab close all keep the rail in sync with the loop idling afterwards; two-column rail at the 65% dock height, single column back at the minimum; Undock/Dock/Close/Clear/Delete labels present and centered docked and floating; zero error lines.
