### PR TITLE
Normal loss: apply user masks to the normal terms and gate the prior-depth term

### DIFF
--- a/src/training/kernels/normal_consistency_loss.cu
+++ b/src/training/kernels/normal_consistency_loss.cu
@@ -486,7 +486,8 @@ namespace lfs::training::kernels {
 
             const double sum_alpha = sums[0];
             const double count = sums[1];
-            const bool valid = sum_alpha > 0.0;
+            const bool valid = count >= kNormalConsistencyMinValidCount &&
+                               sum_alpha >= kNormalConsistencyMinValidWeight;
 
             finals[slots::kValid] = valid ? 1.0f : 0.0f;
             finals[slots::kSumAlpha] = static_cast<float>(sum_alpha);

--- a/src/training/losses/mask_loss.cpp
+++ b/src/training/losses/mask_loss.cpp
@@ -53,7 +53,8 @@ namespace lfs::training::losses {
         MaskPreprocessWorkspace& ws,
         const lfs::core::Tensor& user_mask,
         const lfs::core::Tensor& roi_weight,
-        const bool segment_and_ignore) {
+        const bool segment_and_ignore,
+        const bool require_float) {
         if (!user_mask.is_valid() || user_mask.numel() == 0) {
             return roi_weight;
         }
@@ -81,7 +82,8 @@ namespace lfs::training::losses {
         }
 
         // No user remap + no ROI: return original (UInt8 ok for masked SSIM).
-        if (!segment_and_ignore && !roi_weight.is_valid()) {
+        if (!segment_and_ignore && !roi_weight.is_valid() &&
+            (!require_float || user_mask.dtype() == lfs::core::DataType::Float32)) {
             return user_mask;
         }
 

--- a/src/training/losses/mask_loss.hpp
+++ b/src/training/losses/mask_loss.hpp
@@ -34,12 +34,14 @@ namespace lfs::training::losses {
 
     /// Fuse SegmentAndIgnore photometric band remap (or BinaryGt0) + optional ROI
     /// into `ws.photometric_weight`. Returns a view of that buffer.
+    /// `require_float` also materializes binary byte masks for normal kernels.
     /// When `user_mask` is invalid, returns `roi_weight` (or empty) without writes.
     [[nodiscard]] lfs::core::Tensor fuse_photometric_mask_weight(
         MaskPreprocessWorkspace& ws,
         const lfs::core::Tensor& user_mask,
         const lfs::core::Tensor& roi_weight,
-        bool segment_and_ignore);
+        bool segment_and_ignore,
+        bool require_float = false);
 
     /// Fuse Segment / SegmentAndIgnore opacity-penalty band + pow + mean/grad.
     [[nodiscard]] MaskOpacityPenalty fuse_mask_opacity_penalty(

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -1861,13 +1861,18 @@ namespace lfs::training {
              mode == param::MaskMode::Ignore ||
              mode == param::MaskMode::SegmentAndIgnore);
 
+        const bool normal_terms_on =
+            (opt_params.use_normal_loss && opt_params.normal_loss_weight > 0.0f) ||
+            opt_params.normal_consistency_weight > 0.0f;
+
         // Fused mask preprocess: SegmentAndIgnore band remap + optional ROI → one kernel.
         // Steady state is allocation-free via mask_preprocess_workspace_ (grow-only).
         const Tensor photometric_weight = losses::fuse_photometric_mask_weight(
             mask_preprocess_workspace_,
             user_masks_photometric ? mask_2d : Tensor{},
             roi_weight,
-            mode == param::MaskMode::SegmentAndIgnore);
+            mode == param::MaskMode::SegmentAndIgnore,
+            user_masks_photometric && normal_terms_on);
 
         Tensor loss, grad_corrected, grad_raw, grad_alpha;
         const bool use_decoupled_appearance_loss =
@@ -1958,7 +1963,8 @@ namespace lfs::training {
             .loss = loss,
             .grad_corrected = grad_corrected,
             .grad_raw = grad_raw,
-            .grad_alpha = grad_alpha};
+            .grad_alpha = grad_alpha,
+            .normal_pixel_weight = user_masks_photometric && normal_terms_on ? photometric_weight : Tensor{}};
     }
 
     // Returns GPU tensor for loss - NO SYNC!
@@ -6853,6 +6859,8 @@ namespace lfs::training {
                         lfs::core::Tensor tile_grad_normal;
                         lfs::core::Tensor tile_error_map;
                         lfs::core::Tensor mask_tile;
+                        // Retain the photometric workspace view through all normal terms.
+                        lfs::core::Tensor normal_terms_weight;
                         bool depth_grad_buffers_active = false;
                         const auto roi_weight_ptr_on_stream =
                             [&](const cudaStream_t stream) -> const float* {
@@ -6861,6 +6869,15 @@ namespace lfs::training {
                             }
                             roi_weight.sync_to_stream(stream);
                             return roi_weight.ptr<float>();
+                        };
+
+                        const auto normal_weight_ptr_on_stream =
+                            [&](const cudaStream_t stream) -> const float* {
+                            if (!normal_terms_weight.is_valid()) {
+                                return roi_weight_ptr_on_stream(stream);
+                            }
+                            normal_terms_weight.sync_to_stream(stream);
+                            return normal_terms_weight.ptr<float>();
                         };
 
                         const auto ensure_depth_grad_buffers =
@@ -6951,6 +6968,7 @@ namespace lfs::training {
                                 tile_grad = result->grad_corrected;
                                 tile_grad_raw = result->grad_raw;
                                 tile_grad_alpha = result->grad_alpha;
+                                normal_terms_weight = result->normal_pixel_weight;
                             } else {
                                 auto result = compute_photometric_loss_with_gradient(
                                     corrected_image, gt_tile, params_.optimization, raw_loss_input);
@@ -7186,7 +7204,7 @@ namespace lfs::training {
                                     normal_loss_partials_.set_stream(normal_stream);
 
                                     const float* const normal_pixel_weight =
-                                        roi_weight_ptr_on_stream(normal_stream);
+                                        normal_weight_ptr_on_stream(normal_stream);
                                     lfs::core::pin_operands({&rendered_normal, &rendered_alpha, &target_normal});
                                     lfs::training::kernels::launch_normal_loss(
                                         rendered_normal.ptr<float>(),
@@ -7363,7 +7381,7 @@ namespace lfs::training {
                                 lfs::core::pin_operands(
                                     {&rendered_normal, &rendered_depth, &rendered_alpha, &tile_grad_normal});
                                 const float* const consistency_pixel_weight =
-                                    roi_weight_ptr_on_stream(consistency_stream);
+                                    normal_weight_ptr_on_stream(consistency_stream);
                                 lfs::training::kernels::launch_normal_consistency_loss(
                                     rendered_normal.ptr<float>(),
                                     rendered_depth.ptr<float>(),
@@ -8474,6 +8492,22 @@ namespace lfs::training {
             aux_pipeline_config.load_normals =
                 params_.optimization.use_normal_loss &&
                 params_.optimization.normal_loss_weight > 0.0f;
+            if (aux_pipeline_config.load_normals || params_.optimization.normal_consistency_weight > 0.0f) {
+                const auto mode = params_.optimization.mask_mode;
+                const bool user_masks_normal_terms =
+                    (mode == lfs::core::param::MaskMode::Segment ||
+                     mode == lfs::core::param::MaskMode::Ignore ||
+                     mode == lfs::core::param::MaskMode::SegmentAndIgnore) &&
+                    std::any_of(train_dataset_->get_cameras().begin(), train_dataset_->get_cameras().end(),
+                                [&](const auto& camera) {
+                                    return camera && (camera->has_mask() ||
+                                                      (params_.optimization.use_alpha_as_mask && camera->has_alpha()));
+                                });
+                LOG_INFO("Normal terms use user mask: {} (where available); prior-depth gate: count >= {}, weight >= {}",
+                         user_masks_normal_terms ? "yes" : "no",
+                         lfs::training::kernels::kNormalConsistencyMinValidCount,
+                         lfs::training::kernels::kNormalConsistencyMinValidWeight);
+            }
             if (aux_pipeline_config.load_normals) {
                 ensure_training_normal_maps(params_, train_dataset_->get_cameras());
                 if (val_dataset_) {

--- a/src/training/trainer.hpp
+++ b/src/training/trainer.hpp
@@ -564,6 +564,7 @@ namespace lfs::training {
             lfs::core::Tensor grad_corrected;
             lfs::core::Tensor grad_raw;
             lfs::core::Tensor grad_alpha;
+            lfs::core::Tensor normal_pixel_weight;
         };
 
         // Masked photometric loss with optional alpha gradient

--- a/tests/test_roi_weighted_losses.cpp
+++ b/tests/test_roi_weighted_losses.cpp
@@ -6,11 +6,14 @@
 #include "training/kernels/depth_loss.hpp"
 #include "training/kernels/normal_consistency_loss.hpp"
 #include "training/kernels/normal_loss.hpp"
+#include "training/losses/mask_loss.hpp"
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstdint>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -113,6 +116,7 @@ namespace {
         Tensor grad_normal;
         Tensor grad_depth;
         Tensor grad_alpha;
+        Tensor diagnostics;
     };
 
     ConsistencyResult run_consistency_loss(
@@ -202,6 +206,7 @@ namespace {
             0.3f,
             stream,
             pixel_weight.is_valid() ? pixel_weight.ptr<float>() : nullptr);
+        result.diagnostics = partials;
         return result;
     }
 
@@ -367,4 +372,141 @@ TEST_F(RoiWeightedLossTest, NormalConsistencyUsesWeightedCentersAndOnesMatchBase
         prior_all_ones.grad_depth, prior_baseline.grad_depth, 1.0e-6f);
     expect_tensors_near(
         prior_all_ones.grad_alpha, prior_baseline.grad_alpha, 1.0e-6f);
+}
+
+TEST_F(RoiWeightedLossTest, PriorDepthRequiresMinimumCountAndWeight) {
+    using namespace lfs::training::kernels;
+    namespace slots = normal_consistency_slots;
+    constexpr int height = 16;
+    constexpr int width = 16;
+    constexpr size_t pixels = height * width;
+    const auto depth = Tensor::full({size_t{height}, size_t{width}}, 2.0f, Device::CUDA);
+    const auto alpha = Tensor::ones({size_t{height}, size_t{width}}, Device::CUDA);
+
+    // Only prior validity limits the count; every selected centre has a valid
+    // four-neighbour depth stencil. Include both unweighted and weighted gates.
+    for (const int count : {1, 63, 64}) {
+        for (const float pixel_weight : {1.0f, 0.25f, 0.24f}) {
+            SCOPED_TRACE(::testing::Message() << "count=" << count << " weight=" << pixel_weight);
+            std::vector<float> prior_values(3 * pixels, 0.0f);
+            int remaining = count;
+            for (int y = 1; y < height - 1 && remaining > 0; ++y) {
+                for (int x = 1; x < width - 1 && remaining > 0; ++x, --remaining) {
+                    const size_t idx = static_cast<size_t>(y) * width + x;
+                    prior_values[idx] = 0.6f;
+                    prior_values[2 * pixels + idx] = -0.8f;
+                }
+            }
+            const auto prior = Tensor::from_vector(
+                prior_values, {size_t{3}, size_t{height}, size_t{width}}, Device::CUDA);
+            const auto weight = pixel_weight == 1.0f
+                                    ? Tensor{}
+                                    : Tensor::full({size_t{height}, size_t{width}}, pixel_weight, Device::CUDA);
+            const auto result = run_prior_depth_loss(prior, depth, alpha, weight);
+            const bool valid = count >= kNormalConsistencyMinValidCount &&
+                               count * pixel_weight >= kNormalConsistencyMinValidWeight;
+            const auto slot = [&](int index) {
+                return result.diagnostics.slice(0, index, index + 1).item<float>();
+            };
+            EXPECT_FLOAT_EQ(slot(slots::kCount), static_cast<float>(count));
+            EXPECT_FLOAT_EQ(slot(slots::kSumAlpha), count * pixel_weight);
+            EXPECT_FLOAT_EQ(slot(slots::kValid), valid ? 1.0f : 0.0f);
+            if (valid) {
+                EXPECT_GT(slot(slots::kInvNorm), 0.0f);
+                EXPECT_GT(result.loss.item<float>(), 0.0f);
+                EXPECT_GT(result.grad_depth.abs().max().item<float>(), 0.0f);
+                EXPECT_GT(result.grad_alpha.abs().max().item<float>(), 0.0f);
+            } else {
+                EXPECT_EQ(slot(slots::kInvNorm), 0.0f);
+                EXPECT_EQ(result.loss.item<float>(), 0.0f);
+                EXPECT_EQ(result.grad_depth.abs().max().item<float>(), 0.0f);
+                EXPECT_EQ(result.grad_alpha.abs().max().item<float>(), 0.0f);
+            }
+        }
+    }
+}
+
+TEST_F(RoiWeightedLossTest, ComposedUserMaskSuppressesAllNormalLossCenters) {
+    constexpr int height = 16;
+    constexpr int width = 16;
+    constexpr size_t pixels = height * width;
+    std::vector<float> rendered_values(3 * pixels, 0.0f);
+    std::vector<float> prior_values(3 * pixels, 0.0f);
+    std::fill(rendered_values.begin(), rendered_values.begin() + pixels, 0.6f);
+    std::fill(rendered_values.begin() + 2 * pixels, rendered_values.end(), -0.8f);
+    std::fill(prior_values.begin(), prior_values.begin() + pixels, -0.6f);
+    std::fill(prior_values.begin() + 2 * pixels, prior_values.end(), -0.8f);
+    const auto rendered = Tensor::from_vector(
+        rendered_values, {size_t{3}, size_t{height}, size_t{width}}, Device::CUDA);
+    const auto prior = Tensor::from_vector(
+        prior_values, {size_t{3}, size_t{height}, size_t{width}}, Device::CUDA);
+    const auto depth = Tensor::full({size_t{height}, size_t{width}}, 2.0f, Device::CUDA);
+    const auto alpha = Tensor::ones({size_t{height}, size_t{width}}, Device::CUDA);
+    // Independent oracle: invalidate normal loss centres instead of masking them.
+    const auto half_weight = make_half_weight(height, width);
+    const auto active_rendered = rendered * half_weight;
+    const auto active_prior = prior * half_weight;
+
+    for (const bool segment_and_ignore : {false, true}) {
+        for (const bool with_roi : {false, true}) {
+            SCOPED_TRACE(::testing::Message() << "segment_and_ignore=" << segment_and_ignore
+                                              << " roi=" << with_roi);
+            std::vector<uint8_t> mask_values(pixels, 255);
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width / 2; ++x) {
+                    // Segment/Ignore use binary inclusion; SegmentAndIgnore's
+                    // nonzero ignore band must become exactly zero.
+                    mask_values[static_cast<size_t>(y) * width + x] = segment_and_ignore ? 127 : 0;
+                }
+            }
+            const auto mask = Tensor::from_blob(
+                                  mask_values.data(), {size_t{height}, size_t{width}},
+                                  Device::CPU, lfs::core::DataType::UInt8)
+                                  .to(Device::CUDA);
+            ASSERT_EQ(mask.dtype(), lfs::core::DataType::UInt8);
+            ASSERT_EQ(mask.device(), Device::CUDA);
+            const auto roi = with_roi
+                                 ? Tensor::full({size_t{height}, size_t{width}}, 0.5f, Device::CUDA)
+                                 : Tensor{};
+            lfs::training::losses::MaskPreprocessWorkspace workspace;
+            const auto weight = lfs::training::losses::fuse_photometric_mask_weight(
+                workspace, mask, roi, segment_and_ignore, true);
+            ASSERT_EQ(weight.dtype(), lfs::core::DataType::Float32);
+            expect_tensors_near(weight, half_weight * (with_roi ? 0.5f : 1.0f), 0.0f);
+
+            const auto normal = run_normal_loss(rendered, alpha, prior, weight);
+            const auto normal_reference = run_normal_loss(rendered, alpha, active_prior, roi);
+            const float normal_loss = normal.loss.item<float>();
+            const float normal_grad_max = normal.grad_normal.abs().max().item<float>();
+            const float ignored_normal_grad_max =
+                normal.grad_normal.slice(2, 0, width / 2).abs().max().item<float>();
+            EXPECT_GT(normal_loss, 0.0f);
+            EXPECT_GT(normal_grad_max, 0.0f);
+            EXPECT_EQ(ignored_normal_grad_max, 0.0f);
+            expect_tensors_near(normal.loss, normal_reference.loss, 1.0e-6f);
+            expect_tensors_near(normal.grad_normal, normal_reference.grad_normal, 1.0e-6f);
+
+            const auto consistency = run_consistency_loss(rendered, depth, alpha, weight);
+            const auto consistency_reference = run_consistency_loss(active_rendered, depth, alpha, roi);
+            EXPECT_EQ(consistency.grad_normal.slice(2, 0, width / 2).abs().max().item<float>(), 0.0f);
+            expect_tensors_near(consistency.grad_normal, consistency_reference.grad_normal, 1.0e-6f);
+            const auto prior_depth = run_prior_depth_loss(prior, depth, alpha, weight);
+            const auto prior_depth_reference = run_prior_depth_loss(active_prior, depth, alpha, roi);
+            for (const auto& pair : {std::pair{consistency, consistency_reference},
+                                     std::pair{prior_depth, prior_depth_reference}}) {
+                const auto& actual = pair.first;
+                const auto& reference = pair.second;
+                EXPECT_GT(actual.loss.item<float>(), 0.0f);
+                EXPECT_GT(actual.grad_depth.abs().max().item<float>(), 0.0f);
+                EXPECT_GT(actual.grad_alpha.abs().max().item<float>(), 0.0f);
+                expect_tensors_near(actual.loss, reference.loss, 1.0e-6f);
+                expect_tensors_near(actual.grad_depth, reference.grad_depth, 1.0e-6f);
+                expect_tensors_near(actual.grad_alpha, reference.grad_alpha, 1.0e-6f);
+                // The stencil writes one pixel beyond an active centre. Only
+                // that boundary column can receive neighbouring contributions.
+                EXPECT_EQ(actual.grad_depth.slice(1, 0, width / 2 - 1).abs().max().item<float>(), 0.0f);
+                EXPECT_EQ(actual.grad_alpha.slice(1, 0, width / 2 - 1).abs().max().item<float>(), 0.0f);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Two robustness gaps in the normal supervision path, found while hunting the late-training fog reports.

- With a user mask active (segment, ignore, or segment_and_ignore), the photometric loss drops the masked pixels, but the prior-normal loss, the prior-depth term and the depth-normal consistency term only ever received the crop-box ROI weight. Masked regions kept getting full normal supervision with no photometric counterweight. All three terms now receive the same composed per-pixel weight the photometric loss uses. Behaviour without a user mask is unchanged.
- The prior-depth term validated with only `sum_alpha > 0`, so a single valid pixel kept it active at full weight while the direct prior term (64 pixels, weight 16) had already switched off. It now uses the same gate as the consistency term.

Training logs one line at start saying whether the normal terms use the user mask and what the prior-depth gate is.

Tests: a gate test at 1, 63 and 64 valid pixels, and a composed-mask test showing every normal term emits zero gradient on masked pixels and matches the unmasked reference elsewhere. Mask, normal and depth suites pass.
