### PR TITLE
Fix projects refusing to open when a camera or crop box was selected at save time

### DIFF
--- a/src/io/include/io/selection_chapter.hpp
+++ b/src/io/include/io/selection_chapter.hpp
@@ -130,10 +130,13 @@ namespace lfs::io::project {
 
     // Phase-A API. Every slice is validated against topology and copied into
     // its final contiguous CPU tensor. topology is not mutated.
+    // extra_owner_uuids are node UUIDs that own selections but are absent from
+    // the partial topology, e.g. the SCNG nodes the shell already restored.
     [[nodiscard]] LFS_IO_API lfs::Result<StagedSelectionChapter>
     stage_selection_chapter(
         const SelectionChapter& chapter,
-        const lfs::core::Scene& topology);
+        const lfs::core::Scene& topology,
+        std::span<const lfs::core::Uuid> extra_owner_uuids = {});
 
     [[nodiscard]] LFS_IO_API lfs::Result<SelectionHydrationReport>
     hydrate_selection_chapter(

--- a/src/io/project/project_document.cpp
+++ b/src/io/project/project_document.cpp
@@ -5067,9 +5067,19 @@ namespace lfs::io::project {
             if (!staged_scene) {
                 return std::move(staged_scene).error();
             }
+            auto nodes = impl_->scene_graph.nodes();
+            if (!nodes) {
+                return std::move(nodes).error();
+            }
+            std::vector<lfs::core::Uuid> selection_owner_uuids;
+            selection_owner_uuids.reserve(nodes->size());
+            for (const auto& node : *nodes) {
+                selection_owner_uuids.push_back(node.uuid);
+            }
             auto staged_selection =
                 stage_selection_chapter(
-                    impl_->selection, **staged_scene);
+                    impl_->selection, **staged_scene,
+                    selection_owner_uuids);
             if (!staged_selection) {
                 return std::move(staged_selection).error();
             }

--- a/src/io/project/selection_chapter.cpp
+++ b/src/io/project/selection_chapter.cpp
@@ -1221,7 +1221,8 @@ namespace lfs::io::project {
     lfs::Result<StagedSelectionChapter>
     stage_selection_chapter(
         const SelectionChapter& chapter,
-        const lfs::core::Scene& topology) {
+        const lfs::core::Scene& topology,
+        std::span<const lfs::core::Uuid> extra_owner_uuids) {
         if (auto groups = validate_groups(
                 chapter.groups(),
                 chapter.active_group_id(),
@@ -1396,13 +1397,16 @@ namespace lfs::io::project {
             }
         }
 
+        const std::unordered_set<lfs::core::Uuid> extra_owners(
+            extra_owner_uuids.begin(), extra_owner_uuids.end());
         std::unordered_set<lfs::core::Uuid> selected_nodes;
         selected_nodes.reserve(
             chapter.selected_node_uuids().size());
         for (const auto& uuid :
              chapter.selected_node_uuids()) {
             if (!ranges.contains(uuid) &&
-                topology.getNodeByUuid(uuid) == nullptr) {
+                topology.getNodeByUuid(uuid) == nullptr &&
+                !extra_owners.contains(uuid)) {
                 return selection_error(
                     lfs::ErrorCode::FailedPrecondition,
                     "A saved node selection refers to a missing scene node.",

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -1625,6 +1625,79 @@ namespace {
     }
 
     TEST(ProjectDocumentTest,
+         ShellRestoredProjectHydratesWithNonGeometryNodeSelected) {
+        Scene source;
+        const auto group = source.addGroup("Empty group");
+        ASSERT_NE(group, lfs::core::NULL_NODE);
+        const auto group_uuid = source.getNodeUuid(group);
+        const auto point_uuid = fixed_uuid(949);
+        auto points = make_point_cloud(2);
+        ASSERT_NE(source.restoreNodeWithUuid(Scene::RestoreNodeDesc{
+                      .uuid = point_uuid,
+                      .type = NodeType::POINTCLOUD,
+                      .name = "Points",
+                      .point_cloud = points,
+                  }),
+                  lfs::core::NULL_NODE);
+        const ScenePayloadBindings bindings{
+            {point_uuid, PayloadBinding{
+                             .fourcc = "PCLD",
+                             .instance_uuid = point_uuid,
+                             .source_kind = "ply",
+                         }}};
+        const auto make_document = [&] {
+            auto document = make_empty_document(fixed_uuid(948), 100);
+            document->edit_scene_graph() =
+                require_result(capture_scene_graph(source, bindings));
+            require_status(document->set_point_cloud(
+                point_uuid, PointCloudPayload(points)));
+            require_status(document->edit_project().upsert_embed_decision(
+                EmbedDecision{
+                    .uuid = point_uuid,
+                    .node_uuid = point_uuid,
+                    .payload_fourcc = "PCLD",
+                    .decision = "embedded",
+                    .reason = "selection regression",
+                }));
+            require_status(document->edit_project().upsert_embedded_payload_provenance(
+                provenance(point_uuid, "PCLD", "assets/points.ply", 39)));
+            return document;
+        };
+
+        TemporaryDirectory temporary;
+        for (const auto& selected_uuid : {point_uuid, group_uuid}) {
+            SCOPED_TRACE(selected_uuid == point_uuid ? "point cloud selected" : "empty group selected");
+            const auto path = temporary.path / (selected_uuid.to_string() + ".licht");
+            auto document = make_document();
+            require_status(document->edit_selection().set_selected_node_uuids(
+                {selected_uuid}));
+            const auto saved = document->save(path, save_options(948, 200));
+            ASSERT_TRUE(saved) << lfs::format_for_developer(saved.error());
+            auto reopened = require_result_ptr(ProjectDocument::open(
+                path, ProjectDocumentOpenOptions{.defer_geometry_payloads = true}));
+            Scene live;
+            auto shell = reopened->stage_shell(live);
+            ASSERT_TRUE(shell) << lfs::format_for_developer(shell.error());
+            live.commitRestoreStage(std::move(*shell));
+            ASSERT_NE(live.getNodeByUuid(group_uuid), nullptr);
+            auto staged = reopened->stage_hydration(live);
+            ASSERT_TRUE(staged) << lfs::format_for_developer(staged.error());
+            EXPECT_EQ(staged->report().selection.selected_node_uuids,
+                      (std::vector<Uuid>{selected_uuid}));
+            const auto report = ProjectDocument::commit_partial_hydration(
+                live, std::move(*staged), true);
+            EXPECT_EQ(report.hydrated_payload_units, 1u);
+            EXPECT_EQ(report.invalidated_payload_units, 0u);
+            EXPECT_TRUE(report.selection_installed);
+            EXPECT_NE(live.getNodeByUuid(group_uuid), nullptr);
+            const auto* point = live.getNodeByUuid(point_uuid);
+            ASSERT_NE(point, nullptr);
+            ASSERT_NE(point->point_cloud, nullptr);
+            EXPECT_EQ(point->point_cloud->size(), 2u);
+        }
+    }
+
+    TEST(ProjectDocumentTest,
          DeferredShellExposesUnloadedUnitsAndCommitsHydrationPerNodeUuid) {
         TemporaryDirectory temporary;
         const auto path =

--- a/tests/test_selection_chapter.cpp
+++ b/tests/test_selection_chapter.cpp
@@ -128,6 +128,31 @@ namespace {
 
 #if !defined(LFS_FORMAT_TEST_TARGET)
     TEST(SelectionChapterTest,
+         SelectedNodeAbsentFromTopologyRequiresExtraOwner) {
+        const auto selected_uuid = fixed_uuid(81);
+        SelectionChapter chapter;
+        ASSERT_TRUE(chapter.set_selected_node_uuids({selected_uuid}));
+        Scene topology;
+        const auto missing = lfs::io::project::stage_selection_chapter(chapter, topology);
+        ASSERT_FALSE(missing);
+        EXPECT_EQ(missing.error().code(), lfs::ErrorCode::FailedPrecondition);
+
+        const std::array unrelated_owners{fixed_uuid(82)};
+        const auto unrelated = lfs::io::project::stage_selection_chapter(
+            chapter, topology, unrelated_owners);
+        ASSERT_FALSE(unrelated);
+        EXPECT_EQ(unrelated.error().code(), lfs::ErrorCode::FailedPrecondition);
+
+        const std::array extra_owners{selected_uuid};
+        const auto staged = lfs::io::project::stage_selection_chapter(
+            chapter, topology, extra_owners);
+        ASSERT_TRUE(staged) << lfs::format_for_developer(staged.error());
+        EXPECT_EQ(staged->report.selected_node_uuids,
+                  (std::vector<Uuid>{selected_uuid}));
+        EXPECT_EQ(topology.getNodeByUuid(selected_uuid), nullptr);
+    }
+
+    TEST(SelectionChapterTest,
          BothDomainsGroupsAndSelectedNodeOrderRoundTrip) {
         const Uuid splat_uuid = fixed_uuid(1);
         const Uuid point_uuid = fixed_uuid(2);


### PR DESCRIPTION
## Problem

Save a project while a **camera** (or crop box / ellipsoid / empty group) is the selected node in the scene panel, then reopen it: the project refuses to load, forever, with

```
Project hydration failed; the coherent shell remains active: lfs::Error[FailedPrecondition/IO]
  user_message: A saved node selection refers to a missing scene node.
  detail: SELM selected node ... has no SCNG owner
```

Reported on Discord (Windows nightly `v0.5.3.dev20260830+50242058`, four projects unopenable after training). Reproduced on Linux master with and without training; the same project opens fine when the point cloud or splat node is selected instead.

## Cause

Since #1868 the open path restores a full shell of the scene graph first and then hydrates only the geometry nodes (plus their ancestors) on top of it. The selection chapter's selected-node check was run against that partial staged topology, which does not contain cameras, crop boxes, ellipsoids or empty groups. The saved file is valid: the writer validates the selection against the complete SCNG node list.

## Fix

`stage_selection_chapter` takes the full set of SCNG node uuids as additional selection owners, and `ProjectDocument::hydrate` passes every scene-graph record. Selection slices are unchanged (geometry nodes are always staged).

Existing broken files open again with this build; no format change.

## Verification

- New unit tests: `ProjectDocumentTest.ShellRestoredProjectHydratesWithNonGeometryNodeSelected` (fails without the call-site change with exactly `SELM selected node ... has no SCNG owner`, passes with it) and `SelectionChapterTest.SelectedNodeAbsentFromTopologyRequiresExtraOwner`. The existing `SelectionReferencingMissingSceneNodeRefusesHydration` still passes, so a selection pointing at a node that is absent from the file is still refused. `ProjectDocumentTest.*` / `SelectionChapterTest.*` / `SceneGraphChapterTest.*` / `CaptureOmitFilterTest.*`: 80 passed; `lichtfeld_format_tests`: 107 passed.
- Live repro on master (Linux): camera selected + save, crop box selected + save, and the reporter's flow (train to completion, camera selected, save) all refused to open with the error above; all three files open with this build.
- GUI pass with the fixed build: dataset loaded, camera clicked in the scene panel, trained to completion, saved, app restarted, project reopened from File > Open Recent; hydration completed and the camera selection was restored.
