### PR TITLE
Tests: skip missing local PLY fixture, isolate VRAM profiler order test

### DIFF
--- a/src/core/tensor/internal/tensor_impl.hpp
+++ b/src/core/tensor/internal/tensor_impl.hpp
@@ -1060,8 +1060,18 @@ namespace lfs::core {
                 const TensorShape shp = shape_;
                 // Stamp stream hint like TensorExpr::operator Tensor so deferred
                 // large binaries keep cross-stream ordering (D4 / stream tests).
-                const cudaStream_t stream_hint =
-                    (dev == Device::CUDA) ? getCurrentCUDAStream() : nullptr;
+                const cudaStream_t stream_hint = [&] {
+                    if (dev != Device::CUDA) {
+                        return static_cast<cudaStream_t>(nullptr);
+                    }
+                    if (const cudaStream_t current = getCurrentCUDAStream()) {
+                        return current;
+                    }
+                    if (const cudaStream_t lhs_stream = lhs_source.stream()) {
+                        return lhs_stream;
+                    }
+                    return rhs_operand.stream();
+                }();
                 Tensor result = make_deferred_expr_tensor(
                     shp, dev, DataType::Float32,
                     [lhs_source, rhs_operand, op, shp, dev, stream_hint]() mutable {

--- a/src/core/tensor/tensor_fused_pointwise.cu
+++ b/src/core/tensor/tensor_fused_pointwise.cu
@@ -441,6 +441,30 @@ namespace lfs::core::tensor_ops {
             }
         }
 
+        __global__ void fused_tiny_segmented_transform_reduce_kernel(
+            const float* __restrict__ input,
+            float* __restrict__ output,
+            size_t num_segments,
+            size_t segment_size,
+            FusedPointwiseOpChain chain,
+            int reduce_op_int) {
+            const size_t seg = blockIdx.x * blockDim.x + threadIdx.x;
+            if (seg >= num_segments) {
+                return;
+            }
+
+            const size_t seg_base = seg * segment_size;
+            float acc = reduce_identity(reduce_op_int);
+            for (size_t i = 0; i < segment_size; ++i) {
+                acc = reduce_combine(
+                    acc, apply_chain(input[seg_base + i], chain, seg_base + i), reduce_op_int);
+            }
+            if (reduce_op_int == 1) {
+                acc *= (1.0f / static_cast<float>(segment_size));
+            }
+            output[seg] = acc;
+        }
+
     } // namespace
 
     void launch_fused_segmented_transform_reduce(
@@ -458,10 +482,17 @@ namespace lfs::core::tensor_ops {
         const int reduce_op_int = static_cast<int>(reduce_op);
         assert(reduce_op_int >= 0 && reduce_op_int <= 4);
 
-        const int grid_size = static_cast<int>(std::min(num_segments, size_t(2048)));
-        fused_segmented_transform_reduce_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
-            input, output, num_segments, segment_size, chain, reduce_op_int);
-        LFS_CUDA_LAUNCH_CHECK(stream, "tensor.fused_pointwise.segmented_transform_reduce");
+        if (segment_size < 32) {
+            const int grid_size = static_cast<int>((num_segments + BLOCK_SIZE - 1) / BLOCK_SIZE);
+            fused_tiny_segmented_transform_reduce_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
+                input, output, num_segments, segment_size, chain, reduce_op_int);
+            LFS_CUDA_LAUNCH_CHECK(stream, "tensor.fused_pointwise.tiny_segmented_transform_reduce");
+        } else {
+            const int grid_size = static_cast<int>(std::min(num_segments, size_t(2048)));
+            fused_segmented_transform_reduce_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
+                input, output, num_segments, segment_size, chain, reduce_op_int);
+            LFS_CUDA_LAUNCH_CHECK(stream, "tensor.fused_pointwise.segmented_transform_reduce");
+        }
         record_tensor_kernel_launch(1);
     }
 

--- a/src/core/tensor/tensor_unified_ops.cpp
+++ b/src/core/tensor/tensor_unified_ops.cpp
@@ -1611,6 +1611,9 @@ namespace lfs::core {
         }
 
         auto result = Tensor::empty(TensorShape(out_shape), input->device_, out_dtype);
+        if (input->device_ == Device::CUDA) {
+            result.set_stream(getCurrentCUDAStream());
+        }
 
         if (input->device_ == Device::CUDA) {
             pin_operands({input});

--- a/tests/test_ply_q16_streamed_encode.cpp
+++ b/tests/test_ply_q16_streamed_encode.cpp
@@ -24,11 +24,9 @@ using namespace lfs::core;
 
 namespace {
 
-    void require_cuda() {
+    [[nodiscard]] bool has_cuda_device() {
         int device_count = 0;
-        if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
-            GTEST_SKIP() << "CUDA device unavailable";
-        }
+        return cudaGetDeviceCount(&device_count) == cudaSuccess && device_count != 0;
     }
 
     Tensor retag_external(Tensor tensor, std::string kind) {
@@ -88,10 +86,8 @@ namespace {
         return std::filesystem::path(PROJECT_ROOT_PATH) / "gd.ply";
     }
 
-    void skip_if_missing_gd_ply() {
-        if (!std::filesystem::exists(gd_ply_path())) {
-            GTEST_SKIP() << "Missing test asset: " << gd_ply_path();
-        }
+    [[nodiscard]] bool gd_ply_exists() {
+        return std::filesystem::exists(gd_ply_path());
     }
 
     SplatData load_ply_q16(std::vector<AllocCall>& calls) {
@@ -146,8 +142,12 @@ namespace {
 } // namespace
 
 TEST(PlyQ16StreamedEncode, GdPlyMatchesSingleShotAndSkipsFloatShN) {
-    require_cuda();
-    skip_if_missing_gd_ply();
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device unavailable";
+    }
+    if (!gd_ply_exists()) {
+        GTEST_SKIP() << "Missing test asset: " << gd_ply_path();
+    }
 
     std::vector<AllocCall> calls_single_shot;
     SplatData single_shot = load_ply_then_quant(calls_single_shot);
@@ -164,8 +164,12 @@ TEST(PlyQ16StreamedEncode, GdPlyMatchesSingleShotAndSkipsFloatShN) {
 }
 
 TEST(PlyQ16StreamedEncode, BandBoundaryMatchesSingleShot) {
-    require_cuda();
-    skip_if_missing_gd_ply();
+    if (!has_cuda_device()) {
+        GTEST_SKIP() << "CUDA device unavailable";
+    }
+    if (!gd_ply_exists()) {
+        GTEST_SKIP() << "Missing test asset: " << gd_ply_path();
+    }
 
     std::vector<AllocCall> calls_single_shot;
     SplatData single_shot = load_ply_then_quant(calls_single_shot);

--- a/tests/test_vram_profiler_metrics.cpp
+++ b/tests/test_vram_profiler_metrics.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 using lfs::diagnostics::VramAllocationMethod;
 using lfs::diagnostics::VramProfiler;
@@ -102,10 +103,16 @@ namespace {
         p.recordCurrentBytes("test.medium", "tensor", 1024 * 1024, VramAllocationMethod::External);
 
         const auto snap = p.snapshot();
-        ASSERT_GE(snap.top_live.size(), 3u);
-        EXPECT_EQ(snap.top_live[0].scope, "test.large");
-        EXPECT_EQ(snap.top_live[1].scope, "test.medium");
-        EXPECT_EQ(snap.top_live[2].scope, "test.small");
+        std::vector<std::string> test_scopes;
+        for (const auto& entry : snap.top_live) {
+            if (entry.scope.starts_with("test.")) {
+                test_scopes.push_back(entry.scope);
+            }
+        }
+        ASSERT_EQ(test_scopes.size(), 3u);
+        EXPECT_EQ(test_scopes[0], "test.large");
+        EXPECT_EQ(test_scopes[1], "test.medium");
+        EXPECT_EQ(test_scopes[2], "test.small");
     }
 
     TEST_F(VramProfilerMetricsTest, TimerSampleFillsWallPercentiles) {


### PR DESCRIPTION
Three tests fail on master when the full test binary runs locally. This fixes the causes.

- The lazy tensor runtime returned wrong values for a fused reduction over rows of 3 elements (the erank test: values from row 10240 on came back as ~1.0 instead of ~2.99). Tiny segments now reduce with one thread per segment, and deferred results keep the inherited CUDA stream.
- The VRAM profiler order test compared against the process-wide profiler, so a live allocation from an earlier test changed the order. It now checks only its own scopes.
- Two PLY q16 streaming tests asserted on a developer-local file that is not in the repository. They now skip when the file is missing.
