### PR TITLE
Expose consistent 3DGS and 3DGUT training backend identities

### DIFF
--- a/docs/docs/development/training-backend-contract.md
+++ b/docs/docs/development/training-backend-contract.md
@@ -52,16 +52,13 @@ result instead of duplicating UI text in the descriptor.
   and Python writers of `gut` therefore remain effective.
 - JSON accepts `raster_backend: "3dgs"` or `"3dgut"`. Files containing only
   `gut` retain their original meaning. Missing both selects the existing 3DGS default.
-- New JSON writes both names consistently. While `gut` remains the compatibility
-  storage, its value takes precedence if a previous application preserved a stale
-  known `raster_backend` field while changing `gut`. Unknown identifiers and
-  incorrect JSON types are still errors.
-- This precedence also applies to `--config` JSON. If both fields disagree,
-  `gut` wins and a warning is logged. When editing a config, update both fields
-  consistently or remove `gut` to select solely through `raster_backend`.
-  For example, `{"gut": true, "raster_backend": "3dgs"}` still selects 3DGUT;
-  `{"raster_backend": "3dgs"}` selects 3DGS. An explicit CLI backend selection
-  overrides either valid config after loading it.
+- New JSON writes both names consistently. If both fields are present, they
+  must agree. A disagreement, unknown identifier, or incorrect JSON type is an
+  error, including in configs, checkpoint parameters, and project presets.
+- For example, `{"gut": true, "raster_backend": "3dgs"}` is rejected;
+  `{"raster_backend": "3dgs"}` selects 3DGS. Config authors must update both
+  fields consistently or specify only one. Explicit CLI selection overrides a
+  valid config, not an invalid file that already failed loading.
 - `--raster-backend 3dgs|3dgut` is additive. `--gut` remains an alias for 3DGUT.
   `--gut --raster-backend 3dgs` is an error, independent of argument order.
 - Explicit CLI selection overrides a valid configuration's backend. Its captured
@@ -70,14 +67,10 @@ result instead of duplicating UI text in the descriptor.
   fail their existing load-time validation before CLI overrides are applied.
 - Checkpoint parameter JSON and `.licht` parameter presets use the same adapters.
   The binary checkpoint format and `.licht` chapter schema are unchanged.
-- A stored `.licht` preset may retain an unsupported 3DGUT option so legacy
-  projects can still open without silently changing user data. Storage validation
-  continues to reject malformed values; trainer validation reports the backend
-  conflict when Start is requested.
-- Older applications ignore the new field and continue to read `gut`. In `.licht`,
-  they can preserve the unknown new field while changing `gut`; the precedence
-  rule above ensures that the file still reopens with the legacy application's
-  selected backend.
+- Stored parameters follow the strict validation established by PR #2047.
+  Unsupported 3DGUT combinations are rejected by validating load paths, as
+  well as start/resume preflight. There is no separate storage-validation mode,
+  inherited-option normalization, or older `.licht` writer precedence rule.
 
 ## Python and viewer lifecycle
 
@@ -87,6 +80,9 @@ notification path. `backend_capabilities` returns the complete high-level map fo
 the selected backend using the strings `supported` and `unsupported`.
 `lf.training_backends()` lists IDs, labels, descriptions, viewer IDs, and the
 same capability map without needing to change the current selection.
+`set("raster_backend", value)` rejects non-string values and unknown names with
+an actionable `ValueError`, without changing the selected backend. `None` retains
+the existing binding-level `TypeError` before setter dispatch.
 
 These are next-run parameter APIs, not an atomic command to replace an active
 trainer and viewer. The existing panel change path still updates its viewer
@@ -96,8 +92,11 @@ and active trainer state. The future RmlUi selector should use the descriptors
 and the existing scene/lifecycle commands rather than mutating active training
 from a parameter setter.
 
-Training and evaluation dispatch use the named identity. The existing viewer
-hand-off in `application.cpp` and `visualizer_impl.cpp`, status-bar label, and
+Training and evaluation dispatch use the named identity. The status bar uses
+the active trainer's backend or, before restoration, the saved checkpoint's
+backend. Missing identity is omitted rather than presented as 3DGS. Labels come
+from the backend descriptors, independently of viewer and next-run choices.
+The existing viewer hand-off in `application.cpp` and `visualizer_impl.cpp` and
 training panel still consume the compatibility `gut` boolean. These consumers
 must also migrate before a backend beyond the current two can be installed.
 Training and viewer identifiers use the same `3dgs`/`3dgut` vocabulary.
@@ -107,7 +106,7 @@ Training and viewer identifiers use the same `3dgs`/`3dgut` vocabulary.
 This is a compatibility step, not runtime backend registration. An additional
 backend needs its implementation, descriptor, an explicit state for every
 high-level capability, explicit dispatch, and a replacement for boolean `gut`
-storage with legacy accessors. Unknown enum values are rejected by the
+storage with accessors for the existing API. Unknown enum values are rejected by the
 compatibility setter. Do not map an additional backend to either boolean value or
 assume that adding a descriptor installs a rasterizer.
 
@@ -120,7 +119,7 @@ runtime libraries on the library search path. The chapter test belongs to
 ```powershell
 .\build\tests\lichtfeld_tests.exe '--gtest_filter=TrainingParametersTest.*:ArgumentParserTest.*Backend*:ArgumentParserTest.Gut*:TrainerConstructionTest.*:CheckpointParamsJsonTest.*:ParameterManagerTest.PendingProjectRestoreChangesOnlyRoleQualifiedManagerState' --gtest_color=no
 .\build\tests\lichtfeld_format_tests.exe '--gtest_filter=ProjectChapterTest.TrainingBackendIdentityRoundTripAndCompatibility' --gtest_color=no
-python -m pytest tests/python/test_property_system.py -q -p no:cacheprovider
+.\build\vcpkg_installed\x64-windows\tools\python3\python.exe -m pytest tests/python/test_property_system.py -q -p no:cacheprovider
 ```
 
 On Linux, with the build's Python module and libraries available:
@@ -128,15 +127,18 @@ On Linux, with the build's Python module and libraries available:
 ```sh
 ./build/tests/lichtfeld_tests --gtest_filter='TrainingParametersTest.*:ArgumentParserTest.*Backend*:ArgumentParserTest.Gut*:TrainerConstructionTest.*:CheckpointParamsJsonTest.*:ParameterManagerTest.PendingProjectRestoreChangesOnlyRoleQualifiedManagerState'
 ./build/tests/lichtfeld_format_tests --gtest_filter='ProjectChapterTest.TrainingBackendIdentityRoundTripAndCompatibility'
-python3 -m pytest tests/python/test_property_system.py -q -p no:cacheprovider
+./build/vcpkg_installed/x64-linux/tools/python3/python3.12 -m pytest tests/python/test_property_system.py -q -p no:cacheprovider
 ```
 
-Use the Python interpreter matching the built extension. Local shell helpers
+These paths assume the standard vcpkg triplets. Use the Python interpreter
+matching the built extension, with pytest installed and the built module and
+its runtime libraries available; a system Python is not interchangeable.
+Local shell helpers
 are not repository prerequisites. After changing native Python bindings,
 generate the committed stubs from the rebuilt module via `refresh_python_stubs`
 and run `check_python_stubs`; do not maintain binding stubs by hand.
 
-Manual checks: open legacy 3DGS and 3DGUT projects/checkpoints, save and reopen
+Manual checks: open valid 3DGS and 3DGUT projects/checkpoints, save and reopen
 them, change the backend through Python and the existing panel, and verify a
 valid training run with each backend. Exercise CLI selection, config overrides,
 viewer startup, and invalid aliases. Confirm that changing next-run settings

--- a/docs/docs/development/training-backend-contract.md
+++ b/docs/docs/development/training-backend-contract.md
@@ -1,0 +1,118 @@
+# Training backend identity and compatibility
+
+Training strategy and raster backend are independent choices. `3dgs` is the
+default training backend; `3dgut` selects Gaussian Unscented Transform rendering.
+No additional backend alias is introduced for 3DGS.
+
+`core/training_backend.hpp` owns the backend identifiers, labels, descriptions,
+viewer mapping, and high-level training capabilities. Its descriptions provide
+technical tooltip text for later UI consumers. The capability map is exhaustive
+for the high-level feature groups exposed by the training panel; a consumer does
+not need to infer support from a missing key.
+
+Each capability has one of two states:
+
+- `supported`: the backend path is established and may be presented normally;
+- `unsupported`: the combination is a known hard incompatibility and may prevent
+  training from starting.
+
+Only `unsupported` participates in central backend validation. The current
+matrix is:
+
+| Feature group | 3DGS | 3DGUT |
+| --- | --- | --- |
+| MCMC strategy | supported | supported |
+| MRNF strategy | supported | supported |
+| IGS+ strategy | supported | unsupported |
+| Undistortion | supported | supported |
+| Mip Filter | supported | unsupported |
+| Depth supervision | supported | unsupported |
+| Normal supervision | supported | unsupported |
+| Masking | supported | supported |
+| Segmentation | supported | supported |
+| Background modes | supported | supported |
+| Background Improvements | supported | supported |
+| Exposure correction | supported | supported |
+| Bilateral grid | supported | supported |
+| PPISP | supported | supported |
+| Sparsity | supported | supported |
+
+This matrix describes backend compatibility, not complete option availability.
+Detailed numeric controls, strategy-specific applicability, mutually exclusive
+option groups, and dataset requirements still belong to the property registry
+and the later resolved UI model. For example, Background Improvements is an MRNF
+option even though the backend matrix also reports its backend support state.
+Localized conflict reasons continue to come from the existing backend-conflict
+result instead of duplicating UI text in the descriptor.
+
+## Compatibility rules
+
+- `OptimizationParameters::raster_backend()` and `set_raster_backend()` adapt the
+  existing `gut` storage. There is no second mutable backend field. Existing C++
+  and Python writers of `gut` therefore remain effective.
+- JSON accepts `raster_backend: "3dgs"` or `"3dgut"`. Files containing only
+  `gut` retain their original meaning. Missing both selects the existing 3DGS default.
+- New JSON writes both names consistently. While `gut` remains the compatibility
+  storage, its value takes precedence if a previous application preserved a stale
+  known `raster_backend` field while changing `gut`. Unknown identifiers and
+  incorrect JSON types are still errors.
+- `--raster-backend 3dgs|3dgut` is additive. `--gut` remains an alias for 3DGUT.
+  `--gut --raster-backend 3dgs` is an error, independent of argument order.
+- Explicit CLI selection overrides a valid configuration's backend. Its captured
+  overrides contain both aliases so subsequent checkpoint restoration cannot
+  combine a stale config alias with the CLI choice. Invalid configurations still
+  fail their existing load-time validation before CLI overrides are applied.
+- Checkpoint parameter JSON and `.licht` parameter presets use the same adapters.
+  The binary checkpoint format and `.licht` chapter schema are unchanged.
+- A stored `.licht` preset may retain an unsupported 3DGUT option so legacy
+  projects can still open without silently changing user data. Storage validation
+  continues to reject malformed values; trainer validation reports the backend
+  conflict when Start is requested.
+- Older applications ignore the new field and continue to read `gut`. In `.licht`,
+  they can preserve the unknown new field while changing `gut`; the precedence
+  rule above ensures that the file still reopens with the legacy application's
+  selected backend.
+
+## Python and viewer lifecycle
+
+`lf.optimization_params().raster_backend` and `get/set("raster_backend", ...)`
+access the same backend as `gut`. The new setter uses the existing `gut` property
+notification path. `backend_capabilities` returns the complete high-level map for
+the selected backend using the strings `supported` and `unsupported`.
+`lf.training_backends()` lists IDs, labels, descriptions, viewer IDs, and the
+same capability map without needing to change the current selection.
+
+These are next-run parameter APIs, not an atomic command to replace an active
+trainer and viewer. The existing panel change path still updates its viewer
+setting; viewer startup receives the resolved compatibility value. Project
+restoration preserves the distinction between session defaults, next-run presets,
+and active trainer state. The future RmlUi selector should use the descriptors
+and the existing scene/lifecycle commands rather than mutating active training
+from a parameter setter.
+
+## Adding another backend later
+
+This is a compatibility step, not runtime backend registration. An additional
+backend needs its implementation, descriptor, an explicit state for every
+high-level capability, explicit dispatch, and a replacement for boolean `gut`
+storage with legacy accessors. Unknown enum values are rejected by the
+compatibility setter. Do not map an additional backend to either boolean value or
+assume that adding a descriptor installs a rasterizer.
+
+## Verification
+
+After updating the native binaries, run from the repository in the normal
+PowerShell development environment:
+
+```powershell
+lfsdev
+.\build\tests\lichtfeld_tests.exe --gtest_filter="TrainingParametersTest.BackendIdentityCompatibility:TrainingParametersTest.SupportedThreeDGUTCapabilitiesRemainNonBlocking:TrainingParametersTest.StoredBackendConflictPreservesSettingsButStillRejectsInvalidNumbers:ArgumentParserTest.ExplicitBackendSelectionAndLegacyAlias:ArgumentParserTest.BackendCliOverrideReplacesConfigAliasesTogether:ArgumentParserTest.ViewerBackendSelectionSurvivesParameterDefaults:ProjectChapterTest.TrainingBackendIdentityRoundTripAndCompatibility:ParameterManagerTest.PendingProjectRestoreChangesOnlyRoleQualifiedManagerState" --gtest_color=no
+lfspytest tests/python/test_property_system.py -q -p no:cacheprovider
+```
+
+Manual checks: open legacy 3DGS and 3DGUT projects/checkpoints, save and reopen
+them, change the backend through Python and the existing panel, and verify a
+valid training run with each backend. Exercise CLI selection, config overrides,
+viewer startup, and invalid aliases. Confirm that changing next-run settings
+does not replace an active trainer. The parameter/chapter tests do not prove
+end-to-end project restoration or GPU training behavior.

--- a/docs/docs/development/training-backend-contract.md
+++ b/docs/docs/development/training-backend-contract.md
@@ -56,6 +56,12 @@ result instead of duplicating UI text in the descriptor.
   storage, its value takes precedence if a previous application preserved a stale
   known `raster_backend` field while changing `gut`. Unknown identifiers and
   incorrect JSON types are still errors.
+- This precedence also applies to `--config` JSON. If both fields disagree,
+  `gut` wins and a warning is logged. When editing a config, update both fields
+  consistently or remove `gut` to select solely through `raster_backend`.
+  For example, `{"gut": true, "raster_backend": "3dgs"}` still selects 3DGUT;
+  `{"raster_backend": "3dgs"}` selects 3DGS. An explicit CLI backend selection
+  overrides either valid config after loading it.
 - `--raster-backend 3dgs|3dgut` is additive. `--gut` remains an alias for 3DGUT.
   `--gut --raster-backend 3dgs` is an error, independent of argument order.
 - Explicit CLI selection overrides a valid configuration's backend. Its captured
@@ -90,6 +96,12 @@ and active trainer state. The future RmlUi selector should use the descriptors
 and the existing scene/lifecycle commands rather than mutating active training
 from a parameter setter.
 
+Training and evaluation dispatch use the named identity. The existing viewer
+hand-off in `application.cpp` and `visualizer_impl.cpp`, status-bar label, and
+training panel still consume the compatibility `gut` boolean. These consumers
+must also migrate before a backend beyond the current two can be installed.
+Training and viewer identifiers use the same `3dgs`/`3dgut` vocabulary.
+
 ## Adding another backend later
 
 This is a compatibility step, not runtime backend registration. An additional
@@ -101,14 +113,28 @@ assume that adding a descriptor installs a rasterizer.
 
 ## Verification
 
-After updating the native binaries, run from the repository in the normal
-PowerShell development environment:
+After updating the native binaries, run from the repository with the application's
+runtime libraries on the library search path. The chapter test belongs to
+`lichtfeld_format_tests`, not `lichtfeld_tests`.
 
 ```powershell
-lfsdev
-.\build\tests\lichtfeld_tests.exe --gtest_filter="TrainingParametersTest.BackendIdentityCompatibility:TrainingParametersTest.SupportedThreeDGUTCapabilitiesRemainNonBlocking:TrainingParametersTest.StoredBackendConflictPreservesSettingsButStillRejectsInvalidNumbers:ArgumentParserTest.ExplicitBackendSelectionAndLegacyAlias:ArgumentParserTest.BackendCliOverrideReplacesConfigAliasesTogether:ArgumentParserTest.ViewerBackendSelectionSurvivesParameterDefaults:ProjectChapterTest.TrainingBackendIdentityRoundTripAndCompatibility:ParameterManagerTest.PendingProjectRestoreChangesOnlyRoleQualifiedManagerState" --gtest_color=no
-lfspytest tests/python/test_property_system.py -q -p no:cacheprovider
+.\build\tests\lichtfeld_tests.exe '--gtest_filter=TrainingParametersTest.*:ArgumentParserTest.*Backend*:ArgumentParserTest.Gut*:TrainerConstructionTest.*:CheckpointParamsJsonTest.*:ParameterManagerTest.PendingProjectRestoreChangesOnlyRoleQualifiedManagerState' --gtest_color=no
+.\build\tests\lichtfeld_format_tests.exe '--gtest_filter=ProjectChapterTest.TrainingBackendIdentityRoundTripAndCompatibility' --gtest_color=no
+python -m pytest tests/python/test_property_system.py -q -p no:cacheprovider
 ```
+
+On Linux, with the build's Python module and libraries available:
+
+```sh
+./build/tests/lichtfeld_tests --gtest_filter='TrainingParametersTest.*:ArgumentParserTest.*Backend*:ArgumentParserTest.Gut*:TrainerConstructionTest.*:CheckpointParamsJsonTest.*:ParameterManagerTest.PendingProjectRestoreChangesOnlyRoleQualifiedManagerState'
+./build/tests/lichtfeld_format_tests --gtest_filter='ProjectChapterTest.TrainingBackendIdentityRoundTripAndCompatibility'
+python3 -m pytest tests/python/test_property_system.py -q -p no:cacheprovider
+```
+
+Use the Python interpreter matching the built extension. Local shell helpers
+are not repository prerequisites. After changing native Python bindings,
+generate the committed stubs from the rebuilt module via `refresh_python_stubs`
+and run `check_python_stubs`; do not maintain binding stubs by hand.
 
 Manual checks: open legacy 3DGS and 3DGUT projects/checkpoints, save and reopen
 them, change the backend through Python and the existing panel, and verify a

--- a/src/core/argument_parser.cpp
+++ b/src/core/argument_parser.cpp
@@ -701,6 +701,7 @@ namespace {
             ::args::Flag ppisp_freeze_from_sidecar(rendering_group, "ppisp_freeze", lfs::core::args::optimization_cli_help("--ppisp-freeze"), {"ppisp-freeze"});
             ::args::ValueFlag<std::string> ppisp_sidecar_path(rendering_group, "path", "Path to PPISP sidecar (.ppisp) used for frozen PPISP training", {"ppisp-sidecar"});
             ::args::Flag gut(rendering_group, "gut", lfs::core::args::optimization_cli_help("--gut"), {"gut"});
+            ::args::ValueFlag<std::string> raster_backend(rendering_group, "raster_backend", "Training raster backend: 3dgs or 3dgut (--gut is the legacy 3dgut alias)", {"raster-backend"});
 
             // =============================================================================
             // OUTPUT OPTIONS
@@ -864,6 +865,17 @@ namespace {
 
             params.include_provenance = !no_provenance;
 
+            std::optional<lfs::core::param::RasterBackendId> selected_backend;
+            if (raster_backend) {
+                selected_backend = lfs::core::param::parse_training_backend(::args::get(raster_backend));
+                if (!selected_backend)
+                    return std::unexpected("Unknown --raster-backend; expected 3dgs or 3dgut");
+                if (gut && *selected_backend != lfs::core::param::RasterBackendId::ThreeDGUT)
+                    return std::unexpected("Conflicting --gut with a 3DGS --raster-backend selection");
+            } else if (gut) {
+                selected_backend = lfs::core::param::RasterBackendId::ThreeDGUT;
+            }
+
             // NO ARGUMENTS = VIEWER MODE (empty)
             if (args.size() == 1) {
                 return std::make_tuple(ParseResult::Success, std::function<void()>{});
@@ -887,9 +899,8 @@ namespace {
                         return std::unexpected(applied.error());
                 }
 
-                if (gut) {
-                    params.optimization.gut = true;
-                }
+                if (selected_backend)
+                    params.optimization.set_raster_backend(*selected_backend);
                 if (!valid_mcp_port(per_launch_mcp_port)) {
                     return std::unexpected(kMcpPortRangeError);
                 }
@@ -898,8 +909,16 @@ namespace {
                 // after this return; re-apply so --no-splash survives.
                 return std::make_tuple(
                     ParseResult::Success,
-                    std::function<void()>([&params, per_launch_no_splash,
+                    std::function<void()>([&params, per_launch_no_splash, selected_backend,
                                            per_launch_mcp_port]() {
+                        if (selected_backend) {
+                            params.optimization.set_raster_backend(*selected_backend);
+                            lfs::core::param::merge_explicit_json_overlay(
+                                params.overrides.optimization_json,
+                                nlohmann::json{{"gut", params.optimization.gut},
+                                               {"raster_backend", std::string(lfs::core::param::training_backend_descriptor(*selected_backend).wire_name)}}
+                                    .dump());
+                        }
                         apply_per_launch_ui_flags(
                             params, per_launch_no_splash, per_launch_mcp_port);
                     }));
@@ -1310,6 +1329,7 @@ namespace {
                                         bg_color_val = parsed_bg_color,
                                         bg_image_path_val = cli_option_present({"--bg-image-path"}) ? std::optional<std::string>(::args::get(bg_image_path)) : std::optional<std::string>(),
                                         random_flag = bool(random),
+                                        selected_backend,
                                         gut_flag = bool(gut),
                                         undistort_flag = bool(undistort),
                                         enable_sparsity_flag = bool(enable_sparsity),
@@ -1475,6 +1495,8 @@ namespace {
                 }
                 setFlag(random_flag, opt.random);
                 setFlag(gut_flag, opt.gut);
+                if (selected_backend)
+                    opt.set_raster_backend(*selected_backend);
                 setFlag(undistort_flag, opt.undistort);
                 setFlag(enable_sparsity_flag, opt.enable_sparsity);
                 if (no_error_map_flag)
@@ -1590,7 +1612,8 @@ namespace {
                 note_opt("bg_color", bg_color_val.has_value());
                 note_opt("bg_image_path", bg_image_path_val.has_value());
                 note_opt("random", random_flag);
-                note_opt("gut", gut_flag);
+                note_opt("gut", selected_backend.has_value());
+                note_opt("raster_backend", selected_backend.has_value());
                 note_opt("undistort", undistort_flag);
                 note_opt("enable_sparsity", enable_sparsity_flag);
                 note_opt("use_error_map", no_error_map_flag);

--- a/src/core/include/core/parameters.hpp
+++ b/src/core/include/core/parameters.hpp
@@ -6,6 +6,7 @@
 
 #include "core/export.hpp"
 #include "core/mesh2splat.hpp"
+#include "core/training_backend.hpp"
 
 #include <algorithm>
 #include <array>
@@ -329,6 +330,17 @@ namespace lfs::core {
             nlohmann::json to_json() const;
             static OptimizationParameters from_json(const nlohmann::json& j);
 
+            // Compatibility storage remains gut until all legacy writers migrate.
+            [[nodiscard]] RasterBackendId raster_backend() const {
+                return gut ? RasterBackendId::ThreeDGUT : RasterBackendId::ThreeDGS;
+            }
+            void set_raster_backend(RasterBackendId backend) {
+                switch (backend) {
+                case RasterBackendId::ThreeDGS: gut = false; return;
+                case RasterBackendId::ThreeDGUT: gut = true; return;
+                }
+                throw std::invalid_argument("Unsupported training raster backend");
+            }
             [[nodiscard]] TrainingBackendConflict backend_conflict() const;
             [[nodiscard]] std::string backend_conflict_message() const;
             [[nodiscard]] std::string validate() const;

--- a/src/core/include/core/training_backend.hpp
+++ b/src/core/include/core/training_backend.hpp
@@ -1,0 +1,133 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <array>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
+
+namespace lfs::core::param {
+    enum class RasterBackendId {
+        ThreeDGS,
+        ThreeDGUT,
+    };
+
+    enum class TrainingFeatureSupport {
+        Supported,
+        Unsupported,
+    };
+
+    [[nodiscard]] inline constexpr std::string_view training_feature_support_name(
+        const TrainingFeatureSupport support) {
+        switch (support) {
+        case TrainingFeatureSupport::Supported:
+            return "supported";
+        case TrainingFeatureSupport::Unsupported:
+            return "unsupported";
+        }
+        throw std::invalid_argument("Unknown training feature support state");
+    }
+
+    [[nodiscard]] inline constexpr bool is_training_feature_unsupported(
+        const TrainingFeatureSupport support) noexcept {
+        return support == TrainingFeatureSupport::Unsupported;
+    }
+
+    struct TrainingBackendCapabilities {
+        TrainingFeatureSupport mcmc = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport mrnf = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport igs_plus = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport undistort = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport mip_filter = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport depth_supervision = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport normal_supervision = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport masking = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport segmentation = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport background_modes = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport background_improvements = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport exposure_correction = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport bilateral_grid = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport ppisp = TrainingFeatureSupport::Unsupported;
+        TrainingFeatureSupport sparsity = TrainingFeatureSupport::Unsupported;
+    };
+
+    struct TrainingBackendDescriptor {
+        RasterBackendId id;
+        std::string_view wire_name;
+        std::string_view label;
+        std::string_view viewer_name;
+        std::string_view description;
+        TrainingBackendCapabilities capabilities;
+    };
+
+    // High-level feature groups belong here. Unsupported entries are hard backend
+    // conflicts. Descriptors must explicitly assess every feature before exposure.
+    inline constexpr std::array kTrainingBackends{
+        TrainingBackendDescriptor{
+            .id = RasterBackendId::ThreeDGS,
+            .wire_name = "3dgs",
+            .label = "3DGS",
+            .viewer_name = "3dgs",
+            .description = "3DGS: Original 3D Gaussian Splatting based on EWA projection",
+            .capabilities = {
+                .mcmc = TrainingFeatureSupport::Supported,
+                .mrnf = TrainingFeatureSupport::Supported,
+                .igs_plus = TrainingFeatureSupport::Supported,
+                .undistort = TrainingFeatureSupport::Supported,
+                .mip_filter = TrainingFeatureSupport::Supported,
+                .depth_supervision = TrainingFeatureSupport::Supported,
+                .normal_supervision = TrainingFeatureSupport::Supported,
+                .masking = TrainingFeatureSupport::Supported,
+                .segmentation = TrainingFeatureSupport::Supported,
+                .background_modes = TrainingFeatureSupport::Supported,
+                .background_improvements = TrainingFeatureSupport::Supported,
+                .exposure_correction = TrainingFeatureSupport::Supported,
+                .bilateral_grid = TrainingFeatureSupport::Supported,
+                .ppisp = TrainingFeatureSupport::Supported,
+                .sparsity = TrainingFeatureSupport::Supported,
+            },
+        },
+        TrainingBackendDescriptor{
+            .id = RasterBackendId::ThreeDGUT,
+            .wire_name = "3dgut",
+            .label = "3DGUT",
+            .viewer_name = "3dgut",
+            .description =
+                "3DGUT: Gaussian rasterization using the Unscented Transform for nonlinear "
+                "and distorted camera models",
+            .capabilities = {
+                .mcmc = TrainingFeatureSupport::Supported,
+                .mrnf = TrainingFeatureSupport::Supported,
+                .igs_plus = TrainingFeatureSupport::Unsupported,
+                .undistort = TrainingFeatureSupport::Supported,
+                .mip_filter = TrainingFeatureSupport::Unsupported,
+                .depth_supervision = TrainingFeatureSupport::Unsupported,
+                .normal_supervision = TrainingFeatureSupport::Unsupported,
+                .masking = TrainingFeatureSupport::Supported,
+                .segmentation = TrainingFeatureSupport::Supported,
+                .background_modes = TrainingFeatureSupport::Supported,
+                .background_improvements = TrainingFeatureSupport::Supported,
+                .exposure_correction = TrainingFeatureSupport::Supported,
+                .bilateral_grid = TrainingFeatureSupport::Supported,
+                .ppisp = TrainingFeatureSupport::Supported,
+                .sparsity = TrainingFeatureSupport::Supported,
+            },
+        },
+    };
+
+    [[nodiscard]] inline std::optional<RasterBackendId> parse_training_backend(std::string_view name) {
+        for (const auto& backend : kTrainingBackends)
+            if (backend.wire_name == name)
+                return backend.id;
+        return std::nullopt;
+    }
+
+    [[nodiscard]] inline const TrainingBackendDescriptor& training_backend_descriptor(RasterBackendId id) {
+        for (const auto& backend : kTrainingBackends)
+            if (backend.id == id)
+                return backend;
+        throw std::invalid_argument("Unknown training raster backend");
+    }
+} // namespace lfs::core::param

--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -170,15 +170,14 @@ namespace lfs::core {
                     if (!backend)
                         throw std::invalid_argument("Unknown training raster_backend: " + name);
                     if (json.contains("gut")) {
-                        const bool legacy_gut = json.at("gut").get<bool>();
-                        const auto legacy_backend = legacy_gut
+                        const bool gut = json.at("gut").get<bool>();
+                        const auto boolean_backend = gut
                                                         ? RasterBackendId::ThreeDGUT
                                                         : RasterBackendId::ThreeDGS;
-                        if (*backend != legacy_backend) {
-                            LOG_WARN(
-                                "Conflicting raster_backend '{}' and legacy gut={}; using the legacy value for backward compatibility",
-                                name, legacy_gut);
-                            backend = legacy_backend;
+                        if (*backend != boolean_backend) {
+                            throw std::invalid_argument(std::format(
+                                "Conflicting raster_backend '{}' and gut={}; set both consistently or specify only one",
+                                name, gut));
                         }
                     }
                 }

--- a/src/core/parameters.cpp
+++ b/src/core/parameters.cpp
@@ -163,6 +163,25 @@ namespace lfs::core {
                 OptimizationParameters& params,
                 const nlohmann::json& json,
                 const bool skip_missing = false) {
+                std::optional<RasterBackendId> backend;
+                if (json.contains("raster_backend")) {
+                    const auto name = json.at("raster_backend").get<std::string>();
+                    backend = parse_training_backend(name);
+                    if (!backend)
+                        throw std::invalid_argument("Unknown training raster_backend: " + name);
+                    if (json.contains("gut")) {
+                        const bool legacy_gut = json.at("gut").get<bool>();
+                        const auto legacy_backend = legacy_gut
+                                                        ? RasterBackendId::ThreeDGUT
+                                                        : RasterBackendId::ThreeDGS;
+                        if (*backend != legacy_backend) {
+                            LOG_WARN(
+                                "Conflicting raster_backend '{}' and legacy gut={}; using the legacy value for backward compatibility",
+                                name, legacy_gut);
+                            backend = legacy_backend;
+                        }
+                    }
+                }
                 if (json.contains("strategy")) {
                     const auto strategy = json.at("strategy").get<std::string>();
                     if (const auto canonical = canonical_strategy_name(strategy); !canonical.empty()) {
@@ -172,6 +191,9 @@ namespace lfs::core {
                     }
                 }
                 read_registered_optimization_properties(json, params, skip_missing);
+
+                if (backend)
+                    params.set_raster_backend(*backend);
 
                 if (json.contains("eval_steps")) {
                     params.eval_steps.clear();
@@ -339,6 +361,7 @@ namespace lfs::core {
         nlohmann::json OptimizationParameters::to_json() const {
             nlohmann::json opt_json;
             write_registered_optimization_properties(opt_json, *this);
+            opt_json["raster_backend"] = training_backend_descriptor(raster_backend()).wire_name;
 
             const auto canonical_strategy = canonical_strategy_name(strategy);
             opt_json["strategy"] = canonical_strategy.empty() ? strategy : std::string(canonical_strategy);
@@ -377,15 +400,15 @@ namespace lfs::core {
         }
 
         TrainingBackendConflict OptimizationParameters::backend_conflict() const {
-            if (!gut)
-                return TrainingBackendConflict::None;
-            if (canonical_strategy_name(strategy) == kStrategyIGSPlus)
+            const auto& capabilities = training_backend_descriptor(raster_backend()).capabilities;
+            if (is_training_feature_unsupported(capabilities.igs_plus) &&
+                canonical_strategy_name(strategy) == kStrategyIGSPlus)
                 return TrainingBackendConflict::IGSPlus;
-            if (mip_filter)
+            if (is_training_feature_unsupported(capabilities.mip_filter) && mip_filter)
                 return TrainingBackendConflict::MipFilter;
-            if (use_depth_loss)
+            if (is_training_feature_unsupported(capabilities.depth_supervision) && use_depth_loss)
                 return TrainingBackendConflict::DepthSupervision;
-            if (use_normal_loss)
+            if (is_training_feature_unsupported(capabilities.normal_supervision) && use_normal_loss)
                 return TrainingBackendConflict::NormalSupervision;
             return TrainingBackendConflict::None;
         }

--- a/src/python/lfs/py_params.cpp
+++ b/src/python/lfs/py_params.cpp
@@ -174,6 +174,29 @@ namespace lfs::python {
         std::mutex python_property_subscriptions_mutex;
         std::set<size_t> python_property_subscriptions;
 
+        nb::dict python_backend_capabilities(const TrainingBackendCapabilities& capabilities) {
+            nb::dict result;
+            const auto add = [&result](const char* id, const TrainingFeatureSupport support) {
+                result[id] = std::string(training_feature_support_name(support));
+            };
+            add("mcmc", capabilities.mcmc);
+            add("mrnf", capabilities.mrnf);
+            add("igs_plus", capabilities.igs_plus);
+            add("undistort", capabilities.undistort);
+            add("mip_filter", capabilities.mip_filter);
+            add("depth_supervision", capabilities.depth_supervision);
+            add("normal_supervision", capabilities.normal_supervision);
+            add("masking", capabilities.masking);
+            add("segmentation", capabilities.segmentation);
+            add("background_modes", capabilities.background_modes);
+            add("background_improvements", capabilities.background_improvements);
+            add("exposure_correction", capabilities.exposure_correction);
+            add("bilateral_grid", capabilities.bilateral_grid);
+            add("ppisp", capabilities.ppisp);
+            add("sparsity", capabilities.sparsity);
+            return result;
+        }
+
         void track_python_property_subscription(const size_t id) {
             std::lock_guard lock(python_property_subscriptions_mutex);
             python_property_subscriptions.insert(id);
@@ -252,6 +275,8 @@ namespace lfs::python {
     }
 
     nb::object PyOptimizationParams::get(const std::string& prop_id) const {
+        if (prop_id == "raster_backend")
+            return nb::cast(std::string(training_backend_descriptor(params().raster_backend()).wire_name));
         auto meta = PropertyRegistry::instance().get_property("optimization", prop_id);
         if (!meta) {
             throw std::runtime_error("Unknown property: " + prop_id);
@@ -280,6 +305,15 @@ namespace lfs::python {
     }
 
     void PyOptimizationParams::set(const std::string& prop_id, nb::object value) {
+        if (prop_id == "raster_backend") {
+            const auto name = nb::cast<std::string>(value);
+            const auto backend = parse_training_backend(name);
+            if (!backend)
+                throw std::invalid_argument("Unknown training raster_backend: " + name);
+            // Reuse the legacy property setter and its notification contract.
+            set("gut", nb::cast(*backend == RasterBackendId::ThreeDGUT));
+            return;
+        }
         auto meta = PropertyRegistry::instance().get_property("optimization", prop_id);
         if (!meta) {
             throw std::runtime_error("Unknown property: " + prop_id);
@@ -805,6 +839,19 @@ namespace lfs::python {
             .value("IMAGE", BackgroundMode::Image)
             .value("RANDOM", BackgroundMode::Random);
 
+        m.def("training_backends", [] {
+            nb::list result;
+            for (const auto& backend : core::param::kTrainingBackends) {
+                nb::dict item;
+                item["id"] = std::string(backend.wire_name);
+                item["label"] = std::string(backend.label);
+                item["viewer_backend"] = std::string(backend.viewer_name);
+                item["description"] = std::string(backend.description);
+                item["capabilities"] = python_backend_capabilities(backend.capabilities);
+                result.append(item);
+            }
+            return result; }, "Available training backends and their viewer mapping");
+
         nb::class_<PyOptimizationParams>(m, "OptimizationParams")
             .def(nb::init<>())
             .def_prop_ro(
@@ -1019,6 +1066,21 @@ namespace lfs::python {
                 },
                 nb::arg("image_count"),
                 "Auto-scale steps for all strategies based on image count")
+            .def_prop_rw(
+                "raster_backend",
+                [](PyOptimizationParams& self) {
+                    return std::string(core::param::training_backend_descriptor(self.params().raster_backend()).wire_name);
+                },
+                [](PyOptimizationParams& self, const std::string& name) {
+                    self.set("raster_backend", nb::cast(name));
+                },
+                "Training raster backend: 3dgs or 3dgut; shares storage with legacy gut")
+            .def_prop_ro(
+                "backend_capabilities",
+                [](PyOptimizationParams& self) {
+                    return python_backend_capabilities(core::param::training_backend_descriptor(self.params().raster_backend()).capabilities);
+                },
+                "Verified capabilities for the selected training backend")
             .def_prop_rw(
                 "gut",
                 [](PyOptimizationParams& self) { return self.params().gut; },

--- a/src/python/lfs/py_params.cpp
+++ b/src/python/lfs/py_params.cpp
@@ -306,11 +306,13 @@ namespace lfs::python {
 
     void PyOptimizationParams::set(const std::string& prop_id, nb::object value) {
         if (prop_id == "raster_backend") {
+            if (!nb::isinstance<nb::str>(value))
+                throw std::invalid_argument("Training raster_backend must be a string: 3dgs or 3dgut");
             const auto name = nb::cast<std::string>(value);
             const auto backend = parse_training_backend(name);
             if (!backend)
                 throw std::invalid_argument("Unknown training raster_backend: " + name);
-            // Reuse the legacy property setter and its notification contract.
+            // Reuse the gut property setter and its notification contract.
             set("gut", nb::cast(*backend == RasterBackendId::ThreeDGUT));
             return;
         }

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -430,6 +430,10 @@ def trainer_eta_seconds() -> float:
 def trainer_strategy_type() -> str:
     """Get training strategy type (mcmc, default, etc.)"""
 
+def training_backends() -> list[dict[str, object]]:
+    """Available backends and their complete high-level capability maps."""
+
+
 def trainer_is_gut_enabled() -> bool:
     """Check if GUT is enabled"""
 
@@ -2209,6 +2213,17 @@ class OptimizationParams:
 
     def auto_scale_steps(self, image_count: int) -> None:
         """Auto-scale steps for all strategies based on image count"""
+
+    @property
+    def raster_backend(self) -> str:
+        """Training backend: 3dgs or 3dgut; shares storage with legacy gut."""
+
+    @raster_backend.setter
+    def raster_backend(self, value: str) -> None: ...
+
+    @property
+    def backend_capabilities(self) -> dict[str, str]:
+        """Feature support states: supported or unsupported."""
 
     @property
     def gut(self) -> bool:

--- a/src/python/stubs/lichtfeld/__init__.pyi
+++ b/src/python/stubs/lichtfeld/__init__.pyi
@@ -430,10 +430,6 @@ def trainer_eta_seconds() -> float:
 def trainer_strategy_type() -> str:
     """Get training strategy type (mcmc, default, etc.)"""
 
-def training_backends() -> list[dict[str, object]]:
-    """Available backends and their complete high-level capability maps."""
-
-
 def trainer_is_gut_enabled() -> bool:
     """Check if GUT is enabled"""
 
@@ -1958,6 +1954,9 @@ class BackgroundMode(enum.Enum):
 
     RANDOM = 3
 
+def training_backends() -> list:
+    """Available training backends and their viewer mapping"""
+
 class OptimizationParams:
     def __init__(self) -> None: ...
 
@@ -2216,14 +2215,14 @@ class OptimizationParams:
 
     @property
     def raster_backend(self) -> str:
-        """Training backend: 3dgs or 3dgut; shares storage with legacy gut."""
+        """Training raster backend: 3dgs or 3dgut; shares storage with legacy gut"""
 
     @raster_backend.setter
-    def raster_backend(self, value: str) -> None: ...
+    def raster_backend(self, arg: str, /) -> None: ...
 
     @property
-    def backend_capabilities(self) -> dict[str, str]:
-        """Feature support states: supported or unsupported."""
+    def backend_capabilities(self) -> dict:
+        """Verified capabilities for the selected training backend"""
 
     @property
     def gut(self) -> bool:

--- a/src/training/metrics/metrics.cpp
+++ b/src/training/metrics/metrics.cpp
@@ -724,7 +724,7 @@ namespace lfs::training {
             mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore;
 
         bool render_normal = false;
-        if (!_params.optimization.gut) {
+        if (_params.optimization.raster_backend() == lfs::core::param::RasterBackendId::ThreeDGS) {
             for (size_t image_idx = 0; image_idx < val_dataset_size; ++image_idx) {
                 if (val_dataset->get_camera(image_idx)->has_normal()) {
                     render_normal = true;
@@ -766,7 +766,7 @@ namespace lfs::training {
 
             auto& splatData_mutable = const_cast<lfs::core::SplatData&>(splatData);
             RenderOutput r_output;
-            if (_params.optimization.gut) {
+            if (_params.optimization.raster_backend() == lfs::core::param::RasterBackendId::ThreeDGUT) {
                 r_output = gsplat_rasterize(*cam, splatData_mutable, background,
                                             1.0f, false, GsplatRenderMode::RGB, true);
             } else {

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -3438,7 +3438,7 @@ namespace lfs::training {
 
             try {
                 RenderOutput output;
-                if (params.optimization.gut) {
+                if (params.optimization.raster_backend() == lfs::core::param::RasterBackendId::ThreeDGUT) {
                     output = gsplat_rasterize(
                         camera, model, background,
                         1.0f, false, GsplatRenderMode::RGB, true);
@@ -6016,7 +6016,7 @@ namespace lfs::training {
                     profiler.sampleCudaMemory();
                 }
 
-                if (params_.optimization.gut) {
+                if (params_.optimization.raster_backend() == lfs::core::param::RasterBackendId::ThreeDGUT) {
                     if (cam->camera_model_type() == core::CameraModelType::ORTHO) {
                         return lfs::make_error(lfs::ErrorInit{
                             .code = lfs::ErrorCode::InvalidArgument,
@@ -6121,7 +6121,7 @@ namespace lfs::training {
                     bg_image = get_random_background_for_camera(cam->image_width(), cam->image_height(), iter);
                 }
 
-                const bool fastgs_path = !params_.optimization.gut;
+                const bool three_dgs_path = params_.optimization.raster_backend() == lfs::core::param::RasterBackendId::ThreeDGS;
 
                 if (!loss_accumulator_.is_valid()) {
                     loss_accumulator_ = core::Tensor::zeros({1}, core::Device::CUDA);
@@ -6180,14 +6180,14 @@ namespace lfs::training {
                     densification_type = DensificationType::MRNF;
                 const bool update_gaussians_this_iter = !freeze_gaussians_this_iter;
                 const bool run_fastgs_gaussian_backward =
-                    fastgs_path &&
+                    three_dgs_path &&
                     update_gaussians_this_iter;
 
                 bool fastgs_strategy_hooks_at_start = false;
                 const bool refining_this_step =
                     strategy_ && strategy_->is_refining(iter);
                 const bool morton_due = morton_reorder_due(iter);
-                if (fastgs_path && !in_sparsification) {
+                if (three_dgs_path && !in_sparsification) {
                     current_phase = StepPhase::RefinementCommit;
                     LFS_VRAM_SCOPE("train.strategy.fastgs_pre_step");
                     LOG_VRAM_DIFF("train.strategy.fastgs_pre_step");
@@ -6306,12 +6306,12 @@ namespace lfs::training {
                     ++mutation_epoch_;
                     persistent_commit = true;
                 }
-                if (fastgs_path && refining_this_step && !in_sparsification) {
+                if (three_dgs_path && refining_this_step && !in_sparsification) {
                     // Post-barrier topology publish (deferred from inside densify).
                     auto& model_after = strategy_->get_model();
                     syncTrainingSceneTopology(scene_, model_after);
                 }
-                if (fastgs_path && in_sparsification) {
+                if (three_dgs_path && in_sparsification) {
                     install_cropbox_step_damping(strategy_->get_model(), strategy_->get_optimizer());
                 }
 
@@ -6324,7 +6324,7 @@ namespace lfs::training {
                 lfs::core::Tensor fused_opacity_reg_loss_gpu;
                 lfs::core::Tensor sparsity_loss_gpu;
                 const bool run_gut_gaussian_backward =
-                    params_.optimization.gut && update_gaussians_this_iter;
+                    params_.optimization.raster_backend() == lfs::core::param::RasterBackendId::ThreeDGUT && update_gaussians_this_iter;
                 if (run_fastgs_gaussian_backward || run_gut_gaussian_backward) {
                     auto& model = strategy_->get_model();
                     edge_score_scratch = strategy_->edge_score_scratch(iter);
@@ -6339,7 +6339,7 @@ namespace lfs::training {
                 } else if (edge_weight_scoring_active_) {
                     clearEdgeWeightCache();
                 }
-                if (fastgs_path) {
+                if (three_dgs_path) {
                     LFS_VRAM_SCOPE("train.regularizers.fastgs_forward_only");
                     LOG_VRAM_DIFF("train.regularizers.fastgs_forward_only");
                     auto& model = strategy_->get_model();
@@ -6464,7 +6464,7 @@ namespace lfs::training {
                         LFS_VRAM_SCOPE("train.rasterize_forward");
                         LOG_VRAM_DIFF("train.rasterize_forward");
                         current_phase = StepPhase::Forward;
-                        if (params_.optimization.gut) {
+                        if (params_.optimization.raster_backend() == lfs::core::param::RasterBackendId::ThreeDGUT) {
                             const MutationStamp forward_stamp{
                                 static_cast<std::uint64_t>(iter), mutation_epoch_,
                                 StepPhase::Forward, fastgs_strategy_hooks_at_start};
@@ -7715,7 +7715,7 @@ namespace lfs::training {
                         nvtxRangePush("compute_scale_reg_loss");
                         LFS_VRAM_SCOPE("train.regularizers.scale_loss");
                         LOG_VRAM_DIFF("train.regularizers.scale_loss");
-                        if (fastgs_path) {
+                        if (three_dgs_path) {
                             loss_tensor_gpu = loss_tensor_gpu + fused_scale_reg_loss_gpu;
                         } else {
                             auto scale_loss_result = compute_scale_reg_loss(strategy_->get_model(), strategy_->get_optimizer(), params_.optimization);
@@ -7739,7 +7739,7 @@ namespace lfs::training {
                         nvtxRangePush("compute_opacity_reg_loss");
                         LFS_VRAM_SCOPE("train.regularizers.opacity_loss");
                         LOG_VRAM_DIFF("train.regularizers.opacity_loss");
-                        if (fastgs_path) {
+                        if (three_dgs_path) {
                             loss_tensor_gpu = loss_tensor_gpu + fused_opacity_reg_loss_gpu;
                         } else {
                             auto opacity_loss_result = compute_opacity_reg_loss(
@@ -7803,7 +7803,7 @@ namespace lfs::training {
                 // Sparsity loss - ALL ON GPU, no CPU sync here
                 if (sparsity_optimizer_ &&
                     sparsity_optimizer_->should_apply_loss(iter) &&
-                    (!fastgs_path || update_gaussians_this_iter)) {
+                    (!three_dgs_path || update_gaussians_this_iter)) {
                     nvtxRangePush("sparsity_loss");
                     LFS_VRAM_SCOPE("train.regularizers.sparsity_loss");
                     LOG_VRAM_DIFF("train.regularizers.sparsity_loss");
@@ -7982,7 +7982,7 @@ namespace lfs::training {
                             strategy_->post_backward(iter, r_output);
                             maybe_morton_reorder(iter);
                         }
-                        if (!fastgs_path) {
+                        if (!three_dgs_path) {
                             install_cropbox_step_damping(model, strategy_->get_optimizer());
                         }
 
@@ -8170,7 +8170,7 @@ namespace lfs::training {
                                 }
 
                                 RenderOutput rendered_timelapse_output;
-                                if (params_.optimization.gut) {
+                                if (params_.optimization.raster_backend() == lfs::core::param::RasterBackendId::ThreeDGUT) {
                                     rendered_timelapse_output = gsplat_rasterize(*cam_to_use, strategy_->get_model(), background_,
                                                                                  1.0f, false, GsplatRenderMode::RGB, true);
                                 } else {

--- a/src/visualizer/gui/rml_status_bar.cpp
+++ b/src/visualizer/gui/rml_status_bar.cpp
@@ -24,6 +24,7 @@
 #include "scene/scene_manager.hpp"
 #include "theme/theme.hpp"
 #include "training/training_manager.hpp"
+#include "training/trainer.hpp"
 #include "visualizer/app_store.hpp"
 #include "visualizer_impl.hpp"
 
@@ -42,6 +43,15 @@
 #include "git_version.h"
 
 namespace lfs::vis::gui {
+
+    std::string trainingBackendStatusLabel(
+        const std::optional<lfs::core::param::RasterBackendId> active_backend,
+        const std::string_view stored_backend) {
+        const auto backend = active_backend ? active_backend
+                                            : lfs::core::param::parse_training_backend(stored_backend);
+        return backend ? std::string(lfs::core::param::training_backend_descriptor(*backend).label)
+                       : std::string{};
+    }
 
     using rml_theme::colorToRml;
     using rml_theme::colorToRmlAlpha;
@@ -1243,12 +1253,14 @@ namespace lfs::vis::gui {
         auto content_type = sm ? sm->getContentType() : SceneManager::ContentType::Empty;
         auto training_state = tm ? tm->getState() : TrainingState::Idle;
         std::string stored_strategy;
+        std::string stored_backend;
         if (viewer && (!tm || !tm->hasTrainer())) {
             const auto session = viewer->projectTrainingSessionState();
             if (session.available) {
                 training_state = session.completed ? TrainingState::Finished
                                                    : TrainingState::Paused;
                 stored_strategy = session.strategy;
+                stored_backend = session.raster_backend;
             }
         }
 
@@ -1266,8 +1278,11 @@ namespace lfs::vis::gui {
                                            ? stored_strategy.c_str()
                                        : tm ? tm->getStrategyType()
                                             : "default";
-            bool gut = tm && tm->isGutEnabled();
-            std::string method = gut ? "GUT" : "3DGS";
+            const auto* trainer = tm ? tm->getTrainer() : nullptr;
+            const auto method = trainingBackendStatusLabel(
+                trainer ? std::optional{trainer->getParams().optimization.raster_backend()}
+                        : std::nullopt,
+                stored_backend);
             std::string strat_name;
             const std::string_view strategy = strategy_raw ? std::string_view(strategy_raw) : std::string_view{};
             if (strategy == "mcmc") {
@@ -1280,7 +1295,8 @@ namespace lfs::vis::gui {
                 strat_name = LOC("status_bar.strategy_default");
             }
 
-            auto suffix = std::format(" ({}/{})", strat_name, method);
+            auto suffix = method.empty() ? std::format(" ({})", strat_name)
+                                         : std::format(" ({}/{})", strat_name, method);
 
             switch (training_state) {
             case TrainingState::Running:

--- a/src/visualizer/gui/rml_status_bar.hpp
+++ b/src/visualizer/gui/rml_status_bar.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "core/reactive/store.hpp"
+#include "core/training_backend.hpp"
 #include "gui/error_surface_types.hpp"
 #include "gui/gpu_memory_query.hpp"
 #include "gui/panel_registry.hpp"
@@ -21,6 +22,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace Rml {
@@ -34,6 +36,10 @@ namespace lfs::vis {
     struct Theme;
 }
 namespace lfs::vis::gui {
+
+    [[nodiscard]] LFS_VIS_API std::string trainingBackendStatusLabel(
+        std::optional<lfs::core::param::RasterBackendId> active_backend,
+        std::string_view stored_backend);
 
     class RmlStatusBarTestAccess;
 

--- a/src/visualizer/include/visualizer/visualizer.hpp
+++ b/src/visualizer/include/visualizer/visualizer.hpp
@@ -300,6 +300,7 @@ namespace lfs::vis {
             bool hydrated = false;
             bool restoring = false;
             std::string error;
+            std::string raster_backend;
         };
 
         [[nodiscard]] virtual ProjectTrainingSessionState

--- a/src/visualizer/project/project_lifecycle.cpp
+++ b/src/visualizer/project/project_lifecycle.cpp
@@ -955,6 +955,7 @@ namespace lfs::vis::project {
         stored_dataset_output_path_.clear();
         stored_max_iterations_ = 0;
         stored_strategy_.clear();
+        stored_raster_backend_.clear();
         stored_completed_ = false;
         training_session_hydrated_.store(
             false, std::memory_order_release);
@@ -1002,6 +1003,7 @@ namespace lfs::vis::project {
             state.error = training_session_error_;
             state.max_iterations = stored_max_iterations_;
             state.strategy = stored_strategy_;
+            state.raster_backend = stored_raster_backend_;
             state.completed = stored_completed_;
         }
         if (stored_training_kind_ ==
@@ -1024,6 +1026,7 @@ namespace lfs::vis::project {
         stored_dataset_output_path_.clear();
         stored_max_iterations_ = 0;
         stored_strategy_.clear();
+        stored_raster_backend_.clear();
         stored_completed_ = false;
         training_session_hydrated_.store(
             false, std::memory_order_release);
@@ -1050,6 +1053,16 @@ namespace lfs::vis::project {
             std::lock_guard lock(training_session_mutex_);
             stored_max_iterations_ = max_iterations;
             stored_strategy_ = std::move(strategy);
+            // A checkpoint's backend belongs to the saved run, not the next-run preset.
+            if (report.checkpoint_params) {
+                stored_raster_backend_ = lfs::core::param::training_backend_descriptor(
+                                            report.checkpoint_params->optimization.raster_backend())
+                                            .wire_name;
+            } else if (!report.trainer_state_pending) {
+                stored_raster_backend_ = lfs::core::param::training_backend_descriptor(
+                                            params.raster_backend())
+                                            .wire_name;
+            }
             stored_completed_ = completed;
         };
         struct PresentationGuard {

--- a/src/visualizer/project/project_lifecycle.hpp
+++ b/src/visualizer/project/project_lifecycle.hpp
@@ -299,6 +299,7 @@ namespace lfs::vis::project {
             bool hydrated = false;
             bool restoring = false;
             std::string error;
+            std::string raster_backend;
         };
 
         [[nodiscard]] TrainingSessionState
@@ -792,6 +793,7 @@ namespace lfs::vis::project {
         std::string training_session_error_;
         int stored_max_iterations_ = 0;
         std::string stored_strategy_;
+        std::string stored_raster_backend_;
         bool stored_completed_ = false;
         mutable std::mutex thread_mutex_;
         std::vector<std::jthread> hydration_threads_;

--- a/src/visualizer/rendering/vksplat_viewport_renderer.hpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.hpp
@@ -135,8 +135,8 @@ namespace lfs::vis {
             OutputSlot output_slot = OutputSlot::Main;
         };
 
-        VksplatViewportRenderer();
-        ~VksplatViewportRenderer();
+        LFS_VIS_API VksplatViewportRenderer();
+        LFS_VIS_API ~VksplatViewportRenderer();
 
         VksplatViewportRenderer(const VksplatViewportRenderer&) = delete;
         VksplatViewportRenderer& operator=(const VksplatViewportRenderer&) = delete;
@@ -471,7 +471,7 @@ namespace lfs::vis {
                                       std::size_t sort_capacity,
                                       std::size_t image_width,
                                       std::size_t image_height);
-        void releasePrivateScratchBuffers();
+        LFS_VIS_API void releasePrivateScratchBuffers();
         void releaseGpuLodTreeStorage();
         void detachSharedScratchBuffers();
         void releaseSharedScratchImportOnly();

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -3780,6 +3780,7 @@ namespace lfs::vis {
         state.iteration = session.iteration;
         state.max_iterations = session.max_iterations;
         state.strategy = session.strategy;
+        state.raster_backend = session.raster_backend;
         state.completed = session.completed;
         state.hydrated = session.hydrated;
         state.restoring = session.restoring;

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -397,6 +397,7 @@ namespace lfs::vis {
         friend class VisualizerImplResetTest_TrainingCheckpointReopenRestoresPausedResumableState_Test;
         friend class VisualizerImplResetTest_ErrorFinishedCheckpointProjectReopensPausedAndResumable_Test;
         friend class VisualizerImplResetTest_CompletedCheckpointProjectStillReopensFinished_Test;
+        friend class VisualizerImplResetTest_StoredTrainingBackendComesFromCheckpointBeforeTrainerRestore_Test;
         friend class VisualizerImplResetTest_EditModeSaveRetainsUnboundCheckpointHistory_Test;
         friend class VisualizerImplResetTest_ReopenedTwoSplatProjectBuildsExternalCombinedModel_Test;
         friend class VisualizerImplResetTest_ForceExitDiscardDeletesAutosaveSidecarOnTeardown_Test;

--- a/src/visualizer/window/vulkan_context.hpp
+++ b/src/visualizer/window/vulkan_context.hpp
@@ -55,7 +55,7 @@ namespace lfs::vis {
         };
 
         VulkanContext() = default;
-        ~VulkanContext();
+        LFS_VIS_API ~VulkanContext();
 
         VulkanContext(const VulkanContext&) = delete;
         VulkanContext& operator=(const VulkanContext&) = delete;
@@ -273,18 +273,18 @@ namespace lfs::vis {
             return debug_utils_enabled_ && debug_name_writer_.enabled();
         }
 
-        [[nodiscard]] bool beginFrame(const VkClearValue& clear_value, Frame& frame);
+        [[nodiscard]] LFS_VIS_API bool beginFrame(const VkClearValue& clear_value, Frame& frame);
         // Dynamic rendering must be closed while external-image layout barriers
         // are recorded. These helpers bracket that interop window.
         [[nodiscard]] bool finishActiveRendering(VkCommandBuffer command_buffer);
         [[nodiscard]] bool restartActiveRendering(VkCommandBuffer command_buffer,
                                                   const Frame& frame);
-        [[nodiscard]] bool endFrame();
+        [[nodiscard]] LFS_VIS_API bool endFrame();
         [[nodiscard]] bool hasActiveFrame() const noexcept { return frame_active_; }
         [[nodiscard]] LFS_VIS_API std::expected<WindowCapture, std::string> captureAndEndActiveFrameRgba();
         [[nodiscard]] bool waitForNextFrameSlot();
         [[nodiscard]] bool waitForCurrentFrameSlot();
-        [[nodiscard]] bool waitForSubmittedFrames();
+        [[nodiscard]] LFS_VIS_API bool waitForSubmittedFrames();
         // Serial of the most recent graphics frame submission attempt (pre-incremented
         // before vkQueueSubmit; advances even if the submit fails).
         [[nodiscard]] std::uint64_t lastFrameSubmitSerial() const;
@@ -384,9 +384,10 @@ namespace lfs::vis {
         // clear last_error_ and return false; Quarantined/DeviceLost/other fail().
         // When set_framebuffer_resized_on_hard_error is true (image-fence site), only
         // hard Error results set framebuffer_resized_ (never Quarantined/soft).
-        [[nodiscard]] bool mapWaitOutcome(lfs::Result<lfs::rendering::WaitOutcome> result,
-                                          std::string_view op,
-                                          bool set_framebuffer_resized_on_hard_error = false);
+        [[nodiscard]] LFS_VIS_API bool mapWaitOutcome(
+            lfs::Result<lfs::rendering::WaitOutcome> result,
+            std::string_view op,
+            bool set_framebuffer_resized_on_hard_error = false);
         // Validation timeline waits (sites 5–6): every non-Ready path fails with detail.
         [[nodiscard]] bool mapValidationWaitOutcome(lfs::Result<lfs::rendering::WaitOutcome> result,
                                                     std::string_view detail_on_fail);

--- a/tests/data/param_json_golden/igs_plus.json
+++ b/tests/data/param_json_golden/igs_plus.json
@@ -79,6 +79,7 @@
   "prune_opacity": 0.004999999888241291,
   "prune_ratio": 0.6000000238418579,
   "random": false,
+  "raster_backend": "3dgs",
   "refine_every": 500,
   "reset_every": 3000,
   "rotation_lr": 0.001500000013038516,

--- a/tests/data/param_json_golden/mcmc.json
+++ b/tests/data/param_json_golden/mcmc.json
@@ -79,6 +79,7 @@
   "prune_opacity": 0.004999999888241291,
   "prune_ratio": 0.6000000238418579,
   "random": false,
+  "raster_backend": "3dgs",
   "refine_every": 100,
   "reset_every": 3000,
   "rotation_lr": 0.0010000000474974513,

--- a/tests/data/param_json_golden/mrnf.json
+++ b/tests/data/param_json_golden/mrnf.json
@@ -79,6 +79,7 @@
   "prune_opacity": 0.004999999888241291,
   "prune_ratio": 0.6000000238418579,
   "random": false,
+  "raster_backend": "3dgs",
   "refine_every": 200,
   "reset_every": 3000,
   "rotation_lr": 0.0020000000949949026,

--- a/tests/python/test_property_system.py
+++ b/tests/python/test_property_system.py
@@ -61,6 +61,23 @@ class TestOptimizationParams:
         finally:
             params.gut = original
 
+    @pytest.mark.parametrize("value", [5, 1.5, True, None, [], {}, b"3dgs", "unknown"])
+    def test_invalid_backend_set_preserves_selection(self, lf, value):
+        params = lf.optimization_params()
+        original = params.gut
+        try:
+            for backend in ("3dgs", "3dgut"):
+                params.set("raster_backend", backend)
+                # None is rejected by the existing binding before setter dispatch.
+                error_type = TypeError if value is None else ValueError
+                error_match = "incompatible function arguments" if value is None else "raster_backend"
+                with pytest.raises(error_type, match=error_match):
+                    params.set("raster_backend", value)
+                assert params.raster_backend == backend
+                assert params.gut is (backend == "3dgut")
+        finally:
+            params.gut = original
+
     def test_optimization_params_exists(self, lf):
         """optimization_params() function should be available."""
         assert hasattr(lf, "optimization_params")

--- a/tests/python/test_property_system.py
+++ b/tests/python/test_property_system.py
@@ -42,6 +42,8 @@ class TestOptimizationParams:
             params.gut = False
             assert params.raster_backend == "3dgs"
             assert set(params.backend_capabilities.values()) == {"supported"}
+            params.raster_backend = "3dgs"
+            assert params.gut is False
             params.set("raster_backend", "3dgut")
             assert params.gut is True
             with pytest.raises(ValueError, match="Unknown training raster_backend"):

--- a/tests/python/test_property_system.py
+++ b/tests/python/test_property_system.py
@@ -15,6 +15,50 @@ def clear_property_callbacks(lf):
 class TestOptimizationParams:
     """Tests for lf.optimization_params() and property introspection."""
 
+    def test_training_backend_alias_and_capabilities(self, lf):
+        params = lf.optimization_params()
+        original = params.gut
+        try:
+            params.raster_backend = "3dgut"
+            assert params.gut is True
+            assert params.get("raster_backend") == "3dgut"
+            assert params.backend_capabilities == {
+                "mcmc": "supported",
+                "mrnf": "supported",
+                "igs_plus": "unsupported",
+                "undistort": "supported",
+                "mip_filter": "unsupported",
+                "depth_supervision": "unsupported",
+                "normal_supervision": "unsupported",
+                "masking": "supported",
+                "segmentation": "supported",
+                "background_modes": "supported",
+                "background_improvements": "supported",
+                "exposure_correction": "supported",
+                "bilateral_grid": "supported",
+                "ppisp": "supported",
+                "sparsity": "supported",
+            }
+            params.gut = False
+            assert params.raster_backend == "3dgs"
+            assert set(params.backend_capabilities.values()) == {"supported"}
+            params.set("raster_backend", "3dgut")
+            assert params.gut is True
+            with pytest.raises(ValueError, match="Unknown training raster_backend"):
+                params.raster_backend = "unknown"
+            assert params.raster_backend == "3dgut"
+            descriptors = {item["id"]: item for item in lf.training_backends()}
+            assert set(descriptors) == {"3dgs", "3dgut"}
+            assert descriptors["3dgs"]["label"] == "3DGS"
+            assert descriptors["3dgs"]["viewer_backend"] == "3dgs"
+            assert "EWA projection" in descriptors["3dgs"]["description"]
+            assert descriptors["3dgut"]["viewer_backend"] == "3dgut"
+            assert "Unscented Transform" in descriptors["3dgut"]["description"]
+            assert "distorted camera models" in descriptors["3dgut"]["description"]
+            assert descriptors["3dgut"]["capabilities"] == params.backend_capabilities
+        finally:
+            params.gut = original
+
     def test_optimization_params_exists(self, lf):
         """optimization_params() function should be available."""
         assert hasattr(lf, "optimization_params")

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -144,8 +144,30 @@ TEST(ArgumentParserTest, ExplicitBackendSelectionAndLegacyAlias) {
         apply_explicit_training_overrides(restored, (*parsed)->overrides);
         EXPECT_EQ(restored.optimization.gut, gut);
         const auto combined = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
-        EXPECT_EQ(combined.has_value(), gut);
+        ASSERT_EQ(combined.has_value(), gut);
+        const char* reversed_argv[] = {"LichtFeld-Studio", "-d", data.c_str(), "-o", output.c_str(),
+                                       "--strategy", "mcmc", "--gut", "--raster-backend", name};
+        const auto reversed = lfs::core::args::parse_args_and_params(
+            static_cast<int>(std::size(reversed_argv)), reversed_argv);
+        ASSERT_EQ(reversed.has_value(), gut);
+        if (gut) {
+            EXPECT_TRUE((*reversed)->optimization.gut);
+        } else {
+            EXPECT_NE(combined.error().find("Conflicting --gut"), std::string::npos);
+            EXPECT_NE(reversed.error().find("Conflicting --gut"), std::string::npos);
+        }
     }
+}
+
+TEST(ArgumentParserTest, ExplicitGutBackendAcceptsUndistort) {
+    const auto data = make_test_path("lfs_explicit_gut_undistort_data");
+    const auto output = make_test_path("lfs_explicit_gut_undistort_output");
+    const char* argv[] = {"LichtFeld-Studio", "-d", data.c_str(), "-o", output.c_str(),
+                          "--strategy", "mcmc", "--raster-backend", "3dgut", "--undistort"};
+    const auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+    EXPECT_TRUE((*parsed)->optimization.gut);
+    EXPECT_TRUE((*parsed)->optimization.undistort);
 }
 
 TEST(ArgumentParserTest, BackendCliOverrideReplacesConfigAliasesTogether) {
@@ -168,6 +190,35 @@ TEST(ArgumentParserTest, BackendCliOverrideReplacesConfigAliasesTogether) {
     restored.optimization.gut = true;
     apply_explicit_training_overrides(restored, (*parsed)->overrides);
     EXPECT_FALSE(restored.optimization.gut);
+}
+
+TEST(ArgumentParserTest, ConfigBackendDisagreementKeepsLegacySelection) {
+    const auto data = make_test_path("lfs_backend_legacy_config_data");
+    const auto output = make_test_path("lfs_backend_legacy_config_output");
+    const auto config = std::filesystem::path(output) / "backend.json";
+    auto params = lfs::core::param::OptimizationParameters::mcmc_defaults();
+    params.gut = true;
+    auto json = params.to_json();
+    json["raster_backend"] = "3dgs";
+    {
+        std::ofstream file(config);
+        file << json;
+    }
+    const auto config_text = config.string();
+    const char* argv[] = {"LichtFeld-Studio", "-d", data.c_str(), "-o", output.c_str(),
+                          "--config", config_text.c_str()};
+    const auto legacy = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(legacy.has_value()) << legacy.error();
+    EXPECT_TRUE((*legacy)->optimization.gut);
+
+    json.erase("gut");
+    {
+        std::ofstream file(config);
+        file << json;
+    }
+    const auto named = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(named.has_value()) << named.error();
+    EXPECT_FALSE((*named)->optimization.gut);
 }
 
 TEST(ArgumentParserTest, ViewerBackendSelectionSurvivesParameterDefaults) {

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -122,6 +122,72 @@ TEST(ArgumentParserTest, GutAcceptsUndistort) {
     EXPECT_TRUE((*parsed)->optimization.undistort);
 }
 
+TEST(ArgumentParserTest, ExplicitBackendSelectionAndLegacyAlias) {
+    const auto data = make_test_path("lfs_backend_identity_data");
+    const auto output = make_test_path("lfs_backend_identity_output");
+    for (const auto* name : {"3dgs", "3dgut", "unknown"}) {
+        SCOPED_TRACE(name);
+        const char* argv[] = {"LichtFeld-Studio", "-d", data.c_str(), "-o", output.c_str(),
+                              "--strategy", "mcmc", "--raster-backend", name, "--gut"};
+        auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)) - 1, argv);
+        if (std::string_view(name) == "unknown") {
+            ASSERT_FALSE(parsed.has_value());
+            EXPECT_NE(parsed.error().find("--raster-backend"), std::string::npos);
+            continue;
+        }
+        ASSERT_TRUE(parsed.has_value()) << parsed.error();
+        const bool gut = std::string_view(name) == "3dgut";
+        EXPECT_EQ((*parsed)->optimization.gut, gut);
+        // The explicit CLI selection must also survive checkpoint overrides.
+        lfs::core::param::TrainingParameters restored;
+        restored.optimization.gut = !gut;
+        apply_explicit_training_overrides(restored, (*parsed)->overrides);
+        EXPECT_EQ(restored.optimization.gut, gut);
+        const auto combined = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+        EXPECT_EQ(combined.has_value(), gut);
+    }
+}
+
+TEST(ArgumentParserTest, BackendCliOverrideReplacesConfigAliasesTogether) {
+    const auto data = make_test_path("lfs_backend_config_data");
+    const auto output = make_test_path("lfs_backend_config_output");
+    const auto config = std::filesystem::path(output) / "backend.json";
+    auto params = lfs::core::param::OptimizationParameters::mcmc_defaults();
+    params.gut = true;
+    {
+        std::ofstream file(config);
+        file << params.to_json();
+    }
+    const auto config_text = config.string();
+    const char* argv[] = {"LichtFeld-Studio", "-d", data.c_str(), "-o", output.c_str(),
+                          "--config", config_text.c_str(), "--raster-backend", "3dgs"};
+    const auto parsed = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_TRUE(parsed.has_value()) << parsed.error();
+    EXPECT_FALSE((*parsed)->optimization.gut);
+    lfs::core::param::TrainingParameters restored;
+    restored.optimization.gut = true;
+    apply_explicit_training_overrides(restored, (*parsed)->overrides);
+    EXPECT_FALSE(restored.optimization.gut);
+}
+
+TEST(ArgumentParserTest, ViewerBackendSelectionSurvivesParameterDefaults) {
+    const auto directory = make_test_path("lfs_view_backend_identity");
+    const auto path = std::filesystem::path(directory) / "session.licht";
+    std::ofstream(path).put('\n');
+    const auto path_text = path.string();
+    for (const bool legacy : {false, true}) {
+        const char* argv[] = {"LichtFeld-Studio", "-v", path_text.c_str(),
+                              legacy ? "--gut" : "--raster-backend", "3dgut"};
+        const auto parsed = lfs::core::args::parse_args_and_params(
+            static_cast<int>(std::size(argv)) - (legacy ? 1 : 0), argv);
+        ASSERT_TRUE(parsed.has_value()) << parsed.error();
+        EXPECT_TRUE((*parsed)->optimization.gut);
+        lfs::core::param::TrainingParameters restored;
+        apply_explicit_training_overrides(restored, (*parsed)->overrides);
+        EXPECT_TRUE(restored.optimization.gut);
+    }
+}
+
 TEST(ArgumentParserTest,
      GuiProjectAndResumeLichtSelectProjectOpenFlow) {
     const auto directory =

--- a/tests/test_argument_parser.cpp
+++ b/tests/test_argument_parser.cpp
@@ -192,7 +192,7 @@ TEST(ArgumentParserTest, BackendCliOverrideReplacesConfigAliasesTogether) {
     EXPECT_FALSE(restored.optimization.gut);
 }
 
-TEST(ArgumentParserTest, ConfigBackendDisagreementKeepsLegacySelection) {
+TEST(ArgumentParserTest, ConfigBackendDisagreementIsRejected) {
     const auto data = make_test_path("lfs_backend_legacy_config_data");
     const auto output = make_test_path("lfs_backend_legacy_config_output");
     const auto config = std::filesystem::path(output) / "backend.json";
@@ -207,9 +207,9 @@ TEST(ArgumentParserTest, ConfigBackendDisagreementKeepsLegacySelection) {
     const auto config_text = config.string();
     const char* argv[] = {"LichtFeld-Studio", "-d", data.c_str(), "-o", output.c_str(),
                           "--config", config_text.c_str()};
-    const auto legacy = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
-    ASSERT_TRUE(legacy.has_value()) << legacy.error();
-    EXPECT_TRUE((*legacy)->optimization.gut);
+    const auto conflict = lfs::core::args::parse_args_and_params(static_cast<int>(std::size(argv)), argv);
+    ASSERT_FALSE(conflict.has_value());
+    EXPECT_NE(conflict.error().find("Conflicting raster_backend"), std::string::npos);
 
     json.erase("gut");
     {

--- a/tests/test_crash_handler.cpp
+++ b/tests/test_crash_handler.cpp
@@ -22,6 +22,14 @@ namespace {
 
     constexpr int FIREWALL_EXIT_CODE = 70; // EX_SOFTWARE, frozen contract
 
+    int current_process_id() noexcept {
+#ifdef _WIN32
+        return _getpid();
+#else
+        return static_cast<int>(getpid());
+#endif
+    }
+
 } // namespace
 
 TEST(CrashHandlerTest, FlushAndExitExitsWithRequestedCodeZero) {
@@ -65,11 +73,7 @@ TEST(CrashHandlerTest, HandledGpuFailureIsSavedOutsideRotatingLogs) {
                         .capture_stack = false};
                     for (int i = 0; i < 200; ++i)
                         lfs::core::emit_failure_report(report, lfs::core::FailureReportSeverity::Error);
-#ifdef _WIN32
-                    const auto pid = _getpid();
-#else
-                    const auto pid = getpid();
-#endif
+                    const auto pid = current_process_id();
                     const auto path = std::filesystem::temp_directory_path() /
                                       ("lichtfeld-studio-crash-" + std::to_string(pid) + ".log");
                     std::ifstream file(path);

--- a/tests/test_project_chapters.cpp
+++ b/tests/test_project_chapters.cpp
@@ -414,6 +414,38 @@ namespace {
                   lfs::ErrorCode::DataLoss);
     }
 
+    TEST(ProjectChapterTest, TrainingBackendIdentityRoundTripAndCompatibility) {
+        ParametersChapter chapter;
+        auto snapshot = parameter_snapshot();
+        snapshot.mrnf_current.set_raster_backend(lfs::core::param::RasterBackendId::ThreeDGUT);
+        ASSERT_TRUE(chapter.set_snapshot(snapshot));
+        auto reparsed = ParametersChapter::from_bytes(chapter.to_bytes());
+        ASSERT_TRUE(reparsed);
+        auto restored = reparsed->snapshot();
+        ASSERT_TRUE(restored);
+        EXPECT_TRUE(restored->mrnf_current.gut);
+        EXPECT_FALSE(restored->mrnf_session.gut);
+        ASSERT_TRUE(chapter.dom().set_json("presets.mrnf.current.raster_backend", "unknown"));
+        EXPECT_FALSE(chapter.snapshot());
+        ASSERT_TRUE(chapter.dom().set_json("presets.mrnf.current.raster_backend", "3dgs"));
+        auto legacy_modified = chapter.snapshot();
+        ASSERT_TRUE(legacy_modified);
+        EXPECT_TRUE(legacy_modified->mrnf_current.gut);
+
+        auto legacy_json = lfs::io::JsonChapterDom::Json::parse(chapter.dom().dump());
+        for (const auto* strategy : {"mcmc", "mrnf", "igs+"}) {
+            for (const auto* role : {"session", "current"})
+                legacy_json["presets"][strategy][role].erase("raster_backend");
+        }
+        auto legacy_chapter = ParametersChapter::parse(legacy_json.dump());
+        ASSERT_TRUE(legacy_chapter) << lfs::format_for_developer(legacy_chapter.error());
+        auto legacy_snapshot = legacy_chapter->snapshot();
+        ASSERT_TRUE(legacy_snapshot);
+        EXPECT_TRUE(legacy_snapshot->mrnf_current.gut);
+        EXPECT_FALSE(legacy_snapshot->mrnf_session.gut);
+
+    }
+
     TEST(ProjectChapterTest, ParametersMutationRetainsUnknownNestedObjects) {
         ParametersChapter chapter;
         auto snapshot = parameter_snapshot();

--- a/tests/test_project_chapters.cpp
+++ b/tests/test_project_chapters.cpp
@@ -433,9 +433,7 @@ namespace {
         ASSERT_TRUE(chapter.dom().set_json("presets.mrnf.current.raster_backend", "unknown"));
         EXPECT_FALSE(chapter.snapshot());
         ASSERT_TRUE(chapter.dom().set_json("presets.mrnf.current.raster_backend", "3dgs"));
-        auto legacy_modified = chapter.snapshot();
-        ASSERT_TRUE(legacy_modified);
-        EXPECT_TRUE(legacy_modified->mrnf_current.gut);
+        EXPECT_FALSE(chapter.snapshot());
 
         auto legacy_json = lfs::io::JsonChapterDom::Json::parse(chapter.dom().dump());
         for (const auto* strategy : {"mcmc", "mrnf", "igs+"}) {

--- a/tests/test_project_chapters.cpp
+++ b/tests/test_project_chapters.cpp
@@ -421,6 +421,11 @@ namespace {
         ASSERT_TRUE(chapter.set_snapshot(snapshot));
         auto reparsed = ParametersChapter::from_bytes(chapter.to_bytes());
         ASSERT_TRUE(reparsed);
+        const auto persisted = lfs::io::JsonChapterDom::Json::parse(reparsed->dom().dump());
+        EXPECT_EQ(persisted["presets"]["mrnf"]["current"]["raster_backend"], "3dgut");
+        EXPECT_EQ(persisted["presets"]["mrnf"]["current"]["gut"], true);
+        EXPECT_EQ(persisted["presets"]["mrnf"]["session"]["raster_backend"], "3dgs");
+        EXPECT_EQ(persisted["presets"]["mrnf"]["session"]["gut"], false);
         auto restored = reparsed->snapshot();
         ASSERT_TRUE(restored);
         EXPECT_TRUE(restored->mrnf_current.gut);
@@ -443,7 +448,6 @@ namespace {
         ASSERT_TRUE(legacy_snapshot);
         EXPECT_TRUE(legacy_snapshot->mrnf_current.gut);
         EXPECT_FALSE(legacy_snapshot->mrnf_session.gut);
-
     }
 
     TEST(ProjectChapterTest, ParametersMutationRetainsUnknownNestedObjects) {

--- a/tests/test_status_bar_fit.cpp
+++ b/tests/test_status_bar_fit.cpp
@@ -23,6 +23,19 @@
 
 namespace lfs::vis::gui {
 
+    TEST(StatusBarBackendTest, UsesActiveTrainerBeforeStoredSession) {
+        using lfs::core::param::RasterBackendId;
+        EXPECT_EQ(trainingBackendStatusLabel(RasterBackendId::ThreeDGUT, "3dgs"), "3DGUT");
+        EXPECT_EQ(trainingBackendStatusLabel(RasterBackendId::ThreeDGS, "3dgut"), "3DGS");
+    }
+
+    TEST(StatusBarBackendTest, UsesStoredBackendWithoutInventingDefault) {
+        EXPECT_EQ(trainingBackendStatusLabel(std::nullopt, "3dgut"), "3DGUT");
+        EXPECT_EQ(trainingBackendStatusLabel(std::nullopt, "3dgs"), "3DGS");
+        EXPECT_TRUE(trainingBackendStatusLabel(std::nullopt, "").empty());
+        EXPECT_TRUE(trainingBackendStatusLabel(std::nullopt, "unknown").empty());
+    }
+
     class RmlStatusBarTestAccess {
     public:
         static void attach(RmlStatusBar& status_bar,

--- a/tests/test_training_parameters.cpp
+++ b/tests/test_training_parameters.cpp
@@ -7,6 +7,7 @@
 #include "core/property_registry.hpp"
 #include "python/lfs/py_params.hpp"
 
+#include "core/checkpoint_format.hpp"
 #include <algorithm>
 #include <any>
 #include <array>
@@ -249,6 +250,7 @@ namespace {
             {"enable_save_eval_images", "evaluation image output is not a registry property"},
             {"eval_steps", "vector-valued evaluation schedule is managed separately"},
             {"ppisp_sidecar_path", "PPISP sidecar path uses its dedicated Python binding"},
+            {"raster_backend", "explicit backend name is an adapter over the legacy gut property"},
             {"save_steps", "vector-valued save schedule is managed separately"},
         };
 
@@ -595,6 +597,120 @@ namespace {
         EXPECT_FALSE(params.normal_supervision_active(scaled_start - 1));
         EXPECT_TRUE(params.normal_supervision_active(scaled_start));
         EXPECT_TRUE(params.normal_supervision_active(scaled_total));
+    }
+
+    TEST_F(TrainingParametersTest, BackendIdentityCompatibility) {
+        using namespace lfs::core::param;
+        for (const bool gut : {false, true}) {
+            auto params = OptimizationParameters::mrnf_defaults();
+            params.gut = gut;
+            const auto json = params.to_json();
+            EXPECT_EQ(json.at("raster_backend"), gut ? "3dgut" : "3dgs");
+            EXPECT_EQ(OptimizationParameters::from_json(json).gut, gut);
+            auto legacy = json;
+            legacy.erase("raster_backend");
+            EXPECT_EQ(OptimizationParameters::from_json(legacy).gut, gut);
+            const auto checkpoint = lfs::core::parse_checkpoint_params_json(
+                nlohmann::json{{"optimization", legacy}}.dump());
+            EXPECT_EQ(checkpoint.optimization.gut, gut);
+            EXPECT_EQ(lfs::core::parse_checkpoint_params_json(
+                          nlohmann::json{{"optimization", json}}.dump())
+                          .optimization.gut,
+                      gut);
+            auto explicit_only = json;
+            explicit_only.erase("gut");
+            EXPECT_EQ(OptimizationParameters::from_json(explicit_only).gut, gut);
+            auto conflict = json;
+            conflict["gut"] = !gut;
+            EXPECT_EQ(OptimizationParameters::from_json(conflict).gut, !gut);
+
+            TrainingParameters target;
+            target.optimization = params;
+            ExplicitTrainingOverrides overrides;
+            overrides.optimization_json = nlohmann::json{{"gut", !gut}}.dump();
+            apply_explicit_training_overrides(target, overrides);
+            EXPECT_EQ(target.optimization.gut, !gut);
+            overrides.optimization_json = nlohmann::json{{"raster_backend", gut ? "3dgut" : "3dgs"}}.dump();
+            apply_explicit_training_overrides(target, overrides);
+            EXPECT_EQ(target.optimization.gut, gut);
+        }
+        auto json = OptimizationParameters::mrnf_defaults().to_json();
+        auto without_backend_selection = json;
+        without_backend_selection.erase("raster_backend");
+        without_backend_selection.erase("gut");
+        const auto default_backend = OptimizationParameters::from_json(without_backend_selection);
+        EXPECT_FALSE(default_backend.gut);
+        EXPECT_EQ(default_backend.raster_backend(), RasterBackendId::ThreeDGS);
+        json["raster_backend"] = "future_backend";
+        EXPECT_THROW((void)OptimizationParameters::from_json(json), std::invalid_argument);
+        json["raster_backend"] = nullptr;
+        EXPECT_THROW((void)OptimizationParameters::from_json(json), nlohmann::json::type_error);
+        EXPECT_FALSE(parse_training_backend("future_backend").has_value());
+        ASSERT_EQ(kTrainingBackends.size(), 2);
+        EXPECT_EQ(training_backend_descriptor(RasterBackendId::ThreeDGS).viewer_name, "3dgs");
+        EXPECT_NE(training_backend_descriptor(RasterBackendId::ThreeDGS).description.find("EWA projection"),
+                  std::string_view::npos);
+        EXPECT_EQ(training_backend_descriptor(RasterBackendId::ThreeDGUT).viewer_name, "3dgut");
+        EXPECT_NE(training_backend_descriptor(RasterBackendId::ThreeDGUT).description.find("Unscented Transform"),
+                  std::string_view::npos);
+        EXPECT_NE(training_backend_descriptor(RasterBackendId::ThreeDGUT).description.find("distorted camera models"),
+                  std::string_view::npos);
+        const auto& gut_capabilities = training_backend_descriptor(RasterBackendId::ThreeDGUT).capabilities;
+        EXPECT_EQ(gut_capabilities.mcmc, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(gut_capabilities.mrnf, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(gut_capabilities.igs_plus, TrainingFeatureSupport::Unsupported);
+        EXPECT_EQ(gut_capabilities.undistort, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(gut_capabilities.mip_filter, TrainingFeatureSupport::Unsupported);
+        EXPECT_EQ(gut_capabilities.depth_supervision, TrainingFeatureSupport::Unsupported);
+        EXPECT_EQ(gut_capabilities.normal_supervision, TrainingFeatureSupport::Unsupported);
+        EXPECT_EQ(gut_capabilities.masking, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(gut_capabilities.segmentation, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(gut_capabilities.background_modes, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(gut_capabilities.background_improvements, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(gut_capabilities.exposure_correction, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(gut_capabilities.bilateral_grid, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(gut_capabilities.ppisp, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(gut_capabilities.sparsity, TrainingFeatureSupport::Supported);
+        EXPECT_EQ(training_feature_support_name(TrainingFeatureSupport::Supported), "supported");
+        EXPECT_EQ(training_feature_support_name(TrainingFeatureSupport::Unsupported), "unsupported");
+    }
+
+    TEST_F(TrainingParametersTest, SupportedThreeDGUTCapabilitiesRemainNonBlocking) {
+        using namespace lfs::core::param;
+        auto baseline = OptimizationParameters::mrnf_defaults();
+        baseline.set_raster_backend(RasterBackendId::ThreeDGUT);
+
+        const auto expect_non_blocking = [](const std::string_view feature,
+                                            const OptimizationParameters& params) {
+            SCOPED_TRACE(feature);
+            EXPECT_EQ(params.backend_conflict(), TrainingBackendConflict::None);
+            const auto error = params.validate(ParameterValidationMode::Runtime);
+            EXPECT_TRUE(error.empty()) << error;
+        };
+
+        auto params = baseline;
+        params.mask_mode = MaskMode::Segment;
+        expect_non_blocking("masking and segmentation", params);
+
+        params = baseline;
+        params.background_improvements = true;
+        expect_non_blocking("background improvements", params);
+
+        params = baseline;
+        params.use_exposure_correction = true;
+        expect_non_blocking("exposure correction", params);
+
+        params = baseline;
+        params.use_bilateral_grid = true;
+        expect_non_blocking("bilateral grid", params);
+
+        params = baseline;
+        params.use_ppisp = true;
+        expect_non_blocking("PPISP", params);
+
+        params = baseline;
+        params.enable_sparsity = true;
+        expect_non_blocking("sparsity", params);
     }
 
     TEST_F(TrainingParametersTest, OldNewToJsonParity) {

--- a/tests/test_training_parameters.cpp
+++ b/tests/test_training_parameters.cpp
@@ -643,8 +643,15 @@ namespace {
         EXPECT_EQ(default_backend.raster_backend(), RasterBackendId::ThreeDGS);
         json["raster_backend"] = "future_backend";
         EXPECT_THROW((void)OptimizationParameters::from_json(json), std::invalid_argument);
-        json["raster_backend"] = nullptr;
-        EXPECT_THROW((void)OptimizationParameters::from_json(json), nlohmann::json::type_error);
+        for (const auto& invalid : {nlohmann::json(nullptr), nlohmann::json(true),
+                                    nlohmann::json(7), nlohmann::json(1.5),
+                                    nlohmann::json::array(), nlohmann::json::object()}) {
+            SCOPED_TRACE(invalid.dump());
+            json["raster_backend"] = invalid;
+            EXPECT_THROW((void)OptimizationParameters::from_json(json), nlohmann::json::type_error);
+        }
+        EXPECT_EQ(parse_training_backend("3dgs"), RasterBackendId::ThreeDGS);
+        EXPECT_EQ(parse_training_backend("3dgut"), RasterBackendId::ThreeDGUT);
         EXPECT_FALSE(parse_training_backend("future_backend").has_value());
         ASSERT_EQ(kTrainingBackends.size(), 2);
         EXPECT_EQ(training_backend_descriptor(RasterBackendId::ThreeDGS).viewer_name, "3dgs");
@@ -689,6 +696,10 @@ namespace {
         };
 
         auto params = baseline;
+        params.undistort = true;
+        expect_non_blocking("undistortion", params);
+
+        params = baseline;
         params.mask_mode = MaskMode::Segment;
         expect_non_blocking("masking and segmentation", params);
 

--- a/tests/test_training_parameters.cpp
+++ b/tests/test_training_parameters.cpp
@@ -622,7 +622,10 @@ namespace {
             EXPECT_EQ(OptimizationParameters::from_json(explicit_only).gut, gut);
             auto conflict = json;
             conflict["gut"] = !gut;
-            EXPECT_EQ(OptimizationParameters::from_json(conflict).gut, !gut);
+            EXPECT_THROW((void)OptimizationParameters::from_json(conflict), std::invalid_argument);
+            EXPECT_THROW((void)lfs::core::parse_checkpoint_params_json(
+                             nlohmann::json{{"optimization", conflict}}.dump()),
+                         std::invalid_argument);
 
             TrainingParameters target;
             target.optimization = params;
@@ -691,7 +694,7 @@ namespace {
                                             const OptimizationParameters& params) {
             SCOPED_TRACE(feature);
             EXPECT_EQ(params.backend_conflict(), TrainingBackendConflict::None);
-            const auto error = params.validate(ParameterValidationMode::Runtime);
+            const auto error = params.validate();
             EXPECT_TRUE(error.empty()) << error;
         };
 

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -869,7 +869,8 @@ namespace {
     make_training_autosave_checkpoint_payload(
         const lfs::core::Uuid& checkpoint_uuid,
         const std::filesystem::path& dataset_path = {},
-        const int sh_degree = 0) {
+        const int sh_degree = 0,
+        const bool gut = false) {
         const std::size_t count = sh_degree > 0 ? 8 : 2;
         auto model = sh_degree > 0
                          ? make_degree1_splat(count)
@@ -880,6 +881,7 @@ namespace {
             lfs::core::param::OptimizationParameters::
                 mcmc_defaults();
         parameters.optimization.sh_degree = sh_degree;
+        parameters.optimization.gut = gut;
         parameters.optimization.max_cap =
             static_cast<int>(count);
         parameters.dataset.data_path = dataset_path;
@@ -1023,7 +1025,8 @@ namespace {
                 lfs::io::project::
                     TrainingFinishReason::None,
         const int sh_degree = 0,
-        const int prms_iterations = -1) {
+        const int prms_iterations = -1,
+        const bool gut = false) {
         auto document = lfs::test::licht::make_empty_document(
             lfs::core::generate_uuid_v4(), 1);
         lfs::core::Scene source;
@@ -1073,7 +1076,7 @@ namespace {
                 checkpoint_uuid,
                 make_training_autosave_checkpoint_payload(
                     checkpoint_uuid, dataset_path,
-                    sh_degree)));
+                    sh_degree, gut)));
         if (finish_reason !=
             lfs::io::project::TrainingFinishReason::
                 None) {
@@ -13474,6 +13477,35 @@ namespace lfs::vis {
         EXPECT_EQ(manager->checkpointBaselineIteration(),
                   std::optional<int>{11});
         EXPECT_EQ(manager->getCurrentIteration(), 11);
+    }
+
+    TEST_F(VisualizerImplResetTest,
+           StoredTrainingBackendComesFromCheckpointBeforeTrainerRestore) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+        for (const bool gut : {false, true}) {
+            const auto project_path = temporary_.path / (gut ? "gut-backend.licht" : "gs-backend.licht");
+            const auto dataset_path = temporary_.path / (gut ? "gut-dataset" : "gs-dataset");
+            write_minimal_transforms_dataset(dataset_path);
+            write_resumable_project_with_checkpoint(
+                project_path, lfs::core::generate_uuid_v4(), lfs::core::generate_uuid_v4(),
+                dataset_path, lfs::io::project::TrainingFinishReason::Completed, 0, -1, gut);
+            auto options = projectOptions();
+            VisualizerImpl viewer(options);
+            ASSERT_TRUE(viewer.getParameterManager()->ensureLoaded());
+            ASSERT_TRUE(viewer.getWindowManager()->init());
+            ASSERT_TRUE(viewer.projectOpen(project_path, ProjectSwitchDisposition::DiscardChanges));
+            viewer.noteGuiSessionRestoreOwnerReady(1);
+            ASSERT_TRUE(pumpUntil(viewer.work_queue_mutex_, viewer.work_queue_, [&] {
+                const auto info = viewer.projectGetInfo();
+                return info && info->hydration_state == "complete";
+            }));
+            const auto session = viewer.projectTrainingSessionState();
+            ASSERT_TRUE(session.available);
+            EXPECT_EQ(session.raster_backend, gut ? "3dgut" : "3dgs");
+            EXPECT_FALSE(viewer.getTrainerManager()->hasTrainer());
+        }
     }
 
     TEST_F(VisualizerImplResetTest,


### PR DESCRIPTION
## Summary

Depends on #2047 and must be merged after it.

Expose explicit `3dgs` and `3dgut` training backend identities through JSON,
`--raster-backend`, and Python, while retaining `gut` as the single backing
value and preserving the existing `--gut` option.

3DGS remains the default when no backend is specified. Training and viewer
APIs use the same backend vocabulary.

## Changes

- Centralize backend identifiers, labels, technical descriptions, viewer mapping,
  and high-level capability information.
- Use the named identity for training/evaluation dispatch and the capability table
  for backend conflict checks.
- Expose backend selection and capability information through Python.
- Report the active trainer's backend in the status bar, or the saved checkpoint's
  backend before trainer restoration. Do not assume 3DGS when identity is unavailable.

3DGUT supports Undistort. IGS+, Mip Filter, Depth Loss, and Normal Loss remain
unsupported.

## Parameter behavior

- JSON accepts either `gut` or `raster_backend` alone. New output writes both
  consistently.
- When both fields are present, they must agree. Conflicts are errors in configs,
  checkpoint parameters, and project presets.
- Unknown names and incorrect JSON types are rejected.
- Explicit CLI backend selection overrides a valid configuration/checkpoint
  selection and records both aliases for checkpoint overrides.
- Invalid configurations fail before CLI overrides are applied.
- `--gut` remains an alias for 3DGUT. Contradictory CLI options fail independently
  of argument order.
- Python `set("raster_backend", value)` rejects unknown names and non-string
  values with ValueError without changing the selection. None retains the
  existing binding-level TypeError.

Strict parameter validation and start/resume behavior come from #2047.
There is no separate storage-validation mode, inherited-option normalization,
or older-writer precedence policy.

## Scope

The Training panel layout remains unchanged.

Viewer hand-off and existing panel consumers still use `gut`. Adding another
backend requires implementation, storage and consumer migration, and explicit
dispatch; adding a descriptor alone does not install a rasterizer.

Next-run parameter changes do not replace an active trainer or viewer.

## What to test

- Train and evaluate with 3DGS and 3DGUT, including 3DGUT with Undistort.
- Confirm 3DGS is selected when no backend is specified.
- Compare `--gut` with `--raster-backend 3dgut`.
- Reject contradictory CLI flags in both orders and unknown backend names.
- Load matching JSON aliases and either field alone. Reject disagreeing aliases
  and non-string backend values.
- Override a valid 3DGUT config/checkpoint with `--raster-backend 3dgs`, then
  resume without flags and confirm the saved selection persists.
- Save and reopen valid projects/checkpoints, preserving current and session
  parameter selections.
- Reject unsupported 3DGUT combinations, correct the settings, and start training.
- Exercise Python properties and get/set, including invalid values, and confirm
  rejected assignments leave the selection unchanged.
- After a 3DGUT run, confirm the bottom status bar reports 3DGUT.
- Reopen that project and confirm the backend is correct before trainer restoration.
- Change next-run or viewer settings and confirm they do not relabel the saved
  or active training session.
- Exercise pause, resume, Stop, Save As, masks, segmentation, background, and
  appearance settings.