### PR TITLE
Deferred splat loads no longer collide with the async import slot

### DIFF
--- a/src/visualizer/gui/async_task_manager.cpp
+++ b/src/visualizer/gui/async_task_manager.cpp
@@ -1148,6 +1148,7 @@ namespace lfs::vis::gui {
             scheduleImportCompletionDismiss();
         publishImportOverlayState();
         splat_load_state_.worker_complete.store(false, std::memory_order_release);
+        viewer_->schedulePendingTrainingAction();
     }
 
     void AsyncTaskManager::setupEvents() {
@@ -1266,6 +1267,7 @@ namespace lfs::vis::gui {
             if (e.success)
                 scheduleImportCompletionDismiss();
             publishImportOverlayState();
+            viewer_->schedulePendingTrainingAction();
         });
 
         cmd::SequencerExportVideo::when([this](const auto& evt) {
@@ -2277,6 +2279,7 @@ namespace lfs::vis::gui {
             import_state_.thread->join();
             import_state_.thread.reset();
         }
+        viewer_->schedulePendingTrainingAction();
     }
 
     void AsyncTaskManager::applyLoadedDataToScene() {

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -2990,6 +2990,18 @@ namespace lfs::vis {
         }
 
         LOG_INFO("Loading PLY file: {}", lfs::core::path_to_utf8(path));
+        if (trainer_manager_ &&
+            (trainer_manager_->isTrainingActive() ||
+             trainer_manager_->isCompletionPending())) {
+            cmd::LoadFile{
+                .path = path,
+                .is_dataset = false,
+                .stop_training = true,
+                .discard_changes = true,
+                .replace = true}
+                .emit();
+            return {};
+        }
         return data_loader_->loadPLY(path);
     }
 
@@ -4353,9 +4365,17 @@ namespace lfs::vis {
             auto commands =
                 std::exchange(
                     pending_load_files_, {});
-            for (auto& command : commands) {
-                command.stop_training = false;
-                command.emit();
+            if (commands.empty()) {
+                break;
+            }
+            auto command = std::move(commands.front());
+            commands.erase(commands.begin());
+            auto remaining = std::move(commands);
+            command.stop_training = false;
+            command.emit();
+            if (!remaining.empty()) {
+                pending_load_files_ = std::move(remaining);
+                pending_training_action_ = PendingTrainingAction::LoadDataset;
             }
             break;
         }

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -60,6 +60,7 @@ namespace lfs::vis {
 
     class LFS_VIS_API VisualizerImpl : public Visualizer {
         friend class gui::GuiManager;
+        friend class gui::AsyncTaskManager;
 
     public:
         explicit VisualizerImpl(const ViewerOptions& options);

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -501,6 +501,22 @@ protected:
         return condition();
     }
 
+    [[nodiscard]] bool pumpUntilImportSettled(
+        lfs::vis::VisualizerImpl& viewer,
+        std::mutex& queue_mutex,
+        std::vector<lfs::vis::Visualizer::WorkItem>& queue,
+        const std::chrono::milliseconds timeout = std::chrono::seconds(30)) {
+        return pumpUntil(
+            queue_mutex, queue,
+            [&] {
+                auto& tasks = viewer.getGuiManager()->asyncTasks();
+                tasks.pollImportCompletion();
+                return !tasks.isImporting() &&
+                       !tasks.hasPendingMainThreadCompletions();
+            },
+            timeout);
+    }
+
     void installModalOverlay(
         std::unique_ptr<lfs::vis::gui::RmlModalOverlay>& overlay,
         lfs::vis::gui::RmlUIManager& manager) {
@@ -5575,10 +5591,13 @@ namespace lfs::vis {
                     "Keep until splat load"),
                 nullptr);
 
+            auto* const gui = viewer.getGuiManager();
+            ASSERT_NE(gui, nullptr);
             ASSERT_TRUE(pumpUntil(
                 viewer.work_queue_mutex_,
                 viewer.work_queue_,
                 [&] {
+                    gui->asyncTasks().pollImportCompletion();
                     return viewer.pending_training_action_ ==
                                VisualizerImpl::PendingTrainingAction::
                                    None &&
@@ -5587,7 +5606,9 @@ namespace lfs::vis {
                            !viewer.getTrainerManager()
                                 ->isTrainingActive() &&
                            !viewer.getTrainerManager()
-                                ->isCompletionPending();
+                                ->isCompletionPending() &&
+                           !gui->asyncTasks().isImporting() &&
+                           !gui->asyncTasks().hasPendingMainThreadCompletions();
                 }));
             EXPECT_FALSE(drop_blocked) << drop_error;
             EXPECT_FALSE(
@@ -5693,10 +5714,13 @@ namespace lfs::vis {
                 viewer.getSceneManager()->getContentType(),
                 SceneManager::ContentType::Dataset);
 
+            auto* const gui = viewer.getGuiManager();
+            ASSERT_NE(gui, nullptr);
             ASSERT_TRUE(pumpUntil(
                 viewer.work_queue_mutex_,
                 viewer.work_queue_,
                 [&] {
+                    gui->asyncTasks().pollImportCompletion();
                     return viewer.pending_training_action_ ==
                                VisualizerImpl::PendingTrainingAction::
                                    None &&
@@ -5705,7 +5729,9 @@ namespace lfs::vis {
                            !viewer.getTrainerManager()
                                 ->isTrainingActive() &&
                            !viewer.getTrainerManager()
-                                ->isCompletionPending();
+                                ->isCompletionPending() &&
+                           !gui->asyncTasks().isImporting() &&
+                           !gui->asyncTasks().hasPendingMainThreadCompletions();
                 }));
             EXPECT_FALSE(drop_blocked) << drop_error;
             EXPECT_EQ(
@@ -6030,6 +6056,8 @@ namespace lfs::vis {
                 .discard_changes = true}
                 .emit();
 
+            ASSERT_TRUE(pumpUntilImportSettled(
+                viewer, viewer.work_queue_mutex_, viewer.work_queue_));
             EXPECT_FALSE(lifecycle->hasSourcePath());
             EXPECT_FALSE(lifecycle->isScratchBoundSession());
             EXPECT_EQ(
@@ -6093,6 +6121,8 @@ namespace lfs::vis {
                 .is_dataset = false}
                 .emit();
 
+            ASSERT_TRUE(pumpUntilImportSettled(
+                viewer, viewer.work_queue_mutex_, viewer.work_queue_));
             EXPECT_TRUE(lifecycle->hasSourcePath());
             EXPECT_FALSE(lifecycle->isScratchBoundSession());
             const auto has_path = viewer.projectHasPath();


### PR DESCRIPTION
Four `VisualizerImplResetTest` cases fail on master since #1962 made splat loading asynchronous:

```
LoadFileStopTrainingDefersSplatLoadUntilTrainerStops
LoadFileStopTrainingDefersWholeBatchInOrder
SplatAddOntoSplatSceneKeepsTitledProject
SplatDropOntoTitledDatasetProjectStartsUntitledSessionAndKeepsProjectFile
[error] data_loading_service.cpp:112  Failed to load tests/data/bike.ply: Import already in progress
```

They describe product behaviour: a load requested while training is being stopped waits for the trainer and is applied in order with the rest of the batch. The replay in `performPendingTrainingAction` emitted the whole deferred batch in one loop; the first command reserved the single `JobType::Import` slot, and the next command re-entered the loader before that import reached main-thread completion, so the #1962 guard in `AsyncTaskManager::startSplatLoad` rejected it.

Fix: the replay emits one deferred load at a time and re-queues the rest after the emit (so a session reset triggered by the first load cannot drop the remainder); import completion (splat, dataset, generic) schedules the next pending action; `VisualizerImpl::loadPLY` called while training is active or completion-pending now goes through the same deferred `LoadFile` path instead of racing the trainer. Async loading stays async. The tests pump the real import completion before asserting.

Verified: build, the four tests plus the full `VisualizerImplResetTest`/`JobRegistryTest`/`ProjectLifecycle*` set (200 passed, 1 pre-existing skip); GUI over MCP: `data/bicycle` training to iteration 5169, then a `3k.ply` load request stops the trainer, the splat loads right after the thread finishes, no "Import already in progress", scene shows the node.
