### PR TITLE
Recover VkSplat shared scratch after training pause

### DIFF
--- a/src/core/cuda/memory_arena.cu
+++ b/src/core/cuda/memory_arena.cu
@@ -998,15 +998,48 @@ namespace lfs::core {
     }
 
     bool RasterizerMemoryArena::grow_external_backing(const void* device_ptr, size_t new_size,
-                                                      const std::function<bool(size_t)>& commit) {
-        // Non-blocking on purpose: this is called by the render thread while it
-        // holds the trainer's render_mutex_ (shared). Waiting here for the arena
-        // to drain would deadlock against a refining training step that holds the
-        // arena frame and is itself blocked on render_mutex_ (write). If the arena
-        // is busy we bail; the caller falls back to a cached frame and retries.
-        std::unique_lock<std::mutex> sync_lock(sync_mutex_, std::try_to_lock);
-        if (!sync_lock.owns_lock() || active_frames_ != 0 || pending_render_frames_ != 0) {
+                                                      const std::function<bool(size_t)>& commit,
+                                                      const uint32_t timeout_ms,
+                                                      ExternalGrowFailure* failure) {
+        if (failure) {
+            *failure = ExternalGrowFailure::None;
+        }
+        const auto fail = [failure](ExternalGrowFailure reason) {
+            if (failure) {
+                *failure = reason;
+            }
             return false;
+        };
+        std::unique_lock<std::mutex> sync_lock(sync_mutex_, std::try_to_lock);
+        if (!sync_lock.owns_lock() || pending_render_frames_ != 0) {
+            return fail(ExternalGrowFailure::Busy);
+        }
+        if (active_frames_ != 0) {
+            if (timeout_ms == 0) {
+                return fail(ExternalGrowFailure::Busy);
+            }
+            // Growth happens before the renderer acquires its arena frame.
+            // Reserve that same idle window here, otherwise consecutive training
+            // frames can starve growth and leave the viewport on its cached image.
+            // Never wait indefinitely: refining can hold the arena while waiting
+            // for the caller's shared model lock to be released.
+            ++pending_render_frames_;
+            bool idle = false;
+            try {
+                idle = sync_cv_.wait_for(sync_lock, std::chrono::milliseconds(timeout_ms),
+                                         [this] { return active_frames_ == 0; });
+            } catch (...) {
+                --pending_render_frames_;
+                sync_cv_.notify_all();
+                throw;
+            }
+            --pending_render_frames_;
+            sync_cv_.notify_all();
+            if (!idle) {
+                return fail(ExternalGrowFailure::Busy);
+            }
+            // Keep sync_mutex_ through commit: no new frame can enter between
+            // releasing the reservation and updating the physical backing.
         }
 
         const cudaError_t sync_status = cudaDeviceSynchronize();
@@ -1015,7 +1048,7 @@ namespace lfs::core {
                 sync_status, "cudaDeviceSynchronize(external arena growth)",
                 detail::format_cuda_safe("requested_bytes={}", new_size),
                 LFS_SOURCE_SITE_CURRENT(), CudaFailureDisposition::LogOnly);
-            return false;
+            return fail(ExternalGrowFailure::CudaFailure);
         }
 
         std::scoped_lock lock(arena_mutex_, frame_mutex_);
@@ -1031,7 +1064,7 @@ namespace lfs::core {
         if (!target) {
             sync_lock.unlock();
             sync_cv_.notify_all();
-            return false;
+            return fail(ExternalGrowFailure::BackingMissing);
         }
         if (new_size <= target->committed_size) {
             sync_lock.unlock();
@@ -1047,7 +1080,7 @@ namespace lfs::core {
         if (!commit(new_size)) {
             sync_lock.unlock();
             sync_cv_.notify_all();
-            return false;
+            return fail(ExternalGrowFailure::CommitFailure);
         }
         TrainingChurnMetrics::instance().record_arena_recommit(static_cast<std::uint64_t>(
             std::chrono::duration_cast<std::chrono::microseconds>(
@@ -1069,11 +1102,12 @@ namespace lfs::core {
         return true;
     }
 
-    bool RasterizerMemoryArena::using_external_backing() const {
+    bool RasterizerMemoryArena::using_external_backing(const void* device_ptr) const {
         std::lock_guard<std::mutex> lock(arena_mutex_);
         for (const auto& entry : device_arenas_) {
             const auto& arena_ptr = entry.second;
-            if (arena_ptr && arena_ptr->external_backing) {
+            if (arena_ptr && arena_ptr->external_backing &&
+                (!device_ptr || arena_ptr->fallback_buffer == device_ptr)) {
                 return true;
             }
         }
@@ -2226,8 +2260,10 @@ namespace lfs::core {
     }
 
     bool GlobalArenaManager::grow_external_backing(const void* device_ptr, size_t new_size,
-                                                   const std::function<bool(size_t)>& commit) {
-        return get_arena().grow_external_backing(device_ptr, new_size, commit);
+                                                   const std::function<bool(size_t)>& commit,
+                                                   const uint32_t timeout_ms,
+                                                   RasterizerMemoryArena::ExternalGrowFailure* failure) {
+        return get_arena().grow_external_backing(device_ptr, new_size, commit, timeout_ms, failure);
     }
 
     void GlobalArenaManager::clear_external_backing(const void* device_ptr) {

--- a/src/core/cuda/memory_arena.cu
+++ b/src/core/cuda/memory_arena.cu
@@ -876,24 +876,52 @@ namespace lfs::core {
         return install_external_backing_impl(std::move(backing), true);
     }
 
-    bool RasterizerMemoryArena::try_install_external_backing(ExternalBacking backing) {
-        return install_external_backing_impl(std::move(backing), false);
+    bool RasterizerMemoryArena::try_install_external_backing(ExternalBacking backing, const uint32_t timeout_ms) {
+        return install_external_backing_impl(std::move(backing), false, timeout_ms);
     }
 
-    bool RasterizerMemoryArena::install_external_backing_impl(ExternalBacking backing, bool wait) {
+    bool RasterizerMemoryArena::install_external_backing_impl(ExternalBacking backing, const bool wait,
+                                                               const uint32_t timeout_ms) {
         if (!backing.valid()) {
             LOG_WARN("RasterizerMemoryArena::install_external_backing called with invalid backing");
             return false;
         }
 
-        std::unique_lock<std::mutex> sync_lock(sync_mutex_);
+        std::unique_lock<std::mutex> sync_lock(sync_mutex_, std::defer_lock);
+        if (wait) {
+            sync_lock.lock();
+        } else if (!sync_lock.try_lock()) {
+            return false;
+        }
         const auto can_install = [this]() {
             return active_frames_ == 0 && pending_render_frames_ == 0;
         };
         if (wait) {
             sync_cv_.wait(sync_lock, can_install);
         } else if (!can_install()) {
-            return false;
+            if (timeout_ms == 0 || pending_render_frames_ != 0) {
+                return false;
+            }
+            // Installation happens before the renderer acquires its arena frame.
+            // Reserve the next idle window so resumed training cannot continuously
+            // win it and leave a detached viewer backing permanently uninstalled.
+            ++pending_render_frames_;
+            bool idle = false;
+            try {
+                idle = sync_cv_.wait_for(sync_lock, std::chrono::milliseconds(timeout_ms),
+                                         [this] { return active_frames_ == 0; });
+            } catch (...) {
+                --pending_render_frames_;
+                sync_cv_.notify_all();
+                throw;
+            }
+            --pending_render_frames_;
+            sync_cv_.notify_all();
+            if (!idle) {
+                return false;
+            }
+            // Keep sync_mutex_ through installation: no training frame can enter
+            // after the reservation is released and before the backing is visible.
         }
 
         // A submitted viewport batch may still be reading the current backing;
@@ -2255,8 +2283,9 @@ namespace lfs::core {
         return get_arena().install_external_backing(std::move(backing));
     }
 
-    bool GlobalArenaManager::try_install_external_backing(RasterizerMemoryArena::ExternalBacking backing) {
-        return get_arena().try_install_external_backing(std::move(backing));
+    bool GlobalArenaManager::try_install_external_backing(RasterizerMemoryArena::ExternalBacking backing,
+                                                           const uint32_t timeout_ms) {
+        return get_arena().try_install_external_backing(std::move(backing), timeout_ms);
     }
 
     bool GlobalArenaManager::grow_external_backing(const void* device_ptr, size_t new_size,

--- a/src/core/cuda/memory_arena.hpp
+++ b/src/core/cuda/memory_arena.hpp
@@ -287,7 +287,9 @@ namespace lfs::core {
         bool release_at_boundary();
         void full_reset();
         bool install_external_backing(ExternalBacking backing);
-        bool try_install_external_backing(ExternalBacking backing);
+        // With a nonzero timeout, reserve the next idle window against new training
+        // frames. Zero keeps the try-only path used by callers that must not wait.
+        bool try_install_external_backing(ExternalBacking backing, uint32_t timeout_ms = 0);
         // Grows the committed size of an already-installed external backing whose
         // base pointer is `device_ptr` (which must stay constant). The arena
         // drains all frames and the device, then invokes `commit(new_size)` — which
@@ -330,7 +332,7 @@ namespace lfs::core {
         // and clears it. Must run before any path that frees or replaces arena
         // backing — a device sync cannot observe the in-flight Vulkan batch.
         void drain_external_release();
-        bool install_external_backing_impl(ExternalBacking backing, bool wait);
+        bool install_external_backing_impl(ExternalBacking backing, bool wait, uint32_t timeout_ms = 0);
         char* allocate_internal(Arena& arena, size_t size, uint64_t frame_id,
                                 const char* label);
         void release_arena_storage(Arena& arena);
@@ -356,7 +358,8 @@ namespace lfs::core {
         RasterizerMemoryArena& get_arena();
         RasterizerMemoryArena* try_get_arena();
         bool install_external_backing(RasterizerMemoryArena::ExternalBacking backing);
-        bool try_install_external_backing(RasterizerMemoryArena::ExternalBacking backing);
+        bool try_install_external_backing(RasterizerMemoryArena::ExternalBacking backing,
+                                          uint32_t timeout_ms = 0);
         bool grow_external_backing(const void* device_ptr, size_t new_size,
                                    const std::function<bool(size_t)>& commit,
                                    uint32_t timeout_ms = 0,

--- a/src/core/cuda/memory_arena.hpp
+++ b/src/core/cuda/memory_arena.hpp
@@ -293,10 +293,20 @@ namespace lfs::core {
         // drains all frames and the device, then invokes `commit(new_size)` — which
         // performs the physical grow + Vulkan re-import — inside that safe window;
         // on success the arena's committed capacity is bumped to new_size.
+        // With a nonzero timeout, reserve the next idle window against new
+        // training frames. The wait is bounded because callers may hold model
+        // locks needed by an active training frame. Zero keeps the try-only path.
+        enum class ExternalGrowFailure { None,
+                                         Busy,
+                                         BackingMissing,
+                                         CudaFailure,
+                                         CommitFailure };
         bool grow_external_backing(const void* device_ptr, size_t new_size,
-                                   const std::function<bool(size_t)>& commit);
+                                   const std::function<bool(size_t)>& commit,
+                                   uint32_t timeout_ms = 0,
+                                   ExternalGrowFailure* failure = nullptr);
         void clear_external_backing(const void* device_ptr = nullptr);
-        [[nodiscard]] bool using_external_backing() const;
+        [[nodiscard]] bool using_external_backing(const void* device_ptr = nullptr) const;
 
         Statistics get_statistics() const;
         MemoryInfo get_memory_info() const;
@@ -348,7 +358,9 @@ namespace lfs::core {
         bool install_external_backing(RasterizerMemoryArena::ExternalBacking backing);
         bool try_install_external_backing(RasterizerMemoryArena::ExternalBacking backing);
         bool grow_external_backing(const void* device_ptr, size_t new_size,
-                                   const std::function<bool(size_t)>& commit);
+                                   const std::function<bool(size_t)>& commit,
+                                   uint32_t timeout_ms = 0,
+                                   RasterizerMemoryArena::ExternalGrowFailure* failure = nullptr);
         void clear_external_backing(const void* device_ptr = nullptr);
         void reset();
         void shutdown() { shutdown_global_arena_manager(); }

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -3499,6 +3499,21 @@ namespace lfs::vis {
         // in reimportSharedScratchIfGrown() once the render owns the arena frame
         // (which excludes training), so the block is stable when we read it.
 
+        // B3 pause/end can detach the backing on the training thread without
+        // changing this renderer's cached installation flag. Reinstall the same
+        // block before either the capacity fast path or growth uses it again.
+        if (shared_scratch_.block) {
+            shared_scratch_.installed_in_training_arena =
+                lfs::core::GlobalArenaManager::instance().get_arena().using_external_backing(
+                    shared_scratch_.block->device_ptr);
+            if (!shared_scratch_.installed_in_training_arena) {
+                if (!try_install_existing()) {
+                    return std::unexpected("VkSplat shared scratch training rasterizer arena is busy");
+                }
+                shared_scratch_.installed_in_training_arena = true;
+            }
+        }
+
         // Fast path: an installed block already large enough for this frame.
         if (shared_scratch_.block && shared_scratch_.bytes >= required_bytes &&
             shared_scratch_.imported_buffer.buffer != VK_NULL_HANDLE) {
@@ -3556,15 +3571,28 @@ namespace lfs::vis {
                 return true;
             };
             const std::size_t exact_required_bytes = alignUp(required_bytes, kSharedScratchPageBytes);
+            using GrowFailure = lfs::core::RasterizerMemoryArena::ExternalGrowFailure;
+            GrowFailure failure = GrowFailure::None;
             bool grew = lfs::core::GlobalArenaManager::instance().grow_external_backing(
-                device_ptr, exact_required_bytes, commit);
+                device_ptr, exact_required_bytes, commit, /*timeout_ms=*/15, &failure);
             if (!grew) {
+                if (failure == GrowFailure::Busy || failure == GrowFailure::BackingMissing) {
+                    if (failure == GrowFailure::BackingMissing) {
+                        shared_scratch_.installed_in_training_arena = false;
+                    }
+                    LOG_PERF("VkSplat shared scratch grow deferred: {}",
+                             failure == GrowFailure::Busy ? "arena busy" : "backing detached; reinstall next frame");
+                    return std::unexpected("VkSplat shared scratch training rasterizer arena is busy");
+                }
+                if (commit_error.empty()) {
+                    commit_error = failure == GrowFailure::CudaFailure
+                                       ? "CUDA synchronization failed (see preceding CUDA diagnostic)"
+                                       : "allocation or Vulkan binding callback failed without detail";
+                }
                 LOG_ERROR("VkSplat shared scratch grow to {} MiB failed: {}",
                           exact_required_bytes >> 20,
-                          commit_error.empty() ? "unknown error" : commit_error);
-                return std::unexpected(commit_error.empty()
-                                           ? std::string("VkSplat shared scratch training rasterizer arena is busy")
-                                           : std::format("VkSplat shared scratch grow failed: {}", commit_error));
+                          commit_error);
+                return std::unexpected(std::format("VkSplat shared scratch grow failed: {}", commit_error));
             }
             shared_scratch_.installed_in_training_arena = true;
             publish_capacity();
@@ -8986,6 +9014,15 @@ namespace lfs::vis {
                 try {
                     if (!shared_arena_guard) {
                         shared_arena_guard.emplace();
+                    }
+                    // Pause can detach after ensureSharedScratchArena checked
+                    // installation but before this frame acquired ownership.
+                    // Never bind the retained block against an unrelated arena.
+                    if (!lfs::core::GlobalArenaManager::instance().get_arena().using_external_backing(
+                            shared_scratch_.block->device_ptr)) {
+                        shared_scratch_.installed_in_training_arena = false;
+                        shared_arena_guard.reset();
+                        return std::unexpected("VkSplat shared scratch training rasterizer arena is busy");
                     }
                     // Now that the render owns the arena frame (training is
                     // excluded), it is safe to re-import the block if training grew

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -1055,6 +1055,7 @@ namespace lfs::vis {
 
         constexpr std::size_t kSharedScratchPageBytes = std::size_t{2} << 20;
         constexpr std::size_t kSharedScratchMinBytes = std::size_t{128} << 20;
+        constexpr uint32_t kSharedScratchIdleReservationTimeoutMs = 15;
 
         enum InputRegion : std::size_t {
             InputXyzWs = 0,
@@ -3490,7 +3491,8 @@ namespace lfs::vis {
                 return false;
             }
             auto backing = make_external_backing(shared_scratch_.block);
-            return lfs::core::GlobalArenaManager::instance().try_install_external_backing(std::move(backing));
+            return lfs::core::GlobalArenaManager::instance().try_install_external_backing(
+                std::move(backing), kSharedScratchIdleReservationTimeoutMs);
         };
 
         // NOTE: if the training thread grew the block in place (new export handle),
@@ -3574,7 +3576,7 @@ namespace lfs::vis {
             using GrowFailure = lfs::core::RasterizerMemoryArena::ExternalGrowFailure;
             GrowFailure failure = GrowFailure::None;
             bool grew = lfs::core::GlobalArenaManager::instance().grow_external_backing(
-                device_ptr, exact_required_bytes, commit, /*timeout_ms=*/15, &failure);
+                device_ptr, exact_required_bytes, commit, kSharedScratchIdleReservationTimeoutMs, &failure);
             if (!grew) {
                 if (failure == GrowFailure::Busy || failure == GrowFailure::BackingMissing) {
                     if (failure == GrowFailure::BackingMissing) {
@@ -3633,7 +3635,8 @@ namespace lfs::vis {
         }
 
         auto backing = make_external_backing(*block_result);
-        if (!lfs::core::GlobalArenaManager::instance().try_install_external_backing(std::move(backing))) {
+        if (!lfs::core::GlobalArenaManager::instance().try_install_external_backing(
+                std::move(backing), kSharedScratchIdleReservationTimeoutMs)) {
             context.destroyExternalBuffer(imported);
             return std::unexpected("VkSplat shared scratch training rasterizer arena is busy");
         }

--- a/tests/python/test_vksplat_output_lifetime_regressions.py
+++ b/tests/python/test_vksplat_output_lifetime_regressions.py
@@ -12,6 +12,19 @@ def _read(rel_path: str) -> str:
     return (PROJECT_ROOT / rel_path).read_text(encoding="utf-8")
 
 
+def test_live_training_reserves_shared_scratch_before_render_frame():
+    source = _read("src/visualizer/rendering/vksplat_viewport_renderer.cpp")
+    render_start = source.index("VksplatViewportRenderer::render(")
+    render_body = source[render_start:]
+
+    # A timed install/grow reservation needs an idle window. Taking the render
+    # guard first makes the renderer itself an active frame and starves that
+    # reservation. Keep scratch setup ahead of the guard acquisition.
+    ensure_pos = render_body.index("ensureSharedScratchArena(context, required_shared_scratch)")
+    guard_pos = render_body.index("shared_arena_guard.emplace()")
+    assert ensure_pos < guard_pos
+
+
 def test_vksplat_output_resize_retires_gui_sampled_images_into_pool():
     source = _read("src/visualizer/rendering/vksplat_viewport_renderer.cpp")
     function_start = source.index("VksplatViewportRenderer::ensureOutputImages")

--- a/tests/test_arena_metrics_contention.cpp
+++ b/tests/test_arena_metrics_contention.cpp
@@ -402,14 +402,25 @@ TEST_F(ArenaMetricsContentionTest, ViewerGrowReservesIdleWindowAfterTrainingFram
     std::atomic<bool> finished{false};
     bool grew = false;
     size_t committed = 0;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
     std::thread viewer([&] {
         EXPECT_EQ(cudaSetDevice(0), cudaSuccess);
-        grew = arena.grow_external_backing(device_ptr, 2 * MiB, [&](size_t requested) {
-            committed = requested;
-            return true; }, 2000);
+        // The observer below briefly owns sync_mutex_. A try-lock miss is a
+        // legitimate Busy result, so retry it as the viewer does on later frames.
+        // The reserved assertion still rejects an implementation that never queues.
+        using Failure = RasterizerMemoryArena::ExternalGrowFailure;
+        do {
+            Failure failure = Failure::None;
+            grew = arena.grow_external_backing(device_ptr, 2 * MiB, [&](size_t requested) {
+                committed = requested;
+                return true;
+            }, 2000, &failure);
+            if (grew || failure != Failure::Busy)
+                break;
+            std::this_thread::yield();
+        } while (std::chrono::steady_clock::now() < deadline);
         finished.store(true, std::memory_order_release);
     });
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
     bool reserved = false;
     while (!(reserved = arena.is_rendering_active()) &&
            !finished.load(std::memory_order_acquire) &&
@@ -428,6 +439,103 @@ TEST_F(ArenaMetricsContentionTest, ViewerGrowReservesIdleWindowAfterTrainingFram
     const auto next = arena.try_begin_frame(nullptr, false);
     ASSERT_TRUE(next.has_value());
     arena.end_frame(*next, nullptr, false);
+}
+
+TEST_F(ArenaMetricsContentionTest, ViewerInstallReservesIdleWindowAfterTrainingFrame) {
+    constexpr size_t MiB = 1024 * 1024;
+    void* device_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&device_ptr, MiB), cudaSuccess);
+    auto owner = std::shared_ptr<void>(device_ptr, [](void* ptr) {
+        EXPECT_EQ(cudaFree(ptr), cudaSuccess);
+    });
+    RasterizerMemoryArena::Config config;
+    config.max_physical = MiB;
+    config.enable_vmm = false;
+    config.granularity = MiB;
+    RasterizerMemoryArena arena(config);
+    const RasterizerMemoryArena::ExternalBacking backing{
+        .device_ptr = device_ptr,
+        .size = MiB,
+        .device = 0,
+        .owner = owner,
+        .label = "test.external.viewer_reinstall",
+    };
+
+    // Reproduce the B3 detach while the viewer retains the physical block.
+    ASSERT_TRUE(arena.install_external_backing(backing));
+    arena.clear_external_backing(device_ptr);
+    ASSERT_FALSE(arena.using_external_backing(device_ptr));
+
+    const auto held = arena.begin_frame(nullptr, false);
+    std::atomic<bool> finished{false};
+    bool installed = false;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    std::thread viewer([&] {
+        EXPECT_EQ(cudaSetDevice(0), cudaSuccess);
+        // Observing the reservation also locks sync_mutex_; a failed initial
+        // try-lock must not make this test depend on which thread runs first.
+        do {
+            installed = arena.try_install_external_backing(backing, 2000);
+            if (installed)
+                break;
+            std::this_thread::yield();
+        } while (std::chrono::steady_clock::now() < deadline);
+        finished.store(true, std::memory_order_release);
+    });
+    bool reserved = false;
+    while (!(reserved = arena.is_rendering_active()) &&
+           !finished.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    // The retained block must register its request before training releases its
+    // frame; this fails with the former try-only reinstall path.
+    EXPECT_TRUE(reserved);
+    arena.end_frame(held, nullptr, false);
+    viewer.join();
+
+    EXPECT_TRUE(installed);
+    EXPECT_TRUE(arena.using_external_backing(device_ptr));
+    EXPECT_FALSE(arena.is_rendering_active());
+    arena.clear_external_backing(device_ptr);
+}
+
+TEST_F(ArenaMetricsContentionTest, ViewerInstallTimeoutReleasesOnlyItsOwnReservation) {
+    constexpr size_t MiB = 1024 * 1024;
+    void* device_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&device_ptr, MiB), cudaSuccess);
+    auto owner = std::shared_ptr<void>(device_ptr, [](void* ptr) {
+        EXPECT_EQ(cudaFree(ptr), cudaSuccess);
+    });
+    RasterizerMemoryArena arena;
+    const RasterizerMemoryArena::ExternalBacking backing{
+        .device_ptr = device_ptr,
+        .size = MiB,
+        .device = 0,
+        .owner = owner,
+        .label = "test.external.install_timeout",
+    };
+
+    const auto held = arena.begin_frame(nullptr, false);
+    EXPECT_FALSE(arena.try_install_external_backing(backing, 15));
+    EXPECT_FALSE(arena.is_rendering_active());
+    EXPECT_FALSE(arena.using_external_backing(device_ptr));
+    arena.end_frame(held, nullptr, false);
+
+    // A timed-out installer must allow training to continue.
+    const auto next = arena.try_begin_frame(nullptr, false);
+    ASSERT_TRUE(next.has_value());
+    arena.end_frame(*next, nullptr, false);
+
+    // A different viewer's reservation must not be consumed by installation.
+    arena.set_rendering_active(true);
+    EXPECT_FALSE(arena.try_install_external_backing(backing, 15));
+    EXPECT_TRUE(arena.is_rendering_active());
+    EXPECT_FALSE(arena.using_external_backing(device_ptr));
+    arena.set_rendering_active(false);
+    ASSERT_TRUE(arena.try_install_external_backing(backing, 15));
+    EXPECT_TRUE(arena.using_external_backing(device_ptr));
+    arena.clear_external_backing(device_ptr);
 }
 
 TEST_F(ArenaMetricsContentionTest, FullResetRetainsExternalBackingAndCapacity) {

--- a/tests/test_arena_metrics_contention.cpp
+++ b/tests/test_arena_metrics_contention.cpp
@@ -73,44 +73,42 @@ TEST_F(ArenaMetricsContentionTest, BoundedBeginFrameBailsWhileFrameHeld) {
 TEST_F(ArenaMetricsContentionTest, TrainerMetricsOppositeOrderNoDeadlock) {
     RasterizerMemoryArena arena;
     std::shared_mutex render_mutex;
-    std::atomic<bool> trainer_done{false};
-    std::atomic<bool> metrics_started{false};
-    std::atomic<int> metrics_attempts{0};
-    std::atomic<int> metrics_acquired{0};
+    std::atomic<bool> trainer_has_frame{false};
+    std::atomic<bool> metrics_has_render_lock{false};
+    std::atomic<bool> metrics_timed_out{false};
+    std::atomic<bool> trainer_acquired_render_lock{false};
 
-    const bool finished = completes_within(std::chrono::milliseconds(20000), [&] {
-        // Trainer: frame-then-lock, exclusive on "refine" iterations.
+    const bool finished = completes_within(std::chrono::milliseconds(2000), [&] {
+        // Reproduce one deterministic lock inversion:
+        // trainer: arena frame -> exclusive render lock
+        // metrics: shared render lock -> bounded arena frame
         std::thread trainer([&] {
             cudaSetDevice(0);
-            while (!metrics_started.load(std::memory_order_acquire)) {
+            const uint64_t frame = arena.begin_frame(nullptr, false);
+            trainer_has_frame.store(true, std::memory_order_release);
+            while (!metrics_has_render_lock.load(std::memory_order_acquire)) {
                 std::this_thread::yield();
             }
-            for (int i = 1; i <= 400; ++i) {
-                const uint64_t frame = arena.begin_frame(nullptr, false);
-                std::optional<std::unique_lock<std::shared_mutex>> excl;
-                if (i % 5 == 0) {
-                    excl.emplace(render_mutex); // hold lock while holding frame
-                }
-                arena.end_frame(frame, nullptr, false);
+            {
+                std::unique_lock<std::shared_mutex> exclusive(render_mutex);
+                trainer_acquired_render_lock.store(true, std::memory_order_release);
             }
-            trainer_done.store(true, std::memory_order_release);
+            arena.end_frame(frame, nullptr, false);
         });
 
-        // Metrics: lock-then-(bounded)-frame, the opposite order.
         std::thread metrics([&] {
             cudaSetDevice(0);
-            metrics_started.store(true, std::memory_order_release);
-            while (!trainer_done.load(std::memory_order_acquire)) {
-                std::shared_lock<std::shared_mutex> shared(render_mutex);
-                const RasterizerMemoryArena::ScopedBeginFrameTimeout timeout(20);
-                metrics_attempts.fetch_add(1, std::memory_order_relaxed);
-                try {
-                    const uint64_t frame = arena.begin_frame(nullptr, false);
-                    metrics_acquired.fetch_add(1, std::memory_order_relaxed);
-                    arena.end_frame(frame, nullptr, false);
-                } catch (const std::exception&) {
-                    // Bounded bail under contention — expected, no deadlock.
-                }
+            while (!trainer_has_frame.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            std::shared_lock<std::shared_mutex> shared(render_mutex);
+            metrics_has_render_lock.store(true, std::memory_order_release);
+            const RasterizerMemoryArena::ScopedBeginFrameTimeout timeout(20);
+            try {
+                const uint64_t frame = arena.begin_frame(nullptr, false);
+                arena.end_frame(frame, nullptr, false);
+            } catch (const std::exception&) {
+                metrics_timed_out.store(true, std::memory_order_release);
             }
         });
 
@@ -119,9 +117,11 @@ TEST_F(ArenaMetricsContentionTest, TrainerMetricsOppositeOrderNoDeadlock) {
     });
 
     EXPECT_TRUE(finished) << "trainer/metrics contention deadlocked";
-    EXPECT_GT(metrics_attempts.load(), 0);
-    // It should manage at least some real acquisitions across 400 iterations.
-    EXPECT_GT(metrics_acquired.load(), 0);
+    EXPECT_TRUE(metrics_timed_out.load());
+    EXPECT_TRUE(trainer_acquired_render_lock.load());
+    const auto next = arena.try_begin_frame(nullptr, false);
+    ASSERT_TRUE(next.has_value());
+    arena.end_frame(*next, nullptr, false);
 }
 
 TEST_F(ArenaMetricsContentionTest, ExternalGrowWaitsForPendingRender) {
@@ -290,6 +290,144 @@ TEST_F(ArenaMetricsContentionTest, ExternalGrowCommitsExactAlignedNeed) {
     ASSERT_EQ(requests.size(), 1u);
     EXPECT_EQ(requests[0], aligned_need);
     EXPECT_EQ(arena.get_statistics().capacity, aligned_need);
+}
+
+TEST_F(ArenaMetricsContentionTest, DetachedViewerBackingCanBeReinstalledAndGrown) {
+    constexpr size_t MiB = 1024 * 1024;
+    void* device_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&device_ptr, 2 * MiB), cudaSuccess);
+    auto owner = std::shared_ptr<void>(device_ptr, [](void* ptr) {
+        EXPECT_EQ(cudaFree(ptr), cudaSuccess);
+    });
+    RasterizerMemoryArena arena;
+    const RasterizerMemoryArena::ExternalBacking backing{
+        .device_ptr = device_ptr,
+        .size = MiB,
+        .device = 0,
+        .owner = owner,
+        .label = "test.external.pause_resume",
+    };
+    ASSERT_TRUE(arena.install_external_backing(backing));
+    ASSERT_TRUE(arena.using_external_backing(device_ptr));
+    EXPECT_FALSE(arena.using_external_backing(static_cast<char*>(device_ptr) + 1));
+
+    // Trainer B3 detaches independently of the viewer's retained block/import.
+    arena.clear_external_backing();
+    EXPECT_FALSE(arena.using_external_backing(device_ptr));
+    bool committed = false;
+    const auto commit = [&](size_t) {
+        committed = true;
+        return true;
+    };
+    using GrowFailure = RasterizerMemoryArena::ExternalGrowFailure;
+    GrowFailure failure = GrowFailure::None;
+    EXPECT_FALSE(arena.grow_external_backing(device_ptr, 2 * MiB, commit, 0, &failure));
+    EXPECT_EQ(failure, GrowFailure::BackingMissing);
+    EXPECT_FALSE(committed);
+
+    // Reinstallation must defer while resumed training owns an arena frame.
+    const auto held = arena.begin_frame(nullptr, false);
+    EXPECT_FALSE(arena.try_install_external_backing(backing));
+    arena.end_frame(held, nullptr, false);
+    ASSERT_TRUE(arena.try_install_external_backing(backing));
+    EXPECT_TRUE(arena.using_external_backing(device_ptr));
+    EXPECT_FALSE(arena.grow_external_backing(device_ptr, 2 * MiB, [](size_t) { return false; }, 0, &failure));
+    EXPECT_EQ(failure, GrowFailure::CommitFailure);
+    EXPECT_EQ(arena.get_statistics().capacity, MiB);
+    ASSERT_TRUE(arena.grow_external_backing(device_ptr, 2 * MiB, commit, 0, &failure));
+    EXPECT_EQ(failure, GrowFailure::None);
+    EXPECT_TRUE(committed);
+    EXPECT_EQ(arena.get_statistics().capacity, 2 * MiB);
+
+    arena.clear_external_backing();
+    EXPECT_FALSE(arena.using_external_backing(device_ptr));
+}
+
+TEST_F(ArenaMetricsContentionTest, ViewerGrowTimeoutReleasesReservation) {
+    RasterizerMemoryArena arena;
+    const auto held = arena.begin_frame(nullptr, false);
+    bool committed = false;
+    using GrowFailure = RasterizerMemoryArena::ExternalGrowFailure;
+    GrowFailure failure = GrowFailure::None;
+    const auto started = std::chrono::steady_clock::now();
+    EXPECT_FALSE(arena.grow_external_backing(nullptr, 1, [&](size_t) {
+        committed = true;
+        return true; }, 15, &failure));
+    EXPECT_EQ(failure, GrowFailure::Busy);
+    EXPECT_LT(std::chrono::steady_clock::now() - started, std::chrono::seconds(2));
+    EXPECT_FALSE(committed);
+    EXPECT_FALSE(arena.is_rendering_active());
+    arena.end_frame(held, nullptr, false);
+    // A timed-out viewer must not leave training gated behind a stale request.
+    const auto next = arena.try_begin_frame(nullptr, false);
+    ASSERT_TRUE(next.has_value());
+    arena.end_frame(*next, nullptr, false);
+}
+
+TEST_F(ArenaMetricsContentionTest, ViewerGrowPreservesExistingRenderReservation) {
+    RasterizerMemoryArena arena;
+    arena.set_rendering_active(true);
+    bool committed = false;
+    EXPECT_FALSE(arena.grow_external_backing(nullptr, 1, [&](size_t) {
+        committed = true;
+        return true; }, 15));
+    EXPECT_FALSE(committed);
+    EXPECT_TRUE(arena.is_rendering_active());
+    arena.set_rendering_active(false);
+    const auto next = arena.try_begin_frame(nullptr, false);
+    ASSERT_TRUE(next.has_value());
+    arena.end_frame(*next, nullptr, false);
+}
+
+TEST_F(ArenaMetricsContentionTest, ViewerGrowReservesIdleWindowAfterTrainingFrame) {
+    constexpr size_t MiB = 1024 * 1024;
+    void* device_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&device_ptr, 2 * MiB), cudaSuccess);
+    auto owner = std::shared_ptr<void>(device_ptr, [](void* ptr) {
+        EXPECT_EQ(cudaFree(ptr), cudaSuccess);
+    });
+    RasterizerMemoryArena::Config config;
+    config.max_physical = 2 * MiB;
+    config.enable_vmm = false;
+    config.granularity = MiB;
+    RasterizerMemoryArena arena(config);
+    ASSERT_TRUE(arena.install_external_backing({
+        .device_ptr = device_ptr,
+        .size = MiB,
+        .device = 0,
+        .owner = owner,
+        .label = "test.external.viewer_growth",
+    }));
+    const auto held = arena.begin_frame(nullptr, false);
+    std::atomic<bool> finished{false};
+    bool grew = false;
+    size_t committed = 0;
+    std::thread viewer([&] {
+        EXPECT_EQ(cudaSetDevice(0), cudaSuccess);
+        grew = arena.grow_external_backing(device_ptr, 2 * MiB, [&](size_t requested) {
+            committed = requested;
+            return true; }, 2000);
+        finished.store(true, std::memory_order_release);
+    });
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    bool reserved = false;
+    while (!(reserved = arena.is_rendering_active()) &&
+           !finished.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    // Release only after growth has registered interest, avoiding a sleep-based
+    // race that could let the old try-only implementation pass accidentally.
+    arena.end_frame(held, nullptr, false);
+    viewer.join();
+    EXPECT_TRUE(reserved);
+    EXPECT_TRUE(grew);
+    EXPECT_EQ(committed, 2 * MiB);
+    EXPECT_EQ(arena.get_statistics().capacity, 2 * MiB);
+    EXPECT_FALSE(arena.is_rendering_active());
+    const auto next = arena.try_begin_frame(nullptr, false);
+    ASSERT_TRUE(next.has_value());
+    arena.end_frame(*next, nullptr, false);
 }
 
 TEST_F(ArenaMetricsContentionTest, FullResetRetainsExternalBackingAndCapacity) {


### PR DESCRIPTION
Related to #2029.

## Problem

Pausing training can detach the shared external rasterizer backing at the B3 boundary. VkSplat retained its installed state after that detach and could attempt to reuse or grow backing that was no longer attached to the arena.

After resuming training, this could leave the viewport presenting its cached splat image while the grid and camera overlays continued to move.

The original recovery also left retained-backing reinstall as a try-only operation. Under continuous training-frame activity, reinstall could therefore be starved even though scratch growth already used a bounded idle-window reservation.

## Changes

- Verify shared backing by device pointer before reuse or growth.
- Reinstall renderer-owned backing when the trainer has detached it.
- Recheck backing ownership after acquiring the renderer arena frame.
- Give reinstall, initial installation, and growth the same bounded 15 ms idle-window reservation.
- Keep the arena synchronization mutex through installation so a new training frame cannot consume the reserved idle window.
- Release only the caller's reservation on success, timeout, or failure.
- Preserve zero-timeout try-only behavior and the existing unbounded installation path for other callers.
- Return typed external-growth outcomes so busy and detached states can defer and retry without misleading error messages.
- Keep actionable diagnostics for CUDA synchronization and callback failures.

## Regression coverage

- Detached backing detection and reinstallation.
- Successful reinstall after an active training frame releases the arena.
- Reinstall timeout cleanup.
- Preservation of an existing render reservation.
- External backing growth results and timeout cleanup.
- Deterministic trainer/metrics lock-order contention.
- Shared-scratch setup occurring before the render frame is acquired.
- Retry handling for legitimate try-lock contention introduced by reservation observation in the tests.

## Validation

Reported from Windows Release:

- build succeeded;
- all `ArenaMetricsContentionTest.*` cases passed for 20 repeated iterations with `--gtest_break_on_failure`;
- `tests/python/test_vksplat_output_lifetime_regressions.py`: 9 passed;
- dataset was exercised through repeated training pause/resume and scratch growth without reproducing the frozen splat viewport.

A longer validation run on another GPU is still recommended because the original failure depends on runtime timing and GPU resource behavior.