### PR TITLE
3DGUT: honor prepared undistortion instead of applying distortion twice

### DIFF
--- a/src/training/rasterization/gsplat_rasterizer.cpp
+++ b/src/training/rasterization/gsplat_rasterizer.cpp
@@ -129,9 +129,10 @@ namespace lfs::training {
 
             const float* viewmat_ptr = viewpoint_camera.world_view_transform_ptr();
 
-            // Convert from lfs::core::CameraModelType (enum class) to global CameraModelType (plain enum) for CUDA kernels
-            const ::CameraModelType camera_model = static_cast<::CameraModelType>(
-                static_cast<int>(viewpoint_camera.camera_model_type()));
+            // Prepared undistortion already supplies pinhole intrinsics and undistorted images.
+            // Ignore the retained camera model and coefficients to avoid applying distortion twice.
+            const bool undistorted = viewpoint_camera.is_undistort_prepared();
+            const ::CameraModelType camera_model = undistorted ? CameraModelType::PINHOLE : static_cast<::CameraModelType>(static_cast<int>(viewpoint_camera.camera_model_type()));
 
             // Build K directly from intrinsics to avoid extra CUDA->CPU->CUDA roundtrips.
             const auto [fx, fy, cx, cy] = viewpoint_camera.get_intrinsics();
@@ -301,40 +302,42 @@ namespace lfs::training {
                 gsplat_thread_caches.staging.copy_to(dest, host.ptr<float>(), copy_n, fwd_stream);
             };
 
-            switch (camera_model) {
-            case CameraModelType::THIN_PRISM_FISHEYE:
-                if (radial_dist.is_valid() && radial_dist.numel() == 4) {
-                    upload_dist(radial_dist, 4, gsplat_thread_caches.radial);
-                    radial_cuda = gsplat_thread_caches.radial;
+            if (!undistorted) {
+                switch (camera_model) {
+                case CameraModelType::THIN_PRISM_FISHEYE:
+                    if (radial_dist.is_valid() && radial_dist.numel() == 4) {
+                        upload_dist(radial_dist, 4, gsplat_thread_caches.radial);
+                        radial_cuda = gsplat_thread_caches.radial;
+                    }
+                    if (tangential_dist.is_valid() && tangential_dist.numel() == 4) {
+                        upload_dist(tangential_dist, 4, gsplat_thread_caches.thin_prism);
+                        thin_prism_cuda = gsplat_thread_caches.thin_prism;
+                    }
+                    break;
+                case CameraModelType::FISHEYE:
+                    if (radial_dist.is_valid() && radial_dist.numel() >= 4) {
+                        upload_dist(radial_dist.numel() == 4 ? radial_dist : radial_dist.slice(0, 0, 4),
+                                    4, gsplat_thread_caches.radial);
+                        radial_cuda = gsplat_thread_caches.radial;
+                    }
+                    break;
+                case CameraModelType::PINHOLE: {
+                    if (radial_dist.is_valid() && radial_dist.numel() > 0) {
+                        const size_t n_rad = std::min(radial_dist.numel(), size_t(6));
+                        upload_dist(radial_dist.numel() == n_rad ? radial_dist : radial_dist.slice(0, 0, n_rad),
+                                    n_rad, gsplat_thread_caches.radial);
+                        radial_cuda = gsplat_thread_caches.radial;
+                    }
+                    if (tangential_dist.is_valid() && tangential_dist.numel() >= 2) {
+                        upload_dist(tangential_dist.numel() == 2 ? tangential_dist : tangential_dist.slice(0, 0, 2),
+                                    2, gsplat_thread_caches.tangential);
+                        tangential_cuda = gsplat_thread_caches.tangential;
+                    }
+                    break;
                 }
-                if (tangential_dist.is_valid() && tangential_dist.numel() == 4) {
-                    upload_dist(tangential_dist, 4, gsplat_thread_caches.thin_prism);
-                    thin_prism_cuda = gsplat_thread_caches.thin_prism;
+                default:
+                    break;
                 }
-                break;
-            case CameraModelType::FISHEYE:
-                if (radial_dist.is_valid() && radial_dist.numel() >= 4) {
-                    upload_dist(radial_dist.numel() == 4 ? radial_dist : radial_dist.slice(0, 0, 4),
-                                4, gsplat_thread_caches.radial);
-                    radial_cuda = gsplat_thread_caches.radial;
-                }
-                break;
-            case CameraModelType::PINHOLE: {
-                if (radial_dist.is_valid() && radial_dist.numel() > 0) {
-                    const size_t n_rad = std::min(radial_dist.numel(), size_t(6));
-                    upload_dist(radial_dist.numel() == n_rad ? radial_dist : radial_dist.slice(0, 0, n_rad),
-                                n_rad, gsplat_thread_caches.radial);
-                    radial_cuda = gsplat_thread_caches.radial;
-                }
-                if (tangential_dist.is_valid() && tangential_dist.numel() >= 2) {
-                    upload_dist(tangential_dist.numel() == 2 ? tangential_dist : tangential_dist.slice(0, 0, 2),
-                                2, gsplat_thread_caches.tangential);
-                    tangential_cuda = gsplat_thread_caches.tangential;
-                }
-                break;
-            }
-            default:
-                break;
             }
             if (radial_cuda.is_valid() && radial_cuda.numel() > 0) {
                 radial_ptr = radial_cuda.ptr<float>();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -320,6 +320,7 @@ set(TEST_FILES
     test_adam_capacity_invariant.cpp
     test_dual_rep_optimizer.cpp
     test_gut_shN_joint_adam.cpp
+    test_gut_undistort_parity.cpp
     test_sparsity_optimizer.cpp
     test_mcmc_tensor_ops.cpp
     test_training_cropbox_mask.cpp

--- a/tests/test_gut_undistort_parity.cpp
+++ b/tests/test_gut_undistort_parity.cpp
@@ -1,0 +1,98 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/camera.hpp"
+#include "core/cuda/memory_arena.hpp"
+#include "core/splat_data.hpp"
+#include "core/tensor.hpp"
+#include "training/rasterization/gsplat/Ops.h"
+#include "training/rasterization/gsplat_rasterizer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace lfs::core;
+using namespace lfs::training;
+
+class GutUndistortParity : public ::testing::Test {
+protected:
+    void TearDown() override {
+        (void)gsplat_lfs::release_intersect_thread_local_cache();
+        (void)lfs::training::release_gsplat_rasterizer_thread_local_caches();
+        lfs::core::GlobalArenaManager::instance().get_arena().full_reset();
+    }
+};
+
+TEST_F(GutUndistortParity, PreparedCameraMatchesPinholeWithoutCoefficients) {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "CUDA device unavailable";
+    }
+
+    constexpr size_t n = 35;
+    std::vector<float> means(n * 3);
+    std::vector<float> rotations(n * 4, 0.0f);
+    for (size_t i = 0; i < n; ++i) {
+        means[i * 3] = (static_cast<float>(i % 7) - 3.0f) * 0.4f;
+        means[i * 3 + 1] = (static_cast<float>(i / 7) - 2.0f) * 0.35f;
+        means[i * 3 + 2] = 3.0f + 0.01f * static_cast<float>(i);
+        rotations[i * 4] = 1.0f;
+    }
+    SplatData model(
+        0, Tensor::from_vector(means, {n, 3}, Device::CUDA),
+        Tensor::full({n, 1, 3}, 0.5f, Device::CUDA),
+        Tensor::zeros({n, 0, 3}, Device::CUDA),
+        Tensor::full({n, 3}, -3.0f, Device::CUDA),
+        Tensor::from_vector(rotations, {n, 4}, Device::CUDA),
+        Tensor::full({n}, 2.0f, Device::CUDA), 1.0f);
+    auto background = Tensor::zeros({3}, Device::CUDA);
+    const auto R = Tensor::from_vector({1.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f},
+                                       {3, 3}, Device::CUDA);
+    const auto T = Tensor::zeros({3}, Device::CUDA);
+    // GUT reads six pinhole radial coefficients; explicitly zero the unused terms.
+    const auto radial = Tensor::from_vector({-0.25f, 0.08f, 0.f, 0.f, 0.f, 0.f}, {6}, Device::CPU);
+    Camera A(R, T, 200.f, 200.f, 128.f, 96.f, radial, Tensor(),
+             lfs::core::CameraModelType::PINHOLE, "prepared", "", "", 256, 192, 0);
+    A.prepare_undistortion();
+    ASSERT_TRUE(A.is_undistort_prepared());
+
+    // get_intrinsics() scales the prepared values to the current image dimensions.
+    const auto [fx, fy, cx, cy] = A.get_intrinsics();
+    Camera B(R, T, fx, fy, cx, cy, Tensor(), Tensor(),
+             lfs::core::CameraModelType::PINHOLE, "pinhole", "", "",
+             A.image_width(), A.image_height(), 1);
+    Camera C(R, T, 200.f, 200.f, 128.f, 96.f, radial, Tensor(),
+             lfs::core::CameraModelType::PINHOLE, "distorted", "", "", 256, 192, 2);
+    ASSERT_FALSE(C.is_undistort_prepared());
+    ASSERT_TRUE(C.has_distortion());
+
+    // Snapshot each image before the next render reuses the thread-local output buffer.
+    const auto render_cpu = [&](Camera& camera) {
+        return gsplat_rasterize(camera, model, background, 1.0f, false,
+                                GsplatRenderMode::RGB, true)
+            .image.cpu()
+            .contiguous();
+    };
+    const auto image_a = render_cpu(A);
+    const auto image_b = render_cpu(B);
+    const auto image_c = render_cpu(C);
+    ASSERT_EQ(image_a.shape(), image_b.shape());
+    ASSERT_EQ(image_c.shape(), image_b.shape());
+    ASSERT_GT(image_b.numel(), 0u);
+    const float* a = image_a.ptr<float>();
+    const float* b = image_b.ptr<float>();
+    const float* c = image_c.ptr<float>();
+    float max_ab = 0.0f, max_cb = 0.0f, max_pixel = 0.0f;
+    for (size_t i = 0; i < image_b.numel(); ++i) {
+        ASSERT_TRUE(std::isfinite(a[i]) && std::isfinite(b[i]) && std::isfinite(c[i]));
+        max_ab = std::max(max_ab, std::abs(a[i] - b[i]));
+        max_cb = std::max(max_cb, std::abs(c[i] - b[i]));
+        max_pixel = std::max(max_pixel, b[i]);
+    }
+    EXPECT_EQ(max_ab, 0.0f);
+    EXPECT_GT(max_pixel, 0.0f);
+    EXPECT_GT(max_cb, 0.0f);
+}


### PR DESCRIPTION
`--gut --undistort` did not work: the undistorted images were trained against a camera that still applied its distortion, so on fisheye datasets 3DGUT produced a round blob instead of the scene. FastGS was unaffected because it never looks at the coefficients.

The GUT rasterizer now treats an undistorted camera as a plain pinhole camera. With this, `--gut --undistort` renders the same view as `--undistort`, and 3DGUT trains fine on undistorted images as it does on distorted ones.

A new test checks that an undistorted camera renders exactly like a pinhole camera without coefficients, and that a still-distorted camera does not. It fails on master and passes here. Verified on alameda (OPENCV_FISHEYE): before, `--gut --undistort` rendered a fisheye circle; after, it renders the rectilinear view FastGS produces.
