### PR TITLE
Vulkan: complete the 8-bit overlay flag transition on master (port of #2019)

### DIFF
--- a/src/rendering/rasterizer/vulkan/shader/src/slang/alphablend_shader.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/alphablend_shader.slang
@@ -159,7 +159,7 @@ layout(binding=9) RWStructuredBuffer<float> pixel_depth_weight;
 layout(binding=14) ByteAddressBuffer selection_mask;
 layout(binding=15) ByteAddressBuffer preview_mask;
 layout(binding=16) StructuredBuffer<float4> selection_colors;
-layout(binding=17) StructuredBuffer<uint> gaussian_overlay_flags;
+layout(binding=17) ByteAddressBuffer gaussian_overlay_flags;
 layout(binding=18) StructuredBuffer<float4> overlay_params;
 layout(binding=19) ByteAddressBuffer transform_indices;
 layout(binding=20) StructuredBuffer<float4> model_transforms;
@@ -167,7 +167,7 @@ layout(binding=20) StructuredBuffer<float4> model_transforms;
 layout(binding=10) ByteAddressBuffer selection_mask;
 layout(binding=11) ByteAddressBuffer preview_mask;
 layout(binding=12) StructuredBuffer<float4> selection_colors;
-layout(binding=13) StructuredBuffer<uint> gaussian_overlay_flags;
+layout(binding=13) ByteAddressBuffer gaussian_overlay_flags;
 layout(binding=14) StructuredBuffer<float4> overlay_params;
 #endif
 

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/macro_compose.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/macro_compose.slang
@@ -37,7 +37,7 @@ layout(binding=11) RWStructuredBuffer<int32_t> final_n_contributors;
 layout(binding=12) ByteAddressBuffer selection_mask;
 layout(binding=13) ByteAddressBuffer preview_mask;
 layout(binding=14) StructuredBuffer<float4> selection_colors;
-layout(binding=15) StructuredBuffer<uint> gaussian_overlay_flags;
+layout(binding=15) ByteAddressBuffer gaussian_overlay_flags;
 layout(binding=16) StructuredBuffer<float4> overlay_params;
 layout(binding=17) StructuredBuffer<int32_t> orig_ids;
 #endif
@@ -85,7 +85,7 @@ void replay_batch(uint range_start,
         // Replay streams from global (no cooperative stage). Hoisted uniforms
         // still remove overlay_params traffic from the per-splat path.
         // Flags are keyed by macro-sorted slot; selection masks by original id.
-        const uint flags = gaussian_overlay_flags[slot];
+        const uint flags = read_byte(gaussian_overlay_flags, slot);
         const uint sel_splat_id = uint(orig_ids[slot]);
         const uint selection_byte = overlay_state.selection_mask_enabled
             ? read_byte(selection_mask, sel_splat_id) : 0u;

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/macro_raster.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/macro_raster.slang
@@ -78,7 +78,7 @@ layout(binding=7) RWStructuredBuffer<uint32_t> macro_batch_active_mask;
 layout(binding=8) ByteAddressBuffer selection_mask;
 layout(binding=9) ByteAddressBuffer preview_mask;
 layout(binding=10) StructuredBuffer<float4> selection_colors;
-layout(binding=11) StructuredBuffer<uint> gaussian_overlay_flags;
+layout(binding=11) ByteAddressBuffer gaussian_overlay_flags;
 layout(binding=12) StructuredBuffer<float4> overlay_params;
 layout(binding=13) StructuredBuffer<int32_t> orig_ids;
 #endif
@@ -206,7 +206,7 @@ void main(uint3 groupThreadID : SV_GroupThreadID,
             // Selection masks are indexed by original gaussian id, not the
             // macro-sorted slot (LOD may rematerialize).
             const uint sel_splat_id = uint(orig_ids[slot]);
-            const uint flags = gaussian_overlay_flags[slot];
+            const uint flags = read_byte(gaussian_overlay_flags, slot);
             const uint selection_byte = overlay_state.selection_mask_enabled
                 ? read_byte(selection_mask, sel_splat_id) : 0u;
             const uint preview_byte = overlay_state.preview_mask_enabled

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/overlay_flags.inc
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/overlay_flags.inc
@@ -1,0 +1,9 @@
+#ifndef LFS_VK_OVERLAY_FLAGS_INC
+#define LFS_VK_OVERLAY_FLAGS_INC
+
+// One byte per splat, accessed as packed 32-bit words on every Vulkan device.
+// Shared by the host allocation/dispatch and the shader writer.
+#define LFS_VK_OVERLAY_WORD_BYTES 4u
+#define LFS_VK_OVERLAY_WRITE_BIT 64u
+
+#endif // LFS_VK_OVERLAY_FLAGS_INC

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/tile_batch_shader.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/tile_batch_shader.slang
@@ -107,7 +107,7 @@ layout(binding=6) RWStructuredBuffer<int32_t> tile_batch_n_contributors;
 layout(binding=7) ByteAddressBuffer selection_mask;
 layout(binding=8) ByteAddressBuffer preview_mask;
 layout(binding=9) StructuredBuffer<float4> selection_colors;
-layout(binding=10) StructuredBuffer<uint> gaussian_overlay_flags;
+layout(binding=10) ByteAddressBuffer gaussian_overlay_flags;
 layout(binding=11) StructuredBuffer<float4> overlay_params;
 #endif
 
@@ -266,7 +266,7 @@ layout(binding=11) RWStructuredBuffer<int32_t> final_n_contributors;
 layout(binding=12) ByteAddressBuffer selection_mask;
 layout(binding=13) ByteAddressBuffer preview_mask;
 layout(binding=14) StructuredBuffer<float4> selection_colors;
-layout(binding=15) StructuredBuffer<uint> gaussian_overlay_flags;
+layout(binding=15) ByteAddressBuffer gaussian_overlay_flags;
 layout(binding=16) StructuredBuffer<float4> overlay_params;
 #endif
 

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/utils.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/utils.slang
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "config.slang"
+#include "overlay_flags.inc"
 
 static const float eps = 1e-7;
 
@@ -1119,6 +1120,19 @@ uint read_byte(ByteAddressBuffer buffer, uint idx)
     return (buffer.Load(aligned_idx) >> shift) & 0xffu;
 }
 
+// The host clears every word before projection. Atomic OR preserves adjacent
+// bytes even when compact survivor slots in one word come from different waves.
+// All-zero flags need no store; clearing also removes flags from the last frame.
+[ForceInline]
+void write_overlay_byte(RWByteAddressBuffer buffer, uint idx, uint flags, uint lod_enabled)
+{
+    if ((lod_enabled & LFS_VK_OVERLAY_WRITE_BIT) == 0u || (flags & 0xffu) == 0u)
+        return;
+    const uint word_offset = idx & ~(LFS_VK_OVERLAY_WORD_BYTES - 1u);
+    const uint shift = (idx & (LFS_VK_OVERLAY_WORD_BYTES - 1u)) * 8u;
+    buffer.InterlockedOr(word_offset, (flags & 0xffu) << shift);
+}
+
 [ForceInline]
 int read_int32(ByteAddressBuffer buffer, uint idx)
 {
@@ -1203,12 +1217,12 @@ uint unpack_overlay_preview_byte(uint packed)
 [ForceInline]
 uint load_overlay_per_splat_pack(
     uint splat_id,
-    StructuredBuffer<uint> gaussian_overlay_flags,
+    ByteAddressBuffer gaussian_overlay_flags,
     ByteAddressBuffer selection_mask,
     ByteAddressBuffer preview_mask,
     OverlayUniformState state)
 {
-    uint flags = gaussian_overlay_flags[splat_id];
+    uint flags = read_byte(gaussian_overlay_flags, splat_id);
     uint selection_byte = state.selection_mask_enabled ? read_byte(selection_mask, splat_id) : 0u;
     uint preview_byte = state.preview_mask_enabled ? read_byte(preview_mask, splat_id) : 0u;
     return pack_overlay_per_splat(flags, selection_byte, preview_byte);

--- a/src/rendering/rasterizer/vulkan/shader/src/slang/vertex_shader.slang
+++ b/src/rendering/rasterizer/vulkan/shader/src/slang/vertex_shader.slang
@@ -671,9 +671,8 @@ layout(binding=5) StructuredBuffer<float> opacity_raw;  // 1
 
 // Output buffers
 #if !LFS_PROJECTION_SURVIVORS
-// The macro chain derives coverage from the rect + ellipse; tiles_touched and
-// radii are legacy-chain outputs only and their bindings are absent in the
-// survivor variant.
+// The macro chain derives coverage from the rect + ellipse; tiles_touched is
+// a legacy-chain output only. Binding 8 (write-only radii) was retired.
 layout(binding=6) RWStructuredBuffer<int> out_tiles_touched;
 #endif
 #if USE_EMULATED_INT64
@@ -681,14 +680,11 @@ layout(binding=7) RWStructuredBuffer<int32_t> out_rect_tile_space;
 #else
 layout(binding=7) RWStructuredBuffer<int64_t> out_rect_tile_space;
 #endif
-#if !LFS_PROJECTION_SURVIVORS
-layout(binding=8) RWStructuredBuffer<int> out_radii;
-#endif
 layout(binding=9) RWStructuredBuffer<float2> out_xy_vs;
 layout(binding=10) RWStructuredBuffer<float> out_depths;
 layout(binding=11) RWStructuredBuffer<float4> out_inv_cov_vs;
 layout(binding=12) RWStructuredBuffer<float> out_rgb;
-layout(binding=13) RWStructuredBuffer<uint> out_overlay_flags;
+layout(binding=13) RWByteAddressBuffer out_overlay_flags;
 layout(binding=14) ByteAddressBuffer transform_indices;
 layout(binding=15) ByteAddressBuffer node_mask;
 layout(binding=16) StructuredBuffer<float4> overlay_params;
@@ -744,9 +740,8 @@ layout(binding=24) StructuredBuffer<float2> shN_bounds;
 // Legacy N-wide variant only: the survivor-list variant never clears, because
 // rejected splats simply do not append a compact slot.
 [ForceInline]
-void clear_forward_projection_output(uint out_idx, uint overlay_flags) {
-    out_overlay_flags[out_idx] = overlay_flags;
-    out_radii[out_idx] = 0;
+void clear_forward_projection_output(uint out_idx, uint overlay_flags, uint lod_enabled) {
+    write_overlay_byte(out_overlay_flags, out_idx, overlay_flags, lod_enabled);
     out_tiles_touched[out_idx] = 0;
   #if USE_EMULATED_INT64
     out_rect_tile_space[2*out_idx+0] = 0;
@@ -835,7 +830,7 @@ void main(
         if ((uniforms.lod_enabled & 32u) != 0u) {
             const uint valid = min(lod_counts[0], uniforms.lod_count);
             if (render_idx >= valid) {
-                clear_forward_projection_output(out_idx, 0u);
+                clear_forward_projection_output(out_idx, 0u, uniforms.lod_enabled);
                 return;
             }
         }
@@ -843,7 +838,7 @@ void main(
         g_idx = lod_indices[render_idx];
         if (g_idx == 0xffffffffu || g_idx >= uniforms.model_num_splats) {
           #if EXPORT_MODE == EXPORT_MODE_VULKAN_FORWARD && !LFS_PROJECTION_SURVIVORS
-            clear_forward_projection_output(out_idx, 0u);
+            clear_forward_projection_output(out_idx, 0u, uniforms.lod_enabled);
           #endif
             return;
         }
@@ -945,7 +940,7 @@ void main(
       #if LFS_PROJECTION_SURVIVORS
         return;
       #else
-        clear_forward_projection_output(out_idx, overlay_flags);
+        clear_forward_projection_output(out_idx, overlay_flags, uniforms.lod_enabled);
         return;
       #endif
     }
@@ -1008,7 +1003,7 @@ void main(
         splat.det <= 0.0
     ) {
         #if EXPORT_MODE == EXPORT_MODE_VULKAN_FORWARD && !LFS_PROJECTION_SURVIVORS
-            clear_forward_projection_output(out_idx, overlay_flags);
+            clear_forward_projection_output(out_idx, overlay_flags, uniforms.lod_enabled);
         #endif
         return;
     }
@@ -1036,7 +1031,7 @@ void main(
     int32_t n_tiles = int32_t(rect_tile_space.max_x - rect_tile_space.min_x) * int32_t(rect_tile_space.max_y - rect_tile_space.min_y);
     if (n_tiles == 0) {
         #if EXPORT_MODE == EXPORT_MODE_VULKAN_FORWARD && !LFS_PROJECTION_SURVIVORS
-            clear_forward_projection_output(out_idx, overlay_flags);
+            clear_forward_projection_output(out_idx, overlay_flags, uniforms.lod_enabled);
         #endif
         return;
     }
@@ -1086,8 +1081,6 @@ void main(
     out_sort_ids[out_idx] = int32_t(out_idx);
     out_orig_ids[out_idx] = int32_t(logical_idx);
 #else
-    // out_radii[g_idx] = (uint32_t)radius;  // inria
-    out_radii[out_idx] = (uint32_t)ceil(max(radii.x, radii.y));  // gsplat, only used in densification
     out_tiles_touched[out_idx] = n_tiles;
   #if USE_EMULATED_INT64
     out_rect_tile_space[2*out_idx+0] = (int32_t)rect_tile_space.min_x | ((int32_t)rect_tile_space.min_y << 16);
@@ -1097,7 +1090,7 @@ void main(
   #endif
 
     if (n_tiles == 0) {
-        out_overlay_flags[out_idx] = overlay_flags;
+        write_overlay_byte(out_overlay_flags, out_idx, overlay_flags, uniforms.lod_enabled);
         return;
     }
 
@@ -1126,7 +1119,7 @@ void main(
     out_depths[out_idx] = splat.xyz_vs.z;
     out_inv_cov_vs[out_idx] = splat.inv_cov_vs_opac;
     write_t3_float3(splat.rgb, out_idx, out_rgb);
-    out_overlay_flags[out_idx] = overlay_flags;
+    write_overlay_byte(out_overlay_flags, out_idx, overlay_flags, uniforms.lod_enabled);
 
 #elif EXPORT_MODE == EXPORT_MODE_VULKAN_BACKWARD
 

--- a/src/rendering/rasterizer/vulkan/src/buffer.h
+++ b/src/rendering/rasterizer/vulkan/src/buffer.h
@@ -191,10 +191,11 @@ struct VulkanGSPipelineBuffers {
     Buffer<float> depths;             // (N, 1)
     Buffer<float> inv_cov_vs_opacity; // (N, 4)
     Buffer<float> rgb;                // (N, 3)
-    // 3-bit payload (DIM|NONSELECTABLE|FLASH). Allocated N-wide only while
-    // raster overlays are active; otherwise a 1-element dummy is bound and
-    // projection skips the store (lod_enabled bit 6).
-    Buffer<uint8_t> overlay_flags; // (N,) or (1,) dummy
+    // 3-bit payload (DIM|NONSELECTABLE|FLASH), one byte per splat. Byte-address
+    // access rounds the descriptor up to a whole 32-bit word. Projection clears
+    // the words before atomically ORing each byte; raster-only refreshes reuse
+    // them. With writes disabled, bit 6 is clear and a one-word dummy is bound.
+    Buffer<uint8_t> overlay_flags; // round_up(N, 4) bytes, minimum 4
 
     // Two-stage sort (Splatshop): visible primitives are compacted and sorted by
     // radial distance (depth), then tile instances are emitted in depth order and

--- a/src/rendering/rasterizer/vulkan/src/gs_renderer.cpp
+++ b/src/rendering/rasterizer/vulkan/src/gs_renderer.cpp
@@ -1235,6 +1235,25 @@ void VulkanGSRenderer::executeSelectLodThreshold(const VulkanGSLodSelectUniforms
     recordLodSelectionReadback(buffers, uniforms.output_capacity);
 }
 
+_VulkanBuffer& VulkanGSRenderer::prepareOverlayFlags(
+    VulkanGSPipelineBuffers& buffers,
+    const size_t num_splats,
+    const bool write_overlay_flags) {
+    constexpr size_t kWordBytes = LFS_VK_OVERLAY_WORD_BYTES;
+    if (!write_overlay_flags) {
+        return resizeDeviceBuffer(buffers.overlay_flags, kWordBytes);
+    }
+    if (num_splats > std::numeric_limits<size_t>::max() - (kWordBytes - 1)) {
+        lfs::rendering::throw_renderer_contract(
+            "VkSplat overlay flag byte count overflows word alignment",
+            LFS_SOURCE_SITE_CURRENT());
+    }
+    // ByteAddressBuffer loads and atomic OR stores access complete words,
+    // including the final partial word and the non-empty dummy for N == 0.
+    const size_t bytes = std::max(kWordBytes, (num_splats + kWordBytes - 1) & ~(kWordBytes - 1));
+    return clearDeviceBuffer(buffers.overlay_flags, bytes);
+}
+
 void VulkanGSRenderer::executeProjectionForward(
     const VulkanGSRendererUniforms& uniforms,
     VulkanGSPipelineBuffers& buffers,
@@ -1300,8 +1319,7 @@ void VulkanGSRenderer::executeProjectionForward(
     auto& depths = resizeDeviceBuffer(buffers.depths, alloc_size);
     auto& inv_cov = resizeDeviceBuffer(buffers.inv_cov_vs_opacity, 4 * alloc_size);
     auto& rgb = resizeDeviceBuffer(buffers.rgb, 3 * alloc_size);
-    auto& overlay_flags = resizeDeviceBuffer(
-        buffers.overlay_flags, write_overlay_flags ? alloc_size : size_t{1});
+    auto& overlay_flags = prepareOverlayFlags(buffers, alloc_size, write_overlay_flags);
     // A2: keys die after compact (L4); sort indices are born at the post-radix
     // copy (L6). Same int32 allocation, existing L5 barrier between them.
     aliasDeviceView(buffers.primitive_sort_indices.deviceBuffer, primitive_depth_keys);
@@ -1328,7 +1346,7 @@ void VulkanGSRenderer::executeProjectionForward(
         {depths, BufferUse::ComputeWrite},
         {inv_cov, BufferUse::ComputeWrite},
         {rgb, BufferUse::ComputeWrite},
-        {overlay_flags, write_overlay_flags ? BufferUse::ComputeWrite : BufferUse::ComputeRead},
+        {overlay_flags, write_overlay_flags ? BufferUse::ComputeReadWrite : BufferUse::ComputeRead},
         {transform_indices, BufferUse::ComputeRead},
         {node_mask, BufferUse::ComputeRead},
         {overlay_params, BufferUse::ComputeRead},
@@ -2651,8 +2669,7 @@ void VulkanGSRenderer::executeProjectionForwardSurvivors(
     auto& depths = resizeDeviceBuffer(buffers.depths, visible_capacity);
     auto& inv_cov = resizeDeviceBuffer(buffers.inv_cov_vs_opacity, 4 * visible_capacity);
     auto& rgb = resizeDeviceBuffer(buffers.rgb, 3 * visible_capacity);
-    auto& overlay_flags = resizeDeviceBuffer(
-        buffers.overlay_flags, write_overlay_flags ? visible_capacity : size_t{1});
+    auto& overlay_flags = prepareOverlayFlags(buffers, visible_capacity, write_overlay_flags);
     auto& orig_ids = resizeDeviceBuffer(buffers.orig_ids, visible_capacity);
 
     const _VulkanBuffer lod_indices_binding =
@@ -2683,7 +2700,7 @@ void VulkanGSRenderer::executeProjectionForwardSurvivors(
         {depths, BufferUse::ComputeWrite},                          // 10
         {inv_cov, BufferUse::ComputeWrite},                         // 11
         {rgb, BufferUse::ComputeWrite},                             // 12
-        {overlay_flags, write_overlay_flags ? BufferUse::ComputeWrite
+        {overlay_flags, write_overlay_flags ? BufferUse::ComputeReadWrite
                                             : BufferUse::ComputeRead},          // 13
         {transform_indices, BufferUse::ComputeRead},                            // 14
         {node_mask, BufferUse::ComputeRead},                                    // 15

--- a/src/rendering/rasterizer/vulkan/src/gs_renderer.h
+++ b/src/rendering/rasterizer/vulkan/src/gs_renderer.h
@@ -2,6 +2,7 @@
 
 #include "gs_pipeline.h"
 
+#include "../shader/src/slang/overlay_flags.inc"
 #include "indirect_layout.h"
 #include "perf_timer.h"
 
@@ -56,8 +57,8 @@
 }
 
 // lod_enabled bit 6: projection writes overlay_flags. Clear when the bound
-// buffer is the 1-element dummy (raster overlays idle).
-constexpr uint32_t kLodEnabledWriteOverlayFlags = 64u;
+// buffer is the one-word dummy (raster overlays idle).
+constexpr uint32_t kLodEnabledWriteOverlayFlags = LFS_VK_OVERLAY_WRITE_BIT;
 
 PACK_STRUCT(struct VulkanGSRendererUniforms {
     uint32_t image_height;
@@ -385,6 +386,12 @@ public:
                                    VulkanGSPipelineBuffers& buffers);
 
 protected:
+    // Projection ORs individual bytes into zeroed words. Raster-only overlay
+    // refreshes retain these flags and must not clear them.
+    _VulkanBuffer& prepareOverlayFlags(VulkanGSPipelineBuffers& buffers,
+                                       size_t num_splats,
+                                       bool write_overlay_flags);
+
     // Export W_rec can exceed the interactive wave budget. Callers disable
     // timestamps after W_MAX so fixed-size query rings remain bounded while all
     // scan work is still recorded and executed.

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -3335,7 +3335,7 @@ namespace lfs::vis {
         add_count(per_visible, sizeof(float));        // depths
         add_count(4 * per_visible, sizeof(float));    // inv_cov_vs_opacity
         add_count(3 * per_visible, sizeof(float));    // rgb
-        add_count(per_visible, sizeof(std::int32_t)); // overlay_flags
+        add_count(per_visible, sizeof(std::uint8_t)); // overlay_flags (region alignment pads the last word)
         if (macro_chain) {
             add_count(per_visible, sizeof(std::int32_t)); // orig_ids
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -961,6 +961,7 @@ set(LFS_PYTHON_SLOW_TESTS
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_signals.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_toolbar_hooks.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_vksplat_orthographic_regressions.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/test_vksplat_overlay_storage.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/test_vksplat_output_lifetime_regressions.py
 )
 

--- a/tests/python/test_vksplat_overlay_storage.py
+++ b/tests/python/test_vksplat_overlay_storage.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Host/shader contracts for #2014; also runnable with stdlib unittest.
+
+These checks read source and evaluate the writer's integer address expressions.
+They do not compile Slang or replace the scripted Vulkan and real GPU tests.
+"""
+
+import ast
+from pathlib import Path
+import random
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VULKAN = ROOT / "src/rendering/rasterizer/vulkan"
+SHADERS = VULKAN / "shader/src/slang"
+
+
+def read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def body(source, signature):
+    start = source.index("{", source.index(signature))
+    depth = 1
+    for end in range(start + 1, len(source)):
+        depth += (source[end] == "{") - (source[end] == "}")
+        if depth == 0:
+            return source[start + 1:end]
+    raise AssertionError(f"Unclosed function: {signature}")
+
+
+def integer_expression(expression, values):
+    """Interpret only the integer operations used by the actual shader writer."""
+    expression = re.sub(r"\b(0x[0-9a-fA-F]+|[0-9]+)[uU]\b", r"\1", expression)
+    tree = ast.parse(expression, mode="eval")
+    allowed = (ast.Expression, ast.BinOp, ast.UnaryOp, ast.Constant, ast.Name,
+               ast.Load, ast.BitAnd, ast.BitOr, ast.LShift, ast.RShift,
+               ast.Invert, ast.Add, ast.Sub, ast.Mult)
+    if any(not isinstance(node, allowed) for node in ast.walk(tree)):
+        raise AssertionError(f"Unexpected shader address expression: {expression}")
+    return eval(compile(tree, "<shader integer expression>", "eval"), {"__builtins__": {}}, values)
+
+
+class VkSplatOverlayStorageTests(unittest.TestCase):
+    def test_every_shader_uses_byte_addressed_overlay_storage(self):
+        vertex = read(SHADERS / "vertex_shader.slang")
+        self.assertIn("layout(binding=13) RWByteAddressBuffer out_overlay_flags;", vertex)
+        self.assertNotRegex(vertex, r"out_overlay_flags\s*\[")
+        for name in ("alphablend_shader.slang", "tile_batch_shader.slang",
+                     "macro_raster.slang", "macro_compose.slang", "utils.slang"):
+            with self.subTest(shader=name):
+                source = read(SHADERS / name)
+                self.assertRegex(source, r"\bByteAddressBuffer\s+gaussian_overlay_flags\b")
+                self.assertNotRegex(source, r"StructuredBuffer<[^>]+>\s+gaussian_overlay_flags")
+                self.assertNotRegex(source, r"gaussian_overlay_flags\s*\[")
+        for name in ("macro_raster.slang", "macro_compose.slang"):
+            self.assertIn("read_byte(gaussian_overlay_flags, slot)", read(SHADERS / name))
+        self.assertIn("read_byte(gaussian_overlay_flags, splat_id)", read(SHADERS / "utils.slang"))
+
+    def test_shader_writer_guards_dummy_and_uses_atomic_or(self):
+        writer = body(read(SHADERS / "utils.slang"), "void write_overlay_byte(")
+        self.assertRegex(writer, r"lod_enabled\s*&\s*LFS_VK_OVERLAY_WRITE_BIT")
+        self.assertLess(writer.index("return;"), writer.index(".InterlockedOr("))
+        self.assertNotIn(".Store(", writer)
+        self.assertNotIn(".Load(", writer)
+        self.assertEqual(writer.count(".InterlockedOr("), 1)
+
+    def test_actual_shader_address_expressions_preserve_neighbour_bytes(self):
+        defines = {name: int(value) for name, value in re.findall(
+            r"#define\s+(LFS_VK_OVERLAY_\w+)\s+(\d+)u", read(SHADERS / "overlay_flags.inc"))}
+        self.assertEqual(defines["LFS_VK_OVERLAY_WORD_BYTES"], 4)
+        writer = body(read(SHADERS / "utils.slang"), "void write_overlay_byte(")
+        offset_expr = re.search(r"const uint word_offset\s*=\s*(.*?);", writer).group(1)
+        shift_expr = re.search(r"const uint shift\s*=\s*(.*?);", writer).group(1)
+        value_expr = re.search(r"\.InterlockedOr\(word_offset,\s*(.*?)\);", writer).group(1)
+        rng = random.Random(2014)
+        for count in (1, 2, 3, 4, 5, 31, 32, 33, 127, 128, 129, 513):
+            # Survivor emission order may interleave the bytes of one word.
+            # Exercise all currently valid flags, zero, and the full byte range.
+            flags = [(i * 37 + count) & 0xff for i in range(count)]
+            flags[:min(count, 8)] = list(range(min(count, 8)))
+            indices = list(range(count))
+            for _ in range(8):
+                rng.shuffle(indices)
+                storage = bytearray(((count + 3) // 4) * 4)
+                for index in indices:
+                    values = dict(defines, idx=index, flags=flags[index])
+                    offset = integer_expression(offset_expr, values)
+                    shift = integer_expression(shift_expr, values)
+                    value = integer_expression(value_expr, dict(values, shift=shift))
+                    self.assertEqual(offset % 4, 0)
+                    self.assertLessEqual(offset + 4, len(storage))
+                    word = int.from_bytes(storage[offset:offset + 4], "little") | value
+                    storage[offset:offset + 4] = word.to_bytes(4, "little")
+                self.assertEqual(list(storage[:count]), flags)
+                self.assertFalse(any(storage[count:]))
+
+    def test_host_clears_padded_storage_for_both_projection_paths(self):
+        source = read(VULKAN / "src/gs_renderer.cpp")
+        prepare = body(source, "VulkanGSRenderer::prepareOverlayFlags(")
+        self.assertIn("LFS_VK_OVERLAY_WORD_BYTES", prepare)
+        self.assertIn("clearDeviceBuffer(buffers.overlay_flags, bytes)", prepare)
+        self.assertIn("resizeDeviceBuffer(buffers.overlay_flags, kWordBytes)", prepare)
+        self.assertIn("if (!write_overlay_flags)", prepare)
+        for signature in ("VulkanGSRenderer::executeProjectionForward(",
+                          "VulkanGSRenderer::executeProjectionForwardSurvivors("):
+            projection = body(source, signature)
+            self.assertIn("prepareOverlayFlags(buffers,", projection)
+            self.assertRegex(projection, r"overlay_flags,\s*write_overlay_flags\s*\?\s*BufferUse::ComputeReadWrite")
+            self.assertIn("|= kLodEnabledWriteOverlayFlags", projection)
+            self.assertIn("&= ~kLodEnabledWriteOverlayFlags", projection)
+        self.assertIn("kLodEnabledWriteOverlayFlags = LFS_VK_OVERLAY_WRITE_BIT",
+                      read(VULKAN / "src/gs_renderer.h"))
+        self.assertIn("Buffer<uint8_t> overlay_flags", read(VULKAN / "src/buffer.h"))
+
+    def test_arena_estimate_and_bind_use_one_byte_per_flag(self):
+        source = read(ROOT / "src/visualizer/rendering/vksplat_viewport_renderer.cpp")
+        estimate = body(source, "VksplatViewportRenderer::estimateSharedScratchBytes(")
+        self.assertRegex(estimate, r"add_count\(per_visible,\s*sizeof\(std::uint8_t\)\);\s*// overlay_flags")
+        bind = body(source, "VksplatViewportRenderer::bindSharedScratchBuffers(")
+        self.assertIn("count * sizeof(Value)", bind)
+        self.assertIn("bind_count(buffers_.overlay_flags, per_visible)", bind)
+        # Changing only selection must retain the projection's classification.
+        rerender = body(source, "VksplatViewportRenderer::rerenderSelectionOverlay(")
+        self.assertNotIn("prepareOverlayFlags", rerender)
+        self.assertNotIn("clearDeviceBuffer", rerender)
+
+    def test_all_projection_reject_paths_receive_the_write_gate(self):
+        source = read(SHADERS / "vertex_shader.slang")
+        calls = re.findall(r"clear_forward_projection_output\(([^()]*)\)", source)
+        self.assertGreaterEqual(len(calls), 6)
+        for call in calls:
+            self.assertEqual(len(call.split(",")), 3, call)
+        for call in calls[1:]:
+            self.assertTrue(call.strip().endswith("uniforms.lod_enabled"), call)
+        clear = body(source, "void clear_forward_projection_output(")
+        self.assertNotIn("uniforms.", clear)  # Uniforms are a main() parameter.
+        self.assertIn("write_overlay_byte(out_overlay_flags, out_idx, overlay_flags, lod_enabled)", clear)
+
+    def test_retired_radii_output_is_absent_from_forward_shader(self):
+        self.assertNotIn("out_radii", read(SHADERS / "vertex_shader.slang"))
+        self.assertIn("pipeline_projection_forward = _ComputePipeline(vksplatSkipBinding(24, 8))",
+                      read(VULKAN / "src/gs_renderer.h"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vksplat_tagged_dispatch.cpp
+++ b/tests/test_vksplat_tagged_dispatch.cpp
@@ -14,6 +14,8 @@
 
 #include <array>
 #include <cstdint>
+#include <cstring>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -113,12 +115,21 @@ namespace {
         std::uint32_t memory_barrier_count = 0;
     };
 
+    struct CapturedFill {
+        VkBuffer buffer;
+        VkDeviceSize offset;
+        VkDeviceSize size;
+        std::uint32_t value;
+    };
+
     // Scripted dispatch: captures barrier2 dependency infos AND
     // bind/dispatch/push order. Also covers begin/end/submit/reset_query so
     // beginCommandBatch/endCommandBatch work without a real device.
     struct DispatchScript {
         std::vector<RecordedOp> ops;
         std::vector<CapturedBarrier2> barriers;
+        std::vector<CapturedFill> fills;
+        std::vector<VulkanGSRendererUniforms> projection_uniforms;
         int submit_calls = 0;
         int begin_calls = 0;
         int end_calls = 0;
@@ -137,6 +148,8 @@ namespace {
         void clear_recording() {
             ops.clear();
             barriers.clear();
+            fills.clear();
+            projection_uniforms.clear();
         }
 
         [[nodiscard]] std::size_t buffer_barrier_calls() const {
@@ -261,11 +274,16 @@ namespace {
         static VKAPI_ATTR void VKAPI_CALL push_constants(VkCommandBuffer,
                                                          VkPipelineLayout,
                                                          VkShaderStageFlags,
-                                                         uint32_t,
-                                                         uint32_t,
-                                                         const void*) {
+                                                         uint32_t offset,
+                                                         uint32_t size,
+                                                         const void* data) {
             EXPECT_NE(active(), nullptr);
             active()->ops.push_back(RecordedOp::PushConstants);
+            if (offset == 0 && size == sizeof(VulkanGSRendererUniforms) && data != nullptr) {
+                VulkanGSRendererUniforms uniforms{};
+                std::memcpy(&uniforms, data, sizeof(uniforms));
+                active()->projection_uniforms.push_back(uniforms);
+            }
         }
 
         static VKAPI_ATTR void VKAPI_CALL dispatch(VkCommandBuffer, uint32_t, uint32_t, uint32_t) {
@@ -279,12 +297,13 @@ namespace {
         }
 
         static VKAPI_ATTR void VKAPI_CALL fill_buffer(VkCommandBuffer,
-                                                      VkBuffer,
-                                                      VkDeviceSize,
-                                                      VkDeviceSize,
-                                                      uint32_t) {
+                                                      VkBuffer buffer,
+                                                      VkDeviceSize offset,
+                                                      VkDeviceSize size,
+                                                      uint32_t value) {
             EXPECT_NE(active(), nullptr);
             active()->ops.push_back(RecordedOp::FillBuffer);
+            active()->fills.push_back({buffer, offset, size, value});
         }
 
         static VKAPI_ATTR void VKAPI_CALL copy_buffer(VkCommandBuffer,
@@ -907,6 +926,8 @@ namespace {
 
     class TestableRenderer final : public VulkanGSRenderer {
     public:
+        using VulkanGSRenderer::prepareOverlayFlags;
+
         ~TestableRenderer() {
             disarm_for_destruction();
         }
@@ -1186,13 +1207,14 @@ namespace {
     // P4 baselines (catalog struct counts).
     constexpr std::size_t kAuditSelectionMask = 13;            // 11 pre + 2 post
     constexpr std::size_t kAuditSelectionPolygonRasterize = 3; // 2 pre + 1 post
-    constexpr std::size_t kAuditProjectionForwardNoLod = 12;   // 10 + 1 + 1 (no L1218)
-    constexpr std::size_t kAuditProjectionForwardWithLod = 16; // +4 LOD
+    // Packed flags add prior access -> clear and clear -> atomic projection.
+    constexpr std::size_t kAuditProjectionForwardNoLod = 12 + 2;
+    constexpr std::size_t kAuditProjectionForwardWithLod = 16 + 2;
     // P4 r2: cull 5+1+(0..2)+1+1+2; survivors 5+(0..2).
     constexpr std::size_t kAuditCullSplatsNoLod = 10;
     constexpr std::size_t kAuditCullSplatsWithLod = 12;
-    constexpr std::size_t kAuditProjectionSurvivorsNoLod = 5;
-    constexpr std::size_t kAuditProjectionSurvivorsWithLod = 7;
+    constexpr std::size_t kAuditProjectionSurvivorsNoLod = 5 + 2;
+    constexpr std::size_t kAuditProjectionSurvivorsWithLod = 7 + 2;
     // P4 r3: cumsum single-pass begin=3 structs (input+output; no blockSums) + phases 0;
     // prepare tile sort 2; generous caps for multi-phase + sort chain under freeze N=64.
     constexpr std::size_t kAuditCumsumSinglePass = 8;
@@ -1547,6 +1569,59 @@ TEST(VkSplatTaggedDispatch, SelectionChainAuditWithinBaseline) {
 // recordVisibleCount/InstanceCount owned by later chains — not migrated here.
 // =============================================================================
 
+// Catches: partial-word descriptors, stale flags, and incorrect arena fill ranges.
+TEST(VkSplatTaggedDispatch, OverlayFlagsUsePaddedBytesAndClearReusedStorage) {
+    DispatchScript script;
+    BindScript bind(script);
+    TestableRenderer renderer;
+    renderer.install_fake_handles();
+    renderer.setVulkanDispatch(make_scripted_dispatch());
+
+    VulkanGSPipelineBuffers buffers;
+    forge_owned_u8(buffers.overlay_flags, 0xD100, 8192);
+    // Exercise an arena view whose start is not the start of its parent buffer.
+    buffers.overlay_flags.deviceBuffer.offset = 256;
+    buffers.overlay_flags.deviceBuffer.allocSize += 256;
+    renderer.beginCommandBatch();
+    track_buf(renderer, buffers.overlay_flags.deviceBuffer);
+
+    for (const std::size_t count : {0u, 1u, 2u, 3u, 4u, 5u, 31u, 32u, 33u, 4097u, 5u}) {
+        SCOPED_TRACE(count);
+        script.clear_recording();
+        auto& flags = renderer.prepareOverlayFlags(buffers, count, true);
+        const std::size_t expected = count == 0 ? 4 : ((count - 1) / 4 + 1) * 4;
+        EXPECT_EQ(flags.size, expected);
+        EXPECT_EQ(flags.capacity, 8192u); // Reuse must still clear on every call.
+        ASSERT_EQ(script.fills.size(), 1u);
+        EXPECT_EQ(script.fills[0].buffer, flags.buffer);
+        EXPECT_EQ(script.fills[0].offset, 256u);
+        EXPECT_EQ(script.fills[0].size, expected);
+        EXPECT_EQ(script.fills[0].value, 0u);
+    }
+
+    script.clear_recording();
+    EXPECT_EQ(renderer.prepareOverlayFlags(buffers, 4097, false).size, 4u);
+    EXPECT_TRUE(script.fills.empty());
+
+    script.clear_recording();
+    EXPECT_EQ(renderer.prepareOverlayFlags(buffers, 5, true).size, 8u);
+    ASSERT_EQ(script.fills.size(), 1u);
+    EXPECT_EQ(script.fills[0].size, 8u);
+    renderer.endCommandBatch(/*use_fence=*/false);
+}
+
+TEST(VkSplatTaggedDispatch, OverlayFlagsRejectAlignmentOverflowBeforeRecording) {
+    DispatchScript script;
+    BindScript bind(script);
+    TestableRenderer renderer;
+    renderer.install_fake_handles();
+    renderer.setVulkanDispatch(make_scripted_dispatch());
+    VulkanGSPipelineBuffers buffers;
+    EXPECT_THROW(renderer.prepareOverlayFlags(buffers, std::numeric_limits<std::size_t>::max(), true),
+                 lfs::Exception);
+    EXPECT_TRUE(script.ops.empty());
+}
+
 // Catches: projection still hand-writing barriers / fill not planTransfer-recorded.
 TEST(VkSplatTaggedDispatch, ProjectionForwardAuditWithinBaseline) {
     DispatchScript script;
@@ -1642,6 +1717,8 @@ TEST(VkSplatTaggedDispatch, ProjectionForwardAuditWithinBaseline) {
         // sentinel fill: prior compute/R/W → transfer write, then transfer → compute R/W
         {buffers.primitive_depth_keys.deviceBuffer.buffer, BM::TRANSFER_WRITE,
          BM::COMPUTE_SHADER_WRITE, "depth_keys fill→projection write"},
+        {buffers.overlay_flags.deviceBuffer.buffer, BM::TRANSFER_WRITE,
+         BM::COMPUTE_SHADER_READ_WRITE, "overlay clear→packed atomic write"},
         // LOD inputs (when valid): prior write → compute read
         {lod_indices.buffer, BM::COMPUTE_SHADER_WRITE, BM::COMPUTE_SHADER_READ,
          "lod_indices → projection read"},
@@ -1671,6 +1748,26 @@ TEST(VkSplatTaggedDispatch, ProjectionForwardAuditWithinBaseline) {
         (stats_before.barriers_emitted + stats_before.accesses_elided);
     EXPECT_GT(planned_activity, 0u)
         << "projection must exercise planner (tagged + planTransfer fill)";
+
+    for (const bool enabled : {false, true}) {
+        script.clear_recording();
+        renderer.executeProjectionForward(
+            u, buffers, transform_indices, node_mask, overlay_params, model_transforms,
+            kAuditSplatCount, false, {}, {}, {}, {}, {}, enabled);
+        ASSERT_FALSE(script.projection_uniforms.empty());
+        EXPECT_EQ((script.projection_uniforms.back().lod_enabled & kLodEnabledWriteOverlayFlags) != 0,
+                  enabled);
+        std::size_t overlay_clears = 0;
+        for (const auto& fill : script.fills) {
+            if (fill.buffer == buffers.overlay_flags.deviceBuffer.buffer) {
+                ++overlay_clears;
+                EXPECT_EQ(fill.size, kAuditSplatCount);
+                EXPECT_EQ(fill.value, 0u);
+            }
+        }
+        EXPECT_EQ(overlay_clears, enabled ? 1u : 0u);
+        EXPECT_EQ(buffers.overlay_flags.deviceBuffer.size, enabled ? kAuditSplatCount : 4u);
+    }
 
     std::printf("ProjectionForwardAudit with_lod=%zu (≤%zu) no_lod=%zu (≤%zu) "
                 "derived=%zu planned_activity=%llu\n",
@@ -1853,6 +1950,8 @@ TEST(VkSplatTaggedDispatch, CullAndSurvivorsProjectionAuditWithinBaseline) {
         // emit_count prepare write → projection R/W
         {buffers.visible_emit_count.deviceBuffer.buffer, BM::COMPUTE_SHADER_WRITE,
          BM::COMPUTE_SHADER_READ_WRITE, "emit_count prepare→projection"},
+        {buffers.overlay_flags.deviceBuffer.buffer, BM::TRANSFER_WRITE,
+         BM::COMPUTE_SHADER_READ_WRITE, "overlay clear→survivor packed atomic write"},
     };
     for (const auto& edge : edges) {
         EXPECT_TRUE(edge_covered(derived, edge)) << "missing edge: " << edge.name;
@@ -1864,6 +1963,26 @@ TEST(VkSplatTaggedDispatch, CullAndSurvivorsProjectionAuditWithinBaseline) {
         (stats_before.barriers_emitted + stats_before.accesses_elided);
     EXPECT_GT(planned_activity, 0u)
         << "cull/survivors must exercise planner (tagged + clear planTransfer)";
+
+    for (const bool enabled : {false, true}) {
+        script.clear_recording();
+        renderer.executeProjectionForwardSurvivors(
+            u, buffers, transform_indices, node_mask, overlay_params, model_transforms,
+            kAuditSplatCount, {}, {}, {}, {}, {}, enabled);
+        ASSERT_FALSE(script.projection_uniforms.empty());
+        EXPECT_EQ((script.projection_uniforms.back().lod_enabled & kLodEnabledWriteOverlayFlags) != 0,
+                  enabled);
+        std::size_t overlay_clears = 0;
+        for (const auto& fill : script.fills) {
+            if (fill.buffer == buffers.overlay_flags.deviceBuffer.buffer) {
+                ++overlay_clears;
+                EXPECT_EQ(fill.size, kAuditSplatCount);
+                EXPECT_EQ(fill.value, 0u);
+            }
+        }
+        EXPECT_EQ(overlay_clears, enabled ? 1u : 0u);
+        EXPECT_EQ(buffers.overlay_flags.deviceBuffer.size, enabled ? kAuditSplatCount : 4u);
+    }
 
     std::printf(
         "CullSurvivorsAudit cull_with_lod=%zu (≤%zu) cull_no_lod=%zu (≤%zu) "


### PR DESCRIPTION
Port of #2019 (merged into dev as cc94095d6, author @francescofugazzi) to master. The cherry-pick applies with no conflicts and the content is identical to the dev merge; the commit keeps the original author and message.

**master has the same two defects that #2014 exposed on dev.** #1917 changed the host `overlay_flags` buffer to one byte per splat while every projection and raster shader kept 32-bit elements, so the buffer is a quarter of the size the shaders address and projection writes past the end of it (the device runs without robustBufferAccess, so this is a real out-of-bounds GPU write into the neighbouring shared-scratch region). On master the visible consumers are crop-box desaturate, emphasis dim and flash. #1917 also removed binding 8 from the host pipeline layouts but left `out_radii` in `vertex_shader.slang`, so every projection dispatch writes to an unbound storage buffer and the validation layer reports 11 errors per session.

**The fix keeps one byte per splat and completes the format transition.** Byte-addressed storage in all shader readers, four flags per word, a buffer clear before each projection and one atomic OR per flagged splat, the write-enable bit honoured in the shader, the shared-scratch estimate at one byte, and the retired `out_radii` output removed.

Verified on master (RTX 4090, `output/splat_11521.ply`, 1.95M splats, `LFS_VK_VALIDATION=1`), old master build vs this branch, crop box on the central third with desaturate on:

| | before | after |
|---|---:|---:|
| foreground pixels dimmed outside the crop box | 82.5% | 96.3% |
| undimmed connected components | 1998 (patchy) | 65 (one dominant central region) |
| Vulkan validation errors | 11 (`out_radii`, binding 8) | 0 |

Tests: `VkSplatTaggedDispatch.*` 22/22, `*SharedScratch*:*Overlay*:*Vksplat*:*VkSplat*` 71/71, `tests/python/test_vksplat_overlay_storage.py` 7/7. SPIR-V audit of all 20 generated modules that bind the flags: uint runtime arrays with stride 4, `OpAtomicOr` on binding 13 in all 12 projection variants. On dev the same change measured +0.006 ms in ProjectionSurvivors with the whole frame within noise.

Related to #2014 (dev side fixed by #2019).
