### PR TITLE
Avoid unnecessary CMake regeneration for core edits and runtime assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,13 +497,14 @@ configure_file(
         @ONLY
 )
 
-# App/core ABI tripwire. Recompute it before ABI consumers build, rather than
-# making every core source/header a configure dependency. Define this after the
-# effective CUDA architecture selection so the stamp represents the actual
+# App/core ABI tripwire. Seed headers for IDEs and syntax checks at configure
+# time, then refresh before ABI consumers build without making core source/header
+# edits configure dependencies. Define this after the effective CUDA architecture
+# selection so the stamp represents the actual
 # target configuration. Each multi-config configuration gets its own header so
 # Debug and Release cannot race or overwrite each other.
-set(LFS_CORE_ABI_INCLUDE_DIR "${CMAKE_BINARY_DIR}/include/$<CONFIG>")
-set(LFS_CORE_ABI_HEADER "${LFS_CORE_ABI_INCLUDE_DIR}/lfs_core_abi_stamp.h")
+include(cmake/InitializeCoreAbiStamp.cmake)
+lfs_initialize_core_abi_stamps()
 add_custom_target(lfs_core_abi_stamp ALL
     BYPRODUCTS "${LFS_CORE_ABI_HEADER}"
     COMMAND ${CMAKE_COMMAND}
@@ -596,12 +597,10 @@ add_executable(${PROJECT_NAME}
     resources/lichtfeld-studio.manifest
 )
 
-foreach(_lfs_core_abi_consumer IN ITEMS ${PROJECT_NAME} lfs_core)
-    add_dependencies(${_lfs_core_abi_consumer} lfs_core_abi_stamp)
-    target_include_directories(${_lfs_core_abi_consumer} BEFORE PRIVATE
-        "${LFS_CORE_ABI_INCLUDE_DIR}"
-    )
-endforeach()
+add_dependencies(${PROJECT_NAME} lfs_core_abi_stamp)
+target_include_directories(${PROJECT_NAME} BEFORE PRIVATE
+    "${LFS_CORE_ABI_INCLUDE_DIR}"
+)
 
 # The binary only carries code for these architectures; the app refuses to start on anything
 # lower instead of dying inside the first kernel launch (#1540).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,35 +162,6 @@ add_custom_target(lfs_git_version ALL
     VERBATIM
 )
 
-# App/core ABI tripwire. Hash every lfs_core implementation and interface input,
-# because a dirty-worktree rebuild cannot rely on the Git commit alone to
-# distinguish a newly linked app from a stale shared library.
-file(GLOB_RECURSE LFS_CORE_BUILD_INPUTS CONFIGURE_DEPENDS
-    "${CMAKE_SOURCE_DIR}/src/core/*.cpp"
-    "${CMAKE_SOURCE_DIR}/src/core/*.cu"
-    "${CMAKE_SOURCE_DIR}/src/core/*.cuh"
-    "${CMAKE_SOURCE_DIR}/src/core/*.hpp"
-)
-list(APPEND LFS_CORE_BUILD_INPUTS
-    "${CMAKE_SOURCE_DIR}/src/core/CMakeLists.txt"
-)
-list(SORT LFS_CORE_BUILD_INPUTS)
-set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
-    ${LFS_CORE_BUILD_INPUTS}
-)
-set(_lfs_core_abi_material
-    "${PROJECT_VERSION}|${GIT_COMMIT_HASH_SHORT}|${CMAKE_BUILD_TYPE}|${CMAKE_SYSTEM_NAME}|${CMAKE_SIZEOF_VOID_P}|${CMAKE_CXX_COMPILER_ID}|${CMAKE_CXX_COMPILER_VERSION}|${CMAKE_CUDA_COMPILER_ID}|${CMAKE_CUDA_COMPILER_VERSION}|${CMAKE_CUDA_ARCHITECTURES}|${VCPKG_TARGET_TRIPLET}")
-foreach(_lfs_core_build_input IN LISTS LFS_CORE_BUILD_INPUTS)
-    file(SHA256 "${_lfs_core_build_input}" _lfs_core_build_input_hash)
-    string(APPEND _lfs_core_abi_material "|${_lfs_core_build_input_hash}")
-endforeach()
-string(SHA256 LFS_CORE_ABI_STAMP "${_lfs_core_abi_material}")
-configure_file(
-    "${CMAKE_SOURCE_DIR}/cmake/lfs_core_abi_stamp.h.in"
-    "${CMAKE_BINARY_DIR}/include/lfs_core_abi_stamp.h"
-    @ONLY
-)
-
 option(BUILD_TESTS "Build tests" OFF)
 option(BUILD_FORMAT_TESTS "Build only the CPU-only .licht format tests (no CUDA)" OFF)
 option(BUILD_UNICODE_TEST_ONLY "Build only Unicode path test (no CUDA)" OFF)
@@ -526,6 +497,35 @@ configure_file(
         @ONLY
 )
 
+# App/core ABI tripwire. Recompute it before ABI consumers build, rather than
+# making every core source/header a configure dependency. Define this after the
+# effective CUDA architecture selection so the stamp represents the actual
+# target configuration. Each multi-config configuration gets its own header so
+# Debug and Release cannot race or overwrite each other.
+set(LFS_CORE_ABI_INCLUDE_DIR "${CMAKE_BINARY_DIR}/include/$<CONFIG>")
+set(LFS_CORE_ABI_HEADER "${LFS_CORE_ABI_INCLUDE_DIR}/lfs_core_abi_stamp.h")
+add_custom_target(lfs_core_abi_stamp ALL
+    BYPRODUCTS "${LFS_CORE_ABI_HEADER}"
+    COMMAND ${CMAKE_COMMAND}
+        "-DLFS_SOURCE_DIR=${CMAKE_SOURCE_DIR}"
+        "-DLFS_CORE_ABI_TEMPLATE=${CMAKE_SOURCE_DIR}/cmake/lfs_core_abi_stamp.h.in"
+        "-DLFS_CORE_ABI_HEADER=${LFS_CORE_ABI_HEADER}"
+        "-DLFS_PROJECT_VERSION=${PROJECT_VERSION}"
+        "-DLFS_CONFIGURED_GIT_COMMIT_HASH_SHORT=${GIT_COMMIT_HASH_SHORT}"
+        "-DLFS_BUILD_CONFIG=$<CONFIG>"
+        "-DLFS_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}"
+        "-DLFS_SIZEOF_VOID_P=${CMAKE_SIZEOF_VOID_P}"
+        "-DLFS_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}"
+        "-DLFS_CXX_COMPILER_VERSION=${CMAKE_CXX_COMPILER_VERSION}"
+        "-DLFS_CUDA_COMPILER_ID=${CMAKE_CUDA_COMPILER_ID}"
+        "-DLFS_CUDA_COMPILER_VERSION=${CMAKE_CUDA_COMPILER_VERSION}"
+        "-DLFS_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}"
+        "-DLFS_VCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}"
+        -P "${CMAKE_SOURCE_DIR}/cmake/GenerateCoreAbiStamp.cmake"
+    COMMENT "Refreshing lfs_core ABI stamp"
+    VERBATIM
+)
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     if(NOT MSVC)
         set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
@@ -595,6 +595,13 @@ add_executable(${PROJECT_NAME}
     resources/lichtfeld-studio.rc
     resources/lichtfeld-studio.manifest
 )
+
+foreach(_lfs_core_abi_consumer IN ITEMS ${PROJECT_NAME} lfs_core)
+    add_dependencies(${_lfs_core_abi_consumer} lfs_core_abi_stamp)
+    target_include_directories(${_lfs_core_abi_consumer} BEFORE PRIVATE
+        "${LFS_CORE_ABI_INCLUDE_DIR}"
+    )
+endforeach()
 
 # The binary only carries code for these architectures; the app refuses to start on anything
 # lower instead of dying inside the first kernel launch (#1540).
@@ -771,8 +778,17 @@ if(WIN32 AND DEFINED VCPKG_TARGET_TRIPLET)
     set(_vcpkg_debug_bin_dir "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/debug/bin")
     set(_vcpkg_release_bin_dir "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/bin")
     file(GLOB _vcpkg_release_dlls CONFIGURE_DEPENDS "${_vcpkg_release_bin_dir}/*.dll")
-    file(GLOB _vcpkg_debug_dlls CONFIGURE_DEPENDS "${_vcpkg_debug_bin_dir}/*.dll")
-    
+
+    # A single-config Release/RelWithDebInfo build never consumes Debug DLLs,
+    # so changes in debug/bin must not invalidate its CMake graph. Multi-config
+    # generators still need both lists because one graph serves all configs.
+    get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(_is_multi_config OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+        file(GLOB _vcpkg_debug_dlls CONFIGURE_DEPENDS "${_vcpkg_debug_bin_dir}/*.dll")
+    else()
+        set(_vcpkg_debug_dlls)
+    endif()
+
     # Always copy release DLLs - needed for both Release and Debug builds
     if(_vcpkg_release_dlls)
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
@@ -782,11 +798,10 @@ if(WIN32 AND DEFINED VCPKG_TARGET_TRIPLET)
             COMMENT "Copying vcpkg release DLLs"
         )
     endif()
-    
+
     # Only copy debug DLLs for Debug builds (they link to debug CRT which breaks Release)
     # For single-config generators (Ninja, Makefiles): check CMAKE_BUILD_TYPE
     # For multi-config generators (VS, Xcode): use generator expression
-    get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
     if(_is_multi_config)
         # Multi-config: use generator expression to conditionally copy
         if(_vcpkg_debug_dlls)

--- a/cmake/GenerateCoreAbiStamp.cmake
+++ b/cmake/GenerateCoreAbiStamp.cmake
@@ -25,8 +25,8 @@ if(NOT EXISTS "${LFS_CORE_ABI_TEMPLATE}")
     message(FATAL_ERROR "LFS core ABI template does not exist: ${LFS_CORE_ABI_TEMPLATE}")
 endif()
 
-# This scan intentionally happens at build time. Source/header content changes
-# must update the ABI tripwire without making CMake regenerate the whole graph.
+# Seeded at configure time and refreshed at build time. Source/header content
+# changes update the ABI tripwire without making CMake regenerate the whole graph.
 file(GLOB_RECURSE LFS_CORE_BUILD_INPUTS LIST_DIRECTORIES FALSE
     "${LFS_SOURCE_DIR}/src/core/*.cpp"
     "${LFS_SOURCE_DIR}/src/core/*.cu"

--- a/cmake/GenerateCoreAbiStamp.cmake
+++ b/cmake/GenerateCoreAbiStamp.cmake
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+foreach(_lfs_required_variable IN ITEMS
+        LFS_SOURCE_DIR
+        LFS_CORE_ABI_TEMPLATE
+        LFS_CORE_ABI_HEADER
+        LFS_PROJECT_VERSION
+        LFS_BUILD_CONFIG
+        LFS_SYSTEM_NAME
+        LFS_SIZEOF_VOID_P
+        LFS_CXX_COMPILER_ID
+        LFS_CXX_COMPILER_VERSION
+        LFS_CUDA_COMPILER_ID
+        LFS_CUDA_COMPILER_VERSION)
+    if(NOT DEFINED ${_lfs_required_variable})
+        message(FATAL_ERROR "${_lfs_required_variable} is required")
+    endif()
+endforeach()
+
+if(NOT IS_DIRECTORY "${LFS_SOURCE_DIR}/src/core")
+    message(FATAL_ERROR "LFS core source directory does not exist: ${LFS_SOURCE_DIR}/src/core")
+endif()
+if(NOT EXISTS "${LFS_CORE_ABI_TEMPLATE}")
+    message(FATAL_ERROR "LFS core ABI template does not exist: ${LFS_CORE_ABI_TEMPLATE}")
+endif()
+
+# This scan intentionally happens at build time. Source/header content changes
+# must update the ABI tripwire without making CMake regenerate the whole graph.
+file(GLOB_RECURSE LFS_CORE_BUILD_INPUTS LIST_DIRECTORIES FALSE
+    "${LFS_SOURCE_DIR}/src/core/*.cpp"
+    "${LFS_SOURCE_DIR}/src/core/*.cu"
+    "${LFS_SOURCE_DIR}/src/core/*.cuh"
+    "${LFS_SOURCE_DIR}/src/core/*.hpp"
+)
+list(APPEND LFS_CORE_BUILD_INPUTS
+    "${LFS_SOURCE_DIR}/src/core/CMakeLists.txt"
+)
+list(SORT LFS_CORE_BUILD_INPUTS)
+
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY "${LFS_SOURCE_DIR}"
+    OUTPUT_VARIABLE _lfs_git_commit_hash_short
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT _lfs_git_commit_hash_short AND
+   DEFINED LFS_CONFIGURED_GIT_COMMIT_HASH_SHORT AND
+   NOT LFS_CONFIGURED_GIT_COMMIT_HASH_SHORT STREQUAL "" AND
+   NOT LFS_CONFIGURED_GIT_COMMIT_HASH_SHORT STREQUAL "unknown")
+    set(_lfs_git_commit_hash_short "${LFS_CONFIGURED_GIT_COMMIT_HASH_SHORT}")
+endif()
+if(NOT _lfs_git_commit_hash_short AND
+   DEFINED ENV{GITHUB_SHA} AND NOT "$ENV{GITHUB_SHA}" STREQUAL "")
+    string(SUBSTRING "$ENV{GITHUB_SHA}" 0 7 _lfs_git_commit_hash_short)
+endif()
+if(NOT _lfs_git_commit_hash_short)
+    set(_lfs_git_commit_hash_short "unknown")
+endif()
+
+set(_lfs_core_abi_material
+    "${LFS_PROJECT_VERSION}|${_lfs_git_commit_hash_short}|${LFS_BUILD_CONFIG}|${LFS_SYSTEM_NAME}|${LFS_SIZEOF_VOID_P}|${LFS_CXX_COMPILER_ID}|${LFS_CXX_COMPILER_VERSION}|${LFS_CUDA_COMPILER_ID}|${LFS_CUDA_COMPILER_VERSION}|${LFS_CUDA_ARCHITECTURES}|${LFS_VCPKG_TARGET_TRIPLET}")
+foreach(_lfs_core_build_input IN LISTS LFS_CORE_BUILD_INPUTS)
+    file(SHA256 "${_lfs_core_build_input}" _lfs_core_build_input_hash)
+    string(APPEND _lfs_core_abi_material "|${_lfs_core_build_input_hash}")
+endforeach()
+
+string(SHA256 LFS_CORE_ABI_STAMP "${_lfs_core_abi_material}")
+get_filename_component(_lfs_core_abi_header_dir "${LFS_CORE_ABI_HEADER}" DIRECTORY)
+file(MAKE_DIRECTORY "${_lfs_core_abi_header_dir}")
+
+# configure_file only updates the timestamp when the generated content changes.
+# That keeps no-op builds from recompiling the ABI consumers.
+configure_file(
+    "${LFS_CORE_ABI_TEMPLATE}"
+    "${LFS_CORE_ABI_HEADER}"
+    @ONLY
+)

--- a/cmake/InitializeCoreAbiStamp.cmake
+++ b/cmake/InitializeCoreAbiStamp.cmake
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+function(lfs_initialize_core_abi_stamps)
+    # A dedicated directory also isolates an unnamed single-config build from
+    # the legacy shared header on lfs_core's public include path.
+    set(_lfs_include_root "${CMAKE_BINARY_DIR}/include/core-abi")
+    file(REMOVE "${CMAKE_BINARY_DIR}/include/lfs_core_abi_stamp.h")
+
+    set(LFS_SOURCE_DIR "${CMAKE_SOURCE_DIR}")
+    set(LFS_CORE_ABI_TEMPLATE "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/lfs_core_abi_stamp.h.in")
+    set(LFS_PROJECT_VERSION "${PROJECT_VERSION}")
+    set(LFS_CONFIGURED_GIT_COMMIT_HASH_SHORT "${GIT_COMMIT_HASH_SHORT}")
+    set(LFS_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}")
+    set(LFS_SIZEOF_VOID_P "${CMAKE_SIZEOF_VOID_P}")
+    set(LFS_CXX_COMPILER_ID "${CMAKE_CXX_COMPILER_ID}")
+    set(LFS_CXX_COMPILER_VERSION "${CMAKE_CXX_COMPILER_VERSION}")
+    set(LFS_CUDA_COMPILER_ID "${CMAKE_CUDA_COMPILER_ID}")
+    set(LFS_CUDA_COMPILER_VERSION "${CMAKE_CUDA_COMPILER_VERSION}")
+    set(LFS_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+    set(LFS_VCPKG_TARGET_TRIPLET "${VCPKG_TARGET_TRIPLET}")
+
+    # Dependencies can populate CMAKE_CONFIGURATION_TYPES even for Ninja.
+    # Only the generator property determines whether these are actual configs.
+    get_property(_lfs_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(_lfs_multi_config)
+        foreach(LFS_BUILD_CONFIG IN LISTS CMAKE_CONFIGURATION_TYPES)
+            set(LFS_CORE_ABI_HEADER "${_lfs_include_root}/${LFS_BUILD_CONFIG}/lfs_core_abi_stamp.h")
+            include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/GenerateCoreAbiStamp.cmake")
+        endforeach()
+    else()
+        set(LFS_BUILD_CONFIG "${CMAKE_BUILD_TYPE}")
+        set(LFS_CORE_ABI_HEADER "${_lfs_include_root}/${LFS_BUILD_CONFIG}/lfs_core_abi_stamp.h")
+        include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/GenerateCoreAbiStamp.cmake")
+    endif()
+
+    set(LFS_CORE_ABI_INCLUDE_DIR "${_lfs_include_root}/$<CONFIG>" PARENT_SCOPE)
+    set(LFS_CORE_ABI_HEADER "${_lfs_include_root}/$<CONFIG>/lfs_core_abi_stamp.h" PARENT_SCOPE)
+endfunction()

--- a/cmake/SyncVisualizerResources.cmake
+++ b/cmake/SyncVisualizerResources.cmake
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+foreach(_lfs_required_variable IN ITEMS
+        LFS_VISUALIZER_SOURCE_DIR
+        LFS_RENDERING_SOURCE_DIR
+        LFS_DESTINATION_DIR
+        LFS_ALLOWED_DESTINATION_ROOT)
+    if(NOT DEFINED ${_lfs_required_variable} OR "${${_lfs_required_variable}}" STREQUAL "")
+        message(FATAL_ERROR "${_lfs_required_variable} is required")
+    endif()
+endforeach()
+
+cmake_path(ABSOLUTE_PATH LFS_ALLOWED_DESTINATION_ROOT NORMALIZE
+    OUTPUT_VARIABLE _lfs_allowed_destination_root)
+cmake_path(ABSOLUTE_PATH LFS_DESTINATION_DIR NORMALIZE
+    OUTPUT_VARIABLE _lfs_destination_dir)
+cmake_path(IS_PREFIX _lfs_allowed_destination_root "${_lfs_destination_dir}"
+    NORMALIZE _lfs_destination_is_allowed)
+
+if(NOT _lfs_destination_is_allowed OR
+   _lfs_destination_dir STREQUAL _lfs_allowed_destination_root)
+    message(FATAL_ERROR
+        "Refusing to synchronize outside a child of the visualizer build directory: "
+        "${_lfs_destination_dir}")
+endif()
+
+function(_lfs_copy_resource_file _lfs_source_file _lfs_relative_destination _lfs_optional)
+    set(_lfs_destination_file "${_lfs_destination_dir}/${_lfs_relative_destination}")
+    if(EXISTS "${_lfs_source_file}" AND NOT IS_DIRECTORY "${_lfs_source_file}")
+        if(IS_DIRECTORY "${_lfs_destination_file}")
+            message(FATAL_ERROR
+                "Visualizer resource destination is unexpectedly a directory: "
+                "${_lfs_destination_file}")
+        endif()
+        get_filename_component(_lfs_destination_parent "${_lfs_destination_file}" DIRECTORY)
+        file(MAKE_DIRECTORY "${_lfs_destination_parent}")
+        file(COPY_FILE
+            "${_lfs_source_file}"
+            "${_lfs_destination_file}"
+            ONLY_IF_DIFFERENT
+            INPUT_MAY_BE_RECENT
+        )
+    elseif(NOT _lfs_optional)
+        message(FATAL_ERROR "Required visualizer resource does not exist: ${_lfs_source_file}")
+    elseif(IS_DIRECTORY "${_lfs_destination_file}")
+        message(FATAL_ERROR
+            "Optional visualizer resource destination is unexpectedly a directory: "
+            "${_lfs_destination_file}")
+    elseif(EXISTS "${_lfs_destination_file}")
+        file(REMOVE "${_lfs_destination_file}")
+    endif()
+endfunction()
+
+function(_lfs_sync_resource_directory
+        _lfs_source_dir
+        _lfs_relative_destination
+        _lfs_glob_pattern
+        _lfs_recurse
+        _lfs_remove_stale
+        _lfs_source_optional)
+    set(_lfs_preserve_relative_files ${ARGN})
+    set(_lfs_destination_subdir "${_lfs_destination_dir}/${_lfs_relative_destination}")
+
+    if(NOT IS_DIRECTORY "${_lfs_source_dir}")
+        if(_lfs_source_optional)
+            return()
+        endif()
+        message(FATAL_ERROR "Visualizer resource directory does not exist: ${_lfs_source_dir}")
+    endif()
+
+    file(MAKE_DIRECTORY "${_lfs_destination_subdir}")
+    if(_lfs_recurse)
+        file(GLOB_RECURSE _lfs_source_files LIST_DIRECTORIES FALSE
+            RELATIVE "${_lfs_source_dir}"
+            "${_lfs_source_dir}/${_lfs_glob_pattern}"
+        )
+    else()
+        file(GLOB _lfs_source_files LIST_DIRECTORIES FALSE
+            RELATIVE "${_lfs_source_dir}"
+            "${_lfs_source_dir}/${_lfs_glob_pattern}"
+        )
+    endif()
+    list(SORT _lfs_source_files)
+
+    foreach(_lfs_relative_file IN LISTS _lfs_source_files)
+        set(_lfs_source_file "${_lfs_source_dir}/${_lfs_relative_file}")
+        set(_lfs_destination_file "${_lfs_destination_subdir}/${_lfs_relative_file}")
+        get_filename_component(_lfs_destination_parent "${_lfs_destination_file}" DIRECTORY)
+        file(MAKE_DIRECTORY "${_lfs_destination_parent}")
+        file(COPY_FILE
+            "${_lfs_source_file}"
+            "${_lfs_destination_file}"
+            ONLY_IF_DIFFERENT
+            INPUT_MAY_BE_RECENT
+        )
+    endforeach()
+
+    if(_lfs_remove_stale)
+        if(_lfs_recurse)
+            file(GLOB_RECURSE _lfs_destination_files LIST_DIRECTORIES FALSE
+                RELATIVE "${_lfs_destination_subdir}"
+                "${_lfs_destination_subdir}/${_lfs_glob_pattern}"
+            )
+        else()
+            file(GLOB _lfs_destination_files LIST_DIRECTORIES FALSE
+                RELATIVE "${_lfs_destination_subdir}"
+                "${_lfs_destination_subdir}/${_lfs_glob_pattern}"
+            )
+        endif()
+        foreach(_lfs_relative_file IN LISTS _lfs_destination_files)
+            list(FIND _lfs_source_files "${_lfs_relative_file}" _lfs_source_index)
+            list(FIND _lfs_preserve_relative_files "${_lfs_relative_file}" _lfs_preserve_index)
+            if(_lfs_source_index EQUAL -1 AND _lfs_preserve_index EQUAL -1)
+                file(REMOVE "${_lfs_destination_subdir}/${_lfs_relative_file}")
+            endif()
+        endforeach()
+    endif()
+endfunction()
+
+file(MAKE_DIRECTORY "${_lfs_destination_dir}/assets/fonts")
+
+# Preserve the old optional overlay behavior. This directory is absent in the
+# current tree, but files added to it later are picked up without reconfiguring.
+_lfs_sync_resource_directory(
+    "${LFS_VISUALIZER_SOURCE_DIR}/resources/assets"
+    "assets"
+    "*"
+    OFF
+    OFF
+    ON
+)
+
+_lfs_copy_resource_file(
+    "${LFS_VISUALIZER_SOURCE_DIR}/gui/assets/JetBrainsMono-Regular.ttf"
+    "assets/JetBrainsMono-Regular.ttf"
+    ON
+)
+_lfs_copy_resource_file(
+    "${LFS_VISUALIZER_SOURCE_DIR}/gui/assets/lichtfeld-icon.png"
+    "assets/lichtfeld-icon.png"
+    ON
+)
+_lfs_copy_resource_file(
+    "${LFS_RENDERING_SOURCE_DIR}/resources/assets/JetBrainsMono-Regular.ttf"
+    "assets/fonts/JetBrainsMono-Regular.ttf"
+    ON
+)
+
+_lfs_sync_resource_directory(
+    "${LFS_VISUALIZER_SOURCE_DIR}/gui/assets/icon"
+    "assets/icon"
+    "*.png"
+    OFF
+    ON
+    OFF
+)
+_lfs_sync_resource_directory(
+    "${LFS_VISUALIZER_SOURCE_DIR}/gui/assets/icon/scene"
+    "assets/icon/scene"
+    "*.png"
+    OFF
+    ON
+    OFF
+)
+_lfs_sync_resource_directory(
+    "${LFS_VISUALIZER_SOURCE_DIR}/gui/assets/icon/sequencer"
+    "assets/icon/sequencer"
+    "*.png"
+    OFF
+    ON
+    OFF
+)
+_lfs_sync_resource_directory(
+    "${LFS_VISUALIZER_SOURCE_DIR}/gui/assets/environments"
+    "assets/environments"
+    "*"
+    OFF
+    ON
+    OFF
+)
+_lfs_sync_resource_directory(
+    "${LFS_VISUALIZER_SOURCE_DIR}/gui/rmlui/resources"
+    "assets/rmlui"
+    "*"
+    OFF
+    ON
+    OFF
+    "soft_shadow.png"
+)
+_lfs_copy_resource_file(
+    "${LFS_VISUALIZER_SOURCE_DIR}/gui/assets/rmlui/soft_shadow.png"
+    "assets/rmlui/soft_shadow.png"
+    OFF
+)
+_lfs_sync_resource_directory(
+    "${LFS_VISUALIZER_SOURCE_DIR}/gui/resources/locales"
+    "locales"
+    "*.json"
+    OFF
+    ON
+    OFF
+)
+_lfs_copy_resource_file(
+    "${LFS_VISUALIZER_SOURCE_DIR}/gui/resources/locale_index.json"
+    "locale_index.json"
+    OFF
+)

--- a/docs/docs/development/assertions.md
+++ b/docs/docs/development/assertions.md
@@ -178,10 +178,17 @@ redundant verification and belongs in a debug-only round-trip validator.
 
 ## ABI tripwire
 
-An always-run build helper generates `lfs_core_abi_stamp.h` from the core
-implementation and build inputs before its consumers compile. It writes the
-header only when the stamp changes, without forcing CMake to regenerate the
-project graph for ordinary core edits. The application compares its compiled
+CMake initially generates `lfs_core_abi_stamp.h` from the core implementation and
+build inputs during configuration, so IDEs and syntax checks can read it before
+the first build. Each actual configuration gets its own header under
+`build/include/core-abi/<config>/`; an unnamed single-config build uses the
+`core-abi/` directory itself. Configuration removes the legacy shared header
+from `build/include/` to prevent stale fallback through the public include path.
+
+An always-run build helper refreshes the stamp before its consumers compile.
+Both generation paths write the header only when its content changes, without
+forcing CMake to regenerate the project graph for ordinary core edits. The
+application compares its compiled
 stamp with the loaded `lfs_core` stamp before argument parsing or CUDA
 initialization. A mismatch
 prints both stamps, tells the user to remove stale binaries and rebuild, and

--- a/docs/docs/development/assertions.md
+++ b/docs/docs/development/assertions.md
@@ -178,9 +178,12 @@ redundant verification and belongs in a debug-only round-trip validator.
 
 ## ABI tripwire
 
-CMake generates `lfs_core_abi_stamp.h` from the core implementation and build
-inputs. The application compares its compiled stamp with the loaded
-`lfs_core` stamp before argument parsing or CUDA initialization. A mismatch
+An always-run build helper generates `lfs_core_abi_stamp.h` from the core
+implementation and build inputs before its consumers compile. It writes the
+header only when the stamp changes, without forcing CMake to regenerate the
+project graph for ordinary core edits. The application compares its compiled
+stamp with the loaded `lfs_core` stamp before argument parsing or CUDA
+initialization. A mismatch
 prints both stamps, tells the user to remove stale binaries and rebuild, and
 exits with status 2. This is an always-on startup boundary and must remain the
 first executable check.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -111,6 +111,9 @@ set(CORE_SOURCES
 
 add_library(lfs_core SHARED ${CORE_SOURCES} ${TENSOR_SOURCES})
 
+add_dependencies(lfs_core lfs_core_abi_stamp)
+target_include_directories(lfs_core BEFORE PRIVATE "${LFS_CORE_ABI_INCLUDE_DIR}")
+
 target_compile_definitions(lfs_core PRIVATE LFS_CORE_EXPORTS)
 
 target_include_directories(lfs_core

--- a/src/visualizer/CMakeLists.txt
+++ b/src/visualizer/CMakeLists.txt
@@ -430,110 +430,20 @@ set(VISUALIZER_BUILD_RESOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/resources")
 set(VISUALIZER_SOURCE_RESOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/resources")
 set(RENDERING_SOURCE_RESOURCE_DIR "${PROJECT_SOURCE_DIR}/src/rendering/resources")
 
-# Create resource directories in build folder
-file(MAKE_DIRECTORY "${VISUALIZER_BUILD_RESOURCE_DIR}/assets")
-file(MAKE_DIRECTORY "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/fonts")
-
-# Copy assets from resources/assets if they exist
-file(GLOB ASSET_FILES CONFIGURE_DEPENDS "${VISUALIZER_SOURCE_RESOURCE_DIR}/assets/*")
-foreach (ASSET_FILE ${ASSET_FILES})
-    get_filename_component(ASSET_NAME ${ASSET_FILE} NAME)
-    configure_file(${ASSET_FILE} "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/${ASSET_NAME}" COPYONLY)
-endforeach ()
-
-set(GUI_ASSET_FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/gui/assets/JetBrainsMono-Regular.ttf"
-        "${CMAKE_CURRENT_SOURCE_DIR}/gui/assets/lichtfeld-icon.png"
+# Synchronize runtime resources at build time. The helper scans directories
+# without registering them as CMake configure dependencies, copies only changed
+# files, and removes stale files only inside the explicitly allowed build tree.
+add_custom_target(copy_visualizer_resources ALL
+    COMMAND ${CMAKE_COMMAND}
+        "-DLFS_VISUALIZER_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
+        "-DLFS_RENDERING_SOURCE_DIR=${PROJECT_SOURCE_DIR}/src/rendering"
+        "-DLFS_DESTINATION_DIR=${VISUALIZER_BUILD_RESOURCE_DIR}"
+        "-DLFS_ALLOWED_DESTINATION_ROOT=${CMAKE_CURRENT_BINARY_DIR}"
+        -P "${PROJECT_SOURCE_DIR}/cmake/SyncVisualizerResources.cmake"
+    COMMENT "Syncing visualizer runtime resources"
+    VERBATIM
 )
-
-foreach (GUI_ASSET_FILE ${GUI_ASSET_FILES})
-    if (EXISTS ${GUI_ASSET_FILE} AND NOT IS_DIRECTORY ${GUI_ASSET_FILE})
-        get_filename_component(ASSET_NAME ${GUI_ASSET_FILE} NAME)
-        configure_file(${GUI_ASSET_FILE} "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/${ASSET_NAME}" COPYONLY)
-    endif ()
-endforeach ()
-
-set(RENDERING_FONT_FILES
-        "${RENDERING_SOURCE_RESOURCE_DIR}/assets/JetBrainsMono-Regular.ttf"
-)
-
-foreach (RENDERING_FONT_FILE ${RENDERING_FONT_FILES})
-    if (EXISTS ${RENDERING_FONT_FILE} AND NOT IS_DIRECTORY ${RENDERING_FONT_FILE})
-        get_filename_component(FONT_NAME ${RENDERING_FONT_FILE} NAME)
-        configure_file(${RENDERING_FONT_FILE} "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/fonts/${FONT_NAME}" COPYONLY)
-    endif ()
-endforeach ()
-
-# Copy icon files
-file(MAKE_DIRECTORY "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/icon")
-file(GLOB ICON_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/gui/assets/icon/*.png")
-foreach (ICON_FILE ${ICON_FILES})
-    get_filename_component(ICON_NAME ${ICON_FILE} NAME)
-    configure_file(${ICON_FILE} "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/icon/${ICON_NAME}" COPYONLY)
-endforeach ()
-
-# Copy scene icon files (used by RmlUI scene panel)
-file(MAKE_DIRECTORY "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/icon/scene")
-file(GLOB SCENE_ICON_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/gui/assets/icon/scene/*.png")
-foreach (ICON_FILE ${SCENE_ICON_FILES})
-    get_filename_component(ICON_NAME ${ICON_FILE} NAME)
-    configure_file(${ICON_FILE} "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/icon/scene/${ICON_NAME}" COPYONLY)
-endforeach ()
-
-# Copy sequencer icon files (used by RmlUI sequencer panel)
-file(MAKE_DIRECTORY "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/icon/sequencer")
-file(GLOB SEQUENCER_ICON_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/gui/assets/icon/sequencer/*.png")
-foreach (ICON_FILE ${SEQUENCER_ICON_FILES})
-    get_filename_component(ICON_NAME ${ICON_FILE} NAME)
-    configure_file(${ICON_FILE} "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/icon/sequencer/${ICON_NAME}" COPYONLY)
-endforeach ()
-
-# Copy bundled environment maps
-file(MAKE_DIRECTORY "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/environments")
-file(GLOB ENVIRONMENT_ASSET_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/gui/assets/environments/*")
-foreach (ENVIRONMENT_ASSET_FILE ${ENVIRONMENT_ASSET_FILES})
-    if (EXISTS ${ENVIRONMENT_ASSET_FILE} AND NOT IS_DIRECTORY ${ENVIRONMENT_ASSET_FILE})
-        get_filename_component(ENVIRONMENT_ASSET_NAME ${ENVIRONMENT_ASSET_FILE} NAME)
-        configure_file(${ENVIRONMENT_ASSET_FILE} "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/environments/${ENVIRONMENT_ASSET_NAME}" COPYONLY)
-    endif ()
-endforeach ()
-
-# Copy RmlUI resources (re-copy on every build so edits are picked up)
-file(MAKE_DIRECTORY "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/rmlui")
-file(GLOB RMLUI_RESOURCE_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/gui/rmlui/resources/*")
-set(RMLUI_ASSET_FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/gui/assets/rmlui/soft_shadow.png"
-)
-foreach (RMLUI_FILE ${RMLUI_RESOURCE_FILES})
-    get_filename_component(RMLUI_NAME ${RMLUI_FILE} NAME)
-    configure_file(${RMLUI_FILE} "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/rmlui/${RMLUI_NAME}" COPYONLY)
-endforeach ()
-foreach (RMLUI_ASSET_FILE ${RMLUI_ASSET_FILES})
-    if (EXISTS ${RMLUI_ASSET_FILE} AND NOT IS_DIRECTORY ${RMLUI_ASSET_FILE})
-        get_filename_component(RMLUI_ASSET_NAME ${RMLUI_ASSET_FILE} NAME)
-        configure_file(${RMLUI_ASSET_FILE} "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/rmlui/${RMLUI_ASSET_NAME}" COPYONLY)
-    endif ()
-endforeach ()
-add_custom_target(copy_rmlui_resources ALL
-    COMMAND ${CMAKE_COMMAND} -E rm -rf "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/rmlui"
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/rmlui"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${RMLUI_RESOURCE_FILES}
-        ${RMLUI_ASSET_FILES}
-        "${VISUALIZER_BUILD_RESOURCE_DIR}/assets/rmlui/"
-    COMMENT "Syncing RmlUI resources"
-)
-add_dependencies(lfs_visualizer copy_rmlui_resources)
-
-# Copy locale files
-file(MAKE_DIRECTORY "${VISUALIZER_BUILD_RESOURCE_DIR}/locales")
-file(GLOB LOCALE_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/gui/resources/locales/*.json")
-foreach (LOCALE_FILE ${LOCALE_FILES})
-    get_filename_component(LOCALE_NAME ${LOCALE_FILE} NAME)
-    configure_file(${LOCALE_FILE} "${VISUALIZER_BUILD_RESOURCE_DIR}/locales/${LOCALE_NAME}" COPYONLY)
-endforeach ()
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gui/resources/locale_index.json
-        "${VISUALIZER_BUILD_RESOURCE_DIR}/locale_index.json" COPYONLY)
+add_dependencies(lfs_visualizer copy_visualizer_resources)
 
 set(LFS_VISUALIZER_DEV_RESOURCE_DEFINITIONS)
 if(LFS_DEV_IMPORT_SOURCE_RESOURCES AND NOT BUILD_PORTABLE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -567,6 +567,10 @@ list(APPEND TEST_SOURCES
 # Create test executable
 add_executable(lichtfeld_tests ${TEST_SOURCES})
 
+# test_assert_hardening.cpp includes the generated ABI header directly. Ensure
+# the build-time tripwire has run before this target starts compiling.
+add_dependencies(lichtfeld_tests lfs_core_abi_stamp)
+
 # Python integration tests import the in-tree extension at runtime.
 add_dependencies(lichtfeld_tests lfs_py)
 
@@ -581,6 +585,7 @@ set_target_properties(lichtfeld_tests PROPERTIES
 
 # Include directories
 target_include_directories(lichtfeld_tests PRIVATE
+    ${LFS_CORE_ABI_INCLUDE_DIR}
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_BINARY_DIR}/include
     ${CMAKE_SOURCE_DIR}/tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -899,6 +899,7 @@ set_tests_properties(lichtfeld.discovery PROPERTIES
 set(LFS_PYTHON_FAST_TESTS
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_asset_identity.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_bug_report.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/test_core_abi_stamp.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_event_keypad_mapping.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_export_panel.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_gizmo_context.py
@@ -989,6 +990,7 @@ set_tests_properties(lichtfeld.python.fast PROPERTIES
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     LABELS "fast"
     TIMEOUT 60
+    ENVIRONMENT_MODIFICATION "CMAKE_COMMAND=set:${CMAKE_COMMAND}"
 )
 
 add_test(NAME lichtfeld.python.slow

--- a/tests/python/test_core_abi_stamp.py
+++ b/tests/python/test_core_abi_stamp.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Exercise ABI generation in CMake script mode, without configuring or building C++."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CMAKE = os.environ.get("CMAKE_COMMAND") or shutil.which("cmake")
+
+
+@unittest.skipUnless(CMAKE, "CMake is required for ABI script tests")
+class CoreAbiStampTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name).resolve()
+        self.source = self.root / "source"
+        self.build = self.root / "build with spaces"
+        core = self.source / "src/core"
+        core.mkdir(parents=True)
+        (core / "CMakeLists.txt").write_text("# fixture\n", encoding="utf-8")
+        self.core_file = core / "sample.cpp"
+        self.core_file.write_text("int value = 1;\n", encoding="utf-8")
+        self.metadata = {
+            "CMAKE_SOURCE_DIR": self.source.as_posix(),
+            "CMAKE_BINARY_DIR": self.build.as_posix(),
+            "PROJECT_VERSION": "1.0",
+            "GIT_COMMIT_HASH_SHORT": "fixture",
+            "CMAKE_SYSTEM_NAME": "Windows",
+            "CMAKE_SIZEOF_VOID_P": "8",
+            "CMAKE_CXX_COMPILER_ID": "MSVC",
+            "CMAKE_CXX_COMPILER_VERSION": "19.44",
+            "CMAKE_CUDA_COMPILER_ID": "NVIDIA",
+            "CMAKE_CUDA_COMPILER_VERSION": "12.8",
+            "CMAKE_CUDA_ARCHITECTURES": "86;89",
+            "VCPKG_TARGET_TRIPLET": "x64-windows-release",
+        }
+
+    def run_script(self, body, generator="Ninja"):
+        script = self.root / "fixture.cmake"
+        prelude = "cmake_minimum_required(VERSION 3.30)\n"
+        prelude += "".join(f'set({key} "{value}")\n' for key, value in self.metadata.items())
+        script.write_text(prelude + body, encoding="utf-8")
+        result = subprocess.run(
+            [CMAKE, "-G", generator, "-P", str(script)],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+    def initialize(self, configuration="Release", generator="Ninja"):
+        self.run_script(
+            # Mimic dependencies populating this variable for single-config Ninja.
+            'set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo")\n'
+            f'set(CMAKE_BUILD_TYPE "{configuration}")\n'
+            f'include("{ROOT.as_posix()}/cmake/InitializeCoreAbiStamp.cmake")\n'
+            'lfs_initialize_core_abi_stamps()\n', generator,
+        )
+
+    def header(self, configuration):
+        return self.build / "include/core-abi" / configuration / "lfs_core_abi_stamp.h"
+
+    def test_single_config_seeds_only_actual_configuration_and_removes_legacy(self):
+        for configuration in ("Debug", "Release", "RelWithDebInfo", "MinSizeRel", ""):
+            with self.subTest(configuration=configuration):
+                self.build = self.root / (configuration or "unnamed")
+                self.metadata["CMAKE_BINARY_DIR"] = self.build.as_posix()
+                legacy = self.build / "include/lfs_core_abi_stamp.h"
+                legacy.parent.mkdir(parents=True)
+                legacy.write_text("stale", encoding="utf-8")
+                self.initialize(configuration)
+                self.assertFalse(legacy.exists())
+                self.assertEqual([self.header(configuration)],
+                                 list((self.build / "include").rglob("lfs_core_abi_stamp.h")))
+
+    def test_multi_config_seeds_distinct_headers_before_any_build(self):
+        self.initialize(generator="Ninja Multi-Config")
+        stamps = {self.header(config).read_text(encoding="utf-8")
+                  for config in ("Debug", "Release", "RelWithDebInfo")}
+        self.assertEqual(3, len(stamps))
+
+    def test_noop_keeps_timestamp_and_core_edit_changes_stamp(self):
+        self.initialize()
+        header = self.header("Release")
+        before = header.read_bytes()
+        os.utime(header, (1_000_000_000, 1_000_000_000))
+        timestamp = header.stat().st_mtime_ns
+        self.initialize()
+        self.assertEqual(timestamp, header.stat().st_mtime_ns)
+        self.core_file.write_text("int value = 2;\n", encoding="utf-8")
+        self.initialize()
+        self.assertNotEqual(before, header.read_bytes())
+
+    def test_build_refresh_matches_configure_seed(self):
+        self.initialize()
+        header = self.header("Release")
+        initial = header.read_bytes()
+        # Independently supply the same metadata as the production build target.
+        values = {
+            "LFS_SOURCE_DIR": self.source.as_posix(),
+            "LFS_CORE_ABI_TEMPLATE": f"{ROOT.as_posix()}/cmake/lfs_core_abi_stamp.h.in",
+            "LFS_CORE_ABI_HEADER": header.as_posix(),
+            "LFS_PROJECT_VERSION": "1.0",
+            "LFS_CONFIGURED_GIT_COMMIT_HASH_SHORT": "fixture",
+            "LFS_BUILD_CONFIG": "Release",
+            "LFS_SYSTEM_NAME": "Windows", "LFS_SIZEOF_VOID_P": "8",
+            "LFS_CXX_COMPILER_ID": "MSVC", "LFS_CXX_COMPILER_VERSION": "19.44",
+            "LFS_CUDA_COMPILER_ID": "NVIDIA", "LFS_CUDA_COMPILER_VERSION": "12.8",
+            "LFS_CUDA_ARCHITECTURES": "86;89", "LFS_VCPKG_TARGET_TRIPLET": "x64-windows-release",
+        }
+        body = "".join(f'set({key} "{value}")\n' for key, value in values.items())
+        body += f'include("{ROOT.as_posix()}/cmake/GenerateCoreAbiStamp.cmake")\n'
+        self.run_script(body)
+        self.assertEqual(initial, header.read_bytes())
+        self.core_file.write_text("int value = 3;\n", encoding="utf-8")
+        self.run_script(body)
+        self.assertNotEqual(initial, header.read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ordinary core source edits and runtime resource changes currently cause unnecessary CMake regeneration or copies. This moves their refresh work to build-time helpers while preserving ABI validation and resource discovery.

The core ABI header is now also seeded during configuration, so clangd, CLion, and direct syntax checks can use it before the first build. Actual multi-config generators receive one header per configuration; single-config generators use their build type even if a dependency populated `CMAKE_CONFIGURATION_TYPES`.

Headers live under `build/include/core-abi/<config>/`, with the directory itself used for an unnamed configuration. Configuration removes the legacy shared `build/include/lfs_core_abi_stamp.h`, preventing stale fallback through the public include path. The core target owns its private ABI include path and generation dependency.

The always-run helper still refreshes the stamp before the application, core, and test consumers build. Core content hashes, Git identity, compiler/platform/CUDA/architecture/configuration/triplet inputs, and the runtime stale-library guard remain intact. Unchanged content preserves the header timestamp. Core source/header edits do not become configure dependencies.

Runtime resource synchronization:

- discovers assets at build time, copies changed files, and removes stale managed files;
- preserves directory/extension scope and optional legacy overlay behavior;
- validates destination containment and handles recently written Windows files;
- avoids unconditional RmlUI directory replacement.

Single-config non-Debug builds also skip unused vcpkg Debug DLL membership checks. Normal CMake inputs, overlay tracking, Release DLL tracking, and Python stub membership checks remain enabled.

The branch is rebased onto master `1cc94ba82`, including the #2012 icons and the upstream Unicode assertion fix. The configure-time seed allows #2008 to remove its special header-target build workaround.

Validation of the review corrections:

- Four CMake script-mode tests pass on Python 3.10 and 3.11: all single-config variants including an empty build type, multi-config separation, legacy-header removal, unchanged timestamps, core-content changes, and configure/build stamp parity.
- Tests are registered in the fast Python suite with the configured CMake executable.
- Merge-tree checks accept this PR, corrected #2008, and the local Release-only vcpkg branch together without conflicts.
- `git diff --check` passes; ABI documentation is updated.

No application configuration, native C++/CUDA build, or runtime execution was performed locally for this revision. The maintainer's [Linux review of the preceding revision](https://github.com/MrNeRF/LichtFeld-Studio/pull/2018#pullrequestreview-5111065879) separately covers no-op/core-edit timings, resource changes, the stale-library guard, multi-config builds, and GUI execution.