### PR TITLE
Viewport never keeps showing a stale splat image while the camera moves during training

### DIFF
--- a/src/visualizer/rendering/rendering_manager.cpp
+++ b/src/visualizer/rendering/rendering_manager.cpp
@@ -396,6 +396,7 @@ namespace lfs::vis {
     }
 
     void RenderingManager::releaseSceneRenderResources() {
+        vksplat_stale_frame_guard_.onSuccess();
         viewport_artifact_service_.clearViewportOutput();
         invalidateGTComparisonImageCache();
         clearVulkanViewportImageState();

--- a/src/visualizer/rendering/rendering_manager.hpp
+++ b/src/visualizer/rendering/rendering_manager.hpp
@@ -24,6 +24,7 @@
 #include "rendering_types.hpp"
 #include "spark_lod_controller.hpp"
 #include "split_view_service.hpp"
+#include "stale_frame_guard.hpp"
 #include "viewport_appearance_correction.hpp"
 #include "viewport_artifact_service.hpp"
 #include "viewport_frame_lifecycle_service.hpp"
@@ -789,6 +790,7 @@ namespace lfs::vis {
         std::shared_ptr<const lfs::core::Tensor> vulkan_viewport_image_;
         std::uint64_t vulkan_viewport_image_generation_ = 0;
         std::string last_logged_vksplat_render_error_;
+        StaleFrameGuard vksplat_stale_frame_guard_;
         std::uint64_t viewport_projection_generation_ = 1;
         std::unique_ptr<VksplatViewportRenderer> vksplat_viewport_renderer_;
         std::unique_ptr<PointCloudVulkanRenderer> point_cloud_vulkan_renderer_;

--- a/src/visualizer/rendering/rendering_manager_vulkan.cpp
+++ b/src/visualizer/rendering/rendering_manager_vulkan.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/camera.hpp"
+#include "core/cuda/memory_arena.hpp"
 #include "core/cuda/undistort/undistort.hpp"
 #include "core/image_loader.hpp"
 #include "core/logger.hpp"
@@ -1648,6 +1649,15 @@ namespace lfs::vis {
 
     RenderingManager::VulkanFrameResult RenderingManager::renderVulkanFrame(const RenderContext& context) {
         LOG_TIMER("renderVulkanFrame");
+        if (vksplat_stale_frame_guard_.takeRecoveryRequest() && vksplat_viewport_renderer_) {
+            // clear_external_backing waits for the arena to be idle. Do this
+            // before taking either trainer lock, after the failed frame's borrow
+            // publisher has run, so training can finish its active frame. Detach
+            // first, outside releaseScratchOnIdle's readback mutex: the arena's
+            // shrink callback takes that mutex while holding the arena gate.
+            lfs::core::GlobalArenaManager::instance().clear_external_backing();
+            vksplat_viewport_renderer_->releaseScratchOnIdle(true);
+        }
         const RenderSettings frame_settings = [this] {
             std::lock_guard lock(settings_mutex_);
             return settings_;
@@ -1708,6 +1718,9 @@ namespace lfs::vis {
 
         std::optional<lfs::core::CUDAStreamGuard> frame_stream_guard;
         const auto cached_frame_result = [this, current_size]() -> VulkanFrameResult {
+            if (!vksplat_stale_frame_guard_.canUseCachedFrame()) {
+                return {};
+            }
             if (vulkan_external_viewport_image_ != VK_NULL_HANDLE) {
                 return {.image = {},
                         .external_image = vulkan_external_viewport_image_,
@@ -1737,6 +1750,18 @@ namespace lfs::vis {
                     .flip_y = vulkan_viewport_image_flip_y_,
                     .matches_viewport_extent =
                         vulkan_viewport_coordinate_size_ == current_size};
+        };
+        const auto defer_shared_scratch = [this](const std::string& reason) {
+            if (vksplat_stale_frame_guard_.onDeferral()) {
+                LOG_WARN("VkSplat shared scratch deferred {} viewport attempts; dropping stale viewport and resetting scratch before the next attempt: {}",
+                         StaleFrameGuard::kMaxCachedDeferrals, reason);
+                // Reset alone still needs arena access on the next render.
+                // Hide the old publication until fresh output is available;
+                // the renderer retains its output allocations and GPU fences.
+                clearVulkanViewportImageState();
+                clearVulkanMeshFrame();
+                viewport_artifact_service_.clearViewportOutput();
+            }
         };
         const auto update_cached_split_position = [this, &frame_settings](const bool require_position_change) -> bool {
             if (!split_view_service_.isActive(frame_settings)) {
@@ -3391,6 +3416,7 @@ namespace lfs::vis {
             isRetryableSharedScratchUnavailable(render_error)) {
             dirty_mask_.fetch_or(frame_dirty != 0 ? frame_dirty : DirtyFlag::SPLATS,
                                  std::memory_order_relaxed);
+            defer_shared_scratch(render_error);
             render_lock.reset();
             LOG_DEBUG("Split-view shared scratch unavailable ({}); returning cached split image",
                       render_error);
@@ -3561,6 +3587,7 @@ namespace lfs::vis {
                 }
 
                 render_lock.reset();
+                vksplat_stale_frame_guard_.onSuccess();
                 clearVulkanViewportImageState(render_result->size, render_result->flip_y);
                 vulkan_external_viewport_image_ = render_result->image;
                 vulkan_external_viewport_image_view_ = render_result->image_view;
@@ -3854,6 +3881,7 @@ namespace lfs::vis {
                         vksplat_viewport_renderer_ = std::make_unique<VksplatViewportRenderer>();
                     }
                     const auto publish_vksplat_result = [&](const VksplatViewportRenderer::RenderResult& render_result) -> VulkanFrameResult {
+                        vksplat_stale_frame_guard_.onSuccess();
                         render_lock.reset();
                         note_lod_page_generation(render_result.lod_page_generation);
                         note_vksplat_render_progress(render_result);
@@ -4176,6 +4204,7 @@ namespace lfs::vis {
                                   "VkSplat shared scratch unavailable",
                                   render_result.error(),
                                   retry_dirty);
+                        defer_shared_scratch(render_result.error());
                         render_lock.reset();
                         return cached_frame_result();
                     }
@@ -4233,6 +4262,9 @@ namespace lfs::vis {
             pending_split_view.enabled;
 
         if (!rendered_image && has_gpu_only_pass) {
+            if (pending_split_view.enabled || render_error.empty()) {
+                vksplat_stale_frame_guard_.onSuccess();
+            }
             clearVulkanViewportImageState(render_size, false);
             vulkan_gt_comparison_content_size_ =
                 rendered_image_contains_ground_truth ? rendered_gt_content_size : glm::ivec2{0, 0};
@@ -4405,6 +4437,7 @@ namespace lfs::vis {
                               "VkSplat shared scratch unavailable",
                               render_error,
                               retry_dirty);
+                    defer_shared_scratch(render_error);
                     return cached_frame_result();
                 }
 
@@ -4451,6 +4484,7 @@ namespace lfs::vis {
         }
 
         auto viewport_image = std::move(rendered_image);
+        vksplat_stale_frame_guard_.onSuccess();
         vulkan_viewport_image_ = viewport_image;
         ++vulkan_viewport_image_generation_;
         if (vulkan_viewport_image_generation_ == 0)

--- a/src/visualizer/rendering/stale_frame_guard.hpp
+++ b/src/visualizer/rendering/stale_frame_guard.hpp
@@ -1,0 +1,50 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+
+namespace lfs::vis {
+
+    // An episode is the pending viewport refresh since the last publication.
+    // Camera/model changes coalesce into that request: changing attempt ids,
+    // error text or a continuously moving camera must not restart its budget.
+    class StaleFrameGuard {
+    public:
+        static constexpr std::uint32_t kMaxCachedDeferrals = 30;
+
+        // True exactly once, on the attempt that exhausts the cache budget.
+        [[nodiscard]] bool onDeferral() {
+            if (deferrals_ == kMaxCachedDeferrals) {
+                return false;
+            }
+            if (++deferrals_ == kMaxCachedDeferrals) {
+                recovery_pending_ = true;
+                return true;
+            }
+            return false;
+        }
+
+        [[nodiscard]] bool canUseCachedFrame() const {
+            return deferrals_ < kMaxCachedDeferrals;
+        }
+
+        // Consume before acquiring trainer locks: the existing scratch reset
+        // waits for an idle arena and must not run while holding those locks.
+        [[nodiscard]] bool takeRecoveryRequest() {
+            return std::exchange(recovery_pending_, false);
+        }
+
+        void onSuccess() {
+            deferrals_ = 0;
+            recovery_pending_ = false;
+        }
+
+    private:
+        std::uint32_t deferrals_ = 0;
+        bool recovery_pending_ = false;
+    };
+
+} // namespace lfs::vis

--- a/src/visualizer/rendering/vksplat_shared_scratch_install.hpp
+++ b/src/visualizer/rendering/vksplat_shared_scratch_install.hpp
@@ -1,0 +1,24 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#pragma once
+
+namespace lfs::vis {
+
+    // Called for a retained viewer block BEFORE capacity reuse or growth. B3
+    // can detach the arena backing without updating the renderer's cached flag.
+    // Keep the ownership decision independent of Vulkan import/allocation work.
+    template <typename IsInstalled, typename TryInstall>
+    [[nodiscard]] bool ensureRetainedSharedScratchInstalled(
+        bool& installed, IsInstalled&& is_installed, TryInstall&& try_install) {
+        installed = is_installed();
+        if (!installed) {
+            if (!try_install()) {
+                return false;
+            }
+            installed = true;
+        }
+        return true;
+    }
+
+} // namespace lfs::vis

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -26,6 +26,7 @@
 #include "rendering/vulkan_wait.hpp"
 #include "viewport/vksplat_compose.comp.spv.h"
 #include "vksplat_input_packer.hpp"
+#include "vksplat_shared_scratch_install.hpp"
 #include "vulkan_external_tensor.hpp"
 #include "window/vulkan_result.hpp"
 
@@ -3505,14 +3506,14 @@ namespace lfs::vis {
         // changing this renderer's cached installation flag. Reinstall the same
         // block before either the capacity fast path or growth uses it again.
         if (shared_scratch_.block) {
-            shared_scratch_.installed_in_training_arena =
-                lfs::core::GlobalArenaManager::instance().get_arena().using_external_backing(
-                    shared_scratch_.block->device_ptr);
-            if (!shared_scratch_.installed_in_training_arena) {
-                if (!try_install_existing()) {
-                    return std::unexpected("VkSplat shared scratch training rasterizer arena is busy");
-                }
-                shared_scratch_.installed_in_training_arena = true;
+            if (!ensureRetainedSharedScratchInstalled(
+                    shared_scratch_.installed_in_training_arena,
+                    [&] {
+                        return lfs::core::GlobalArenaManager::instance().get_arena().using_external_backing(
+                            shared_scratch_.block->device_ptr);
+                    },
+                    try_install_existing)) {
+                return std::unexpected("VkSplat shared scratch training rasterizer arena is busy");
             }
         }
 

--- a/tests/test_arena_metrics_contention.cpp
+++ b/tests/test_arena_metrics_contention.cpp
@@ -21,6 +21,7 @@
 
 #include "core/cuda/memory_arena.hpp"
 #include "core/logger.hpp"
+#include "visualizer/rendering/vksplat_shared_scratch_install.hpp"
 
 using lfs::core::RasterizerMemoryArena;
 
@@ -341,6 +342,110 @@ TEST_F(ArenaMetricsContentionTest, DetachedViewerBackingCanBeReinstalledAndGrown
 
     arena.clear_external_backing();
     EXPECT_FALSE(arena.using_external_backing(device_ptr));
+}
+
+class VkSplatSharedScratch : public ArenaMetricsContentionTest {};
+
+TEST_F(VkSplatSharedScratch, PauseDetachThenLargerScratchRequestReinstallsBeforeGrow) {
+    constexpr size_t MiB = 1024 * 1024;
+    void* device_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&device_ptr, 2 * MiB), cudaSuccess);
+    auto retained_block = std::shared_ptr<void>(device_ptr, [](void* ptr) {
+        EXPECT_EQ(cudaFree(ptr), cudaSuccess);
+    });
+    // A local real arena keeps this test isolated from the global trainer.
+    // B3's GlobalArenaManager::clear_external_backing forwards to this method.
+    RasterizerMemoryArena arena;
+    const RasterizerMemoryArena::ExternalBacking backing{
+        .device_ptr = device_ptr,
+        .size = MiB,
+        .device = 0,
+        .owner = retained_block,
+        .label = "test.vksplat.retained_scratch",
+    };
+    ASSERT_TRUE(arena.install_external_backing(backing));
+    bool renderer_installed = true;
+    size_t renderer_capacity = MiB;
+    arena.clear_external_backing();
+    ASSERT_FALSE(arena.using_external_backing(device_ptr));
+    ASSERT_TRUE(renderer_installed); // The viewer did not observe B3 detachment.
+
+    constexpr size_t requested_capacity = 2 * MiB;
+    ASSERT_GT(requested_capacity, renderer_capacity);
+    int reinstall_count = 0;
+    // This is the production renderer seam, called before its capacity/grow
+    // branches. No Vulkan device or import is needed for the ownership decision.
+    ASSERT_TRUE(lfs::vis::ensureRetainedSharedScratchInstalled(
+        renderer_installed,
+        [&] { return arena.using_external_backing(retained_block.get()); },
+        [&] {
+            ++reinstall_count;
+            return arena.try_install_external_backing(backing);
+        }));
+
+    bool committed = false;
+    using GrowFailure = RasterizerMemoryArena::ExternalGrowFailure;
+    GrowFailure failure = GrowFailure::None;
+    EXPECT_TRUE(arena.grow_external_backing(
+        retained_block.get(), requested_capacity,
+        [&](const size_t bytes) {
+            committed = true;
+            renderer_capacity = bytes;
+            return true;
+        },
+        0, &failure));
+    EXPECT_EQ(failure, GrowFailure::None); // Neither BackingMissing nor Busy.
+    EXPECT_TRUE(committed);
+    EXPECT_EQ(reinstall_count, 1);
+    EXPECT_TRUE(renderer_installed);
+    EXPECT_TRUE(arena.using_external_backing(retained_block.get()));
+    EXPECT_EQ(renderer_capacity, requested_capacity);
+    EXPECT_EQ(arena.get_statistics().capacity, requested_capacity);
+    EXPECT_EQ(cudaMemset(retained_block.get(), 0, requested_capacity), cudaSuccess);
+}
+
+TEST_F(VkSplatSharedScratch, DetachedBackingDefersWhileTrainingOwnsArenaThenRetries) {
+    constexpr size_t MiB = 1024 * 1024;
+    void* device_ptr = nullptr;
+    ASSERT_EQ(cudaMalloc(&device_ptr, MiB), cudaSuccess);
+    auto retained_block = std::shared_ptr<void>(device_ptr, [](void* ptr) {
+        EXPECT_EQ(cudaFree(ptr), cudaSuccess);
+    });
+    RasterizerMemoryArena arena;
+    const RasterizerMemoryArena::ExternalBacking backing{
+        .device_ptr = device_ptr,
+        .size = MiB,
+        .device = 0,
+        .owner = retained_block,
+        .label = "test.vksplat.busy_scratch",
+    };
+    ASSERT_TRUE(arena.install_external_backing(backing));
+    bool renderer_installed = true;
+    arena.clear_external_backing();
+    const auto held = arena.begin_frame(nullptr, false);
+    int reinstall_count = 0;
+    const auto ensure_installed = [&] {
+        return lfs::vis::ensureRetainedSharedScratchInstalled(
+            renderer_installed,
+            [&] { return arena.using_external_backing(device_ptr); },
+            [&] {
+                ++reinstall_count;
+                return arena.try_install_external_backing(backing);
+            });
+    };
+    const bool ready = ensure_installed();
+    arena.end_frame(held, nullptr, false);
+    EXPECT_FALSE(ready);
+    EXPECT_FALSE(renderer_installed);
+    EXPECT_EQ(reinstall_count, 1);
+    EXPECT_TRUE(ensure_installed());
+    EXPECT_TRUE(renderer_installed);
+    EXPECT_TRUE(arena.using_external_backing(device_ptr));
+    EXPECT_EQ(reinstall_count, 2);
+    // The capacity-sufficient path must revalidate too, but an attached backing
+    // needs no additional installation.
+    EXPECT_TRUE(ensure_installed());
+    EXPECT_EQ(reinstall_count, 2);
 }
 
 TEST_F(ArenaMetricsContentionTest, ViewerGrowTimeoutReleasesReservation) {

--- a/tests/test_rendering_refactor_services.cpp
+++ b/tests/test_rendering_refactor_services.cpp
@@ -21,6 +21,7 @@
 #include "visualizer/rendering/rendering_manager.hpp"
 #include "visualizer/rendering/split_view_composition.hpp"
 #include "visualizer/rendering/split_view_service.hpp"
+#include "visualizer/rendering/stale_frame_guard.hpp"
 #include "visualizer/rendering/viewport_artifact_service.hpp"
 #include "visualizer/rendering/viewport_frame_lifecycle_service.hpp"
 #include "visualizer/rendering/viewport_request_builder.hpp"
@@ -39,6 +40,48 @@
 #include <vector>
 
 namespace lfs::vis {
+
+    TEST(StaleFrameGuardTest, DeferralsBelowBoundKeepCachedThenEscalateOnce) {
+        StaleFrameGuard guard;
+        EXPECT_TRUE(guard.canUseCachedFrame());
+        EXPECT_FALSE(guard.takeRecoveryRequest());
+        for (std::uint32_t attempt = 1; attempt < StaleFrameGuard::kMaxCachedDeferrals; ++attempt) {
+            EXPECT_FALSE(guard.onDeferral()) << attempt;
+            EXPECT_TRUE(guard.canUseCachedFrame()) << attempt;
+            EXPECT_FALSE(guard.takeRecoveryRequest()) << attempt;
+        }
+        EXPECT_TRUE(guard.onDeferral());
+        EXPECT_FALSE(guard.canUseCachedFrame());
+        EXPECT_TRUE(guard.takeRecoveryRequest());
+        EXPECT_FALSE(guard.takeRecoveryRequest());
+        // Reimport/reset is not a successful publication. Failure after reset
+        // must not restore the stale image or trigger another reset/WARN.
+        for (int attempt = 0; attempt < 100; ++attempt) {
+            EXPECT_FALSE(guard.onDeferral());
+            EXPECT_FALSE(guard.canUseCachedFrame());
+            EXPECT_FALSE(guard.takeRecoveryRequest());
+        }
+    }
+
+    TEST(StaleFrameGuardTest, SuccessfulPublicationResetsTheWholeEpisode) {
+        StaleFrameGuard guard;
+        for (int episode = 0; episode < 2; ++episode) {
+            for (std::uint32_t attempt = 1; attempt < StaleFrameGuard::kMaxCachedDeferrals; ++attempt) {
+                EXPECT_FALSE(guard.onDeferral());
+            }
+            EXPECT_TRUE(guard.onDeferral());
+            guard.onSuccess();
+            EXPECT_TRUE(guard.canUseCachedFrame());
+            EXPECT_FALSE(guard.takeRecoveryRequest());
+        }
+        // Success also clears a partially consumed budget.
+        EXPECT_FALSE(guard.onDeferral());
+        guard.onSuccess();
+        for (std::uint32_t attempt = 1; attempt < StaleFrameGuard::kMaxCachedDeferrals; ++attempt) {
+            EXPECT_FALSE(guard.onDeferral());
+        }
+        EXPECT_TRUE(guard.onDeferral());
+    }
 
     namespace {
         std::unique_ptr<lfs::core::SplatData> makeTestSplat(const float x) {


### PR DESCRIPTION
Fixes #2029.

**What went wrong**
While training, orbiting the viewport moved the grid, the camera frustums and the orientation gizmo, but the splat image stayed frozen at the old view. Reproduced on the reporter's commit with this sequence: train, Pause, Resume, let the model grow, orbit. The log shows the viewer asking for shared training scratch, being told the arena is busy, and returning the previous viewport image on every single frame (2,863 times in about two minutes) because a retained viewer block had been detached from the arena at the pause boundary while the viewer still believed it was installed. #2041 fixed that ownership mistake, and master no longer freezes in this sequence. What remained is that nothing bounded how long a changed camera could be answered with an old image.

**What changed**
- A small deferral budget in the rendering manager: after 30 consecutive cached returns for the same pending refresh it warns once, stops presenting the old image, and resets the shared scratch import before the next attempt so the renderer re-imports instead of retrying the same state. Short contention (a few frames) behaves exactly as before, and any successful render resets the budget.
- The ownership check that #2041 introduced (reinstall a retained block before capacity reuse or growth when the arena no longer reports it as its backing) is factored into a small helper so it can be tested directly. No behaviour change.

**Proof**
- New tests: `VkSplatSharedScratch.PauseDetachThenLargerScratchRequestReinstallsBeforeGrow` and `VkSplatSharedScratch.DetachedBackingDefersWhileTrainingOwnsArenaThenRetries` (real arena, pause-style detach, larger request) and `StaleFrameGuardTest.*` for the budget policy. All arena contention tests still pass.
- GUI on this branch: the same pause / resume / growth (350k to 4.5M splats) orbit sequence re-renders the new camera every time (pixel difference between two views around 75, noise floor under 4), the guard never fires, no errors. Manual orbit drags with the mouse during training move the splat image immediately.
- GUI on the reporter's commit for comparison: identical splat pixels between the two views after growth while the overlays moved.