### PR TITLE
Autosave no longer collides with its own geometry capture

### DIFF
--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -4752,6 +4752,13 @@ namespace lfs::vis::project {
             !synchronized) {
             return synchronized;
         }
+        // Synchronization may queue an asynchronous geometry capture in the
+        // same exclusive ProjectWrite slot. Autosave can continue only after
+        // that capture has settled; do not attempt the document write in the
+        // same tick and turn the expected overlap into an error.
+        if (viewer_.jobs().anyRunning(JobType::ProjectWrite)) {
+            return {};
+        }
         const bool untitled_crash_dirty =
             untitled &&
             (hasUntitledCrashDirtyChapters(

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -14307,8 +14307,7 @@ namespace lfs::vis {
         ASSERT_NE(node, nullptr);
         ASSERT_NE(node->model, nullptr);
 
-        auto started = lifecycle->synchronizeDocumentFromViewer(
-            project::ProjectLifecycle::DocumentSyncMode::Autosave);
+        auto started = lifecycle->startAutosave();
         ASSERT_TRUE(started)
             << lfs::format_for_developer(started.error());
         ASSERT_TRUE(viewer.jobs().anyRunning(JobType::ProjectWrite));


### PR DESCRIPTION
Every session logged this at the first autosave, then recovered a minute later:

```
[warn] project_lifecycle.cpp:5746  Autosave deferred: lfs::Error[FailedPrecondition/App] ...
  user_message: Another project write is already running.
  detail: Project save, autosave, and compaction share one exclusive job slot
```

Nothing else was writing. The autosave was colliding with itself: `startAutosave()` calls `synchronizeDocumentFromViewer(Autosave)`, which queues the asynchronous geometry capture and reserves the exclusive `ProjectWrite` job slot for it, and then the same call went on to `startDocumentWrite()`, whose `jobs.init(ProjectWrite)` failed against that capture. The failure path logged the full error dump and armed the 60 s failure backoff, which is the one-minute delay seen in the log. Confirmed with temporary job-registry instrumentation on an isolated home: the holder at the deferral is the capture started by the same tick (`Downloading geometry snapshot`, status Running).

Fix: after synchronization, `startAutosave()` returns cleanly when a `ProjectWrite` job is running. Maintenance already settles the capture before the next autosave tick, and the autosave timer is not reset by the early return, so the document write follows as soon as the capture has settled. No registry or interval policy change. `AsyncCaptureKeepsNewerSceneDirty` now drives `startAutosave()` instead of bypassing it, so it fails on the old self-collision.

Verified: build, `VisualizerImplResetTest.*`, `JobRegistryTest.*`, lifecycle gtests green; isolated GUI run with a 20 s interval and `--view gd.ply`: first autosave published 22 s after the load with zero deferrals, then "no changes" skips; the same path deferred on master.
