### PR TITLE
Resuming a project with Undistort on no longer undistorts the cameras twice

### DIFF
--- a/src/io/include/io/project_chapters.hpp
+++ b/src/io/include/io/project_chapters.hpp
@@ -360,6 +360,8 @@ namespace lfs::io::project {
         friend bool operator==(const EllipsoidRecord&, const EllipsoidRecord&) = default;
     };
 
+    // Camera calibration in SCNG is always the source (pre-rectification) calibration
+    // that belongs to the stored distortion model; rectified calibration is derived runtime state.
     struct CameraRecord {
         std::int32_t uid = -1;
         std::int32_t camera_id = 0;

--- a/src/io/project/scene_chapter_adapter.cpp
+++ b/src/io/project/scene_chapter_adapter.cpp
@@ -14,10 +14,12 @@
 #include <format>
 #include <functional>
 #include <glm/gtc/type_ptr.hpp>
+#include <map>
 #include <optional>
 #include <ranges>
 #include <span>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -197,6 +199,15 @@ namespace lfs::io::project {
                 static_cast<std::int32_t>(camera.camera_model_type());
             result.camera_width = camera.camera_width();
             result.camera_height = camera.camera_height();
+            if (camera.is_undistort_prepared()) {
+                const auto& source = camera.undistort_params();
+                result.focal_x = source.src_fx;
+                result.focal_y = source.src_fy;
+                result.center_x = source.src_cx;
+                result.center_y = source.src_cy;
+                result.camera_width = source.src_width;
+                result.camera_height = source.src_height;
+            }
             result.image_width = camera.image_width();
             result.image_height = camera.image_height();
             result.image_name = camera.image_name();
@@ -391,8 +402,14 @@ namespace lfs::io::project {
                 lfs::core::Device::CPU);
         }
 
+        using UndistortCacheKey = std::tuple<
+            std::int32_t, float, float, float, float,
+            std::int32_t, std::int32_t, std::int32_t,
+            std::vector<float>, std::vector<float>>;
+        using UndistortCache = std::map<UndistortCacheKey, lfs::core::UndistortParams>;
+
         std::shared_ptr<lfs::core::Camera> hydrate_camera(
-            const CameraRecord& value) {
+            const CameraRecord& value, UndistortCache& undistort_cache) {
             auto camera = std::make_shared<lfs::core::Camera>(
                 float_tensor(value.rotation, {3, 3}),
                 float_tensor(value.translation, {3}),
@@ -407,6 +424,21 @@ namespace lfs::io::project {
                 value.camera_height, value.uid, value.camera_id,
                 lfs::core::utf8_to_path(value.depth_path),
                 lfs::core::utf8_to_path(value.normal_path));
+            if (camera->has_distortion()) {
+                // Camera IDs can overlap across datasets; reuse only identical calibrations.
+                UndistortCacheKey key{
+                    value.camera_id, value.focal_x, value.focal_y,
+                    value.center_x, value.center_y, value.camera_width,
+                    value.camera_height, value.camera_model_type,
+                    value.radial_distortion, value.tangential_distortion};
+                const auto cached = undistort_cache.find(key);
+                if (cached != undistort_cache.end()) {
+                    camera->adopt_undistortion(cached->second);
+                } else {
+                    camera->precompute_undistortion(0.0f);
+                    undistort_cache.emplace(std::move(key), camera->undistort_params());
+                }
+            }
             camera->set_image_dimensions(value.image_width, value.image_height);
             camera->set_has_alpha(value.has_alpha);
             camera->set_has_image(value.has_image);
@@ -530,6 +562,7 @@ namespace lfs::io::project {
             const ScenePayloadResolver& resolver,
             const bool defer_geometry_payloads,
             const bool payload_units_only) {
+            UndistortCache undistort_cache;
             auto nodes = chapter.nodes();
             if (!nodes) {
                 return lfs::Result<void>::failure(std::move(nodes).error());
@@ -713,7 +746,7 @@ namespace lfs::io::project {
                 }
                 if (record.camera) {
                     try {
-                        desc.camera = hydrate_camera(*record.camera);
+                        desc.camera = hydrate_camera(*record.camera, undistort_cache);
                     } catch (const std::exception& error) {
                         // LFS-CENSUS-OK(empty-catch): reject malformed camera tensors before mutating the scene.
                         return fail<void>(

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -1062,17 +1062,21 @@ namespace {
     }
 
     std::shared_ptr<lfs::core::Camera> make_adapter_test_camera(
-        const std::string& image_name, const int uid) {
+        const std::string& image_name, const int uid, const bool distorted = false) {
         const auto empty_distortion = Tensor::zeros(
             {0}, Device::CPU, DataType::Float32);
+        const auto radial = distorted
+                                ? Tensor::from_vector({0.5f}, {1}, Device::CPU)
+                                : empty_distortion;
+        const int size = distorted ? 100 : 64;
         return std::make_shared<lfs::core::Camera>(
             Tensor::eye(3, Device::CPU),
             Tensor::zeros({3}, Device::CPU),
-            100.0f, 100.0f, 32.0f, 32.0f,
-            empty_distortion, empty_distortion,
+            100.0f, 100.0f, size / 2.0f, size / 2.0f,
+            radial, empty_distortion,
             lfs::core::CameraModelType::PINHOLE,
             image_name, std::filesystem::path{},
-            std::filesystem::path{}, 64, 64, uid);
+            std::filesystem::path{}, size, size, uid);
     }
 
     TEST(SceneChapterAdapterTest,
@@ -1176,6 +1180,113 @@ namespace {
         EXPECT_TRUE(std::ranges::any_of(active, [](const auto& camera) {
             return camera && camera->uid() == 3;
         }));
+    }
+
+    TEST(SceneChapterAdapterTest, PreparedCameraRoundTripPreservesSourceCalibration) {
+        if (!cuda_device_available()) {
+            GTEST_SKIP() << "CUDA device unavailable";
+        }
+
+        auto source = std::make_unique<Scene>();
+        const auto dataset = source->addDataset("Dataset");
+        const auto group = source->addCameraGroup("Training", dataset, 2);
+        ASSERT_NE(dataset, lfs::core::NULL_NODE);
+        ASSERT_NE(group, lfs::core::NULL_NODE);
+        auto prepared = make_adapter_test_camera("prepared.png", 1, true);
+        auto unprepared = make_adapter_test_camera("unprepared.png", 2, true);
+        ASSERT_NE(source->addCamera("prepared.png", group, prepared), lfs::core::NULL_NODE);
+        ASSERT_NE(source->addCamera("unprepared.png", group, unprepared), lfs::core::NULL_NODE);
+
+        prepared->prepare_undistortion();
+        const auto destination = prepared->undistort_params();
+        ASSERT_EQ(destination.dst_width, 84);
+        ASSERT_EQ(destination.dst_height, 84);
+        EXPECT_FLOAT_EQ(destination.dst_fx, 100.0f);
+        EXPECT_FLOAT_EQ(destination.dst_fy, 100.0f);
+        EXPECT_FLOAT_EQ(destination.dst_cx, 42.0f);
+        EXPECT_FLOAT_EQ(destination.dst_cy, 42.0f);
+        prepared->set_image_dimensions(destination.dst_width, destination.dst_height);
+
+        const auto expect_destination = [&](const lfs::core::Camera& camera) {
+            EXPECT_TRUE(camera.is_undistort_precomputed());
+            EXPECT_TRUE(camera.is_undistort_prepared());
+            EXPECT_FLOAT_EQ(camera.focal_x(), destination.dst_fx);
+            EXPECT_FLOAT_EQ(camera.focal_y(), destination.dst_fy);
+            EXPECT_FLOAT_EQ(camera.center_x(), destination.dst_cx);
+            EXPECT_FLOAT_EQ(camera.center_y(), destination.dst_cy);
+            EXPECT_EQ(camera.camera_width(), destination.dst_width);
+            EXPECT_EQ(camera.camera_height(), destination.dst_height);
+        };
+
+        for (int cycle = 0; cycle < 2; ++cycle) {
+            SCOPED_TRACE(cycle);
+            auto chapter = capture_scene_graph(*source, ScenePayloadBindings{});
+            ASSERT_TRUE(chapter) << lfs::format_for_developer(chapter.error());
+            auto nodes = chapter->nodes();
+            ASSERT_TRUE(nodes) << lfs::format_for_developer(nodes.error());
+            size_t camera_count = 0;
+            for (const auto& node : *nodes) {
+                if (!node.camera) {
+                    continue;
+                }
+                ++camera_count;
+                const auto& record = *node.camera;
+                // Both the prepared camera and the unprepared control store source calibration.
+                EXPECT_FLOAT_EQ(record.focal_x, 100.0f);
+                EXPECT_FLOAT_EQ(record.focal_y, 100.0f);
+                EXPECT_FLOAT_EQ(record.center_x, 50.0f);
+                EXPECT_FLOAT_EQ(record.center_y, 50.0f);
+                EXPECT_EQ(record.camera_width, 100);
+                EXPECT_EQ(record.camera_height, 100);
+                EXPECT_EQ(record.radial_distortion, std::vector<float>{0.5f});
+                EXPECT_TRUE(record.tangential_distortion.empty());
+                EXPECT_EQ(record.camera_model_type,
+                          static_cast<std::int32_t>(lfs::core::CameraModelType::PINHOLE));
+                EXPECT_EQ(record.image_width, node.name == "prepared.png" ? 84 : 100);
+                EXPECT_EQ(record.image_height, node.name == "prepared.png" ? 84 : 100);
+            }
+            ASSERT_EQ(camera_count, 2u);
+            expect_destination(*prepared);
+            EXPECT_EQ(prepared->image_width(), 84);
+            EXPECT_EQ(prepared->image_height(), 84);
+            EXPECT_TRUE(prepared->has_distortion());
+            EXPECT_FALSE(unprepared->is_undistort_prepared());
+            EXPECT_FLOAT_EQ(unprepared->center_x(), 50.0f);
+            EXPECT_EQ(unprepared->camera_width(), 100);
+
+            const auto bytes = chapter->to_bytes();
+            auto decoded = SceneGraphChapter::from_bytes(bytes);
+            ASSERT_TRUE(decoded) << lfs::format_for_developer(decoded.error());
+            auto restored = std::make_unique<Scene>();
+            auto hydrated = hydrate_scene_graph(*decoded, *restored, ScenePayloadResolver{});
+            ASSERT_TRUE(hydrated) << lfs::format_for_developer(hydrated.error());
+            for (const auto* name : {"prepared.png", "unprepared.png"}) {
+                const auto* node = restored->getNode(name);
+                ASSERT_NE(node, nullptr);
+                ASSERT_NE(node->camera, nullptr);
+                const auto& camera = *node->camera;
+                EXPECT_TRUE(camera.has_distortion());
+                EXPECT_TRUE(camera.is_undistort_precomputed());
+                EXPECT_FALSE(camera.is_undistort_prepared());
+                EXPECT_FLOAT_EQ(camera.focal_x(), 100.0f);
+                EXPECT_FLOAT_EQ(camera.focal_y(), 100.0f);
+                EXPECT_FLOAT_EQ(camera.center_x(), 50.0f);
+                EXPECT_FLOAT_EQ(camera.center_y(), 50.0f);
+                EXPECT_EQ(camera.camera_width(), 100);
+                EXPECT_EQ(camera.camera_height(), 100);
+                EXPECT_FLOAT_EQ(camera.undistort_params().src_fx, destination.src_fx);
+                EXPECT_FLOAT_EQ(camera.undistort_params().src_fy, destination.src_fy);
+                EXPECT_FLOAT_EQ(camera.undistort_params().src_cx, destination.src_cx);
+                EXPECT_FLOAT_EQ(camera.undistort_params().src_cy, destination.src_cy);
+                EXPECT_EQ(camera.undistort_params().src_width, destination.src_width);
+                EXPECT_EQ(camera.undistort_params().src_height, destination.src_height);
+            }
+            prepared = restored->getNode("prepared.png")->camera;
+            unprepared = restored->getNode("unprepared.png")->camera;
+            prepared->prepare_undistortion();
+            expect_destination(*prepared);
+            source = std::move(restored);
+        }
     }
 
     TEST(ProjectDocumentTest,


### PR DESCRIPTION
Fixes #2034.

**What went wrong**
Training with Undistort rewrites each camera's intrinsics and calibration size with the rectified values. The project saved those rectified values next to the original distortion coefficients. After closing and reopening, the trainer saw a camera that still looked distorted and undistorted it again, so every training view was warped a second time and the model trained against misaligned targets. Loss jumped and stayed high right after Resume.

**What changed**
- The project now stores the original (pre-rectification) calibration for prepared cameras, which is the calibration that actually belongs to the stored distortion model.
- Cameras loaded from a project precompute their undistortion mapping once per distinct calibration, the same state a fresh dataset import has, so a cold open behaves exactly like the in-process case.
- Nothing else changes: unprepared cameras, pinhole cameras and the trainer's prepare step behave as before.

**Proof**
- New test `SceneChapterAdapterTest.PreparedCameraRoundTripPreservesSourceCalibration` fails on master (record holds 84x84 / 42,42 instead of 100x100 / 50,50) and passes with the fix, including two save/reopen/prepare cycles without drift.
- Headless: train a fisheye dataset with `--undistort`, then `--resume` the project. Master logs `Undistort: 876x403 -> 876x806` on resume; with the fix the resume solves `438x292 -> 876x403` exactly like the first run, and a second resume is identical.
- GUI: train with Undistort, Pause, Save Project, quit, reopen the project, Resume. One undistort solve on open, none on Resume; mean loss over the 110 iterations before the pause (0.0312) and the 250 after the cold resume (0.0308) are the same.

Projects saved with the old writer already lost their original calibration and cannot be repaired automatically; they need to be re-imported from the dataset.