### PR TITLE
Honor transforms.json mask paths and preserve nested mask lookup

### DIFF
--- a/src/io/formats/colmap.hpp
+++ b/src/io/formats/colmap.hpp
@@ -94,6 +94,8 @@ namespace lfs::io {
         float _center_y = 0.f;
         std::string _image_name;
         std::filesystem::path _image_path;
+        // Explicit transforms.json mask_path, resolved against the JSON directory.
+        std::filesystem::path _mask_path;
         bool _has_image = true;
         lfs::core::CameraModelType _camera_model_type = lfs::core::CameraModelType::PINHOLE;
         int _width = 0;

--- a/src/io/formats/transforms.cpp
+++ b/src/io/formats/transforms.cpp
@@ -50,8 +50,21 @@ namespace lfs::io {
 
         struct ValidatedTransformFrame {
             std::string file_path;
+            std::string mask_path;
             std::array<float, 16> matrix{};
         };
+
+        [[nodiscard]] std::string validated_frame_path(
+            const nlohmann::json& frame, const char* key, const size_t frame_index) {
+            if (!frame.is_object() || !frame.contains(key) || !frame[key].is_string())
+                throw std::runtime_error(std::format("Frame {} must contain a string {}", frame_index, key));
+            std::string path = frame[key].get<std::string>();
+            if (path.empty() || path.size() > MAX_TRANSFORMS_PATH_BYTES ||
+                path.find('\0') != std::string::npos) {
+                throw std::runtime_error(std::format("Frame {} {} is empty, too long or contains a null byte", frame_index, key));
+            }
+            return path;
+        }
 
         [[nodiscard]] float finite_json_float_value(
             const nlohmann::json& value,
@@ -148,17 +161,15 @@ namespace lfs::io {
                 if ((frame_index % 256) == 0)
                     throw_if_load_cancel_requested(options, "Transforms schema validation cancelled");
                 const auto& frame = frames[frame_index];
-                if (!frame.is_object() || !frame.contains("file_path") || !frame["file_path"].is_string())
-                    throw std::runtime_error(std::format("Frame {} must contain a string file_path", frame_index));
-                std::string file_path = frame["file_path"].get<std::string>();
-                if (file_path.empty() || file_path.size() > MAX_TRANSFORMS_PATH_BYTES ||
-                    file_path.find('\0') != std::string::npos) {
-                    throw std::runtime_error(std::format("Frame {} file_path is empty or too long", frame_index));
-                }
+                std::string file_path = validated_frame_path(frame, "file_path", frame_index);
+                std::string mask_path;
+                if (frame.contains("mask_path"))
+                    mask_path = validated_frame_path(frame, "mask_path", frame_index);
                 if (!frame.contains("transform_matrix"))
                     throw std::runtime_error(std::format("Frame {} is missing transform_matrix", frame_index));
                 result.push_back({
                     .file_path = std::move(file_path),
+                    .mask_path = std::move(mask_path),
                     .matrix = validated_transform_matrix(frame["transform_matrix"], frame_index),
                 });
             }
@@ -585,6 +596,8 @@ namespace lfs::io {
                 lfs::core::Tensor T = w2c.slice(0, 0, 3).slice(1, 3, 4).squeeze(1);
 
                 camdata._image_path = GetTransformImagePath(dir_path, frame.file_path);
+                if (!frame.mask_path.empty())
+                    camdata._mask_path = dir_path / lfs::core::utf8_to_path(frame.mask_path);
                 camdata._has_image = [&] {
                     std::error_code exists_error;
                     return std::filesystem::is_regular_file(camdata._image_path, exists_error);

--- a/src/io/include/io/filesystem_utils.hpp
+++ b/src/io/include/io/filesystem_utils.hpp
@@ -45,6 +45,11 @@ namespace lfs::io {
             return normalize_lookup_key(lfs::core::path_to_utf8(value.lexically_normal()));
         }
 
+        inline std::string raw_lookup_key(const fs::path& value) {
+            const auto utf8 = value.generic_u8string();
+            return {utf8.begin(), utf8.end()};
+        }
+
         inline void throw_if_scan_cancel_requested(const CancelCallback& cancel_requested,
                                                    const std::string_view message) {
             if (cancel_requested && cancel_requested()) {
@@ -215,7 +220,7 @@ namespace lfs::io {
                 if (rel.empty())
                     continue;
 
-                raw_entries_.emplace(rel.generic_string(), entry.path());
+                raw_entries_.emplace(detail::raw_lookup_key(rel), entry.path());
 
                 const std::string rel_key = detail::normalize_lookup_key(rel);
                 if (auto [it_exact, inserted] = exact_entries_.emplace(rel_key, entry.path());
@@ -232,7 +237,7 @@ namespace lfs::io {
                 }
 
                 if (const std::string digit_key =
-                        trailing_digit_run(entry.path().stem().string());
+                        trailing_digit_run(lfs::core::path_to_utf8(entry.path().stem()));
                     !digit_key.empty()) {
                     if (auto [it_digits, inserted] =
                             digit_entries_.emplace(digit_key, entry.path());
@@ -272,11 +277,11 @@ namespace lfs::io {
             return {};
         }
 
-        [[nodiscard]] FileLookupResult lookup(const fs::path& relative_or_name) const {
+        [[nodiscard]] FileLookupResult lookup_exact(const fs::path& relative_or_name) const {
             if (relative_or_name.empty())
                 return {};
 
-            if (auto it = raw_entries_.find(relative_or_name.generic_string());
+            if (auto it = raw_entries_.find(detail::raw_lookup_key(relative_or_name));
                 it != raw_entries_.end()) {
                 return FileLookupResult{LookupStatus::Found, it->second};
             }
@@ -289,6 +294,15 @@ namespace lfs::io {
                 it != exact_entries_.end()) {
                 return FileLookupResult{LookupStatus::Found, it->second};
             }
+
+            return {};
+        }
+
+        [[nodiscard]] FileLookupResult lookup(const fs::path& relative_or_name) const {
+            if (relative_or_name.empty())
+                return {};
+            if (auto result = lookup_exact(relative_or_name); result.status != LookupStatus::NotFound)
+                return result;
 
             const std::string basename_key =
                 detail::normalize_lookup_key(relative_or_name.filename());
@@ -371,6 +385,20 @@ namespace lfs::io {
 
             const std::vector<fs::path> lookup_keys = build_lookup_keys(image_name);
             bool saw_ambiguous_match = false;
+
+            // Check every relative-path/extension candidate before considering a
+            // basename match, which may belong to a different camera subfolder.
+            for (const auto& dir_index : dir_indices_) {
+                for (const auto& key : lookup_keys) {
+                    if (auto result = dir_index.lookup_exact(key); result.found()) {
+                        return result;
+                    } else if (result.ambiguous()) {
+                        saw_ambiguous_match = true;
+                    }
+                }
+            }
+            if (saw_ambiguous_match)
+                return FileLookupResult{LookupStatus::Ambiguous, {}};
 
             for (const auto& dir_index : dir_indices_) {
                 for (const auto& key : lookup_keys) {
@@ -473,7 +501,7 @@ namespace lfs::io {
             // not apply (e.g. several sidecar kinds per frame), so it degrades
             // to "no match" instead of failing the dataset.
             const std::string digit_key = RecursiveFileCache::trailing_digit_run(
-                lfs::core::utf8_to_path(image_name).stem().string());
+                lfs::core::path_to_utf8(lfs::core::utf8_to_path(image_name).stem()));
             for (const auto& dir_index : dir_indices_) {
                 if (auto result = dir_index.lookup_by_digit_suffix(digit_key); result.found()) {
                     return result;

--- a/src/io/loaders/blender_loader.cpp
+++ b/src/io/loaders/blender_loader.cpp
@@ -26,6 +26,19 @@
 
 namespace lfs::io {
 
+    namespace {
+        std::string mask_lookup_name(const std::filesystem::path& image_path,
+                                     const std::filesystem::path& absolute_dataset_path) {
+            auto relative = std::filesystem::absolute(image_path).lexically_normal().lexically_relative(absolute_dataset_path);
+            if (relative.empty() || *relative.begin() == "..")
+                return lfs::core::path_to_utf8(image_path.filename());
+            // Masks mirror the path below images/, or the dataset root for Blender layouts.
+            if (detail::normalize_lookup_key(*relative.begin()) == "images")
+                relative = relative.lexically_relative(*relative.begin());
+            return lfs::core::path_to_utf8(relative);
+        }
+    } // namespace
+
     // Import types from lfs::core for convenience
     using lfs::core::DataType;
     using lfs::core::Device;
@@ -201,7 +214,8 @@ namespace lfs::io {
                 LOG_INFO("mask maps present but unused (mask usage disabled)");
             }
 
-            MaskDirCache mask_cache(base_path, options.cancel_requested);
+            const auto absolute_base_path = std::filesystem::absolute(transforms_file).parent_path().lexically_normal();
+            std::optional<MaskDirCache> mask_cache;
             DepthDirCache depth_cache(base_path, options.cancel_requested);
             NormalDirCache normal_cache(base_path, options.cancel_requested);
 
@@ -212,20 +226,34 @@ namespace lfs::io {
                 const auto& info = camera_infos[i];
 
                 try {
-                    std::filesystem::path mask_path;
-                    if (auto mask_lookup = mask_cache.lookup(info._image_name); mask_lookup.found()) {
-                        mask_path = std::move(mask_lookup.path);
-                    } else if (mask_lookup.ambiguous()) {
-                        if (options.load_masks) {
-                            return make_error(
-                                ErrorCode::INVALID_DATASET,
-                                std::format("Mask for image '{}' is ambiguous across the dataset mask folders. "
-                                            "Keep masks in the same relative subdirectories as the images or rename them uniquely.",
-                                            info._image_name),
-                                base_path);
+                    std::filesystem::path mask_path = info._mask_path;
+                    if (!mask_path.empty()) {
+                        // Explicit metadata is authoritative, including when the referenced
+                        // file is missing. Never substitute a guessed sidecar in that case.
+                        if (info._has_image && options.load_masks && !safe_is_regular_file(mask_path)) {
+                            return make_error(ErrorCode::MISSING_REQUIRED_FILES,
+                                              std::format("Explicit mask_path for image '{}' does not reference a regular file",
+                                                          lfs::core::path_to_utf8(info._image_path)),
+                                              mask_path);
                         }
-                        LOG_WARN("Mask for image '{}' is ambiguous; skipping sidecar because mask usage is disabled",
-                                 info._image_name);
+                    } else {
+                        if (!mask_cache)
+                            mask_cache.emplace(base_path, options.cancel_requested);
+                        const auto lookup_name = mask_lookup_name(info._image_path, absolute_base_path);
+                        if (auto mask_lookup = mask_cache->lookup(lookup_name); mask_lookup.found()) {
+                            mask_path = std::move(mask_lookup.path);
+                        } else if (mask_lookup.ambiguous()) {
+                            if (options.load_masks) {
+                                return make_error(
+                                    ErrorCode::INVALID_DATASET,
+                                    std::format("Mask for image '{}' is ambiguous across the dataset mask folders. "
+                                                "Keep masks in the same relative subdirectories as the images or rename them uniquely.",
+                                                lookup_name),
+                                    base_path);
+                            }
+                            LOG_WARN("Mask for image '{}' is ambiguous; skipping sidecar because mask usage is disabled",
+                                     lookup_name);
+                        }
                     }
 
                     std::filesystem::path depth_path;

--- a/tests/test_colmap_image_layout.cpp
+++ b/tests/test_colmap_image_layout.cpp
@@ -610,6 +610,39 @@ TEST_F(ColmapImageLayoutTest, DepthDirCacheFrameNumberFallbackSkipsAmbiguousMatc
     EXPECT_FALSE(result.ambiguous());
 }
 
+TEST_F(ColmapImageLayoutTest, MaskCachePrefersRelativePathAcrossExtensionsAndRoots) {
+    const auto root = temp_dir_ / "mask_extension_priority";
+    const auto wrong_camera = root / "masks/back/frame.jpg";
+    const auto correct_camera = root / "segmentation/front/frame.png";
+    write_png(wrong_camera);
+    write_png(correct_camera);
+    const lfs::io::MaskDirCache cache(root);
+    const auto result = cache.lookup("front/frame.jpg");
+    ASSERT_TRUE(result.found());
+    EXPECT_EQ(result.path, correct_camera);
+}
+
+TEST_F(ColmapImageLayoutTest, MaskCacheRetainsUniqueBasenameFallback) {
+    const auto root = temp_dir_ / "mask_basename_fallback";
+    const auto mask = root / "masks/frame.png";
+    write_png(mask);
+    const lfs::io::MaskDirCache cache(root);
+    const auto result = cache.lookup("front/frame.jpg");
+    ASSERT_TRUE(result.found());
+    EXPECT_EQ(result.path, mask);
+}
+
+TEST_F(ColmapImageLayoutTest, MaskCachePreservesUnicodeRelativeKeys) {
+    const auto root = temp_dir_ / "unicode_mask_keys";
+    const auto relative = fs::path(u8"cam \u00e8/frame \u6d4b\u8bd5.png");
+    const auto mask = root / "masks" / relative;
+    write_png(mask);
+    const lfs::io::MaskDirCache cache(root);
+    const auto result = cache.lookup(lfs::core::path_to_utf8(relative));
+    ASSERT_TRUE(result.found());
+    EXPECT_EQ(result.path, mask);
+}
+
 TEST_F(ColmapImageLayoutTest, ResolvesDuplicateNestedImagesAndMasksByRelativePath) {
     const fs::path dataset_dir = temp_dir_ / "dataset";
     const fs::path image_a = dataset_dir / "images" / "img1" / "frame_0001.png";

--- a/tests/test_python_io.cpp
+++ b/tests/test_python_io.cpp
@@ -25,6 +25,7 @@
 #include "core/camera_types.h"
 #include "core/error.hpp"
 #include "core/image_io.hpp"
+#include "core/path_utils.hpp"
 #include "core/point_cloud.hpp"
 #include "core/splat_data.hpp"
 #include "io/exporter.hpp"
@@ -655,6 +656,225 @@ TEST_F(PythonIOTest, RejectsMalformedTransformsCameraContractsBeforeCameraConstr
     invalid = valid;
     invalid["frames"][0]["transform_matrix"][3] = nlohmann::json::array({0.0, 0.0, 1.0, 1.0});
     expect_rejected(std::move(invalid));
+}
+
+class TransformsMaskTest : public PythonIOTest {
+protected:
+    void write_dataset(const fs::path& root, nlohmann::json frames) const {
+        const nlohmann::json identity = {
+            {1, 0, 0, 0},
+            {0, 1, 0, 0},
+            {0, 0, 1, 0},
+            {0, 0, 0, 1}};
+        for (auto& frame : frames)
+            frame["transform_matrix"] = identity;
+        write_text_file(root / "transforms.json", nlohmann::json{
+                                                      {"w", 2},
+                                                      {"h", 2},
+                                                      {"fl_x", 2},
+                                                      {"fl_y", 2},
+                                                      {"frames", std::move(frames)}}
+                                                      .dump());
+        // Avoid random initialization so the fixture has only two known points.
+        write_text_file(root / "pointcloud.ply",
+                        "ply\nformat ascii 1.0\nelement vertex 2\n"
+                        "property float x\nproperty float y\nproperty float z\n"
+                        "property uchar red\nproperty uchar green\nproperty uchar blue\n"
+                        "end_header\n0 0 -2 255 0 0\n1 0 -2 0 255 0\n");
+    }
+};
+
+TEST_F(TransformsMaskTest, ExplicitPathsOverrideDiscoveryForFolderAndJson) {
+    const auto root = temp_dir / "explicit_masks";
+    write_dataset(root, {{{"file_path", "images/front/000001.png"}, {"mask_path", "labels/front.png"}},
+                         {{"file_path", "images/back/000001.png"}, {"mask_path", "labels/back.png"}}});
+    for (const auto* side : {"front", "back"}) {
+        write_png(root / "images" / side / "000001.png", 2, 2);
+        write_png(root / "labels" / (std::string(side) + ".png"), 2, 2);
+        // A guessed mask must not win over explicit metadata or fail dimension validation.
+        write_png(root / "masks" / side / "000001.png", 1, 1);
+    }
+    auto loader = Loader::create();
+    for (const auto& source : {root, root / "transforms.json"}) {
+        SCOPED_TRACE(lfs::core::path_to_utf8(source));
+        auto result = loader->load(source, {.load_masks = true});
+        ASSERT_TRUE(result) << result.error().format();
+        const auto& cameras = std::get<LoadedScene>(result->data).cameras;
+        ASSERT_EQ(cameras.size(), 2u);
+        EXPECT_EQ(cameras[0]->mask_path(), root / "labels/front.png");
+        EXPECT_EQ(cameras[1]->mask_path(), root / "labels/back.png");
+        EXPECT_EQ(cameras[0]->image_name(), "000001.png");
+    }
+}
+
+TEST_F(TransformsMaskTest, ImplicitMasksRetainCameraSubdirectories) {
+    const auto root = temp_dir / "implicit_masks";
+    write_dataset(root, {{{"file_path", "./images/front/000001.png"}},
+                         {{"file_path", "images/back/000001.png"}}});
+    for (const auto* side : {"front", "back"}) {
+        write_png(root / "images" / side / "000001.png", 2, 2);
+        write_png(root / "masks" / side / "000001.png", 2, 2);
+    }
+    auto result = Loader::create()->load(root, {.load_masks = true});
+    ASSERT_TRUE(result) << result.error().format();
+    const auto& cameras = std::get<LoadedScene>(result->data).cameras;
+    ASSERT_EQ(cameras.size(), 2u);
+    EXPECT_EQ(cameras[0]->mask_path(), root / "masks/front/000001.png");
+    EXPECT_EQ(cameras[1]->mask_path(), root / "masks/back/000001.png");
+}
+
+TEST_F(TransformsMaskTest, AbsoluteImagePathRetainsRelativeMaskLookup) {
+    const auto root = temp_dir / "absolute_image";
+    const auto image = root / "images/front/000001.png";
+    write_dataset(root, {{{"file_path", lfs::core::path_to_utf8(image)}}});
+    write_png(image, 2, 2);
+    write_png(root / "masks/front/000001.png", 2, 2);
+    write_png(root / "masks/back/000001.png", 1, 1);
+    auto result = Loader::create()->load(root, {.load_masks = true});
+    ASSERT_TRUE(result) << result.error().format();
+    EXPECT_EQ(std::get<LoadedScene>(result->data).cameras.front()->mask_path(), root / "masks/front/000001.png");
+}
+
+TEST_F(TransformsMaskTest, ExtensionlessBlenderImageKeepsUniqueBasenameFallback) {
+    const auto root = temp_dir / "blender_masks";
+    write_dataset(root, {{{"file_path", "./train/r_0"}}});
+    write_png(root / "train/r_0.png", 2, 2);
+    write_png(root / "masks/r_0.png", 2, 2);
+    auto result = Loader::create()->load(root, {.load_masks = true});
+    ASSERT_TRUE(result) << result.error().format();
+    EXPECT_EQ(std::get<LoadedScene>(result->data).cameras.front()->mask_path(), root / "masks/r_0.png");
+}
+
+TEST_F(TransformsMaskTest, ExplicitAndImplicitMasksCanBeMixed) {
+    const auto root = temp_dir / "mixed_masks";
+    write_dataset(root, {{{"file_path", "images/front/000001.png"}, {"mask_path", "labels/front.png"}},
+                         {{"file_path", "images/back/000001.png"}}});
+    write_png(root / "images/front/000001.png", 2, 2);
+    write_png(root / "images/back/000001.png", 2, 2);
+    write_png(root / "labels/front.png", 2, 2);
+    write_png(root / "masks/back/000001.png", 2, 2);
+    auto result = Loader::create()->load(root, {.load_masks = true});
+    ASSERT_TRUE(result) << result.error().format();
+    const auto& cameras = std::get<LoadedScene>(result->data).cameras;
+    ASSERT_EQ(cameras.size(), 2u);
+    EXPECT_EQ(cameras[0]->mask_path(), root / "labels/front.png");
+    EXPECT_EQ(cameras[1]->mask_path(), root / "masks/back/000001.png");
+}
+
+TEST_F(TransformsMaskTest, ExplicitMaskPathsResolveFromJsonAndAllowAbsolutePaths) {
+    const auto root = temp_dir / "json_location";
+    const auto mask = temp_dir / "shared_masks/mask.png";
+    write_png(root / "images/frame.png", 2, 2);
+    write_png(mask, 2, 2);
+    for (const auto& mask_text : {std::string("../shared_masks/mask.png"), lfs::core::path_to_utf8(mask)}) {
+        SCOPED_TRACE(mask_text);
+        write_dataset(root, {{{"file_path", "images/frame.png"}, {"mask_path", mask_text}}});
+        auto result = Loader::create()->load(root / "transforms.json", {.load_masks = true});
+        ASSERT_TRUE(result) << result.error().format();
+        EXPECT_TRUE(fs::equivalent(std::get<LoadedScene>(result->data).cameras.front()->mask_path(), mask));
+    }
+}
+
+TEST_F(TransformsMaskTest, UnicodePathsWorkForExplicitAndImplicitMasks) {
+    const auto root = temp_dir / fs::path(u8"dataset \u00e8 \u6d4b\u8bd5");
+    const auto relative_image = fs::path(u8"images/cam \u00e8/frame \u6d4b\u8bd5.png");
+    const auto relative_mask = fs::path(u8"masks/cam \u00e8/frame \u6d4b\u8bd5.png");
+    write_png(root / relative_image, 2, 2);
+    write_png(root / relative_mask, 2, 2);
+    for (const bool explicit_path : {true, false}) {
+        nlohmann::json frame = {{"file_path", lfs::core::path_to_utf8(relative_image)}};
+        if (explicit_path)
+            frame["mask_path"] = lfs::core::path_to_utf8(relative_mask);
+        write_dataset(root, nlohmann::json::array({frame}));
+        auto result = Loader::create()->load(root, {.load_masks = true});
+        ASSERT_TRUE(result) << result.error().format();
+        EXPECT_EQ(std::get<LoadedScene>(result->data).cameras.front()->mask_path(), root / relative_mask);
+    }
+}
+
+TEST_F(TransformsMaskTest, MissingExplicitMaskNeverFallsBackToGuessedMask) {
+    const auto root = temp_dir / "missing_explicit_mask";
+    write_dataset(root, {{{"file_path", "images/frame.png"}, {"mask_path", "labels/missing.png"}}});
+    write_png(root / "images/frame.png", 2, 2);
+    write_png(root / "masks/frame.png", 2, 2);
+    auto loader = Loader::create();
+    auto enabled = loader->load(root, {.load_masks = true});
+    ASSERT_FALSE(enabled);
+    EXPECT_EQ(enabled.error().code, ErrorCode::MISSING_REQUIRED_FILES);
+    EXPECT_EQ(enabled.error().path, root / "labels/missing.png");
+
+    auto disabled = loader->load(root, {.load_masks = false});
+    ASSERT_TRUE(disabled) << disabled.error().format();
+    const auto& camera = std::get<LoadedScene>(disabled->data).cameras.front();
+    EXPECT_EQ(camera->mask_path(), root / "labels/missing.png");
+    EXPECT_FALSE(camera->has_mask());
+}
+
+TEST_F(TransformsMaskTest, ExplicitMaskDimensionsAreCheckedOnlyWhenEnabled) {
+    const auto root = temp_dir / "mask_dimensions";
+    write_dataset(root, {{{"file_path", "images/frame.png"}, {"mask_path", "labels/mask.png"}}});
+    write_png(root / "images/frame.png", 2, 2);
+    write_png(root / "labels/mask.png", 1, 1);
+    auto loader = Loader::create();
+    auto enabled = loader->load(root, {.load_masks = true});
+    ASSERT_FALSE(enabled);
+    EXPECT_EQ(enabled.error().code, ErrorCode::MASK_SIZE_MISMATCH);
+    auto disabled = loader->load(root, {.load_masks = false});
+    ASSERT_TRUE(disabled) << disabled.error().format();
+    EXPECT_EQ(std::get<LoadedScene>(disabled->data).cameras.front()->mask_path(), root / "labels/mask.png");
+}
+
+TEST_F(TransformsMaskTest, BrokenExplicitMaskIsValidatedOnlyWhenEnabled) {
+    const auto root = temp_dir / "broken_explicit_mask";
+    write_dataset(root, {{{"file_path", "images/frame.png"}, {"mask_path", "labels/mask.png"}}});
+    write_png(root / "images/frame.png", 2, 2);
+    write_text_file(root / "labels/mask.png", "not an image");
+    auto loader = Loader::create();
+    auto enabled = loader->load(root, {.load_masks = true});
+    EXPECT_FALSE(enabled);
+    auto disabled = loader->load(root, {.load_masks = false});
+    ASSERT_TRUE(disabled) << disabled.error().format();
+    EXPECT_EQ(std::get<LoadedScene>(disabled->data).cameras.front()->mask_path(), root / "labels/mask.png");
+}
+
+TEST_F(TransformsMaskTest, MissingImageDoesNotRequireItsExplicitMask) {
+    const auto root = temp_dir / "missing_image_mask";
+    write_dataset(root, {{{"file_path", "images/present.png"}},
+                         {{"file_path", "images/missing.png"}, {"mask_path", "labels/missing.png"}}});
+    write_png(root / "images/present.png", 2, 2);
+    auto result = Loader::create()->load(root, {.load_masks = true});
+    ASSERT_TRUE(result) << result.error().format();
+    const auto& cameras = std::get<LoadedScene>(result->data).cameras;
+    ASSERT_EQ(cameras.size(), 2u);
+    EXPECT_FALSE(cameras[1]->has_image());
+    EXPECT_EQ(cameras[1]->mask_path(), root / "labels/missing.png");
+}
+
+TEST_F(TransformsMaskTest, AmbiguousImplicitMasksRemainAnErrorWhenEnabled) {
+    const auto root = temp_dir / "ambiguous_masks";
+    write_dataset(root, {{{"file_path", "images/frame.png"}}});
+    write_png(root / "images/frame.png", 2, 2);
+    write_png(root / "masks/front/frame.png", 2, 2);
+    write_png(root / "masks/back/frame.png", 2, 2);
+    auto loader = Loader::create();
+    auto enabled = loader->load(root, {.load_masks = true});
+    ASSERT_FALSE(enabled);
+    EXPECT_EQ(enabled.error().code, ErrorCode::INVALID_DATASET);
+    auto disabled = loader->load(root, {.load_masks = false});
+    ASSERT_TRUE(disabled) << disabled.error().format();
+    EXPECT_TRUE(std::get<LoadedScene>(disabled->data).cameras.front()->mask_path().empty());
+}
+
+TEST_F(TransformsMaskTest, InvalidMaskMetadataIsRejectedBeforeCameraAssembly) {
+    const auto root = temp_dir / "invalid_mask_metadata";
+    const std::vector<nlohmann::json> invalid = {
+        nullptr, 42, true, nlohmann::json::array({"mask.png"}), nlohmann::json::object(),
+        "", std::string(4097, 'x'), std::string("mask\0.png", 9)};
+    for (const auto& mask_path : invalid) {
+        SCOPED_TRACE(mask_path.dump());
+        write_dataset(root, {{{"file_path", "images/frame.png"}, {"mask_path", mask_path}}});
+        EXPECT_THROW((void)read_transforms_cameras_and_images(root / "transforms.json"), std::runtime_error);
+    }
 }
 
 TEST_F(PythonIOTest, LoadTransformsPerFrameIntrinsics) {


### PR DESCRIPTION
The transforms loader ignores per-frame `mask_path` and searches for masks by image basename. Datasets such as `images/front/000001.jpg` and `images/back/000001.jpg` can therefore produce ambiguous or incorrect mask associations.

- Parse and validate optional per-frame `mask_path`, resolving relative paths against the transforms JSON directory and preserving absolute paths.
- Give explicit mask paths precedence over discovery. Report missing explicit masks when masks are enabled instead of silently selecting a different file.
- Preserve image subdirectories for implicit mask lookup, stripping the leading `images/` component while retaining the legacy unique-basename fallback.
- Prefer matching relative paths across mask extensions and search folders before falling back to a basename, preventing masks from another camera from winning.
- Preserve Unicode paths in the shared file index and defer mask indexing until discovery is needed.
- Retain camera display names and split behavior, and associate mask paths without validating mask files when mask loading is disabled.
- Add importer and mask-cache regressions for explicit, implicit, mixed, nested, Unicode, missing, malformed and dimension-mismatched mask inputs.

Fixes https://github.com/MrNeRF/LichtFeld-Studio/issues/1422