### PR TITLE
Add opt-in Release-only vcpkg presets for Windows and Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,9 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/VcpkgProfiles.cmake")
+lfs_validate_vcpkg_profile()
+
 project(LichtFeld-Studio VERSION 0.5.3 LANGUAGES CUDA CXX C)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/SelectFastLinker.cmake")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,6 +28,63 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
+    },
+    {
+      "name": "release-only-base",
+      "hidden": true,
+      "inherits": "build",
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "cacheVariables": {
+        "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/cmake/triplets/release-only"
+      }
+    },
+    {
+      "name": "windows-release",
+      "displayName": "Windows x64 Release (Release-only dependencies)",
+      "description": "Native Windows x64 Release build with Release-only target and host dependencies; keeps build/ and build-debug/ intact",
+      "inherits": "release-only-base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "VCPKG_HOST_TRIPLET": "x64-windows"
+      }
+    },
+    {
+      "name": "windows-relwithdebinfo",
+      "displayName": "Windows x64 RelWithDebInfo (Release-only dependencies)",
+      "description": "Optimized Windows x64 application with debug information, reusing the windows-release dependency profile; Vulkan validation remains enabled",
+      "inherits": "windows-release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "linux-release",
+      "displayName": "Linux x64 Release (Release-only dependencies)",
+      "description": "Native Linux x64 Release build with Release-only target and host dependencies; keeps build/ and build-debug/ intact",
+      "inherits": "release-only-base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-linux",
+        "VCPKG_HOST_TRIPLET": "x64-linux"
+      }
+    },
+    {
+      "name": "linux-relwithdebinfo",
+      "displayName": "Linux x64 RelWithDebInfo (Release-only dependencies)",
+      "description": "Optimized Linux x64 application with debug information, reusing the linux-release dependency profile; Vulkan validation remains enabled",
+      "inherits": "linux-release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
     }
   ],
   "buildPresets": [
@@ -39,6 +96,46 @@
     {
       "name": "debug",
       "configurePreset": "debug",
+      "jobs": 6
+    },
+    {
+      "name": "windows-release",
+      "configurePreset": "windows-release",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "jobs": 6
+    },
+    {
+      "name": "windows-relwithdebinfo",
+      "configurePreset": "windows-relwithdebinfo",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "jobs": 6
+    },
+    {
+      "name": "linux-release",
+      "configurePreset": "linux-release",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "jobs": 6
+    },
+    {
+      "name": "linux-relwithdebinfo",
+      "configurePreset": "linux-relwithdebinfo",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
       "jobs": 6
     }
   ]

--- a/cmake/VcpkgProfiles.cmake
+++ b/cmake/VcpkgProfiles.cmake
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+include_guard(GLOBAL)
+
+# Validate the opt-in overlay before project() runs vcpkg. Standard presets,
+# custom triplets and user-managed overlays keep their existing behavior.
+function(lfs_validate_vcpkg_profile)
+    file(REAL_PATH "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/triplets/release-only" _release_overlay)
+    set(_uses_release_overlay FALSE)
+    foreach(_overlay IN LISTS VCPKG_OVERLAY_TRIPLETS)
+        file(REAL_PATH "${_overlay}" _overlay BASE_DIRECTORY "${CMAKE_SOURCE_DIR}")
+        if(_overlay STREQUAL _release_overlay)
+            set(_uses_release_overlay TRUE)
+        endif()
+    endforeach()
+    if(NOT _uses_release_overlay)
+        return()
+    endif()
+
+    # OpenMesh caches CMAKE_CONFIGURATION_TYPES even for single-config Ninja.
+    # Only the generator property describes the active build system; the cache
+    # entry must not reject an existing tree or its next regeneration.
+    get_property(_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(_multi_config OR NOT CMAKE_BUILD_TYPE MATCHES "^(Release|RelWithDebInfo|MinSizeRel)$")
+        message(FATAL_ERROR
+            "The LichtFeld Release-only vcpkg profile requires a single-config "
+            "Release, RelWithDebInfo or MinSizeRel build. Use a separate build "
+            "directory with the standard triplet for Debug or multi-config builds "
+            "(for example, cmake --preset debug). "
+            "Active generator: '${CMAKE_GENERATOR}', build type: '${CMAKE_BUILD_TYPE}'.")
+    endif()
+
+    if(NOT VCPKG_TARGET_TRIPLET MATCHES "^x64-(windows|linux)$" OR
+       NOT VCPKG_HOST_TRIPLET STREQUAL VCPKG_TARGET_TRIPLET)
+        message(FATAL_ERROR
+            "The LichtFeld Release-only vcpkg profile requires matching native "
+            "x64-windows or x64-linux target and host triplets. Use the standard "
+            "presets for other architectures or custom triplets.")
+    endif()
+
+    # Changes to an active recipe must rerun vcpkg during normal regeneration.
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+        "${_release_overlay}/${VCPKG_TARGET_TRIPLET}.cmake")
+    message(STATUS "vcpkg profile: Release-only (${VCPKG_TARGET_TRIPLET}, target and host)")
+endfunction()

--- a/cmake/triplets/release-only/x64-linux.cmake
+++ b/cmake/triplets/release-only/x64-linux.cmake
@@ -1,0 +1,7 @@
+# Native x64-linux linkage, with one dependency configuration.
+# Keep this recipe identical for Release and RelWithDebInfo consumers.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+set(VCPKG_BUILD_TYPE release)

--- a/cmake/triplets/release-only/x64-windows.cmake
+++ b/cmake/triplets/release-only/x64-windows.cmake
@@ -1,0 +1,6 @@
+# Native x64-windows linkage, with one dependency configuration.
+# Keep this recipe identical for Release and RelWithDebInfo consumers.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_BUILD_TYPE release)

--- a/docs/building_and_distribution.md
+++ b/docs/building_and_distribution.md
@@ -67,6 +67,35 @@ cmake --build build -j 16
 ./build/LichtFeld-Studio -d /path/to/data -o /path/to/output
 ```
 
+#### Release-only dependencies (optional)
+
+Native x64 Windows and Linux builds can use these presets to build only the
+Release variants of vcpkg dependencies, including host tools:
+
+| Platform | Release application | Optimized application with debug information |
+| --- | --- | --- |
+| Windows x64 | `windows-release` | `windows-relwithdebinfo` |
+| Linux x64 | `linux-release` | `linux-relwithdebinfo` |
+
+For example, from an initialized Windows x64 MSVC/CUDA development shell:
+
+```sh
+cmake --preset windows-release
+cmake --build --preset windows-release
+```
+
+Each preset uses its own build directory. Release and RelWithDebInfo on the
+same platform share the dependency recipe and can reuse compatible binary
+cache entries; the first Release-only install may rebuild packages. The
+standard `build` and `debug` presets remain available, with tests opt-in.
+
+See the [developer build guide](docs/development/build.md#release-only-dependency-profiles)
+for all commands, cache behavior and dependency-symbol coverage. To keep an
+existing `cmake --build build ...` command, follow the
+[existing Ninja directory migration](docs/development/build.md#keeping-an-existing-ninja-build-directory),
+including `-B build` and `-DBUILD_TESTS=ON` when building `lichtfeld_tests`.
+The [test prerequisites](#tests) still apply.
+
 ### 2. Portable Build (Distribution)
 
 Creates a self-contained package that works on any machine with an NVIDIA driver.

--- a/docs/docs/development/build.md
+++ b/docs/docs/development/build.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Building LichtFeld Studio
 
-Two presets are available, `build` and `debug`. Both build the complete
+The standard presets, `build` and `debug`, both build the complete
 application feature set, keep tests out of the normal app graph, compile for one
 native CUDA architecture, use at most six parallel jobs, and automatically use
 `sccache` or `ccache` when either launcher is installed.
@@ -29,6 +29,128 @@ support. The compiler cache can be disabled without changing the feature set:
 cmake -S . -B build -DENABLE_COMPILER_CACHE=OFF
 cmake --build build -j6
 ```
+
+## Release-only dependency profiles
+
+Native x64 Windows and Linux builds can opt into Release-only vcpkg packages.
+Release and RelWithDebInfo use the same dependency recipe, with separate build
+and installation directories so switching presets preserves each application's
+objects and configuration:
+
+| Platform | Configure and build preset | Application configuration | Build directory |
+| --- | --- | --- | --- |
+| Windows x64 | `windows-release` | Release | `build-windows-release/` |
+| Windows x64 | `windows-relwithdebinfo` | RelWithDebInfo | `build-windows-relwithdebinfo/` |
+| Linux x64 | `linux-release` | Release | `build-linux-release/` |
+| Linux x64 | `linux-relwithdebinfo` | RelWithDebInfo | `build-linux-relwithdebinfo/` |
+
+CMake only lists the profiles for the current host OS. These profiles require
+the same compiler, CUDA toolkit and system dependencies as the standard build;
+they do not install or change the development environment.
+
+On Windows, from the existing x64 MSVC/CUDA development shell:
+
+```sh
+cmake --preset windows-release
+cmake --build --preset windows-release
+cmake --preset windows-relwithdebinfo
+cmake --build --preset windows-relwithdebinfo
+```
+
+On Linux:
+
+```sh
+cmake --preset linux-release
+cmake --build --preset linux-release
+cmake --preset linux-relwithdebinfo
+cmake --build --preset linux-relwithdebinfo
+```
+
+The profiles select `cmake/triplets/release-only/` as a vcpkg triplet overlay.
+It retains the standard `x64-windows` / `x64-linux` names and linkage policies,
+and sets `VCPKG_BUILD_TYPE` to `release` inside the triplet. Both target and
+host tools use that recipe; host tools do not introduce another Debug package
+graph. The installed vcpkg checkout and its built-in triplets are not edited.
+
+All application features remain enabled, with tests off and the same compiler
+cache and parallelism settings as `build`. RelWithDebInfo retains the normal
+developer defaults, including Vulkan validation and shader debug information.
+Consequently, its first configure may install additional validation packages.
+RelWithDebInfo adds symbols to the application; it does not automatically add
+symbols to every vcpkg dependency. Windows vcpkg Release builds normally request
+debug information, while Linux dependency symbols depend on the port and its
+compiler flags. These profiles do not change those flags or disable optimization.
+
+### Reusing packages when switching configurations
+
+Each build directory keeps its own `vcpkg_installed/`. Share the **vcpkg binary
+archive cache**, not an installation directory. The presets preserve the normal
+vcpkg cache configuration, including user-provided `VCPKG_BINARY_SOURCES` and
+`VCPKG_DEFAULT_BINARY_CACHE`; no private feed is required. On a cache miss,
+vcpkg builds the missing package through the normal manifest/registry path.
+
+The first Release-only install may need to compile packages even if the standard
+dual-configuration packages are already cached: the overlay has a different ABI
+hash, and vcpkg cannot extract just the Release half as a new cached package.
+Once stored, compatible packages can be restored into the other profile's
+installation directory. Returning to either existing build directory reuses its
+installed packages and incremental build outputs.
+
+This requires unchanged compiler/toolchain, port versions, features and overlay
+contents, and a binary cache that allows reading and writing. A changed package
+or dependency ABI can require a rebuild. Windows and Linux packages are distinct;
+they do not share compiled binaries. An `already installed` or `Restored ...`
+message is reuse, not source compilation. Application CMake regeneration may
+still take time even when vcpkg installs nothing.
+
+### Keeping an existing Ninja build directory
+
+To migrate an existing native Windows x64 Ninja Release tree in `build/` and
+keep the usual application/test build command, configure it once with:
+
+```sh
+cmake --preset windows-release -B build -DBUILD_TESTS=ON
+cmake --build build --config Release --target LichtFeld-Studio lichtfeld_tests -j 4
+```
+
+On Linux x64, use `linux-release` in the configure command. `-B build` overrides
+the preset's default directory; without it the configure and build commands
+would address different trees. For single-config Ninja, `--config Release` is
+optional: the configuration comes from `CMAKE_BUILD_TYPE` at configure time.
+
+The migration lets vcpkg reconcile installed packages with the Release-only
+recipe and may rebuild dependencies once. Keep this directory on that profile
+afterward, and keep Debug in a separate tree. There is no need to delete the
+existing build cache. In particular, OpenMesh can populate
+`CMAKE_CONFIGURATION_TYPES` even for Ninja; the profile guard checks the actual
+generator rather than treating that cache entry as evidence of a multi-config
+build.
+
+### Debug and standard fallback
+
+Use `cmake --preset debug` and `cmake --build --preset debug` for Debug. The
+standard `build` and `debug` profiles and their existing directories are
+unchanged. vcpkg's standard triplets provide both dependency configurations;
+Debug-only ports are not generally supported.
+
+The Release-only overlay is rejected before vcpkg installation if it is used
+with Debug, an unknown build configuration, a multi-config generator, or
+nonmatching target and host triplets. Use a separate standard build directory
+for multi-config generators, other architectures or custom triplets. Apart
+from a deliberate migration as described above, do not alternate standard and
+Release-only profile policies inside one directory.
+
+The guard can be checked without configuring or compiling the application:
+
+```sh
+cmake --list-presets=all
+cmake -P tests/cmake/test_vcpkg_profiles.cmake
+```
+
+For build validation, build and launch both profiles on the target OS, then
+switch back without deleting either directory. Check the vcpkg install log for
+reuse; exercise Python imports and Vulkan validation in the RelWithDebInfo
+application. The script checks above do not replace compiler or runtime tests.
 
 ## Reproducible build measurements
 

--- a/tests/cmake/test_vcpkg_profiles.cmake
+++ b/tests/cmake/test_vcpkg_profiles.cmake
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Script-mode checks only: no project(), compiler detection or vcpkg execution.
+cmake_minimum_required(VERSION 3.30)
+get_filename_component(_project_root "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+include("${_project_root}/cmake/VcpkgProfiles.cmake")
+
+if(DEFINED LFS_PROFILE_TEST_CASE)
+    set(VCPKG_TARGET_TRIPLET "x64-${LFS_PROFILE_TEST_PLATFORM}")
+    set(VCPKG_HOST_TRIPLET "${VCPKG_TARGET_TRIPLET}")
+    set(VCPKG_OVERLAY_TRIPLETS "${_project_root}/cmake/triplets/release-only")
+    set(CMAKE_BUILD_TYPE "Release")
+    set(CMAKE_CONFIGURATION_TYPES "")
+
+    if(LFS_PROFILE_TEST_CASE STREQUAL "relwithdebinfo")
+        set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+    elseif(LFS_PROFILE_TEST_CASE MATCHES "^(ninja-cached-configs|relwithdebinfo-cached-configs)$")
+        # OpenMesh writes this cache entry even with single-config Ninja.
+        unset(CMAKE_CONFIGURATION_TYPES)
+        set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo" CACHE STRING "")
+        if(LFS_PROFILE_TEST_CASE STREQUAL "relwithdebinfo-cached-configs")
+            set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+        endif()
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "minsizerel")
+        set(CMAKE_BUILD_TYPE "MinSizeRel")
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "debug")
+        set(CMAKE_BUILD_TYPE "Debug")
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "unknown")
+        set(CMAKE_BUILD_TYPE "Profile")
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "multi")
+        set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "multi-empty-configs")
+        # A fresh multi-config tree has no configuration list before project().
+        unset(CMAKE_CONFIGURATION_TYPES)
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "host-mismatch")
+        set(VCPKG_HOST_TRIPLET "arm64-linux")
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "custom-triplet")
+        set(VCPKG_TARGET_TRIPLET "custom-release")
+        set(VCPKG_HOST_TRIPLET "custom-release")
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "standard-debug")
+        set(CMAKE_BUILD_TYPE "Debug")
+        unset(VCPKG_OVERLAY_TRIPLETS)
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "standard-multi")
+        set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
+        unset(VCPKG_OVERLAY_TRIPLETS)
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "user-overlay")
+        set(VCPKG_TARGET_TRIPLET "custom-debug")
+        set(VCPKG_HOST_TRIPLET "custom-debug")
+        set(CMAKE_BUILD_TYPE "Debug")
+        set(VCPKG_OVERLAY_TRIPLETS "${_project_root}/custom-triplets")
+    elseif(LFS_PROFILE_TEST_CASE STREQUAL "normalized-path")
+        set(VCPKG_OVERLAY_TRIPLETS
+            "${_project_root}/custom-triplets;${_project_root}/cmake/../cmake/triplets/release-only/")
+    elseif(NOT LFS_PROFILE_TEST_CASE STREQUAL "release")
+        message(FATAL_ERROR "Unknown test case: ${LFS_PROFILE_TEST_CASE}")
+    endif()
+
+    set(_original_overlays "${VCPKG_OVERLAY_TRIPLETS}")
+    lfs_validate_vcpkg_profile()
+    if(NOT "${VCPKG_OVERLAY_TRIPLETS}" STREQUAL "${_original_overlays}")
+        message(FATAL_ERROR "Validation changed the user's overlay selection")
+    endif()
+    if(LFS_PROFILE_TEST_CASE MATCHES "^(release|relwithdebinfo|minsizerel|normalized-path|ninja-cached-configs|relwithdebinfo-cached-configs)$")
+        get_property(_configure_deps DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
+        set(_triplet "${_project_root}/cmake/triplets/release-only/${VCPKG_TARGET_TRIPLET}.cmake")
+        if(NOT _triplet IN_LIST _configure_deps)
+            message(FATAL_ERROR "Active triplet edits would not trigger regeneration")
+        endif()
+    endif()
+    return()
+endif()
+
+set(_total_cases 0)
+foreach(_platform windows linux)
+    foreach(_case release relwithdebinfo ninja-cached-configs relwithdebinfo-cached-configs
+                  minsizerel normalized-path standard-debug standard-multi user-overlay
+                  debug unknown multi multi-empty-configs host-mismatch custom-triplet)
+        # -G selects the real generator property in script mode without
+        # configuring a project, finding Ninja or invoking any compiler.
+        if(_case MATCHES "^(multi|multi-empty-configs|standard-multi)$")
+            set(_generator "Ninja Multi-Config")
+        else()
+            set(_generator "Ninja")
+        endif()
+        execute_process(
+            COMMAND "${CMAKE_COMMAND}"
+                -G "${_generator}"
+                "-DLFS_PROFILE_TEST_CASE=${_case}"
+                "-DLFS_PROFILE_TEST_PLATFORM=${_platform}"
+                -P "${CMAKE_CURRENT_LIST_FILE}"
+            RESULT_VARIABLE _result
+            OUTPUT_VARIABLE _stdout
+            ERROR_VARIABLE _stderr)
+        if(_case MATCHES "^(debug|unknown|multi|multi-empty-configs)$")
+            set(_expected_error "requires a single-config")
+        elseif(_case MATCHES "^(host-mismatch|custom-triplet)$")
+            set(_expected_error "requires matching native")
+        else()
+            set(_expected_error "")
+        endif()
+        if(_expected_error)
+            if(_result EQUAL 0 OR NOT _stderr MATCHES "${_expected_error}")
+                message(FATAL_ERROR "${_platform}/${_case}: expected profile rejection\n${_stdout}${_stderr}")
+            endif()
+        elseif(NOT _result EQUAL 0)
+            message(FATAL_ERROR "${_platform}/${_case}: ${_stdout}${_stderr}")
+        endif()
+        math(EXPR _total_cases "${_total_cases} + 1")
+    endforeach()
+endforeach()
+message(STATUS "vcpkg profile checks passed (${_total_cases} cases; no configure or build)")


### PR DESCRIPTION
Standard vcpkg triplets build both Debug and Release dependencies even when the application only needs Release libraries. This adds optional native x64 Windows and Linux profiles that avoid building unused Debug dependencies.

The new configure/build presets are:

- `windows-release`
- `windows-relwithdebinfo`
- `linux-release`
- `linux-relwithdebinfo`

They use project-local triplet overlays with `VCPKG_BUILD_TYPE=release` for both target dependencies and host tools, preserving the standard triplet names and linkage policies. Existing `build` and `debug` presets retain their behavior.

Release and RelWithDebInfo share the same dependency recipe, while each build directory keeps its own `vcpkg_installed` tree. Compatible packages can be restored through the existing binary cache. The first installation may rebuild packages because the overlay changes their ABI; subsequent reuse still requires matching toolchains, features, and recipes.

RelWithDebInfo retains application debug information and its normal Vulkan validation defaults. It does not request Debug builds of vcpkg dependencies.

Profile validation runs before vcpkg installation and rejects incompatible configurations, multi-config generators, and mismatched target/host triplets. It uses `GENERATOR_IS_MULTI_CONFIG`, avoiding false rejection when OpenMesh populates `CMAKE_CONFIGURATION_TYPES` in a single-config Ninja build.

Documentation covers preset selection, cache behavior, dependency symbols, Debug fallback, and migration of an existing build directory.