### PR TITLE
Avoid waiting for training initialization on the viewer thread

### DIFF
--- a/src/python/lfs/module.cpp
+++ b/src/python/lfs/module.cpp
@@ -1010,20 +1010,26 @@ NB_MODULE(lichtfeld, m) {
     m.def(
         "start_training", []() {
             nb::gil_scoped_release release;
+            auto* const viewer = lfs::python::get_visualizer();
+            // Capture the caller's thread before marshalling the command. UI
+            // callbacks must return so initialization can post work back to
+            // the viewer; off-thread scripts retain the synchronous contract.
+            const bool called_on_viewer = viewer && viewer->isOnViewerThread();
             auto* const trainer_manager = lfs::python::get_trainer_manager();
             emit_project_cmd_marshaled(
                 "python.start_training", [] {
                     lfs::core::events::cmd::StartTraining{}
                         .emit();
                 });
-            if (trainer_manager) {
+            if (trainer_manager && !called_on_viewer) {
                 if (auto initialized = trainer_manager->waitForInitialization();
                     !initialized) {
                     throw std::runtime_error(lfs::format_for_developer(initialized.error()));
                 }
             }
         },
-        "Start training with current parameters; waits for off-thread initialization");
+        "Start training with current parameters. Returns after dispatch on the viewer thread; "
+        "other callers wait for initialization. Asynchronous failures are reported through training state.");
     m.def(
         "training_start_overwrite_conflict",
         []() -> std::optional<int> {

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -247,7 +247,10 @@ def prepare_training_from_scene() -> None:
 
 def start_training() -> None:
     """
-    Start training with current parameters; waits for off-thread initialization
+    Start training with current parameters.
+
+    Returns after dispatch when called on the viewer thread. Other callers wait
+    for initialization. Asynchronous failures are reported through training state.
     """
 
 def training_start_overwrite_conflict() -> int | None:


### PR DESCRIPTION
## Problem

PR #1974 moved training initialization off the UI thread so that starting a training session would not block the window.

The Python `start_training()` binding still waited unconditionally for initialization after dispatching the command. When invoked by the training panel on the viewer thread, `TrainingManager::waitForInitialization()` rejected that wait and raised a misleading `Data model event error`, even though initialization continued in the background.

## Change

Capture the calling thread before marshalling the training command.

Calls from the viewer thread now return after dispatch, allowing asynchronous initialization to proceed normally. Off-thread Python callers retain the existing synchronous wait and initialization error propagation.

The Python binding documentation and type stub now describe both behaviors.

## Validation

- Windows Release build completed successfully.
- Targeted `TrainerConstructionTest` tests passed: 2/2.
- Manual training from the UI initialized successfully, reached iteration 210, paused and stopped cleanly.
- The original `Cannot wait for training initialization on the viewer thread` error and Python data-model traceback no longer appeared.
- A failed start caused by distorted images was reported through the normal asynchronous training error state.
- Python panel regression suite reported 61 passed and 2 unrelated, pre-existing Windows test failures: locale decoding without UTF-8 mode and a path-separator assertion.

Follow-up to #1974.