### PR TITLE
New Project accepts a typed source path; stale tests repaired

### DIFF
--- a/src/python/lfs_plugins/import_panels.py
+++ b/src/python/lfs_plugins/import_panels.py
@@ -17,6 +17,7 @@ from .ui import RuntimeState
 
 _new_project_panel = None
 _resume_checkpoint_panel = None
+_SOURCE_PROBE_DEBOUNCE_SECONDS = 0.3
 
 __lfs_panel_classes__ = ["NewProjectPanel", "ResumeCheckpointPanel"]
 __lfs_panel_ids__ = ["lfs.new_project", "lfs.resume_checkpoint"]
@@ -88,6 +89,7 @@ class _ImportDialogPanel(Panel):
         if hasattr(self, "_dialog_mounted"):
             self._dialog_mounted = False
             self._source_generation += 1
+            self._source_probe_update_generation += 1
             self._source_probe_cancel.set()
             self._source_probe_active = False
         self._unsubscribe_reactive_state()
@@ -192,6 +194,7 @@ class NewProjectPanel(_ImportDialogPanel):
         self._last_lang = ""
         self._source_generation = 0
         self._source_probe_due = 0.0
+        self._source_probe_update_generation = 0
         self._source_probe_active = False
         self._source_probe_cancel = threading.Event()
         self._dialog_mounted = False
@@ -315,7 +318,8 @@ class NewProjectPanel(_ImportDialogPanel):
             self._source_kind = "splat"
         else:
             self._source_kind = "checking"
-            self._source_probe_due = time.monotonic() + 0.3
+            self._source_probe_due = time.monotonic() + _SOURCE_PROBE_DEBOUNCE_SECONDS
+            self._schedule_source_probe_update()
 
         self._dirty_model(
             "source_path",
@@ -364,6 +368,7 @@ class NewProjectPanel(_ImportDialogPanel):
     def _start_source_probe(self) -> None:
         if self._source_probe_active:
             return
+        self._source_probe_due = 0.0
         self._source_probe_active = True
         path = self._source_path
         name = self._name
@@ -457,10 +462,33 @@ class NewProjectPanel(_ImportDialogPanel):
         scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
         if callable(scheduler):
             self._target_exists_cached = False
-            self._source_probe_due = time.monotonic() + 0.3
+            self._source_probe_due = time.monotonic() + _SOURCE_PROBE_DEBOUNCE_SECONDS
+            self._schedule_source_probe_update()
         else:
             self._refresh_target_cache()
         self._dirty_model("name", "name_valid", "target_exists", "can_create", "location_preview", "create_hint")
+
+    def _schedule_source_probe_update(self) -> None:
+        self._source_probe_update_generation += 1
+        generation = self._source_probe_update_generation
+        due = self._source_probe_due
+        delay = max(0.0, due - time.monotonic())
+
+        def fire() -> None:
+            if (
+                generation != self._source_probe_update_generation
+                or self._source_probe_due != due
+            ):
+                return
+            scheduler = getattr(lf.ui, "schedule_on_ui_thread", None)
+            if callable(scheduler):
+                scheduler(self._request_reactive_update)
+            else:
+                self._request_reactive_update()
+
+        timer = threading.Timer(delay, fire)
+        timer.daemon = True
+        timer.start()
 
     def _name_is_valid(self) -> bool:
         name = self._name.strip()

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -155,6 +155,13 @@ def isolate_lichtfeld_module_overrides():
 
     sys.modules.update(before)
 
+    # A test may delete and re-import the manager while a stub is installed;
+    # restore its logging bridge to the restored runtime module as well.
+    restored_manager = sys.modules.get("lfs_plugins.manager")
+    restored_lf = sys.modules.get("lichtfeld")
+    if restored_manager is not None and restored_lf is not None:
+        restored_manager._lf = restored_lf
+
     # `sys.modules.pop("lfs_plugins.types")` + reimport rebinds the live
     # package attribute even after the original module is restored in
     # sys.modules. Native register_class looks up Operator via

--- a/tests/python/test_import_dialog_panels.py
+++ b/tests/python/test_import_dialog_panels.py
@@ -67,3 +67,53 @@ def test_import_panel_registration_keeps_only_new_project_and_resume():
     source = (Path(__file__).parents[2] / "src" / "python" / "lfs_plugins" / "import_panels.py").read_text()
     assert "NewProjectPanel" in source
     assert "lfs.new_project" in source
+
+
+def test_new_project_typed_source_path_validates(import_dialog_module, monkeypatch):
+    module, _state, _checkpoint, dataset = import_dialog_module
+    panel = module.NewProjectPanel()
+    panel._dialog_mounted = True
+    panel._set_name("untitled")
+
+    panel._handle = SimpleNamespace(
+        dirty=lambda _field: None,
+        dirty_all=lambda: None,
+        request_update=lambda: None,
+    )
+    now = [10.0]
+    monkeypatch.setattr(module.time, "monotonic", lambda: now[0])
+    timers = []
+
+    class _Timer:
+        def __init__(self, _delay, callback):
+            timers.append(callback)
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(module.threading, "Timer", _Timer)
+    browse_calls = []
+    monkeypatch.setattr(
+        module.lf.ui,
+        "open_dataset_folder_dialog",
+        lambda: browse_calls.append(True),
+    )
+    module.lf.is_dataset_path = lambda path: str(path) == str(dataset)
+    module.lf.detect_dataset_info = lambda _path: SimpleNamespace(
+        sparse_path="",
+        has_masks=False,
+        image_count=0,
+        mask_count=0,
+    )
+
+    panel._set_source_path(str(dataset))
+    assert panel._source_kind == "checking"
+    assert len(timers) == 1
+
+    now[0] += 0.31
+    timers.pop()()
+    panel.on_update(None)
+
+    assert panel._source_kind == "dataset"
+    assert panel._can_create() is True
+    assert browse_calls == []

--- a/tests/test_checkpoint_resume.cpp
+++ b/tests/test_checkpoint_resume.cpp
@@ -2627,6 +2627,13 @@ namespace {
         EXPECT_EQ(
             run_b_reader->superblock().project_uuid,
             project_uuid);
+        // #1943 intentionally retains unbound historical CKPT chapters during
+        // compaction. That conflicts with #1696's fresh-run contract that a
+        // second CLI run on a leftover project does not grow the file.
+        GTEST_SKIP()
+            << "Checkpoint-history retention policy (#1943) conflicts with "
+               "the fresh-run no-growth contract (#1696); maintainer decision "
+               "required before restoring this size assertion.";
         EXPECT_LT(s2, s1 + s1 / 2);
 
         std::filesystem::remove_all(output_path, ec);

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -517,6 +517,16 @@ protected:
             timeout);
     }
 
+    [[nodiscard]] std::filesystem::path makeSplatFixture(
+        const std::string_view stem) const {
+        const auto path = temporary_.path / (std::string(stem) + ".ply");
+        const auto saved = lfs::io::save_ply(
+            *lfs::test::licht::make_splat(2),
+            {.output_path = path, .binary = true, .async = false});
+        EXPECT_TRUE(saved);
+        return path;
+    }
+
     void installModalOverlay(
         std::unique_ptr<lfs::vis::gui::RmlModalOverlay>& overlay,
         lfs::vis::gui::RmlUIManager& manager) {
@@ -5410,9 +5420,7 @@ namespace lfs::vis {
 
     TEST_F(VisualizerImplResetTest,
            LoadFileWipeGateDirtyDatasetDiscardAndSplatAdd) {
-        const auto splat_path =
-            std::filesystem::path(PROJECT_ROOT_PATH) /
-            "tests/data/bicycle_ref.sog";
+        const auto splat_path = makeSplatFixture("bicycle_ref");
         ASSERT_TRUE(std::filesystem::exists(splat_path));
 
         bool prompted = false;
@@ -5518,9 +5526,7 @@ namespace lfs::vis {
         if (!cuda_device_available()) {
             GTEST_SKIP() << "CUDA device unavailable";
         }
-        const auto splat_path =
-            std::filesystem::path(PROJECT_ROOT_PATH) /
-            "tests/data/bicycle_ref.sog";
+        const auto splat_path = makeSplatFixture("bicycle_ref");
         ASSERT_TRUE(std::filesystem::exists(splat_path));
 
         auto options = projectOptions();
@@ -5631,9 +5637,7 @@ namespace lfs::vis {
         if (!cuda_device_available()) {
             GTEST_SKIP() << "CUDA device unavailable";
         }
-        const auto first_path =
-            std::filesystem::path(PROJECT_ROOT_PATH) /
-            "tests/data/bicycle_ref.sog";
+        const auto first_path = makeSplatFixture("bicycle_ref");
         const auto second_path =
             std::filesystem::path(PROJECT_ROOT_PATH) /
             "tests/data/bike.ply";


### PR DESCRIPTION
Follow-ups from re-running the 20/08 .licht test plan against master.

**New Project ignored a typed source path.** Typing a dataset folder or splat file into the Source field left the dialog "checking" forever and Create did nothing; only Browse worked. The typed path now validates after the usual short debounce and Create enables. Regression test added.

**Stale tests repaired** (none of these run in CI, which only runs the format tests):
- Three project-lifecycle tests depended on an uncommitted local fixture (`tests/data/bicycle_ref.sog`); they now generate a tiny splat fixture.
- The Python fast tier failed 13 plugin-system tests whenever they ran after a stubbing test, because the restored `lfs_plugins.manager` kept a stale module reference.
- `SecondRunCompactsLeftoverProjectFile` asserts #1696's "a fresh run over a leftover project file does not grow it", which #1943's checkpoint-history retention deliberately changed. It is skipped with both references rather than rewritten, pending a decision on which contract wins.

Verified: the three fixture tests pass and the compaction test skips; `lichtfeld.python.fast` 100% green; New Project typed-path flow verified on screen.