### PR TITLE
Preserve Unicode in Windows console logs

### DIFF
--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -22,6 +22,7 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
+#include "windows_console.hpp"
 #else
 #include <unistd.h>
 #endif
@@ -313,6 +314,19 @@ namespace lfs::core {
 
                 std::string output_msg = is_perf ? strip_perf_prefix(msg_view) : std::string(msg_view);
 
+#ifdef _WIN32
+                const auto console = detail::console_output_handle(target_);
+                if (console != INVALID_HANDLE_VALUE) {
+                    const auto line = std::format("[{:02}:{:02}:{:02}.{:03}] {}[{}]{} {}:{}  {}\n",
+                                                  tm.tm_hour, tm.tm_min, tm.tm_sec, static_cast<int>(millis),
+                                                  color, level_str, ANSI_RESET, filename, msg.source.line, output_msg);
+                    // Flush earlier CRT writes before bypassing stdio. WriteConsoleW
+                    // does not depend on or change the shared console code page.
+                    std::fflush(target_);
+                    if (detail::write_console_utf8(console, line))
+                        return;
+                }
+#endif
                 std::fprintf(target_, "[%02d:%02d:%02d.%03d] %s[%s]%s %.*s:%d  %s\n",
                              tm.tm_hour, tm.tm_min, tm.tm_sec, static_cast<int>(millis),
                              color, level_str, ANSI_RESET,
@@ -590,6 +604,14 @@ namespace lfs::core {
         impl_->logger->flush_on(spdlog::level::err);
         spdlog::set_default_logger(impl_->logger);
         spdlog::flush_every(std::chrono::seconds(2));
+
+#ifdef _WIN32
+        // Deliberately keep a small, visible probe near the top of every Windows
+        // startup log. It exercises the same UTF-8 -> UTF-16 console path as a
+        // real diagnostic without changing the terminal's shared code page.
+        impl_->logger->log(spdlog::source_loc{__FILE__, __LINE__, __func__}, spdlog::level::info,
+                           "LichtFeld logger initialized \xE2\x80\x94 UTF-8 console: \xE2\x9C\x93");
+#endif
 
         global_level_ = static_cast<uint8_t>(console_level);
         capture_all_to_file_ = !log_file.empty();

--- a/src/core/windows_console.hpp
+++ b/src/core/windows_console.hpp
@@ -1,0 +1,79 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <io.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace lfs::core::detail {
+
+    // Inspect the CRT stream, not GetStdHandle: capture/redirect code can replace
+    // the descriptor without replacing the process standard handle.
+    inline HANDLE console_output_handle(FILE* stream) {
+        const int fd = _fileno(stream);
+        if (fd < 0)
+            return INVALID_HANDLE_VALUE;
+        const auto handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+        DWORD mode = 0;
+        return handle != INVALID_HANDLE_VALUE && GetConsoleMode(handle, &mode)
+                   ? handle
+                   : INVALID_HANDLE_VALUE;
+    }
+
+    // False means nothing was written and the caller may use its byte fallback.
+    // Never replay the whole message after a partial console write.
+    inline bool write_console_utf8(HANDLE handle, std::string_view text) {
+        if (text.empty())
+            return true;
+        if (text.size() > static_cast<size_t>((std::numeric_limits<int>::max)()))
+            return false;
+        const int bytes = static_cast<int>(text.size());
+        const int length = MultiByteToWideChar(CP_UTF8, 0, text.data(), bytes, nullptr, 0);
+        if (length <= 0)
+            return false;
+        std::wstring wide(static_cast<size_t>(length), L'\0');
+        if (MultiByteToWideChar(CP_UTF8, 0, text.data(), bytes, wide.data(), length) != length)
+            return false;
+
+        // Match the CRT text stream's LF -> CRLF translation, including multiline
+        // tracebacks. WriteConsoleW bypasses that translation.
+        if (wide.find(L'\n') != std::wstring::npos) {
+            std::wstring translated;
+            translated.reserve(wide.size());
+            for (const wchar_t character : wide) {
+                if (character == L'\n')
+                    translated += L'\r';
+                translated += character;
+            }
+            wide = std::move(translated);
+        }
+
+        size_t offset = 0;
+        while (offset < wide.size()) {
+            size_t count = (std::min)(size_t{16 * 1024}, wide.size() - offset);
+            // Do not divide a UTF-16 surrogate pair at a chunk boundary.
+            const wchar_t last = wide[offset + count - 1];
+            if (offset + count < wide.size() && last >= 0xd800 && last <= 0xdbff)
+                --count;
+            DWORD written = 0;
+            if (!WriteConsoleW(handle, wide.data() + offset, static_cast<DWORD>(count), &written, nullptr) || written == 0)
+                return offset != 0;
+            offset += written;
+        }
+        return true;
+    }
+
+} // namespace lfs::core::detail
+#endif

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -9,7 +9,11 @@
 #include <string_view>
 #include <utility>
 #include <vector>
-#ifndef _WIN32
+#ifdef _WIN32
+#include "core/windows_console.hpp"
+#include <fcntl.h>
+#include <memory>
+#else
 #include <unistd.h>
 #endif
 
@@ -71,6 +75,91 @@ namespace {
     }
 
 } // namespace
+
+#ifdef _WIN32
+TEST(LoggerWindowsConsoleTest, UnicodeUsesPrivateScreenBufferWithoutChangingConsoleSettings) {
+    // An inactive buffer exercises real WriteConsoleW without touching the user's
+    // visible output or changing the console code pages, modes or active buffer.
+    const HANDLE buffer = CreateConsoleScreenBuffer(GENERIC_READ | GENERIC_WRITE,
+                                                    FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                                    nullptr, CONSOLE_TEXTMODE_BUFFER, nullptr);
+    if (buffer == INVALID_HANDLE_VALUE)
+        GTEST_SKIP() << "Requires an attached Windows console";
+    const int fd = _open_osfhandle(reinterpret_cast<intptr_t>(buffer), _O_WRONLY | _O_TEXT);
+    if (fd < 0) {
+        CloseHandle(buffer);
+        FAIL() << "Cannot create console descriptor";
+    }
+    FILE* raw = _fdopen(fd, "w");
+    if (!raw) {
+        _close(fd);
+        FAIL() << "Cannot create console stream";
+    }
+    const std::unique_ptr<FILE, decltype(&std::fclose)> stream(raw, &std::fclose);
+    const auto input_cp = GetConsoleCP();
+    const auto output_cp = GetConsoleOutputCP();
+    DWORD mode_before = 0;
+    ASSERT_TRUE(GetConsoleMode(buffer, &mode_before));
+    EXPECT_EQ(lfs::core::detail::console_output_handle(stream.get()), buffer);
+
+    // Cross the writer's chunk boundary before the visible Unicode suffix.
+    std::string message(40'000, '\r');
+    message += "caf\xc3\xa9 \xe2\x80\x94 \xce\xa9 \xd0\x96\n";
+    ASSERT_TRUE(lfs::core::detail::write_console_utf8(buffer, message));
+    const std::wstring expected = L"caf\u00e9 \u2014 \u03a9 \u0416";
+    std::wstring actual(expected.size(), L'\0');
+    DWORD read = 0;
+    ASSERT_TRUE(ReadConsoleOutputCharacterW(buffer, actual.data(), static_cast<DWORD>(actual.size()),
+                                           COORD{0, 0}, &read));
+    EXPECT_EQ(read, expected.size());
+    EXPECT_EQ(actual, expected);
+    CONSOLE_SCREEN_BUFFER_INFO info{};
+    ASSERT_TRUE(GetConsoleScreenBufferInfo(buffer, &info));
+    EXPECT_EQ(info.dwCursorPosition.X, 0);
+    EXPECT_EQ(info.dwCursorPosition.Y, 1);
+    DWORD mode_after = 0;
+    ASSERT_TRUE(GetConsoleMode(buffer, &mode_after));
+    EXPECT_EQ(mode_after, mode_before);
+    EXPECT_EQ(GetConsoleCP(), input_cp);
+    EXPECT_EQ(GetConsoleOutputCP(), output_cp);
+}
+
+TEST(LoggerWindowsConsoleTest, RedirectedStdoutAndStderrRetainUtf8Bytes) {
+    LoggerInitGuard restore;
+    auto& logger = lfs::core::Logger::get();
+    const std::string message = "caf\xc3\xa9 \xe2\x80\x94 \xe6\x97\xa5\xe6\x9c\xac \xf0\x9f\x8c\x8d";
+    for (const bool use_stderr : {false, true}) {
+        logger.init(lfs::core::LogLevel::Info, "", "", use_stderr);
+        // Capture after init to guard against caching the old stream handle.
+        if (use_stderr)
+            testing::internal::CaptureStderr();
+        else
+            testing::internal::CaptureStdout();
+        const auto handle = lfs::core::detail::console_output_handle(use_stderr ? stderr : stdout);
+        logger.log(lfs::core::LogLevel::Info, LFS_SOURCE_SITE_CURRENT(), message);
+        const auto captured = use_stderr ? testing::internal::GetCapturedStderr()
+                                         : testing::internal::GetCapturedStdout();
+        EXPECT_EQ(handle, INVALID_HANDLE_VALUE);
+        EXPECT_EQ(count_occurrences(captured, message), 1);
+        EXPECT_NE(logger.buffered_logs_as_text().find(message), std::string::npos);
+    }
+}
+
+TEST(LoggerWindowsConsoleTest, InitializationWritesUnicodeProbeToLogFile) {
+    LoggerInitGuard restore;
+    const auto directory = unique_temp_dir("unicode_probe");
+    const auto log_file = directory / "startup.log";
+    std::filesystem::create_directories(directory);
+    lfs::core::Logger::get().init(lfs::core::LogLevel::Info, log_file.string());
+    lfs::core::Logger::get().flush();
+
+    const auto content = read_file(log_file);
+    EXPECT_NE(content.find("\xE2\x80\x94 UTF-8 console: \xE2\x9C\x93"), std::string::npos);
+    // Release the explicit rotating sink before deleting its Windows file.
+    lfs::core::Logger::get().init();
+    std::filesystem::remove_all(directory);
+}
+#endif
 
 TEST(LoggerTest, ScopedTimerThresholdSuppressesBelowThresholdPerfLog) {
     auto& logger = lfs::core::Logger::get();


### PR DESCRIPTION
Complements #2021.

Windows console logs were written as UTF-8 bytes through stdio. When the active console used a legacy code page, valid diagnostics could appear as mojibake, for example `ÔÇö` instead of `—`.

The logger now detects an attached Windows console and writes the formatted UTF-8 log line through `WriteConsoleW` after converting it to UTF-16. This preserves Unicode without changing the console code page, console mode, or the user's terminal configuration.

Redirected stdout and stderr keep the existing byte-oriented UTF-8 path, preserving behavior for files, pipes, CI, and log collectors. Console writes retain CRT-style CRLF handling for multiline messages such as Python tracebacks.

Windows startup logs now include:

```text
LichtFeld logger initialized — UTF-8 console: ✓