### PR TITLE
Tensor: order synchronous host copies against the home stream

### DIFF
--- a/src/core/tensor/cuda_stream_context.cpp
+++ b/src/core/tensor/cuda_stream_context.cpp
@@ -70,6 +70,18 @@ namespace lfs::core {
         }
     }
 
+    cudaError_t memcpy_ordered(void* const dst, const void* const src, const size_t bytes,
+                               const cudaMemcpyKind kind, const cudaStream_t stream) {
+        if (stream != nullptr && kind == cudaMemcpyDeviceToHost) {
+            bridgeStreams(stream, nullptr);
+        }
+        const cudaError_t status = cudaMemcpy(dst, src, bytes, kind);
+        if (status == cudaSuccess && stream != nullptr && kind == cudaMemcpyHostToDevice) {
+            bridgeStreams(nullptr, stream);
+        }
+        return status;
+    }
+
     cudaStream_t prepare_inputs_for_stream(
         const std::initializer_list<const Tensor*> inputs,
         const std::optional<cudaStream_t> requested_stream) {

--- a/src/core/tensor/internal/cuda_stream_context.hpp
+++ b/src/core/tensor/internal/cuda_stream_context.hpp
@@ -25,6 +25,17 @@ namespace lfs::core {
         std::initializer_list<const Tensor*> inputs,
         std::optional<cudaStream_t> execution_stream = std::nullopt);
 
+    // Synchronous host<->device copy ordered against `stream`, the tensor's
+    // home stream. cudaMemcpy runs on the legacy default stream, which a
+    // non-blocking home stream neither waits for nor is waited on by: an
+    // upload from pageable memory returns while its DMA is still in flight,
+    // and a download may read before the home stream's producer finished.
+    // Downloads make the legacy stream wait for `stream` first; uploads make
+    // `stream` wait for the legacy stream afterwards. The host never waits on
+    // `stream` itself, so a gated or capturing home stream cannot deadlock.
+    LFS_CORE_API cudaError_t memcpy_ordered(void* dst, const void* src, size_t bytes,
+                                            cudaMemcpyKind kind, cudaStream_t stream);
+
     /**
      * RAII guard for temporarily setting the current CUDA stream
      * (PyTorch's CUDAStreamGuard pattern)

--- a/src/core/tensor/tensor.cpp
+++ b/src/core/tensor/tensor.cpp
@@ -1772,8 +1772,8 @@ namespace lfs::core {
                 const float* const download_src = ptr<float>();
                 const size_t download_bytes = bytes();
                 LFS_CUDA_CHECK_MSG_ARGS(
-                    cudaMemcpy(download_dst, download_src, download_bytes,
-                               cudaMemcpyDeviceToHost),
+                    memcpy_ordered(download_dst, download_src, download_bytes,
+                                   cudaMemcpyDeviceToHost, stream()),
                     reinterpret_cast<uintptr_t>(download_dst),
                     reinterpret_cast<uintptr_t>(download_src),
                     download_bytes,
@@ -1789,8 +1789,8 @@ namespace lfs::core {
                 unsigned char* const upload_dst = result.ptr<unsigned char>();
                 const size_t upload_bytes = numel();
                 LFS_CUDA_CHECK_MSG_ARGS(
-                    cudaMemcpy(upload_dst, dst_cpu, upload_bytes,
-                               cudaMemcpyHostToDevice),
+                    memcpy_ordered(upload_dst, dst_cpu, upload_bytes,
+                                   cudaMemcpyHostToDevice, result.stream()),
                     reinterpret_cast<uintptr_t>(upload_dst),
                     reinterpret_cast<uintptr_t>(dst_cpu),
                     upload_bytes,
@@ -1899,8 +1899,8 @@ namespace lfs::core {
                 const int* const download_src = ptr<int>();
                 const size_t download_bytes = bytes();
                 LFS_CUDA_CHECK_MSG_ARGS(
-                    cudaMemcpy(download_dst, download_src, download_bytes,
-                               cudaMemcpyDeviceToHost),
+                    memcpy_ordered(download_dst, download_src, download_bytes,
+                                   cudaMemcpyDeviceToHost, stream()),
                     reinterpret_cast<uintptr_t>(download_dst),
                     reinterpret_cast<uintptr_t>(download_src),
                     download_bytes,
@@ -1917,8 +1917,8 @@ namespace lfs::core {
                 const unsigned char* const upload_src = result_cpu.ptr<unsigned char>();
                 const size_t upload_bytes = numel() * sizeof(unsigned char);
                 LFS_CUDA_CHECK_MSG_ARGS(
-                    cudaMemcpy(upload_dst, upload_src, upload_bytes,
-                               cudaMemcpyHostToDevice),
+                    memcpy_ordered(upload_dst, upload_src, upload_bytes,
+                                   cudaMemcpyHostToDevice, result.stream()),
                     reinterpret_cast<uintptr_t>(upload_dst),
                     reinterpret_cast<uintptr_t>(upload_src),
                     upload_bytes,
@@ -1990,8 +1990,8 @@ namespace lfs::core {
                 const int64_t* const download_src = ptr<int64_t>();
                 const size_t download_bytes = bytes();
                 LFS_CUDA_CHECK_MSG_ARGS(
-                    cudaMemcpy(download_dst, download_src, download_bytes,
-                               cudaMemcpyDeviceToHost),
+                    memcpy_ordered(download_dst, download_src, download_bytes,
+                                   cudaMemcpyDeviceToHost, stream()),
                     reinterpret_cast<uintptr_t>(download_dst),
                     reinterpret_cast<uintptr_t>(download_src),
                     download_bytes,
@@ -2008,8 +2008,8 @@ namespace lfs::core {
                 const unsigned char* const upload_src = result_cpu.ptr<unsigned char>();
                 const size_t upload_bytes = numel() * sizeof(unsigned char);
                 LFS_CUDA_CHECK_MSG_ARGS(
-                    cudaMemcpy(upload_dst, upload_src, upload_bytes,
-                               cudaMemcpyHostToDevice),
+                    memcpy_ordered(upload_dst, upload_src, upload_bytes,
+                                   cudaMemcpyHostToDevice, result.stream()),
                     reinterpret_cast<uintptr_t>(upload_dst),
                     reinterpret_cast<uintptr_t>(upload_src),
                     upload_bytes,
@@ -2064,8 +2064,8 @@ namespace lfs::core {
                 const __half* const download_src = ptr<__half>();
                 const size_t download_bytes = bytes();
                 LFS_CUDA_CHECK_MSG_ARGS(
-                    cudaMemcpy(download_dst, download_src, download_bytes,
-                               cudaMemcpyDeviceToHost),
+                    memcpy_ordered(download_dst, download_src, download_bytes,
+                                   cudaMemcpyDeviceToHost, stream()),
                     reinterpret_cast<uintptr_t>(download_dst),
                     reinterpret_cast<uintptr_t>(download_src),
                     download_bytes,
@@ -2090,8 +2090,8 @@ namespace lfs::core {
                 const unsigned char* const upload_src = result_cpu.ptr<unsigned char>();
                 const size_t upload_bytes = numel() * sizeof(unsigned char);
                 LFS_CUDA_CHECK_MSG_ARGS(
-                    cudaMemcpy(upload_dst, upload_src, upload_bytes,
-                               cudaMemcpyHostToDevice),
+                    memcpy_ordered(upload_dst, upload_src, upload_bytes,
+                                   cudaMemcpyHostToDevice, result.stream()),
                     reinterpret_cast<uintptr_t>(upload_dst),
                     reinterpret_cast<uintptr_t>(upload_src),
                     upload_bytes,
@@ -2275,7 +2275,7 @@ namespace lfs::core {
             unsigned char bool_val = (value != 0.0f) ? 1 : 0;
             if (device_ == Device::CUDA) {
                 std::vector<unsigned char> temp(numel(), bool_val);
-                LFS_CUDA_CHECK(cudaMemcpy(dest, temp.data(), bytes(), cudaMemcpyHostToDevice));
+                LFS_CUDA_CHECK(memcpy_ordered(dest, temp.data(), bytes(), cudaMemcpyHostToDevice, stream()));
             } else {
                 unsigned char* data = static_cast<unsigned char*>(dest);
                 std::fill(data, data + numel(), bool_val);
@@ -2288,7 +2288,7 @@ namespace lfs::core {
             int int_val = static_cast<int>(value);
             if (device_ == Device::CUDA) {
                 std::vector<int> temp(numel(), int_val);
-                LFS_CUDA_CHECK(cudaMemcpy(dest, temp.data(), bytes(), cudaMemcpyHostToDevice));
+                LFS_CUDA_CHECK(memcpy_ordered(dest, temp.data(), bytes(), cudaMemcpyHostToDevice, stream()));
             } else {
                 int* data = static_cast<int*>(dest);
                 std::fill(data, data + numel(), int_val);
@@ -2299,7 +2299,7 @@ namespace lfs::core {
         // Handle Float32 dtype (original code)
         if (device_ == Device::CUDA) {
             std::vector<float> temp(numel(), value);
-            LFS_CUDA_CHECK(cudaMemcpy(dest, temp.data(), bytes(), cudaMemcpyHostToDevice));
+            LFS_CUDA_CHECK(memcpy_ordered(dest, temp.data(), bytes(), cudaMemcpyHostToDevice, stream()));
         } else {
             float* data = static_cast<float*>(dest);
             std::fill(data, data + numel(), value);
@@ -2427,10 +2427,10 @@ namespace lfs::core {
                                                cudaMemcpyDeviceToDevice, execution_stream));
             } else if (device_ == Device::CUDA && src.device_ == Device::CPU) {
                 prepare_inputs_for_stream({this, &src}, stream());
-                LFS_CUDA_CHECK(cudaMemcpy(data_ptr(), src.data_ptr(), bytes(), cudaMemcpyHostToDevice));
+                LFS_CUDA_CHECK(memcpy_ordered(data_ptr(), src.data_ptr(), bytes(), cudaMemcpyHostToDevice, stream()));
             } else if (device_ == Device::CPU && src.device_ == Device::CUDA) {
                 prepare_inputs_for_stream({this, &src}, src.stream());
-                LFS_CUDA_CHECK(cudaMemcpy(data_ptr(), src.data_ptr(), bytes(), cudaMemcpyDeviceToHost));
+                LFS_CUDA_CHECK(memcpy_ordered(data_ptr(), src.data_ptr(), bytes(), cudaMemcpyDeviceToHost, src.stream()));
             } else {
                 std::memcpy(data_ptr(), src.data_ptr(), bytes());
             }
@@ -3111,7 +3111,8 @@ namespace lfs::core {
 
         if (device_ == Device::CUDA) {
             LOG_DEBUG("Copying from CUDA to CPU, bytes: {}", bytes());
-            LFS_CUDA_CHECK(cudaMemcpy(result.data(), data_ptr(), bytes(), cudaMemcpyDeviceToHost));
+            LFS_CUDA_CHECK(memcpy_ordered(result.data(), data_ptr(), bytes(),
+                                          cudaMemcpyDeviceToHost, stream()));
             LOG_DEBUG("CUDA copy complete");
         } else {
             LOG_DEBUG("Copying from CPU memory, bytes: {}", bytes());
@@ -3156,7 +3157,8 @@ namespace lfs::core {
         std::vector<int> result(numel());
 
         if (device_ == Device::CUDA) {
-            LFS_CUDA_CHECK(cudaMemcpy(result.data(), data_ptr(), bytes(), cudaMemcpyDeviceToHost));
+            LFS_CUDA_CHECK(memcpy_ordered(result.data(), data_ptr(), bytes(),
+                                          cudaMemcpyDeviceToHost, stream()));
         } else {
             std::memcpy(result.data(), data_ptr(), bytes());
         }

--- a/src/core/tensor/tensor_masking_ops.cpp
+++ b/src/core/tensor/tensor_masking_ops.cpp
@@ -2137,8 +2137,8 @@ namespace lfs::core {
         if (device_ == Device::CUDA) {
             float value;
             LFS_CUDA_CHECK_MSG(
-                cudaMemcpy(&value, ptr<float>() + linear_idx, sizeof(float),
-                           cudaMemcpyDeviceToHost),
+                memcpy_ordered(&value, ptr<float>() + linear_idx, sizeof(float),
+                               cudaMemcpyDeviceToHost, stream()),
                 "Tensor::at readback (bytes={}, linear_index={}, tensor_shape={}, "
                 "source_pointer={})",
                 sizeof(float), linear_idx, shape_.str(),
@@ -2161,8 +2161,8 @@ namespace lfs::core {
 
         if (t.numel() > 0 && data.data() != nullptr) {
             if (device == Device::CUDA) {
-                LFS_CUDA_CHECK(cudaMemcpy(t.data_ptr(), data.data(), t.bytes(),
-                                          cudaMemcpyHostToDevice));
+                LFS_CUDA_CHECK(memcpy_ordered(t.data_ptr(), data.data(), t.bytes(),
+                                              cudaMemcpyHostToDevice, t.stream()));
             } else {
                 std::memcpy(t.data_ptr(), data.data(), t.bytes());
             }
@@ -2220,8 +2220,8 @@ namespace lfs::core {
 
         if (device_ == Device::CUDA) {
             LFS_CUDA_CHECK_MSG(
-                cudaMemcpy(ptr<unsigned char>() + linear_idx, &val, 1,
-                           cudaMemcpyHostToDevice),
+                memcpy_ordered(ptr<unsigned char>() + linear_idx, &val, 1,
+                               cudaMemcpyHostToDevice, stream()),
                 "Tensor::set_bool upload (bytes=1, linear_index={}, tensor_shape={}, value={})",
                 linear_idx, shape_.str(), value);
         } else {
@@ -2248,8 +2248,8 @@ namespace lfs::core {
         if (device_ == Device::CUDA) {
             unsigned char val;
             LFS_CUDA_CHECK_MSG(
-                cudaMemcpy(&val, ptr<unsigned char>() + linear_idx, 1,
-                           cudaMemcpyDeviceToHost),
+                memcpy_ordered(&val, ptr<unsigned char>() + linear_idx, 1,
+                               cudaMemcpyDeviceToHost, stream()),
                 "Tensor::get_bool readback (bytes=1, linear_index={}, tensor_shape={})",
                 linear_idx, shape_.str());
             return val != 0;


### PR DESCRIPTION
## Summary

`TensorLazyRuntimeTest.ErankExpressionMatchesTorchOnInheritedStream` fails now and then in full-suite runs and never in isolation. When it fails, a handful of scattered rows carry values computed from garbage input (erank 1.1 to 1.4 where 2.998 is expected), which points at the upload, not the kernels.

The cause is a CUDA rule for pageable copies: `cudaMemcpy` from pageable host memory returns once the source has been staged, while its DMA may still be in flight on the legacy default stream. A non-blocking stream neither waits for the legacy stream nor is waited on by it, so a tensor created with `from_vector` under a stream guard and consumed by kernels on that stream can be read before its data has landed. The same rule bites downloads: a `cudaMemcpy` device-to-host copy on the legacy stream does not wait for a producer kernel on a non-blocking home stream.

## Fix

`memcpy_ordered` (internal, `cuda_stream_context.hpp`) keeps the copy a synchronous legacy-stream `cudaMemcpy` and adds the event edge the rest of the library already uses in `Tensor::to`:

- download: the legacy stream waits for the tensor's home stream first
- upload: the home stream waits for the legacy stream afterwards

The host never waits on the home stream itself, so a gated or capturing home stream cannot deadlock (a first attempt that waited on the home stream deadlocked `TensorMultiStreamTest.ExplicitH2DViewMoveAssignmentGuardsDroppedPinnedSource`, whose gate opens only after the copy returns). Tensors without a home stream keep the plain `cudaMemcpy`.

Call sites: `from_vector`, the host-staged `fill_` paths, `copy_from` between CPU and CUDA, the host-staged conversions in `to(DataType)`, `at`, `set_bool`, `get_bool`, `to_vector_int` and `to_vector_int64`. The reads that already synchronize the device first (`item`, `debug_values`, `to_vector`) are untouched.

## Test

```
./build/tests/lichtfeld_tests --gtest_filter='*Tensor*:CudaEventPoolTest.*'
```

1,188 tests pass on this branch. Three tests fail in the build lane for reasons outside the change: the two Python integration tests find no built module there, and `AllocCounterTest.FreshLargeTensorIncrementsCounter` is order-dependent inside that broad filter and passes on its own. The stream, multi-stream and lazy runtime suites pass three times in a row (58 tests each). The busy-copy-engine unit test I tried could not force the race deterministically, so the proof for the flake itself is the full suite on the tensor-backend branch, where the same pattern is applied; I will note the result here when those runs finish.
