### PR TITLE
Scene graph: fix undo for group/duplicate/paste, locked nodes, hidden-child merge

### DIFF
--- a/src/core/include/core/scene.hpp
+++ b/src/core/include/core/scene.hpp
@@ -59,6 +59,20 @@ namespace lfs::core {
         PLY_SEQUENCE    // Container for ordered PLY sequence frames
     };
 
+    [[nodiscard]] inline bool isSceneNodeParentCompatible(const NodeType parent,
+                                                          const NodeType child) {
+        const bool group_like = parent == NodeType::GROUP ||
+                                parent == NodeType::DATASET ||
+                                parent == NodeType::CAMERA_GROUP ||
+                                parent == NodeType::IMAGE_GROUP ||
+                                parent == NodeType::KEYFRAME_GROUP ||
+                                parent == NodeType::PLY_SEQUENCE;
+        if (group_like)
+            return true;
+        return (parent == NodeType::SPLAT || parent == NodeType::POINTCLOUD) &&
+               (child == NodeType::CROPBOX || child == NodeType::ELLIPSOID);
+    }
+
     enum class SelectionDomain : uint8_t {
         Splat = 1,
         PointCloud = 2,
@@ -197,6 +211,7 @@ namespace lfs::core {
 
         struct RestoreNodeDesc {
             Uuid uuid;
+            NodeId preferred_id = NULL_NODE;
             NodeType type = NodeType::GROUP;
             std::string name;
             NodeId parent = NULL_NODE;
@@ -689,7 +704,8 @@ namespace lfs::core {
         void rebuildConsolidatedTransformIndices() const;
         [[nodiscard]] NodeId insertNode(
             std::unique_ptr<SceneNode> node,
-            bool allow_duplicate_name = false);
+            bool allow_duplicate_name = false,
+            std::optional<NodeId> preferred_id = std::nullopt);
         mutable std::shared_ptr<lfs::core::SplatData> cached_combined_;
         mutable bool cached_combined_includes_hidden_ = false;
         mutable std::shared_ptr<lfs::core::Tensor> cached_transform_indices_;
@@ -770,6 +786,7 @@ namespace lfs::core {
         void rebuildModelCacheIfNeeded() const;
         void rebuildModelCacheIfNeeded(bool include_hidden_splats) const;
         void pollCombinedModelBuild() const;
+        void waitForCombinedModelBuild() const;
         void requestCombinedModelBuildIfNeeded(bool include_hidden_splats = false) const;
         [[nodiscard]] std::shared_ptr<const lfs::core::SplatData>
         borrowCombinedModel(const lfs::core::SplatData* model) const;

--- a/src/core/include/core/scene.hpp
+++ b/src/core/include/core/scene.hpp
@@ -291,7 +291,7 @@ namespace lfs::core {
 
         void removeNode(std::string name, bool keep_children = false);
         void removeNodeById(NodeId id, bool keep_children = false);
-        [[nodiscard]] std::vector<std::unique_ptr<lfs::core::SplatData>> detachSplatModelsForRemoval(
+        [[nodiscard]] std::vector<std::pair<Uuid, std::unique_ptr<lfs::core::SplatData>>> detachSplatModelsForRemoval(
             NodeId id,
             bool keep_children = false);
         void replaceNodeModel(const std::string& name, std::unique_ptr<lfs::core::SplatData> model);

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -343,7 +343,8 @@ namespace lfs::core {
 
     NodeId Scene::insertNode(
         std::unique_ptr<SceneNode> node,
-        const bool allow_duplicate_name) {
+        const bool allow_duplicate_name,
+        const std::optional<NodeId> preferred_id) {
         if (!node) {
             LOG_WARN("Cannot add null scene node");
             return NULL_NODE;
@@ -359,6 +360,13 @@ namespace lfs::core {
         if (node->parent_id != NULL_NODE && !getNodeById(node->parent_id)) {
             LOG_WARN("Cannot add node '{}': parent id {} does not exist", node->name, node->parent_id);
             return NULL_NODE;
+        }
+        if (node->parent_id != NULL_NODE) {
+            const auto* parent = getNodeById(node->parent_id);
+            if (!parent || !isSceneNodeParentCompatible(parent->type, node->type)) {
+                LOG_WARN("Cannot add node '{}': parent is incompatible", node->name);
+                return NULL_NODE;
+            }
         }
 
         const bool minted_uuid = node->uuid.is_nil();
@@ -382,7 +390,11 @@ namespace lfs::core {
             single_node_model_ = nullptr;
         }
 
-        const NodeId id = next_node_id_++;
+        const NodeId id = preferred_id && *preferred_id >= 0 && !id_to_index_.contains(*preferred_id)
+                              ? *preferred_id
+                              : next_node_id_++;
+        if (id >= next_node_id_)
+            next_node_id_ = id + 1;
         node->id = id;
         const NodeId parent_id = node->parent_id;
         const std::string name = node->name;
@@ -724,9 +736,11 @@ namespace lfs::core {
 
     void Scene::setNodeTransform(const NodeId id, const glm::mat4& transform) {
         auto* node = getNodeById(id);
-        if (node) {
+        if (node && !static_cast<bool>(node->locked)) {
             node->local_transform.set(transform, false);
             invalidateTransformCache();
+        } else if (node) {
+            LOG_WARN("Cannot transform '{}': node is locked", node->name);
         }
     }
 
@@ -856,6 +870,12 @@ namespace lfs::core {
                 // load both are null, so this intentionally returns null rather
                 // than rebuilding synchronously on the render thread.
                 return single_node_model_ ? single_node_model_ : cached_combined_.get();
+            }
+            if (visible_node_count < 2) {
+                // A stale multi-node worker must be drained before the
+                // synchronous single-node cache is installed. Otherwise the
+                // worker remains pending after the scene has become small.
+                waitForCombinedModelBuild();
             }
         }
         rebuildModelCacheIfNeeded();
@@ -1198,6 +1218,13 @@ namespace lfs::core {
         // The scope above destroys the completed build, releasing its input
         // aliases. Only now may models parked by a mutation be destroyed.
         combined_model_lifetime_->releaseRetiredAfterJoin();
+    }
+
+    void Scene::waitForCombinedModelBuild() const {
+        if (combined_model_build_thread_ && combined_model_build_thread_->joinable()) {
+            combined_model_build_thread_->join();
+        }
+        pollCombinedModelBuild();
     }
 
     void Scene::requestCombinedModelBuild(bool include_hidden_splats) const {
@@ -3126,6 +3153,54 @@ namespace lfs::core {
     }
 
     size_t Scene::applyDeleted() {
+        // SplatData::apply_deleted() restores one model when its own gather
+        // fails. Validate every model first as well, so a later invalid mask
+        // cannot leave earlier models compacted.
+        for (const auto& node : nodes_) {
+            if (!node->model || !node->model->has_deleted_mask())
+                continue;
+
+            const auto& model = *node->model;
+            const auto& mask = model.deleted();
+            const auto& means = model.means_raw();
+            const auto& sh0 = model.sh0();
+            const auto& scaling = model.scaling_raw();
+            const auto& rotation = model.rotation_raw();
+            const auto& opacity = model.opacity_raw();
+            const auto& shN = model.shN();
+            if (!means.is_valid() || means.ndim() == 0) {
+                LOG_ERROR("applyDeleted: invalid means for node '{}', aborting", node->name);
+                return 0;
+            }
+            const size_t model_size = static_cast<size_t>(model.size());
+            if (!sh0.is_valid() || sh0.ndim() == 0 || !scaling.is_valid() || scaling.ndim() == 0 ||
+                !rotation.is_valid() || rotation.ndim() == 0 || !opacity.is_valid() || opacity.ndim() == 0 ||
+                mask.ndim() != 1 ||
+                static_cast<size_t>(mask.numel()) != model_size ||
+                mask.dtype() != DataType::Bool ||
+                mask.device() != means.device() || sh0.size(0) != model_size ||
+                scaling.size(0) != model_size || rotation.size(0) != model_size ||
+                opacity.size(0) != model_size ||
+                (shN.is_valid() && shN.device() != means.device())) {
+                LOG_ERROR("applyDeleted: invalid deletion state for node '{}', aborting", node->name);
+                return 0;
+            }
+
+            try {
+                const auto keep_mask = mask.logical_not();
+                if (keep_mask.sum_scalar() == 0) {
+                    LOG_WARN("applyDeleted: node '{}' would lose all gaussians, aborting", node->name);
+                    return 0;
+                }
+            } catch (const std::exception& error) {
+                LOG_ERROR("applyDeleted: cannot validate node '{}': {}, aborting", node->name, error.what());
+                return 0;
+            } catch (...) {
+                LOG_ERROR("applyDeleted: cannot validate node '{}', aborting", node->name);
+                return 0;
+            }
+        }
+
         size_t total_removed = 0;
 
         for (auto& node : nodes_) {
@@ -3389,6 +3464,11 @@ namespace lfs::core {
     }
 
     NodeId Scene::addGroup(const std::string& name, const NodeId parent) {
+        if (parent != NULL_NODE) {
+            const auto* parent_node = getNodeById(parent);
+            if (!parent_node || !isSceneNodeParentCompatible(parent_node->type, NodeType::GROUP))
+                return NULL_NODE;
+        }
         auto node = std::make_unique<SceneNode>();
         node->parent_id = parent;
         node->type = NodeType::GROUP;
@@ -3414,6 +3494,11 @@ namespace lfs::core {
     }
 
     NodeId Scene::addSplatPlaceholder(const std::string& name, const NodeId parent) {
+        if (parent != NULL_NODE) {
+            const auto* parent_node = getNodeById(parent);
+            if (!parent_node || !isSceneNodeParentCompatible(parent_node->type, NodeType::SPLAT))
+                return NULL_NODE;
+        }
         auto node = std::make_unique<SceneNode>();
         node->parent_id = parent;
         node->type = NodeType::SPLAT;
@@ -3431,6 +3516,12 @@ namespace lfs::core {
         if (!model) {
             LOG_WARN("Cannot add splat node '{}': model is null", name);
             return NULL_NODE;
+        }
+
+        if (parent != NULL_NODE) {
+            const auto* parent_node = getNodeById(parent);
+            if (!parent_node || !isSceneNodeParentCompatible(parent_node->type, NodeType::SPLAT))
+                return NULL_NODE;
         }
 
         if (getNodeIdByName(name) != NULL_NODE) {
@@ -3460,6 +3551,11 @@ namespace lfs::core {
         if (!point_cloud) {
             LOG_WARN("Cannot add point cloud node '{}': point cloud is null", name);
             return NULL_NODE;
+        }
+        if (parent != NULL_NODE) {
+            const auto* parent_node = getNodeById(parent);
+            if (!parent_node || !isSceneNodeParentCompatible(parent_node->type, NodeType::POINTCLOUD))
+                return NULL_NODE;
         }
 
         const size_t point_count = point_cloud->size();
@@ -3496,6 +3592,11 @@ namespace lfs::core {
         if (!mesh_data) {
             LOG_WARN("Cannot add mesh node '{}': mesh data is null", name);
             return NULL_NODE;
+        }
+        if (parent != NULL_NODE) {
+            const auto* parent_node = getNodeById(parent);
+            if (!parent_node || !isSceneNodeParentCompatible(parent_node->type, NodeType::MESH))
+                return NULL_NODE;
         }
 
         const std::string unique_name = makeUniqueNodeName(name_to_id_, name);
@@ -3538,6 +3639,10 @@ namespace lfs::core {
             LOG_WARN("Cannot add cropbox '{}': parent id {} does not exist", name, parent_id);
             return NULL_NODE;
         }
+        if (!isSceneNodeParentCompatible(parent->type, NodeType::CROPBOX)) {
+            LOG_WARN("Cannot add cropbox '{}': parent is incompatible", name);
+            return NULL_NODE;
+        }
         for (const NodeId child_id : parent->children) {
             const auto* child = getNodeById(child_id);
             if (child && child->type == NodeType::CROPBOX) {
@@ -3574,6 +3679,10 @@ namespace lfs::core {
         const auto* parent = getNodeById(parent_id);
         if (!parent) {
             LOG_WARN("Cannot add ellipsoid '{}': parent id {} does not exist", name, parent_id);
+            return NULL_NODE;
+        }
+        if (!isSceneNodeParentCompatible(parent->type, NodeType::ELLIPSOID)) {
+            LOG_WARN("Cannot add ellipsoid '{}': parent is incompatible", name);
             return NULL_NODE;
         }
         for (const NodeId child_id : parent->children) {
@@ -3691,9 +3800,16 @@ namespace lfs::core {
             LOG_ERROR("Cannot restore node with UUID {}: name is empty", desc.uuid.to_string());
             return NULL_NODE;
         }
-        if (desc.parent != NULL_NODE && !getNodeById(desc.parent)) {
-            LOG_ERROR("Cannot restore node '{}': parent id {} does not exist", desc.name, desc.parent);
-            return NULL_NODE;
+        if (desc.parent != NULL_NODE) {
+            const auto* parent = getNodeById(desc.parent);
+            if (!parent) {
+                LOG_ERROR("Cannot restore node '{}': parent id {} does not exist", desc.name, desc.parent);
+                return NULL_NODE;
+            }
+            if (!isSceneNodeParentCompatible(parent->type, desc.type)) {
+                LOG_ERROR("Cannot restore node '{}': parent is incompatible", desc.name);
+                return NULL_NODE;
+            }
         }
 
         auto node = std::make_unique<SceneNode>();
@@ -3786,7 +3902,7 @@ namespace lfs::core {
 
         const std::string restored_name = node->name;
         const Uuid restored_uuid = node->uuid;
-        const NodeId id = insertNode(std::move(node), true);
+        const NodeId id = insertNode(std::move(node), true, desc.preferred_id);
         if (id != NULL_NODE) {
             LOG_TRACE("Restored node '{}' (id={}, uuid={})",
                       restored_name,
@@ -4099,6 +4215,10 @@ namespace lfs::core {
             if (!current) {
                 continue;
             }
+            if (static_cast<bool>(current->locked)) {
+                LOG_WARN("Cannot duplicate '{}': node is locked", current->name);
+                return "";
+            }
             if (current->type == NodeType::SPLAT &&
                 current->gaussian_count.load(std::memory_order_acquire) > 0) {
                 duplicates_splat_range = true;
@@ -4184,9 +4304,9 @@ namespace lfs::core {
             }
 
             if (auto* new_node = getNodeById(new_id)) {
-                new_node->local_transform = src_transform;
-                new_node->visible = src_visible;
-                new_node->locked = src_locked;
+                new_node->local_transform.setQuiet(src_transform);
+                new_node->visible.setQuiet(src_visible);
+                new_node->locked.setQuiet(src_locked);
                 new_node->transform_dirty = true;
             }
 
@@ -4248,12 +4368,15 @@ namespace lfs::core {
             return "";
         }
 
+        const bool group_visible = group_node->visible;
+        bool contains_locked_node = false;
         std::vector<std::pair<const lfs::core::SplatData*, glm::mat4>> splats;
         const std::function<void(NodeId)> collect = [&](const NodeId id) {
             const auto* const node = getNodeById(id);
             if (!node)
                 return;
-            if (node->type == NodeType::SPLAT && node->model && isNodeEffectivelyVisible(node->id)) {
+            contains_locked_node = contains_locked_node || static_cast<bool>(node->locked);
+            if (node->type == NodeType::SPLAT && node->model) {
                 splats.emplace_back(node->model.get(), getWorldTransform(id));
             }
             for (const NodeId cid : node->children)
@@ -4262,6 +4385,10 @@ namespace lfs::core {
 
         const NodeId parent_id = group_node->parent_id;
         collect(group_id);
+        if (contains_locked_node) {
+            LOG_WARN("Cannot merge '{}': node is locked", group_name);
+            return "";
+        }
 
         auto merged = mergeSplatsWithTransforms(splats);
         if (!merged) {
@@ -4275,6 +4402,8 @@ namespace lfs::core {
             LOG_ERROR("Failed to add merged group '{}'", group_name);
             return "";
         }
+        if (auto* merged_node = getNodeById(merged_id))
+            merged_node->visible.setQuiet(group_visible);
         assert(getNodeIdByName(group_name) == merged_id);
         markPayloadDiverged(merged_id);
 
@@ -4628,8 +4757,17 @@ namespace lfs::core {
         auto* node = getNodeById(node_id);
         if (!node)
             return false;
+        if (static_cast<bool>(node->locked)) {
+            LOG_WARN("Cannot reparent '{}': node is locked", node->name);
+            return false;
+        }
 
         if (new_parent != NULL_NODE) {
+            const auto* parent = getNodeById(new_parent);
+            if (!parent || !isSceneNodeParentCompatible(parent->type, node->type)) {
+                LOG_WARN("Cannot reparent: destination is not a group");
+                return false;
+            }
             NodeId check = new_parent;
             while (check != NULL_NODE) {
                 if (check == node_id) {
@@ -4683,8 +4821,17 @@ namespace lfs::core {
         auto* node = getNodeById(node_id);
         if (!node)
             return false;
+        if (static_cast<bool>(node->locked)) {
+            LOG_WARN("Cannot move '{}': node is locked", node->name);
+            return false;
+        }
 
         if (new_parent != NULL_NODE) {
+            const auto* parent = getNodeById(new_parent);
+            if (!parent || !isSceneNodeParentCompatible(parent->type, node->type)) {
+                LOG_WARN("Cannot move: destination is not a group");
+                return false;
+            }
             NodeId check = new_parent;
             while (check != NULL_NODE) {
                 if (check == node_id) {

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -485,10 +485,10 @@ namespace lfs::core {
         }
     }
 
-    std::vector<std::unique_ptr<lfs::core::SplatData>> Scene::detachSplatModelsForRemoval(
+    std::vector<std::pair<lfs::core::Uuid, std::unique_ptr<lfs::core::SplatData>>> Scene::detachSplatModelsForRemoval(
         const NodeId root_id,
         const bool keep_children) {
-        std::vector<std::unique_ptr<lfs::core::SplatData>> detached;
+        std::vector<std::pair<lfs::core::Uuid, std::unique_ptr<lfs::core::SplatData>>> detached;
 
         if (root_id == NULL_NODE) {
             return detached;
@@ -507,7 +507,7 @@ namespace lfs::core {
             if (node->model) {
                 if (auto model = retireCombinedModelIfInFlight(
                         std::move(node->model))) {
-                    detached.push_back(std::move(model));
+                    detached.emplace_back(node->uuid, std::move(model));
                 }
             }
 

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -4271,6 +4271,16 @@ namespace lfs::core {
                         }
                     }
                 }
+            } else if (src_type == NodeType::ELLIPSOID) {
+                const auto* src_for_ellipsoid = getNodeById(src_id);
+                if (src_for_ellipsoid && src_for_ellipsoid->ellipsoid && parent_id != NULL_NODE) {
+                    new_id = addEllipsoid(new_name, parent_id);
+                    if (auto* new_node = getNodeById(new_id)) {
+                        if (new_node->ellipsoid) {
+                            *new_node->ellipsoid = *src_for_ellipsoid->ellipsoid;
+                        }
+                    }
+                }
             } else if (src_type == NodeType::MESH) {
                 const auto* src_for_mesh = getNodeById(src_id);
                 if (src_for_mesh && src_for_mesh->mesh) {

--- a/src/python/lfs/py_prop_traits.hpp
+++ b/src/python/lfs/py_prop_traits.hpp
@@ -147,11 +147,19 @@ namespace lfs::python {
         template <>
         struct PropTraits<core::prop::PropType::Mat4> {
             static nb::object to_python(const std::any& v) {
-                const auto arr = std::any_cast<std::array<float, 16>>(v);
                 nb::list rows;
-                for (int i = 0; i < 4; ++i) {
-                    rows.append(nb::make_tuple(arr[i * 4 + 0], arr[i * 4 + 1],
-                                               arr[i * 4 + 2], arr[i * 4 + 3]));
+                if (v.type() == typeid(glm::mat4)) {
+                    const auto& matrix = std::any_cast<const glm::mat4&>(v);
+                    for (int row = 0; row < 4; ++row) {
+                        rows.append(nb::make_tuple(matrix[0][row], matrix[1][row],
+                                                   matrix[2][row], matrix[3][row]));
+                    }
+                } else {
+                    const auto arr = std::any_cast<std::array<float, 16>>(v);
+                    for (int i = 0; i < 4; ++i) {
+                        rows.append(nb::make_tuple(arr[i * 4 + 0], arr[i * 4 + 1],
+                                                   arr[i * 4 + 2], arr[i * 4 + 3]));
+                    }
                 }
                 return rows;
             }

--- a/src/python/lfs/py_scene.cpp
+++ b/src/python/lfs/py_scene.cpp
@@ -176,6 +176,10 @@ namespace lfs::python {
         apply_node_transform_with_undo(node_->name, ndarray_to_mat4(transform), scene_);
     }
 
+    nb::tuple PySceneNode::local_transform() const {
+        return mat4_to_tuple(node_->local_transform.get());
+    }
+
     nb::tuple PySceneNode::world_transform() const {
         return mat4_to_tuple(scene_->getWorldTransform(node_->id));
     }
@@ -1159,6 +1163,7 @@ namespace lfs::python {
             .def_prop_ro("children", &PySceneNode::children, "List of child node IDs")
             .def_prop_ro("type", &PySceneNode::type, "Node type (SPLAT, GROUP, CAMERA, etc.)")
             // Transform (special conversion to tuple/ndarray)
+            .def_prop_ro("local_transform", &PySceneNode::local_transform, "Local transform as 4x4 row-major tuple")
             .def_prop_ro("world_transform", &PySceneNode::world_transform, "World-space transform as 4x4 row-major tuple")
             .def("set_local_transform", &PySceneNode::set_local_transform, "Set local transform from a [4, 4] ndarray")
             // Metadata (read-only)

--- a/src/python/lfs/py_scene.cpp
+++ b/src/python/lfs/py_scene.cpp
@@ -148,6 +148,7 @@ namespace lfs::python {
             .mode = vis::op::SceneGraphCaptureMode::FULL,
             .include_selected_nodes = include_selected_nodes,
             .include_scene_context = include_scene_context,
+            .payload_uuids = std::vector<core::Uuid>{},
         };
     }
 

--- a/src/python/lfs/py_scene.hpp
+++ b/src/python/lfs/py_scene.hpp
@@ -222,6 +222,7 @@ namespace lfs::python {
 
         // Transform (special matrix conversion)
         void set_local_transform(nb::ndarray<float, nb::shape<4, 4>> transform);
+        nb::tuple local_transform() const;
         nb::tuple world_transform() const;
 
         // Metadata (read-only)
@@ -317,7 +318,7 @@ namespace lfs::python {
         nb::list python_dir() const {
             nb::list result;
             for (const char* attr : {"id", "uuid", "parent_id", "children", "type",
-                                     "world_transform", "set_local_transform",
+                                     "local_transform", "world_transform", "set_local_transform",
                                      "gaussian_count", "centroid",
                                      "splat_data", "point_cloud", "mesh", "cropbox", "ellipsoid", "keyframe_data",
                                      "camera_uid", "image_path", "mask_path", "depth_path", "has_camera",

--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
@@ -30,6 +30,7 @@
 
 #include <RmlUi/Core.h>
 #include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/Elements/ElementFormControlInput.h>
 #include <RmlUi/Core/Event.h>
 #include <RmlUi/Core/Input.h>
 #include <SDL3/SDL_keyboard.h>
@@ -320,8 +321,10 @@ namespace lfs::vis::gui {
                    !parent_is_dataset;
         }
 
-        [[nodiscard]] bool canDrag(const core::NodeType type, const bool parent_is_dataset) {
-            if (parent_is_dataset)
+        [[nodiscard]] bool canDrag(const core::NodeType type,
+                                   const bool parent_is_dataset,
+                                   const bool locked) {
+            if (parent_is_dataset || locked)
                 return false;
             switch (type) {
             case core::NodeType::SPLAT:
@@ -913,6 +916,7 @@ namespace lfs::vis::gui {
             snapshot.type = node->type;
             snapshot.name = node->name;
             snapshot.visible = static_cast<bool>(node->visible);
+            snapshot.locked = static_cast<bool>(node->locked);
             snapshot.has_children = !node->children.empty();
             snapshot.training_enabled = node->training_enabled;
             snapshot.camera_uid = node->camera_uid;
@@ -1010,9 +1014,11 @@ namespace lfs::vis::gui {
             const auto parent_it = snapshots.find(snapshot.parent_id);
             const bool parent_is_dataset =
                 parent_it != snapshots.end() && parent_it->second.type == core::NodeType::DATASET;
-            snapshot.draggable = canDrag(snapshot.type, parent_is_dataset);
+            snapshot.draggable = canDrag(snapshot.type, parent_is_dataset, snapshot.locked);
             snapshot.can_delete = isDeletable(snapshot.type, parent_is_dataset);
-            snapshot.delete_enabled = snapshot.can_delete && !delete_blocked_ids.contains(id);
+            snapshot.delete_enabled = snapshot.can_delete &&
+                                      !snapshot.locked &&
+                                      !delete_blocked_ids.contains(id);
             snapshot.can_rename = isRenamable(snapshot.type, parent_is_dataset);
             snapshot.rename_enabled = snapshot.can_rename;
             snapshot.can_toggle_training =
@@ -1509,8 +1515,11 @@ namespace lfs::vis::gui {
             if (rename_buffer_.empty())
                 rename_buffer_ = snapshot.name;
             setCachedAttribute(slot.rename_input, "value", rename_buffer_);
-            if (rename_focus_pending_ && slot.rename_input->Focus())
+            if (rename_focus_pending_ && slot.rename_input->Focus()) {
+                if (auto* input = dynamic_cast<Rml::ElementFormControlInput*>(slot.rename_input))
+                    input->Select();
                 rename_focus_pending_ = false;
+            }
         }
 
         slot.bound_id = row.id;
@@ -2638,6 +2647,10 @@ namespace lfs::vis::gui {
         for (const core::NodeId node_id : node_ids) {
             const auto snapshot_it = node_snapshots_.find(node_id);
             const auto* node = scene.getNodeById(node_id);
+            if (node && static_cast<bool>(node->locked)) {
+                LOG_WARN("Scene node deletion request aborted: node is locked");
+                return;
+            }
             if (!node || snapshot_it == node_snapshots_.end() || !snapshot_it->second.delete_enabled) {
                 LOG_WARN("Scene node deletion request aborted: the complete selection is no longer removable");
                 return;
@@ -2766,10 +2779,7 @@ namespace lfs::vis::gui {
                                        prefixedAction("select_hierarchy")));
             const auto groupable_selection = selectedDraggableNodeIds();
             if (node_snapshots_.contains(node_id) && node_snapshots_.at(node_id).draggable &&
-                groupable_selection.size() >= 2 &&
-                std::ranges::all_of(groupable_selection, [this](const core::NodeId id) {
-                    return node_snapshots_.at(id).type != core::NodeType::GROUP;
-                })) {
+                groupable_selection.size() >= 2) {
                 items.push_back(makeAction(tr("scene.group_selected"),
                                            prefixedAction("group_selected"), true));
             }
@@ -2915,7 +2925,8 @@ namespace lfs::vis::gui {
 
             if (node->type != core::NodeType::CAMERA &&
                 node->type != core::NodeType::CROPBOX &&
-                node->type != core::NodeType::ELLIPSOID) {
+                node->type != core::NodeType::ELLIPSOID &&
+                !node_snapshots_.at(node_id).locked) {
                 items.push_back(makeAction(
                     tr("scene.duplicate"),
                     prefixedAction(std::format("duplicate:{}", node_id))));
@@ -2971,8 +2982,7 @@ namespace lfs::vis::gui {
         core::NodeId parent_id = core::NULL_NODE;
         for (const core::NodeId id : selected_ids_) {
             const auto it = node_snapshots_.find(id);
-            if (it == node_snapshots_.end() || !it->second.draggable ||
-                it->second.type == core::NodeType::GROUP)
+            if (it == node_snapshots_.end() || !it->second.draggable)
                 return;
             if (ids.empty())
                 parent_id = it->second.parent_id;

--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
@@ -2619,9 +2619,32 @@ namespace lfs::vis::gui {
     }
 
     void SceneGraphElement::requestDeleteSelection() {
-        if (!selectionActionState().all_delete_enabled)
+        if (selected_ids_.empty())
             return;
-        deleteSelectedNodes();
+
+        std::vector<core::NodeId> node_ids;
+        node_ids.reserve(selected_ids_.size());
+        for (const core::NodeId id : selected_ids_) {
+            const auto it = node_snapshots_.find(id);
+            if (it == node_snapshots_.end())
+                continue;
+
+            bool covered_by_selected_ancestor = false;
+            for (core::NodeId parent_id = it->second.parent_id;
+                 parent_id != core::NULL_NODE;) {
+                if (selected_ids_.contains(parent_id)) {
+                    covered_by_selected_ancestor = true;
+                    break;
+                }
+                const auto parent_it = node_snapshots_.find(parent_id);
+                if (parent_it == node_snapshots_.end())
+                    break;
+                parent_id = parent_it->second.parent_id;
+            }
+            if (!covered_by_selected_ancestor)
+                node_ids.push_back(id);
+        }
+        requestDeleteNodes(node_ids);
     }
 
     void SceneGraphElement::clearSelectedNodes() {

--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.cpp
@@ -481,7 +481,9 @@ namespace lfs::vis::gui {
 
     } // namespace
 
-    SceneGraphElement::SceneGraphElement(const Rml::String& tag) : Rml::Element(tag) {}
+    SceneGraphElement::SceneGraphElement(const Rml::String& tag) : Rml::Element(tag) {
+        SetAttribute("tab-index", "0");
+    }
 
     bool SceneGraphElement::ownsContextMenuAction(const std::string_view action) {
         return action.starts_with(kContextActionPrefix);
@@ -603,10 +605,10 @@ namespace lfs::vis::gui {
         if (!owner)
             return;
         auto* target = event.GetTargetElement();
+        const auto type = event.GetType();
         if (owner->rename_node_id_ == core::NULL_NODE || !owner->isTextInputTarget(target))
             return;
 
-        const auto type = event.GetType();
         if (type == "input" || type == "change") {
             owner->captureRenameBuffer();
             event.StopPropagation();
@@ -809,6 +811,7 @@ namespace lfs::vis::gui {
         collapsed_ids_.clear();
         selected_ids_.clear();
         click_anchor_id_ = core::NULL_NODE;
+        keyboard_cursor_id_ = core::NULL_NODE;
         rename_node_id_ = core::NULL_NODE;
         rename_buffer_.clear();
         rename_conflict_modal_pending_ = false;
@@ -1687,8 +1690,10 @@ namespace lfs::vis::gui {
     }
 
     void SceneGraphElement::focusTree() {
-        if (rename_node_id_ == core::NULL_NODE)
+        if (rename_node_id_ == core::NULL_NODE) {
+            SetProperty("tab-index", "0");
             Focus();
+        }
     }
 
     void SceneGraphElement::beginRename(const core::NodeId node_id) {
@@ -2091,17 +2096,26 @@ namespace lfs::vis::gui {
             return false;
 
         const core::NodeId current = selectionCursor();
-        core::NodeId target = core::NULL_NODE;
+        size_t target_index = 0;
         if (current == core::NULL_NODE) {
-            target = delta > 0 ? flat_rows_.front().id : flat_rows_.back().id;
+            target_index = delta > 0 ? 0 : flat_rows_.size() - 1;
         } else {
             const size_t index = flat_index_by_id_.contains(current) ? flat_index_by_id_.at(current) : 0;
-            const size_t target_index = std::clamp<int>(
-                static_cast<int>(index) + delta, 0, static_cast<int>(flat_rows_.size()) - 1);
-            target = flat_rows_[target_index].id;
+            target_index = static_cast<size_t>(std::clamp<int>(
+                static_cast<int>(index) + delta, 0, static_cast<int>(flat_rows_.size()) - 1));
         }
-        if (target == core::NULL_NODE)
+        return selectKeyboardRow(target_index, extend, toggle);
+    }
+
+    bool SceneGraphElement::selectKeyboardRow(const size_t target_index,
+                                              const bool extend,
+                                              const bool toggle) {
+        auto* scene_manager = services().sceneOrNull();
+        if (!scene_manager || target_index >= flat_rows_.size())
             return false;
+
+        const core::NodeId current = selectionCursor();
+        const core::NodeId target = flat_rows_[target_index].id;
 
         if (extend) {
             const core::NodeId anchor = click_anchor_id_ != core::NULL_NODE
@@ -2128,6 +2142,11 @@ namespace lfs::vis::gui {
                 selected_ids_.insert(toggled);
             scene_manager->selectNodesById(
                 std::vector<core::NodeId>(selected_ids_.begin(), selected_ids_.end()));
+        } else {
+            scene_manager->selectNode(target);
+            selected_ids_.clear();
+            selected_ids_.insert(target);
+            click_anchor_id_ = target;
         }
         keyboard_cursor_id_ = target;
         if (camera_preview_navigation_active_ &&
@@ -3332,6 +3351,8 @@ namespace lfs::vis::gui {
         } else if (type == "keydown") {
             const auto key =
                 static_cast<Rml::Input::KeyIdentifier>(event.GetParameter("key_identifier", 0));
+            const bool event_ctrl = event.GetParameter<int>("ctrl_key", 0) != 0 || ctrlDown();
+            const bool event_shift = event.GetParameter<int>("shift_key", 0) != 0 || shiftDown();
 
             if (key == Rml::Input::KI_ESCAPE && drag_source_id_ != core::NULL_NODE) {
                 cancelDrag();
@@ -3344,11 +3365,33 @@ namespace lfs::vis::gui {
 
             switch (key) {
             case Rml::Input::KI_UP:
-                if (moveSelectionCursor(-1, shiftDown(), ctrlDown() && !shiftDown()))
+                if (moveSelectionCursor(-1, event_shift, event_ctrl && !event_shift))
                     event.StopPropagation();
                 break;
             case Rml::Input::KI_DOWN:
-                if (moveSelectionCursor(1, shiftDown(), ctrlDown() && !shiftDown()))
+                if (moveSelectionCursor(1, event_shift, event_ctrl && !event_shift))
+                    event.StopPropagation();
+                break;
+            case Rml::Input::KI_LEFT:
+            case Rml::Input::KI_RIGHT: {
+                const core::NodeId node_id = selectionCursor();
+                const auto node_it = node_snapshots_.find(node_id);
+                if (node_it != node_snapshots_.end() && node_it->second.has_children) {
+                    const bool collapsed = collapsed_ids_.contains(node_id);
+                    const bool should_toggle = key == Rml::Input::KI_LEFT ? !collapsed : collapsed;
+                    if (should_toggle)
+                        toggleExpand(node_id);
+                    event.StopPropagation();
+                }
+                break;
+            }
+            case Rml::Input::KI_HOME:
+                if (selectKeyboardRow(0, event_shift, false))
+                    event.StopPropagation();
+                break;
+            case Rml::Input::KI_END:
+                if (!flat_rows_.empty() &&
+                    selectKeyboardRow(flat_rows_.size() - 1, event_shift, false))
                     event.StopPropagation();
                 break;
             case Rml::Input::KI_RETURN: {

--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.hpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.hpp
@@ -211,6 +211,7 @@ namespace lfs::vis::gui {
         void handlePrimaryClick(core::NodeId node_id);
         void handleSecondaryClick(core::NodeId node_id, float mouse_x, float mouse_y);
         bool activateNode(core::NodeId node_id);
+        bool selectKeyboardRow(size_t row_index, bool extend, bool toggle);
         bool moveSelectionCursor(int delta, bool extend, bool toggle);
         std::vector<core::NodeId> rangeSelectionIds(core::NodeId a, core::NodeId b) const;
         core::NodeId selectionCursor() const;

--- a/src/visualizer/gui/rmlui/elements/scene_graph_element.hpp
+++ b/src/visualizer/gui/rmlui/elements/scene_graph_element.hpp
@@ -115,6 +115,7 @@ namespace lfs::vis::gui {
             size_t training_total_count = 0;
             bool can_toggle_training = false;
             std::string label;
+            bool locked = false;
             bool draggable = false;
             bool has_mask = false;
             bool can_delete = false;

--- a/src/visualizer/gui/rmlui/sdl_rml_key_mapping.hpp
+++ b/src/visualizer/gui/rmlui/sdl_rml_key_mapping.hpp
@@ -56,6 +56,7 @@ namespace lfs::vis::gui {
         case SDLK_SEMICOLON:    return Rml::Input::KI_OEM_1;
         case SDLK_EQUALS:       return Rml::Input::KI_OEM_PLUS;
         case SDLK_PLUS:         return Rml::Input::KI_OEM_PLUS;
+        case SDLK_APOSTROPHE:   return Rml::Input::KI_OEM_7;
         case SDLK_COMMA:        return Rml::Input::KI_OEM_COMMA;
         case SDLK_MINUS:        return Rml::Input::KI_OEM_MINUS;
         case SDLK_PERIOD:       return Rml::Input::KI_OEM_PERIOD;
@@ -134,6 +135,7 @@ namespace lfs::vis::gui {
         // still comes from SDL text events through text_codepoints.
         // clang-format off
         switch (sc) {
+        case SDL_SCANCODE_ESCAPE:          return Rml::Input::KI_ESCAPE;
         case SDL_SCANCODE_SPACE:          return Rml::Input::KI_SPACE;
         case SDL_SCANCODE_APOSTROPHE:     return Rml::Input::KI_OEM_7;
         case SDL_SCANCODE_COMMA:          return Rml::Input::KI_OEM_COMMA;

--- a/src/visualizer/gui_capabilities.cpp
+++ b/src/visualizer/gui_capabilities.cpp
@@ -21,6 +21,7 @@
 #include "visualizer/scene_coordinate_utils.hpp"
 #include <algorithm>
 #include <cmath>
+#include <format>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/euler_angles.hpp>
@@ -596,7 +597,8 @@ namespace lfs::vis::cap {
             if (!local_transform)
                 return std::unexpected("Node not found: " + name);
 
-            scene_manager.setNodeTransform(name, *local_transform);
+            if (!scene_manager.setNodeTransform(name, *local_transform))
+                return std::unexpected("Cannot transform '" + name + "': node is locked");
             return {};
         }
 
@@ -864,8 +866,18 @@ namespace lfs::vis::cap {
         auto entry = std::make_unique<vis::op::SceneSnapshot>(scene_manager, std::string(undo_label));
         entry->captureTransforms(targets);
 
-        for (const auto& name : targets)
-            scene_manager.setNodeTransform(name, transform);
+        for (const auto& name : targets) {
+            const auto* node = scene_manager.getScene().getNode(name);
+            if (!node)
+                return std::unexpected(std::format("Cannot transform '{}': node not found", name));
+            if (static_cast<bool>(node->locked))
+                return std::unexpected(std::format("Cannot transform '{}': node is locked", name));
+        }
+
+        for (const auto& name : targets) {
+            if (!scene_manager.setNodeTransform(name, transform))
+                return std::unexpected(std::format("Cannot transform '{}': node is locked", name));
+        }
 
         entry->captureAfter();
         vis::op::pushSceneSnapshotIfChanged(std::move(entry));

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -1683,6 +1683,14 @@ namespace lfs::vis {
             bound_action = resolveCrossToolActivationShortcut(bindings_, tool_mode, logical_key, mods);
         }
 
+        const bool gui_keyboard_focus = input_router_
+                                            ? input_router_->keyboardFocus() == input::InputTarget::Gui
+                                            : gui::guiFocusState().want_capture_keyboard;
+        if (action == input::ACTION_PRESS && logical_key == input::KEY_ESCAPE &&
+            gui_keyboard_focus) {
+            return;
+        }
+
         const bool is_mcp_runtime_action =
             bound_action == input::Action::TOGGLE_MCP_SERVER ||
             bound_action == input::Action::TOGGLE_MCP_BINDING;
@@ -1727,7 +1735,6 @@ namespace lfs::vis {
         const bool modal_open = input_router_
                                     ? input_router_->isModalOpen()
                                     : (gui && gui->isModalWindowOpen());
-
         if (action != input::ACTION_PRESS && action != input::ACTION_REPEAT)
             return;
 

--- a/src/visualizer/input/input_controller.cpp
+++ b/src/visualizer/input/input_controller.cpp
@@ -1957,6 +1957,17 @@ namespace lfs::vis {
                 return;
 
             case input::Action::DELETE_SELECTED:
+                if (tool_context_) {
+                    if (auto* sm = tool_context_->getSceneManager();
+                        sm && !sm->getScene().hasSelection()) {
+                        const auto selected = sm->getSelectedNodeNames();
+                        if (!selected.empty()) {
+                            for (const auto& name : selected)
+                                cmd::RemovePLY{.name = name, .keep_children = false}.emit();
+                            return;
+                        }
+                    }
+                }
                 cmd::DeleteSelected{}.emit();
                 return;
 

--- a/src/visualizer/operation/undo_entry.cpp
+++ b/src/visualizer/operation/undo_entry.cpp
@@ -825,6 +825,7 @@ namespace lfs::vis::op {
                                                    const lfs::core::Scene::PerNodeSelectionSlices& selection_slices) {
             SceneGraphNodeSnapshot snapshot;
             snapshot.uuid = node.uuid;
+            snapshot.id = node.id;
             snapshot.name = node.name;
             snapshot.type = node.type;
             snapshot.local_transform = node.local_transform.get();
@@ -839,7 +840,15 @@ namespace lfs::vis::op {
                 if (const auto* parent = scene_manager.getScene().getNodeById(node.parent_id)) {
                     snapshot.parent_uuid = parent->uuid;
                     snapshot.parent_name = parent->name;
+                    const auto it = std::ranges::find(parent->children, node.id);
+                    if (it != parent->children.end())
+                        snapshot.order_index = static_cast<int>(std::distance(parent->children.begin(), it));
                 }
+            } else {
+                const auto roots = scene_manager.getScene().getRootNodes();
+                const auto it = std::ranges::find(roots, node.id);
+                if (it != roots.end())
+                    snapshot.order_index = static_cast<int>(std::distance(roots.begin(), it));
             }
 
             if (auto path = scene_manager.getPlyPath(node.uuid); path) {
@@ -890,11 +899,13 @@ namespace lfs::vis::op {
         struct SnapshotTraversalNode {
             const SceneGraphNodeSnapshot* snapshot = nullptr;
             const SceneGraphNodeSnapshot* tree_parent = nullptr;
+            int order_index = -1;
         };
 
         struct PreparedRestoreNode {
             const SceneGraphNodeSnapshot* snapshot = nullptr;
             lfs::core::Uuid parent_uuid;
+            int order_index = -1;
             lfs::core::Scene::RestoreNodeDesc desc;
         };
 
@@ -906,20 +917,22 @@ namespace lfs::vis::op {
 
         void flattenSnapshotTree(const SceneGraphNodeSnapshot& snapshot,
                                  const SceneGraphNodeSnapshot* tree_parent,
+                                 const int order_index,
                                  std::vector<SnapshotTraversalNode>& result) {
             result.push_back(SnapshotTraversalNode{
                 .snapshot = &snapshot,
                 .tree_parent = tree_parent,
+                .order_index = snapshot.order_index >= 0 ? snapshot.order_index : order_index,
             });
-            for (const auto& child : snapshot.children) {
-                flattenSnapshotTree(child, &snapshot, result);
+            for (size_t i = 0; i < snapshot.children.size(); ++i) {
+                flattenSnapshotTree(snapshot.children[i], &snapshot, static_cast<int>(i), result);
             }
         }
 
         std::vector<SnapshotTraversalNode> flattenSnapshotState(const SceneGraphStateSnapshot& state) {
             std::vector<SnapshotTraversalNode> result;
-            for (const auto& root : state.roots) {
-                flattenSnapshotTree(root, nullptr, result);
+            for (size_t i = 0; i < state.roots.size(); ++i) {
+                flattenSnapshotTree(state.roots[i], nullptr, static_cast<int>(i), result);
             }
             return result;
         }
@@ -939,6 +952,56 @@ namespace lfs::vis::op {
             });
         }
 
+        void validateSnapshotPayload(const SceneGraphNodeSnapshot& snapshot) {
+            switch (snapshot.type) {
+            case lfs::core::NodeType::POINTCLOUD:
+                if (!snapshot.point_cloud) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore point-cloud node '" + snapshot.name + "': payload is missing");
+                }
+                break;
+            case lfs::core::NodeType::MESH:
+                if (!snapshot.mesh) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore mesh node '" + snapshot.name + "': payload is missing");
+                }
+                break;
+            case lfs::core::NodeType::CROPBOX:
+                if (!snapshot.cropbox) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore crop-box node '" + snapshot.name + "': payload is missing");
+                }
+                break;
+            case lfs::core::NodeType::ELLIPSOID:
+                if (!snapshot.ellipsoid) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore ellipsoid node '" + snapshot.name + "': payload is missing");
+                }
+                break;
+            case lfs::core::NodeType::CAMERA:
+                if (!snapshot.camera) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore camera node '" + snapshot.name + "': payload is missing");
+                }
+                break;
+            case lfs::core::NodeType::KEYFRAME:
+                if (!snapshot.keyframe) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore keyframe node '" + snapshot.name + "': payload is missing");
+                }
+                break;
+            case lfs::core::NodeType::SPLAT:
+            case lfs::core::NodeType::GROUP:
+            case lfs::core::NodeType::DATASET:
+            case lfs::core::NodeType::CAMERA_GROUP:
+            case lfs::core::NodeType::IMAGE_GROUP:
+            case lfs::core::NodeType::IMAGE:
+            case lfs::core::NodeType::KEYFRAME_GROUP:
+            case lfs::core::NodeType::PLY_SEQUENCE:
+                break;
+            }
+        }
+
         void collectSnapshotUuids(const SceneGraphNodeSnapshot& snapshot,
                                   std::unordered_set<lfs::core::Uuid>& result) {
             if (!snapshot.uuid.is_nil()) {
@@ -952,13 +1015,17 @@ namespace lfs::vis::op {
         std::unordered_set<lfs::core::Uuid> uuidsToRemove(
             const SceneGraphStateSnapshot& desired,
             const SceneGraphStateSnapshot& current) {
+            std::unordered_set<lfs::core::Uuid> desired_uuids;
+            for (const auto& root : desired.roots)
+                collectSnapshotUuids(root, desired_uuids);
+
             std::unordered_set<lfs::core::Uuid> result;
-            for (const auto& root : desired.roots) {
-                collectSnapshotUuids(root, result);
-            }
             for (const auto& root : current.roots) {
                 collectSnapshotUuids(root, result);
             }
+            std::erase_if(result, [&](const lfs::core::Uuid& uuid) {
+                return desired_uuids.contains(uuid);
+            });
             return result;
         }
 
@@ -1023,19 +1090,7 @@ namespace lfs::vis::op {
                         resolved_parent_uuid.to_string() + " is not resolvable in restore order");
                 }
 
-                const std::string restored_name =
-                    lfs::core::makeUniqueNodeName(reserved_names, snapshot.name);
-                if (restored_name.empty() || reserved_names.contains(restored_name)) {
-                    throw HistoryCorruptionError(
-                        "Cannot restore scene node '" + snapshot.name + "': display name is not insertable");
-                }
-                reserved_names.insert(restored_name);
-
-                lfs::core::Scene::RestoreNodeDesc desc;
-                desc.uuid = snapshot.uuid;
-                desc.type = snapshot.type;
-                desc.name = restored_name;
-                desc.gaussian_count = snapshot.gaussian_count;
+                validateSnapshotPayload(snapshot);
 
                 if (snapshot.selection_slice) {
                     if (snapshot.type != lfs::core::NodeType::SPLAT) {
@@ -1065,6 +1120,31 @@ namespace lfs::vis::op {
                             "': " + error.what());
                     }
                 }
+
+                if (scene.getNodeByUuid(snapshot.uuid)) {
+                    plan.nodes.push_back(PreparedRestoreNode{
+                        .snapshot = &snapshot,
+                        .parent_uuid = resolved_parent_uuid,
+                        .order_index = item.order_index,
+                        .desc = {},
+                    });
+                    continue;
+                }
+
+                const std::string restored_name =
+                    lfs::core::makeUniqueNodeName(reserved_names, snapshot.name);
+                if (restored_name.empty() || reserved_names.contains(restored_name)) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore scene node '" + snapshot.name + "': display name is not insertable");
+                }
+                reserved_names.insert(restored_name);
+
+                lfs::core::Scene::RestoreNodeDesc desc;
+                desc.uuid = snapshot.uuid;
+                desc.preferred_id = desired.preserve_node_ids ? snapshot.id : lfs::core::NULL_NODE;
+                desc.type = snapshot.type;
+                desc.name = restored_name;
+                desc.gaussian_count = snapshot.gaussian_count;
 
                 try {
                     switch (snapshot.type) {
@@ -1139,6 +1219,7 @@ namespace lfs::vis::op {
                 plan.nodes.push_back(PreparedRestoreNode{
                     .snapshot = &snapshot,
                     .parent_uuid = resolved_parent_uuid,
+                    .order_index = item.order_index,
                     .desc = std::move(desc),
                 });
             }
@@ -1376,17 +1457,136 @@ namespace lfs::vis::op {
             }
         }
 
+        void restorePreparedPayload(lfs::core::Scene& scene,
+                                    lfs::core::SceneNode& node,
+                                    const SceneGraphNodeSnapshot& snapshot) {
+            switch (snapshot.type) {
+            case lfs::core::NodeType::SPLAT:
+                if (snapshot.model) {
+                    auto allocator = makeViewerSplatTensorAllocator();
+                    auto model = cloneRendererReadySplatData(*snapshot.model, allocator);
+                    if (allocator) {
+                        scene.setCombinedModelAllocator(std::move(allocator));
+                    }
+                    scene.replaceNodeModel(node.name, std::move(model));
+                }
+                break;
+            case lfs::core::NodeType::POINTCLOUD:
+                if (!snapshot.point_cloud) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore point-cloud node '" + snapshot.name + "': payload is missing");
+                }
+                node.point_cloud = clonePointCloud(*snapshot.point_cloud);
+                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
+                break;
+            case lfs::core::NodeType::MESH:
+                if (!snapshot.mesh) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore mesh node '" + snapshot.name + "': payload is missing");
+                }
+                node.mesh = cloneMeshData(*snapshot.mesh);
+                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
+                break;
+            case lfs::core::NodeType::CROPBOX:
+                if (!snapshot.cropbox) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore crop-box node '" + snapshot.name + "': payload is missing");
+                }
+                node.cropbox = std::make_unique<lfs::core::CropBoxData>(*snapshot.cropbox);
+                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
+                break;
+            case lfs::core::NodeType::ELLIPSOID:
+                if (!snapshot.ellipsoid) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore ellipsoid node '" + snapshot.name + "': payload is missing");
+                }
+                node.ellipsoid = std::make_unique<lfs::core::EllipsoidData>(*snapshot.ellipsoid);
+                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
+                break;
+            case lfs::core::NodeType::CAMERA:
+                if (!snapshot.camera) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore camera node '" + snapshot.name + "': payload is missing");
+                }
+                node.camera = restoreCamera(*snapshot.camera);
+                node.camera_uid = node.camera->uid();
+                node.image_path = lfs::core::path_to_utf8(node.camera->image_path());
+                node.mask_path = lfs::core::path_to_utf8(node.camera->mask_path());
+                node.depth_path = lfs::core::path_to_utf8(node.camera->depth_path());
+                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
+                break;
+            case lfs::core::NodeType::KEYFRAME:
+                if (!snapshot.keyframe) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore keyframe node '" + snapshot.name + "': payload is missing");
+                }
+                node.keyframe = std::make_unique<lfs::core::KeyframeData>(*snapshot.keyframe);
+                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
+                break;
+            case lfs::core::NodeType::GROUP:
+            case lfs::core::NodeType::DATASET:
+            case lfs::core::NodeType::CAMERA_GROUP:
+            case lfs::core::NodeType::IMAGE_GROUP:
+            case lfs::core::NodeType::IMAGE:
+            case lfs::core::NodeType::KEYFRAME_GROUP:
+            case lfs::core::NodeType::PLY_SEQUENCE:
+                break;
+            }
+        }
+
         void restorePreparedNode(SceneManager& scene_manager, PreparedRestoreNode& prepared) {
             auto& scene = scene_manager.getScene();
             const auto& snapshot = *prepared.snapshot;
+            lfs::core::NodeId desired_parent = lfs::core::NULL_NODE;
             if (!prepared.parent_uuid.is_nil()) {
-                prepared.desc.parent = scene.getNodeIdByUuid(prepared.parent_uuid);
-                const lfs::core::NodeId parent_id = prepared.desc.parent;
-                if (parent_id == lfs::core::NULL_NODE) {
+                desired_parent = scene.getNodeIdByUuid(prepared.parent_uuid);
+                if (desired_parent == lfs::core::NULL_NODE) {
                     throw HistoryCorruptionError(
                         "Prevalidated parent UUID disappeared while restoring node '" + snapshot.name + "'");
                 }
             }
+
+            if (auto* existing = scene.getNodeByUuid(snapshot.uuid)) {
+                if (existing->type != snapshot.type) {
+                    existing->type = snapshot.type;
+                    existing->model.reset();
+                    existing->point_cloud.reset();
+                    existing->mesh.reset();
+                    existing->cropbox.reset();
+                    existing->ellipsoid.reset();
+                    existing->camera.reset();
+                    existing->keyframe.reset();
+                    existing->camera_uid = -1;
+                    existing->image_path.clear();
+                    existing->mask_path.clear();
+                    existing->depth_path.clear();
+                }
+                if (existing->parent_id != desired_parent) {
+                    const bool was_locked = existing->locked;
+                    existing->locked.setQuiet(false);
+                    (void)scene.moveNode(existing->id, desired_parent, -1);
+                    existing->locked.setQuiet(was_locked);
+                    existing = scene.getNodeByUuid(snapshot.uuid);
+                    if (!existing || existing->parent_id != desired_parent) {
+                        throw HistoryCorruptionError(
+                            "Failed to reparent existing scene node '" + snapshot.name + "'");
+                    }
+                }
+
+                existing->local_transform.setQuiet(snapshot.local_transform);
+                existing->visible.setQuiet(snapshot.visible);
+                existing->locked.setQuiet(snapshot.locked);
+                existing->training_enabled = snapshot.training_enabled;
+                existing->payload_diverged = snapshot.payload_diverged;
+                existing->gaussian_count.store(snapshot.gaussian_count, std::memory_order_release);
+                existing->centroid = snapshot.centroid;
+                existing->transform_dirty = true;
+                restorePreparedPayload(scene, *existing, snapshot);
+                restorePlyPathForSnapshot(scene_manager, snapshot.uuid, snapshot.source_path);
+                return;
+            }
+
+            prepared.desc.parent = desired_parent;
 
             const std::string restored_name = prepared.desc.name;
             const lfs::core::NodeId node_id = scene.restoreNodeWithUuid(std::move(prepared.desc));
@@ -1415,6 +1615,86 @@ namespace lfs::vis::op {
                 LOG_WARN("Restored node '{}' as '{}' because its display label was already in use",
                          snapshot.name,
                          restored_name);
+            }
+        }
+
+        void restoreSnapshotOrder(lfs::core::Scene& scene,
+                                  const SceneGraphStateSnapshot& desired) {
+            const auto moveForRestore = [&](const lfs::core::Uuid& uuid,
+                                            const lfs::core::NodeId parent_id,
+                                            const int order_index) {
+                auto* node = scene.getNodeByUuid(uuid);
+                if (!node) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore order for missing scene node " + uuid.to_string());
+                }
+
+                const bool was_locked = node->locked;
+                node->locked.setQuiet(false);
+                (void)scene.moveNode(node->id, parent_id, order_index);
+                node = scene.getNodeByUuid(uuid);
+                if (node) {
+                    node->locked.setQuiet(was_locked);
+                }
+                if (!node || node->parent_id != parent_id) {
+                    throw HistoryCorruptionError(
+                        "Failed to restore order for scene node " + uuid.to_string());
+                }
+            };
+
+            const auto restoreChildren = [&](const auto& self,
+                                             const SceneGraphNodeSnapshot& snapshot) -> void {
+                const auto* parent = scene.getNodeByUuid(snapshot.uuid);
+                if (!parent) {
+                    throw HistoryCorruptionError(
+                        "Cannot restore children for missing scene node " + snapshot.uuid.to_string());
+                }
+                for (size_t i = 0; i < snapshot.children.size(); ++i) {
+                    moveForRestore(snapshot.children[i].uuid, parent->id, static_cast<int>(i));
+                }
+                for (const auto& child : snapshot.children) {
+                    self(self, child);
+                }
+            };
+
+            const auto live_roots = scene.getRootNodes();
+            std::unordered_set<lfs::core::Uuid> desired_root_uuids;
+            desired_root_uuids.reserve(desired.roots.size());
+            const bool has_complete_root_order =
+                desired.roots.size() == live_roots.size() &&
+                std::ranges::all_of(desired.roots, [&](const auto& root) {
+                    return root.parent_uuid.is_nil() && desired_root_uuids.insert(root.uuid).second;
+                }) &&
+                std::ranges::all_of(live_roots, [&](const auto id) {
+                    const auto* node = scene.getNodeById(id);
+                    return node && desired_root_uuids.contains(node->uuid);
+                });
+
+            // A snapshot may intentionally cover only one root of a larger
+            // scene. Its root order_index is relative to the captured roots,
+            // not a command to reorder unrelated live roots. Child lists are
+            // complete for every captured parent and remain safe to restore.
+            // ID-preserving replacement snapshots (currently merge and batch
+            // deletion) also carry an explicit scene-root position for their
+            // replacement subtree, even when the snapshot is scoped to that
+            // subtree.
+            if (has_complete_root_order || desired.preserve_node_ids) {
+                for (size_t i = 0; i < desired.roots.size(); ++i) {
+                    const auto& root = desired.roots[i];
+                    const auto parent_id = root.parent_uuid.is_nil()
+                                               ? lfs::core::NULL_NODE
+                                               : scene.getNodeIdByUuid(root.parent_uuid);
+                    if (!root.parent_uuid.is_nil() && parent_id == lfs::core::NULL_NODE) {
+                        throw HistoryCorruptionError(
+                            "Cannot restore order for missing parent " + root.parent_uuid.to_string());
+                    }
+                    moveForRestore(root.uuid,
+                                   parent_id,
+                                   root.order_index >= 0 ? root.order_index : static_cast<int>(i));
+                }
+            }
+            for (const auto& root : desired.roots) {
+                restoreChildren(restoreChildren, root);
             }
         }
 
@@ -1565,6 +1845,7 @@ namespace lfs::vis::op {
 
     SceneGraphNodeSnapshot::SceneGraphNodeSnapshot(const SceneGraphNodeSnapshot& other)
         : uuid(other.uuid),
+          id(other.id),
           parent_uuid(other.parent_uuid),
           name(other.name),
           parent_name(other.parent_name),
@@ -1576,6 +1857,7 @@ namespace lfs::vis::op {
           payload_diverged(other.payload_diverged),
           gaussian_count(other.gaussian_count),
           centroid(other.centroid),
+          order_index(other.order_index),
           payload_device(other.payload_device),
           selection_slice_device(other.selection_slice_device),
           source_path(other.source_path),
@@ -2877,6 +3159,7 @@ namespace lfs::vis::op {
                                                                     const std::vector<lfs::core::NodeId>& root_ids,
                                                                     const SceneGraphCaptureOptions options) {
         SceneGraphStateSnapshot snapshot;
+        snapshot.preserve_node_ids = options.preserve_node_ids;
         if (options.include_selected_nodes) {
             const auto selected_node_ids = scene_manager.getSelectedNodeIds();
             std::vector<std::string> selected_node_names;
@@ -2993,6 +3276,9 @@ namespace lfs::vis::op {
         // replace the live tree.
         auto restore_plan = prepareRestorePlan(scene_, desired, uuids_to_remove);
         const auto removal_roots = removalRoots(scene, uuids_to_remove);
+        std::unordered_set<lfs::core::Uuid> desired_uuids;
+        for (const auto& root : desired.roots)
+            collectSnapshotUuids(root, desired_uuids);
         const bool translates_selection =
             snapshotStateContainsSplat(desired) || snapshotStateContainsSplat(current);
         lfs::core::Scene::PerNodeSelectionSlices selection_slices;
@@ -3013,19 +3299,58 @@ namespace lfs::vis::op {
                 scene.setCombinedModelAllocator(std::move(restore_plan.combined_model_allocator));
             }
 
+            const auto subtree_contains_desired = [&](const auto& self, const lfs::core::NodeId id) -> bool {
+                const auto* node = scene.getNodeById(id);
+                if (!node)
+                    return false;
+                if (desired_uuids.contains(node->uuid))
+                    return true;
+                return std::ranges::any_of(node->children, [&](const lfs::core::NodeId child_id) {
+                    return self(self, child_id);
+                });
+            };
+            const auto remove_exclusive_children = [&](const auto& self, const lfs::core::NodeId id) -> void {
+                const auto* node = scene.getNodeById(id);
+                if (!node)
+                    return;
+                const auto children = node->children;
+                for (const auto child_id : children) {
+                    const auto* child = scene.getNodeById(child_id);
+                    if (!child)
+                        continue;
+                    if (desired_uuids.contains(child->uuid)) {
+                        self(self, child_id);
+                    } else if (uuids_to_remove.contains(child->uuid)) {
+                        if (subtree_contains_desired(subtree_contains_desired, child_id)) {
+                            self(self, child_id);
+                            scene.removeNodeById(child_id, true);
+                        } else {
+                            clearPlyPathsForSubtree(scene_, child_id);
+                            scene.removeNodeById(child_id, false);
+                        }
+                    }
+                }
+            };
+
             for (const auto id : removal_roots) {
-                clearPlyPathsForSubtree(scene_, id);
-                scene.removeNodeById(id, false);
+                const bool keeps_desired_descendants = subtree_contains_desired(subtree_contains_desired, id);
+                if (keeps_desired_descendants)
+                    remove_exclusive_children(remove_exclusive_children, id);
+                if (!keeps_desired_descendants)
+                    clearPlyPathsForSubtree(scene_, id);
+                scene.removeNodeById(id, keeps_desired_descendants);
             }
 
             for (auto& prepared : restore_plan.nodes) {
                 restorePreparedNode(scene_, prepared);
             }
+            restoreSnapshotOrder(scene, desired);
 
             if (translates_selection) {
                 scene.applyPerNodeSelectionSlices(selection_slices);
             }
         }
+        scene.invalidateTransformCache();
 
         for (const auto& root : current.roots) {
             emitRemovedEvents(root);

--- a/src/visualizer/operation/undo_entry.cpp
+++ b/src/visualizer/operation/undo_entry.cpp
@@ -822,7 +822,9 @@ namespace lfs::vis::op {
         SceneGraphNodeSnapshot captureNodeSnapshot(const SceneManager& scene_manager,
                                                    const lfs::core::SceneNode& node,
                                                    const SceneGraphCaptureMode mode,
-                                                   const lfs::core::Scene::PerNodeSelectionSlices& selection_slices) {
+                                                   const lfs::core::Scene::PerNodeSelectionSlices& selection_slices,
+                                                   const std::unordered_set<lfs::core::Uuid>& payload_uuids,
+                                                   const bool capture_all_payloads) {
             SceneGraphNodeSnapshot snapshot;
             snapshot.uuid = node.uuid;
             snapshot.id = node.id;
@@ -861,39 +863,46 @@ namespace lfs::vis::op {
                 snapshot.selection_slice_device = slice->second.device();
             }
 
-            if (mode == SceneGraphCaptureMode::FULL && node.model) {
+            const bool capture_payload = mode == SceneGraphCaptureMode::FULL &&
+                                         (capture_all_payloads || payload_uuids.contains(node.uuid));
+            if (capture_payload && node.model) {
                 snapshot.payload_device = node.model->means_raw().device();
                 snapshot.model = cloneSplatData(*node.model);
             }
-            if (mode == SceneGraphCaptureMode::FULL && node.point_cloud) {
+            if (capture_payload && node.point_cloud) {
                 snapshot.payload_device = node.point_cloud->means.device();
                 snapshot.point_cloud = clonePointCloud(*node.point_cloud);
             }
-            if (mode == SceneGraphCaptureMode::FULL && node.mesh) {
+            if (capture_payload && node.mesh) {
                 snapshot.payload_device = node.mesh->vertices.device();
                 snapshot.mesh = cloneMeshData(*node.mesh);
             }
-            if (node.cropbox) {
+            if (capture_payload && node.cropbox) {
                 snapshot.cropbox = std::make_unique<lfs::core::CropBoxData>(*node.cropbox);
             }
-            if (node.ellipsoid) {
+            if (capture_payload && node.ellipsoid) {
                 snapshot.ellipsoid = std::make_unique<lfs::core::EllipsoidData>(*node.ellipsoid);
             }
-            if (node.keyframe) {
+            if (capture_payload && node.keyframe) {
                 snapshot.keyframe = std::make_unique<lfs::core::KeyframeData>(*node.keyframe);
             }
-            if (node.camera) {
+            if (capture_payload && node.camera) {
                 snapshot.camera = captureCameraSnapshot(*node.camera);
             }
 
             for (const auto child_id : node.children) {
                 if (const auto* child = scene_manager.getScene().getNodeById(child_id)) {
                     snapshot.children.push_back(
-                        captureNodeSnapshot(scene_manager, *child, mode, selection_slices));
+                        captureNodeSnapshot(scene_manager, *child, mode, selection_slices,
+                                            payload_uuids, capture_all_payloads));
                 }
             }
 
             return snapshot;
+        }
+
+        const lfs::core::SplatData* snapshotSplatModel(const SceneGraphNodeSnapshot& snapshot) {
+            return snapshot.model ? snapshot.model.get() : snapshot.shared_model.get();
         }
 
         struct SnapshotTraversalNode {
@@ -952,7 +961,11 @@ namespace lfs::vis::op {
             });
         }
 
-        void validateSnapshotPayload(const SceneGraphNodeSnapshot& snapshot) {
+        void validateSnapshotPayload(const SceneGraphNodeSnapshot& snapshot,
+                                     const bool require_payload) {
+            if (!require_payload) {
+                return;
+            }
             switch (snapshot.type) {
             case lfs::core::NodeType::POINTCLOUD:
                 if (!snapshot.point_cloud) {
@@ -1090,7 +1103,9 @@ namespace lfs::vis::op {
                         resolved_parent_uuid.to_string() + " is not resolvable in restore order");
                 }
 
-                validateSnapshotPayload(snapshot);
+                const auto* existing = scene.getNodeByUuid(snapshot.uuid);
+                validateSnapshotPayload(snapshot,
+                                        !existing || existing->type != snapshot.type);
 
                 if (snapshot.selection_slice) {
                     if (snapshot.type != lfs::core::NodeType::SPLAT) {
@@ -1121,7 +1136,7 @@ namespace lfs::vis::op {
                     }
                 }
 
-                if (scene.getNodeByUuid(snapshot.uuid)) {
+                if (existing) {
                     plan.nodes.push_back(PreparedRestoreNode{
                         .snapshot = &snapshot,
                         .parent_uuid = resolved_parent_uuid,
@@ -1149,9 +1164,9 @@ namespace lfs::vis::op {
                 try {
                     switch (snapshot.type) {
                     case lfs::core::NodeType::SPLAT:
-                        if (snapshot.model) {
+                        if (const auto* model = snapshotSplatModel(snapshot)) {
                             auto allocator = makeViewerSplatTensorAllocator();
-                            desc.model = cloneRendererReadySplatData(*snapshot.model, allocator);
+                            desc.model = cloneRendererReadySplatData(*model, allocator);
                             if (allocator) {
                                 plan.combined_model_allocator = std::move(allocator);
                             }
@@ -1293,15 +1308,15 @@ namespace lfs::vis::op {
             if (snapshot.selection_slice) {
                 total += tensorBytes(*snapshot.selection_slice);
             }
-            if (snapshot.model) {
-                total += tensorBytes(snapshot.model->means_raw());
-                total += tensorBytes(snapshot.model->sh0_raw());
-                total += tensorBytes(snapshot.model->shN_raw());
-                total += tensorBytes(snapshot.model->scaling_raw());
-                total += tensorBytes(snapshot.model->rotation_raw());
-                total += tensorBytes(snapshot.model->opacity_raw());
-                total += tensorBytes(snapshot.model->deleted());
-                total += tensorBytes(snapshot.model->_densification_info);
+            if (const auto* model = snapshotSplatModel(snapshot)) {
+                total += tensorBytes(model->means_raw());
+                total += tensorBytes(model->sh0_raw());
+                total += tensorBytes(model->shN_raw());
+                total += tensorBytes(model->scaling_raw());
+                total += tensorBytes(model->rotation_raw());
+                total += tensorBytes(model->opacity_raw());
+                total += tensorBytes(model->deleted());
+                total += tensorBytes(model->_densification_info);
             }
             if (snapshot.point_cloud) {
                 total += tensorBytes(snapshot.point_cloud->means);
@@ -1320,6 +1335,15 @@ namespace lfs::vis::op {
                 total += tensorBytes(snapshot.mesh->texcoords);
                 total += tensorBytes(snapshot.mesh->colors);
                 total += tensorBytes(snapshot.mesh->indices);
+            }
+            if (snapshot.cropbox) {
+                total += sizeof(*snapshot.cropbox);
+            }
+            if (snapshot.ellipsoid) {
+                total += sizeof(*snapshot.ellipsoid);
+            }
+            if (snapshot.keyframe) {
+                total += sizeof(*snapshot.keyframe);
             }
             if (snapshot.camera) {
                 total += tensorBytes(snapshot.camera->R);
@@ -1347,14 +1371,23 @@ namespace lfs::vis::op {
             if (snapshot.selection_slice) {
                 total += tensorMemory(*snapshot.selection_slice);
             }
-            if (snapshot.model) {
-                total += estimateSplatDataMemory(*snapshot.model);
+            if (const auto* model = snapshotSplatModel(snapshot)) {
+                total += estimateSplatDataMemory(*model);
             }
             if (snapshot.point_cloud) {
                 total += estimatePointCloudMemory(*snapshot.point_cloud);
             }
             if (snapshot.mesh) {
                 total += estimateMeshMemory(*snapshot.mesh);
+            }
+            if (snapshot.cropbox) {
+                total.cpu_bytes += sizeof(*snapshot.cropbox);
+            }
+            if (snapshot.ellipsoid) {
+                total.cpu_bytes += sizeof(*snapshot.ellipsoid);
+            }
+            if (snapshot.keyframe) {
+                total.cpu_bytes += sizeof(*snapshot.keyframe);
             }
             if (snapshot.camera) {
                 total += estimateCameraMemory(*snapshot.camera);
@@ -1462,66 +1495,54 @@ namespace lfs::vis::op {
                                     const SceneGraphNodeSnapshot& snapshot) {
             switch (snapshot.type) {
             case lfs::core::NodeType::SPLAT:
-                if (snapshot.model) {
+                if (const auto* model = snapshotSplatModel(snapshot)) {
                     auto allocator = makeViewerSplatTensorAllocator();
-                    auto model = cloneRendererReadySplatData(*snapshot.model, allocator);
+                    auto restored_model = cloneRendererReadySplatData(*model, allocator);
                     if (allocator) {
                         scene.setCombinedModelAllocator(std::move(allocator));
                     }
-                    scene.replaceNodeModel(node.name, std::move(model));
+                    scene.replaceNodeModel(node.name, std::move(restored_model));
                 }
                 break;
             case lfs::core::NodeType::POINTCLOUD:
-                if (!snapshot.point_cloud) {
-                    throw HistoryCorruptionError(
-                        "Cannot restore point-cloud node '" + snapshot.name + "': payload is missing");
+                if (snapshot.point_cloud) {
+                    node.point_cloud = clonePointCloud(*snapshot.point_cloud);
+                    scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 }
-                node.point_cloud = clonePointCloud(*snapshot.point_cloud);
-                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 break;
             case lfs::core::NodeType::MESH:
-                if (!snapshot.mesh) {
-                    throw HistoryCorruptionError(
-                        "Cannot restore mesh node '" + snapshot.name + "': payload is missing");
+                if (snapshot.mesh) {
+                    node.mesh = cloneMeshData(*snapshot.mesh);
+                    scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 }
-                node.mesh = cloneMeshData(*snapshot.mesh);
-                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 break;
             case lfs::core::NodeType::CROPBOX:
-                if (!snapshot.cropbox) {
-                    throw HistoryCorruptionError(
-                        "Cannot restore crop-box node '" + snapshot.name + "': payload is missing");
+                if (snapshot.cropbox) {
+                    node.cropbox = std::make_unique<lfs::core::CropBoxData>(*snapshot.cropbox);
+                    scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 }
-                node.cropbox = std::make_unique<lfs::core::CropBoxData>(*snapshot.cropbox);
-                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 break;
             case lfs::core::NodeType::ELLIPSOID:
-                if (!snapshot.ellipsoid) {
-                    throw HistoryCorruptionError(
-                        "Cannot restore ellipsoid node '" + snapshot.name + "': payload is missing");
+                if (snapshot.ellipsoid) {
+                    node.ellipsoid = std::make_unique<lfs::core::EllipsoidData>(*snapshot.ellipsoid);
+                    scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 }
-                node.ellipsoid = std::make_unique<lfs::core::EllipsoidData>(*snapshot.ellipsoid);
-                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 break;
             case lfs::core::NodeType::CAMERA:
-                if (!snapshot.camera) {
-                    throw HistoryCorruptionError(
-                        "Cannot restore camera node '" + snapshot.name + "': payload is missing");
+                if (snapshot.camera) {
+                    node.camera = restoreCamera(*snapshot.camera);
+                    node.camera_uid = node.camera->uid();
+                    node.image_path = lfs::core::path_to_utf8(node.camera->image_path());
+                    node.mask_path = lfs::core::path_to_utf8(node.camera->mask_path());
+                    node.depth_path = lfs::core::path_to_utf8(node.camera->depth_path());
+                    scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 }
-                node.camera = restoreCamera(*snapshot.camera);
-                node.camera_uid = node.camera->uid();
-                node.image_path = lfs::core::path_to_utf8(node.camera->image_path());
-                node.mask_path = lfs::core::path_to_utf8(node.camera->mask_path());
-                node.depth_path = lfs::core::path_to_utf8(node.camera->depth_path());
-                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 break;
             case lfs::core::NodeType::KEYFRAME:
-                if (!snapshot.keyframe) {
-                    throw HistoryCorruptionError(
-                        "Cannot restore keyframe node '" + snapshot.name + "': payload is missing");
+                if (snapshot.keyframe) {
+                    node.keyframe = std::make_unique<lfs::core::KeyframeData>(*snapshot.keyframe);
+                    scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 }
-                node.keyframe = std::make_unique<lfs::core::KeyframeData>(*snapshot.keyframe);
-                scene.notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
                 break;
             case lfs::core::NodeType::GROUP:
             case lfs::core::NodeType::DATASET:
@@ -2034,6 +2055,7 @@ namespace lfs::vis::op {
           payload_device(other.payload_device),
           selection_slice_device(other.selection_slice_device),
           source_path(other.source_path),
+          shared_model(other.shared_model),
           camera(other.camera),
           children(other.children) {
         if (other.selection_slice) {
@@ -3422,11 +3444,18 @@ namespace lfs::vis::op {
             selection_slices = scene.capturePerNodeSelectionSlices();
         }
 
+        std::unordered_set<lfs::core::Uuid> payload_uuids;
+        if (options.payload_uuids) {
+            payload_uuids.insert(options.payload_uuids->begin(), options.payload_uuids->end());
+        }
+        const bool capture_all_payloads = !options.payload_uuids.has_value();
+
         snapshot.roots.reserve(root_nodes.size());
         for (const auto* root : root_nodes) {
             assert(root);
             snapshot.roots.push_back(
-                captureNodeSnapshot(scene_manager, *root, options.mode, selection_slices));
+                captureNodeSnapshot(scene_manager, *root, options.mode, selection_slices,
+                                    payload_uuids, capture_all_payloads));
         }
 
         return snapshot;

--- a/src/visualizer/operation/undo_entry.cpp
+++ b/src/visualizer/operation/undo_entry.cpp
@@ -1657,28 +1657,10 @@ namespace lfs::vis::op {
                 }
             };
 
-            const auto live_roots = scene.getRootNodes();
-            std::unordered_set<lfs::core::Uuid> desired_root_uuids;
-            desired_root_uuids.reserve(desired.roots.size());
-            const bool has_complete_root_order =
-                desired.roots.size() == live_roots.size() &&
-                std::ranges::all_of(desired.roots, [&](const auto& root) {
-                    return root.parent_uuid.is_nil() && desired_root_uuids.insert(root.uuid).second;
-                }) &&
-                std::ranges::all_of(live_roots, [&](const auto id) {
-                    const auto* node = scene.getNodeById(id);
-                    return node && desired_root_uuids.contains(node->uuid);
-                });
-
-            // A snapshot may intentionally cover only one root of a larger
-            // scene. Its root order_index is relative to the captured roots,
-            // not a command to reorder unrelated live roots. Child lists are
-            // complete for every captured parent and remain safe to restore.
-            // ID-preserving replacement snapshots (currently merge and batch
-            // deletion) also carry an explicit scene-root position for their
-            // replacement subtree, even when the snapshot is scoped to that
-            // subtree.
-            if (has_complete_root_order || desired.preserve_node_ids) {
+            if (desired.complete_root_order) {
+                // Complete root snapshots record positions in the global root
+                // list. Apply those absolute positions after all nodes exist,
+                // so fresh IDs cannot make an older entry rotate the roots.
                 for (size_t i = 0; i < desired.roots.size(); ++i) {
                     const auto& root = desired.roots[i];
                     const auto parent_id = root.parent_uuid.is_nil()
@@ -1715,6 +1697,8 @@ namespace lfs::vis::op {
             std::vector<lfs::core::NodeId> selected_node_ids;
             selected_node_ids.reserve(selected_node_uuids.size());
             for (const auto& uuid : selected_node_uuids) {
+                if (uuid.is_nil())
+                    continue;
                 const auto id = scene_manager.getScene().getNodeIdByUuid(uuid);
                 if (id != lfs::core::NULL_NODE) {
                     selected_node_ids.push_back(id);
@@ -1729,10 +1713,11 @@ namespace lfs::vis::op {
             }
         }
 
-        [[nodiscard]] SceneTopologyProof
-        captureTopologyProof(
-            const lfs::core::Scene& scene) {
+        [[nodiscard]] SceneTopologyProof captureTopologyProof(
+            const lfs::core::Scene& scene,
+            const SceneGraphStateSnapshot* scope = nullptr) {
             SceneTopologyProof proof;
+            proof.scoped = scope && scope->scoped_topology;
             proof.training_model_uuid =
                 scene.getTrainingModelNodeUuid();
             proof.consolidated =
@@ -1741,9 +1726,23 @@ namespace lfs::vis::op {
                 scene.getTotalGaussianCount();
 
             const auto nodes = scene.getNodes();
-            proof.nodes.reserve(nodes.size());
+            std::unordered_set<lfs::core::Uuid> scoped_uuids;
+            if (proof.scoped) {
+                for (const auto& root : scope->roots) {
+                    collectSnapshotUuids(root, scoped_uuids);
+                    proof.roots.push_back(root.uuid);
+                }
+            } else {
+                proof.roots.reserve(scene.getRootNodes().size());
+                for (const auto root_id : scene.getRootNodes()) {
+                    if (const auto* root = scene.getNodeById(root_id)) {
+                        proof.roots.push_back(root->uuid);
+                    }
+                }
+            }
+            proof.nodes.reserve(proof.scoped ? scoped_uuids.size() : nodes.size());
             for (const auto* node : nodes) {
-                if (!node) {
+                if (!node || (proof.scoped && !scoped_uuids.contains(node->uuid))) {
                     continue;
                 }
                 SceneTopologyNodeProof item{
@@ -1801,8 +1800,9 @@ namespace lfs::vis::op {
                     if (const auto* child =
                             scene.getNodeById(
                                 child_id)) {
-                        item.children.push_back(
-                            child->uuid);
+                        if (!proof.scoped || scoped_uuids.contains(child->uuid)) {
+                            item.children.push_back(child->uuid);
+                        }
                     }
                 }
                 proof.nodes.push_back(
@@ -1834,10 +1834,183 @@ namespace lfs::vis::op {
                  current == *allowed_compound_transition)) {
                 return;
             }
+
+            const auto uuid_text = [](const lfs::core::Uuid& uuid) {
+                return uuid.is_nil() ? std::string("<root>") : uuid.to_string();
+            };
+            const auto list_text = [&](const std::vector<lfs::core::Uuid>& uuids) {
+                std::string result = "[";
+                for (size_t i = 0; i < uuids.size(); ++i) {
+                    if (i > 0)
+                        result += ", ";
+                    result += uuid_text(uuids[i]);
+                }
+                result += ']';
+                return result;
+            };
+
+            if (expected.scoped) {
+                std::string difference;
+                std::unordered_set<lfs::core::Uuid> expected_uuids;
+                expected_uuids.reserve(expected.nodes.size());
+                for (const auto& node : expected.nodes) {
+                    expected_uuids.insert(node.uuid);
+                }
+
+                const auto current_node = [&](const lfs::core::Uuid& uuid) {
+                    return std::ranges::find(current.nodes, uuid, &SceneTopologyNodeProof::uuid);
+                };
+                for (const auto& expected_node : expected.nodes) {
+                    const auto current_it = current_node(expected_node.uuid);
+                    if (current_it == current.nodes.end()) {
+                        difference = "missing scoped node " + uuid_text(expected_node.uuid);
+                        break;
+                    }
+                    if (expected_node.parent_uuid != current_it->parent_uuid) {
+                        difference = "scoped parent mismatch for " + uuid_text(expected_node.uuid) +
+                                     ": expected " + uuid_text(expected_node.parent_uuid) +
+                                     ", actual " + uuid_text(current_it->parent_uuid);
+                        break;
+                    }
+                    std::vector<lfs::core::Uuid> current_children;
+                    for (const auto& child : current_it->children) {
+                        if (expected_uuids.contains(child)) {
+                            current_children.push_back(child);
+                        }
+                    }
+                    if (expected_node.children != current_children) {
+                        difference = "scoped child order mismatch for " + uuid_text(expected_node.uuid) +
+                                     ": expected " + list_text(expected_node.children) +
+                                     ", actual " + list_text(current_children);
+                        break;
+                    }
+                    if (expected_node.type != current_it->type ||
+                        expected_node.primary_extent != current_it->primary_extent ||
+                        expected_node.secondary_extent != current_it->secondary_extent) {
+                        difference = "scoped node payload/topology mismatch for " +
+                                     uuid_text(expected_node.uuid);
+                        break;
+                    }
+                }
+
+                if (difference.empty()) {
+                    std::vector<std::pair<lfs::core::Uuid, std::vector<lfs::core::Uuid>>> sibling_groups;
+                    for (const auto& root_uuid : expected.roots) {
+                        const auto root_it = current_node(root_uuid);
+                        const auto parent_uuid = root_it == current.nodes.end()
+                                                     ? lfs::core::Uuid{}
+                                                     : root_it->parent_uuid;
+                        const auto group_it = std::ranges::find(sibling_groups, parent_uuid,
+                                                                [](const auto& group) { return group.first; });
+                        if (group_it == sibling_groups.end()) {
+                            sibling_groups.emplace_back(parent_uuid,
+                                                        std::vector<lfs::core::Uuid>{root_uuid});
+                        } else {
+                            group_it->second.push_back(root_uuid);
+                        }
+                    }
+                    for (const auto& [parent_uuid, expected_siblings] : sibling_groups) {
+                        std::vector<lfs::core::Uuid> actual_siblings;
+                        const auto sibling_ids = parent_uuid.is_nil()
+                                                     ? scene.getRootNodes()
+                                                     : (scene.getNodeIdByUuid(parent_uuid) == lfs::core::NULL_NODE
+                                                            ? std::vector<lfs::core::NodeId>{}
+                                                            : scene.getNodeByUuid(parent_uuid)->children);
+                        for (const auto sibling_id : sibling_ids) {
+                            const auto* sibling = scene.getNodeById(sibling_id);
+                            if (sibling && std::ranges::find(expected_siblings, sibling->uuid) != expected_siblings.end()) {
+                                actual_siblings.push_back(sibling->uuid);
+                            }
+                        }
+                        if (expected_siblings != actual_siblings) {
+                            difference = "scoped sibling order mismatch under " + uuid_text(parent_uuid) +
+                                         ": expected " + list_text(expected_siblings) +
+                                         ", actual " + list_text(actual_siblings);
+                            break;
+                        }
+                    }
+                }
+
+                if (difference.empty()) {
+                    return;
+                }
+                throw HistoryCorruptionError(
+                    "Cannot replay undo entry '" + std::string(entry_name) +
+                    "' after scene topology changed (" + difference + ")");
+            }
+
+            std::string difference;
+            const size_t root_count = std::min(expected.roots.size(), current.roots.size());
+            for (size_t i = 0; i < root_count; ++i) {
+                if (expected.roots[i] != current.roots[i]) {
+                    difference = "root order mismatch at index " + std::to_string(i) + ": expected " +
+                                 uuid_text(expected.roots[i]) + ", actual " + uuid_text(current.roots[i]);
+                    break;
+                }
+            }
+            if (difference.empty() && expected.roots.size() != current.roots.size()) {
+                difference = "root order length mismatch: expected " + std::to_string(expected.roots.size()) +
+                             ", actual " + std::to_string(current.roots.size()) +
+                             "; expected roots=" + list_text(expected.roots) +
+                             ", actual roots=" + list_text(current.roots);
+            }
+
+            if (difference.empty()) {
+                const size_t node_count = std::min(expected.nodes.size(), current.nodes.size());
+                for (size_t i = 0; i < node_count; ++i) {
+                    const auto& expected_node = expected.nodes[i];
+                    const auto& current_node = current.nodes[i];
+                    if (expected_node.uuid != current_node.uuid) {
+                        difference = "node order/set mismatch at index " + std::to_string(i) +
+                                     ": expected " + uuid_text(expected_node.uuid) +
+                                     ", actual " + uuid_text(current_node.uuid);
+                        break;
+                    }
+                    if (expected_node.parent_uuid != current_node.parent_uuid) {
+                        difference = "parent mismatch for " + uuid_text(expected_node.uuid) +
+                                     ": expected " + uuid_text(expected_node.parent_uuid) +
+                                     ", actual " + uuid_text(current_node.parent_uuid);
+                        break;
+                    }
+                    if (expected_node.children != current_node.children) {
+                        difference = "child order mismatch for " + uuid_text(expected_node.uuid) +
+                                     ": expected " + list_text(expected_node.children) +
+                                     ", actual " + list_text(current_node.children);
+                        break;
+                    }
+                    if (expected_node.type != current_node.type ||
+                        expected_node.primary_extent != current_node.primary_extent ||
+                        expected_node.secondary_extent != current_node.secondary_extent) {
+                        difference = "node payload/topology mismatch for " + uuid_text(expected_node.uuid);
+                        break;
+                    }
+                }
+                if (difference.empty() && expected.nodes.size() != current.nodes.size()) {
+                    difference = "node count mismatch: expected " + std::to_string(expected.nodes.size()) +
+                                 ", actual " + std::to_string(current.nodes.size());
+                }
+            }
+
+            if (difference.empty() && expected.training_model_uuid != current.training_model_uuid) {
+                difference = "training-model UUID mismatch: expected " +
+                             uuid_text(expected.training_model_uuid) + ", actual " +
+                             uuid_text(current.training_model_uuid);
+            }
+            if (difference.empty() && expected.consolidated != current.consolidated) {
+                difference = "consolidation-state mismatch";
+            }
+            if (difference.empty() && expected.consolidated_extent != current.consolidated_extent) {
+                difference = "consolidated extent mismatch: expected " +
+                             std::to_string(expected.consolidated_extent) + ", actual " +
+                             std::to_string(current.consolidated_extent);
+            }
+            if (difference.empty())
+                difference = "unknown topology-proof mismatch";
+
             throw HistoryCorruptionError(
                 "Cannot replay undo entry '" +
                 std::string(entry_name) +
-                "' after scene topology changed");
+                "' after scene topology changed (" + difference + ")");
         }
     } // namespace
 
@@ -3160,6 +3333,7 @@ namespace lfs::vis::op {
                                                                     const SceneGraphCaptureOptions options) {
         SceneGraphStateSnapshot snapshot;
         snapshot.preserve_node_ids = options.preserve_node_ids;
+        snapshot.scoped_topology = options.scoped_topology;
         if (options.include_selected_nodes) {
             const auto selected_node_ids = scene_manager.getSelectedNodeIds();
             std::vector<std::string> selected_node_names;
@@ -3167,7 +3341,8 @@ namespace lfs::vis::op {
             selected_node_names.reserve(selected_node_ids.size());
             selected_node_uuids.reserve(selected_node_ids.size());
             for (const auto id : selected_node_ids) {
-                if (const auto* node = scene_manager.getScene().getNodeById(id)) {
+                if (const auto* node = scene_manager.getScene().getNodeById(id);
+                    node && !node->uuid.is_nil()) {
                     selected_node_names.push_back(node->name);
                     selected_node_uuids.push_back(node->uuid);
                 }
@@ -3196,6 +3371,12 @@ namespace lfs::vis::op {
         }
 
         const auto& scene = scene_manager.getScene();
+        const auto scene_roots = scene.getRootNodes();
+        const std::set<lfs::core::NodeId> scene_root_ids(scene_roots.begin(), scene_roots.end());
+        snapshot.complete_root_order = unique_ids.size() == scene_roots.size() &&
+                                       std::ranges::all_of(unique_ids, [&](const auto id) {
+                                           return scene_root_ids.contains(id);
+                                       });
         const std::set<lfs::core::NodeId> requested(unique_ids.begin(), unique_ids.end());
         std::vector<const lfs::core::SceneNode*> root_nodes;
         root_nodes.reserve(unique_ids.size());
@@ -3261,7 +3442,7 @@ namespace lfs::vis::op {
           after_(std::move(after)),
           expected_topology_(
               captureTopologyProof(
-                  scene.getScene())) {}
+                  scene.getScene(), &after_)) {}
 
     void SceneGraphPatchEntry::applyState(const SceneGraphStateSnapshot& desired,
                                           const SceneGraphStateSnapshot& current) {
@@ -3269,7 +3450,18 @@ namespace lfs::vis::op {
             scene_.getScene(),
             expected_topology_, name_);
         auto& scene = scene_.getScene();
-        const auto uuids_to_remove = uuidsToRemove(desired, current);
+        auto uuids_to_remove = uuidsToRemove(desired, current);
+        if (current.complete_root_order) {
+            std::unordered_set<lfs::core::Uuid> desired_uuids;
+            for (const auto& root : desired.roots) {
+                collectSnapshotUuids(root, desired_uuids);
+            }
+            for (const auto* node : scene_.getScene().getNodes()) {
+                if (node && !desired_uuids.contains(node->uuid)) {
+                    uuids_to_remove.insert(node->uuid);
+                }
+            }
+        }
 
         // Scene::Transaction batches events only. All logical failure paths must be
         // exhausted before the first removal so an invalid snapshot cannot partially
@@ -3389,7 +3581,7 @@ namespace lfs::vis::op {
             scene_.publishLiveCameraCount();
         }
         expected_topology_ =
-            captureTopologyProof(scene);
+            captureTopologyProof(scene, &desired);
     }
 
     void SceneGraphPatchEntry::undo() {

--- a/src/visualizer/operation/undo_entry.hpp
+++ b/src/visualizer/operation/undo_entry.hpp
@@ -69,10 +69,12 @@ namespace lfs::vis::op {
     };
 
     struct SceneTopologyProof {
+        std::vector<lfs::core::Uuid> roots;
         std::vector<SceneTopologyNodeProof> nodes;
         lfs::core::Uuid training_model_uuid;
         bool consolidated = false;
         std::size_t consolidated_extent = 0;
+        bool scoped = false;
 
         friend bool operator==(
             const SceneTopologyProof&,
@@ -431,6 +433,7 @@ namespace lfs::vis::op {
         bool include_selected_nodes = true;
         bool include_scene_context = true;
         bool preserve_node_ids = false;
+        bool scoped_topology = false;
     };
 
     struct SceneGraphCameraSnapshot {
@@ -503,6 +506,8 @@ namespace lfs::vis::op {
     struct LFS_VIS_API SceneGraphStateSnapshot {
         std::vector<SceneGraphNodeSnapshot> roots;
         bool preserve_node_ids = false;
+        bool complete_root_order = false;
+        bool scoped_topology = false;
         std::optional<std::vector<lfs::core::Uuid>> selected_node_uuids;
         std::optional<std::vector<std::string>> selected_node_names;
         std::optional<SceneGraphContextSnapshot> context;

--- a/src/visualizer/operation/undo_entry.hpp
+++ b/src/visualizer/operation/undo_entry.hpp
@@ -434,6 +434,9 @@ namespace lfs::vis::op {
         bool include_scene_context = true;
         bool preserve_node_ids = false;
         bool scoped_topology = false;
+        // A missing allowlist preserves the legacy FULL capture behavior. An
+        // engaged allowlist captures payloads only for these node UUIDs.
+        std::optional<std::vector<lfs::core::Uuid>> payload_uuids;
     };
 
     struct SceneGraphCameraSnapshot {
@@ -487,6 +490,7 @@ namespace lfs::vis::op {
         std::optional<std::filesystem::path> source_path;
         std::shared_ptr<lfs::core::Tensor> selection_slice;
         std::unique_ptr<lfs::core::SplatData> model;
+        std::shared_ptr<const lfs::core::SplatData> shared_model;
         std::shared_ptr<lfs::core::PointCloud> point_cloud;
         std::shared_ptr<lfs::core::MeshData> mesh;
         std::unique_ptr<lfs::core::CropBoxData> cropbox;

--- a/src/visualizer/operation/undo_entry.hpp
+++ b/src/visualizer/operation/undo_entry.hpp
@@ -430,6 +430,7 @@ namespace lfs::vis::op {
         SceneGraphCaptureMode mode = SceneGraphCaptureMode::FULL;
         bool include_selected_nodes = true;
         bool include_scene_context = true;
+        bool preserve_node_ids = false;
     };
 
     struct SceneGraphCameraSnapshot {
@@ -465,6 +466,7 @@ namespace lfs::vis::op {
         ~SceneGraphNodeSnapshot();
 
         lfs::core::Uuid uuid;
+        lfs::core::NodeId id = lfs::core::NULL_NODE;
         lfs::core::Uuid parent_uuid;
         std::string name;
         std::string parent_name;
@@ -476,6 +478,7 @@ namespace lfs::vis::op {
         bool payload_diverged = false;
         size_t gaussian_count = 0;
         glm::vec3 centroid{0.0f};
+        int order_index = -1;
         lfs::core::Device payload_device = lfs::core::Device::CUDA;
         lfs::core::Device selection_slice_device = lfs::core::Device::CUDA;
         std::optional<std::filesystem::path> source_path;
@@ -499,6 +502,7 @@ namespace lfs::vis::op {
 
     struct LFS_VIS_API SceneGraphStateSnapshot {
         std::vector<SceneGraphNodeSnapshot> roots;
+        bool preserve_node_ids = false;
         std::optional<std::vector<lfs::core::Uuid>> selected_node_uuids;
         std::optional<std::vector<std::string>> selected_node_names;
         std::optional<SceneGraphContextSnapshot> context;

--- a/src/visualizer/operation/undo_history.cpp
+++ b/src/visualizer/operation/undo_history.cpp
@@ -530,7 +530,28 @@ namespace lfs::vis::op {
         }
 
         if (auto* const scene_manager = services().sceneOrNull()) {
-            scene_manager->completePendingSelectionCounts();
+            try {
+                scene_manager->completePendingSelectionCounts();
+            } catch (const std::exception& e) {
+                LOG_ERROR("{} preflight failed: {}",
+                          undo_direction ? "Undo" : "Redo",
+                          e.what());
+                return HistoryResult{
+                    .success = false,
+                    .changed = false,
+                    .steps_performed = 0,
+                    .error = e.what(),
+                };
+            } catch (...) {
+                LOG_ERROR("{} preflight failed: unknown exception",
+                          undo_direction ? "Undo" : "Redo");
+                return HistoryResult{
+                    .success = false,
+                    .changed = false,
+                    .steps_performed = 0,
+                    .error = "unknown exception",
+                };
+            }
         }
 
         std::unique_lock playback_lock(playback_mutex_, std::try_to_lock);

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -54,6 +54,7 @@
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 namespace lfs::vis {
 
@@ -100,6 +101,7 @@ namespace lfs::vis {
                 .mode = op::SceneGraphCaptureMode::FULL,
                 .include_selected_nodes = include_selected_nodes,
                 .include_scene_context = include_scene_context,
+                .payload_uuids = std::vector<core::Uuid>{},
             };
         }
 
@@ -169,8 +171,11 @@ namespace lfs::vis {
                                         std::string label,
                                         op::SceneGraphStateSnapshot before,
                                         const std::vector<std::string>& after_roots,
-                                        const op::SceneGraphCaptureOptions options = sceneGraphCaptureOptions()) {
-            auto after = op::SceneGraphPatchEntry::captureState(scene_manager, after_roots, options);
+                                        const op::SceneGraphCaptureOptions options = sceneGraphCaptureOptions(),
+                                        const std::vector<core::Uuid>& after_payload_uuids = {}) {
+            auto after_options = options;
+            after_options.payload_uuids = after_payload_uuids;
+            auto after = op::SceneGraphPatchEntry::captureState(scene_manager, after_roots, after_options);
             op::undoHistory().push(
                 std::make_unique<op::SceneGraphPatchEntry>(scene_manager, std::move(label),
                                                            std::move(before), std::move(after)));
@@ -180,8 +185,11 @@ namespace lfs::vis {
                                              std::string label,
                                              op::SceneGraphStateSnapshot before,
                                              const std::vector<core::NodeId>& after_roots,
-                                             const op::SceneGraphCaptureOptions options = sceneGraphCaptureOptions()) {
-            auto after = op::SceneGraphPatchEntry::captureStateByIds(scene_manager, after_roots, options);
+                                             const op::SceneGraphCaptureOptions options = sceneGraphCaptureOptions(),
+                                             const std::vector<core::Uuid>& after_payload_uuids = {}) {
+            auto after_options = options;
+            after_options.payload_uuids = after_payload_uuids;
+            auto after = op::SceneGraphPatchEntry::captureStateByIds(scene_manager, after_roots, after_options);
             op::undoHistory().push(
                 std::make_unique<op::SceneGraphPatchEntry>(scene_manager, std::move(label),
                                                            std::move(before), std::move(after)));
@@ -203,7 +211,8 @@ namespace lfs::vis {
             }
         }
 
-        void retireSplatModelsAsync(std::vector<std::unique_ptr<core::SplatData>> models) {
+        void retireSplatModelsAsync(
+            std::vector<std::pair<core::Uuid, std::unique_ptr<core::SplatData>>> models) {
             if (models.empty()) {
                 return;
             }
@@ -216,6 +225,37 @@ namespace lfs::vis {
                 LOG_WARN("Failed to start asynchronous splat retirement: {}", e.what());
                 models.clear();
                 core::Tensor::trim_memory_pool();
+            }
+        }
+
+        bool attachDetachedSplatModel(op::SceneGraphNodeSnapshot& snapshot,
+                                      const core::Uuid& uuid,
+                                      std::unique_ptr<core::SplatData>& model) {
+            if (snapshot.uuid == uuid) {
+                snapshot.model.reset();
+                snapshot.shared_model = std::shared_ptr<const core::SplatData>(std::move(model));
+                return true;
+            }
+            for (auto& child : snapshot.children) {
+                if (attachDetachedSplatModel(child, uuid, model)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void attachDetachedSplatModels(
+            op::SceneGraphStateSnapshot& snapshot,
+            std::vector<std::pair<core::Uuid, std::unique_ptr<core::SplatData>>>& models) {
+            for (auto& [uuid, model] : models) {
+                if (!model) {
+                    continue;
+                }
+                for (auto& root : snapshot.roots) {
+                    if (attachDetachedSplatModel(root, uuid, model)) {
+                        break;
+                    }
+                }
             }
         }
 
@@ -277,6 +317,19 @@ namespace lfs::vis {
                 pending.insert(pending.end(), node->children.begin(), node->children.end());
             }
             return nullptr;
+        }
+
+        void collectSubtreeUuids(const core::Scene& scene,
+                                 const core::NodeId root_id,
+                                 std::vector<core::Uuid>& result) {
+            const auto* node = scene.getNodeById(root_id);
+            if (!node) {
+                return;
+            }
+            result.push_back(node->uuid);
+            for (const auto child_id : node->children) {
+                collectSubtreeUuids(scene, child_id, result);
+            }
         }
 
         [[nodiscard]] bool hasActiveSelectionFilter(const RenderingManager* const rendering_manager) {
@@ -1502,6 +1555,13 @@ namespace lfs::vis {
         history_options.preserve_node_ids = preserve_node_ids;
         std::optional<op::SceneGraphStateSnapshot> history_before;
         if (record_history) {
+            std::vector<core::Uuid> payload_uuids;
+            if (keep_children) {
+                payload_uuids.push_back(node_to_remove->uuid);
+            } else {
+                collectSubtreeUuids(scene_, id, payload_uuids);
+            }
+            history_options.payload_uuids = std::move(payload_uuids);
             history_before = op::SceneGraphPatchEntry::captureStateByIds(
                 *this,
                 capture_full_scene ? scene_.getRootNodes() : std::vector<core::NodeId>{id},
@@ -1577,6 +1637,9 @@ namespace lfs::vis {
         }
 
         auto detached_models = scene_.detachSplatModelsForRemoval(id, keep_children);
+        if (history_before) {
+            attachDetachedSplatModels(*history_before, detached_models);
+        }
         scene_.removeNodeById(id, keep_children);
         scheduleConsolidatedCompaction();
         {
@@ -1713,6 +1776,16 @@ namespace lfs::vis {
 
         auto history_options = sceneGraphCaptureOptions(true, true);
         history_options.scoped_topology = true;
+        std::vector<core::Uuid> payload_uuids;
+        for (const auto& [id, impact] : planned_removals) {
+            (void)impact;
+            if (keep_children) {
+                payload_uuids.push_back(scene_.getNodeById(id)->uuid);
+            } else {
+                collectSubtreeUuids(scene_, id, payload_uuids);
+            }
+        }
+        history_options.payload_uuids = std::move(payload_uuids);
         const bool preserve_node_ids = planned_removals.size() == 1 &&
                                        scene_.getNodeById(planned_removals.front().first)->type ==
                                            core::NodeType::CAMERA;
@@ -4481,7 +4554,8 @@ namespace lfs::vis {
                 .emit();
         }
 
-        pushSceneGraphHistoryEntry(*this, "Add Simplified Splat", std::move(history_before), {generated_name}, history_options);
+        pushSceneGraphHistoryEntry(*this, "Add Simplified Splat", std::move(history_before), {generated_name}, history_options,
+                                   {scene_.getNodeUuid(node_id)});
         return generated_name;
     }
 
@@ -4574,8 +4648,10 @@ namespace lfs::vis {
             };
 
         emit_added(new_name, parent_name);
+        std::vector<core::Uuid> duplicated_payload_uuids;
+        collectSubtreeUuids(scene_, scene_.getNodeIdByName(new_name), duplicated_payload_uuids);
         pushSceneGraphHistoryEntryByIds(*this, "Duplicate Node", std::move(history_before),
-                                        scene_.getRootNodes(), history_options);
+                                        scene_.getRootNodes(), history_options, duplicated_payload_uuids);
         return new_name;
     }
 
@@ -4607,8 +4683,6 @@ namespace lfs::vis {
         }
 
         const auto history_options = sceneGraphCaptureOptions(true, false);
-        auto history_before = op::SceneGraphPatchEntry::captureStateByIds(
-            *this, scene_.getRootNodes(), history_options);
         const core::Uuid group_uuid = group->uuid;
         const core::NodeId parent_id = group->parent_id;
         const bool group_visible = group->visible;
@@ -4636,6 +4710,15 @@ namespace lfs::vis {
             }
         };
         collect_children(group);
+
+        auto history_options_with_payload = history_options;
+        std::vector<core::Uuid> payload_uuids;
+        for (const auto child_id : group->children) {
+            collectSubtreeUuids(scene_, child_id, payload_uuids);
+        }
+        history_options_with_payload.payload_uuids = std::move(payload_uuids);
+        auto history_before = op::SceneGraphPatchEntry::captureStateByIds(
+            *this, scene_.getRootNodes(), history_options_with_payload);
 
         std::vector<std::unique_ptr<core::SplatData>> cropped_splats;
         std::vector<std::pair<const core::SplatData*, glm::mat4>> splats;
@@ -4694,6 +4777,7 @@ namespace lfs::vis {
         }
 
         core::NodeId merged_id = core::NULL_NODE;
+        std::vector<std::pair<core::Uuid, std::unique_ptr<core::SplatData>>> detached_models;
         {
             std::lock_guard lock(state_mutex_);
             for (const core::Uuid& uuid : uuids_to_remove) {
@@ -4702,6 +4786,8 @@ namespace lfs::vis {
         }
         {
             core::Scene::Transaction txn(scene_);
+            detached_models = scene_.detachSplatModelsForRemoval(group_id, false);
+            attachDetachedSplatModels(history_before, detached_models);
             scene_.removeNodeById(group_id, false);
             merged_id = scene_.addSplat(group_name, std::move(merged_model), parent_id);
             if (merged_id != core::NULL_NODE) {
@@ -4735,7 +4821,7 @@ namespace lfs::vis {
             LOG_ERROR("Failed to add merged group '{}'", group_name);
             emit_removed_events();
             pushSceneGraphHistoryEntryByIds(*this, "Merge Group", std::move(history_before),
-                                            scene_.getRootNodes(), history_options);
+                                            scene_.getRootNodes(), history_options_with_payload);
             return {};
         }
         assert(scene_.getNodeById(merged_id));
@@ -4773,7 +4859,8 @@ namespace lfs::vis {
 
         LOG_INFO("Merged group '{0}' -> '{0}'", group_name);
         pushSceneGraphHistoryEntryByIds(*this, "Merge Group", std::move(history_before),
-                                        scene_.getRootNodes(), history_options);
+                                        scene_.getRootNodes(), history_options_with_payload,
+                                        {scene_.getNodeUuid(merged_id)});
         return group_name;
     }
 
@@ -5267,7 +5354,8 @@ namespace lfs::vis {
         }
 
         LOG_INFO("Pasted {} Gaussians as '{}'", count, name);
-        pushSceneGraphHistoryEntry(*this, "Paste", std::move(history_before), {name}, history_options);
+        pushSceneGraphHistoryEntry(*this, "Paste", std::move(history_before), {name}, history_options,
+                                   {scene_.getNodeUuid(pasted_id)});
         return {name};
     }
 
@@ -5343,6 +5431,7 @@ namespace lfs::vis {
         auto history_before = op::SceneGraphPatchEntry::captureState(*this, {}, history_options);
 
         pasted_names.reserve(clipboard_.size());
+        std::vector<core::Uuid> pasted_payload_uuids;
         core::Scene::Transaction txn(scene_);
 
         for (const auto& entry : clipboard_) {
@@ -5502,6 +5591,7 @@ namespace lfs::vis {
                 }
             }
 
+            collectSubtreeUuids(scene_, pasted_id, pasted_payload_uuids);
             pasted_names.push_back(pasted_name);
         }
 
@@ -5516,7 +5606,8 @@ namespace lfs::vis {
         if (!pasted_names.empty()) {
             clearSelection();
             scene_.invalidateTransformCache();
-            pushSceneGraphHistoryEntry(*this, "Paste", std::move(history_before), pasted_names, history_options);
+            pushSceneGraphHistoryEntry(*this, "Paste", std::move(history_before), pasted_names, history_options,
+                                       pasted_payload_uuids);
         }
         return pasted_names;
     }
@@ -5884,9 +5975,14 @@ namespace lfs::vis {
             return std::unexpected(plan.error());
         }
 
-        const auto history_options = sceneGraphCaptureOptions(true, true);
+        auto history_options = sceneGraphCaptureOptions(true, true);
         std::optional<op::SceneGraphStateSnapshot> graph_before;
         if (!plan->removed_node_names.empty()) {
+            std::vector<core::Uuid> payload_uuids;
+            for (const auto& name : plan->removed_node_names) {
+                collectSubtreeUuids(scene_, scene_.getNodeIdByName(name), payload_uuids);
+            }
+            history_options.payload_uuids = std::move(payload_uuids);
             graph_before = op::SceneGraphPatchEntry::captureState(*this, plan->removed_node_names, history_options);
         }
 

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -53,6 +53,7 @@
 #include <shared_mutex>
 #include <stdexcept>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace lfs::vis {
 
@@ -259,6 +260,23 @@ namespace lfs::vis {
                    type == core::NodeType::CAMERA_GROUP ||
                    type == core::NodeType::IMAGE_GROUP ||
                    type == core::NodeType::KEYFRAME_GROUP;
+        }
+
+        [[nodiscard]] const core::SceneNode* firstLockedNode(
+            const core::Scene& scene,
+            const core::NodeId root_id) {
+            std::vector<core::NodeId> pending{root_id};
+            while (!pending.empty()) {
+                const core::NodeId id = pending.back();
+                pending.pop_back();
+                const auto* node = scene.getNodeById(id);
+                if (!node)
+                    continue;
+                if (static_cast<bool>(node->locked))
+                    return node;
+                pending.insert(pending.end(), node->children.begin(), node->children.end());
+            }
+            return nullptr;
         }
 
         [[nodiscard]] bool hasActiveSelectionFilter(const RenderingManager* const rendering_manager) {
@@ -1425,6 +1443,11 @@ namespace lfs::vis {
             return {};
         }
 
+        if (const auto* locked = firstLockedNode(scene_, id)) {
+            return std::unexpected(
+                std::format("Cannot delete '{}': node is locked", locked->name));
+        }
+
         auto* trainer = services().trainerOrNull();
         if (!trainer || impact == TrainingRemovalImpact::None) {
             return {};
@@ -1647,10 +1670,14 @@ namespace lfs::vis {
         const bool keep_children) {
         std::vector<std::pair<core::NodeId, TrainingRemovalImpact>> planned_removals;
         planned_removals.reserve(ids.size());
+        std::unordered_set<core::NodeId> unique_ids;
+        unique_ids.reserve(ids.size());
 
         for (const core::NodeId id : ids) {
             if (id == core::NULL_NODE || !scene_.getNodeById(id))
                 return std::unexpected("Node not found: " + std::to_string(id));
+            if (!unique_ids.insert(id).second)
+                return std::unexpected("Duplicate node id: " + std::to_string(id));
 
             const auto impact = classifyTrainingRemovalImpact(id);
             if (const auto result = validateNodeRemoval(id, impact); !result) {
@@ -1659,11 +1686,40 @@ namespace lfs::vis {
             planned_removals.emplace_back(id, impact);
         }
 
+        if (planned_removals.size() == 1) {
+            op::TransactionGuard transaction("Delete Nodes");
+            const auto& [id, impact] = planned_removals.front();
+            if (const auto result = removeNodeImpl(id, keep_children, HistoryMode::Record, impact); !result)
+                return result;
+            transaction.commit();
+            return {};
+        }
+
+        const auto history_options = sceneGraphCaptureOptions(true, true);
+        auto history_before = op::SceneGraphPatchEntry::captureStateByIds(
+            *this, scene_.getRootNodes(),
+            op::SceneGraphCaptureOptions{
+                .mode = history_options.mode,
+                .include_selected_nodes = history_options.include_selected_nodes,
+                .include_scene_context = history_options.include_scene_context,
+                .preserve_node_ids = true,
+            });
+
+        op::TransactionGuard transaction("Delete Nodes");
         for (const auto& [id, impact] : planned_removals) {
-            if (const auto result = removeNodeImpl(id, keep_children, HistoryMode::Record, impact); !result) {
+            if (const auto result = removeNodeImpl(id, keep_children, HistoryMode::Skip, impact); !result) {
                 return result;
             }
         }
+        transaction.commit();
+        pushSceneGraphHistoryEntryByIds(
+            *this, "Delete Nodes", std::move(history_before), scene_.getRootNodes(),
+            op::SceneGraphCaptureOptions{
+                .mode = history_options.mode,
+                .include_selected_nodes = history_options.include_selected_nodes,
+                .include_scene_context = history_options.include_scene_context,
+                .preserve_node_ids = true,
+            });
         return {};
     }
 
@@ -1867,7 +1923,13 @@ namespace lfs::vis {
     std::vector<core::NodeId> SceneManager::getSelectedNodeIds() const {
         std::shared_lock lock(selection_.mutex());
         const auto& ids = selection_.selectedNodeIds();
-        return {ids.begin(), ids.end()};
+        std::vector<core::NodeId> valid_ids;
+        valid_ids.reserve(ids.size());
+        for (const auto id : ids) {
+            if (scene_.getNodeById(id))
+                valid_ids.push_back(id);
+        }
+        return valid_ids;
     }
 
     bool SceneManager::hasSelectedNode() const {
@@ -2401,8 +2463,16 @@ namespace lfs::vis {
 
     // ========== Node Transforms ==========
 
-    void SceneManager::setNodeTransform(const std::string& name, const glm::mat4& transform) {
+    bool SceneManager::setNodeTransform(const std::string& name, const glm::mat4& transform) {
+        const auto* node = scene_.getNode(name);
+        if (!node)
+            return false;
+        if (static_cast<bool>(node->locked)) {
+            LOG_WARN("Cannot transform '{}': node is locked", name);
+            return false;
+        }
         scene_.setNodeTransform(name, transform);
+        return true;
     }
 
     glm::mat4 SceneManager::getNodeTransform(const std::string& name) const {
@@ -3912,6 +3982,10 @@ namespace lfs::vis {
         if (old_name == new_name) {
             return true;
         }
+        if (const auto* existing = scene_.getNode(new_name); existing && existing->id != id) {
+            LOG_WARN("Failed to rename '{}' to '{}' - name already exists", old_name, new_name);
+            return false;
+        }
 
         LOG_DEBUG("Renaming '{}' to '{}'", old_name, new_name);
         const auto history_before = op::SceneGraphMetadataEntry::captureNodes(*this, {old_name});
@@ -3956,8 +4030,13 @@ namespace lfs::vis {
         const auto* node = scene_.getNodeById(node_id);
         if (!node)
             return false;
+        if (const auto* locked = firstLockedNode(scene_, node_id)) {
+            LOG_WARN("Cannot reparent '{}': node is locked", locked->name);
+            return false;
+        }
         const auto* parent = new_parent_id == core::NULL_NODE ? nullptr : scene_.getNodeById(new_parent_id);
-        if (new_parent_id != core::NULL_NODE && !parent)
+        if (new_parent_id != core::NULL_NODE &&
+            (!parent || !core::isSceneNodeParentCompatible(parent->type, node->type)))
             return false;
 
         const std::string node_name = node->name;
@@ -3988,8 +4067,13 @@ namespace lfs::vis {
         const auto* node = scene_.getNodeById(node_id);
         if (!node)
             return false;
+        if (const auto* locked = firstLockedNode(scene_, node_id)) {
+            LOG_WARN("Cannot move '{}': node is locked", locked->name);
+            return false;
+        }
         const auto* parent = new_parent_id == core::NULL_NODE ? nullptr : scene_.getNodeById(new_parent_id);
-        if (new_parent_id != core::NULL_NODE && !parent)
+        if (new_parent_id != core::NULL_NODE &&
+            (!parent || !core::isSceneNodeParentCompatible(parent->type, node->type)))
             return false;
 
         const std::string node_name = node->name;
@@ -4018,9 +4102,9 @@ namespace lfs::vis {
     bool SceneManager::moveNodes(const std::vector<core::NodeId>& node_ids,
                                  const core::NodeId new_parent_id,
                                  const int index) {
-        if (node_ids.empty() || (new_parent_id != core::NULL_NODE &&
-                                 (!scene_.getNodeById(new_parent_id) ||
-                                  scene_.getNodeById(new_parent_id)->type != core::NodeType::GROUP))) {
+        const auto* destination = new_parent_id == core::NULL_NODE ? nullptr : scene_.getNodeById(new_parent_id);
+        if (node_ids.empty() ||
+            (new_parent_id != core::NULL_NODE && !destination)) {
             return false;
         }
 
@@ -4029,6 +4113,13 @@ namespace lfs::vis {
         for (const core::NodeId id : node_ids) {
             if (!scene_.getNodeById(id) || std::ranges::find(ids, id) != ids.end())
                 return false;
+            if (destination &&
+                !core::isSceneNodeParentCompatible(destination->type, scene_.getNodeById(id)->type))
+                return false;
+            if (const auto* locked = firstLockedNode(scene_, id)) {
+                LOG_WARN("Cannot move '{}': node is locked", locked->name);
+                return false;
+            }
             ids.push_back(id);
         }
 
@@ -4125,7 +4216,7 @@ namespace lfs::vis {
         std::vector<core::NodeId> ids;
         for (const core::NodeId id : node_ids) {
             const auto* node = scene_.getNodeById(id);
-            if (!node || node->type == core::NodeType::GROUP)
+            if (!node || std::ranges::find(ids, id) != ids.end())
                 return false;
             ids.push_back(id);
         }
@@ -4144,6 +4235,15 @@ namespace lfs::vis {
         for (const core::NodeId id : ids)
             if (scene_.getNodeById(id)->parent_id != parent_id)
                 return false;
+        for (const core::NodeId id : ids) {
+            if (const auto* locked = firstLockedNode(scene_, id)) {
+                LOG_WARN("Cannot group '{}': node is locked", locked->name);
+                return false;
+            }
+        }
+        std::ranges::sort(ids, [&](const core::NodeId lhs, const core::NodeId rhs) {
+            return std::ranges::find(siblings, lhs) < std::ranges::find(siblings, rhs);
+        });
         int first_index = static_cast<int>(siblings.size());
         for (const core::NodeId id : ids) {
             const auto it = std::ranges::find(siblings, id);
@@ -4169,7 +4269,7 @@ namespace lfs::vis {
             if (!scene_.moveNode(ids[i], group_id, static_cast<int>(i)))
                 return false;
         selection_.invalidateNodeMask();
-        pushSceneGraphHistoryEntryByIds(*this, "Group Selected", std::move(before), roots_before, options);
+        pushSceneGraphHistoryEntryByIds(*this, "Group Selected", std::move(before), scene_.getRootNodes(), options);
         return true;
     }
 
@@ -4177,6 +4277,10 @@ namespace lfs::vis {
         const auto* group = scene_.getNodeById(node_id);
         if (!group || group->type != core::NodeType::GROUP)
             return false;
+        if (const auto* locked = firstLockedNode(scene_, node_id)) {
+            LOG_WARN("Cannot ungroup '{}': node is locked", locked->name);
+            return false;
+        }
         const auto roots_before = [&] {
             std::vector<core::NodeId> roots;
             for (const auto* node : scene_.getNodes())
@@ -4199,7 +4303,7 @@ namespace lfs::vis {
             return false;
         scene_.removeNodeById(node_id, false);
         selection_.invalidateNodeMask();
-        pushSceneGraphHistoryEntryByIds(*this, "Ungroup", std::move(before), roots_before, options);
+        pushSceneGraphHistoryEntryByIds(*this, "Ungroup", std::move(before), scene_.getRootNodes(), options);
         return true;
     }
 
@@ -4218,7 +4322,8 @@ namespace lfs::vis {
         if (name.empty())
             return {};
         const auto* parent = parent_id == core::NULL_NODE ? nullptr : scene_.getNodeById(parent_id);
-        if (parent_id != core::NULL_NODE && !parent)
+        if (parent_id != core::NULL_NODE &&
+            (!parent || !core::isSceneNodeParentCompatible(parent->type, core::NodeType::GROUP)))
             return {};
 
         const std::string unique_name = makeUniqueNodeName(scene_, name);
@@ -4379,6 +4484,10 @@ namespace lfs::vis {
         const auto* src = scene_.getNodeById(id);
         if (!src)
             return {};
+        if (const auto* locked = firstLockedNode(scene_, id)) {
+            LOG_WARN("Cannot duplicate '{}': node is locked", locked->name);
+            return {};
+        }
         const std::string node_name = src->name;
         assert(!node_name.empty());
 
@@ -4481,11 +4590,23 @@ namespace lfs::vis {
         if (group->type != core::NodeType::GROUP) {
             return {};
         }
+        if (const auto* locked = firstLockedNode(scene_, group_id)) {
+            LOG_WARN("Cannot merge '{}': node is locked", locked->name);
+            return {};
+        }
 
-        const auto history_options = sceneGraphCaptureOptions(true, false);
+        const auto history_options = [&] {
+            auto options = sceneGraphCaptureOptions(true, false);
+            // Merge replaces the group subtree with a new splat. Preserve the
+            // old IDs so undo can restore that subtree exactly, including the
+            // IDs of its descendants.
+            options.preserve_node_ids = true;
+            return options;
+        }();
         auto history_before = op::SceneGraphPatchEntry::captureState(*this, {group_name}, history_options);
         const core::Uuid group_uuid = group->uuid;
         const core::NodeId parent_id = group->parent_id;
+        const bool group_visible = group->visible;
 
         std::string parent_name;
         if (parent_id != core::NULL_NODE) {
@@ -4496,9 +4617,6 @@ namespace lfs::vis {
 
         // Check if the group being merged is currently selected
         const bool was_selected = selection_.isNodeSelected(group_id);
-        if (was_selected) {
-            selection_.removeFromSelection(group_id);
-        }
 
         // Collect children to emit PLYRemoved events
         std::vector<std::pair<std::string, core::Uuid>> children_to_remove;
@@ -4519,7 +4637,7 @@ namespace lfs::vis {
             const auto* const node = scene_.getNodeById(id);
             if (!node)
                 return;
-            if (node->type == core::NodeType::SPLAT && node->model && scene_.isNodeEffectivelyVisible(node->id)) {
+            if (node->type == core::NodeType::SPLAT && node->model) {
                 splats.emplace_back(node->model.get(), scene_.getWorldTransform(id));
             }
             for (const core::NodeId child_id : node->children)
@@ -4543,6 +4661,10 @@ namespace lfs::vis {
             scene_.setCombinedModelAllocator(std::move(allocator));
         }
 
+        if (was_selected) {
+            selection_.removeFromSelection(group_id);
+        }
+
         core::NodeId merged_id = core::NULL_NODE;
         {
             std::lock_guard lock(state_mutex_);
@@ -4555,6 +4677,8 @@ namespace lfs::vis {
             scene_.removeNodeById(group_id, false);
             merged_id = scene_.addSplat(group_name, std::move(merged_model), parent_id);
             if (merged_id != core::NULL_NODE) {
+                if (auto* merged = scene_.getNodeById(merged_id))
+                    merged->visible.setQuiet(group_visible);
                 scene_.markPayloadDiverged(merged_id);
             }
         }
@@ -4781,8 +4905,22 @@ namespace lfs::vis {
     }
     SceneManager::ClipboardEntry::HierarchyNode SceneManager::copyNodeHierarchy(const core::SceneNode* node) {
         ClipboardEntry::HierarchyNode result;
+        result.name = node->name;
         result.type = node->type;
         result.local_transform = node->local_transform.get();
+        result.visible = node->visible;
+        result.locked = node->locked;
+
+        if (node->model && node->model->size() > 0) {
+            if (node->model->has_deleted_mask() &&
+                node->model->deleted().numel() == static_cast<size_t>(node->model->size())) {
+                const auto keep = node->model->deleted().logical_not();
+                if (keep.count_nonzero() > 0)
+                    result.data = cloneSplatDataToCpu(lfs::core::extract_by_mask(*node->model, keep));
+            } else {
+                result.data = cloneSplatDataToCpu(*node->model);
+            }
+        }
 
         if (node->cropbox) {
             result.cropbox = std::make_unique<core::CropBoxData>(*node->cropbox);
@@ -4879,7 +5017,7 @@ namespace lfs::vis {
                 entry.data = keep.is_valid()
                                  ? cloneSplatDataToCpu(lfs::core::extract_by_mask(model, keep))
                                  : cloneSplatDataToCpu(model);
-            } else {
+            } else if (!entry.hierarchy || entry.hierarchy->type != core::NodeType::GROUP) {
                 continue;
             }
 
@@ -5019,7 +5157,7 @@ namespace lfs::vis {
         if (!hasGaussianClipboard() || gaussian_clipboard_->size() == 0)
             return {};
 
-        const auto history_options = sceneGraphCaptureOptions(false, false);
+        const auto history_options = sceneGraphCaptureOptions(true, false);
         auto history_before = op::SceneGraphPatchEntry::captureState(*this, {}, history_options);
 
         const auto& src = *gaussian_clipboard_;
@@ -5151,7 +5289,7 @@ namespace lfs::vis {
             return pasted_names;
         }
 
-        const auto history_options = sceneGraphCaptureOptions(false, false);
+        const auto history_options = sceneGraphCaptureOptions(true, false);
         auto history_before = op::SceneGraphPatchEntry::captureState(*this, {}, history_options);
 
         pasted_names.reserve(clipboard_.size());
@@ -5160,7 +5298,58 @@ namespace lfs::vis {
         for (const auto& entry : clipboard_) {
             std::string name;
             core::NodeId pasted_id = core::NULL_NODE;
-            if (entry.mesh) {
+            if (entry.hierarchy && entry.hierarchy->type == core::NodeType::GROUP) {
+                name = makeUniqueCounterNodeName(scene_, "Pasted", clipboard_counter_);
+                pasted_id = scene_.addGroup(name);
+                if (pasted_id != core::NULL_NODE) {
+                    std::function<void(const ClipboardEntry::HierarchyNode&, core::NodeId)> paste_hierarchy =
+                        [&](const ClipboardEntry::HierarchyNode& source, const core::NodeId parent_id) {
+                            for (const auto& child : source.children) {
+                                const std::string child_name = makeUniqueNodeName(
+                                    scene_, child.name.empty() ? "Pasted" : child.name);
+                                core::NodeId child_id = core::NULL_NODE;
+                                if (child.type == core::NodeType::GROUP) {
+                                    child_id = scene_.addGroup(child_name, parent_id);
+                                } else if (child.type == core::NodeType::SPLAT && child.data) {
+                                    auto paste_data = std::make_unique<lfs::core::SplatData>(
+                                        child.data->get_max_sh_degree(),
+                                        child.data->means_raw().cuda(), child.data->sh0_raw().cuda(),
+                                        child.data->shN_raw().is_valid() ? child.data->shN_raw().cuda() : lfs::core::Tensor{},
+                                        child.data->scaling_raw().cuda(), child.data->rotation_raw().cuda(),
+                                        child.data->opacity_raw().cuda(), child.data->get_scene_scale(),
+                                        lfs::core::SplatData::ShNLayout::Swizzled);
+                                    paste_data->set_active_sh_degree(
+                                        child.data->get_active_sh_degree(),
+                                        child.data->shN_value_quantized() ? child.data->shN_value_bounds().cuda()
+                                                                          : lfs::core::Tensor{});
+                                    child_id = scene_.addSplat(child_name, std::move(paste_data), parent_id);
+                                } else if (child.type == core::NodeType::CROPBOX && child.cropbox) {
+                                    child_id = scene_.addCropBox(child_name, parent_id);
+                                    if (auto* pasted_cropbox = scene_.getCropBoxData(child_id))
+                                        *pasted_cropbox = *child.cropbox;
+                                }
+                                if (child_id == core::NULL_NODE)
+                                    continue;
+                                if (auto* pasted_child = scene_.getNodeById(child_id)) {
+                                    pasted_child->local_transform.setQuiet(child.local_transform);
+                                    pasted_child->visible.setQuiet(child.visible);
+                                    pasted_child->locked.setQuiet(child.locked);
+                                    pasted_child->transform_dirty = true;
+                                }
+                                paste_hierarchy(child, child_id);
+                            }
+                        };
+                    const auto* pasted_group = scene_.getNodeById(pasted_id);
+                    if (pasted_group) {
+                        auto* mutable_group = scene_.getMutableNode(pasted_group->name);
+                        mutable_group->local_transform.setQuiet(entry.hierarchy->local_transform);
+                        mutable_group->visible.setQuiet(entry.hierarchy->visible);
+                        mutable_group->locked.setQuiet(entry.hierarchy->locked);
+                        mutable_group->transform_dirty = true;
+                    }
+                    paste_hierarchy(*entry.hierarchy, pasted_id);
+                }
+            } else if (entry.mesh) {
                 name = makeUniqueCounterNodeName(scene_, "Pasted", clipboard_counter_);
                 auto cloned = std::make_shared<core::MeshData>();
                 cloned->vertices = entry.mesh->vertices.clone();
@@ -5221,7 +5410,9 @@ namespace lfs::vis {
             }
             const std::string pasted_name = pasted_node->name;
             if (entry.transform != IDENTITY) {
-                scene_.setNodeTransform(pasted_name, entry.transform);
+                auto* mutable_pasted_node = scene_.getMutableNode(pasted_name);
+                mutable_pasted_node->local_transform.setQuiet(entry.transform);
+                mutable_pasted_node->transform_dirty = true;
             }
 
             if (entry.hierarchy) {
@@ -5269,6 +5460,8 @@ namespace lfs::vis {
 
         LOG_DEBUG("Pasted {} nodes", pasted_names.size());
         if (!pasted_names.empty()) {
+            clearSelection();
+            scene_.invalidateTransformCache();
             pushSceneGraphHistoryEntry(*this, "Paste", std::move(history_before), pasted_names, history_options);
         }
         return pasted_names;
@@ -5330,7 +5523,9 @@ namespace lfs::vis {
             if (!combined) {
                 return std::unexpected("No visible nodes");
             }
-            if (static_cast<size_t>(plan.selection_mask.numel()) != static_cast<size_t>(combined->size())) {
+            if (!plan.selection_mask.is_valid() || plan.selection_mask.ndim() != 1 ||
+                plan.selection_mask.dtype() != core::DataType::Bool ||
+                static_cast<size_t>(plan.selection_mask.numel()) != static_cast<size_t>(combined->size())) {
                 return std::unexpected("Selection size mismatch");
             }
             if (combined->has_deleted_mask() &&
@@ -5410,15 +5605,46 @@ namespace lfs::vis {
 
     std::expected<void, std::string> SceneManager::applySelectedGaussianDeletionPlan(
         const GaussianDeletionPlan& plan) {
+        struct PreparedPartialDeletion {
+            core::Uuid uuid;
+            core::Tensor mask;
+            bool had_deleted_mask = false;
+            core::Tensor previous_deleted_mask;
+            bool payload_diverged = false;
+        };
+
         std::vector<std::pair<core::NodeId, TrainingRemovalImpact>> removed_node_impacts;
+        std::vector<PreparedPartialDeletion> prepared_partial_deletions;
+        std::optional<core::Tensor> prepared_consolidated_mask;
 
         if (plan.consolidated) {
             auto* combined = const_cast<core::SplatData*>(scene_.getCombinedModel());
             if (!combined) {
                 return std::unexpected("No visible nodes");
             }
-            if (static_cast<size_t>(plan.selection_mask.numel()) != static_cast<size_t>(combined->size())) {
+            if (!plan.selection_mask.is_valid() || plan.selection_mask.ndim() != 1 ||
+                plan.selection_mask.dtype() != core::DataType::Bool ||
+                static_cast<size_t>(plan.selection_mask.numel()) != static_cast<size_t>(combined->size())) {
                 return std::unexpected("Selection size mismatch");
+            }
+            for (const auto* node : scene_.getNodes()) {
+                if (node && node->type == core::NodeType::SPLAT &&
+                    scene_.isNodeEffectivelyVisible(node->id) && static_cast<bool>(node->locked)) {
+                    return std::unexpected(std::format("Cannot delete '{}': node is locked", node->name));
+                }
+            }
+            try {
+                auto mask = plan.selection_mask;
+                const auto model_device = combined->means_raw().device();
+                if (mask.device() != model_device) {
+                    mask = mask.to(model_device);
+                }
+                prepared_consolidated_mask = std::move(mask);
+            } catch (const std::exception& error) {
+                return std::unexpected(
+                    std::format("Cannot prepare consolidated soft-delete mask: {}", error.what()));
+            } catch (...) {
+                return std::unexpected("Cannot prepare consolidated soft-delete mask: unknown exception");
             }
         } else {
             removed_node_impacts.reserve(plan.removed_node_names.size());
@@ -5440,39 +5666,140 @@ namespace lfs::vis {
                     return std::unexpected(std::format("Visible node '{}' is missing a mutable model", slice.node_name));
                 }
             }
-        }
 
-        scene_.clearSelection();
-
-        if (plan.consolidated) {
-            auto* combined = const_cast<core::SplatData*>(scene_.getCombinedModel());
-            if (!combined) {
-                return std::unexpected("Consolidated soft-delete requires a combined model");
-            }
-            combined->soft_delete(plan.selection_mask);
-            for (const auto* node : scene_.getNodes()) {
-                if (node && node->type == core::NodeType::SPLAT && node->model &&
-                    scene_.isNodeEffectivelyVisible(node->id)) {
-                    scene_.markPayloadDiverged(node->id);
-                }
-            }
-        } else {
+            prepared_partial_deletions.reserve(plan.partial_slices.size());
             for (const auto& slice : plan.partial_slices) {
                 auto* node = scene_.getMutableNode(slice.node_name);
                 if (!node || !node->model) {
-                    continue;
+                    return std::unexpected(std::format("Visible node '{}' is missing a mutable model", slice.node_name));
                 }
-                node->model->soft_delete(plan.selection_mask.slice(0, slice.begin, slice.end));
-                scene_.markPayloadDiverged(node->id);
-            }
+                if (static_cast<bool>(node->locked)) {
+                    return std::unexpected(std::format("Cannot delete '{}': node is locked", node->name));
+                }
 
-            for (const auto& [id, impact] : removed_node_impacts) {
-                if (const auto result = removeNodeImpl(id, false, HistoryMode::Skip, impact); !result) {
-                    return result;
+                const auto& means = node->model->means_raw();
+                if (!means.is_valid() || means.ndim() == 0) {
+                    return std::unexpected(std::format("Visible node '{}' has an invalid model", node->name));
+                }
+                const size_t model_size = static_cast<size_t>(node->model->size());
+                if (slice.end < slice.begin || slice.end - slice.begin != model_size ||
+                    !plan.selection_mask.is_valid() || plan.selection_mask.ndim() != 1 ||
+                    slice.end > static_cast<size_t>(plan.selection_mask.numel())) {
+                    return std::unexpected(std::format("Selection size mismatch for node '{}'", node->name));
+                }
+                if (node->model->has_deleted_mask() &&
+                    (node->model->deleted().ndim() != 1 ||
+                     static_cast<size_t>(node->model->deleted().numel()) != model_size)) {
+                    return std::unexpected(std::format("Deleted mask size mismatch for node '{}'", node->name));
+                }
+                const auto model_device = means.device();
+                if (node->model->has_deleted_mask() &&
+                    node->model->deleted().device() != model_device) {
+                    return std::unexpected(
+                        std::format("Deleted mask device mismatch for node '{}'", node->name));
+                }
+
+                try {
+                    auto mask = plan.selection_mask.slice(0, slice.begin, slice.end);
+                    if (mask.device() != model_device) {
+                        mask = mask.to(model_device);
+                    }
+                    prepared_partial_deletions.push_back(PreparedPartialDeletion{
+                        .uuid = node->uuid,
+                        .mask = std::move(mask),
+                        .had_deleted_mask = node->model->has_deleted_mask(),
+                        .previous_deleted_mask = node->model->has_deleted_mask()
+                                                     ? node->model->deleted().clone()
+                                                     : core::Tensor{},
+                        .payload_diverged = node->payload_diverged,
+                    });
+                } catch (const std::exception& error) {
+                    return std::unexpected(
+                        std::format("Cannot prepare soft-delete for '{}': {}", node->name, error.what()));
+                } catch (...) {
+                    return std::unexpected(
+                        std::format("Cannot prepare soft-delete for '{}': unknown exception", node->name));
                 }
             }
         }
 
+        const auto rollback_partial_deletions = [&] {
+            for (const auto& prepared : prepared_partial_deletions) {
+                auto* node = scene_.getNodeByUuid(prepared.uuid);
+                if (!node || !node->model) {
+                    continue;
+                }
+                if (prepared.had_deleted_mask) {
+                    node->model->deleted() = prepared.previous_deleted_mask.clone();
+                    node->model->notify_deleted_mask_changed();
+                    node->model->refresh_deleted_count();
+                } else {
+                    node->model->clear_deleted();
+                }
+                node->payload_diverged = prepared.payload_diverged;
+            }
+        };
+
+        try {
+            if (plan.consolidated) {
+                auto* combined = const_cast<core::SplatData*>(scene_.getCombinedModel());
+                if (!combined) {
+                    return std::unexpected("Consolidated soft-delete requires a combined model");
+                }
+                assert(prepared_consolidated_mask);
+                if (!combined->soft_delete(*prepared_consolidated_mask).is_valid()) {
+                    throw std::runtime_error("soft-delete rejected the prepared mask");
+                }
+                for (const auto* node : scene_.getNodes()) {
+                    if (node && node->type == core::NodeType::SPLAT && node->model &&
+                        scene_.isNodeEffectivelyVisible(node->id)) {
+                        scene_.markPayloadDiverged(node->id);
+                    }
+                }
+            } else {
+                for (const auto& prepared : prepared_partial_deletions) {
+                    auto* node = scene_.getNodeByUuid(prepared.uuid);
+                    if (!node || !node->model) {
+                        throw std::runtime_error("a target node disappeared during soft-delete");
+                    }
+                    if (!node->model->soft_delete(prepared.mask).is_valid()) {
+                        throw std::runtime_error("soft-delete rejected the prepared mask");
+                    }
+                    scene_.markPayloadDiverged(node->id);
+                }
+
+                for (const auto& [id, impact] : removed_node_impacts) {
+                    if (const auto result = removeNodeImpl(id, false, HistoryMode::Skip, impact); !result) {
+                        rollback_partial_deletions();
+                        return result;
+                    }
+                }
+            }
+        } catch (const std::exception& error) {
+            try {
+                rollback_partial_deletions();
+            } catch (const std::exception& rollback_error) {
+                return std::unexpected(std::format(
+                    "Failed to soft-delete selected Gaussians: {}; rollback failed: {}",
+                    error.what(),
+                    rollback_error.what()));
+            } catch (...) {
+                return std::unexpected(std::format(
+                    "Failed to soft-delete selected Gaussians: {}; rollback failed with unknown exception",
+                    error.what()));
+            }
+            return std::unexpected(std::format("Failed to soft-delete selected Gaussians: {}", error.what()));
+        } catch (...) {
+            try {
+                rollback_partial_deletions();
+            } catch (...) {
+                return std::unexpected(
+                    "Failed to soft-delete selected Gaussians: unknown exception; rollback failed");
+            }
+            return std::unexpected("Failed to soft-delete selected Gaussians: unknown exception");
+        }
+
+        scene_.clearSelection();
         scene_.notifyMutation(core::Scene::MutationType::MODEL_CHANGED);
 
         if (auto* rm = services().renderingOrNull()) {
@@ -5484,11 +5811,17 @@ namespace lfs::vis {
     }
 
     std::expected<void, std::string> SceneManager::softDeleteSelectedGaussians() {
-        auto plan = buildSelectedGaussianDeletionPlan();
-        if (!plan) {
-            return std::unexpected(plan.error());
+        try {
+            auto plan = buildSelectedGaussianDeletionPlan();
+            if (!plan) {
+                return std::unexpected(plan.error());
+            }
+            return applySelectedGaussianDeletionPlan(*plan);
+        } catch (const std::exception& error) {
+            return std::unexpected(std::format("Failed to soft-delete selected Gaussians: {}", error.what()));
+        } catch (...) {
+            return std::unexpected("Failed to soft-delete selected Gaussians: unknown exception");
         }
-        return applySelectedGaussianDeletionPlan(*plan);
     }
 
     std::expected<void, std::string> SceneManager::deleteSelectedGaussiansWithHistory() {

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -1495,11 +1495,17 @@ namespace lfs::vis {
         const bool removes_training_model = training_removal_impact == TrainingRemovalImpact::TrainingModel;
 
         bool trainer_cleared = false;
-        const bool record_history = history_mode == HistoryMode::Record;
-        const auto history_options = sceneGraphCaptureOptions(true, true);
+        const bool record_history = history_mode != HistoryMode::Skip;
+        const bool capture_full_scene = history_mode != HistoryMode::Record;
+        const bool preserve_node_ids = history_mode == HistoryMode::RecordPreserveIds;
+        auto history_options = sceneGraphCaptureOptions(true, true);
+        history_options.preserve_node_ids = preserve_node_ids;
         std::optional<op::SceneGraphStateSnapshot> history_before;
         if (record_history) {
-            history_before = op::SceneGraphPatchEntry::captureStateByIds(*this, std::vector{id}, history_options);
+            history_before = op::SceneGraphPatchEntry::captureStateByIds(
+                *this,
+                capture_full_scene ? scene_.getRootNodes() : std::vector<core::NodeId>{id},
+                history_options);
         }
 
         if (removes_training_model) {
@@ -1623,8 +1629,11 @@ namespace lfs::vis {
         }
 
         if (history_before) {
+            const auto after_roots = capture_full_scene
+                                         ? scene_.getRootNodes()
+                                         : (keep_children ? promoted_children : std::vector<core::NodeId>{});
             pushSceneGraphHistoryEntryByIds(*this, "Delete Node", std::move(*history_before),
-                                            keep_children ? promoted_children : std::vector<core::NodeId>{},
+                                            after_roots,
                                             history_options);
         }
         retireSplatModelsAsync(std::move(detached_models));
@@ -1678,7 +1687,23 @@ namespace lfs::vis {
                 return std::unexpected("Node not found: " + std::to_string(id));
             if (!unique_ids.insert(id).second)
                 return std::unexpected("Duplicate node id: " + std::to_string(id));
+        }
 
+        for (const core::NodeId id : ids) {
+            bool covered_by_selected_ancestor = false;
+            for (auto parent_id = scene_.getNodeById(id)->parent_id;
+                 parent_id != core::NULL_NODE;) {
+                if (unique_ids.contains(parent_id)) {
+                    covered_by_selected_ancestor = true;
+                    break;
+                }
+                const auto* parent = scene_.getNodeById(parent_id);
+                if (!parent)
+                    break;
+                parent_id = parent->parent_id;
+            }
+            if (covered_by_selected_ancestor)
+                continue;
             const auto impact = classifyTrainingRemovalImpact(id);
             if (const auto result = validateNodeRemoval(id, impact); !result) {
                 return result;
@@ -1686,24 +1711,14 @@ namespace lfs::vis {
             planned_removals.emplace_back(id, impact);
         }
 
-        if (planned_removals.size() == 1) {
-            op::TransactionGuard transaction("Delete Nodes");
-            const auto& [id, impact] = planned_removals.front();
-            if (const auto result = removeNodeImpl(id, keep_children, HistoryMode::Record, impact); !result)
-                return result;
-            transaction.commit();
-            return {};
-        }
-
-        const auto history_options = sceneGraphCaptureOptions(true, true);
+        auto history_options = sceneGraphCaptureOptions(true, true);
+        history_options.scoped_topology = true;
+        const bool preserve_node_ids = planned_removals.size() == 1 &&
+                                       scene_.getNodeById(planned_removals.front().first)->type ==
+                                           core::NodeType::CAMERA;
+        history_options.preserve_node_ids = preserve_node_ids;
         auto history_before = op::SceneGraphPatchEntry::captureStateByIds(
-            *this, scene_.getRootNodes(),
-            op::SceneGraphCaptureOptions{
-                .mode = history_options.mode,
-                .include_selected_nodes = history_options.include_selected_nodes,
-                .include_scene_context = history_options.include_scene_context,
-                .preserve_node_ids = true,
-            });
+            *this, scene_.getRootNodes(), history_options);
 
         op::TransactionGuard transaction("Delete Nodes");
         for (const auto& [id, impact] : planned_removals) {
@@ -1713,13 +1728,7 @@ namespace lfs::vis {
         }
         transaction.commit();
         pushSceneGraphHistoryEntryByIds(
-            *this, "Delete Nodes", std::move(history_before), scene_.getRootNodes(),
-            op::SceneGraphCaptureOptions{
-                .mode = history_options.mode,
-                .include_selected_nodes = history_options.include_selected_nodes,
-                .include_scene_context = history_options.include_scene_context,
-                .preserve_node_ids = true,
-            });
+            *this, "Delete Nodes", std::move(history_before), scene_.getRootNodes(), history_options);
         return {};
     }
 
@@ -1791,7 +1800,7 @@ namespace lfs::vis {
         if (id == core::NULL_NODE) {
             return {};
         }
-        return removeNodeImpl(id, keep_children, HistoryMode::Record);
+        return removeNodeImpl(id, keep_children, HistoryMode::RecordFull);
     }
 
     // ========== Node Selection ==========
@@ -4499,7 +4508,8 @@ namespace lfs::vis {
         }
 
         const auto history_options = sceneGraphCaptureOptions(false, false);
-        auto history_before = op::SceneGraphPatchEntry::captureState(*this, {}, history_options);
+        auto history_before = op::SceneGraphPatchEntry::captureStateByIds(
+            *this, scene_.getRootNodes(), history_options);
         const std::string new_name = scene_.duplicateNode(node_name);
         if (new_name.empty())
             return {};
@@ -4564,7 +4574,8 @@ namespace lfs::vis {
             };
 
         emit_added(new_name, parent_name);
-        pushSceneGraphHistoryEntry(*this, "Duplicate Node", std::move(history_before), {new_name}, history_options);
+        pushSceneGraphHistoryEntryByIds(*this, "Duplicate Node", std::move(history_before),
+                                        scene_.getRootNodes(), history_options);
         return new_name;
     }
 
@@ -4595,15 +4606,9 @@ namespace lfs::vis {
             return {};
         }
 
-        const auto history_options = [&] {
-            auto options = sceneGraphCaptureOptions(true, false);
-            // Merge replaces the group subtree with a new splat. Preserve the
-            // old IDs so undo can restore that subtree exactly, including the
-            // IDs of its descendants.
-            options.preserve_node_ids = true;
-            return options;
-        }();
-        auto history_before = op::SceneGraphPatchEntry::captureState(*this, {group_name}, history_options);
+        const auto history_options = sceneGraphCaptureOptions(true, false);
+        auto history_before = op::SceneGraphPatchEntry::captureStateByIds(
+            *this, scene_.getRootNodes(), history_options);
         const core::Uuid group_uuid = group->uuid;
         const core::NodeId parent_id = group->parent_id;
         const bool group_visible = group->visible;
@@ -4632,13 +4637,36 @@ namespace lfs::vis {
         };
         collect_children(group);
 
+        std::vector<std::unique_ptr<core::SplatData>> cropped_splats;
         std::vector<std::pair<const core::SplatData*, glm::mat4>> splats;
+        cropped_splats.reserve(scene_.getNodes().size());
+        splats.reserve(scene_.getNodes().size());
         const std::function<void(core::NodeId)> collect_splats = [&](const core::NodeId id) {
             const auto* const node = scene_.getNodeById(id);
             if (!node)
                 return;
             if (node->type == core::NodeType::SPLAT && node->model) {
-                splats.emplace_back(node->model.get(), scene_.getWorldTransform(id));
+                auto model = std::make_unique<core::SplatData>(node->model->clone());
+                const glm::mat4 splat_world = scene_.getWorldTransform(id);
+                for (const core::NodeId child_id : node->children) {
+                    const auto* child = scene_.getNodeById(child_id);
+                    if (!child)
+                        continue;
+
+                    if (child->type == core::NodeType::CROPBOX && child->cropbox && child->cropbox->enabled) {
+                        geometry::BoundingBox crop_box;
+                        crop_box.setBounds(child->cropbox->min, child->cropbox->max);
+                        crop_box.setworld2BBox(glm::inverse(scene_.getWorldTransform(child_id)) * splat_world);
+                        (void)core::soft_crop_by_cropbox(*model, crop_box, child->cropbox->inverse);
+                    } else if (child->type == core::NodeType::ELLIPSOID && child->ellipsoid && child->ellipsoid->enabled) {
+                        const glm::mat4 splat_to_ellipsoid =
+                            glm::inverse(scene_.getWorldTransform(child_id)) * splat_world;
+                        (void)core::soft_crop_by_ellipsoid(
+                            *model, splat_to_ellipsoid, child->ellipsoid->radii, child->ellipsoid->inverse);
+                    }
+                }
+                cropped_splats.push_back(std::move(model));
+                splats.emplace_back(cropped_splats.back().get(), splat_world);
             }
             for (const core::NodeId child_id : node->children)
                 collect_splats(child_id);
@@ -4706,7 +4734,8 @@ namespace lfs::vis {
         if (merged_id == core::NULL_NODE) {
             LOG_ERROR("Failed to add merged group '{}'", group_name);
             emit_removed_events();
-            pushSceneGraphHistoryEntry(*this, "Merge Group", std::move(history_before), {group_name}, history_options);
+            pushSceneGraphHistoryEntryByIds(*this, "Merge Group", std::move(history_before),
+                                            scene_.getRootNodes(), history_options);
             return {};
         }
         assert(scene_.getNodeById(merged_id));
@@ -4743,7 +4772,8 @@ namespace lfs::vis {
         }
 
         LOG_INFO("Merged group '{0}' -> '{0}'", group_name);
-        pushSceneGraphHistoryEntry(*this, "Merge Group", std::move(history_before), {group_name}, history_options);
+        pushSceneGraphHistoryEntryByIds(*this, "Merge Group", std::move(history_before),
+                                        scene_.getRootNodes(), history_options);
         return group_name;
     }
 
@@ -4925,6 +4955,9 @@ namespace lfs::vis {
         if (node->cropbox) {
             result.cropbox = std::make_unique<core::CropBoxData>(*node->cropbox);
         }
+        if (node->ellipsoid) {
+            result.ellipsoid = std::make_unique<core::EllipsoidData>(*node->ellipsoid);
+        }
 
         for (const core::NodeId child_id : node->children) {
             if (const auto* child = scene_.getNodeById(child_id)) {
@@ -4949,8 +4982,25 @@ namespace lfs::vis {
                 auto* cropbox_node = scene_.getMutableNode(cropbox_info->name);
                 if (cropbox_node && cropbox_node->cropbox) {
                     *cropbox_node->cropbox = *child.cropbox;
-                    cropbox_node->local_transform = child.local_transform;
+                    cropbox_node->local_transform.setQuiet(child.local_transform);
                     cropbox_node->transform_dirty = true;
+                }
+            } else if (child.type == core::NodeType::ELLIPSOID && child.ellipsoid) {
+                core::NodeId ellipsoid_id = scene_.getEllipsoidForSplat(parent_id);
+                if (ellipsoid_id == core::NULL_NODE)
+                    ellipsoid_id = scene_.addEllipsoid(child.name, parent_id);
+                if (ellipsoid_id == core::NULL_NODE)
+                    continue;
+
+                const auto* ellipsoid_info = scene_.getNodeById(ellipsoid_id);
+                if (!ellipsoid_info)
+                    continue;
+
+                auto* ellipsoid_node = scene_.getMutableNode(ellipsoid_info->name);
+                if (ellipsoid_node && ellipsoid_node->ellipsoid) {
+                    *ellipsoid_node->ellipsoid = *child.ellipsoid;
+                    ellipsoid_node->local_transform.setQuiet(child.local_transform);
+                    ellipsoid_node->transform_dirty = true;
                 }
             }
         }
@@ -5327,6 +5377,10 @@ namespace lfs::vis {
                                     child_id = scene_.addCropBox(child_name, parent_id);
                                     if (auto* pasted_cropbox = scene_.getCropBoxData(child_id))
                                         *pasted_cropbox = *child.cropbox;
+                                } else if (child.type == core::NodeType::ELLIPSOID && child.ellipsoid) {
+                                    child_id = scene_.addEllipsoid(child_name, parent_id);
+                                    if (auto* pasted_ellipsoid = scene_.getEllipsoidData(child_id))
+                                        *pasted_ellipsoid = *child.ellipsoid;
                                 }
                                 if (child_id == core::NULL_NODE)
                                     continue;

--- a/src/visualizer/scene/scene_manager.hpp
+++ b/src/visualizer/scene/scene_manager.hpp
@@ -166,7 +166,7 @@ namespace lfs::vis {
             const glm::ivec2& viewport_size) const;
 
         // Node transforms
-        void setNodeTransform(const std::string& name, const glm::mat4& transform);
+        bool setNodeTransform(const std::string& name, const glm::mat4& transform);
         glm::mat4 getNodeTransform(const std::string& name) const;
 
         // Full transform for selected node (includes rotation and scale)
@@ -398,8 +398,12 @@ namespace lfs::vis {
             std::shared_ptr<lfs::core::MeshData> mesh;
             glm::mat4 transform{1.0f};
             struct HierarchyNode {
+                std::string name;
                 core::NodeType type = core::NodeType::SPLAT;
                 glm::mat4 local_transform{1.0f};
+                bool visible = true;
+                bool locked = false;
+                std::unique_ptr<lfs::core::SplatData> data;
                 std::unique_ptr<core::CropBoxData> cropbox;
                 std::vector<HierarchyNode> children;
             };

--- a/src/visualizer/scene/scene_manager.hpp
+++ b/src/visualizer/scene/scene_manager.hpp
@@ -317,6 +317,8 @@ namespace lfs::vis {
     private:
         enum class HistoryMode : uint8_t {
             Record,
+            RecordFull,
+            RecordPreserveIds,
             Skip,
         };
 
@@ -405,6 +407,7 @@ namespace lfs::vis {
                 bool locked = false;
                 std::unique_ptr<lfs::core::SplatData> data;
                 std::unique_ptr<core::CropBoxData> cropbox;
+                std::unique_ptr<core::EllipsoidData> ellipsoid;
                 std::vector<HierarchyNode> children;
             };
             std::optional<HierarchyNode> hierarchy;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -423,6 +423,7 @@ set(TEST_FILES
     test_extended_unary_ops_vs_torch.cpp
     test_scene_validity.cpp
     test_scene_consolidation.cpp
+    test_scene_graph_fuzz.cpp
     test_uuid.cpp
     test_render_settings_defaults.cpp
     test_scene_upscaler_registry.cpp

--- a/tests/test_input_controller_focus.cpp
+++ b/tests/test_input_controller_focus.cpp
@@ -206,6 +206,23 @@ namespace lfs::vis {
         EXPECT_EQ(toggle_split_count, 1);
     }
 
+    TEST_F(InputControllerFocusTest, EscapeWithScenePanelFocusStaysWithGui) {
+        Viewport viewport(200, 200);
+        InputController controller(nullptr, viewport);
+        input::InputRouter router;
+        router.setInputController(&controller);
+        controller.setInputRouter(&router);
+
+        auto& focus = gui::guiFocusState();
+        focus.want_capture_keyboard = true;
+        focus.any_item_active = true;
+
+        ASSERT_EQ(router.keyboardFocus(), input::InputTarget::Gui);
+        controller.handleKey(input::KEY_ESCAPE, input::ACTION_PRESS, input::KEYMOD_NONE);
+        EXPECT_EQ(router.keyboardFocus(), input::InputTarget::Gui);
+        EXPECT_FALSE(router.isViewportKeyboardFocused());
+    }
+
     TEST_F(InputControllerFocusTest, ProgrammaticViewportFocusAllowsViewportHotkeys) {
         Viewport viewport(200, 200);
         InputController controller(nullptr, viewport);

--- a/tests/test_scene_graph_fuzz.cpp
+++ b/tests/test_scene_graph_fuzz.cpp
@@ -106,11 +106,23 @@ namespace {
             if (include_ids)
                 out << node->id << ':';
             out << node->uuid.to_string() << ':' << node->name << ':'
-                << static_cast<int>(node->type) << ':' << node->parent_id << ':'
+                << static_cast<int>(node->type) << ':';
+            if (include_ids) {
+                out << node->parent_id;
+            } else if (const auto* parent = scene.getNodeById(node->parent_id)) {
+                out << parent->uuid.to_string();
+            }
+            out << ':'
                 << static_cast<bool>(node->visible) << ':' << static_cast<bool>(node->locked) << ':'
                 << node->gaussian_count.load(std::memory_order_acquire) << ':';
-            for (const NodeId child : node->children)
-                out << child << ',';
+            for (const NodeId child : node->children) {
+                if (include_ids) {
+                    out << child;
+                } else if (const auto* child_node = scene.getNodeById(child)) {
+                    out << child_node->uuid.to_string();
+                }
+                out << ',';
+            }
             const auto transform = scene.getNodeTransform(node->id);
             for (int col = 0; col < 4; ++col)
                 for (int row = 0; row < 4; ++row)
@@ -154,8 +166,8 @@ namespace {
             if (!other.contains(uuid))
                 continue;
             const auto current_it = current.find(uuid);
-            ASSERT_NE(current_it, current.end())
-                << "seed=" << seed << " operation=" << operation << " kind=" << kind;
+            if (current_it == current.end())
+                continue;
             EXPECT_EQ(current_it->second, id)
                 << "seed=" << seed << " operation=" << operation << " kind=" << kind;
         }
@@ -433,6 +445,97 @@ namespace {
         EXPECT_EQ(scene_state(*manager_), before);
     }
 
+    TEST_F(SceneGraphRegression, DuplicatePreservesEllipsoidChild) {
+        auto& scene = manager_->getScene();
+        const NodeId source_id = scene.addSplat("source", make_cpu_splat(2, 0.0f));
+        ASSERT_NE(source_id, lfs::core::NULL_NODE);
+        const NodeId ellipsoid_id = scene.addEllipsoid("source_ellipsoid", source_id);
+        ASSERT_NE(ellipsoid_id, lfs::core::NULL_NODE);
+        auto* source_ellipsoid = scene.getEllipsoidData(ellipsoid_id);
+        ASSERT_NE(source_ellipsoid, nullptr);
+        source_ellipsoid->radii = glm::vec3(2.0f, 3.0f, 4.0f);
+        source_ellipsoid->inverse = true;
+        source_ellipsoid->enabled = true;
+        scene.setNodeTransform(ellipsoid_id, glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 2.0f, 3.0f)));
+        const auto expected_data = *source_ellipsoid;
+        const auto expected_transform = scene.getNodeById(ellipsoid_id)->local_transform.get();
+
+        const auto duplicate_name = manager_->duplicateNodeTree(source_id);
+        ASSERT_FALSE(duplicate_name.empty());
+        const auto* duplicate = scene.getNode(duplicate_name);
+        ASSERT_NE(duplicate, nullptr);
+        ASSERT_NE(duplicate->uuid, scene.getNodeById(source_id)->uuid);
+        const NodeId duplicate_ellipsoid_id = scene.getEllipsoidForSplat(duplicate->id);
+        ASSERT_NE(duplicate_ellipsoid_id, lfs::core::NULL_NODE);
+        const auto* duplicate_ellipsoid = scene.getEllipsoidData(duplicate_ellipsoid_id);
+        ASSERT_NE(duplicate_ellipsoid, nullptr);
+        EXPECT_EQ(duplicate_ellipsoid->radii, expected_data.radii);
+        EXPECT_EQ(duplicate_ellipsoid->inverse, expected_data.inverse);
+        EXPECT_EQ(duplicate_ellipsoid->enabled, expected_data.enabled);
+        EXPECT_EQ(scene.getNodeById(duplicate_ellipsoid_id)->local_transform.get(), expected_transform);
+    }
+
+    TEST_F(SceneGraphRegression, PastePreservesEllipsoidChild) {
+        auto& scene = manager_->getScene();
+        const NodeId source_id = scene.addSplat("source", make_cpu_splat(2, 0.0f));
+        ASSERT_NE(source_id, lfs::core::NULL_NODE);
+        const NodeId ellipsoid_id = scene.addEllipsoid("source_ellipsoid", source_id);
+        ASSERT_NE(ellipsoid_id, lfs::core::NULL_NODE);
+        auto* source_ellipsoid = scene.getEllipsoidData(ellipsoid_id);
+        ASSERT_NE(source_ellipsoid, nullptr);
+        source_ellipsoid->radii = glm::vec3(2.0f, 3.0f, 4.0f);
+        source_ellipsoid->inverse = true;
+        source_ellipsoid->enabled = true;
+        scene.setNodeTransform(ellipsoid_id, glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 2.0f, 3.0f)));
+        const auto expected_data = *source_ellipsoid;
+        const auto expected_transform = scene.getNodeById(ellipsoid_id)->local_transform.get();
+
+        manager_->selectNode(source_id);
+        ASSERT_TRUE(manager_->copySelectedNodes());
+        manager_->clearSelection();
+        const auto pasted = manager_->pasteNodes();
+        ASSERT_EQ(pasted.size(), 1u);
+        ASSERT_EQ(lfs::vis::op::undoHistory().undoCount(), 1u);
+        const auto* pasted_node = scene.getNode(pasted.front());
+        ASSERT_NE(pasted_node, nullptr);
+        const NodeId pasted_ellipsoid_id = scene.getEllipsoidForSplat(pasted_node->id);
+        ASSERT_NE(pasted_ellipsoid_id, lfs::core::NULL_NODE);
+        const auto* pasted_ellipsoid = scene.getEllipsoidData(pasted_ellipsoid_id);
+        ASSERT_NE(pasted_ellipsoid, nullptr);
+        EXPECT_EQ(pasted_ellipsoid->radii, expected_data.radii);
+        EXPECT_EQ(pasted_ellipsoid->inverse, expected_data.inverse);
+        EXPECT_EQ(pasted_ellipsoid->enabled, expected_data.enabled);
+        EXPECT_EQ(scene.getNodeById(pasted_ellipsoid_id)->local_transform.get(), expected_transform);
+    }
+
+    TEST_F(SceneGraphRegression, MergeHonorsEllipsoidCrop) {
+        auto& scene = manager_->getScene();
+        const NodeId group_id = scene.addGroup("ellipsoid_merge");
+        const NodeId splat_id = scene.addSplat(
+            "ellipsoid_model",
+            make_cpu_splat(3, -2.0f),
+            group_id);
+        ASSERT_NE(group_id, lfs::core::NULL_NODE);
+        ASSERT_NE(splat_id, lfs::core::NULL_NODE);
+        const NodeId ellipsoid_id = scene.addEllipsoid("ellipsoid_model_ellipsoid", splat_id);
+        ASSERT_NE(ellipsoid_id, lfs::core::NULL_NODE);
+        auto* ellipsoid = scene.getEllipsoidData(ellipsoid_id);
+        ASSERT_NE(ellipsoid, nullptr);
+        ellipsoid->radii = glm::vec3(0.5f);
+        ellipsoid->enabled = true;
+        scene.setNodeTransform(
+            ellipsoid_id,
+            glm::translate(glm::mat4(1.0f), glm::vec3(-1.0f, 1.0f, -1.0f)));
+
+        ASSERT_EQ(manager_->mergeGroupNode(group_id), "ellipsoid_merge");
+        const auto* merged = scene.getNode("ellipsoid_merge");
+        ASSERT_NE(merged, nullptr);
+        ASSERT_NE(merged->model, nullptr);
+        EXPECT_EQ(merged->model->size(), 1);
+        EXPECT_EQ(merged->model->means_raw().cpu().to_vector(),
+                  (std::vector<float>{-1.0f, 1.0f, -1.0f}));
+    }
+
     TEST_F(SceneGraphFuzzTest, BatchRemovalRejectsDuplicateIdsAtomically) {
         seed_scene();
         const auto& scene = manager_->getScene();
@@ -450,12 +553,45 @@ namespace {
         const auto& scene = manager_->getScene();
         const NodeId a = scene.getNodeIdByName("a");
         const NodeId d = scene.getNodeIdByName("d");
-        const std::string before = scene_state(*manager_);
+        const std::string before_graph = scene_state(*manager_, false);
+        const auto before_ids = node_ids_by_uuid(*manager_);
+        const auto a_uuid = scene.getNodeById(a)->uuid;
+        const auto d_uuid = scene.getNodeById(d)->uuid;
 
         ASSERT_TRUE(manager_->removeNodesByIdsWithResult({a, d}));
         ASSERT_EQ(lfs::vis::op::undoHistory().undoCount(), 1u);
         ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
-        EXPECT_EQ(scene_state(*manager_), before);
+        EXPECT_EQ(scene_state(*manager_, false), before_graph);
+        const auto current_ids = node_ids_by_uuid(*manager_);
+        for (const auto& [uuid, id] : before_ids) {
+            if (uuid == a_uuid || uuid == d_uuid)
+                continue;
+            const auto current_id = current_ids.find(uuid);
+            ASSERT_NE(current_id, current_ids.end());
+            EXPECT_EQ(current_id->second, id);
+        }
+    }
+
+    TEST_F(SceneGraphRegression, ScopedBatchDeleteRootUndoRedoIgnoresUnrelatedRoots) {
+        auto& scene = manager_->getScene();
+        const NodeId deleted_root = scene.addGroup("deleted_root");
+        const NodeId other_root = scene.addGroup("other_root");
+        ASSERT_NE(deleted_root, lfs::core::NULL_NODE);
+        ASSERT_NE(other_root, lfs::core::NULL_NODE);
+        ASSERT_NE(scene.addSplat("deleted_child", make_cuda_splat(1, 0.0f), deleted_root),
+                  lfs::core::NULL_NODE);
+
+        const auto before = scene_state(*manager_, false);
+        ASSERT_TRUE(manager_->removeNodesByIdsWithResult({deleted_root}));
+        ASSERT_NE(scene.addGroup("unrelated_root"), lfs::core::NULL_NODE);
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_NE(scene.getNode("deleted_root"), nullptr);
+        EXPECT_EQ(scene.getNode("unrelated_root"), nullptr);
+        ASSERT_TRUE(lfs::vis::op::undoHistory().redo().success);
+        EXPECT_EQ(scene.getNode("deleted_root"), nullptr);
+        EXPECT_EQ(scene.getNode("unrelated_root"), nullptr);
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_EQ(scene_state(*manager_, false), before);
     }
 
     TEST_F(SceneGraphFuzzTest, MoveNodeIntoSplatLeafIsRejected) {
@@ -519,9 +655,10 @@ namespace {
         const auto nested_transform = glm::rotate(glm::mat4(1.0f), 0.35f, glm::vec3(0.0f, 1.0f, 0.0f));
         scene.setNodeTransform(left, left_transform);
         scene.setNodeTransform(nested, nested_transform);
-        const auto before = scene_state(*manager_);
         manager_->selectNode(left);
         ASSERT_TRUE(manager_->copySelectedNodes());
+        manager_->clearSelection();
+        const auto before = scene_state(*manager_);
 
         const auto pasted = manager_->pasteNodes();
         ASSERT_EQ(pasted.size(), 1u);
@@ -699,8 +836,8 @@ namespace {
                 };
 
                 std::string before = scene_state(*manager_);
-                const std::string before_graph = scene_state(*manager_, false);
-                const auto before_ids = node_ids_by_uuid(*manager_);
+                std::string before_graph = scene_state(*manager_, false);
+                auto before_ids = node_ids_by_uuid(*manager_);
                 const size_t undo_before = lfs::vis::op::undoHistory().undoCount();
                 const int kind = static_cast<int>(rng() % 18);
                 bool changed = false;
@@ -801,6 +938,11 @@ namespace {
                     if (node) {
                         manager_->selectNodesById({node->id});
                         manager_->copySelectedNodes();
+                        // Selecting the node is part of the delete command's
+                        // pre-state, just like it is in the GUI.
+                        before = scene_state(*manager_);
+                        before_graph = scene_state(*manager_, false);
+                        before_ids = node_ids_by_uuid(*manager_);
                         if ((rng() & 1u) != 0) {
                             const auto result = manager_->removeNodeWithResult(node->id);
                             changed = result.has_value();
@@ -864,23 +1006,29 @@ namespace {
                     if (!undo_frames.empty() && lfs::vis::op::undoHistory().canUndo() &&
                         (redo_frames.empty() || (rng() & 1u) == 0)) {
                         const auto frame = undo_frames.back();
+                        const auto replay_ids = node_ids_by_uuid(*manager_);
                         const auto result = lfs::vis::op::undoHistory().undo();
-                        ASSERT_TRUE(result.success) << result.error;
+                        ASSERT_TRUE(result.success)
+                            << result.error << " seed=" << seed << " operation=" << operation
+                            << " kind=" << frame.kind;
                         EXPECT_EQ(scene_state(*manager_, false), frame.before_graph)
                             << "seed=" << seed << " operation=" << operation << " kind=" << frame.kind;
                         if (frame.stable_common_ids)
-                            expect_common_node_ids(*manager_, frame.before_ids, frame.after_ids,
+                            expect_common_node_ids(*manager_, replay_ids, frame.before_ids,
                                                    seed, operation, frame.kind);
                         undo_frames.pop_back();
                         redo_frames.push_back(frame);
                     } else if (!redo_frames.empty() && lfs::vis::op::undoHistory().canRedo()) {
                         const auto frame = redo_frames.back();
+                        const auto replay_ids = node_ids_by_uuid(*manager_);
                         const auto result = lfs::vis::op::undoHistory().redo();
-                        ASSERT_TRUE(result.success) << result.error;
+                        ASSERT_TRUE(result.success)
+                            << result.error << " seed=" << seed << " operation=" << operation
+                            << " kind=" << frame.kind;
                         EXPECT_EQ(scene_state(*manager_, false), frame.after_graph)
                             << "seed=" << seed << " operation=" << operation << " kind=" << frame.kind;
                         if (frame.stable_common_ids)
-                            expect_common_node_ids(*manager_, frame.before_ids, frame.after_ids,
+                            expect_common_node_ids(*manager_, replay_ids, frame.after_ids,
                                                    seed, operation, frame.kind);
                         redo_frames.pop_back();
                         undo_frames.push_back(frame);
@@ -965,8 +1113,22 @@ namespace {
                         .before_ids = before_ids,
                         .after_ids = after_ids,
                         .kind = kind,
-                        .stable_common_ids = kind == 3 || kind == 4 || kind == 5 || kind == 6 || kind == 17,
+                        // UUIDs are the history identity. Every UUID present in
+                        // both snapshots must retain its live node ID; only
+                        // nodes absent immediately before replay may receive
+                        // fresh IDs.
+                        .stable_common_ids = true,
                     });
+                    redo_frames.clear();
+                } else if (history_candidate && undo_after == undo_before && !undo_frames.empty()) {
+                    // Property entries can coalesce with the previous history
+                    // entry.  Keep the model of the history stack in sync with
+                    // the merged entry instead of replaying the old after-state.
+                    auto& frame = undo_frames.back();
+                    frame.after = after;
+                    frame.after_graph = after_graph;
+                    frame.after_ids = after_ids;
+                    frame.kind = kind;
                     redo_frames.clear();
                 }
                 if (untracked_mutation) {

--- a/tests/test_scene_graph_fuzz.cpp
+++ b/tests/test_scene_graph_fuzz.cpp
@@ -1,0 +1,980 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/event_bridge/event_bridge.hpp"
+#include "core/event_bus.hpp"
+#include "core/scene.hpp"
+#include "core/splat_data.hpp"
+#include "core/tensor.hpp"
+#include "operation/undo_entry.hpp"
+#include "operation/undo_history.hpp"
+#include "rendering/rendering_manager.hpp"
+#include "scene/scene_manager.hpp"
+#include "visualizer/gui_capabilities.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <format>
+#include <glm/gtc/matrix_transform.hpp>
+#include <gtest/gtest.h>
+#include <iomanip>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace {
+
+    using lfs::core::DataType;
+    using lfs::core::Device;
+    using lfs::core::NodeId;
+    using lfs::core::NodeType;
+    using lfs::core::Tensor;
+
+    std::unique_ptr<lfs::core::SplatData> make_splat(
+        const size_t count,
+        const float offset,
+        const Device device) {
+        std::vector<float> means;
+        means.reserve(count * 3);
+        for (size_t i = 0; i < count; ++i) {
+            means.push_back(offset + static_cast<float>(i));
+            means.push_back(static_cast<float>(i % 3));
+            means.push_back(-static_cast<float>(i));
+        }
+
+        std::vector<float> rotation(count * 4, 0.0f);
+        for (size_t i = 0; i < count; ++i)
+            rotation[i * 4] = 1.0f;
+
+        return std::make_unique<lfs::core::SplatData>(
+            1,
+            Tensor::from_vector(means, {count, size_t{3}}, device),
+            Tensor::zeros({count, size_t{1}, size_t{3}}, device, DataType::Float32),
+            Tensor::zeros({count, size_t{3}, size_t{3}}, device, DataType::Float32),
+            Tensor::zeros({count, size_t{3}}, device, DataType::Float32),
+            Tensor::from_vector(rotation, {count, size_t{4}}, device),
+            Tensor::zeros({count, size_t{1}}, device, DataType::Float32),
+            1.0f);
+    }
+
+    std::unique_ptr<lfs::core::SplatData> make_cpu_splat(const size_t count, const float offset) {
+        return make_splat(count, offset, Device::CPU);
+    }
+
+    std::unique_ptr<lfs::core::SplatData> make_cuda_splat(const size_t count, const float offset) {
+        return make_splat(count, offset, Device::CUDA);
+    }
+
+    uint64_t hash_tensor(const Tensor& tensor) {
+        if (!tensor.is_valid())
+            return 0;
+        const auto values = tensor.cpu().contiguous().to_vector();
+        uint64_t hash = 1469598103934665603ull;
+        for (const float value : values) {
+            uint32_t bits = 0;
+            static_assert(sizeof(bits) == sizeof(value));
+            std::memcpy(&bits, &value, sizeof(bits));
+            hash ^= bits;
+            hash *= 1099511628211ull;
+        }
+        return hash;
+    }
+
+    std::string scene_state(const lfs::vis::SceneManager& manager, const bool include_ids = true) {
+        const auto& scene = manager.getScene();
+        std::ostringstream out;
+        out << std::setprecision(9);
+        std::vector<const lfs::core::SceneNode*> ordered_nodes;
+        const auto append_subtree = [&](const auto& self, const NodeId id) -> void {
+            const auto* node = scene.getNodeById(id);
+            if (!node)
+                return;
+            ordered_nodes.push_back(node);
+            for (const NodeId child : node->children)
+                self(self, child);
+        };
+        for (const NodeId root : scene.getRootNodes())
+            append_subtree(append_subtree, root);
+
+        for (const auto* node : ordered_nodes) {
+            if (include_ids)
+                out << node->id << ':';
+            out << node->uuid.to_string() << ':' << node->name << ':'
+                << static_cast<int>(node->type) << ':' << node->parent_id << ':'
+                << static_cast<bool>(node->visible) << ':' << static_cast<bool>(node->locked) << ':'
+                << node->gaussian_count.load(std::memory_order_acquire) << ':';
+            for (const NodeId child : node->children)
+                out << child << ',';
+            const auto transform = scene.getNodeTransform(node->id);
+            for (int col = 0; col < 4; ++col)
+                for (int row = 0; row < 4; ++row)
+                    out << ':' << transform[col][row];
+            out << ':' << (node->model ? hash_tensor(node->model->means_raw()) : 0);
+            out << ':' << (node->model && node->model->has_deleted_mask() ? hash_tensor(node->model->deleted()) : 0)
+                << ';';
+        }
+        std::vector<NodeId> selected = manager.getSelectedNodeIds();
+        std::ranges::sort(selected);
+        out << "selection:";
+        for (const NodeId id : selected) {
+            const auto* node = scene.getNodeById(id);
+            if (include_ids)
+                out << id;
+            else if (node)
+                out << node->uuid.to_string();
+            out << ',';
+        }
+        if (const auto mask = scene.getSelectionMask())
+            out << "mask:" << hash_tensor(*mask);
+        return out.str();
+    }
+
+    std::unordered_map<lfs::core::Uuid, NodeId> node_ids_by_uuid(const lfs::vis::SceneManager& manager) {
+        std::unordered_map<lfs::core::Uuid, NodeId> result;
+        for (const auto* node : manager.getScene().getNodes())
+            result.emplace(node->uuid, node->id);
+        return result;
+    }
+
+    void expect_common_node_ids(
+        const lfs::vis::SceneManager& manager,
+        const std::unordered_map<lfs::core::Uuid, NodeId>& expected,
+        const std::unordered_map<lfs::core::Uuid, NodeId>& other,
+        const int seed = -1,
+        const int operation = -1,
+        const int kind = -1) {
+        const auto current = node_ids_by_uuid(manager);
+        for (const auto& [uuid, id] : expected) {
+            if (!other.contains(uuid))
+                continue;
+            const auto current_it = current.find(uuid);
+            ASSERT_NE(current_it, current.end())
+                << "seed=" << seed << " operation=" << operation << " kind=" << kind;
+            EXPECT_EQ(current_it->second, id)
+                << "seed=" << seed << " operation=" << operation << " kind=" << kind;
+        }
+    }
+
+    void check_scene_invariants(const lfs::vis::SceneManager& manager) {
+        const auto& scene = manager.getScene();
+        std::unordered_set<NodeId> ids;
+        std::unordered_set<lfs::core::Uuid> uuids;
+        std::unordered_set<std::string> names;
+        size_t visible_gaussians = 0;
+        for (const auto* node : scene.getNodes()) {
+            ASSERT_NE(node, nullptr);
+            ASSERT_TRUE(ids.insert(node->id).second);
+            ASSERT_TRUE(uuids.insert(node->uuid).second);
+            ASSERT_TRUE(names.insert(node->name).second);
+            if (node->parent_id == lfs::core::NULL_NODE) {
+                EXPECT_FALSE(std::ranges::any_of(scene.getNodes(), [&](const auto* parent) {
+                    return parent && std::ranges::count(parent->children, node->id) != 0;
+                }));
+            } else {
+                const auto* parent = scene.getNodeById(node->parent_id);
+                ASSERT_NE(parent, nullptr);
+                EXPECT_EQ(std::ranges::count(parent->children, node->id), 1);
+            }
+            for (const NodeId child_id : node->children) {
+                const auto* child = scene.getNodeById(child_id);
+                ASSERT_NE(child, nullptr);
+                EXPECT_EQ(child->parent_id, node->id);
+                EXPECT_EQ(std::ranges::count(node->children, child_id), 1);
+            }
+            EXPECT_EQ(std::ranges::count(node->children, node->id), 0);
+            if (node->type == NodeType::SPLAT && scene.isNodeEffectivelyVisible(node->id))
+                visible_gaussians += node->gaussian_count.load(std::memory_order_acquire);
+        }
+        EXPECT_EQ(scene.getTotalGaussianCount(), visible_gaussians);
+
+        for (const auto* node : scene.getNodes()) {
+            std::unordered_set<NodeId> visited;
+            for (NodeId current = node->id; current != lfs::core::NULL_NODE;) {
+                ASSERT_TRUE(visited.insert(current).second);
+                const auto* current_node = scene.getNodeById(current);
+                ASSERT_NE(current_node, nullptr);
+                current = current_node->parent_id;
+            }
+        }
+        for (const NodeId id : manager.getSelectedNodeIds())
+            EXPECT_NE(scene.getNodeById(id), nullptr);
+    }
+
+    class SceneGraphFuzzTest : public ::testing::Test {
+    protected:
+        void SetUp() override {
+            lfs::event::EventBridge::instance().clear_all();
+            lfs::core::event::bus().clear_all();
+            lfs::vis::services().clear();
+            lfs::vis::op::undoHistory().clear();
+            manager_ = std::make_unique<lfs::vis::SceneManager>();
+            rendering_ = std::make_unique<lfs::vis::RenderingManager>();
+            lfs::vis::services().set(manager_.get());
+            lfs::vis::services().set(rendering_.get());
+            manager_->changeContentType(lfs::vis::SceneManager::ContentType::SplatFiles);
+        }
+
+        void TearDown() override {
+            lfs::vis::op::undoHistory().clear();
+            lfs::vis::services().clear();
+            rendering_.reset();
+            manager_.reset();
+            lfs::core::event::bus().clear_all();
+            lfs::event::EventBridge::instance().clear_all();
+        }
+
+        void seed_scene() {
+            auto& scene = manager_->getScene();
+            const NodeId left = scene.addGroup("left");
+            const NodeId right = scene.addGroup("right");
+            const NodeId nested = scene.addGroup("nested", left);
+            scene.addSplat("a", make_cuda_splat(2, 0.0f), left);
+            scene.addSplat("b", make_cuda_splat(3, 10.0f), left);
+            scene.addSplat("c", make_cuda_splat(2, 20.0f), nested);
+            scene.addSplat("d", make_cuda_splat(1, 30.0f), right);
+        }
+
+        std::unique_ptr<lfs::vis::SceneManager> manager_;
+        std::unique_ptr<lfs::vis::RenderingManager> rendering_;
+    };
+
+    class SceneGraphRegression : public SceneGraphFuzzTest {};
+
+    TEST_F(SceneGraphRegression, BakeTransformUndoRestoresMeans) {
+        auto& scene = manager_->getScene();
+        const NodeId node_id = scene.addSplat("bake", make_cpu_splat(2, 1.0f));
+        ASSERT_NE(node_id, lfs::core::NULL_NODE);
+        const auto* node = scene.getNodeById(node_id);
+        ASSERT_NE(node, nullptr);
+        ASSERT_NE(node->model, nullptr);
+
+        const auto original_means = node->model->means_raw().cpu().to_vector();
+        const auto original_transform =
+            glm::translate(glm::mat4(1.0f), glm::vec3(4.0f, -2.0f, 3.0f));
+        scene.setNodeTransform(node_id, original_transform);
+
+        ASSERT_TRUE(lfs::vis::cap::bakeNodeTransforms(*manager_, {"bake"}, "Bake Transform"));
+        ASSERT_EQ(lfs::vis::op::undoHistory().undoCount(), 1u);
+        const auto* baked = scene.getNodeById(node_id);
+        ASSERT_NE(baked, nullptr);
+        ASSERT_NE(baked->model, nullptr);
+        const auto baked_means = baked->model->means_raw().cpu().to_vector();
+        EXPECT_NE(baked_means, original_means);
+        EXPECT_EQ(baked->local_transform.get(), glm::mat4(1.0f));
+
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        const auto* undone = scene.getNodeByUuid(baked->uuid);
+        ASSERT_NE(undone, nullptr);
+        ASSERT_NE(undone->model, nullptr);
+        EXPECT_EQ(undone->id, node_id);
+        EXPECT_EQ(undone->model->means_raw().cpu().to_vector(), original_means);
+        EXPECT_EQ(undone->local_transform.get(), original_transform);
+
+        ASSERT_TRUE(lfs::vis::op::undoHistory().redo().success);
+        const auto* redone = scene.getNodeByUuid(undone->uuid);
+        ASSERT_NE(redone, nullptr);
+        ASSERT_NE(redone->model, nullptr);
+        EXPECT_EQ(redone->id, node_id);
+        EXPECT_EQ(redone->model->means_raw().cpu().to_vector(), baked_means);
+        EXPECT_EQ(redone->local_transform.get(), glm::mat4(1.0f));
+
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_EQ(scene.getNodeByUuid(redone->uuid)->model->means_raw().cpu().to_vector(), original_means);
+    }
+
+    TEST_F(SceneGraphRegression, SoftDeleteSelectedIsAtomicOnFailure) {
+        auto& scene = manager_->getScene();
+        const NodeId first_id = scene.addSplat("first", make_cpu_splat(2, 0.0f));
+        const NodeId second_id = scene.addSplat("second", make_cpu_splat(2, 10.0f));
+        ASSERT_NE(first_id, lfs::core::NULL_NODE);
+        ASSERT_NE(second_id, lfs::core::NULL_NODE);
+
+        auto* first = scene.getNodeById(first_id);
+        auto* second = scene.getNodeById(second_id);
+        ASSERT_NE(first, nullptr);
+        ASSERT_NE(second, nullptr);
+        ASSERT_NE(first->model, nullptr);
+        ASSERT_NE(second->model, nullptr);
+
+        // The second model deliberately has a pre-existing deleted mask on a
+        // different device. Preparation must reject the whole operation before
+        // applying the first partial slice.
+        second->model->deleted() = Tensor::zeros({2}, Device::CUDA, DataType::Bool);
+        second->model->notify_deleted_mask_changed();
+        const auto before_second_deleted = second->model->deleted().clone();
+        scene.setSelectionMask(std::make_shared<Tensor>(
+            Tensor::from_vector(std::vector<bool>{true, false, true, false}, {4}, Device::CPU)));
+        const auto before_selection = scene.getSelectionMask()->clone();
+
+        const auto result = manager_->softDeleteSelectedGaussians();
+        ASSERT_FALSE(result);
+        EXPECT_FALSE(first->model->has_deleted_mask());
+        ASSERT_TRUE(second->model->has_deleted_mask());
+        EXPECT_EQ(second->model->deleted().cpu().to_vector_bool(),
+                  before_second_deleted.cpu().to_vector_bool());
+        EXPECT_EQ(scene.getSelectionMask()->cpu().to_vector_bool(),
+                  before_selection.cpu().to_vector_bool());
+        EXPECT_EQ(lfs::vis::op::undoHistory().undoCount(), 0u);
+    }
+
+    TEST_F(SceneGraphFuzzTest, GroupNodesRejectsDuplicateIdsAtomically) {
+        seed_scene();
+        const auto& scene = manager_->getScene();
+        const NodeId a = scene.getNodeIdByName("a");
+        const std::string before = scene_state(*manager_);
+        const size_t history_before = lfs::vis::op::undoHistory().undoCount();
+
+        EXPECT_FALSE(manager_->groupNodes({a, a}));
+        EXPECT_EQ(scene_state(*manager_), before);
+        EXPECT_EQ(lfs::vis::op::undoHistory().undoCount(), history_before);
+    }
+
+    TEST_F(SceneGraphFuzzTest, GroupSelectedUndoRestoresRootsAndRemovesGroup) {
+        auto& scene = manager_->getScene();
+        const NodeId a = scene.addSplat("a", make_cpu_splat(1, 0.0f));
+        const NodeId b = scene.addSplat("b", make_cpu_splat(1, 1.0f));
+        const auto roots_before = scene.getRootNodes();
+
+        manager_->setNodeVisibility(a, false);
+        const auto before_group = scene_state(*manager_);
+
+        ASSERT_TRUE(manager_->groupNodes({a, b}));
+        ASSERT_EQ(lfs::vis::op::undoHistory().undoCount(), 2u);
+        ASSERT_EQ(scene.getRootNodes().size(), 1u);
+        ASSERT_EQ(scene.getNodeById(scene.getRootNodes().front())->type, NodeType::GROUP);
+
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_EQ(scene_state(*manager_), before_group);
+        EXPECT_EQ(scene.getRootNodes(), roots_before);
+        EXPECT_EQ(scene.getNode("a")->id, a);
+        EXPECT_EQ(scene.getNode("b")->id, b);
+
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_TRUE(scene.getNodeById(a)->visible);
+    }
+
+    TEST_F(SceneGraphFuzzTest, UngroupUndoRestoresChildrenWithStableIds) {
+        auto& scene = manager_->getScene();
+        const NodeId group = scene.addGroup("group");
+        const NodeId a = scene.addSplat("a", make_cpu_splat(1, 0.0f), group);
+        const NodeId b = scene.addSplat("b", make_cpu_splat(1, 1.0f), group);
+        const NodeId other = scene.addSplat("other", make_cpu_splat(1, 2.0f));
+        const auto group_uuid = scene.getNodeById(group)->uuid;
+
+        manager_->setNodeVisibility(a, false);
+        const auto node_count_before = scene.getNodeCount();
+        ASSERT_TRUE(manager_->ungroupNode(group));
+        ASSERT_EQ(lfs::vis::op::undoHistory().undoCount(), 2u);
+
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        ASSERT_EQ(scene.getNodeCount(), node_count_before);
+        const auto* restored_group = scene.getNodeByUuid(group_uuid);
+        ASSERT_NE(restored_group, nullptr);
+        EXPECT_EQ(restored_group->children, (std::vector<NodeId>{a, b}));
+        EXPECT_EQ(scene.getNodeById(a)->id, a);
+        EXPECT_EQ(scene.getNodeById(b)->id, b);
+        EXPECT_EQ(scene.getRootNodes().size(), 2u);
+        EXPECT_EQ(scene.getRootNodes()[0], restored_group->id);
+        EXPECT_EQ(scene.getRootNodes()[1], other);
+
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_TRUE(scene.getNodeById(a)->visible);
+    }
+
+    TEST_F(SceneGraphFuzzTest, GroupSelectedAllowsGroupAndSplatSiblings) {
+        auto& scene = manager_->getScene();
+        const NodeId first_group = scene.addGroup("first");
+        const NodeId splat = scene.addSplat("splat", make_cpu_splat(1, 0.0f));
+
+        ASSERT_TRUE(manager_->groupNodes({splat, first_group}));
+        const auto roots = scene.getRootNodes();
+        ASSERT_EQ(roots.size(), 1u);
+        const auto* outer = scene.getNodeById(roots.front());
+        ASSERT_NE(outer, nullptr);
+        ASSERT_EQ(outer->children, (std::vector<NodeId>{first_group, splat}));
+        EXPECT_EQ(scene.getNodeById(first_group)->parent_id, outer->id);
+        EXPECT_EQ(scene.getNodeById(splat)->parent_id, outer->id);
+
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_EQ(scene.getRootNodes(), (std::vector<NodeId>{first_group, splat}));
+    }
+
+    TEST_F(SceneGraphFuzzTest, DuplicateNestedTransformedGroupIsOneUndoStep) {
+        auto& scene = manager_->getScene();
+        const NodeId outer = scene.addGroup("outer");
+        const NodeId inner = scene.addGroup("inner", outer);
+        const NodeId splat = scene.addSplat("splat", make_cpu_splat(1, 0.0f), inner);
+        const auto outer_transform = glm::translate(glm::mat4(1.0f), glm::vec3(3.0f, 1.0f, -2.0f));
+        const auto inner_transform = glm::scale(glm::mat4(1.0f), glm::vec3(2.0f, 3.0f, 4.0f));
+        scene.setNodeTransform(outer, outer_transform);
+        scene.setNodeTransform(inner, inner_transform);
+        const auto before = scene_state(*manager_);
+
+        const auto duplicate_name = manager_->duplicateNodeTree(outer);
+        ASSERT_FALSE(duplicate_name.empty());
+        ASSERT_EQ(lfs::vis::op::undoHistory().undoCount(), 1u);
+        EXPECT_EQ(lfs::vis::op::undoHistory().undoName(), "Duplicate Node");
+        const auto* duplicate = scene.getNode(duplicate_name);
+        ASSERT_NE(duplicate, nullptr);
+        EXPECT_EQ(scene.getNodeById(duplicate->children.front())->local_transform.get(), inner_transform);
+        EXPECT_EQ(duplicate->local_transform.get(), outer_transform);
+
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_EQ(scene_state(*manager_), before);
+        ASSERT_TRUE(lfs::vis::op::undoHistory().redo().success);
+        ASSERT_NE(scene.getNode(duplicate_name), nullptr);
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_EQ(scene_state(*manager_), before);
+    }
+
+    TEST_F(SceneGraphFuzzTest, BatchRemovalRejectsDuplicateIdsAtomically) {
+        seed_scene();
+        const auto& scene = manager_->getScene();
+        const NodeId a = scene.getNodeIdByName("a");
+        const std::string before = scene_state(*manager_);
+        const auto result = manager_->removeNodesByIdsWithResult({a, a});
+
+        EXPECT_FALSE(result);
+        EXPECT_EQ(scene_state(*manager_), before);
+        EXPECT_EQ(lfs::vis::op::undoHistory().undoCount(), 0u);
+    }
+
+    TEST_F(SceneGraphFuzzTest, BatchRemovalIsOneUndoStep) {
+        seed_scene();
+        const auto& scene = manager_->getScene();
+        const NodeId a = scene.getNodeIdByName("a");
+        const NodeId d = scene.getNodeIdByName("d");
+        const std::string before = scene_state(*manager_);
+
+        ASSERT_TRUE(manager_->removeNodesByIdsWithResult({a, d}));
+        ASSERT_EQ(lfs::vis::op::undoHistory().undoCount(), 1u);
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_EQ(scene_state(*manager_), before);
+    }
+
+    TEST_F(SceneGraphFuzzTest, MoveNodeIntoSplatLeafIsRejected) {
+        seed_scene();
+        const auto& scene = manager_->getScene();
+        const NodeId a = scene.getNodeIdByName("a");
+        const NodeId b = scene.getNodeIdByName("b");
+        const std::string before = scene_state(*manager_);
+
+        EXPECT_FALSE(manager_->moveNode(a, b, 0));
+        EXPECT_EQ(scene_state(*manager_), before);
+    }
+
+    TEST_F(SceneGraphFuzzTest, AddGroupUnderSplatLeafIsRejected) {
+        seed_scene();
+        const auto& scene = manager_->getScene();
+        const NodeId a = scene.getNodeIdByName("a");
+        const std::string before = scene_state(*manager_);
+
+        EXPECT_TRUE(manager_->addGroupNode("invalid", a).empty());
+        EXPECT_EQ(scene_state(*manager_), before);
+    }
+
+    TEST_F(SceneGraphFuzzTest, AddSplatUnderSplatLeafIsRejected) {
+        seed_scene();
+        auto& scene = manager_->getScene();
+        const NodeId a = scene.getNodeIdByName("a");
+        const std::string before = scene_state(*manager_);
+
+        EXPECT_EQ(scene.addSplat("invalid", make_cpu_splat(1, 0.0f), a), lfs::core::NULL_NODE);
+        EXPECT_EQ(scene_state(*manager_), before);
+    }
+
+    TEST_F(SceneGraphFuzzTest, ReparentNodeIntoSplatLeafIsRejected) {
+        seed_scene();
+        const auto& scene = manager_->getScene();
+        const NodeId a = scene.getNodeIdByName("a");
+        const NodeId b = scene.getNodeIdByName("b");
+        const std::string before = scene_state(*manager_);
+
+        EXPECT_FALSE(manager_->reparentNode(a, b));
+        EXPECT_EQ(scene_state(*manager_), before);
+    }
+
+    TEST_F(SceneGraphFuzzTest, FailedMergePreservesSelection) {
+        const NodeId empty_group = manager_->getScene().addGroup("empty");
+        ASSERT_NE(empty_group, lfs::core::NULL_NODE);
+        manager_->selectNode(empty_group);
+        const std::string before = scene_state(*manager_);
+
+        EXPECT_TRUE(manager_->mergeGroupNode(empty_group).empty());
+        EXPECT_EQ(scene_state(*manager_), before);
+    }
+
+    TEST_F(SceneGraphFuzzTest, CopyPastePreservesGroupHierarchy) {
+        seed_scene();
+        auto& scene = manager_->getScene();
+        const NodeId left = scene.getNodeIdByName("left");
+        const NodeId nested = scene.getNodeIdByName("nested");
+        const auto left_transform = glm::translate(glm::mat4(1.0f), glm::vec3(4.0f, 0.0f, 2.0f));
+        const auto nested_transform = glm::rotate(glm::mat4(1.0f), 0.35f, glm::vec3(0.0f, 1.0f, 0.0f));
+        scene.setNodeTransform(left, left_transform);
+        scene.setNodeTransform(nested, nested_transform);
+        const auto before = scene_state(*manager_);
+        manager_->selectNode(left);
+        ASSERT_TRUE(manager_->copySelectedNodes());
+
+        const auto pasted = manager_->pasteNodes();
+        ASSERT_EQ(pasted.size(), 1u);
+        ASSERT_EQ(lfs::vis::op::undoHistory().undoCount(), 1u);
+        const auto* pasted_root = scene.getNode(pasted.front());
+        ASSERT_NE(pasted_root, nullptr);
+        ASSERT_EQ(pasted_root->type, NodeType::GROUP);
+        ASSERT_EQ(pasted_root->children.size(), 3u);
+        EXPECT_EQ(pasted_root->local_transform.get(), left_transform);
+        EXPECT_NE(pasted_root->uuid, scene.getNodeById(left)->uuid);
+        EXPECT_NE(pasted_root->name, scene.getNodeById(left)->name);
+        for (size_t i = 0; i < pasted_root->children.size(); ++i) {
+            const auto* source_child = scene.getNodeById(scene.getNodeById(left)->children[i]);
+            const auto* pasted_child = scene.getNodeById(pasted_root->children[i]);
+            ASSERT_NE(source_child, nullptr);
+            ASSERT_NE(pasted_child, nullptr);
+            EXPECT_EQ(pasted_child->type, source_child->type);
+            EXPECT_EQ(pasted_child->local_transform.get(), source_child->local_transform.get());
+            EXPECT_NE(pasted_child->uuid, source_child->uuid);
+            EXPECT_EQ(pasted_child->name, source_child->name + " 1");
+            if (source_child->type == NodeType::GROUP) {
+                ASSERT_EQ(pasted_child->children.size(), source_child->children.size());
+                for (size_t j = 0; j < source_child->children.size(); ++j) {
+                    const auto* source_grandchild = scene.getNodeById(source_child->children[j]);
+                    const auto* pasted_grandchild = scene.getNodeById(pasted_child->children[j]);
+                    ASSERT_NE(source_grandchild, nullptr);
+                    ASSERT_NE(pasted_grandchild, nullptr);
+                    EXPECT_EQ(pasted_grandchild->type, source_grandchild->type);
+                    EXPECT_EQ(pasted_grandchild->local_transform.get(), source_grandchild->local_transform.get());
+                    EXPECT_NE(pasted_grandchild->uuid, source_grandchild->uuid);
+                    EXPECT_EQ(pasted_grandchild->name, source_grandchild->name + " 1");
+                }
+            }
+        }
+
+        ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+        EXPECT_EQ(scene_state(*manager_), before);
+    }
+
+    TEST_F(SceneGraphFuzzTest, CopyPasteGroupHierarchyCanBeRepeatedAfterSourceDelete) {
+        seed_scene();
+        const auto& scene = manager_->getScene();
+        const NodeId left = scene.getNodeIdByName("left");
+        manager_->selectNode(left);
+        ASSERT_TRUE(manager_->copySelectedNodes());
+        ASSERT_EQ(manager_->pasteNodes().size(), 1u);
+        ASSERT_EQ(manager_->pasteNodes().size(), 1u);
+        ASSERT_TRUE(manager_->removeNodeWithResult(left));
+        ASSERT_EQ(manager_->pasteNodes().size(), 1u);
+        check_scene_invariants(*manager_);
+    }
+
+    TEST_F(SceneGraphFuzzTest, MergeBakesChildWorldTransforms) {
+        auto& scene = manager_->getScene();
+        const NodeId group = scene.addGroup("merge");
+        const NodeId child = scene.addSplat("child", make_cpu_splat(2, 3.0f), group);
+        ASSERT_NE(group, lfs::core::NULL_NODE);
+        ASSERT_NE(child, lfs::core::NULL_NODE);
+        scene.setNodeTransform(group, glm::translate(glm::mat4(1.0f), glm::vec3(5.0f, 2.0f, -1.0f)));
+        scene.setNodeTransform(child, glm::translate(glm::mat4(1.0f), glm::vec3(-2.0f, 4.0f, 3.0f)));
+
+        const auto before = scene.getWorldTransform(child);
+        const auto source = scene.getNodeById(child)->model->means_raw().cpu().to_vector();
+        std::vector<float> expected;
+        for (size_t row = 0; row < 2; ++row) {
+            const glm::vec4 world = before * glm::vec4(source[row * 3], source[row * 3 + 1], source[row * 3 + 2], 1.0f);
+            expected.insert(expected.end(), {world.x, world.y, world.z});
+        }
+
+        ASSERT_EQ(manager_->mergeGroupNode(group), "merge");
+        const auto* merged = scene.getNode("merge");
+        ASSERT_NE(merged, nullptr);
+        const auto actual = merged->model->means_raw().cpu().to_vector();
+        ASSERT_EQ(actual.size(), expected.size());
+        for (size_t i = 0; i < actual.size(); ++i)
+            EXPECT_NEAR(actual[i], expected[i], 1e-4f);
+    }
+
+    TEST_F(SceneGraphFuzzTest, MergeIncludesHiddenChildModels) {
+        auto& scene = manager_->getScene();
+        const NodeId group = scene.addGroup("merge_hidden");
+        const NodeId visible_a = scene.addSplat("visible_a", make_cpu_splat(1, 1.0f), group);
+        const NodeId hidden = scene.addSplat("hidden", make_cpu_splat(2, 10.0f), group);
+        const NodeId visible_b = scene.addSplat("visible_b", make_cpu_splat(3, 20.0f), group);
+        ASSERT_NE(group, lfs::core::NULL_NODE);
+        ASSERT_NE(visible_a, lfs::core::NULL_NODE);
+        ASSERT_NE(hidden, lfs::core::NULL_NODE);
+        ASSERT_NE(visible_b, lfs::core::NULL_NODE);
+        scene.setNodeVisibility(hidden, false);
+
+        ASSERT_EQ(manager_->mergeGroupNode(group), "merge_hidden");
+        const auto* merged = scene.getNode("merge_hidden");
+        ASSERT_NE(merged, nullptr);
+        ASSERT_NE(merged->model, nullptr);
+        EXPECT_EQ(merged->model->size(), 6);
+        const auto means = merged->model->means_raw().cpu().to_vector();
+        ASSERT_EQ(means.size(), 18u);
+        EXPECT_FLOAT_EQ(means[0], 1.0f);
+        EXPECT_FLOAT_EQ(means[3], 10.0f);
+        EXPECT_FLOAT_EQ(means[6], 11.0f);
+        EXPECT_FLOAT_EQ(means[9], 20.0f);
+        EXPECT_FLOAT_EQ(means[15], 22.0f);
+    }
+
+    TEST_F(SceneGraphFuzzTest, LockedNodeRejectsTransformMoveDeleteAndDuplicate) {
+        seed_scene();
+        auto& scene = manager_->getScene();
+        const NodeId locked = scene.getNodeIdByName("a");
+        const NodeId destination = scene.getNodeIdByName("right");
+        const auto before_transform = scene.getNodeTransform(locked);
+        const auto before_parent = scene.getNodeById(locked)->parent_id;
+        const size_t before_count = scene.getNodeCount();
+        scene.setNodeLocked("a", true);
+
+        EXPECT_FALSE(manager_->setNodeTransform("a", glm::translate(glm::mat4(1.0f), glm::vec3(4.0f))));
+        EXPECT_FALSE(manager_->moveNode(locked, destination, 0));
+        EXPECT_FALSE(manager_->reparentNode(locked, lfs::core::NULL_NODE));
+        const auto delete_result = manager_->removeNodeWithResult(locked);
+        ASSERT_FALSE(delete_result);
+        EXPECT_NE(delete_result.error().find("node is locked"), std::string::npos);
+        EXPECT_TRUE(manager_->duplicateNodeTree(locked).empty());
+        EXPECT_EQ(scene.getNodeCount(), before_count);
+        EXPECT_EQ(scene.getNodeById(locked)->parent_id, before_parent);
+        EXPECT_EQ(scene.getNodeTransform(locked), before_transform);
+        EXPECT_EQ(lfs::vis::op::undoHistory().undoCount(), 0u);
+    }
+
+    TEST_F(SceneGraphFuzzTest, RenameRejectsExistingName) {
+        auto& scene = manager_->getScene();
+        const NodeId first = scene.addSplat("first", make_cpu_splat(1, 0.0f));
+        const NodeId second = scene.addSplat("second", make_cpu_splat(1, 1.0f));
+        ASSERT_NE(first, lfs::core::NULL_NODE);
+        ASSERT_NE(second, lfs::core::NULL_NODE);
+
+        EXPECT_FALSE(manager_->renameNode(first, "second"));
+        EXPECT_NE(scene.getNode("first"), nullptr);
+        EXPECT_NE(scene.getNode("second"), nullptr);
+        EXPECT_EQ(lfs::vis::op::undoHistory().undoCount(), 0u);
+    }
+
+    TEST_F(SceneGraphFuzzTest, SeededOperationSequencesPreserveSceneInvariants) {
+        constexpr int seed_count = 200;
+        constexpr int operations_per_seed = 60;
+        struct UndoFrame {
+            std::string before;
+            std::string after;
+            std::string before_graph;
+            std::string after_graph;
+            std::unordered_map<lfs::core::Uuid, NodeId> before_ids;
+            std::unordered_map<lfs::core::Uuid, NodeId> after_ids;
+            int kind = -1;
+            bool stable_common_ids = false;
+        };
+        for (int seed = 0; seed < seed_count; ++seed) {
+            manager_->clearSelection();
+            manager_->getScene().clear();
+            lfs::vis::op::undoHistory().clear();
+            seed_scene();
+            std::mt19937 rng(static_cast<uint32_t>(0x51CE'0000u + seed));
+            std::vector<UndoFrame> undo_frames;
+            std::vector<UndoFrame> redo_frames;
+
+            for (int operation = 0; operation < operations_per_seed; ++operation) {
+                auto nodes = manager_->getScene().getNodes();
+                if (nodes.empty()) {
+                    seed_scene();
+                    nodes = manager_->getScene().getNodes();
+                }
+                const auto pick = [&](const bool group_only = false) -> const lfs::core::SceneNode* {
+                    std::vector<const lfs::core::SceneNode*> candidates;
+                    for (const auto* node : nodes)
+                        if (node && (!group_only || node->type == NodeType::GROUP))
+                            candidates.push_back(node);
+                    return candidates.empty() ? nullptr : candidates[rng() % candidates.size()];
+                };
+
+                std::string before = scene_state(*manager_);
+                const std::string before_graph = scene_state(*manager_, false);
+                const auto before_ids = node_ids_by_uuid(*manager_);
+                const size_t undo_before = lfs::vis::op::undoHistory().undoCount();
+                const int kind = static_cast<int>(rng() % 18);
+                bool changed = false;
+                bool history_candidate = false;
+                bool history_navigation = false;
+                bool untracked_mutation = false;
+                std::string operation_error;
+                switch (kind) {
+                case 0:
+                    changed = !manager_->addGroupNode(std::format("g_{}_{}", seed, operation)).empty();
+                    history_candidate = changed;
+                    break;
+                case 1: {
+                    const auto* node = pick();
+                    changed = node && !manager_->duplicateNodeTree(node->id).empty();
+                    history_candidate = changed;
+                    break;
+                }
+                case 2: {
+                    const auto* node = pick();
+                    if (node) {
+                        if ((rng() & 1u) != 0 && nodes.size() > 1) {
+                            const auto* other = nodes[rng() % nodes.size()];
+                            changed = other != node && manager_->renameNode(node->id, other->name);
+                        } else {
+                            changed = manager_->renameNode(node->id, std::format("r_{}_{}", seed, operation));
+                        }
+                    }
+                    history_candidate = changed;
+                    break;
+                }
+                case 3: {
+                    const auto* node = pick();
+                    if (node) {
+                        const auto destination_kind = rng() % 4;
+                        NodeId destination = lfs::core::NULL_NODE;
+                        if (destination_kind == 1) {
+                            destination = node->id;
+                        } else if (destination_kind == 2 && !nodes.empty()) {
+                            destination = nodes[rng() % nodes.size()]->id;
+                        } else if (destination_kind == 3) {
+                            if (const auto* parent = pick(true))
+                                destination = parent->id;
+                        }
+                        changed = manager_->reparentNode(node->id, destination);
+                    }
+                    history_candidate = changed;
+                    break;
+                }
+                case 4: {
+                    const auto* node = pick();
+                    const auto* parent = (rng() & 1u) != 0 ? pick(true) : pick();
+                    if (node && parent) {
+                        const auto index_kind = rng() % 5;
+                        const int index = index_kind == 0
+                                              ? 0
+                                          : index_kind == 1
+                                              ? static_cast<int>(parent->children.size() / 2)
+                                          : index_kind == 2
+                                              ? static_cast<int>(parent->children.size())
+                                          : index_kind == 3
+                                              ? static_cast<int>(parent->children.size() + 3)
+                                              : -1;
+                        changed = manager_->moveNode(node->id, parent->id, index);
+                    }
+                    history_candidate = changed;
+                    break;
+                }
+                case 5: {
+                    std::vector<NodeId> candidates;
+                    for (const auto* node : nodes)
+                        if (node && node->type != NodeType::GROUP)
+                            candidates.push_back(node->id);
+                    if (candidates.size() >= 2) {
+                        std::ranges::shuffle(candidates, rng);
+                        changed = manager_->groupNodes({candidates[0], candidates[1]});
+                        history_candidate = changed;
+                    }
+                    break;
+                }
+                case 6: {
+                    const auto* group = pick(true);
+                    changed = group && manager_->ungroupNode(group->id);
+                    history_candidate = changed;
+                    break;
+                }
+                case 7: {
+                    const auto* node = pick();
+                    if (node) {
+                        manager_->setNodeVisibility(node->id, !static_cast<bool>(node->visible));
+                        changed = true;
+                        history_candidate = true;
+                    }
+                    break;
+                }
+                case 8: {
+                    const auto* node = pick();
+                    if (node) {
+                        manager_->selectNodesById({node->id});
+                        manager_->copySelectedNodes();
+                        if ((rng() & 1u) != 0) {
+                            const auto result = manager_->removeNodeWithResult(node->id);
+                            changed = result.has_value();
+                            history_candidate = changed;
+                        } else {
+                            changed = true;
+                            untracked_mutation = true;
+                        }
+                    }
+                    break;
+                }
+                case 9: {
+                    if (manager_->hasClipboard()) {
+                        changed = !manager_->pasteNodes().empty();
+                        history_candidate = changed;
+                    }
+                    break;
+                }
+                case 10: {
+                    const auto* group = pick(true);
+                    if (group) {
+                        changed = !manager_->mergeGroupNode(group->id).empty();
+                        history_candidate = changed;
+                    }
+                    break;
+                }
+                case 11: {
+                    const auto* node = pick();
+                    if (node) {
+                        auto transform = glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, -2.0f, 0.5f));
+                        transform = glm::rotate(transform, 0.2f, glm::vec3(0.0f, 1.0f, 0.0f));
+                        transform = glm::scale(transform, glm::vec3(1.2f, 0.8f, 1.1f));
+                        manager_->setNodeTransform(node->name, transform);
+                        changed = true;
+                        untracked_mutation = true;
+                    }
+                    break;
+                }
+                case 12: {
+                    auto& scene = manager_->getScene();
+                    const size_t capacity = scene.getSelectionCapacity(lfs::core::SelectionDomain::Splat);
+                    if (capacity > 0) {
+                        std::vector<bool> mask(capacity, false);
+                        mask[rng() % capacity] = true;
+                        scene.setSelectionMask(
+                            std::make_shared<Tensor>(Tensor::from_vector(mask, {capacity}, Device::CUDA)));
+                        // Installing this mask is part of the operation. A
+                        // failed delete must preserve the state after this
+                        // intentional selection change.
+                        before = scene_state(*manager_);
+                        const auto result = manager_->softDeleteSelectedGaussians();
+                        if (!result)
+                            operation_error = result.error();
+                        changed = result.has_value();
+                        untracked_mutation = changed;
+                    }
+                    break;
+                }
+                case 13:
+                    history_navigation = true;
+                    if (!undo_frames.empty() && lfs::vis::op::undoHistory().canUndo() &&
+                        (redo_frames.empty() || (rng() & 1u) == 0)) {
+                        const auto frame = undo_frames.back();
+                        const auto result = lfs::vis::op::undoHistory().undo();
+                        ASSERT_TRUE(result.success) << result.error;
+                        EXPECT_EQ(scene_state(*manager_, false), frame.before_graph)
+                            << "seed=" << seed << " operation=" << operation << " kind=" << frame.kind;
+                        if (frame.stable_common_ids)
+                            expect_common_node_ids(*manager_, frame.before_ids, frame.after_ids,
+                                                   seed, operation, frame.kind);
+                        undo_frames.pop_back();
+                        redo_frames.push_back(frame);
+                    } else if (!redo_frames.empty() && lfs::vis::op::undoHistory().canRedo()) {
+                        const auto frame = redo_frames.back();
+                        const auto result = lfs::vis::op::undoHistory().redo();
+                        ASSERT_TRUE(result.success) << result.error;
+                        EXPECT_EQ(scene_state(*manager_, false), frame.after_graph)
+                            << "seed=" << seed << " operation=" << operation << " kind=" << frame.kind;
+                        if (frame.stable_common_ids)
+                            expect_common_node_ids(*manager_, frame.before_ids, frame.after_ids,
+                                                   seed, operation, frame.kind);
+                        redo_frames.pop_back();
+                        undo_frames.push_back(frame);
+                    }
+                    break;
+                case 14: {
+                    if (nodes.size() >= 2) {
+                        const auto* first = nodes[rng() % nodes.size()];
+                        const auto* second = nodes[rng() % nodes.size()];
+                        if (first != second) {
+                            const auto result = manager_->removeNodesByIdsWithResult(
+                                {first->id, second->id}, (rng() & 1u) != 0);
+                            changed = static_cast<bool>(result);
+                            history_candidate = changed;
+                        }
+                    }
+                    break;
+                }
+                case 15: {
+                    const auto* parent = (rng() & 1u) != 0 ? pick() : nullptr;
+                    changed = manager_->getScene().addSplat(
+                                  std::format("s_{}_{}", seed, operation),
+                                  make_cuda_splat(1 + rng() % 3, static_cast<float>(operation)),
+                                  parent ? parent->id : lfs::core::NULL_NODE) !=
+                              lfs::core::NULL_NODE;
+                    untracked_mutation = changed;
+                    break;
+                }
+                case 16: {
+                    const size_t removed = manager_->applyDeleted();
+                    changed = removed > 0;
+                    untracked_mutation = changed;
+                    break;
+                }
+                case 17: {
+                    const auto* node = pick();
+                    if (node && node->type == NodeType::SPLAT && node->model && node->model->size() > 0) {
+                        const auto options = lfs::vis::op::SceneGraphCaptureOptions{
+                            .mode = lfs::vis::op::SceneGraphCaptureMode::FULL,
+                            .include_selected_nodes = false,
+                            .include_scene_context = false,
+                        };
+                        auto payload_before = lfs::vis::op::SceneGraphPatchEntry::captureStateByIds(
+                            *manager_, manager_->getScene().getRootNodes(), options);
+                        std::vector<bool> mask(static_cast<size_t>(node->model->size()), false);
+                        mask[rng() % mask.size()] = true;
+                        const auto mask_tensor = Tensor::from_vector(
+                                                     mask, {mask.size()}, Device::CPU)
+                                                     .to(node->model->means_raw().device());
+                        node->model->soft_delete(mask_tensor);
+                        manager_->getScene().markPayloadDiverged(node->id);
+                        manager_->getScene().notifyMutation(lfs::core::Scene::MutationType::MODEL_CHANGED);
+                        auto payload_after = lfs::vis::op::SceneGraphPatchEntry::captureStateByIds(
+                            *manager_, manager_->getScene().getRootNodes(), options);
+                        lfs::vis::op::undoHistory().push(std::make_unique<lfs::vis::op::SceneGraphPatchEntry>(
+                            *manager_,
+                            "Fuzz Payload Mutation",
+                            std::move(payload_before),
+                            std::move(payload_after)));
+                        changed = true;
+                        history_candidate = true;
+                    }
+                    break;
+                }
+                }
+
+                check_scene_invariants(*manager_);
+                const std::string after = scene_state(*manager_);
+                const std::string after_graph = scene_state(*manager_, false);
+                const auto after_ids = node_ids_by_uuid(*manager_);
+                const size_t undo_after = lfs::vis::op::undoHistory().undoCount();
+                if (!changed && !history_candidate && !history_navigation)
+                    EXPECT_EQ(after, before)
+                        << "seed=" << seed << " operation=" << operation << " kind=" << kind
+                        << " error=" << operation_error;
+                if (history_candidate && undo_after == undo_before + 1) {
+                    undo_frames.push_back(UndoFrame{
+                        .before = before,
+                        .after = after,
+                        .before_graph = before_graph,
+                        .after_graph = after_graph,
+                        .before_ids = before_ids,
+                        .after_ids = after_ids,
+                        .kind = kind,
+                        .stable_common_ids = kind == 3 || kind == 4 || kind == 5 || kind == 6 || kind == 17,
+                    });
+                    redo_frames.clear();
+                }
+                if (untracked_mutation) {
+                    undo_frames.clear();
+                    redo_frames.clear();
+                }
+            }
+        }
+    }
+
+} // namespace

--- a/tests/test_sdl_rml_key_mapping.cpp
+++ b/tests/test_sdl_rml_key_mapping.cpp
@@ -19,6 +19,19 @@ namespace {
         EXPECT_EQ(lfs::vis::gui::sdlScancodeToRml(SDL_SCANCODE_EQUALS), Rml::Input::KI_OEM_PLUS);
     }
 
+    TEST(SdlRmlKeyMappingTest, ScancodeAndKeycodeMappingsStayInSync) {
+        for (int value = 0; value < SDL_SCANCODE_COUNT; ++value) {
+            const auto scancode = static_cast<SDL_Scancode>(value);
+            const auto keycode = SDL_GetKeyFromScancode(scancode, SDL_KMOD_NONE, false);
+            const auto keycode_mapping = lfs::vis::gui::sdlKeycodeToRml(keycode);
+            if (keycode_mapping == Rml::Input::KI_UNKNOWN)
+                continue;
+
+            EXPECT_EQ(lfs::vis::gui::sdlScancodeToRml(scancode), keycode_mapping)
+                << "scancode=" << value << " keycode=" << keycode;
+        }
+    }
+
     TEST(SdlKeyMappingTest, NumpadScancodesMapToAppKeys) {
         EXPECT_EQ(lfs::vis::input::sdlScancodeToAppKey(SDL_SCANCODE_KP_0), lfs::vis::input::KEY_KP_0);
         EXPECT_EQ(lfs::vis::input::sdlScancodeToAppKey(SDL_SCANCODE_KP_1), lfs::vis::input::KEY_KP_1);

--- a/tests/test_undo_history.cpp
+++ b/tests/test_undo_history.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <any>
 #include <condition_variable>
+#include <cstdint>
 #include <filesystem>
 #include <future>
 #include <glm/gtc/matrix_transform.hpp>
@@ -3012,6 +3013,51 @@ TEST_F(UndoHistoryTest, RapidVisibilityChangesMergeIntoSingleUndoStep) {
 
     lfs::vis::op::undoHistory().redo();
     EXPECT_FALSE(static_cast<bool>(node->visible));
+}
+
+TEST_F(UndoHistoryTest, RapidVisibilityCommandsMergeIntoSingleUndoStep) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    const auto node_id = scene_manager->getScene().addSplat(
+        "model", make_test_splat({0.0f, 0.0f, 0.0f}));
+    ASSERT_NE(node_id, lfs::core::NULL_NODE);
+
+    lfs::core::events::cmd::SetNodeVisibilityById{.node_id = static_cast<std::int32_t>(node_id),
+                                                  .visible = false}
+        .emit();
+    lfs::core::events::cmd::SetNodeVisibilityById{.node_id = static_cast<std::int32_t>(node_id),
+                                                  .visible = true}
+        .emit();
+    lfs::core::events::cmd::SetNodeVisibilityById{.node_id = static_cast<std::int32_t>(node_id),
+                                                  .visible = false}
+        .emit();
+
+    ASSERT_EQ(lfs::vis::op::undoHistory().undoCount(), 1u);
+    EXPECT_EQ(lfs::vis::op::undoHistory().undoName(), "Set Visibility");
+}
+
+TEST_F(UndoHistoryTest, VisibilityCommandsOutsideMergeWindowStaySeparate) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    const auto node_id = scene_manager->getScene().addSplat(
+        "model", make_test_splat({0.0f, 0.0f, 0.0f}));
+    ASSERT_NE(node_id, lfs::core::NULL_NODE);
+
+    lfs::core::events::cmd::SetNodeVisibilityById{.node_id = static_cast<std::int32_t>(node_id),
+                                                  .visible = false}
+        .emit();
+    std::this_thread::sleep_for(std::chrono::milliseconds(650));
+    lfs::core::events::cmd::SetNodeVisibilityById{.node_id = static_cast<std::int32_t>(node_id),
+                                                  .visible = true}
+        .emit();
+
+    EXPECT_EQ(lfs::vis::op::undoHistory().undoCount(), 2u);
 }
 
 TEST_F(UndoHistoryTest, RapidLockChangesMergeIntoSingleUndoStep) {

--- a/tests/test_undo_history.cpp
+++ b/tests/test_undo_history.cpp
@@ -1356,6 +1356,73 @@ TEST_F(UndoHistoryTest, GaussianShWriteScattersOnlySelectedRowsAndIsUndoable) {
               std::vector<float>(replacement.begin() + 9, replacement.end()));
 }
 
+TEST_F(UndoHistoryTest, DeleteSplatUndoRestoresVisibleCropBox) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    auto& scene = scene_manager->getScene();
+    const auto splat_id = scene.addSplat("model", make_test_splat({0.0f, 0.0f, 0.0f}));
+    const auto cropbox_id = scene.addCropBox("model_cropbox", splat_id);
+    ASSERT_NE(splat_id, lfs::core::NULL_NODE);
+    ASSERT_NE(cropbox_id, lfs::core::NULL_NODE);
+    scene.setNodeVisibility(cropbox_id, true);
+    auto* cropbox = scene.getMutableNode("model_cropbox");
+    ASSERT_NE(cropbox, nullptr);
+    ASSERT_NE(cropbox->cropbox, nullptr);
+    cropbox->cropbox->enabled = true;
+    const auto expected_data = *cropbox->cropbox;
+
+    ASSERT_TRUE(scene_manager->removeNodeWithResult(splat_id));
+    ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+
+    const auto* restored_splat = scene.getNode("model");
+    ASSERT_NE(restored_splat, nullptr);
+    const auto restored_cropbox_id = scene.getCropBoxForSplat(restored_splat->id);
+    ASSERT_NE(restored_cropbox_id, lfs::core::NULL_NODE);
+    const auto* restored_cropbox = scene.getNodeById(restored_cropbox_id);
+    ASSERT_NE(restored_cropbox, nullptr);
+    ASSERT_NE(restored_cropbox->cropbox, nullptr);
+    EXPECT_TRUE(restored_cropbox->visible);
+    EXPECT_EQ(restored_cropbox->cropbox->min, expected_data.min);
+    EXPECT_EQ(restored_cropbox->cropbox->max, expected_data.max);
+    EXPECT_EQ(restored_cropbox->cropbox->inverse, expected_data.inverse);
+    EXPECT_EQ(restored_cropbox->cropbox->enabled, expected_data.enabled);
+}
+
+TEST_F(UndoHistoryTest, CropBoxIsAppliedWhenMergingGroup) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    auto& scene = scene_manager->getScene();
+    const auto group_id = scene.addGroup("group");
+    const auto splat_id = scene.addSplat(
+        "model",
+        make_test_splat({-2.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 2.0f, 0.0f, 0.0f}),
+        group_id);
+    const auto cropbox_id = scene.addCropBox("model_cropbox", splat_id);
+    ASSERT_NE(group_id, lfs::core::NULL_NODE);
+    ASSERT_NE(splat_id, lfs::core::NULL_NODE);
+    ASSERT_NE(cropbox_id, lfs::core::NULL_NODE);
+    auto* cropbox = scene.getMutableNode("model_cropbox");
+    ASSERT_NE(cropbox, nullptr);
+    ASSERT_NE(cropbox->cropbox, nullptr);
+    cropbox->cropbox->min = glm::vec3(-0.5f);
+    cropbox->cropbox->max = glm::vec3(0.5f);
+    cropbox->cropbox->enabled = true;
+
+    ASSERT_EQ(scene_manager->mergeGroupNode(group_id), "group");
+    const auto* merged = scene.getNode("group");
+    ASSERT_NE(merged, nullptr);
+    ASSERT_NE(merged->model, nullptr);
+    EXPECT_EQ(merged->model->size(), 1);
+    EXPECT_EQ(merged->model->means_raw().cpu().to_vector(),
+              (std::vector<float>{0.0f, 0.0f, 0.0f}));
+}
+
 TEST_F(UndoHistoryTest, CropBoxCapabilityUndoRestoresNodeVisibilityAndEnabledState) {
     auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
     auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
@@ -2754,6 +2821,55 @@ TEST_F(UndoHistoryTest, CameraDeleteUndoRepublishesCameraCount) {
     EXPECT_EQ(scene.getNode("a.png"), nullptr);
     EXPECT_EQ(scene.getAllCameras().size(), 1u);
     EXPECT_EQ(lfs::vis::app_store().import_overlay_state.get().num_images, 1u);
+}
+
+TEST_F(UndoHistoryTest, CameraBatchDeleteUndoRestoresOrderAndId) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    auto rendering_manager = std::make_unique<lfs::vis::RenderingManager>();
+    lfs::vis::services().set(scene_manager.get());
+    lfs::vis::services().set(rendering_manager.get());
+
+    auto& scene = scene_manager->getScene();
+    const auto cameras_id = scene.addGroup("Cameras");
+    const auto training_id = scene.addCameraGroup("Training", cameras_id, 3);
+    const auto first_id = scene.addCamera("first.png", training_id, make_test_camera("first.png", 1));
+    const auto second_id = scene.addCamera("second.png", training_id, make_test_camera("second.png", 2));
+    const auto third_id = scene.addCamera("third.png", training_id, make_test_camera("third.png", 3));
+    ASSERT_NE(first_id, lfs::core::NULL_NODE);
+    ASSERT_NE(second_id, lfs::core::NULL_NODE);
+    ASSERT_NE(third_id, lfs::core::NULL_NODE);
+    const auto expected_children = scene.getNodeById(training_id)->children;
+
+    const auto remove_result = scene_manager->removeNodesByIdsWithResult({first_id}, false);
+    ASSERT_TRUE(remove_result) << (remove_result ? "" : remove_result.error());
+    ASSERT_TRUE(lfs::vis::op::undoHistory().undo().success);
+
+    ASSERT_NE(scene.getNodeById(first_id), nullptr);
+    EXPECT_EQ(scene.getNodeById(training_id)->children, expected_children);
+    EXPECT_EQ(scene.getNodeById(second_id)->parent_id, training_id);
+    EXPECT_EQ(scene.getNodeById(third_id)->parent_id, training_id);
+}
+
+TEST_F(UndoHistoryTest, DeleteUndoEntriesReplayAfterFreshIdRestore) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    lfs::vis::services().set(scene_manager.get());
+    auto& scene = scene_manager->getScene();
+
+    const auto first_id = scene.addGroup("first");
+    const auto second_id = scene.addGroup("second");
+    ASSERT_NE(first_id, lfs::core::NULL_NODE);
+    ASSERT_NE(second_id, lfs::core::NULL_NODE);
+    const auto first_uuid = scene.getNodeUuid(first_id);
+    const auto second_uuid = scene.getNodeUuid(second_id);
+
+    ASSERT_TRUE(scene_manager->removeNodeWithResult(first_id));
+    ASSERT_TRUE(scene_manager->removeNodeWithResult(second_id));
+    auto result = lfs::vis::op::undoHistory().undo();
+    ASSERT_TRUE(result.success) << result.error;
+    result = lfs::vis::op::undoHistory().undo();
+    ASSERT_TRUE(result.success) << result.error;
+    EXPECT_NE(scene.getNodeByUuid(first_uuid), nullptr);
+    EXPECT_NE(scene.getNodeByUuid(second_uuid), nullptr);
 }
 
 TEST_F(UndoHistoryTest, RenameNodeCreatesUndoableSceneGraphEntry) {

--- a/tests/test_undo_history.cpp
+++ b/tests/test_undo_history.cpp
@@ -29,7 +29,9 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <ranges>
 #include <stdexcept>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -2531,6 +2533,137 @@ TEST_F(UndoHistoryTest, DuplicateSelectedNodeClonesSliceUnderNewUuid) {
     ASSERT_NE(scene.getNodeByUuid(duplicate_uuid), nullptr);
     EXPECT_EQ(selection_mask_values(scene),
               (std::vector<uint8_t>{0, 6, 0, 0, 6, 0}));
+}
+
+TEST_F(UndoHistoryTest, SceneGraphPatchPayloadCaptureIsOperationScoped) {
+    auto scene_manager = std::make_unique<lfs::vis::SceneManager>();
+    lfs::vis::services().set(scene_manager.get());
+    auto& scene = scene_manager->getScene();
+    scene_manager->changeContentType(lfs::vis::SceneManager::ContentType::SplatFiles);
+
+    const auto payload_bytes = [](const lfs::core::SplatData& model) {
+        return model.means_raw().bytes() + model.sh0_raw().bytes() + model.shN_raw().bytes() +
+               model.scaling_raw().bytes() + model.rotation_raw().bytes() + model.opacity_raw().bytes() +
+               (model.has_deleted_mask() ? model.deleted().bytes() : 0u) +
+               (model._densification_info.is_valid() ? model._densification_info.bytes() : 0u);
+    };
+
+    const auto graph_signature = [&] {
+        std::vector<std::string> result;
+        const auto visit = [&](const auto& self, const lfs::core::NodeId id) -> void {
+            const auto* node = scene.getNodeById(id);
+            if (!node) {
+                return;
+            }
+            const auto parent_uuid = node->parent_id == lfs::core::NULL_NODE
+                                         ? lfs::core::Uuid{}
+                                         : scene.getNodeUuid(node->parent_id);
+            std::string row = node->uuid.to_string() + "|" + parent_uuid.to_string() + "|" + node->name + "|" +
+                              std::to_string(static_cast<int>(node->type)) + "|";
+            if (node->model) {
+                const auto means = node->model->means_raw().cpu().to_vector();
+                row += std::to_string(node->model->size()) + "|";
+                if (!means.empty()) {
+                    row += std::to_string(means.front()) + "|" + std::to_string(means[means.size() - 3]);
+                }
+                if (node->model->has_deleted_mask()) {
+                    row += "|" + std::to_string(node->model->deleted().count_nonzero());
+                }
+            }
+            result.push_back(std::move(row));
+            for (const auto child_id : node->children) {
+                self(self, child_id);
+            }
+        };
+        for (const auto root_id : scene.getRootNodes()) {
+            visit(visit, root_id);
+        }
+        return result;
+    };
+
+    const auto check_round_trip = [&](const std::vector<std::string>& before,
+                                      const std::vector<std::string>& after) {
+        auto result = lfs::vis::op::undoHistory().undo();
+        ASSERT_TRUE(result.success) << result.error;
+        EXPECT_EQ(graph_signature(), before);
+        result = lfs::vis::op::undoHistory().redo();
+        ASSERT_TRUE(result.success) << result.error;
+        EXPECT_EQ(graph_signature(), after);
+        result = lfs::vis::op::undoHistory().undo();
+        ASSERT_TRUE(result.success) << result.error;
+        EXPECT_EQ(graph_signature(), before);
+        result = lfs::vis::op::undoHistory().redo();
+        ASSERT_TRUE(result.success) << result.error;
+    };
+
+    std::vector<lfs::core::NodeId> node_ids;
+    node_ids.reserve(10);
+    for (int i = 0; i < 10; ++i) {
+        const auto id = scene.addSplat("model_" + std::to_string(i), make_linear_test_splat(10000));
+        ASSERT_NE(id, lfs::core::NULL_NODE);
+        node_ids.push_back(id);
+    }
+
+    const auto empty_group = scene.addGroup("empty_group");
+    ASSERT_NE(empty_group, lfs::core::NULL_NODE);
+    const auto empty_group_before = graph_signature();
+    ASSERT_TRUE(scene_manager->removeNodesByIdsWithResult({empty_group}, false));
+    const auto empty_group_after = graph_signature();
+    ASSERT_EQ(lfs::vis::op::undoHistory().undoItems().back().metadata.label, "Delete Nodes");
+    EXPECT_LT(lfs::vis::op::undoHistory().undoItems().back().estimated_bytes, 64u * 1024u);
+    check_round_trip(empty_group_before, empty_group_after);
+
+    const auto* deleted_node = scene.getNodeById(node_ids.front());
+    ASSERT_NE(deleted_node, nullptr);
+    ASSERT_NE(deleted_node->model, nullptr);
+    const size_t deleted_payload_bytes = payload_bytes(*deleted_node->model);
+    const auto delete_before = graph_signature();
+    ASSERT_TRUE(scene_manager->removeNodesByIdsWithResult({node_ids.front()}, false));
+    const auto delete_after = graph_signature();
+    EXPECT_LE(lfs::vis::op::undoHistory().undoItems().back().estimated_bytes,
+              deleted_payload_bytes * 3 / 2);
+    check_round_trip(delete_before, delete_after);
+
+    const auto* duplicate_source = scene.getNodeById(node_ids[1]);
+    ASSERT_NE(duplicate_source, nullptr);
+    ASSERT_NE(duplicate_source->model, nullptr);
+    const size_t duplicate_payload_bytes = payload_bytes(*duplicate_source->model);
+    const auto duplicate_before = graph_signature();
+    ASSERT_FALSE(scene_manager->duplicateNodeTree(node_ids[1]).empty());
+    const auto duplicate_after = graph_signature();
+    EXPECT_LE(lfs::vis::op::undoHistory().undoItems().back().estimated_bytes,
+              duplicate_payload_bytes * 3 / 2);
+    check_round_trip(duplicate_before, duplicate_after);
+
+    const auto group_before = graph_signature();
+    ASSERT_TRUE(scene_manager->groupNodes({node_ids[2], node_ids[3]}));
+    const auto group_after = graph_signature();
+    EXPECT_LT(lfs::vis::op::undoHistory().undoItems().back().estimated_bytes, 64u * 1024u);
+    check_round_trip(group_before, group_after);
+
+    const auto grouped_id = [&] {
+        for (const auto* node : scene.getNodes()) {
+            if (node && node->type == lfs::core::NodeType::GROUP &&
+                std::ranges::find(node->children, node_ids[2]) != node->children.end()) {
+                return node->id;
+            }
+        }
+        return lfs::core::NULL_NODE;
+    }();
+    ASSERT_NE(grouped_id, lfs::core::NULL_NODE);
+    const auto ungroup_before = graph_signature();
+    ASSERT_TRUE(scene_manager->ungroupNode(grouped_id));
+    const auto ungroup_after = graph_signature();
+    EXPECT_LT(lfs::vis::op::undoHistory().undoItems().back().estimated_bytes, 64u * 1024u);
+    check_round_trip(ungroup_before, ungroup_after);
+
+    const auto target_group = scene.addGroup("target_group");
+    ASSERT_NE(target_group, lfs::core::NULL_NODE);
+    const auto move_before = graph_signature();
+    ASSERT_TRUE(scene_manager->moveNodes({node_ids[4]}, target_group, -1));
+    const auto move_after = graph_signature();
+    EXPECT_LT(lfs::vis::op::undoHistory().undoItems().back().estimated_bytes, 64u * 1024u);
+    check_round_trip(move_before, move_after);
 }
 
 TEST_F(UndoHistoryTest, DeletingLastNodeRemainsUndoable) {


### PR DESCRIPTION
Stress-testing the scene graph (add, duplicate, delete, merge, group, copy/paste, drag and drop, transforms, cameras, crop volumes, undo/redo) turned up a number of bugs. This fixes them.

- Undoing "Group Selected" (Ctrl+G) left the new group behind and re-created the moved nodes with new ids, which then broke older undo entries and cleared the history. Undo entries now replay by node identity, so history survives re-created nodes.
- Duplicating a group pushed three undo entries instead of one.
- Ctrl+G silently did nothing when the selection contained a group.
- Copying a group (Ctrl+C / Ctrl+V) did nothing. Groups now paste as a full hierarchy and children keep their names.
- Undo after bake transform, crop-volume conversion and similar in-place edits left the old payload in place.
- Soft-deleting selected splats could apply half of the change and then report an error.
- Deleting a camera and undoing it moved the camera to the end of its group. Select all + Delete did nothing.
- Merge silently dropped hidden children and ignored crop boxes. Locked nodes could still be moved, transformed, deleted and duplicated.
- Batch delete is one undo step; duplicate ids are rejected; nodes cannot be parented under a splat leaf.
- Escape never reached any RmlUi panel or modal (missing scancode mapping). The scene panel now supports Escape, arrow-key navigation with Shift ranges, Left/Right collapse and expand, Home/End; rapid eye-icon toggles coalesce into one undo entry.
- Undo entries for delete, duplicate, ungroup and merge snapshotted every model in the scene (1.7 GB and 1 s per operation in a 5.8M-splat scene, history evicted after one step). They now keep only the payloads the operation removes or creates.
- Combined-model worker drain fixes a failing consolidation test on master. Python `local_transform` no longer raises; F2 rename selects the whole name.

Each fix comes with a regression test in `tests/test_scene_graph_fuzz.cpp`, plus a seeded randomized scene-graph fuzzer that checks structure, counts, transform bake and undo/redo round-trips.

Verification: every bug was first reproduced in the running app on master (Ctrl+G then Ctrl+Z leaving an empty group and clearing history, three undo entries for a duplicated group, silent Ctrl+G and Ctrl+V, camera returning at the end of its group, and so on). With master's core library swapped underneath the new test binary, 9 of the regression tests fail; with the fixes all 27 pass, and the full C++ suite shows no new failures.
