### PR TITLE
Align scene consolidation tests with the asynchronous combined-model contract

### DIFF
--- a/tests/test_scene_consolidation.cpp
+++ b/tests/test_scene_consolidation.cpp
@@ -296,6 +296,7 @@ TEST_F(SceneConsolidationExtractTest, WorkerBuildMatchesSynchronousCombinedModel
               lfs::core::NULL_NODE);
     ASSERT_NE(synchronous.addSplat("second", std::make_unique<SplatData>(second->clone())),
               lfs::core::NULL_NODE);
+    ASSERT_EQ(synchronous.consolidateNodeModels(), 2u);
     const auto* expected = synchronous.getCombinedModel();
     ASSERT_NE(expected, nullptr);
 
@@ -304,7 +305,7 @@ TEST_F(SceneConsolidationExtractTest, WorkerBuildMatchesSynchronousCombinedModel
     EXPECT_EQ(worker_build->model->scaling_raw().to_vector(), expected->scaling_raw().to_vector());
     EXPECT_EQ(worker_build->model->rotation_raw().to_vector(), expected->rotation_raw().to_vector());
     EXPECT_EQ(worker_build->model->opacity_raw().to_vector(), expected->opacity_raw().to_vector());
-    EXPECT_EQ(worker_build->model->shN_raw().to_vector(), expected->shN_raw().to_vector());
+    expect_shN_q16(worker_build->model->shN_canonical().to_vector(), expected->shN_canonical().to_vector());
 }
 
 TEST_F(SceneConsolidationExtractTest, SceneDestructionJoinsCombinedModelWorker) {
@@ -446,6 +447,10 @@ TEST_F(SceneConsolidationExtractTest, ReplacingNodeModelRetiresPreviousUntilWork
     // rejected.
     scene.removeNodeById(second_id);
     EXPECT_EQ(scene.getCombinedModel(), replaced->model.get());
+    while (scene.combinedModelBuildPending()) {
+        std::this_thread::yield();
+        static_cast<void>(scene.getCombinedModel());
+    }
     EXPECT_FALSE(scene.combinedModelBuildPending());
 }
 


### PR DESCRIPTION
Two tests in `tests/test_scene_consolidation.cpp` fail on dev:

- `SceneConsolidationExtractTest.WorkerBuildMatchesSynchronousCombinedModel`
- `SceneConsolidationExtractTest.ReplacingNodeModelRetiresPreviousUntilWorkerPoll`

Cause: #1972 moved the combined-model build for large multi-node scenes off the main thread. `getCombinedModel()` now requests a worker build and returns null until it is polled, and `combinedModelBuildPending()` stays true until the finished worker has been consumed. Both tests still asserted the old synchronous contract. The production callers (import completion, render state, selection ops) already follow the asynchronous one, so the tests are what needed to change.

Changes:

- build the comparison model through `consolidateNodeModels()`, the explicit synchronous path, instead of a single `getCombinedModel()` call
- poll `getCombinedModel()` until `combinedModelBuildPending()` clears before asserting it, mirroring the import loop
- compare `shN` through `shN_canonical()` with the q16 tolerance the rest of the file uses; the raw storage is quantized and the two block alignments differ in the last bits

Verification: `lichtfeld_tests --gtest_filter='SceneConsolidationExtractTest.*'` goes from 8/10 to 10/10 on dev.
