### PR TITLE
Invalidate viewport state when training hands the same model to Edit Mode

### DIFF
--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -1938,13 +1938,20 @@ namespace lfs::vis {
         };
         refresh_content_flags();
         size_t model_ptr = reinterpret_cast<size_t>(model);
+        // Edit-mode handoff moves the same SplatData into a scene node. Its
+        // address does not change, but the trainer's GPU handshake is gone.
+        // Use dataset ownership, not Running/Paused, so completion alone does
+        // not reset the renderer while the trainer still owns its fences.
+        const auto model_source = scene_manager && scene_manager->hasDataset()
+                                      ? ViewportFrameLifecycleService::ModelSource::Training
+                                      : ViewportFrameLifecycleService::ModelSource::Scene;
 
         // Skip model-change tracking while the step-boundary lock is contended:
         // model_ptr is null only because densify holds exclusive, not because the
         // scene dropped the model. Treating it as a change would wipe the retained
         // last splat image (the whole point of the cadence path).
         if (!render_lock_contended) {
-            if (const auto model_change = frame_lifecycle_service_.handleModelChange(model_ptr, viewport_artifact_service_);
+            if (const auto model_change = frame_lifecycle_service_.handleModelChange(model_ptr, viewport_artifact_service_, model_source);
                 model_change.changed) {
                 invalidateGTComparisonImageCache();
                 clearVulkanViewportImageState();
@@ -2065,7 +2072,7 @@ namespace lfs::vis {
                 sample_model_under_lock();
                 refresh_content_flags();
                 model_ptr = reinterpret_cast<size_t>(model);
-                (void)frame_lifecycle_service_.handleModelChange(model_ptr, viewport_artifact_service_);
+                (void)frame_lifecycle_service_.handleModelChange(model_ptr, viewport_artifact_service_, model_source);
             }
         }
         // Scene state is authoritative here (contended frames returned above): nothing

--- a/src/visualizer/rendering/viewport_frame_lifecycle_service.cpp
+++ b/src/visualizer/rendering/viewport_frame_lifecycle_service.cpp
@@ -56,8 +56,9 @@ namespace lfs::vis {
 
     ViewportFrameLifecycleService::ModelChangeResult
     ViewportFrameLifecycleService::handleModelChange(const size_t model_ptr,
-                                                     ViewportArtifactService& viewport_artifacts) {
-        if (model_ptr == last_model_ptr_) {
+                                                     ViewportArtifactService& viewport_artifacts,
+                                                     const ModelSource source) {
+        if (model_ptr == last_model_ptr_ && source == last_model_source_) {
             return {};
         }
 
@@ -65,6 +66,7 @@ namespace lfs::vis {
             .changed = true,
             .previous_model_ptr = last_model_ptr_};
         last_model_ptr_ = model_ptr;
+        last_model_source_ = source;
         viewport_artifacts.clearViewportOutput();
         return result;
     }

--- a/src/visualizer/rendering/viewport_frame_lifecycle_service.hpp
+++ b/src/visualizer/rendering/viewport_frame_lifecycle_service.hpp
@@ -21,6 +21,11 @@ namespace lfs::vis {
 
     class LFS_VIS_API ViewportFrameLifecycleService {
     public:
+        enum class ModelSource {
+            Scene,
+            Training,
+        };
+
         struct ResizeResult {
             DirtyMask dirty = 0;
             bool completed = false;
@@ -35,7 +40,8 @@ namespace lfs::vis {
         };
 
         [[nodiscard]] ResizeResult handleViewportResize(const glm::ivec2& current_size);
-        [[nodiscard]] ModelChangeResult handleModelChange(size_t model_ptr, ViewportArtifactService& viewport_artifacts);
+        [[nodiscard]] ModelChangeResult handleModelChange(size_t model_ptr, ViewportArtifactService& viewport_artifacts,
+                                                          ModelSource source = ModelSource::Scene);
         [[nodiscard]] DirtyMask handleTrainingRefresh(bool is_training, float refresh_interval_sec);
         [[nodiscard]] DirtyMask requiredDirtyMask(bool has_viewport_output,
                                                   bool has_renderable_content,
@@ -51,12 +57,16 @@ namespace lfs::vis {
         [[nodiscard]] bool isResizeDeferring() const {
             return resize_active_.load(std::memory_order_relaxed) || resize_settle_pending_;
         }
-        void resetModelTracking() { last_model_ptr_ = 0; }
+        void resetModelTracking() {
+            last_model_ptr_ = 0;
+            last_model_source_ = ModelSource::Scene;
+        }
         [[nodiscard]] glm::ivec2 lastViewportSize() const { return last_viewport_size_; }
 
     private:
         glm::ivec2 last_viewport_size_{0, 0};
         size_t last_model_ptr_ = 0;
+        ModelSource last_model_source_ = ModelSource::Scene;
         std::chrono::steady_clock::time_point last_training_render_{};
         std::chrono::steady_clock::time_point last_resize_change_{};
         std::atomic<bool> resize_active_{false};

--- a/src/visualizer/scene/scene_manager.cpp
+++ b/src/visualizer/scene/scene_manager.cpp
@@ -3383,9 +3383,6 @@ namespace lfs::vis {
 
         core::Scene::Transaction txn(scene_);
 
-        auto splat_data = std::move(model_node->model);
-        const size_t num_gaussians = splat_data->size();
-
         // Preserve the model's world transform so the trained model
         // appears at the same position/orientation in edit mode as it
         // did during training (rendering uses getWorldTransform).
@@ -3398,6 +3395,11 @@ namespace lfs::vis {
                 return;
             }
         }
+
+        // Keep the model owned by the scene until trainer teardown succeeds:
+        // a deferred clear must not destroy it through a local unique_ptr.
+        auto splat_data = std::move(model_node->model);
+        const size_t num_gaussians = splat_data->size();
 
         scene_.clear();
         {

--- a/tests/test_rendering_refactor_services.cpp
+++ b/tests/test_rendering_refactor_services.cpp
@@ -953,6 +953,38 @@ namespace lfs::vis {
         EXPECT_EQ(scene.getVisibleNodeIndex(right_id), 1);
     }
 
+    TEST_F(SceneManagerRenderStateTest, EditHandoffInvalidatesViewportDespitePreservingModelAddress) {
+        SceneManager manager;
+        manager.changeContentType(SceneManager::ContentType::Dataset);
+        auto& scene = manager.getScene();
+        scene.addSplat("Model", makeTestSplat(0.0f));
+        scene.setTrainingModelNode("Model");
+
+        ViewportFrameLifecycleService lifecycle;
+        ViewportArtifactService artifacts;
+        const auto observe = [&] {
+            return lifecycle.handleModelChange(
+                reinterpret_cast<size_t>(manager.getModelForRendering()), artifacts,
+                manager.hasDataset() ? ViewportFrameLifecycleService::ModelSource::Training
+                                     : ViewportFrameLifecycleService::ModelSource::Scene);
+        };
+        const auto* training_model = manager.getModelForRendering();
+        ASSERT_NE(training_model, nullptr);
+        EXPECT_TRUE(observe().changed);
+        EXPECT_FALSE(observe().changed);
+        const auto generation = artifacts.artifactGeneration();
+
+        manager.switchToEditMode();
+
+        ASSERT_FALSE(manager.hasDataset());
+        ASSERT_EQ(manager.getModelForRendering(), training_model);
+        const auto handoff = observe();
+        EXPECT_TRUE(handoff.changed);
+        EXPECT_EQ(handoff.previous_model_ptr, reinterpret_cast<size_t>(training_model));
+        EXPECT_GT(artifacts.artifactGeneration(), generation);
+        EXPECT_FALSE(observe().changed);
+    }
+
     TEST_F(SceneManagerRenderStateTest, SwitchToEditModePlyComparisonUsesCombinedSceneMasks) {
         using lfs::core::DataType;
         using lfs::core::Device;
@@ -2202,6 +2234,28 @@ namespace lfs::vis {
         const auto repeated_change = service.handleModelChange(0x1234, artifacts);
         EXPECT_FALSE(repeated_change.changed);
         EXPECT_EQ(artifacts.artifactGeneration(), generation_after_first_change);
+    }
+
+    TEST(ViewportFrameLifecycleServiceTest, ModelSourceChangesInvalidateOnceInBothDirections) {
+        using Source = ViewportFrameLifecycleService::ModelSource;
+        ViewportFrameLifecycleService service;
+        ViewportArtifactService artifacts;
+
+        EXPECT_TRUE(service.handleModelChange(0x1234, artifacts, Source::Scene).changed);
+        auto generation = artifacts.artifactGeneration();
+        EXPECT_TRUE(service.handleModelChange(0x1234, artifacts, Source::Training).changed);
+        EXPECT_GT(artifacts.artifactGeneration(), generation);
+        generation = artifacts.artifactGeneration();
+        EXPECT_FALSE(service.handleModelChange(0x1234, artifacts, Source::Training).changed);
+        EXPECT_EQ(artifacts.artifactGeneration(), generation);
+        EXPECT_TRUE(service.handleModelChange(0x1234, artifacts, Source::Scene).changed);
+        EXPECT_GT(artifacts.artifactGeneration(), generation);
+        generation = artifacts.artifactGeneration();
+        EXPECT_FALSE(service.handleModelChange(0x1234, artifacts, Source::Scene).changed);
+        EXPECT_EQ(artifacts.artifactGeneration(), generation);
+
+        service.resetModelTracking();
+        EXPECT_TRUE(service.handleModelChange(0x1234, artifacts, Source::Training).changed);
     }
 
     TEST(ViewportArtifactServiceTest, ExplicitSplitPanelSamplingUsesPanelLocalCoordinates) {


### PR DESCRIPTION
Entering Edit Mode moves the existing `SplatData` into a scene node. The
single-model scene path preserves its address, so pointer-only model tracking
could miss the handoff and bypass the renderer's existing model-change reset.

This change tracks the model source (training dataset or scene) alongside its
address. The handoff now invalidates viewport artifacts and reaches the existing
renderer reset path on the next render frame. Pause/resume and training
completion retain dataset ownership; repeated frames with the same source and
address do not trigger additional resets.

The model also stays owned by its scene node until `clearTrainer()` succeeds,
preventing a deferred teardown from destroying it through a local `unique_ptr`.

Related to https://github.com/MrNeRF/LichtFeld-Studio/issues/2030.

### Validation and limitations

**Further testing is required before treating this as a fix for #2030. I have
not been able to test it thoroughly or reproduce the original GPU crash.**

- Local Windows compilation succeeded; the requested GTests passed.
- Manual use performed so far showed no problems.
- Added lifecycle regressions for same-address source transitions and repeated
  frames, plus a SceneManager handoff regression preserving the model address.
- The SceneManager regression does not run a live trainer or Vulkan dispatch.
- Static review, formatting and `git diff --check` completed. The coding agent
  did not configure, compile or run the application/tests.

Please test on the affected setup: complete training and enter Edit Mode both
immediately and after a delay, repeat the transition, orbit/zoom, select/delete
and undo, and verify transforms, appearance correction, save/reopen and PLY
export. On dev, check Native and Temporal Quality separately. Full logs from
any artifacts, hangs or device loss would help confirm whether this addresses
the reported failure.
