### PR TITLE
Fix USD splat CLI opening and preserve Windows Unicode paths

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -24,6 +24,8 @@
 #include <cuda_runtime.h>
 #include <filesystem>
 #include <print>
+#include <string>
+#include <vector>
 
 namespace {
     // Apply CUDA driver-level VRAM-reduction knobs BEFORE the primary context exists.
@@ -185,7 +187,24 @@ namespace {
 
 } // namespace
 
+#ifdef _WIN32
+int wmain(int argc, wchar_t* wide_argv[]) {
+    // The parser expects UTF-8. Narrow CRT argv uses the Windows ANSI code page,
+    // which can lose characters in paths opened from Explorer or the command line.
+    std::vector<std::string> utf8_args;
+    utf8_args.reserve(argc);
+    for (int i = 0; i < argc; ++i)
+        utf8_args.push_back(lfs::core::wstring_to_utf8(wide_argv[i]));
+
+    std::vector<const char*> utf8_argv;
+    utf8_argv.reserve(argc + 1);
+    for (const auto& arg : utf8_args)
+        utf8_argv.push_back(arg.c_str());
+    utf8_argv.push_back(nullptr);
+    const auto* argv = utf8_argv.data();
+#else
 int main(int argc, char* argv[]) {
+#endif
     const char* const loaded_core_stamp = lfs_core_abi_stamp();
     if (loaded_core_stamp == nullptr || !lfs_core_abi_matches(LFS_CORE_ABI_STAMP)) {
         std::println(stderr,

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -316,8 +316,9 @@ namespace {
                 std::format("Path does not exist: {}", lfs::core::path_to_utf8(view_path)));
         }
 
-        constexpr std::array<std::string_view, 13> SUPPORTED_EXTENSIONS = {
+        constexpr std::array<std::string_view, 17> SUPPORTED_EXTENSIONS = {
             ".ply", ".sog", ".spz", ".rad", ".resume",
+            ".usd", ".usda", ".usdc", ".usdz",
             ".obj", ".fbx", ".gltf", ".glb", ".stl", ".dae", ".3ds", ".blend"};
         const auto is_supported = [&](const std::filesystem::path& p) {
             auto ext = p.extension().string();

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -8,6 +8,7 @@
 #include "core/optimization_properties.hpp"
 #include "core/parameter_manager.hpp"
 #include "core/parameters.hpp"
+#include "core/path_utils.hpp"
 #include "core/property_registry.hpp"
 #include "io/project_path.hpp"
 
@@ -244,6 +245,78 @@ TEST(ArgumentParserTest, BarePositionalPlyAndLichtFollowViewFlag) {
     EXPECT_EQ(
         unpublished_parsed.error(),
         lfs::io::project::unpublishedLichtUserMessage(unpublished));
+}
+
+TEST(ArgumentParserTest, UsdFilesAcceptExplicitAndBareViewPaths) {
+    const auto directory = std::filesystem::temp_directory_path() / "lfs_arg_parser_usd" /
+                           std::filesystem::path(u8"splat \u00e8 \u6d4b\u8bd5");
+    std::filesystem::create_directories(directory);
+
+    // Parsing only routes paths; USD decoding is covered by UsdFormatTest.
+    for (const auto* extension : {".usd", ".usda", ".usdc", ".usdz",
+                                  ".USD", ".USDA", ".USDC", ".USDZ",
+                                  ".Usd", ".UsdA", ".UsdC", ".UsdZ"}) {
+        const auto path = directory / (std::string("model with spaces") + extension);
+        std::ofstream file(path);
+        file.put('\n');
+        file.close();
+        ASSERT_TRUE(file.good());
+        const auto path_text = lfs::core::path_to_utf8(path);
+
+        for (const auto* flag : {"-v", "--view", ""}) {
+            SCOPED_TRACE(path_text + " via " + (flag[0] ? flag : "bare path"));
+            std::vector<const char*> argv = {"LichtFeld-Studio"};
+            if (flag[0])
+                argv.push_back(flag);
+            argv.push_back(path_text.c_str());
+
+            auto parsed = lfs::core::args::parse_args_and_params(
+                static_cast<int>(argv.size()), argv.data());
+            ASSERT_TRUE(parsed) << parsed.error();
+            EXPECT_EQ((*parsed)->view_paths, std::vector<std::filesystem::path>{path});
+            EXPECT_FALSE((*parsed)->project_path);
+            EXPECT_FALSE((*parsed)->resume_checkpoint);
+            EXPECT_FALSE((*parsed)->resume_project);
+        }
+    }
+}
+
+TEST(ArgumentParserTest, ViewDirectoryIncludesUsdAndPreservesFiltering) {
+    const auto directory = std::filesystem::temp_directory_path() / "lfs_arg_parser_usd_directory";
+    std::filesystem::create_directories(directory);
+    std::vector<std::filesystem::path> expected;
+    for (const auto* name : {"d.usdz", "b.USDA", "c.UsdC", "a.usd", "f.ply", "e.obj"}) {
+        const auto path = directory / name;
+        std::ofstream file(path);
+        file.put('\n');
+        file.close();
+        ASSERT_TRUE(file.good());
+        expected.push_back(path);
+    }
+    const auto ignored_directory = directory / "nested.usd";
+    std::filesystem::create_directories(ignored_directory);
+    for (const auto& path : {directory / "notes.txt", directory / "project.licht",
+                             ignored_directory / "nested.usda"}) {
+        std::ofstream file(path);
+        file.put('\n');
+        file.close();
+        ASSERT_TRUE(file.good());
+    }
+    std::sort(expected.begin(), expected.end());
+    const auto path_text = lfs::core::path_to_utf8(directory);
+
+    for (const auto* flag : {"-v", "--view", ""}) {
+        SCOPED_TRACE(flag[0] ? flag : "bare directory");
+        std::vector<const char*> argv = {"LichtFeld-Studio"};
+        if (flag[0])
+            argv.push_back(flag);
+        argv.push_back(path_text.c_str());
+        auto parsed = lfs::core::args::parse_args_and_params(
+            static_cast<int>(argv.size()), argv.data());
+        ASSERT_TRUE(parsed) << parsed.error();
+        EXPECT_EQ((*parsed)->view_paths, expected);
+        EXPECT_FALSE((*parsed)->project_path);
+    }
 }
 
 TEST(ArgumentParserTest, GuiViewProjectExtensionIsCaseInsensitive) {


### PR DESCRIPTION
Opening a USD splat through a file association or the command line fails with
`Unsupported file format`, even though the existing importer supports it.

- Accept `.usd`, `.usda`, `.usdc` and `.usdz` through `-v`, `--view`, bare positional paths and directory imports.
- Use `wmain` on Windows and convert UTF-16 arguments to UTF-8 before parsing, preserving accented and non-Latin paths.
- Keep the existing Linux entry point and USD importer.
- Add parser regressions for extension case variations, spaces, Unicode paths, directory filtering and ordering.
- Preserve the separate `.licht` project flow.

Fixes https://github.com/MrNeRF/LichtFeld-Studio/issues/1750