### PR TITLE
Headless runs redirected with -o keep the source project's embedded dataset

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -318,6 +318,7 @@ namespace lfs::app {
             core::param::TrainingParameters params;
             core::Uuid checkpoint_uuid;
             int iteration = 0;
+            std::optional<std::filesystem::path> snapshot_source_path;
         };
 
         lfs::Result<LoadedTrainingProject>
@@ -468,6 +469,16 @@ namespace lfs::app {
             auto checkpoint_params =
                 std::move(**parsed_params);
 
+            // Only retain the source dataset when the effective training root
+            // still denotes the checkpoint's dataset (including path aliases).
+            std::error_code dataset_error;
+            const bool same_dataset = cli_params.dataset.data_path.empty() ||
+                                      std::filesystem::equivalent(
+                                          cli_params.dataset.data_path,
+                                          checkpoint_params.dataset.data_path, dataset_error);
+            const auto snapshot_source_path = same_dataset
+                                                  ? recovery_document.document().source_path()
+                                                  : std::nullopt;
             if (!cli_params.dataset.data_path.empty()) {
                 checkpoint_params.dataset.data_path =
                     cli_params.dataset.data_path;
@@ -548,6 +559,7 @@ namespace lfs::app {
                     hydration
                         ->checkpoint_header
                         ->iteration,
+                .snapshot_source_path = snapshot_source_path,
             };
         }
 
@@ -654,7 +666,8 @@ namespace lfs::app {
                             *installed->trainer,
                             effective_params,
                             headless_project_save_destination(
-                                *params, *params->resume_project));
+                                *params, *params->resume_project),
+                            training_project->snapshot_source_path);
                         manager->setTrainer(
                             std::move(installed->trainer));
                     } else {
@@ -671,7 +684,8 @@ namespace lfs::app {
                         trainer->setParams(effective_params);
                         training::grant_headless_project_saves(
                             *trainer, effective_params,
-                            headless_dataset_project_destination(effective_params));
+                            headless_dataset_project_destination(effective_params),
+                            effective_params.dataset_project);
                         manager->setTrainer(std::move(trainer));
                     }
                 }
@@ -766,7 +780,7 @@ namespace lfs::app {
                     return 1;
                 }
 
-                if (training_project) {
+                if (training_project && !params->dataset.output_path_explicit) {
                     if (auto rebound =
                             training_project->document
                                 .rebind_after_durable_merge();
@@ -874,7 +888,8 @@ namespace lfs::app {
                     training::grant_headless_project_saves(
                         *trainer, project->params,
                         headless_project_save_destination(
-                            *params, *params->resume_project));
+                            *params, *params->resume_project),
+                        project->snapshot_source_path);
                     LOG_INFO(
                         "Project display hydration complete; full "
                         "trainer state restored at iteration {}",
@@ -892,9 +907,9 @@ namespace lfs::app {
                                 result.error()));
                         return 1;
                     }
-                    if (auto rebound =
-                            project->document
-                                .rebind_after_durable_merge();
+                    if (auto rebound = params->dataset.output_path_explicit
+                                           ? lfs::Result<void>{}
+                                           : project->document.rebind_after_durable_merge();
                         !rebound) {
                         LOG_ERROR(
                             "Headless recovery merge could not rebind the live project document: {}",
@@ -988,7 +1003,8 @@ namespace lfs::app {
                         trainer->set_lpips_weights_path(prepare_lpips_weights(!params->no_download));
                     training::grant_headless_project_saves(
                         *trainer, *params,
-                        headless_dataset_project_destination(*params));
+                        headless_dataset_project_destination(*params),
+                        params->dataset_project);
 
                     core::Tensor::trim_memory_pool();
 

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -4684,11 +4684,13 @@ namespace lfs::training {
 
         photometric_loss_.arena().shrink_to_required();
 
+        std::optional<std::filesystem::path> headless_source_path;
         bool first_publish_to_destination =
             false;
         {
             std::lock_guard lock(
                 project_snapshot_mutex_);
+            headless_source_path = headless_project_source_path_;
             project_step_regression_
                 .arm_after_snapshot(iteration);
             first_publish_to_destination =
@@ -4703,7 +4705,7 @@ namespace lfs::training {
 
         try {
             project_writer_thread_ = std::jthread(
-                [this, path, chapters, cpu_state,
+                [this, path, chapters, cpu_state, headless_source_path,
                  request_id, write_kind,
                  base_explicit_commit_uuid,
                  autosave_sequence,
@@ -4820,6 +4822,13 @@ namespace lfs::training {
                             source_path = path;
                             compact_after_publish =
                                 first_publish_to_destination;
+                        } else if (!document_context && headless_source_path) {
+                            source_path = headless_source_path;
+                        }
+                        // A redirected recovery save does not merge into or own
+                        // the original master. Its owner keeps staging alive.
+                        if (!document_context && recovery_session && !recovery_session->writer_lock().owns(path)) {
+                            recovery_session.reset();
                         }
                         bool save_as =
                             !source_path &&
@@ -4917,6 +4926,42 @@ namespace lfs::training {
                                 !created) {
                                 return std::move(created)
                                     .error();
+                            }
+                        }
+
+                        if (!document_context && save_as && headless_source_path) {
+                            // Save As carries DSRC lazily. Reject broken manifests
+                            // before publication, and bind the effective dataset
+                            // relative to the new project rather than the source.
+                            auto manifest = document->parameters().embedded_dataset();
+                            if (!manifest) {
+                                return std::move(manifest).error();
+                            }
+                            if (*manifest) {
+                                for (const auto& entry : (*manifest)->entries) {
+                                    const auto* row = document->source_reader()->find(
+                                        lfs::io::project::FOURCC_DSRC, entry.chunk_uuid);
+                                    if (!row || !row->is_live() || row->uncompressed_bytes != entry.bytes) {
+                                        return project_snapshot_error(
+                                            lfs::ErrorCode::DataLoss,
+                                            "Embedded dataset manifest has a missing or incorrectly sized DSRC payload",
+                                            LFS_SOURCE_SITE_CURRENT());
+                                    }
+                                }
+                            }
+                            auto existing = document->project().dataset_reference();
+                            if (!existing) {
+                                return std::move(existing).error();
+                            }
+                            auto reference = lfs::io::project::upsert_path_reference(
+                                document->edit_references(), path.parent_path(),
+                                chapters->parameters.dataset.data_path,
+                                "dataset", "dataset", *existing);
+                            if (!reference) {
+                                return std::move(reference).error();
+                            }
+                            if (auto bound = document->edit_project().set_dataset_reference(*reference); !bound) {
+                                return std::move(bound).error();
                             }
                         }
 
@@ -5148,7 +5193,7 @@ namespace lfs::training {
                                         document_context
                                             ? document_context
                                                   ->save_as_project_uuid
-                                            : lfs::core::Uuid{},
+                                            : (headless_source_path && save_as ? project_uuid_ : lfs::core::Uuid{}),
                                     .allow_existing_destination_replacement =
                                         document_context &&
                                         document_context
@@ -9047,9 +9092,11 @@ namespace lfs::training {
         std::optional<std::filesystem::path> path,
         std::function<std::optional<
             ProjectSnapshotDocumentContext>()>
-            context_provider) {
+            context_provider,
+        std::optional<std::filesystem::path> headless_source_path) {
         std::lock_guard lock(project_snapshot_mutex_);
         live_project_path_ = std::move(path);
+        headless_project_source_path_ = std::move(headless_source_path);
         live_document_context_provider_ =
             std::move(context_provider);
     }

--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -401,7 +401,8 @@ namespace lfs::training {
             std::optional<std::filesystem::path> path,
             std::function<std::optional<
                 ProjectSnapshotDocumentContext>()>
-                context_provider = {});
+                context_provider = {},
+            std::optional<std::filesystem::path> headless_source_path = std::nullopt);
         [[nodiscard]] bool can_flush_project_snapshot() const {
             return project_snapshot_service_ && strategy_ &&
                    scene_;
@@ -829,6 +830,8 @@ namespace lfs::training {
             last_project_writer_typed_error_;
         std::optional<std::filesystem::path>
             live_project_path_;
+        // Used only to seed a fresh headless destination; never a GUI context.
+        std::optional<std::filesystem::path> headless_project_source_path_;
         TrainerProjectSavePolicy trainer_project_save_policy_{};
         std::function<std::optional<
             ProjectSnapshotDocumentContext>()>

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -1290,7 +1290,8 @@ namespace lfs::training {
     void grant_headless_project_saves(
         Trainer& trainer,
         const lfs::core::param::TrainingParameters& params,
-        const std::filesystem::path& destination) {
+        const std::filesystem::path& destination,
+        std::optional<std::filesystem::path> source_path) {
         if (destination.empty() &&
             params.dataset.output_path.empty()) {
             LOG_WARN(
@@ -1300,7 +1301,8 @@ namespace lfs::training {
         trainer.set_live_project_snapshot(
             destination.empty()
                 ? params.dataset.output_path / "project.licht"
-                : destination);
+                : destination,
+            {}, std::move(source_path));
         trainer.set_trainer_project_save_policy({
             .on_completion = true,
             .on_stop_or_error = true,

--- a/src/training/training_setup.hpp
+++ b/src/training/training_setup.hpp
@@ -36,11 +36,14 @@ namespace lfs::training {
     };
 
     // Headless sessions have no project lifecycle; the application grants the
-    // trainer its standing save destination and triggers here.
+    // trainer its standing save destination and triggers here. source_path may
+    // seed a fresh destination only when it contains the dataset being trained;
+    // recovered sources must remain alive until the trainer finishes saving.
     void grant_headless_project_saves(
         Trainer& trainer,
         const lfs::core::param::TrainingParameters& params,
-        const std::filesystem::path& destination = {});
+        const std::filesystem::path& destination = {},
+        std::optional<std::filesystem::path> source_path = std::nullopt);
 
     /// Write `--export` formats next to project.licht after a terminal project
     /// save. No-op when `params.export_formats` is empty.

--- a/tests/test_checkpoint_resume.cpp
+++ b/tests/test_checkpoint_resume.cpp
@@ -35,12 +35,14 @@
 #include "core/splat_data.hpp"
 #include "core/tensor.hpp"
 #include "core/uuid.hpp"
+#include "io/embedded_dataset.hpp"
 #include "io/exporter.hpp"
 #include "io/loader.hpp"
 #include "io/loaders/checkpoint_loader.hpp"
 #include "io/project_document.hpp"
 #include "lfs/training/sh_value_codec.hpp"
 #include "lfs/training/sh_value_storage.hpp"
+#include "licht_test_support.hpp"
 #include "training/checkpoint.hpp"
 #include "training/components/sparsity_optimizer.hpp"
 #include "training/optimizer/adam_optimizer.hpp"
@@ -2465,6 +2467,148 @@ namespace {
         trainer->shutdown();
 
         std::filesystem::remove_all(output_path, ec);
+    }
+
+    TEST_F(ProjectCheckpointTrainerInstall,
+           HeadlessRedirectPreservesEmbeddedDatasetForDatasetAndResume) {
+        int device_count = 0;
+        const auto cuda_status = cudaGetDeviceCount(&device_count);
+        if (cuda_status != cudaSuccess || device_count == 0) {
+            GTEST_SKIP() << "Requires CUDA: " << cudaGetErrorString(cuda_status);
+        }
+        using namespace lfs::io::project;
+        using namespace lfs::test::licht;
+        TemporaryDirectory temporary;
+        auto params = make_tiny_headless_params(temporary.path / "dataset-out", 1);
+        params.optimization.enable_eval = false;
+        params.optimization.save_steps.clear();
+
+        // Embed real fixture files, including both stored image and compressed
+        // sparse payloads. Assertions do not depend on optimizer numerics.
+        const auto image = first_dataset_image(params.dataset);
+        ASSERT_TRUE(image);
+        const auto sparse = params.dataset.data_path / "sparse" / "0" / "cameras.bin";
+        EmbeddedDatasetManifest manifest{
+            .schema_version = 1,
+            .images_folder = TEST_IMAGES,
+            .complete = true,
+            .entries = {}};
+        std::vector<DatasetEmbedSource> sources;
+        for (const auto& file : {*image, sparse}) {
+            const auto bytes = read_file_bytes(file);
+            EmbeddedDatasetEntry entry{
+                .rel_path = std::filesystem::relative(file, params.dataset.data_path).generic_string(),
+                .kind = file == sparse ? "sparse" : "image",
+                .chunk_uuid = fixed_uuid(2600 + sources.size()),
+                .bytes = bytes.size(),
+                .xxh3_128 = xxh3_128(bytes)};
+            manifest.entries.push_back(entry);
+            sources.push_back({.entry = entry, .source_path = file});
+        }
+        auto source = require_result_ptr(ProjectDocument::create(fixed_uuid(2602), 100));
+        const auto reference = require_result(upsert_path_reference(
+            source->edit_references(), temporary.path, params.dataset.data_path, "dataset", "dataset"));
+        require_status(source->edit_project().set_dataset_reference(reference));
+        auto source_path = temporary.path / "source.licht";
+        (void)require_result(source->save(source_path, deterministic_document_save_options(2032, 2603, 200)));
+        (void)require_result(source->embed_dataset_batch(manifest, sources, deterministic_document_save_options(2032, 2604, 300)));
+        source.reset();
+
+        for (const bool resume : {false, true}) {
+            SCOPED_TRACE(resume ? "--resume source.licht -o fresh" : "-d source.licht -o fresh");
+            const auto output_path = temporary.path / (resume ? "resume-out" : "dataset-out");
+            const auto destination = output_path / "project.licht";
+            params.dataset.output_path = output_path;
+            ASSERT_FALSE(std::filesystem::exists(destination));
+            const int target_iteration = resume ? 2 : 1;
+            params.optimization.iterations = target_iteration;
+            const auto source_hash = require_result(hash_dataset_file(source_path));
+            lfs::core::Scene scene;
+            std::unique_ptr<lfs::training::Trainer> trainer;
+            if (resume) {
+                source = require_result_ptr(ProjectDocument::open(source_path));
+                const auto hydration = require_result(source->hydrate(scene));
+                ASSERT_TRUE(hydration.checkpoint_uuid);
+                auto installed = lfs::training::installTrainerFromProjectCheckpoint(
+                    scene, *source, *hydration.checkpoint_uuid, params,
+                    lfs::core::path_to_utf8(source_path), 1);
+                ASSERT_TRUE(installed) << installed.error();
+                trainer = std::move(installed->trainer);
+            } else {
+                ASSERT_TRUE(lfs::training::loadTrainingDataIntoScene(params, scene));
+                ASSERT_TRUE(lfs::training::initializeTrainingModel(params, scene));
+                trainer = std::make_unique<lfs::training::Trainer>(scene);
+                ASSERT_TRUE(trainer->initialize(params));
+            }
+            lfs::training::grant_headless_project_saves(*trainer, params, destination, source_path);
+            // Publish explicitly below so verification waits for the writer,
+            // and the first save exercises transfer into a fresh destination.
+            auto save_policy = trainer->trainer_project_save_policy();
+            save_policy.on_completion = false;
+            trainer->set_trainer_project_save_policy(save_policy);
+            auto trained = trainer->train();
+            ASSERT_TRUE(trained) << lfs::format_for_developer(trained.error());
+            ASSERT_FALSE(std::filesystem::exists(destination));
+            auto saved = trainer->save_project_to(destination, target_iteration);
+            ASSERT_TRUE(saved) << saved.error();
+            const auto verify = [&] {
+                auto output = require_result_ptr(ProjectDocument::open(destination));
+                EXPECT_EQ(require_result(output->parameters().embedded_dataset()), manifest);
+                const auto dataset_ref = require_result(output->project().dataset_reference());
+                ASSERT_TRUE(dataset_ref);
+                EXPECT_EQ(resolve_path_reference(
+                              output->references(), destination.parent_path(), *dataset_ref),
+                          std::filesystem::absolute(params.dataset.data_path));
+                auto reader = require_result(ProjectReader::open(destination));
+                for (const auto& entry : manifest.entries) {
+                    const auto* row = reader.find(FOURCC_DSRC, entry.chunk_uuid);
+                    ASSERT_NE(row, nullptr);
+                    EXPECT_TRUE(row->is_live());
+                    EXPECT_EQ(require_result(reader.read_chunk(*row)),
+                              read_file_bytes(params.dataset.data_path / entry.rel_path));
+                }
+                const auto checkpoint = require_result(output->bound_checkpoint_uuid());
+                ASSERT_TRUE(checkpoint);
+                EXPECT_EQ(*checkpoint, reader.commit().snapshot_uuid);
+                lfs::core::Scene restored;
+                const auto hydration = require_result(output->hydrate(restored));
+                ASSERT_TRUE(hydration.checkpoint_header);
+                EXPECT_EQ(hydration.checkpoint_header->iteration, target_iteration);
+                EXPECT_EQ(restored.getTrainingModel()->size(), scene.getTrainingModel()->size());
+                EXPECT_NE(output->project_uuid(), fixed_uuid(2602));
+            };
+            ASSERT_NO_FATAL_FAILURE(verify());
+            EXPECT_EQ(require_result(hash_dataset_file(source_path)), source_hash);
+            source.reset();
+            // The second publish must work with the source unavailable and
+            // retain the destination's DSRC spans and container identity.
+            const auto before = require_result(ProjectReader::open(destination));
+            std::filesystem::rename(source_path, source_path.string() + ".hidden");
+            saved = trainer->save_project_to(destination, target_iteration);
+            ASSERT_TRUE(saved) << saved.error();
+            ASSERT_NO_FATAL_FAILURE(verify());
+            const auto after = require_result(ProjectReader::open(destination));
+            EXPECT_EQ(before.superblock().project_uuid, after.superblock().project_uuid);
+            EXPECT_GT(after.commit().generation, before.commit().generation);
+            for (const auto& entry : manifest.entries) {
+                EXPECT_EQ(before.find(FOURCC_DSRC, entry.chunk_uuid)->payload_offset,
+                          after.find(FOURCC_DSRC, entry.chunk_uuid)->payload_offset);
+            }
+            const auto failed_destination = output_path / "missing-source.licht";
+            lfs::training::grant_headless_project_saves(*trainer, params, failed_destination, source_path);
+            EXPECT_FALSE(trainer->save_project_to(failed_destination, target_iteration));
+            EXPECT_FALSE(std::filesystem::exists(failed_destination));
+            // A dataset override supplies no source descriptor. Regranting
+            // must clear the old binding rather than carry foreign DSRC rows.
+            const auto overridden_destination = output_path / "override.licht";
+            lfs::training::grant_headless_project_saves(*trainer, params, overridden_destination);
+            ASSERT_TRUE(trainer->save_project_to(overridden_destination, target_iteration));
+            auto overridden = require_result_ptr(ProjectDocument::open(overridden_destination));
+            EXPECT_FALSE(require_result(overridden->parameters().embedded_dataset()));
+            EXPECT_TRUE(overridden->dataset_source_uuids().empty());
+            trainer->shutdown();
+            source_path = destination;
+        }
     }
 
     TEST_F(ProjectCheckpointTrainerInstall,

--- a/tests/test_project_document.cpp
+++ b/tests/test_project_document.cpp
@@ -6234,6 +6234,36 @@ namespace {
         // Reopen from disk so the DSRC chunks are read as lazy file-backed
         // sources, the way headless training sees them.
         auto reopened = require_result_ptr(ProjectDocument::open(project_path));
+        const auto source_bytes = read_file_bytes(project_path);
+        const auto destination = temporary.path / "redirected" / "project.licht";
+        fs::create_directories(destination.parent_path());
+        auto redirected_options = save_options(2507, 500);
+        redirected_options.save_as_project_uuid = fixed_uuid(2508);
+        (void)require_result(reopened->save_as(destination, redirected_options));
+        EXPECT_EQ(read_file_bytes(project_path), source_bytes);
+        EXPECT_EQ(require_result(reopened->parameters().embedded_dataset()), manifest);
+        const auto dataset_ref = require_result(reopened->project().dataset_reference());
+        ASSERT_TRUE(dataset_ref);
+        EXPECT_EQ(resolve_path_reference(
+                      reopened->references(), destination.parent_path(), *dataset_ref),
+                  dataset);
+        document.reset();
+        fs::remove(project_path);
+        fs::remove_all(dataset);
+        // A second save must reuse the destination after the source and its
+        // external dataset have disappeared. The cache has never been created.
+        (void)require_result(reopened->save(destination, save_options(2509, 600)));
+        reopened = require_result_ptr(ProjectDocument::open(destination));
+        EXPECT_EQ(reopened->project_uuid(), fixed_uuid(2508));
+        EXPECT_EQ(require_result(reopened->parameters().embedded_dataset()), manifest);
+        auto redirected_reader = require_result(ProjectReader::open(destination));
+        for (const auto& entry : manifest.entries) {
+            const auto* row = redirected_reader.find(FOURCC_DSRC, entry.chunk_uuid);
+            ASSERT_NE(row, nullptr);
+            EXPECT_TRUE(row->is_live());
+            EXPECT_EQ(require_result(redirected_reader.read_chunk(*row)),
+                      entry.kind == "image" ? image_bytes : sparse_bytes);
+        }
         const auto extracted = require_result(
             lfs::io::project::extract_embedded_dataset(*reopened, cache));
         ASSERT_TRUE(extracted);
@@ -6252,6 +6282,36 @@ namespace {
         (void)require_result(
             lfs::io::project::extract_embedded_dataset(*reopened, cache));
         EXPECT_EQ(read_file_bytes(cache / "images_2" / "frame.bin"), image_bytes);
+
+        struct ScopedLfsHome {
+            std::optional<std::string> previous;
+            explicit ScopedLfsHome(const fs::path& root) {
+                if (const auto* value = std::getenv("LFS_HOME"))
+                    previous = value;
+#ifdef _WIN32
+                (void)_putenv_s("LFS_HOME", root.string().c_str());
+#else
+                (void)setenv("LFS_HOME", root.string().c_str(), 1);
+#endif
+            }
+            ~ScopedLfsHome() {
+#ifdef _WIN32
+                (void)_putenv_s("LFS_HOME", previous ? previous->c_str() : "");
+#else
+                if (previous)
+                    (void)setenv("LFS_HOME", previous->c_str(), 1);
+                else
+                    (void)unsetenv("LFS_HOME");
+#endif
+            }
+        } home_guard(temporary.path / "user");
+        const auto fallback_cache = require_result(embedded_dataset_cache_dir(*reopened));
+        EXPECT_FALSE(fs::exists(fallback_cache));
+        const auto fallback = require_result(extract_embedded_dataset_if_needed(*reopened));
+        ASSERT_TRUE(fallback);
+        EXPECT_EQ(*fallback, fallback_cache);
+        EXPECT_EQ(read_file_bytes(*fallback / "images_2/frame.bin"), image_bytes);
+        EXPECT_EQ(read_file_bytes(*fallback / "sparse/0/cameras.bin"), sparse_bytes);
     }
 
 } // namespace


### PR DESCRIPTION
Fixes #2032.

**What went wrong**
Starting a headless run from a `.licht` that embeds its dataset and redirecting the result with `-o` wrote a fresh `project.licht` that carried only the trained model. The embedded images, their manifest and the dataset reference were dropped, so the new project could never find its images once the extraction cache or the external folder was gone. Both entry points were affected: `--headless -d source.licht -o out` and `--headless --resume source.licht -o out`. Without `-o` the run trains into the source project and nothing is lost.

**What changed**
Headless saves now remember the source project. When the destination is a fresh file, the writer opens the source and saves it as the new project, the same path a Save As during GUI training already takes, so the embedded payloads travel verbatim, the manifest is checked before publishing, and a dataset reference is bound relative to the new project. Later saves reuse the destination's own payloads. A `--resume` with a `-d` override to a different dataset does not carry the foreign embedded dataset, and a redirected recovery save no longer borrows the source master's lock. The source file is never modified.

**Proof**
- New trainer-level test `ProjectCheckpointTrainerInstall.HeadlessRedirectPreservesEmbeddedDatasetForDatasetAndResume` covers both entry points, a second save with the source removed, a loud failure when the source is unavailable, and the dataset-override case. Without the transfer the output has no manifest and the test fails; with it all six related tests pass.
- Headless: from a 43-file embedded fisheye project (`-d ... -o`) and a 33-file embedded trained project (`--resume ... -o`, +242 iterations) the outputs report complete embedded datasets, the source files keep their checksums, and opening each output in a fresh user profile with the external dataset folder removed extracts all files from the project and loads it at the expected iteration.

Not covered here: headless `--resume` still requires the checkpoint's dataset path to exist and does not fall back to the embedded copy on its own. That is a separate limitation of the resume path.