### PR TITLE
MRNF: keep the far-field mask bound across reorders and carry it into FastGS

### DIFF
--- a/src/training/normal_auto_generate.cpp
+++ b/src/training/normal_auto_generate.cpp
@@ -162,6 +162,10 @@ namespace lfs::training {
 
     } // namespace
 
+    bool training_normal_priors_enabled(const lfs::core::param::OptimizationParameters& opt) {
+        return !opt.gut && opt.use_normal_loss && opt.normal_loss_weight > 0.0f;
+    }
+
     bool normal_auto_generate_needed(
         const bool use_normal_loss,
         const bool normal_auto_generate,
@@ -182,7 +186,7 @@ namespace lfs::training {
         const NormalEstimator& estimator) {
         NormalAutoGenerateOutcome outcome;
         const auto& opt = params.optimization;
-        if (!opt.use_normal_loss || opt.normal_loss_weight <= 0.0f)
+        if (!training_normal_priors_enabled(opt))
             return outcome;
 
         for (const auto& cam : cameras) {

--- a/src/training/normal_auto_generate.hpp
+++ b/src/training/normal_auto_generate.hpp
@@ -31,6 +31,10 @@ namespace lfs::training {
         std::span<const NormalAutoGenerateJob> jobs,
         const NormalGenerateProgress& progress)>;
 
+    // Prior loading and generation require a backend with a normal channel.
+    [[nodiscard]] bool training_normal_priors_enabled(
+        const lfs::core::param::OptimizationParameters& opt);
+
     [[nodiscard]] bool normal_auto_generate_needed(
         bool use_normal_loss,
         bool normal_auto_generate,

--- a/src/training/rasterization/fast_rasterizer.cpp
+++ b/src/training/rasterization/fast_rasterizer.cpp
@@ -12,6 +12,7 @@
 #include "lfs/training/sh_value_storage.hpp"
 #include "training/kernels/grad_alpha.hpp"
 #include "training/rasterization/fastgs/rasterization/include/forward.h"
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <ctime>
@@ -22,6 +23,73 @@
 #include <string>
 
 namespace lfs::training {
+
+    fast_lfs::rasterization::FusedAdamSettings make_fastgs_fused_adam_settings(
+        const FastGSFusedAdamState& optimizer_fused,
+        const FastGSFusedExtraGradients& fused_extra_gradients) {
+        fast_lfs::rasterization::FusedAdamSettings fused_adam;
+        auto convert_param = [](const FastGSFusedAdamParam& src) {
+            fast_lfs::rasterization::FusedAdamParam dst;
+            dst.param = src.param;
+            dst.joint_packed = src.joint_packed;
+            dst.joint_bounds = src.joint_bounds;
+            dst.joint_bits = src.joint_bits;
+            dst.sh_value_bounds = src.sh_value_bounds;
+            dst.sh_value_bits = src.sh_value_bits;
+            dst.sh_value_n_cells = src.sh_value_n_cells;
+            dst.n_primitives = src.n_primitives;
+            dst.frozen_mask = src.frozen_mask;
+            dst.frozen_mask_size = src.frozen_mask_size;
+            dst.frozen_lr_scale = src.frozen_lr_scale;
+            dst.crop_damping_mask = src.crop_damping_mask;
+            dst.crop_damping_mask_size = src.crop_damping_mask_size;
+            dst.cropbox_lr_scale = src.cropbox_lr_scale;
+            dst.n_elements = src.n_elements;
+            dst.n_attributes = src.n_attributes;
+            dst.step_size = src.step_size;
+            dst.bias_correction2_sqrt_rcp = src.bias_correction2_sqrt_rcp;
+            dst.enabled = src.enabled;
+            dst.screen_share_max = src.screen_share_max;
+            dst.screen_share_n = src.screen_share_n;
+            dst.screen_share_limit = src.screen_share_limit;
+            dst.screen_share_penalty = src.screen_share_penalty;
+            return dst;
+        };
+        fused_adam.enabled = optimizer_fused.enabled;
+        fused_adam.beta1 = optimizer_fused.beta1;
+        fused_adam.beta2 = optimizer_fused.beta2;
+        fused_adam.eps = optimizer_fused.eps;
+        fused_adam.scale_reg_weight = fused_extra_gradients.scale_reg_weight;
+        fused_adam.flatten_reg_weight = fused_extra_gradients.flatten_reg_weight;
+        fused_adam.opacity_reg_weight = fused_extra_gradients.opacity_reg_weight;
+        fused_adam.scale_reg_loss_out = fused_extra_gradients.scale_reg_loss_out;
+        fused_adam.opacity_reg_loss_out = fused_extra_gradients.opacity_reg_loss_out;
+        fused_adam.sparsity_opa_sigmoid = fused_extra_gradients.sparsity_opa_sigmoid;
+        fused_adam.sparsity_z = fused_extra_gradients.sparsity_z;
+        fused_adam.sparsity_u = fused_extra_gradients.sparsity_u;
+        fused_adam.sparsity_n = fused_extra_gradients.sparsity_n;
+        fused_adam.sparsity_rho = fused_extra_gradients.sparsity_rho;
+        fused_adam.sparsity_grad_loss = fused_extra_gradients.sparsity_grad_loss;
+        fused_adam.means = convert_param(optimizer_fused.means);
+        fused_adam.scaling = convert_param(optimizer_fused.scaling);
+        fused_adam.rotation = convert_param(optimizer_fused.rotation);
+        fused_adam.opacity = convert_param(optimizer_fused.opacity);
+        fused_adam.sh0 = convert_param(optimizer_fused.sh0);
+        fused_adam.shN = convert_param(optimizer_fused.shN);
+        fused_adam.per_splat_mean_step = optimizer_fused.per_splat_mean_step;
+        fused_adam.mean_step_median_extent = optimizer_fused.mean_step_median_extent;
+        fused_adam.mean_step_r_min = optimizer_fused.mean_step_r_min;
+        fused_adam.mean_step_r_max = optimizer_fused.mean_step_r_max;
+        // The kernel compares an unsigned row index with this count. Reject
+        // nonpositive counts and limit the mask to live mean rows.
+        if (optimizer_fused.mean_step_far_mask != nullptr &&
+            optimizer_fused.mean_step_far_mask_n > 0 && optimizer_fused.means.n_primitives > 0) {
+            fused_adam.mean_step_far_mask = optimizer_fused.mean_step_far_mask;
+            fused_adam.mean_step_far_mask_n = std::min(
+                optimizer_fused.mean_step_far_mask_n, optimizer_fused.means.n_primitives);
+        }
+        return fused_adam;
+    }
 
     namespace {
         struct FastRasterizerThreadLocalCaches {
@@ -729,56 +797,8 @@ namespace lfs::training {
         // loss path); do not allocate a separate pre-blend cache.
         auto raw_image = ctx.image;
 
-        fast_lfs::rasterization::FusedAdamSettings fused_adam;
-        const auto optimizer_fused = optimizer.prepare_fastgs_fused_adam(iteration, stream);
-        auto convert_param = [](const FastGSFusedAdamParam& src) {
-            fast_lfs::rasterization::FusedAdamParam dst;
-            dst.param = src.param;
-            dst.joint_packed = src.joint_packed;
-            dst.joint_bounds = src.joint_bounds;
-            dst.joint_bits = src.joint_bits;
-            dst.sh_value_bounds = src.sh_value_bounds;
-            dst.sh_value_bits = src.sh_value_bits;
-            dst.sh_value_n_cells = src.sh_value_n_cells;
-            dst.n_primitives = src.n_primitives;
-            dst.frozen_mask = src.frozen_mask;
-            dst.frozen_mask_size = src.frozen_mask_size;
-            dst.frozen_lr_scale = src.frozen_lr_scale;
-            dst.crop_damping_mask = src.crop_damping_mask;
-            dst.crop_damping_mask_size = src.crop_damping_mask_size;
-            dst.cropbox_lr_scale = src.cropbox_lr_scale;
-            dst.n_elements = src.n_elements;
-            dst.n_attributes = src.n_attributes;
-            dst.step_size = src.step_size;
-            dst.bias_correction2_sqrt_rcp = src.bias_correction2_sqrt_rcp;
-            dst.enabled = src.enabled;
-            dst.screen_share_max = src.screen_share_max;
-            dst.screen_share_n = src.screen_share_n;
-            dst.screen_share_limit = src.screen_share_limit;
-            dst.screen_share_penalty = src.screen_share_penalty;
-            return dst;
-        };
-        fused_adam.enabled = optimizer_fused.enabled;
-        fused_adam.beta1 = optimizer_fused.beta1;
-        fused_adam.beta2 = optimizer_fused.beta2;
-        fused_adam.eps = optimizer_fused.eps;
-        fused_adam.scale_reg_weight = fused_extra_gradients.scale_reg_weight;
-        fused_adam.flatten_reg_weight = fused_extra_gradients.flatten_reg_weight;
-        fused_adam.opacity_reg_weight = fused_extra_gradients.opacity_reg_weight;
-        fused_adam.scale_reg_loss_out = fused_extra_gradients.scale_reg_loss_out;
-        fused_adam.opacity_reg_loss_out = fused_extra_gradients.opacity_reg_loss_out;
-        fused_adam.sparsity_opa_sigmoid = fused_extra_gradients.sparsity_opa_sigmoid;
-        fused_adam.sparsity_z = fused_extra_gradients.sparsity_z;
-        fused_adam.sparsity_u = fused_extra_gradients.sparsity_u;
-        fused_adam.sparsity_n = fused_extra_gradients.sparsity_n;
-        fused_adam.sparsity_rho = fused_extra_gradients.sparsity_rho;
-        fused_adam.sparsity_grad_loss = fused_extra_gradients.sparsity_grad_loss;
-        fused_adam.means = convert_param(optimizer_fused.means);
-        fused_adam.scaling = convert_param(optimizer_fused.scaling);
-        fused_adam.rotation = convert_param(optimizer_fused.rotation);
-        fused_adam.opacity = convert_param(optimizer_fused.opacity);
-        fused_adam.sh0 = convert_param(optimizer_fused.sh0);
-        fused_adam.shN = convert_param(optimizer_fused.shN);
+        const auto fused_adam = make_fastgs_fused_adam_settings(
+            optimizer.prepare_fastgs_fused_adam(iteration, stream), fused_extra_gradients);
         if (!fused_adam.enabled) {
             throw std::runtime_error("FastGS fused Adam state is not available");
         }

--- a/src/training/rasterization/fast_rasterizer.hpp
+++ b/src/training/rasterization/fast_rasterizer.hpp
@@ -154,6 +154,10 @@ namespace lfs::training {
         float* edge_score_out = nullptr;
     };
 
+    [[nodiscard]] fast_lfs::rasterization::FusedAdamSettings make_fastgs_fused_adam_settings(
+        const FastGSFusedAdamState& optimizer_fused,
+        const FastGSFusedExtraGradients& fused_extra_gradients = {});
+
     // Explicit forward pass - returns render output and context for backward
     // Optional tile parameters for memory-efficient training (tile_width/height=0 means full image)
     // bg_image is optional - if provided, uses per-pixel background blending instead of solid color

--- a/src/training/strategies/mrnf.cpp
+++ b/src/training/strategies/mrnf.cpp
@@ -1247,6 +1247,7 @@ namespace lfs::training {
         if (_far_growth.outside_mask.is_valid()) {
             _far_growth.outside_mask = _far_field_mask;
         }
+        publish_mean_step_far_mask();
     }
 
     bool MRNF::is_refining(int iter) const {
@@ -1502,6 +1503,8 @@ namespace lfs::training {
 
     void MRNF::refresh_camera_hull() {
         _camera_hull_valid = false;
+        // Invalidate the borrowed pointer before any census allocation or early return.
+        publish_mean_step_far_mask();
         _cam_centroid[0] = 0.0f;
         _cam_centroid[1] = 0.0f;
         _cam_centroid[2] = 0.0f;

--- a/src/training/strategies/mrnf.hpp
+++ b/src/training/strategies/mrnf.hpp
@@ -19,6 +19,7 @@ namespace lfs::training::sh_value {
     class ShNMutationBatch;
 }
 
+class MRNFStrategyTest_PermutationRepublishesFarMask_Test;
 class MRNFStrategyTest_EdgeGuidanceFactorPrefersHigherPrecomputedEdgeScores_Test;
 class MRNFStrategyTest_GrowAndSplitResetsOptimizerStateForParents_Test;
 class MRNFStrategyTest_SHDegree0KeepsShNEmptyAndFusedAdamUsableAfterGrowth_Test;
@@ -114,6 +115,7 @@ namespace lfs::training {
         void on_edge_score_accumulated(int iter) override;
 
     private:
+        friend class ::MRNFStrategyTest_PermutationRepublishesFarMask_Test;
         friend class ::MRNFStrategyTest_EdgeWindowNormalizesViewsAndClosesBeforeRefineBackward_Test;
         friend class ::MRNFStrategyTest_EdgeGuidanceFactorPrefersHigherPrecomputedEdgeScores_Test;
         friend class ::MRNFStrategyTest_GrowAndSplitResetsOptimizerStateForParents_Test;

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -8360,6 +8360,9 @@ namespace lfs::training {
         }
         apply_pending_params_at_safe_point();
         LOG_INFO("Starting training loop");
+        if (params_.optimization.gut && params_.optimization.use_normal_loss) {
+            LOG_WARN("normal loss requested but the 3DGUT backend has no normal channel; normal terms are inactive");
+        }
         if (PerfBenchCollector::enabled()) {
             PerfBenchCollector::instance().on_training_start(get_total_iterations());
         }
@@ -8471,9 +8474,7 @@ namespace lfs::training {
                     fitDepthAnchors(cameras_with_depth);
                 }
             }
-            aux_pipeline_config.load_normals =
-                params_.optimization.use_normal_loss &&
-                params_.optimization.normal_loss_weight > 0.0f;
+            aux_pipeline_config.load_normals = training_normal_priors_enabled(params_.optimization);
             if (aux_pipeline_config.load_normals) {
                 ensure_training_normal_maps(params_, train_dataset_->get_cameras());
                 if (val_dataset_) {

--- a/src/training/training_setup.cpp
+++ b/src/training/training_setup.cpp
@@ -22,6 +22,7 @@
 #include "io/loader.hpp"
 #include "io/project_document.hpp"
 #include "lfs/training/sh_value_storage.hpp"
+#include "normal_auto_generate.hpp"
 #include "trainer.hpp"
 #include <algorithm>
 #include <cstdint>
@@ -733,9 +734,8 @@ namespace lfs::training {
             .load_masks = params.optimization.mask_mode != lfs::core::param::MaskMode::None,
             .load_depths = params.optimization.use_depth_loss &&
                            params.optimization.depth_loss_weight > 0.0f,
-            .load_normals = (params.optimization.use_normal_loss &&
-                             params.optimization.normal_loss_weight > 0.0f) ||
-                            params.optimization.enable_eval,
+            .load_normals = training_normal_priors_enabled(params.optimization) ||
+                            (!params.optimization.gut && params.optimization.enable_eval),
             .normal_auto_generate = params.optimization.normal_auto_generate,
             .centralize = parse_centralize(params.dataset.centralize_dataset),
             .progress = [&data_path](float percentage, const std::string& message) {
@@ -1091,8 +1091,7 @@ namespace lfs::training {
             .load_masks = params.optimization.mask_mode != lfs::core::param::MaskMode::None,
             .load_depths = params.optimization.use_depth_loss &&
                            params.optimization.depth_loss_weight > 0.0f,
-            .load_normals = params.optimization.use_normal_loss &&
-                            params.optimization.normal_loss_weight > 0.0f,
+            .load_normals = training_normal_priors_enabled(params.optimization),
             .normal_auto_generate = params.optimization.normal_auto_generate};
 
         auto result = data_loader->load(params.dataset.data_path, load_options);

--- a/tests/test_fastgs_kernels.cpp
+++ b/tests/test_fastgs_kernels.cpp
@@ -2031,3 +2031,49 @@ TEST(JointEncodeZero, SwizzledShN8BitMultiIndexSameBlock) {
         }
     }
 }
+
+TEST(FastGSFusedAdamSettingsTest, CarriesPerSplatMeanStepAndFarMask) {
+    const bool mask[] = {false, true, false, true};
+    FastGSFusedAdamState settings;
+    settings.enabled = true;
+    settings.means.n_primitives = 4;
+    settings.per_splat_mean_step = true;
+    settings.mean_step_median_extent = 0.25f;
+    settings.mean_step_r_min = 1.5f;
+    settings.mean_step_r_max = 42.0f;
+    settings.mean_step_far_mask = mask;
+    settings.mean_step_far_mask_n = 4;
+
+    const auto fused = make_fastgs_fused_adam_settings(settings);
+
+    EXPECT_TRUE(fused.enabled);
+    EXPECT_TRUE(fused.per_splat_mean_step);
+    EXPECT_EQ(fused.mean_step_far_mask, mask);
+    EXPECT_EQ(fused.mean_step_far_mask_n, 4);
+    EXPECT_FLOAT_EQ(fused.mean_step_median_extent, 0.25f);
+    EXPECT_FLOAT_EQ(fused.mean_step_r_min, 1.5f);
+    EXPECT_FLOAT_EQ(fused.mean_step_r_max, 42.0f);
+}
+
+TEST(FastGSFusedAdamSettingsTest, BoundsFarMaskCountToLiveRows) {
+    const bool mask[] = {false, true, false, true};
+    FastGSFusedAdamState settings;
+    settings.means.n_primitives = 4;
+    settings.per_splat_mean_step = true;
+    settings.mean_step_far_mask = mask;
+    for (const int count : {-1, 0, 2, 4, 8}) {
+        SCOPED_TRACE(count);
+        settings.mean_step_far_mask_n = count;
+        const auto fused = make_fastgs_fused_adam_settings(settings);
+        EXPECT_EQ(fused.mean_step_far_mask, count > 0 ? mask : nullptr);
+        EXPECT_EQ(fused.mean_step_far_mask_n, std::clamp(count, 0, 4));
+    }
+    settings.means.n_primitives = 0;
+    EXPECT_EQ(make_fastgs_fused_adam_settings(settings).mean_step_far_mask, nullptr);
+    EXPECT_EQ(make_fastgs_fused_adam_settings(settings).mean_step_far_mask_n, 0);
+    settings.means.n_primitives = 4;
+    settings.mean_step_far_mask = nullptr;
+    EXPECT_EQ(make_fastgs_fused_adam_settings(settings).mean_step_far_mask_n, 0);
+    settings.per_splat_mean_step = false;
+    EXPECT_FALSE(make_fastgs_fused_adam_settings(settings).per_splat_mean_step);
+}

--- a/tests/test_mrnf_strategy.cpp
+++ b/tests/test_mrnf_strategy.cpp
@@ -1942,3 +1942,53 @@ TEST(MRNFStrategyTest, BackgroundImprovementsOnKeepsProfileMechanisms) {
     EXPECT_FLOAT_EQ(strategy.effective_far_decay_scale(), kFarDecayScale);
     EXPECT_FLOAT_EQ(strategy.effective_mean_step_ratio_max(), kPerSplatMeanStepRatioMax);
 }
+
+TEST(MRNFStrategyTest, PermutationRepublishesFarMask) {
+    auto splat = create_mrnf_test_splat_data(4, 0);
+    auto params = vanilla_mrnf_params();
+    params.background_improvements = true;
+    params.max_cap = 8;
+    MRNF strategy(splat);
+    strategy.initialize(params);
+    strategy._camera_hull_valid = true;
+    strategy._far_field_mask = Tensor::from_vector(
+                                   std::vector<int>{0, 1, 0, 1}, TensorShape({4}), Device::CUDA)
+                                   .to(DataType::Bool);
+    strategy._far_growth.outside_mask = strategy._far_field_mask;
+    strategy.publish_mean_step_far_mask();
+    auto& optimizer = strategy.get_optimizer();
+    ASSERT_EQ(optimizer.mean_step_far_mask(), strategy._far_field_mask.ptr<bool>());
+    ASSERT_EQ(optimizer.mean_step_far_mask_n(), 4);
+    // Keep the old allocation alive so allocator reuse cannot hide a stale pointer.
+    const auto old_mask = strategy._far_field_mask;
+    const auto permutation = Tensor::from_vector(
+                                 std::vector<int>{1, 3, 0, 2}, TensorShape({4}), Device::CUDA)
+                                 .to(DataType::Int64);
+
+    strategy.permute_gaussian_rows(permutation);
+
+    EXPECT_NE(strategy._far_field_mask.ptr<bool>(), old_mask.ptr<bool>());
+    EXPECT_EQ(optimizer.mean_step_far_mask(), strategy._far_field_mask.ptr<bool>());
+    EXPECT_EQ(optimizer.mean_step_far_mask_n(), strategy._far_field_mask.numel());
+    EXPECT_EQ(strategy._far_growth.outside_mask.ptr<bool>(), strategy._far_field_mask.ptr<bool>());
+    const auto reordered = strategy._far_field_mask.cpu();
+    const bool* values = reordered.ptr<bool>();
+    EXPECT_TRUE(values[0]);
+    EXPECT_TRUE(values[1]);
+    EXPECT_FALSE(values[2]);
+    EXPECT_FALSE(values[3]);
+
+    // A hull refresh with no cameras must clear the borrowed pointer immediately.
+    strategy.refresh_camera_hull();
+    EXPECT_EQ(optimizer.mean_step_far_mask(), nullptr);
+    EXPECT_EQ(optimizer.mean_step_far_mask_n(), 0);
+
+    strategy._camera_hull_valid = true;
+    strategy.publish_mean_step_far_mask();
+    params.background_improvements = false;
+    strategy._params = std::make_unique<const param::OptimizationParameters>(params);
+    strategy.refresh_camera_hull();
+    EXPECT_FALSE(strategy._far_field_mask.is_valid());
+    EXPECT_EQ(optimizer.mean_step_far_mask(), nullptr);
+    EXPECT_EQ(optimizer.mean_step_far_mask_n(), 0);
+}

--- a/tests/test_normal_auto_generate.cpp
+++ b/tests/test_normal_auto_generate.cpp
@@ -351,3 +351,45 @@ TEST(NormalAutoGenerateIntegration, OverwritesExistingMapWhenCameraHasNone) {
 
     fs::remove_all(root);
 }
+
+TEST(NormalAutoGenerate, PriorLoadingRequiresNormalChannel) {
+    lfs::core::param::OptimizationParameters opt;
+    opt.use_normal_loss = true;
+    opt.normal_loss_weight = 0.05f;
+    opt.gut = false;
+    EXPECT_TRUE(lfs::training::training_normal_priors_enabled(opt));
+    opt.gut = true;
+    EXPECT_FALSE(lfs::training::training_normal_priors_enabled(opt));
+    EXPECT_TRUE(opt.use_normal_loss);
+    opt.gut = false;
+    opt.normal_loss_weight = 0.0f;
+    EXPECT_FALSE(lfs::training::training_normal_priors_enabled(opt));
+    opt.normal_loss_weight = 0.05f;
+    opt.use_normal_loss = false;
+    EXPECT_FALSE(lfs::training::training_normal_priors_enabled(opt));
+}
+
+TEST(NormalAutoGenerateIntegration, GutSkipsEstimatorAndKeepsConfig) {
+    lfs::core::param::TrainingParameters params;
+    params.optimization.gut = true;
+    params.optimization.use_normal_loss = true;
+    params.optimization.normal_auto_generate = true;
+    params.optimization.normal_loss_weight = 0.05f;
+    std::vector<std::shared_ptr<lfs::core::Camera>> cameras{
+        make_camera("missing.jpg", "missing.jpg")};
+    bool called = false;
+    const auto outcome = lfs::training::ensure_training_normal_maps(
+        params, cameras,
+        [&](std::span<const lfs::training::NormalAutoGenerateJob>,
+            const lfs::training::NormalGenerateProgress&) -> std::expected<void, lfs::Error> {
+            called = true;
+            return {};
+        });
+    EXPECT_FALSE(called);
+    EXPECT_FALSE(outcome.attempted);
+    EXPECT_FALSE(outcome.generated);
+    EXPECT_FALSE(outcome.failed);
+    EXPECT_FALSE(cameras.front()->has_normal());
+    EXPECT_TRUE(params.optimization.use_normal_loss);
+    EXPECT_FLOAT_EQ(params.optimization.normal_loss_weight, 0.05f);
+}


### PR DESCRIPTION
Three gaps found while reviewing the normal-loss and MRNF paths.

- With background improvements on, MRNF publishes a raw pointer to its far-field mask so the optimizer can scale mean steps per splat. `permute_gaussian_rows` replaced the mask storage on every Morton reorder without republishing, so the optimizer kept a pointer into the old row order until the next strategy step. It is now republished after every permutation and invalidated when the camera hull is rebuilt.
- The FastGS fused-Adam conversion never copied `per_splat_mean_step`, its ratios, or the far-field mask, so on the fastgs path that scaling was silently disabled. The conversion now lives in one helper that carries all of them, with the mask count bounded to live rows.
- With the 3DGUT backend the normal terms are never computed, yet normal priors were still loaded and auto-generated. Prior loading now keys off a shared gate that excludes 3DGUT, and training start logs a clear warning.

Tests: a permutation test asserting the optimizer's cached mask pointer and count match the permuted tensor, two conversion tests, and two prior-gate tests. MRNF, Morton, fastgs, Adam and optimizer suites pass.
