### PR TITLE
Non-ASCII paths, arguments and environment survive on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,6 +593,7 @@ add_executable(${PROJECT_NAME}
     src/app/mcp_ui_registry_tools.cpp
     src/app/converter.cpp
     resources/lichtfeld-studio.rc
+    resources/lichtfeld-studio.manifest
 )
 
 # The binary only carries code for these architectures; the app refuses to start on anything

--- a/external/zep/src/filesystem.cpp
+++ b/external/zep/src/filesystem.cpp
@@ -1,6 +1,7 @@
 #include "zep/filesystem.h"
 #include "zep/editor.h" // FOR ZEP_UNUSED
 
+#include <cstdio>
 #include <fstream>
 
 #include "zep/mcommon/logger.h"
@@ -23,7 +24,7 @@ namespace Zep {
         // Use the config path
         m_configPath = configPath;
 
-        m_workingDirectory = fs::path(cpp_fs::current_path().string());
+        m_workingDirectory = cpp_fs::current_path();
 
         // Didn't find the config path, try the working directory
         if (!Exists(m_configPath)) {
@@ -42,7 +43,7 @@ namespace Zep {
             return;
         }
         // Set the file system's current working directory too.
-        cpp_fs::current_path(path.string());
+        cpp_fs::current_path(path);
         m_workingDirectory = path;
     }
 
@@ -62,11 +63,11 @@ namespace Zep {
         if (!Exists(path)) {
             return false;
         }
-        return cpp_fs::is_directory(path.string());
+        return cpp_fs::is_directory(path);
     }
 
     bool ZepFileSystemCPP::IsReadOnly(const fs::path& path) const {
-        auto perms = cpp_fs::status(path.string()).permissions();
+        auto perms = cpp_fs::status(path).permissions();
         if ((perms & cpp_fs::perms::owner_write) == cpp_fs::perms::owner_write) {
             return false;
         }
@@ -91,7 +92,11 @@ namespace Zep {
 
     bool ZepFileSystemCPP::Write(const fs::path& fileName, const void* pData, size_t size) {
         FILE* pFile;
+#ifdef _WIN32
+        pFile = _wfopen(fileName.wstring().c_str(), L"wb");
+#else
         pFile = fopen(fileName.string().c_str(), "wb");
+#endif
         if (!pFile) {
             return false;
         }
@@ -104,10 +109,10 @@ namespace Zep {
     }
 
     void ZepFileSystemCPP::ScanDirectory(const fs::path& path, std::function<bool(const fs::path& path, bool& dont_recurse)> fnScan) const {
-        for (auto itr = cpp_fs::recursive_directory_iterator(path.string());
+        for (auto itr = cpp_fs::recursive_directory_iterator(path);
              itr != cpp_fs::recursive_directory_iterator();
              itr++) {
-            auto p = fs::path(itr->path().string());
+            auto p = itr->path();
 
             bool recurse = true;
             if (!fnScan(p, recurse))
@@ -121,7 +126,7 @@ namespace Zep {
 
     bool ZepFileSystemCPP::Exists(const fs::path& path) const {
         try {
-            return cpp_fs::exists(path.string());
+            return cpp_fs::exists(path);
         } catch (cpp_fs::filesystem_error& err) {
             ZEP_UNUSED(err);
             ZLOG(ERROR, "Exception: " << err.what());
@@ -132,10 +137,10 @@ namespace Zep {
     bool ZepFileSystemCPP::Equivalent(const fs::path& path1, const fs::path& path2) const {
         try {
             // The below API expects existing files!  Best we can do is direct compare of paths
-            if (!cpp_fs::exists(path1.string()) || !cpp_fs::exists(path2.string())) {
-                return Canonical(path1).string() == Canonical(path2).string();
+            if (!cpp_fs::exists(path1) || !cpp_fs::exists(path2)) {
+                return Canonical(path1) == Canonical(path2);
             }
-            return cpp_fs::equivalent(path1.string(), path2.string());
+            return cpp_fs::equivalent(path1, path2);
         } catch (cpp_fs::filesystem_error& err) {
             ZEP_UNUSED(err);
             ZLOG(ERROR, "Exception: " << err.what());
@@ -148,9 +153,9 @@ namespace Zep {
 #ifdef __unix__
             // TODO: Remove when unix doesn't need <experimental/filesystem>
             // I can't remember why weakly_connical is used....
-            return fs::path(cpp_fs::canonical(path.string()).string());
+            return cpp_fs::canonical(path);
 #else
-            return fs::path(cpp_fs::weakly_canonical(path.string()).string());
+            return cpp_fs::weakly_canonical(path);
 #endif
         } catch (cpp_fs::filesystem_error& err) {
             ZEP_UNUSED(err);

--- a/resources/lichtfeld-studio.manifest
+++ b/resources/lichtfeld-studio.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Compatibility aid; path correctness still comes from the wide APIs below. -->
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -8,6 +8,7 @@
 #include "core/argument_parser.hpp"
 #include "core/crash_handler.hpp"
 #include "core/cuda_error.hpp"
+#include "core/environment.hpp"
 #include "core/executable_path.hpp"
 #include "core/logger.hpp"
 #include "core/path_utils.hpp"
@@ -48,11 +49,7 @@ namespace {
         const auto publish = [](const char* const name,
                                 const std::filesystem::path& path) {
             const auto value = lfs::core::path_to_utf8(path);
-#ifdef _WIN32
-            (void)_putenv_s(name, value.c_str());
-#else
-            (void)setenv(name, value.c_str(), 1);
-#endif
+            (void)lfs::core::environment::set_value(name, value);
         };
         publish("LFS_RESOLVED_CONFIG_DIR", paths->configDir());
         publish("LFS_RESOLVED_DATA_DIR", paths->dataDir());

--- a/src/core/cuda_error.cpp
+++ b/src/core/cuda_error.cpp
@@ -587,9 +587,12 @@ namespace lfs::core {
 
     unsigned diagnostic_modes() noexcept {
         static const unsigned modes = [] {
+            const auto sync_debug_value = environment::value("LFS_CUDA_SYNC_DEBUG");
+            const auto vk_validation_fatal_value = environment::value("LFS_VK_VALIDATION_FATAL");
             const ParsedDiagnosticModes parsed = parse_diagnostic_modes(
-                environment::value("LFS_CUDA_SYNC_DEBUG"),
-                environment::value("LFS_VK_VALIDATION_FATAL"));
+                sync_debug_value ? std::optional<std::string_view>{*sync_debug_value} : std::nullopt,
+                vk_validation_fatal_value ? std::optional<std::string_view>{*vk_validation_fatal_value}
+                                          : std::nullopt);
             try {
                 if (parsed.legacy_alias_present) {
                     std::fprintf(

--- a/src/core/environment.cpp
+++ b/src/core/environment.cpp
@@ -1,0 +1,67 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/environment.hpp"
+#include "core/path_utils.hpp"
+
+#include <cstdlib>
+#include <exception>
+#include <utility>
+
+namespace lfs::core::environment {
+
+    std::optional<std::string> value(const char* const name) noexcept {
+        if (name == nullptr || *name == '\0') {
+            return std::nullopt;
+        }
+        try {
+#ifdef _WIN32
+            const auto wide_name = utf8_to_wstring(std::string(name));
+            std::wstring wide_value(256, L'\0');
+            for (;;) {
+                const DWORD length = GetEnvironmentVariableW(
+                    wide_name.c_str(), wide_value.data(), static_cast<DWORD>(wide_value.size()));
+                if (length == 0) {
+                    return std::nullopt;
+                }
+                if (length < wide_value.size()) {
+                    wide_value.resize(length);
+                    break;
+                }
+                wide_value.resize(static_cast<std::size_t>(length) + 1);
+            }
+
+            auto result = wstring_to_utf8(wide_value);
+            return result.empty() ? std::nullopt : std::optional<std::string>{std::move(result)};
+#else
+            const char* const raw = std::getenv(name);
+            if (!raw || *raw == '\0') {
+                return std::nullopt;
+            }
+            return std::string(raw);
+#endif
+        } catch (const std::exception&) {
+            // LFS-CENSUS-OK(empty-catch): environment lookup must remain noexcept.
+            return std::nullopt;
+        }
+    }
+
+    bool set_value(const std::string_view name, const std::string_view utf8_value) noexcept {
+        if (name.empty()) {
+            return false;
+        }
+        try {
+#ifdef _WIN32
+            const auto wide_name = utf8_to_wstring(std::string(name));
+            const auto wide_value = utf8_to_wstring(std::string(utf8_value));
+            return _wputenv_s(wide_name.c_str(), wide_value.c_str()) == 0;
+#else
+            return ::setenv(std::string(name).c_str(), std::string(utf8_value).c_str(), 1) == 0;
+#endif
+        } catch (const std::exception&) {
+            // LFS-CENSUS-OK(empty-catch): environment writes must remain noexcept.
+            return false;
+        }
+    }
+
+} // namespace lfs::core::environment

--- a/src/core/include/core/environment.hpp
+++ b/src/core/include/core/environment.hpp
@@ -3,21 +3,20 @@
 
 #pragma once
 
+#include "core/export.hpp"
+
 #include <charconv>
 #include <concepts>
-#include <cstdlib>
 #include <optional>
+#include <string>
 #include <string_view>
 
 namespace lfs::core::environment {
 
-    [[nodiscard]] inline std::optional<std::string_view> value(const char* const name) noexcept {
-        const char* const raw = std::getenv(name);
-        if (!raw || *raw == '\0') {
-            return std::nullopt;
-        }
-        return std::string_view(raw);
-    }
+    [[nodiscard]] LFS_LOGGER_API std::optional<std::string> value(const char* name) noexcept;
+
+    [[nodiscard]] LFS_LOGGER_API bool set_value(std::string_view name,
+                                                std::string_view utf8_value) noexcept;
 
     namespace detail {
         [[nodiscard]] inline bool equals_ignore_ascii_case(const std::string_view lhs,

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/logger.hpp"
+#include "core/environment.hpp"
+#include "core/path_utils.hpp"
 #include "diagnostics/vram_profiler.hpp"
 #include <array>
 #include <cstdio>
@@ -23,7 +25,7 @@
 #else
 #include <unistd.h>
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 #define FMT_UNICODE 0
 #endif
 #include <spdlog/sinks/base_sink.h>
@@ -47,17 +49,17 @@ namespace lfs::core {
 
     std::filesystem::path lichtfeld_home_directory() {
 #ifdef _WIN32
-        if (const char* profile = std::getenv("USERPROFILE"); profile && profile[0])
-            return std::filesystem::path(profile);
-        const char* drive = std::getenv("HOMEDRIVE");
-        const char* homepath = std::getenv("HOMEPATH");
-        if (drive && drive[0] && homepath && homepath[0])
-            return std::filesystem::path(std::string(drive) + homepath);
-        if (const char* home = std::getenv("HOME"); home && home[0])
-            return std::filesystem::path(home);
+        if (const auto profile = environment::value("USERPROFILE"))
+            return utf8_to_path(*profile);
+        const auto drive = environment::value("HOMEDRIVE");
+        const auto homepath = environment::value("HOMEPATH");
+        if (drive && homepath)
+            return utf8_to_path(*drive + *homepath);
+        if (const auto home = environment::value("HOME"))
+            return utf8_to_path(*home);
 #else
-        if (const char* home = std::getenv("HOME"); home && home[0])
-            return std::filesystem::path(home);
+        if (const auto home = environment::value("HOME"))
+            return utf8_to_path(*home);
 #endif
         return std::filesystem::temp_directory_path();
     }
@@ -447,7 +449,7 @@ namespace lfs::core {
 
         fs::path resolve_default_log_directory(const std::string& user_dir_override) {
             if (!user_dir_override.empty())
-                return fs::path(user_dir_override) / "logs";
+                return utf8_to_path(user_dir_override) / "logs";
             return lichtfeld_home_directory() / ".lichtfeld" / "logs";
         }
 
@@ -456,8 +458,9 @@ namespace lfs::core {
         }
 
         std::shared_ptr<spdlog::sinks::rotating_file_sink_mt> make_rotating_file_sink(const fs::path& path) {
+            const auto filename = path_to_utf8(path);
             auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-                path.string(), DEFAULT_LOG_ROTATION_MAX_BYTES, DEFAULT_LOG_ROTATION_MAX_FILES);
+                filename, DEFAULT_LOG_ROTATION_MAX_BYTES, DEFAULT_LOG_ROTATION_MAX_FILES);
             sink->set_level(spdlog::level::trace);
             sink->set_pattern(DEFAULT_LOG_FILE_PATTERN);
             return sink;
@@ -471,14 +474,14 @@ namespace lfs::core {
             fs::create_directories(path.parent_path(), ec);
             if (ec) {
                 std::fprintf(stderr, "lichtfeld: could not create log directory '%s': %s\n",
-                             path.parent_path().string().c_str(), ec.message().c_str());
+                             path_to_utf8(path.parent_path()).c_str(), ec.message().c_str());
                 return nullptr;
             }
             try {
                 return make_rotating_file_sink(path);
             } catch (const std::exception& e) {
                 std::fprintf(stderr, "lichtfeld: could not open default log file '%s': %s\n",
-                             path.string().c_str(), e.what());
+                             path_to_utf8(path).c_str(), e.what());
                 return nullptr;
             }
         }
@@ -576,7 +579,7 @@ namespace lfs::core {
         }
 
         if (!log_file.empty()) {
-            const fs::path explicit_path(log_file);
+            const fs::path explicit_path = utf8_to_path(log_file);
             if (!default_sink_added || !same_log_target(default_log_path, explicit_path)) {
                 sinks.push_back(make_rotating_file_sink(explicit_path));
             }

--- a/src/core/logger/CMakeLists.txt
+++ b/src/core/logger/CMakeLists.txt
@@ -6,11 +6,14 @@
 
 add_library(lfs_logger SHARED
     ../logger.cpp
+    ../environment.cpp
 )
 
 target_include_directories(lfs_logger
     PUBLIC
         ${CMAKE_SOURCE_DIR}/src/core/include
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
 )
 
 target_link_libraries(lfs_logger

--- a/src/core/path_utils.hpp
+++ b/src/core/path_utils.hpp
@@ -5,10 +5,12 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <vector>
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -307,6 +309,14 @@ namespace lfs::core {
 #endif
     }
 
+    inline std::string path_to_generic_utf8(const std::filesystem::path& p) {
+#ifdef _WIN32
+        return wstring_to_utf8(p.generic_wstring());
+#else
+        return p.generic_string();
+#endif
+    }
+
     /**
      * @brief Convert UTF-8 string to filesystem path
      *
@@ -329,6 +339,45 @@ namespace lfs::core {
         // On Linux/Mac, native encoding is UTF-8, so use string directly
         // Also handle embedded nulls by using c_str()
         return std::filesystem::path(utf8_str.c_str());
+#endif
+    }
+
+    /**
+     * @brief Copy process arguments into a UTF-8 representation.
+     *
+     * Windows applications must enter through wmain so the CRT does not first
+     * decode arguments using the active code page. Linux keeps its native argv
+     * surface and simply copies it into the same representation.
+     */
+    inline std::vector<std::string> utf8_argv(int argc, char* argv[]) {
+        std::vector<std::string> result;
+        result.reserve(argc > 0 ? static_cast<std::size_t>(argc) : 0);
+        for (int i = 0; i < argc; ++i) {
+            result.emplace_back(argv[i] != nullptr ? argv[i] : "");
+        }
+        return result;
+    }
+
+#ifdef _WIN32
+    inline std::vector<std::string> utf8_argv(int argc, wchar_t* argv[]) {
+        std::vector<std::string> result;
+        result.reserve(argc > 0 ? static_cast<std::size_t>(argc) : 0);
+        for (int i = 0; i < argc; ++i) {
+            result.emplace_back(argv[i] != nullptr ? wstring_to_utf8(argv[i]) : std::string{});
+        }
+        return result;
+    }
+#endif
+
+    /**
+     * @brief Open a C stdio file using a filesystem path without an ACP round trip.
+     */
+    inline std::FILE* open_file(const std::filesystem::path& path, const char* mode) {
+#ifdef _WIN32
+        const auto wide_mode = utf8_to_wstring(mode != nullptr ? std::string(mode) : std::string{});
+        return wide_mode.empty() ? nullptr : _wfopen(path.wstring().c_str(), wide_mode.c_str());
+#else
+        return std::fopen(path.c_str(), mode);
 #endif
     }
 

--- a/src/core/session_breadcrumb.cpp
+++ b/src/core/session_breadcrumb.cpp
@@ -5,6 +5,7 @@
 #include "core/session_breadcrumb.hpp"
 
 #include "core/logger.hpp"
+#include "core/path_utils.hpp"
 #include "core/user_paths.hpp"
 #include "core/utc_time.hpp"
 
@@ -58,8 +59,8 @@ namespace lfs::core {
 
         std::optional<SessionBreadcrumb> decode_record(const fs::path& path) {
             try {
-                std::ifstream input(path);
-                if (!input)
+                std::ifstream input;
+                if (!open_file_for_read(path, input))
                     return std::nullopt;
                 json value;
                 input >> value;
@@ -92,8 +93,8 @@ namespace lfs::core {
         }
 
         std::string read_log_tail(const fs::path& path) {
-            std::ifstream input(path, std::ios::binary | std::ios::ate);
-            if (!input)
+            std::ifstream input;
+            if (!open_file_for_read(path, std::ios::binary | std::ios::ate, input))
                 return {};
             const auto end = input.tellg();
             if (end <= 0)
@@ -119,7 +120,7 @@ namespace lfs::core {
         bool snapshot_previous_log(const std::string& live_log_path) {
             if (live_log_path.empty())
                 return false;
-            const std::string tail = read_log_tail(fs::path(live_log_path));
+            const std::string tail = read_log_tail(utf8_to_path(live_log_path));
             if (tail.empty())
                 return false;
             return write_atomically(snapshot_path(), tail);
@@ -134,7 +135,7 @@ namespace lfs::core {
             if (previous_record && !previous_record->clean_exit) {
                 try {
                     if (snapshot_previous_log(previous_record->log_path))
-                        previous_record->log_path = snapshot_path().string();
+                        previous_record->log_path = path_to_utf8(snapshot_path());
                     else
                         previous_record->log_path.clear();
                 } catch (...) {
@@ -152,7 +153,7 @@ namespace lfs::core {
             current_record = SessionBreadcrumb{
                 .pid = process_id(),
                 .started_at = utc_now(),
-                .log_path = live_log_path.string(),
+                .log_path = path_to_utf8(live_log_path),
                 .clean_exit = false,
             };
             static_cast<void>(write_record(breadcrumb_path(), *current_record));

--- a/src/core/user_paths.cpp
+++ b/src/core/user_paths.cpp
@@ -45,7 +45,7 @@ namespace lfs::core {
 
         [[nodiscard]] std::optional<std::filesystem::path> environmentPath(const char* const name) {
             if (const auto value = environment::value(name))
-                return utf8_to_path(std::string(*value));
+                return utf8_to_path(*value);
             return std::nullopt;
         }
 

--- a/src/io/include/io/atomic_output.hpp
+++ b/src/io/include/io/atomic_output.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
 #include "core/path_utils.hpp"
+#include "io/atomic_output_path.hpp"
 #include "io/error.hpp"
 #include "io/exporter.hpp"
 
-#include <atomic>
 #include <cerrno>
-#include <chrono>
 #include <cstring>
 #include <filesystem>
 #include <format>
@@ -24,11 +23,6 @@
 
 namespace lfs::io {
 
-    enum class AtomicOutputTempName {
-        AppendSuffix,
-        PreserveExtension
-    };
-
     enum class AtomicOutputDurability {
         Atomic,
         Durable
@@ -42,28 +36,6 @@ namespace lfs::io {
 
     using AtomicOutputCommitObserver = std::function<void(AtomicOutputCommitStage)>;
 
-    inline std::filesystem::path make_atomic_temp_output_path(
-        const std::filesystem::path& output_path,
-        AtomicOutputTempName name_style = AtomicOutputTempName::AppendSuffix) {
-        static std::atomic_uint64_t counter{0};
-
-        const auto ticks = std::chrono::steady_clock::now().time_since_epoch().count();
-#ifdef _WIN32
-        const auto process_id = GetCurrentProcessId();
-#else
-        const auto process_id = ::getpid();
-#endif
-        const auto unique_suffix =
-            std::format(".{}.{}.{}.tmp", ticks, process_id, counter.fetch_add(1, std::memory_order_relaxed));
-
-        if (name_style == AtomicOutputTempName::PreserveExtension && output_path.has_extension()) {
-            const auto temp_name = output_path.stem().string() + unique_suffix + output_path.extension().string();
-            return output_path.parent_path() / temp_name;
-        }
-
-        return output_path.string() + unique_suffix;
-    }
-
     inline Result<void> ensure_output_parent_directory(const std::filesystem::path& output_path) {
         if (output_path.parent_path().empty()) {
             return {};
@@ -74,7 +46,7 @@ namespace lfs::io {
         if (ec) {
             return std::unexpected(Error{
                 ErrorCode::WRITE_FAILURE,
-                std::format("Failed to create output directory '{}': {}", output_path.parent_path().string(), ec.message())});
+                std::format("Failed to create output directory '{}': {}", core::path_to_utf8(output_path.parent_path()), ec.message())});
         }
 
         return {};
@@ -94,7 +66,7 @@ namespace lfs::io {
                 return std::unexpected(Error{
                     ErrorCode::WRITE_FAILURE,
                     std::format("Failed to open temporary output '{}' for durable flush: Windows error {}",
-                                path.string(), GetLastError())});
+                                core::path_to_utf8(path), GetLastError())});
             }
             if (!FlushFileBuffers(handle)) {
                 const auto error = GetLastError();
@@ -102,7 +74,7 @@ namespace lfs::io {
                 return std::unexpected(Error{
                     ErrorCode::WRITE_FAILURE,
                     std::format("Failed to flush temporary output '{}': Windows error {}",
-                                path.string(), error)});
+                                core::path_to_utf8(path), error)});
             }
             CloseHandle(handle);
 #else
@@ -111,7 +83,7 @@ namespace lfs::io {
                 return std::unexpected(Error{
                     ErrorCode::WRITE_FAILURE,
                     std::format("Failed to open temporary output '{}' for durable flush: {}",
-                                path.string(), std::strerror(errno))});
+                                core::path_to_utf8(path), std::strerror(errno))});
             }
             if (::fsync(fd) != 0) {
                 const int error = errno;
@@ -119,13 +91,13 @@ namespace lfs::io {
                 return std::unexpected(Error{
                     ErrorCode::WRITE_FAILURE,
                     std::format("Failed to flush temporary output '{}': {}",
-                                path.string(), std::strerror(error))});
+                                core::path_to_utf8(path), std::strerror(error))});
             }
             if (::close(fd) != 0) {
                 return std::unexpected(Error{
                     ErrorCode::WRITE_FAILURE,
                     std::format("Failed to close temporary output '{}' after durable flush: {}",
-                                path.string(), std::strerror(errno))});
+                                core::path_to_utf8(path), std::strerror(errno))});
             }
 #endif
             return {};
@@ -144,7 +116,7 @@ namespace lfs::io {
                 return std::unexpected(Error{
                     ErrorCode::WRITE_FAILURE,
                     std::format("Failed to open output directory '{}' for durable flush: {}",
-                                parent.string(), std::strerror(errno))});
+                                core::path_to_utf8(parent), std::strerror(errno))});
             }
             if (::fsync(fd) != 0) {
                 const int error = errno;
@@ -152,13 +124,13 @@ namespace lfs::io {
                 return std::unexpected(Error{
                     ErrorCode::WRITE_FAILURE,
                     std::format("Failed to flush output directory '{}': {}",
-                                parent.string(), std::strerror(error))});
+                                core::path_to_utf8(parent), std::strerror(error))});
             }
             if (::close(fd) != 0) {
                 return std::unexpected(Error{
                     ErrorCode::WRITE_FAILURE,
                     std::format("Failed to close output directory '{}' after durable flush: {}",
-                                parent.string(), std::strerror(errno))});
+                                core::path_to_utf8(parent), std::strerror(errno))});
             }
             return {};
 #endif
@@ -189,7 +161,7 @@ namespace lfs::io {
             return std::unexpected(Error{
                 ErrorCode::WRITE_FAILURE,
                 std::format("Failed to replace '{}' with temporary export '{}': Windows error {}",
-                            output_path.string(), temp_path.string(), GetLastError())});
+                            core::path_to_utf8(output_path), core::path_to_utf8(temp_path), GetLastError())});
         }
 #else
         std::error_code ec;
@@ -198,7 +170,7 @@ namespace lfs::io {
             return std::unexpected(Error{
                 ErrorCode::WRITE_FAILURE,
                 std::format("Failed to replace '{}' with temporary export '{}': {}",
-                            output_path.string(), temp_path.string(), ec.message())});
+                            core::path_to_utf8(output_path), core::path_to_utf8(temp_path), ec.message())});
         }
 #endif
 

--- a/src/io/include/io/atomic_output_path.hpp
+++ b/src/io/include/io/atomic_output_path.hpp
@@ -1,0 +1,53 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <format>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace lfs::io {
+
+    enum class AtomicOutputTempName {
+        AppendSuffix,
+        PreserveExtension
+    };
+
+    inline std::filesystem::path make_atomic_temp_output_path(
+        const std::filesystem::path& output_path,
+        AtomicOutputTempName name_style = AtomicOutputTempName::AppendSuffix) {
+        static std::atomic_uint64_t counter{0};
+
+        const auto ticks = std::chrono::steady_clock::now().time_since_epoch().count();
+#ifdef _WIN32
+        const auto process_id = GetCurrentProcessId();
+#else
+        const auto process_id = ::getpid();
+#endif
+        const auto unique_suffix =
+            std::format(".{}.{}.{}.tmp", ticks, process_id, counter.fetch_add(1, std::memory_order_relaxed));
+
+        if (name_style == AtomicOutputTempName::PreserveExtension && output_path.has_extension()) {
+            auto temp_name = output_path.stem();
+            temp_name += unique_suffix;
+            temp_name += output_path.extension();
+            return output_path.parent_path() / temp_name;
+        }
+
+        auto temporary = output_path;
+        temporary += unique_suffix;
+        return temporary;
+    }
+
+} // namespace lfs::io

--- a/src/io/ply_to_rad_lod.cpp
+++ b/src/io/ply_to_rad_lod.cpp
@@ -624,7 +624,7 @@ namespace lfs::io {
 
         [[nodiscard]] bool write_bucket_nodes(const std::filesystem::path& path, const BucketNodes& nodes,
                                               const int rest_coeffs) {
-            FilePtr f(std::fopen(path.string().c_str(), "wb"));
+            FilePtr f(lfs::core::open_file(path, "wb"));
             if (!f) {
                 return false;
             }
@@ -1286,7 +1286,7 @@ namespace lfs::io {
             std::vector<FilePtr> bucket_files(bucket_count);
             std::vector<std::mutex> bucket_mutexes(bucket_count);
             for (std::size_t b = 0; b < bucket_count; ++b) {
-                bucket_files[b].reset(std::fopen(bucket_records_path(b).string().c_str(), "wb"));
+                bucket_files[b].reset(lfs::core::open_file(bucket_records_path(b), "wb"));
                 if (!bucket_files[b]) {
                     return make_error(ErrorCode::WRITE_FAILURE,
                                       std::format("Failed to create bucket file: {}", std::strerror(errno)),
@@ -1465,7 +1465,7 @@ namespace lfs::io {
                     {
                         const std::size_t packed_record_bytes = scatter_record_bytes(record_floats);
                         std::vector<std::uint8_t> packed(count * packed_record_bytes);
-                        FilePtr f(std::fopen(bucket_records_path(b).string().c_str(), "rb"));
+                        FilePtr f(lfs::core::open_file(bucket_records_path(b), "rb"));
                         if (!f || !read_exact(f.get(), packed.data(), packed.size())) {
                             fail(std::format("failed to read bucket records {}: {}", b, std::strerror(errno)));
                             return;
@@ -1785,7 +1785,7 @@ namespace lfs::io {
         // local level order, so each file is read front to back.
         std::vector<FilePtr> node_files(bucket_count);
         for (std::size_t b = 0; b < bucket_count; ++b) {
-            node_files[b].reset(std::fopen(bucket_nodes_path(b).string().c_str(), "rb"));
+            node_files[b].reset(lfs::core::open_file(bucket_nodes_path(b), "rb"));
             std::uint64_t n = 0;
             if (!node_files[b] || !read_exact(node_files[b].get(), &n, sizeof(n)) ||
                 n != summaries[b].node_count) {

--- a/src/io/project/project_chapters.cpp
+++ b/src/io/project/project_chapters.cpp
@@ -678,7 +678,7 @@ namespace lfs::io::project {
                         "REFS", "fingerprint");
                 }
                 Entry entry{
-                    .path = lfs::core::path_to_utf8(relative.generic_string()),
+                    .path = lfs::core::path_to_generic_utf8(relative),
                     .size = 0,
                     .kind = std::filesystem::is_directory(status)
                                 ? 'd'
@@ -1882,8 +1882,8 @@ namespace lfs::io::project {
             if (relative.empty() || relative == ".") {
                 return true;
             }
-            const auto text = relative.generic_string();
-            return !text.starts_with("..");
+            const auto first = relative.begin();
+            return first == relative.end() || *first != std::filesystem::path("..");
         }
 
         bool fingerprint_content_matches(
@@ -1978,10 +1978,10 @@ namespace lfs::io::project {
             const auto root = absolute_lexically(project_root);
             if (path_is_under(root, absolute)) {
                 const auto relative = absolute.lexically_relative(root);
+                const auto first = relative.begin();
                 if (!relative.empty() && relative != "." &&
-                    !relative.generic_string().starts_with("..")) {
-                    locator.preferred =
-                        lfs::core::path_to_utf8(relative.generic_string());
+                    (first == relative.end() || *first != std::filesystem::path(".."))) {
+                    locator.preferred = lfs::core::path_to_generic_utf8(relative);
                     locator.base = LocatorBase::Project;
                 }
             }
@@ -3390,7 +3390,7 @@ namespace lfs::io::project {
                 const bool valid_kind = kind == "image" || kind == "mask" ||
                                         kind == "depth" || kind == "normal" ||
                                         kind == "sparse" || kind == "meta";
-                const auto relative = std::filesystem::path(rel_path);
+                const auto relative = lfs::core::utf8_to_path(rel_path);
                 if (rel_path.empty() || kind.empty() || !uuid || uuid->is_nil() ||
                     !hash || !valid_kind || relative.is_absolute() ||
                     relative.lexically_normal() != relative ||
@@ -3432,7 +3432,7 @@ namespace lfs::io::project {
             const bool valid_kind = entry.kind == "image" || entry.kind == "mask" ||
                                     entry.kind == "depth" || entry.kind == "normal" ||
                                     entry.kind == "sparse" || entry.kind == "meta";
-            const auto relative = std::filesystem::path(entry.rel_path);
+            const auto relative = lfs::core::utf8_to_path(entry.rel_path);
             if (entry.rel_path.empty() || entry.chunk_uuid.is_nil() ||
                 !valid_kind || relative.is_absolute() ||
                 relative.lexically_normal() != relative ||

--- a/src/io/project/project_file.cpp
+++ b/src/io/project/project_file.cpp
@@ -414,7 +414,7 @@ namespace lfs::io::project::detail {
         }
         return static_cast<std::uint64_t>(size.QuadPart);
 #else
-        struct stat status {};
+        struct stat status{};
         if (::fstat(fd_, &status) != 0 || status.st_size < 0) {
             const int error = errno;
             return project_error(native_error_code(error, false),
@@ -690,7 +690,7 @@ namespace lfs::io::project::detail {
 #ifndef _WIN32
     lfs::Result<bool> writer_lock_fd_matches_path(
         const int fd, const std::filesystem::path& lock_path) {
-        struct stat fd_status {};
+        struct stat fd_status{};
         if (::fstat(fd, &fd_status) != 0) {
             const int error = errno;
             return project_error(
@@ -699,7 +699,7 @@ namespace lfs::io::project::detail {
                 std::format("lockfile fstat failed: {}", std::strerror(error)), lock_path,
                 std::nullopt, "writer_lock", error, std::strerror(error));
         }
-        struct stat path_status {};
+        struct stat path_status{};
         if (::stat(lock_path.c_str(), &path_status) != 0 ||
             fd_status.st_dev != path_status.st_dev ||
             fd_status.st_ino != path_status.st_ino) {
@@ -845,10 +845,14 @@ namespace lfs::io::project::detail {
             std::format(".{}.{}.{}.{}.tmp", tag, ticks, process_id,
                         counter.fetch_add(1, std::memory_order_relaxed));
         if (destination.has_extension()) {
-            return destination.parent_path() /
-                   (destination.stem().string() + suffix + destination.extension().string());
+            auto temp_name = destination.stem();
+            temp_name += suffix;
+            temp_name += destination.extension();
+            return destination.parent_path() / temp_name;
         }
-        return std::filesystem::path(destination.string() + suffix);
+        auto temporary = destination;
+        temporary += suffix;
+        return temporary;
     }
 
     lfs::Result<void> ensure_parent_directory(const std::filesystem::path& path) {

--- a/src/preprocessing/preprocess.cpp
+++ b/src/preprocessing/preprocess.cpp
@@ -5,6 +5,7 @@
 #include "preprocessing/preprocess.hpp"
 
 #include "core/cuda_error.hpp"
+#include "core/environment.hpp"
 #include "core/image_io.hpp"
 #include "core/logger.hpp"
 #include "core/nn/models/moge2.hpp"
@@ -144,15 +145,15 @@ namespace {
 
     fs::path home_directory() {
 #ifdef _WIN32
-        if (const char* profile = std::getenv("USERPROFILE"); profile && profile[0])
-            return fs::path(profile);
-        const char* drive = std::getenv("HOMEDRIVE");
-        const char* homepath = std::getenv("HOMEPATH");
-        if (drive && drive[0] && homepath && homepath[0])
-            return fs::path(std::string(drive) + homepath);
+        if (const auto profile = lfs::core::environment::value("USERPROFILE"))
+            return lfs::core::utf8_to_path(*profile);
+        const auto drive = lfs::core::environment::value("HOMEDRIVE");
+        const auto homepath = lfs::core::environment::value("HOMEPATH");
+        if (drive && homepath)
+            return lfs::core::utf8_to_path(*drive + *homepath);
 #else
-        if (const char* home = std::getenv("HOME"); home && home[0])
-            return fs::path(home);
+        if (const auto home = lfs::core::environment::value("HOME"))
+            return lfs::core::utf8_to_path(*home);
 #endif
         return fs::temp_directory_path();
     }
@@ -172,8 +173,8 @@ namespace {
     }
 
     fs::path find_nn_export_script() {
-        if (const char* env = std::getenv("LFS_NN_EXPORT"); env && env[0])
-            return fs::path(env);
+        if (const auto env = lfs::core::environment::value("LFS_NN_EXPORT"))
+            return lfs::core::utf8_to_path(*env);
         std::error_code ec;
         std::vector<fs::path> roots;
 #ifdef __linux__
@@ -197,8 +198,8 @@ namespace {
     }
 
     fs::path find_python_for_export(const fs::path& script) {
-        if (const char* env = std::getenv("LFS_PYTHON"); env && env[0])
-            return fs::path(env);
+        if (const auto env = lfs::core::environment::value("LFS_PYTHON"))
+            return lfs::core::utf8_to_path(*env);
         if (!script.empty()) {
             const auto vcpkg = script.parent_path().parent_path().parent_path() / "build" /
                                "vcpkg_installed" / "x64-linux" / "tools" / "python3" / "python3";
@@ -219,12 +220,18 @@ namespace {
                 " --fp16 --moge2");
         }
         const auto python = find_python_for_export(script);
-        const fs::path tmp = lfw_path.string() + ".tmp";
-        const std::string cmd = path_to_string(python) + " " + path_to_string(script) +
-                                " --onnx " + path_to_string(onnx_path) + " --out " +
-                                path_to_string(tmp) + " --fp16 --moge2";
+        fs::path tmp = lfw_path;
+        tmp += ".tmp";
+        const std::string cmd =
+            path_to_string(python) + " " + path_to_string(script) +
+            " --onnx " + path_to_string(onnx_path) + " --out " +
+            path_to_string(tmp) + " --fp16 --moge2";
         std::cout << "Converting ONNX weights to " << path_to_string(lfw_path) << "\n";
+#ifdef _WIN32
+        const int rc = _wsystem(lfs::core::utf8_to_wstring(cmd).c_str());
+#else
         const int rc = std::system(cmd.c_str());
+#endif
         if (rc != 0 || !fs::is_regular_file(tmp)) {
             remove_file_if_exists(tmp);
             throw std::runtime_error(
@@ -237,17 +244,17 @@ namespace {
     fs::path legacy_model_path() {
         fs::path root;
 #ifdef _WIN32
-        if (const char* local = std::getenv("LOCALAPPDATA"); local && local[0])
-            root = fs::path(local) / "LichtFeld";
-        else if (const char* temp = std::getenv("TEMP"); temp && temp[0])
-            root = fs::path(temp) / "LichtFeld";
+        if (const auto local = lfs::core::environment::value("LOCALAPPDATA"))
+            root = lfs::core::utf8_to_path(*local) / "LichtFeld";
+        else if (const auto temp = lfs::core::environment::value("TEMP"))
+            root = lfs::core::utf8_to_path(*temp) / "LichtFeld";
         else
             root = fs::temp_directory_path() / "LichtFeld";
 #else
-        if (const char* xdg = std::getenv("XDG_CACHE_HOME"); xdg && xdg[0])
-            root = fs::path(xdg) / "lichtfeld";
-        else if (const char* home = std::getenv("HOME"); home && home[0])
-            root = fs::path(home) / ".cache" / "lichtfeld";
+        if (const auto xdg = lfs::core::environment::value("XDG_CACHE_HOME"))
+            root = lfs::core::utf8_to_path(*xdg) / "lichtfeld";
+        else if (const auto home = lfs::core::environment::value("HOME"))
+            root = lfs::core::utf8_to_path(*home) / ".cache" / "lichtfeld";
         else
             root = fs::temp_directory_path() / "lichtfeld";
 #endif
@@ -372,9 +379,11 @@ namespace {
                                 const fs::path& destination,
                                 std::string_view expected_hash) {
         fs::create_directories(destination.parent_path());
-        const fs::path tmp_path = destination.string() + ".tmp";
+        fs::path tmp_path = destination;
+        tmp_path += ".tmp";
 
-        std::ofstream output(tmp_path, std::ios::binary | std::ios::trunc);
+        std::ofstream output;
+        lfs::core::open_file_for_write(tmp_path, std::ios::binary | std::ios::trunc, output);
         if (!output)
             throw std::runtime_error("Could not open " + path_to_string(tmp_path) + " for writing");
 
@@ -593,8 +602,9 @@ namespace {
                              const fs::path& image_path,
                              const fs::path& images_dir) {
         fs::path rel = image_path.lexically_relative(images_dir);
-        const auto generic = rel.generic_string();
-        if (rel.empty() || generic == "." || generic == ".." || generic.starts_with("../")) {
+        const auto first = rel.begin();
+        if (rel.empty() || rel == "." || rel == ".." ||
+            (first != rel.end() && *first == fs::path(".."))) {
             rel = image_path.filename();
         }
         rel.replace_extension(".png");

--- a/src/python/lfs_plugins/dev_setup.py
+++ b/src/python/lfs_plugins/dev_setup.py
@@ -98,7 +98,9 @@ def _generate_vscode_config(
         "python.analysis.extraPaths": extra_paths,
         "python.analysis.typeCheckingMode": "basic",
     }
-    (vscode_dir / "settings.json").write_text(json.dumps(settings, indent=4) + "\n")
+    (vscode_dir / "settings.json").write_text(
+        json.dumps(settings, indent=4, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
 
     pyright = {
         "include": ["."],
@@ -108,7 +110,9 @@ def _generate_vscode_config(
         "venvPath": str(plugin_dir),
         "venv": ".venv",
     }
-    (plugin_dir / "pyrightconfig.json").write_text(json.dumps(pyright, indent=4) + "\n")
+    (plugin_dir / "pyrightconfig.json").write_text(
+        json.dumps(pyright, indent=4, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
 
     launch = {
         "version": "0.2.0",
@@ -121,4 +125,6 @@ def _generate_vscode_config(
             }
         ],
     }
-    (vscode_dir / "launch.json").write_text(json.dumps(launch, indent=4) + "\n")
+    (vscode_dir / "launch.json").write_text(
+        json.dumps(launch, indent=4, ensure_ascii=False) + "\n", encoding="utf-8"
+    )

--- a/src/python/lfs_plugins/installer.py
+++ b/src/python/lfs_plugins/installer.py
@@ -278,7 +278,7 @@ def write_plugin_source_metadata(plugin_dir: Path, info: PluginSourceInfo) -> No
     """Persist install-source metadata next to an installed plugin."""
     path = plugin_source_metadata_path(plugin_dir)
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(info.to_dict(), f, indent=2)
+        json.dump(info.to_dict(), f, indent=2, ensure_ascii=False)
 
 
 def is_git_available() -> bool:

--- a/src/python/lfs_plugins/registry.py
+++ b/src/python/lfs_plugins/registry.py
@@ -160,7 +160,7 @@ class RegistryClient:
 
         if cache_path.exists() and self._cache_is_fresh(cache_path):
             try:
-                with open(cache_path) as f:
+                with open(cache_path, encoding="utf-8") as f:
                     return json.load(f)
             except Exception as exc:
                 _log.debug("Ignoring invalid registry cache '%s': %s", cache_path, exc)
@@ -179,7 +179,7 @@ class RegistryClient:
         # offline or GitHub/registry infrastructure is rate-limiting requests.
         if cache_path.exists():
             try:
-                with open(cache_path) as f:
+                with open(cache_path, encoding="utf-8") as f:
                     stale = json.load(f)
                 _log.warning("Using stale registry detail cache for '%s': %s", plugin_id, last_error)
                 return stale
@@ -304,7 +304,7 @@ class RegistryClient:
         if cache_path.exists() and timestamp_path.exists():
             if datetime.now() - datetime.fromtimestamp(timestamp_path.stat().st_mtime) < cache_ttl:
                 try:
-                    with open(cache_path) as f:
+                    with open(cache_path, encoding="utf-8") as f:
                         self._index = json.load(f)
                     self._index_loaded_at = time.monotonic()
                     return self._index
@@ -322,7 +322,7 @@ class RegistryClient:
         except Exception:
             if cache_path.exists():
                 _log.debug("Registry offline, using cached index")
-                with open(cache_path) as f:
+                with open(cache_path, encoding="utf-8") as f:
                     self._index = json.load(f)
                     self._index_loaded_at = time.monotonic()
                     return self._index
@@ -334,7 +334,7 @@ class RegistryClient:
 
         req = urllib.request.Request(url, headers={"User-Agent": "LichtFeld-PluginManager/1.0"})
         with urlopen(req, timeout=HTTP_TIMEOUT_SEC) as resp:
-            return json.loads(resp.read().decode())
+            return json.loads(resp.read().decode("utf-8"))
 
     def _fetch_json_with_fallback(self, urls: List[str]) -> Dict:
         last_error: Exception | None = None
@@ -362,7 +362,7 @@ class RegistryClient:
                 prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
             )
             with os.fdopen(fd, "w", encoding="utf-8") as stream:
-                json.dump(data, stream)
+                json.dump(data, stream, ensure_ascii=False)
                 stream.flush()
                 os.fsync(stream.fileno())
             os.replace(temporary_path, path)

--- a/src/python/lfs_plugins/settings.py
+++ b/src/python/lfs_plugins/settings.py
@@ -58,7 +58,7 @@ class PluginSettings:
                     delete=False,
                 ) as f:
                     temp_path = Path(f.name)
-                    json.dump(self._data, f, indent=2)
+                    json.dump(self._data, f, indent=2, ensure_ascii=False)
                     f.flush()
                     os.fsync(f.fileno())
                 os.replace(temp_path, self._file)

--- a/src/python/lfs_plugins/templates.py
+++ b/src/python/lfs_plugins/templates.py
@@ -175,16 +175,20 @@ def create_plugin(name: str, target_dir: Optional[Path] = None) -> Path:
     plugin_dir.mkdir(parents=True, exist_ok=True)
     (plugin_dir / "panels").mkdir(exist_ok=True)
 
-    (plugin_dir / "pyproject.toml").write_text(PYPROJECT_TOML.format(name=name))
-    (plugin_dir / "__init__.py").write_text(INIT_PY.format(name=name))
-    (plugin_dir / "panels" / "__init__.py").write_text("")
+    (plugin_dir / "pyproject.toml").write_text(
+        PYPROJECT_TOML.format(name=name), encoding="utf-8"
+    )
+    (plugin_dir / "__init__.py").write_text(INIT_PY.format(name=name), encoding="utf-8")
+    (plugin_dir / "panels" / "__init__.py").write_text("", encoding="utf-8")
     (plugin_dir / "panels" / "main_panel.py").write_text(
-        MAIN_PANEL_PY.format(name=name, title=title)
+        MAIN_PANEL_PY.format(name=name, title=title), encoding="utf-8"
     )
     (plugin_dir / "panels" / "main_panel.rml").write_text(
-        MAIN_PANEL_RML.format(name=name, title=title)
+        MAIN_PANEL_RML.format(name=name, title=title), encoding="utf-8"
     )
-    (plugin_dir / "panels" / "main_panel.rcss").write_text(MAIN_PANEL_RCSS)
+    (plugin_dir / "panels" / "main_panel.rcss").write_text(
+        MAIN_PANEL_RCSS, encoding="utf-8"
+    )
 
     _log.info("Created plugin template at %s", plugin_dir)
     return plugin_dir

--- a/src/python/lfs_splat_lod_hierarchy.py
+++ b/src/python/lfs_splat_lod_hierarchy.py
@@ -230,7 +230,7 @@ class SplatLodHierarchy:
         output_path = Path(path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with open(output_path, "w", encoding="utf-8") as handle:
-            json.dump(self.to_dict(), handle, indent=2)
+            json.dump(self.to_dict(), handle, indent=2, ensure_ascii=False)
         return str(output_path)
 
     def save_ply_levels(

--- a/src/visualizer/CMakeLists.txt
+++ b/src/visualizer/CMakeLists.txt
@@ -297,6 +297,8 @@ find_package(glslang CONFIG REQUIRED)
 add_executable(lfs_shader_compiler EXCLUDE_FROM_ALL
         tools/shader_compiler.cpp)
 target_compile_features(lfs_shader_compiler PRIVATE cxx_std_23)
+target_include_directories(lfs_shader_compiler PRIVATE
+        ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(lfs_shader_compiler
         PRIVATE
         glslang::glslang

--- a/src/visualizer/gui/editor/python_lsp_client.cpp
+++ b/src/visualizer/gui/editor/python_lsp_client.cpp
@@ -161,11 +161,14 @@ namespace lfs::vis::editor {
                 absolute = absolute.lexically_normal();
             }
 
-            std::string utf8 = lfs::core::path_to_utf8(absolute);
+            std::string utf8 = lfs::core::path_to_generic_utf8(absolute);
 #ifdef _WIN32
-            return "file:///" + percent_encode(fs::path(utf8).generic_string());
+            std::ranges::replace(utf8, '\\', '/');
+#endif
+#ifdef _WIN32
+            return "file:///" + percent_encode(utf8);
 #else
-            return "file://" + percent_encode(fs::path(utf8).generic_string());
+            return "file://" + percent_encode(utf8);
 #endif
         }
 
@@ -199,7 +202,7 @@ namespace lfs::vis::editor {
                 return std::nullopt;
             }
 
-            const fs::path candidate(program);
+            const fs::path candidate = lfs::core::utf8_to_path(std::string(program));
             if (candidate.has_parent_path() || candidate.is_absolute()) {
                 if (!is_executable_file(candidate)) {
                     return std::nullopt;
@@ -208,30 +211,32 @@ namespace lfs::vis::editor {
             }
 
 #ifdef _WIN32
-            const DWORD buffer_size = SearchPathA(nullptr, std::string(program).c_str(), nullptr, 0, nullptr, nullptr);
+            const auto program_w = lfs::core::utf8_to_wstring(std::string(program));
+            const DWORD buffer_size = SearchPathW(nullptr, program_w.c_str(), nullptr, 0, nullptr, nullptr);
             if (buffer_size == 0) {
                 return std::nullopt;
             }
 
-            std::string buffer(static_cast<size_t>(buffer_size), '\0');
-            if (SearchPathA(nullptr, std::string(program).c_str(), nullptr, buffer_size, buffer.data(), nullptr) == 0) {
+            std::wstring buffer(static_cast<size_t>(buffer_size) + 1, L'\0');
+            const DWORD length = SearchPathW(nullptr, program_w.c_str(), nullptr,
+                                             static_cast<DWORD>(buffer.size()), buffer.data(), nullptr);
+            if (length == 0) {
                 return std::nullopt;
             }
-            if (!buffer.empty() && buffer.back() == '\0') {
-                buffer.pop_back();
-            }
-            return buffer;
+            buffer.resize(length);
+            return lfs::core::wstring_to_utf8(buffer);
 #else
-            const char* const path_env = std::getenv("PATH");
-            if (!path_env || !*path_env) {
+            const auto path_env = lfs::core::environment::value("PATH");
+            if (!path_env) {
                 return std::nullopt;
             }
 
-            std::string_view remaining(path_env);
+            std::string_view remaining(*path_env);
             while (true) {
                 const size_t separator = remaining.find(':');
                 const std::string_view entry = remaining.substr(0, separator);
-                const fs::path dir = entry.empty() ? fs::current_path() : fs::path(entry);
+                const fs::path dir = entry.empty() ? fs::current_path()
+                                                   : lfs::core::utf8_to_path(std::string(entry));
                 const fs::path resolved = dir / candidate;
                 if (is_executable_file(resolved)) {
                     return lfs::core::path_to_utf8(resolved);
@@ -337,7 +342,7 @@ namespace lfs::vis::editor {
         fs::path get_lichtfeld_dir() {
             if (const auto override_workspace =
                     lfs::core::environment::value("LFS_PYTHON_LSP_WORKSPACE")) {
-                return fs::path(std::string(*override_workspace));
+                return lfs::core::utf8_to_path(*override_workspace);
             }
             const auto paths = lfs::core::UserPaths::resolve();
             if (paths)

--- a/src/visualizer/gui/panels/python_console_panel.cpp
+++ b/src/visualizer/gui/panels/python_console_panel.cpp
@@ -1302,7 +1302,9 @@ namespace {
             if (!python_module_dir.empty()) {
                 PyObject* sys_path = PySys_GetObject("path");
                 if (sys_path) {
-                    PyObject* py_path = PyUnicode_FromString(python_module_dir.string().c_str());
+                    const auto python_module_dir_utf8 =
+                        lfs::core::path_to_utf8(python_module_dir);
+                    PyObject* py_path = PyUnicode_FromString(python_module_dir_utf8.c_str());
                     if (py_path) {
                         PyList_Insert(sys_path, 0, py_path);
                         Py_DECREF(py_path);

--- a/src/visualizer/gui/rmlui/rmlui_vk_backend.cpp
+++ b/src/visualizer/gui/rmlui/rmlui_vk_backend.cpp
@@ -1035,7 +1035,7 @@ Rml::TextureHandle RenderInterface_VK::LoadTexture(Rml::Vector2i& texture_dimens
         try {
             const auto path = lfs::vis::getAssetPath(asset_name);
             if (std::filesystem::exists(path))
-                return load_with_stbi(path.string());
+                return load_with_stbi(lfs::core::path_to_utf8(path));
         } catch (...) {
         }
         return 0;

--- a/src/visualizer/gui/sequencer_ui_manager.cpp
+++ b/src/visualizer/gui/sequencer_ui_manager.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "gui/sequencer_ui_manager.hpp"
+#include "core/environment.hpp"
 #include "core/event_bridge/localization_manager.hpp"
 #include "core/events.hpp"
 #include "core/logger.hpp"
@@ -119,21 +120,19 @@ namespace lfs::vis::gui {
 
         [[nodiscard]] std::filesystem::path plySequenceCacheRoot() {
 #ifdef _WIN32
-            if (const char* local_app_data = std::getenv("LOCALAPPDATA");
-                local_app_data && *local_app_data) {
-                return lfs::core::utf8_to_path(local_app_data) / "LichtFeld" / "ply_sequence_cache";
+            if (const auto local_app_data = lfs::core::environment::value("LOCALAPPDATA")) {
+                return lfs::core::utf8_to_path(*local_app_data) / "LichtFeld" / "ply_sequence_cache";
             }
-            if (const char* temp = std::getenv("TEMP"); temp && *temp) {
-                return lfs::core::utf8_to_path(temp) / "LichtFeld" / "ply_sequence_cache";
+            if (const auto temp = lfs::core::environment::value("TEMP")) {
+                return lfs::core::utf8_to_path(*temp) / "LichtFeld" / "ply_sequence_cache";
             }
             return std::filesystem::path("C:/Temp/LichtFeld/ply_sequence_cache");
 #else
-            if (const char* xdg_cache = std::getenv("XDG_CACHE_HOME");
-                xdg_cache && *xdg_cache) {
-                return lfs::core::utf8_to_path(xdg_cache) / "lichtfeld" / "ply_sequence_cache";
+            if (const auto xdg_cache = lfs::core::environment::value("XDG_CACHE_HOME")) {
+                return lfs::core::utf8_to_path(*xdg_cache) / "lichtfeld" / "ply_sequence_cache";
             }
-            if (const char* home = std::getenv("HOME"); home && *home) {
-                return lfs::core::utf8_to_path(home) / ".cache" / "lichtfeld" / "ply_sequence_cache";
+            if (const auto home = lfs::core::environment::value("HOME")) {
+                return lfs::core::utf8_to_path(*home) / ".cache" / "lichtfeld" / "ply_sequence_cache";
             }
             return std::filesystem::temp_directory_path() / "lichtfeld" / "ply_sequence_cache";
 #endif
@@ -235,8 +234,8 @@ namespace lfs::vis::gui {
                 return false;
             }
 
-            const auto tmp_path = cache_path.parent_path() /
-                                  (cache_path.filename().string() + ".tmp");
+            auto tmp_path = cache_path;
+            tmp_path += ".tmp";
             std::ofstream file;
             if (!lfs::core::open_file_for_write(tmp_path,
                                                 std::ios::binary | std::ios::trunc,
@@ -455,7 +454,7 @@ namespace lfs::vis::gui {
         cmd::SequencerLoadPlySequence::when([this](const auto& event) {
             if (event.fps > 0.0f)
                 ui_state_.sequence_fps = std::clamp(event.fps, MIN_SEQUENCE_FPS, MAX_SEQUENCE_FPS);
-            loadPlySequenceFromDirectory(std::filesystem::path(event.directory));
+            loadPlySequenceFromDirectory(lfs::core::utf8_to_path(event.directory));
         });
 
         state::KeyframeListChanged::when([this](const auto&) {

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -423,7 +423,7 @@ namespace lfs::vis::project {
             if (!input) {
                 return lifecycleError(
                     lfs::ErrorCode::PermissionDenied,
-                    "A dataset file could not be opened.", path.string(),
+                    "A dataset file could not be opened.", lfs::core::path_to_utf8(path),
                     "project.dataset_embed");
             }
             lfs::io::project::Hash128Stream hasher;
@@ -439,14 +439,14 @@ namespace lfs::vis::project {
                         static_cast<std::size_t>(count)))) {
                     return lifecycleError(
                         lfs::ErrorCode::DataLoss,
-                        "A dataset file could not be hashed.", path.string(),
+                        "A dataset file could not be hashed.", lfs::core::path_to_utf8(path),
                         "project.dataset_embed");
                 }
             }
             if (!input.eof() || !hasher.valid()) {
                 return lifecycleError(
                     lfs::ErrorCode::DataLoss,
-                    "A dataset file could not be hashed.", path.string(),
+                    "A dataset file could not be hashed.", lfs::core::path_to_utf8(path),
                     "project.dataset_embed");
             }
             return hasher.digest();
@@ -473,7 +473,7 @@ namespace lfs::vis::project {
         discoverDatasetFiles(const std::filesystem::path& root,
                              std::string& images_folder) {
             const auto info = lfs::io::detect_dataset_info(root);
-            images_folder = info.images_path.lexically_relative(root).generic_string();
+            images_folder = lfs::core::path_to_generic_utf8(info.images_path.lexically_relative(root));
             std::vector<std::pair<std::filesystem::path, std::string>> result;
             const auto append = [&](const auto& directory, const std::string_view kind) {
                 auto files = datasetFiles(directory, kind);
@@ -498,11 +498,11 @@ namespace lfs::vis::project {
             std::set<std::string> seen_paths;
             std::erase_if(result, [&](const auto& item) {
                 return !seen_paths.insert(
-                                      item.first.lexically_relative(root).generic_string())
+                                      lfs::core::path_to_generic_utf8(item.first.lexically_relative(root)))
                             .second;
             });
             std::ranges::sort(result, {}, [&](const auto& item) {
-                return item.first.lexically_relative(root).generic_string();
+                return lfs::core::path_to_generic_utf8(item.first.lexically_relative(root));
             });
             return result;
         }
@@ -569,7 +569,7 @@ namespace lfs::vis::project {
                         "The project-open job requested cancellation",
                         "project.dataset_embed");
                 }
-                const auto relative = std::filesystem::path(entry.rel_path);
+                const auto relative = lfs::core::utf8_to_path(entry.rel_path);
                 if (relative.empty() || relative.is_absolute() ||
                     relative.lexically_normal() != relative) {
                     return lifecycleError(
@@ -617,13 +617,16 @@ namespace lfs::vis::project {
                         "The embedded dataset cache could not be created.",
                         error.message(), "project.dataset_embed");
                 }
-                const auto temporary = destination.string() + ".part";
-                std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
+                auto temporary = destination;
+                temporary += ".part";
+                std::ofstream output;
+                lfs::core::open_file_for_write(
+                    temporary, std::ios::binary | std::ios::trunc, output);
                 if (!output) {
                     return lifecycleError(
                         lfs::ErrorCode::PermissionDenied,
                         "An embedded dataset file could not be extracted.",
-                        destination.string(), "project.dataset_embed");
+                        lfs::core::path_to_utf8(destination), "project.dataset_embed");
                 }
                 lfs::io::project::Hash128Stream hasher;
                 auto copied = source->visit_stream(
@@ -645,7 +648,7 @@ namespace lfs::vis::project {
                                 return lfs::Result<void>::failure(lifecycleError(
                                     lfs::ErrorCode::DataLoss,
                                     "An embedded dataset file could not be extracted.",
-                                    destination.string(), "project.dataset_embed"));
+                                    lfs::core::path_to_utf8(destination), "project.dataset_embed"));
                             }
                             output.write(buffer.data(), count);
                             copied_bytes += static_cast<std::uint64_t>(count);
@@ -654,7 +657,7 @@ namespace lfs::vis::project {
                             return lfs::Result<void>::failure(lifecycleError(
                                 lfs::ErrorCode::DataLoss,
                                 "An embedded dataset file could not be extracted.",
-                                destination.string(), "project.dataset_embed"));
+                                lfs::core::path_to_utf8(destination), "project.dataset_embed"));
                         }
                         return {};
                     });
@@ -664,7 +667,7 @@ namespace lfs::vis::project {
                     return copied ? lifecycleError(
                                         lfs::ErrorCode::DataLoss,
                                         "The embedded dataset file failed hash verification.",
-                                        destination.string(), "project.dataset_embed")
+                                        lfs::core::path_to_utf8(destination), "project.dataset_embed")
                                   : std::move(copied).error();
                 }
                 std::filesystem::rename(temporary, destination, error);
@@ -691,7 +694,7 @@ namespace lfs::vis::project {
                 return lifecycleError(
                     lfs::ErrorCode::PermissionDenied,
                     "The embedded dataset cache could not be finalized.",
-                    marker.string(), "project.dataset_embed");
+                    lfs::core::path_to_utf8(marker), "project.dataset_embed");
             }
             LOG_INFO(
                 "Embedded dataset extraction completed: {} files extracted, {} files reused, cache {}",
@@ -1868,7 +1871,7 @@ namespace lfs::vis::project {
                     lfs::ErrorCode::InvalidArgument,
                     "A project path must end in .licht.",
                     std::format(
-                        "received '{}'", path.string()),
+                        "received '{}'", lfs::core::path_to_utf8(path)),
                     "project.path");
             }
             std::error_code error;
@@ -1898,7 +1901,7 @@ namespace lfs::vis::project {
                         unpublishedLichtUserMessage(
                             path),
                     std::format(
-                        "received '{}'", path.string()),
+                        "received '{}'", lfs::core::path_to_utf8(path)),
                     "project.path");
             }
             return resolved;
@@ -2232,7 +2235,7 @@ namespace lfs::vis::project {
                 return fail<ProjectLifecycleSettings>(
                     lfs::ErrorCode::PermissionDenied,
                     "Project lifecycle settings could not be opened.",
-                    path.string(), "settings.path");
+                    lfs::core::path_to_utf8(path), "settings.path");
             }
             const Json json = Json::parse(stream);
             if (!json.is_object()) {
@@ -3801,7 +3804,7 @@ namespace lfs::vis::project {
             std::chrono::duration<double, std::milli>(
                 start_write_finished - start_write_started)
                 .count(),
-            project_write_destination_.string());
+            lfs::core::path_to_utf8(project_write_destination_));
         return {};
     }
 
@@ -4018,7 +4021,7 @@ namespace lfs::vis::project {
                             fail_worker(lifecycleError(
                                 lfs::ErrorCode::DataLoss,
                                 "A dataset file could not be inspected.",
-                                std::format("{}: {}", path.string(), error.message()),
+                                std::format("{}: {}", lfs::core::path_to_utf8(path), error.message()),
                                 "project.dataset_embed"));
                             return;
                         }
@@ -4032,7 +4035,7 @@ namespace lfs::vis::project {
                             fail_worker(previous.error());
                             return;
                         }
-                        const auto rel = path.lexically_relative(root).generic_string();
+                        const auto rel = lfs::core::path_to_generic_utf8(path.lexically_relative(root));
                         const EmbeddedDatasetEntry* old = nullptr;
                         if (previous->has_value()) {
                             const auto old_it = std::ranges::find_if(
@@ -4443,7 +4446,7 @@ namespace lfs::vis::project {
                     "project.project_location");
             }
             const auto stem = sanitizedProjectFileStem(
-                dataset.data_path.filename().string());
+                lfs::core::path_to_utf8(dataset.data_path.filename()));
             lfs::Error last_error = lifecycleError(
                 lfs::ErrorCode::Unavailable,
                 "The training project could not be created.",
@@ -4457,12 +4460,12 @@ namespace lfs::vis::project {
                         : std::format("-{}", attempt + 1);
                 const auto candidate =
                     location / (stem + suffix + ".licht");
+                auto lock_path = candidate;
+                lock_path += ".lock";
                 std::error_code exists_error;
                 const bool exists =
                     std::filesystem::exists(candidate, exists_error) ||
-                    std::filesystem::exists(
-                        std::filesystem::path(candidate.string() + ".lock"),
-                        exists_error);
+                    std::filesystem::exists(lock_path, exists_error);
                 if (exists_error) {
                     return fail<void>(
                         lfs::ErrorCode::PermissionDenied,
@@ -8842,7 +8845,7 @@ namespace lfs::vis::project {
             !removed) {
             LOG_WARN(
                 "Discarded autosave cleanup failed for {}: {}",
-                master.string(),
+                lfs::core::path_to_utf8(master),
                 developerError(removed.error()));
         }
     }
@@ -9560,8 +9563,8 @@ namespace lfs::vis::project {
                     return lhs.wallclock_unix_ns <
                            rhs.wallclock_unix_ns;
                 }
-                return lhs.selected_path.generic_string() <
-                       rhs.selected_path.generic_string();
+                return lfs::core::path_to_generic_utf8(lhs.selected_path) <
+                       lfs::core::path_to_generic_utf8(rhs.selected_path);
             });
     }
 
@@ -9583,7 +9586,7 @@ namespace lfs::vis::project {
         const auto display_name =
             candidate.untitled_scratch
                 ? std::string(LOC(Keys::UNSAVED_SESSION))
-                : candidate.master_path.stem().string();
+                : lfs::core::path_to_utf8(candidate.master_path.stem());
         const auto saved_at = formatRecoverySavedTime(
             candidate.wallclock_unix_ns,
             candidate.selected_path);

--- a/src/visualizer/project/session_state.cpp
+++ b/src/visualizer/project/session_state.cpp
@@ -314,7 +314,7 @@ namespace lfs::vis::project {
         template <typename Owner, typename Member>
         JsonField<Owner> required_field(
             const std::string_view name,
-            Member Owner::*member) {
+            Member Owner::* member) {
             return {
                 .name = name,
                 .write = [member](const Owner& source) { return Json(source.*member); },
@@ -333,7 +333,7 @@ namespace lfs::vis::project {
         template <typename Owner, typename Member>
         JsonField<Owner> optional_field(
             const std::string_view name,
-            Member Owner::*member) {
+            Member Owner::* member) {
             return {
                 .name = name,
                 .write = [member](const Owner& source) { return Json(source.*member); },
@@ -351,7 +351,7 @@ namespace lfs::vis::project {
         template <typename Owner>
         JsonField<Owner> vec3_field(
             const std::string_view name,
-            glm::vec3 Owner::*member) {
+            glm::vec3 Owner::* member) {
             return {
                 .name = name,
                 .write = [member](const Owner& source) { return vec3_json(source.*member); },
@@ -375,7 +375,7 @@ namespace lfs::vis::project {
                   typename AfterAssign = std::nullptr_t>
         JsonField<Owner> enum_field(
             const std::string_view name,
-            Enum Owner::*member,
+            Enum Owner::* member,
             const int minimum,
             const int maximum,
             const std::string_view invalid_detail,
@@ -467,7 +467,7 @@ namespace lfs::vis::project {
         template <typename Owner, std::size_t Size>
         JsonField<Owner> array_field(
             const std::string_view name,
-            std::array<float, Size> Owner::*member) {
+            std::array<float, Size> Owner::* member) {
             return custom_field<Owner>(
                 name,
                 [member](const Owner& source) {
@@ -503,7 +503,7 @@ namespace lfs::vis::project {
         template <typename Owner>
         JsonField<Owner> nullable_positive_float_field(
             const std::string_view name,
-            std::optional<float> Owner::*member) {
+            std::optional<float> Owner::* member) {
             return custom_field<Owner>(
                 name,
                 [member](const Owner& source) {
@@ -1589,7 +1589,7 @@ namespace lfs::vis::project {
             using Panel = gui::PanelProjectState;
             const auto nullable_float = [](
                                             const std::string_view name,
-                                            float Panel::*member) {
+                                            float Panel::* member) {
                 return custom_field<Panel>(
                     name,
                     [member](const Panel& panel) {
@@ -2516,18 +2516,16 @@ namespace lfs::vis::project {
                                 absolute
                                     .lexically_relative(
                                         root);
+                            const auto relative_text =
+                                lfs::core::path_to_generic_utf8(relative);
+                            const auto first = relative.begin();
                             if (!relative.empty() &&
                                 relative != "." &&
-                                !relative
-                                     .generic_string()
-                                     .starts_with(
-                                         "..")) {
+                                (first == relative.end() ||
+                                 *first != std::filesystem::path(".."))) {
                                 saved_clip
                                     ["directory_hint"] =
-                                        lfs::core::
-                                            path_to_utf8(
-                                                relative
-                                                    .generic_string());
+                                        relative_text;
                             }
                         }
                     }

--- a/src/visualizer/tools/shader_compiler.cpp
+++ b/src/visualizer/tools/shader_compiler.cpp
@@ -6,6 +6,8 @@
 #include <glslang/Public/ShaderLang.h>
 #include <glslang/SPIRV/GlslangToSpv.h>
 
+#include "core/path_utils.hpp"
+
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
@@ -30,7 +32,7 @@ namespace {
         return value.size() >= suffix.size() && value.substr(value.size() - suffix.size()) == suffix;
     }
 
-    [[nodiscard]] std::optional<Args> parseArgs(const int argc, char** argv) {
+    [[nodiscard]] std::optional<Args> parseArgs(const int argc, const char* const argv[]) {
         Args args;
         for (int i = 1; i < argc; ++i) {
             const std::string_view key = argv[i];
@@ -40,9 +42,9 @@ namespace {
             }
             const char* const value = argv[++i];
             if (key == "--input") {
-                args.input = value;
+                args.input = lfs::core::utf8_to_path(value);
             } else if (key == "--output") {
-                args.output = value;
+                args.output = lfs::core::utf8_to_path(value);
             } else if (key == "--symbol") {
                 args.symbol = value;
             } else {
@@ -68,7 +70,7 @@ namespace {
     }
 
     [[nodiscard]] std::optional<EShLanguage> inferStage(const std::filesystem::path& path) {
-        const std::string filename = path.filename().string();
+        const std::string filename = lfs::core::path_to_utf8(path.filename());
         if (endsWith(filename, ".vert") || endsWith(filename, "VS.glsl")) {
             return EShLangVertex;
         }
@@ -85,7 +87,8 @@ namespace {
     }
 
     [[nodiscard]] std::optional<std::string> readTextFile(const std::filesystem::path& path) {
-        std::ifstream file(path, std::ios::binary);
+        std::ifstream file;
+        lfs::core::open_file_for_read(path, std::ios::binary, file);
         if (!file) {
             std::cerr << "Failed to open shader source: " << path << '\n';
             return std::nullopt;
@@ -98,7 +101,7 @@ namespace {
         const std::string& source,
         const EShLanguage stage) {
         const char* source_ptr = source.c_str();
-        const std::string input_name = input.string();
+        const std::string input_name = lfs::core::path_to_utf8(input);
         const char* source_name = input_name.c_str();
 
         glslang::TShader shader(stage);
@@ -137,7 +140,8 @@ namespace {
             std::filesystem::create_directories(parent);
         }
 
-        std::ofstream file(output, std::ios::binary | std::ios::trunc);
+        std::ofstream file;
+        lfs::core::open_file_for_write(output, std::ios::binary | std::ios::trunc, file);
         if (!file) {
             std::cerr << "Failed to open generated header: " << output << '\n';
             return false;
@@ -169,8 +173,13 @@ namespace {
     }
 } // namespace
 
-int main(const int argc, char** argv) {
-    const auto args = parseArgs(argc, argv);
+int run_main(const std::vector<std::string>& arguments) {
+    std::vector<const char*> argv;
+    argv.reserve(arguments.size());
+    for (const auto& argument : arguments)
+        argv.push_back(argument.c_str());
+
+    const auto args = parseArgs(static_cast<int>(argv.size()), argv.data());
     if (!args) {
         return 2;
     }
@@ -203,3 +212,13 @@ int main(const int argc, char** argv) {
     }
     return writeHeader(args->output, args->symbol, *spirv) ? 0 : 1;
 }
+
+#ifdef _WIN32
+int wmain(int argc, wchar_t* argv[]) {
+    return run_main(lfs::core::utf8_argv(argc, argv));
+}
+#else
+int main(int argc, char** argv) {
+    return run_main(lfs::core::utf8_argv(argc, argv));
+}
+#endif

--- a/src/visualizer/window/window_manager.cpp
+++ b/src/visualizer/window/window_manager.cpp
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "window_manager.hpp"
+#include "core/environment.hpp"
 #include "core/events.hpp"
 #include "core/logger.hpp"
+#include "core/path_utils.hpp"
 #include "input/input_controller.hpp"
 #include "input/sdl_key_mapping.hpp"
 #include "rendering/cuda_vulkan_interop.hpp"
@@ -122,22 +124,22 @@ namespace lfs::vis {
             constexpr char path_separator = ':';
 #endif
             std::string layer_path = LFS_VULKAN_VALIDATION_LAYER_DIR;
-            if (const char* const existing_path = std::getenv("VK_ADD_LAYER_PATH");
-                existing_path && *existing_path) {
+            if (const auto existing_path = lfs::core::environment::value("VK_ADD_LAYER_PATH")) {
                 layer_path += path_separator;
-                layer_path += existing_path;
+                layer_path += *existing_path;
             }
 
 #ifdef _WIN32
-            const bool configured = _putenv_s("VK_ADD_LAYER_PATH", layer_path.c_str()) == 0;
+            const bool configured = SetEnvironmentVariableW(
+                                        L"VK_ADD_LAYER_PATH",
+                                        lfs::core::utf8_to_wstring(layer_path).c_str()) != 0;
 #else
             const bool configured = ::setenv("VK_ADD_LAYER_PATH", layer_path.c_str(), 1) == 0;
 #endif
             if (!configured) {
                 LOG_WARN("Failed to configure the pinned Vulkan validation layer path");
-            } else if (const char* const override_path = std::getenv("VK_LAYER_PATH");
-                       override_path && *override_path) {
-                LOG_WARN("VK_LAYER_PATH overrides the pinned Vulkan validation layer path: {}", override_path);
+            } else if (const auto override_path = lfs::core::environment::value("VK_LAYER_PATH")) {
+                LOG_WARN("VK_LAYER_PATH overrides the pinned Vulkan validation layer path: {}", *override_path);
             } else {
                 LOG_INFO("Vulkan validation layer path: {}", LFS_VULKAN_VALIDATION_LAYER_DIR);
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,18 +38,26 @@ if(BUILD_UNICODE_TEST_ONLY)
     # Standalone Unicode path test without CUDA
     add_executable(unicode_path_test
         test_unicode_paths_windows.cpp
+        ${CMAKE_SOURCE_DIR}/src/core/environment.cpp
+        ${CMAKE_SOURCE_DIR}/src/io/stb_image_impl.cpp
     )
 
     target_include_directories(unicode_path_test PRIVATE
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_BINARY_DIR}/include
         ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_SOURCE_DIR}/src/core/include
+        ${CMAKE_SOURCE_DIR}/src/io/include
+        ${CMAKE_SOURCE_DIR}/external
     )
 
     target_link_libraries(unicode_path_test PRIVATE
         GTest::gtest
         GTest::gtest_main
     )
+    target_compile_definitions(unicode_path_test PRIVATE
+        LFS_CORE_EXPORTS
+        LFS_UNICODE_TEST_STANDALONE)
 
     # C++23 standard
     set_target_properties(unicode_path_test PROPERTIES

--- a/tests/python/test_registry.py
+++ b/tests/python/test_registry.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Tests for the plugin registry system."""
 
+import builtins
 import json
+import locale
+import os
 import pytest
 import sys
 import tempfile
@@ -86,6 +89,56 @@ def mock_plugin_detail():
 
 class TestRegistryClient:
     """Tests for RegistryClient."""
+
+    def test_cache_is_utf8_when_locale_default_is_cp932(
+        self, registry_cache_dir, monkeypatch
+    ):
+        """Registry caches must not depend on the process text encoding."""
+        scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+        if str(scripts_dir) not in sys.path:
+            sys.path.insert(0, str(scripts_dir))
+
+        from lfs_plugins.registry import RegistryClient
+
+        monkeypatch.setattr(
+            locale, "getpreferredencoding", lambda do_setlocale=True: "cp932"
+        )
+        real_open = builtins.open
+
+        def locale_default_open(file, mode="r", *args, **kwargs):
+            if "b" not in mode and "encoding" not in kwargs and not args:
+                kwargs["encoding"] = locale.getpreferredencoding(False)
+            return real_open(file, mode, *args, **kwargs)
+
+        # Make an encoding-less open behave like the affected Windows locale even
+        # when this test is running on a UTF-8 host.
+        monkeypatch.setattr(builtins, "open", locale_default_open)
+
+        detail = {
+            "name": "日本語",
+            "namespace": "community",
+            "display_name": "日本語プラグイン",
+            "repository": "https://example.test/日本語",
+            "versions": {},
+        }
+        client = RegistryClient(cache_dir=registry_cache_dir)
+        cache_path = client._plugin_cache_path("community", "日本語")
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(json.dumps(detail, ensure_ascii=False).encode("utf-8"))
+
+        with patch.object(
+            client, "_fetch_json", side_effect=AssertionError("cache should be used")
+        ):
+            assert client.get_plugin("community:日本語") == detail
+
+        cache_path.unlink()
+        with patch.object(client, "_fetch_json", return_value=detail):
+            assert client.get_plugin("community:日本語") == detail
+        assert "日本語" in cache_path.read_bytes().decode("utf-8")
+
+        os.utime(cache_path, (0, 0))
+        with patch.object(client, "_fetch_json", side_effect=RuntimeError("offline")):
+            assert client.get_plugin("community:日本語") == detail
 
     def test_search_by_name(self, registry_cache_dir, mock_registry_index):
         """Should find plugins by name."""

--- a/tests/test_unicode_paths_windows.cpp
+++ b/tests/test_unicode_paths_windows.cpp
@@ -14,6 +14,8 @@
  * This test runs on Windows CI without requiring CUDA/GPU.
  */
 
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -24,13 +26,17 @@
 #include <vector>
 
 // Check if we have access to the full library (not standalone unicode test build)
-#if __has_include("core/parameters.hpp")
+#if __has_include("core/parameters.hpp") && !defined(LFS_UNICODE_TEST_STANDALONE)
 #define LFS_HAS_FULL_LIBRARY 1
 #include "core/parameters.hpp"
 #include <nlohmann/json.hpp>
 #endif
 
+#include "core/environment.hpp"
 #include "core/path_utils.hpp"
+#include "io/atomic_output_path.hpp"
+
+#include <stb_image.h>
 
 namespace fs = std::filesystem;
 using namespace lfs::core;
@@ -211,6 +217,122 @@ TEST_F(UnicodePathTest, PathToUtf8Conversion) {
         std::string utf8 = path_to_utf8(long_path);
         EXPECT_FALSE(utf8.empty());
     }
+}
+
+TEST_F(UnicodePathTest, ProcessBoundaryHelpersPreserveJapanese) {
+    const auto japanese_path = test_root_ / utf8_to_path("山田_プロジェクト");
+
+#ifdef _WIN32
+    wchar_t arg0[] = L"lichtfeld.exe";
+    wchar_t arg1[] = L"--project";
+    wchar_t arg2[] = L"C:\\Users\\山田\\プロジェクト.licht";
+    wchar_t* wide_argv[] = {arg0, arg1, arg2};
+    const auto arguments = utf8_argv(3, wide_argv);
+#else
+    char arg0[] = "lichtfeld";
+    char arg1[] = "--project";
+    char arg2[] = "山田/プロジェクト.licht";
+    char* narrow_argv[] = {arg0, arg1, arg2};
+    const auto arguments = utf8_argv(3, narrow_argv);
+#endif
+    ASSERT_EQ(arguments.size(), 3);
+    EXPECT_EQ(arguments[1], "--project");
+    EXPECT_EQ(arguments[2],
+#ifdef _WIN32
+              "C:\\Users\\山田\\プロジェクト.licht"
+#else
+              "山田/プロジェクト.licht"
+#endif
+    );
+
+    constexpr const char* environment_name = "LFS_UNICODE_PATH_TEST";
+    const auto previous = lfs::core::environment::value(environment_name);
+    const auto japanese_path_utf8 = path_to_utf8(japanese_path);
+    ASSERT_TRUE(environment::set_value(environment_name, japanese_path_utf8));
+#ifdef _WIN32
+    const auto wide_name = utf8_to_wstring(environment_name);
+    const auto* const raw_wide = _wgetenv(wide_name.c_str());
+    ASSERT_NE(raw_wide, nullptr);
+    EXPECT_EQ(wstring_to_utf8(raw_wide), japanese_path_utf8);
+#else
+    const auto* const raw = std::getenv(environment_name);
+    ASSERT_NE(raw, nullptr);
+    EXPECT_STREQ(raw, japanese_path_utf8.c_str());
+#endif
+    const auto observed = lfs::core::environment::value(environment_name);
+    ASSERT_TRUE(observed.has_value());
+    EXPECT_EQ(utf8_to_path(*observed), japanese_path);
+#ifdef _WIN32
+    if (previous) {
+        const auto previous_wide = utf8_to_wstring(*previous);
+        _wputenv_s(wide_name.c_str(), previous_wide.c_str());
+    } else {
+        _wputenv_s(wide_name.c_str(), L"");
+    }
+#else
+    if (previous)
+        setenv(environment_name, previous->c_str(), 1);
+    else
+        unsetenv(environment_name);
+#endif
+}
+
+TEST_F(UnicodePathTest, PathToGenericUtf8UsesForwardSlashes) {
+#ifdef _WIN32
+    const fs::path relative(L"画像\\写真.jpg");
+#else
+    const fs::path relative = fs::path("画像") / "写真.jpg";
+#endif
+    EXPECT_EQ(path_to_generic_utf8(relative), "画像/写真.jpg");
+}
+
+TEST_F(UnicodePathTest, PathAwareFileAndStbiRead) {
+    const auto image_path = test_root_ / utf8_to_path("画像_日本語.ppm");
+    const std::vector<uint8_t> ppm = {
+        'P',
+        '6',
+        '\n',
+        '1',
+        ' ',
+        '1',
+        '\n',
+        '2',
+        '5',
+        '5',
+        '\n',
+        255,
+        0,
+        0,
+    };
+    fs::create_directories(image_path.parent_path());
+    FILE* file = open_file(image_path, "wb");
+    ASSERT_NE(file, nullptr);
+    ASSERT_EQ(fwrite(ppm.data(), 1, ppm.size(), file), ppm.size());
+    fclose(file);
+
+    int width = 0;
+    int height = 0;
+    int channels = 0;
+    stbi_uc* pixels = stbi_load(path_to_utf8(image_path).c_str(),
+                                &width, &height, &channels, 4);
+    ASSERT_NE(pixels, nullptr);
+    EXPECT_EQ(width, 1);
+    EXPECT_EQ(height, 1);
+    stbi_image_free(pixels);
+}
+
+TEST_F(UnicodePathTest, AtomicOutputTempNamingPreservesJapanesePath) {
+    const auto output = test_root_ / utf8_to_path("成果物_日本語.licht");
+    const auto appended = lfs::io::make_atomic_temp_output_path(output);
+    const auto preserved = lfs::io::make_atomic_temp_output_path(
+        output, lfs::io::AtomicOutputTempName::PreserveExtension);
+
+    EXPECT_EQ(appended.parent_path(), output.parent_path());
+    EXPECT_EQ(preserved.parent_path(), output.parent_path());
+    EXPECT_NE(appended, output);
+    EXPECT_NE(preserved, output);
+    EXPECT_EQ(preserved.extension(), output.extension());
+    EXPECT_EQ(path_to_utf8(preserved.parent_path()), path_to_utf8(output.parent_path()));
 }
 
 // ============================================================================
@@ -878,8 +1000,14 @@ TEST_F(UnicodePathTest, RealWorld_ExportWorkflow) {
     auto sog_path = exports_dir / "故宮_ForbiddenCity_紫禁城.sog";
     // SOG is a ZIP archive, create minimal ZIP header
     std::vector<uint8_t> zip_header = {
-        0x50, 0x4B, 0x03, 0x04, // ZIP local file header signature
-        0x14, 0x00, 0x00, 0x00, // Version, flags
+        0x50,
+        0x4B,
+        0x03,
+        0x04, // ZIP local file header signature
+        0x14,
+        0x00,
+        0x00,
+        0x00, // Version, flags
     };
     create_binary_file(sog_path, zip_header);
     verify_file(sog_path);


### PR DESCRIPTION
Japanese and other non-ASCII paths break in several places on Windows: the process tells the CRT it speaks UTF-8 but never tells the OS, environment values go through the ANSI code page, and a number of call sites still open files or re-parse paths through narrow `std::string`. Linux is unaffected; every scenario below already passes there.

What changes

- The executable ships an application manifest with the UTF-8 active code page and long-path awareness, so narrow `fopen`/`getenv`/`std::ifstream(const char*)` calls see UTF-8 on Windows 10 1903+.
- Environment reads and writes go through `lfs::core::environment::value` / `set_value`, which use the wide Win32 API on Windows (`_wputenv_s`, so the CRT and the embedded Python see the same values).
- Relative paths persisted in project files stay in generic slash form on every platform (`path_to_generic_utf8`); before, Windows round-tripped them through narrow strings.
- File I/O that went through narrow paths (logger, session breadcrumb, atomic output, PLY to RAD LOD, preprocessing subprocess, project chapters, sequencer, Python console, LSP client, Zep editor) now opens by `std::filesystem::path` or through path-aware helpers in `path_utils.hpp`.
- Python plugin code opens text files with an explicit `encoding="utf-8"` and writes JSON with `ensure_ascii=False`.
- `tests/test_unicode_paths_windows.cpp` covers argv and environment conversion, the generic-path serializer, atomic temp paths and file opens with Japanese names; it runs on both platforms.

Verified on Linux with the GUI driven by xdotool under Japanese folder names: drag-and-drop, Save As, autosave, crash recovery, recent-projects list, New Project, training and plugin install. Windows behavior is covered by the unit tests in CI.
