### PR TITLE
Stream bridge test: enter through the public wait, pin the retired-handle contract

### DIFF
--- a/src/core/tensor/internal/cuda_event_pool.hpp
+++ b/src/core/tensor/internal/cuda_event_pool.hpp
@@ -62,7 +62,12 @@ namespace lfs::core {
     // Orders all work currently enqueued on `from` before future work on `to`
     // (pooled event edge, host-sync fallback). Unlike waitForCUDAStream, a
     // nullptr `from` (legacy default stream) is still bridged — allocator
-    // reuse must order against legacy-stream work too.
+    // reuse must order against legacy-stream work too. `from` is a stored
+    // home stream that may have been released and destroyed since it was
+    // recorded, so a handle in the retired registry is skipped without
+    // touching the driver. The driver reuses handle values: a caller holding
+    // a live stream goes through waitForCUDAStream (or a guard, set_stream,
+    // the pools), which drops the handle from the registry first.
     LFS_CORE_API void bridgeStreams(cudaStream_t from, cudaStream_t to);
 
 } // namespace lfs::core

--- a/tests/test_cuda_event_pool.cpp
+++ b/tests/test_cuda_event_pool.cpp
@@ -1,13 +1,17 @@
 /* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include <algorithm>
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 #include <thread>
 #include <vector>
 
+#include "core/tensor.hpp"
 #include "core/tensor/internal/cuda_event_pool.hpp"
 #include "core/tensor/internal/cuda_stream_context.hpp"
+#include "core/tensor/internal/memory_pool.hpp"
+#include "core/tensor/internal/stream_lifetime.hpp"
 
 using namespace lfs::core;
 
@@ -108,6 +112,66 @@ TEST_F(CudaEventPoolTest, WaitOrdersCrossStreamWork) {
     cudaStreamDestroy(consumer);
 }
 
+TEST_F(CudaEventPoolTest, FreshStreamHandlesReuseRetiredValuesUntilTheyEnterTheApi) {
+    // The driver hands out the handle values of destroyed streams again, so the
+    // retired-stream registry (which lets bridgeStreams skip dead home streams
+    // without touching the driver) can name a live stream. Every entry point a
+    // caller-live handle passes through must drop it from the registry;
+    // otherwise a bridge from that stream is skipped and its consumer races.
+    std::vector<cudaStream_t> seeds(8);
+    for (auto& seed : seeds) {
+        ASSERT_EQ(cudaStreamCreateWithFlags(&seed, cudaStreamNonBlocking), cudaSuccess);
+        auto touched = Tensor::empty({64}, Device::CUDA);
+        touched.set_stream(seed);
+        touched.fill_(1.0f);
+    }
+    for (auto& seed : seeds) {
+        CudaMemoryPool::instance().release_stream(seed);
+        cudaStreamDestroy(seed);
+    }
+    cudaStream_t producer = nullptr;
+    cudaStream_t consumer = nullptr;
+    ASSERT_EQ(cudaStreamCreateWithFlags(&producer, cudaStreamNonBlocking), cudaSuccess);
+    ASSERT_EQ(cudaStreamCreateWithFlags(&consumer, cudaStreamNonBlocking), cudaSuccess);
+    const bool producer_reused =
+        std::find(seeds.begin(), seeds.end(), producer) != seeds.end();
+    if (producer_reused) {
+        EXPECT_TRUE(is_stream_retired(producer))
+            << "a reused handle still sits in the registry until it enters the API";
+    }
+
+    constexpr size_t kBytes = 64ull * 1024 * 1024;
+    void* buffer = nullptr;
+    ASSERT_EQ(cudaMalloc(&buffer, kBytes), cudaSuccess);
+    for (int pass = 0; pass < 16; ++pass) {
+        ASSERT_EQ(cudaMemsetAsync(buffer, 0x11, kBytes, producer), cudaSuccess);
+    }
+    ASSERT_EQ(cudaMemsetAsync(buffer, 0x6d, kBytes, producer), cudaSuccess);
+    waitForCUDAStream(consumer, producer);
+    EXPECT_FALSE(is_stream_retired(producer));
+    EXPECT_FALSE(is_stream_retired(consumer));
+
+    std::vector<unsigned char> host(kBytes);
+    ASSERT_EQ(cudaMemcpyAsync(host.data(), buffer, kBytes, cudaMemcpyDeviceToHost, consumer),
+              cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+    EXPECT_EQ(host.front(), 0x6d);
+    EXPECT_EQ(host[kBytes / 2], 0x6d);
+    EXPECT_EQ(host.back(), 0x6d);
+
+    {
+        cudaStream_t guarded = nullptr;
+        ASSERT_EQ(cudaStreamCreateWithFlags(&guarded, cudaStreamNonBlocking), cudaSuccess);
+        CUDAStreamGuard guard(guarded);
+        EXPECT_FALSE(is_stream_retired(guarded));
+        cudaStreamDestroy(guarded);
+    }
+
+    cudaFree(buffer);
+    cudaStreamDestroy(producer);
+    cudaStreamDestroy(consumer);
+}
+
 TEST_F(CudaEventPoolTest, EventAcquireFailureSynchronizesProducerFallback) {
     cudaStream_t producer, consumer;
     ASSERT_EQ(cudaStreamCreateWithFlags(&producer, cudaStreamNonBlocking), cudaSuccess);
@@ -118,8 +182,10 @@ TEST_F(CudaEventPoolTest, EventAcquireFailureSynchronizesProducerFallback) {
     ASSERT_EQ(cudaMalloc(&buffer, kBytes), cudaSuccess);
     ASSERT_EQ(cudaMemsetAsync(buffer, 0x6d, kBytes, producer), cudaSuccess);
 
+    // The public entry: bridgeStreams itself takes stored home streams and
+    // skips retired handles, and a fresh handle may reuse a retired value.
     set_cuda_event_acquire_failure_for_testing(true);
-    bridgeStreams(producer, consumer);
+    waitForCUDAStream(consumer, producer);
     set_cuda_event_acquire_failure_for_testing(false);
 
     std::vector<unsigned char> host(kBytes);


### PR DESCRIPTION
## Summary

`CudaEventPoolTest.EventAcquireFailureSynchronizesProducerFallback` fails under GPU load: the consumer reads zeros although the producer's memset was supposed to be ordered first.

The cause is not the fallback. The test bridges two freshly created raw streams through `bridgeStreams`, the internal entry that takes stored home streams and consults the retired-stream registry (streams that went through `release_stream` are recorded there so a bridge from a destroyed handle never touches the driver). The driver reuses handle values immediately: in a fresh process, eight streams created after eight released ones reused all eight values, and all eight were still listed as retired. `bridgeStreams` skipped the edge, and with no ordering the copy raced the memset; it only shows when the GPU is busy enough for the memset to still be pending.

The public entry points already handle this: `waitForCUDAStream`, `CUDAStreamGuard`, `Tensor::set_stream` and the pool registrations drop a handle from the registry when it enters as a live stream. The test bypassed them.

## Changes

- The fallback test goes through `waitForCUDAStream`, which has the same acquire-failure fallback (host sync of the dependency stream).
- `FreshStreamHandlesReuseRetiredValuesUntilTheyEnterTheApi` pins the contract: after releasing streams, a fresh stream that reuses a retired value is still listed as retired, `waitForCUDAStream` drops both handles from the registry and orders the consumer behind a 17-pass 64 MiB producer chain, and a `CUDAStreamGuard` drops its stream as well.
- The `bridgeStreams` comment states the contract for `from`.

No library code changes. Production callers (`selection_service.cpp`, `py_tensor.cpp`, the pools, `sync_to_stream`) pass tensor home streams that entered through those paths.

## Test

```
./build/tests/lichtfeld_tests --gtest_filter='CudaEventPoolTest.*:TensorStreamTest.*'
```

24 tests pass on this branch.
