### PR TITLE
Fix MSVC preprocessing in Unicode path assertions

### DIFF
--- a/tests/test_unicode_paths_windows.cpp
+++ b/tests/test_unicode_paths_windows.cpp
@@ -237,13 +237,11 @@ TEST_F(UnicodePathTest, ProcessBoundaryHelpersPreserveJapanese) {
 #endif
     ASSERT_EQ(arguments.size(), 3);
     EXPECT_EQ(arguments[1], "--project");
-    EXPECT_EQ(arguments[2],
 #ifdef _WIN32
-              "C:\\Users\\山田\\プロジェクト.licht"
+    EXPECT_EQ(arguments[2], "C:\\Users\\山田\\プロジェクト.licht");
 #else
-              "山田/プロジェクト.licht"
+    EXPECT_EQ(arguments[2], "山田/プロジェクト.licht");
 #endif
-    );
 
     constexpr const char* environment_name = "LFS_UNICODE_PATH_TEST";
     const auto previous = lfs::core::environment::value(environment_name);


### PR DESCRIPTION
The `ProcessBoundaryHelpersPreserveJapanese` test added in #2021 places platform preprocessor directives inside `EXPECT_EQ` arguments. MSVC's conforming preprocessor emits C5101 and fails with C2059, followed by cascading GoogleTest expansion errors.

Move the conditional outside the macro invocation and use a complete assertion in each platform branch. The expected Windows and POSIX strings and the test's assertions remain unchanged. This PR changes only the Unicode test.

## Validation

- User confirmed that the local Windows Release build completed successfully with this fix applied.
- Static scan found no remaining platform directives inside GoogleTest assertion argument lists under `tests/`.
- `git diff --check` passed.

No native configuration, compilation, or runtime tests were executed by Codex.