### PR TITLE
Windows: per-request events for overlapped project file I/O (#2038)

### DIFF
--- a/src/io/project/project_file.cpp
+++ b/src/io/project/project_file.cpp
@@ -174,14 +174,79 @@ namespace lfs::io::project::detail {
         }
 
 #ifdef _WIN32
-        lfs::Result<DWORD> wait_for_overlapped(HANDLE handle, OVERLAPPED& operation,
+        struct OverlappedOperation {
+            explicit OverlappedOperation(const std::uint64_t offset) {
+                overlapped.Offset = static_cast<DWORD>(offset & 0xffffffffu);
+                overlapped.OffsetHigh = static_cast<DWORD>(offset >> 32);
+                overlapped.hEvent =
+                    CreateEventW(nullptr, TRUE, FALSE, nullptr);
+                if (overlapped.hEvent == nullptr) {
+                    event_error = GetLastError();
+                }
+            }
+
+            OverlappedOperation(const OverlappedOperation&) = delete;
+            OverlappedOperation& operator=(const OverlappedOperation&) = delete;
+
+            ~OverlappedOperation() {
+                if (pending) {
+                    // An in-flight request must never outlive its OVERLAPPED and buffer.
+                    CancelIoEx(file_handle, &overlapped);
+                    DWORD transferred = 0;
+                    GetOverlappedResult(file_handle, &overlapped, &transferred,
+                                        TRUE);
+                }
+                if (overlapped.hEvent != nullptr) {
+                    CloseHandle(overlapped.hEvent);
+                }
+            }
+
+            [[nodiscard]] bool valid() const noexcept {
+                return overlapped.hEvent != nullptr;
+            }
+
+            void mark_pending(const HANDLE handle) noexcept {
+                file_handle = handle;
+                pending = true;
+            }
+
+            void mark_complete() noexcept { pending = false; }
+
+            [[nodiscard]] DWORD creation_error() const noexcept {
+                return event_error;
+            }
+
+            OVERLAPPED overlapped{};
+
+        private:
+            HANDLE file_handle = INVALID_HANDLE_VALUE;
+            DWORD event_error = ERROR_SUCCESS;
+            bool pending = false;
+        };
+
+        lfs::Error overlapped_operation_start_error(
+            const OverlappedOperation& operation,
+            const std::filesystem::path& path,
+            const std::uint64_t offset,
+            const std::string_view action) {
+            return project_error(
+                lfs::ErrorCode::ResourceExhausted,
+                "The project file operation could not be started.",
+                std::format("{} could not create a completion event with Windows error {}",
+                            action, operation.creation_error()),
+                path, offset, {},
+                static_cast<std::int64_t>(operation.creation_error()), "Win32");
+        }
+
+        lfs::Result<DWORD> wait_for_overlapped(HANDLE handle,
+                                               OverlappedOperation& operation,
                                                const BOOL immediate_result,
                                                const std::filesystem::path& path,
                                                const std::string_view action,
                                                const bool writing) {
             if (immediate_result) {
                 DWORD transferred = 0;
-                if (!GetOverlappedResult(handle, &operation, &transferred, TRUE)) {
+                if (!GetOverlappedResult(handle, &operation.overlapped, &transferred, TRUE)) {
                     const DWORD error = GetLastError();
                     return project_error(native_error_code(static_cast<int>(error), writing),
                                          writing ? "The project could not be written."
@@ -201,8 +266,16 @@ namespace lfs::io::project::detail {
                                      path, std::nullopt, {}, static_cast<std::int64_t>(error),
                                      "Win32");
             }
+            operation.mark_pending(handle);
+            // The event belongs to this operation, so this wait cannot be
+            // satisfied by another request on the same file handle.
             DWORD transferred = 0;
-            if (!GetOverlappedResult(handle, &operation, &transferred, TRUE)) {
+            const BOOL completed =
+                GetOverlappedResult(handle, &operation.overlapped, &transferred, TRUE);
+            if (completed || HasOverlappedIoCompleted(&operation.overlapped)) {
+                operation.mark_complete();
+            }
+            if (!completed) {
                 const DWORD completion_error = GetLastError();
                 return project_error(
                     native_error_code(static_cast<int>(completion_error), writing),
@@ -212,13 +285,6 @@ namespace lfs::io::project::detail {
                     path, std::nullopt, {}, static_cast<std::int64_t>(completion_error), "Win32");
             }
             return transferred;
-        }
-
-        OVERLAPPED operation_at(const std::uint64_t offset) noexcept {
-            OVERLAPPED operation{};
-            operation.Offset = static_cast<DWORD>(offset & 0xffffffffu);
-            operation.OffsetHigh = static_cast<DWORD>(offset >> 32);
-            return operation;
         }
 #endif
 
@@ -435,10 +501,15 @@ namespace lfs::io::project::detail {
 #ifdef _WIN32
             const DWORD request = static_cast<DWORD>(
                 std::min<std::size_t>(remaining, std::numeric_limits<DWORD>::max()));
-            OVERLAPPED operation = operation_at(offset + completed);
+            OverlappedOperation operation(offset + completed);
+            if (!operation.valid()) {
+                return status_failure(overlapped_operation_start_error(
+                    operation, path_, offset + completed, "ReadFile"));
+            }
             const BOOL immediate = ReadFile(handle_, destination.data() + completed, request, nullptr,
-                                            &operation);
-            auto result = wait_for_overlapped(handle_, operation, immediate, path_, "ReadFile", false);
+                                            &operation.overlapped);
+            auto result = wait_for_overlapped(handle_, operation, immediate, path_, "ReadFile",
+                                              false);
             if (!result) {
                 return status_failure(std::move(result).error());
             }
@@ -485,10 +556,16 @@ namespace lfs::io::project::detail {
 #ifdef _WIN32
             const DWORD request = static_cast<DWORD>(
                 std::min<std::size_t>(remaining, std::numeric_limits<DWORD>::max()));
-            OVERLAPPED operation = operation_at(offset + completed);
+            OverlappedOperation operation(offset + completed);
+            if (!operation.valid()) {
+                return status_failure(overlapped_operation_start_error(
+                    operation, path_, offset + completed, "WriteFile"));
+            }
             const BOOL immediate =
-                WriteFile(handle_, source.data() + completed, request, nullptr, &operation);
-            auto result = wait_for_overlapped(handle_, operation, immediate, path_, "WriteFile", true);
+                WriteFile(handle_, source.data() + completed, request, nullptr,
+                          &operation.overlapped);
+            auto result = wait_for_overlapped(handle_, operation, immediate, path_, "WriteFile",
+                                              true);
             if (!result) {
                 return status_failure(std::move(result).error());
             }
@@ -538,9 +615,13 @@ namespace lfs::io::project::detail {
                 lfs::ErrorCode::BoundsViolation, "The project head could not be written.",
                 "single-write request exceeds DWORD", path_, offset, "head_write"));
         }
-        OVERLAPPED operation = operation_at(offset);
+        OverlappedOperation operation(offset);
+        if (!operation.valid()) {
+            return status_failure(overlapped_operation_start_error(
+                operation, path_, offset, "WriteFile(head)"));
+        }
         const BOOL immediate = WriteFile(handle_, source.data(), static_cast<DWORD>(source.size()),
-                                         nullptr, &operation);
+                                         nullptr, &operation.overlapped);
         auto result = wait_for_overlapped(handle_, operation, immediate, path_, "WriteFile(head)",
                                           true);
         if (!result) {

--- a/tests/test_project_container.cpp
+++ b/tests/test_project_container.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <barrier>
 #include <cerrno>
 #include <chrono>
 #include <cmath>
@@ -30,10 +31,12 @@
 #include <limits>
 #include <optional>
 #include <ostream>
+#include <random>
 #include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -317,6 +320,147 @@ namespace {
             const auto crc_ab = crc32c(0, joined.data(), joined.size());
             EXPECT_EQ(crc32c_combine(crc_a, crc_b, suffix.size()), crc_ab)
                 << "n2=" << n2;
+        }
+    }
+
+    // Linux uses pread, so this also passes there without the Windows
+    // overlapped-I/O fix.
+    TEST(ProjectFileNativeFile, ConcurrentReadsOnOneHandleReturnTheirOwnBytes) {
+        constexpr std::uint64_t kInitialBytes = 64ull * 1024 * 1024;
+        constexpr std::uint64_t kTailBytes = 16ull * 1024 * 1024;
+        constexpr std::size_t kWriteBytes = 4ull * 1024 * 1024;
+        constexpr std::size_t kMinReadBytes = 64ull * 1024;
+        constexpr std::size_t kMaxReadBytes = 4ull * 1024 * 1024;
+        constexpr std::size_t kStripeBytes = 1ull * 1024 * 1024;
+        constexpr int kFirstReaderThreads = 16;
+        constexpr int kSecondReaderThreads = 8;
+        constexpr int kWriterThreads = 4;
+        constexpr int kReadsPerReader = 32;
+
+        TemporaryDirectory temporary;
+        const fs::path path = temporary.path / "native-file-overlapped.licht";
+
+        const auto make_pattern = [](const std::uint64_t offset,
+                                     const std::size_t bytes) {
+            std::vector<std::byte> result(bytes);
+            for (std::size_t index = 0; index < bytes; index += sizeof(std::uint64_t)) {
+                const std::uint64_t value = offset + index;
+                std::memcpy(result.data() + index, &value, sizeof(value));
+            }
+            return result;
+        };
+        const auto has_pattern = [](const std::span<const std::byte> bytes,
+                                    const std::uint64_t offset) {
+            if (bytes.size() % sizeof(std::uint64_t) != 0) {
+                return false;
+            }
+            for (std::size_t index = 0; index < bytes.size(); index += sizeof(std::uint64_t)) {
+                std::uint64_t value = 0;
+                std::memcpy(&value, bytes.data() + index, sizeof(value));
+                if (value != offset + index) {
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        auto created = require_result(detail::NativeFile::create_new(path));
+        for (std::uint64_t offset = 0; offset < kInitialBytes; offset += kWriteBytes) {
+            auto bytes = make_pattern(offset, kWriteBytes);
+            require_status(created->write_exact(offset, bytes));
+        }
+        created.reset();
+
+        auto read_file = require_result(detail::NativeFile::open_read(path));
+        std::atomic_bool first_reads_ok{true};
+        {
+            std::vector<std::jthread> readers;
+            readers.reserve(kFirstReaderThreads);
+            for (int reader = 0; reader < kFirstReaderThreads; ++reader) {
+                readers.emplace_back([&, reader] {
+                    std::mt19937_64 random(0x2038'0000ull + static_cast<std::uint64_t>(reader));
+                    std::uniform_int_distribution<std::size_t> length_distribution(
+                        kMinReadBytes / sizeof(std::uint64_t),
+                        kMaxReadBytes / sizeof(std::uint64_t));
+                    for (int read = 0; read < kReadsPerReader; ++read) {
+                        const std::size_t bytes =
+                            length_distribution(random) * sizeof(std::uint64_t);
+                        const auto maximum_word_offset =
+                            (kInitialBytes - bytes) / sizeof(std::uint64_t);
+                        const auto word_offset =
+                            std::uniform_int_distribution<std::uint64_t>(
+                                0, maximum_word_offset)(random);
+                        const std::uint64_t offset =
+                            word_offset * sizeof(std::uint64_t);
+                        std::vector<std::byte> destination(bytes);
+                        if (!read_file->read_exact(offset, destination) ||
+                            !has_pattern(destination, offset)) {
+                            first_reads_ok.store(false, std::memory_order_relaxed);
+                            return;
+                        }
+                    }
+                });
+            }
+        }
+        EXPECT_TRUE(first_reads_ok.load(std::memory_order_relaxed));
+        read_file.reset();
+
+        auto shared_file = require_result(detail::NativeFile::open_read_write(path));
+        std::atomic_bool second_phase_ok{true};
+        std::barrier start(kSecondReaderThreads + kWriterThreads);
+        {
+            std::vector<std::jthread> workers;
+            workers.reserve(kSecondReaderThreads + kWriterThreads);
+            for (int reader = 0; reader < kSecondReaderThreads; ++reader) {
+                workers.emplace_back([&, reader] {
+                    std::mt19937_64 random(0x2038'1000ull + static_cast<std::uint64_t>(reader));
+                    std::uniform_int_distribution<std::size_t> length_distribution(
+                        kMinReadBytes / sizeof(std::uint64_t),
+                        kMaxReadBytes / sizeof(std::uint64_t));
+                    start.arrive_and_wait();
+                    for (int read = 0; read < kReadsPerReader; ++read) {
+                        const std::size_t bytes =
+                            length_distribution(random) * sizeof(std::uint64_t);
+                        const auto maximum_word_offset =
+                            (kInitialBytes - bytes) / sizeof(std::uint64_t);
+                        const auto word_offset =
+                            std::uniform_int_distribution<std::uint64_t>(
+                                0, maximum_word_offset)(random);
+                        const std::uint64_t offset =
+                            word_offset * sizeof(std::uint64_t);
+                        std::vector<std::byte> destination(bytes);
+                        if (!shared_file->read_exact(offset, destination) ||
+                            !has_pattern(destination, offset)) {
+                            second_phase_ok.store(false, std::memory_order_relaxed);
+                            return;
+                        }
+                    }
+                });
+            }
+            for (int writer = 0; writer < kWriterThreads; ++writer) {
+                workers.emplace_back([&, writer] {
+                    start.arrive_and_wait();
+                    for (std::uint64_t stripe = writer;
+                         stripe * kStripeBytes < kTailBytes;
+                         stripe += kWriterThreads) {
+                        const std::uint64_t offset = kInitialBytes + stripe * kStripeBytes;
+                        auto bytes = make_pattern(offset, kStripeBytes);
+                        if (!shared_file->write_exact(offset, bytes)) {
+                            second_phase_ok.store(false, std::memory_order_relaxed);
+                            return;
+                        }
+                    }
+                });
+            }
+        }
+        EXPECT_TRUE(second_phase_ok.load(std::memory_order_relaxed));
+        EXPECT_EQ(require_result(shared_file->size()), kInitialBytes + kTailBytes);
+
+        std::vector<std::byte> tail(kStripeBytes);
+        for (std::uint64_t stripe = 0; stripe * kStripeBytes < kTailBytes; ++stripe) {
+            const std::uint64_t offset = kInitialBytes + stripe * kStripeBytes;
+            require_status(shared_file->read_exact(offset, tail));
+            EXPECT_TRUE(has_pattern(tail, offset)) << "tail stripe " << stripe;
         }
     }
 


### PR DESCRIPTION
Fixes #2038.

**What users saw**: after viewing two PLYs in compare mode for a while on Windows, the log reported the temp project as truncated ("expected 4194304 more bytes, got EOF") and the app became unstable and crashed.

**Cause**: on Windows the project file reader waits for overlapped reads on the file handle itself instead of a per-request event. When several threads read the same file at once (the 4 MiB block verify that runs after every autosave does exactly that), a thread can be woken by another thread's read and see "0 bytes" for its own request, which the code reports as a truncated file. The unfinished read then writes into memory that has already been released, which is what made the app glitch and crash afterwards. Two large PLYs make the untitled autosave rewrite and re-verify a multi-GB temp file every cycle, so the chance of hitting it grows quickly.

**Fix**: every read and write request now gets its own completion event, so each thread only waits for its own request. Linux and macOS use pread/pwrite and were never affected.

**Verification**: new concurrency test on the shared-handle path (passes on Linux, guards Windows); full `lichtfeld_format_tests` green; 30 autosave cycles of a 2.6 GB two-PLY compare session driven through the GUI on Linux ran clean before and after the change (Linux does not reproduce the Windows race by construction).
