### PR TITLE
MRNF: rebuild the far-field mask after hard compaction and ignore stale bindings

### DIFF
--- a/src/training/optimizer/adam_optimizer.cpp
+++ b/src/training/optimizer/adam_optimizer.cpp
@@ -198,6 +198,18 @@ namespace lfs::training {
         mean_step_far_mask_n_ = mask != nullptr ? n : 0;
     }
 
+    void AdamOptimizer::validate_mean_step_far_mask() {
+        const auto& means = splat_data_.means();
+        const size_t n = means.is_valid() && means.ndim() > 0 ? means.shape()[0] : 0;
+        if (mean_step_far_mask_ != nullptr &&
+            (mean_step_far_mask_n_ < 0 || static_cast<size_t>(mean_step_far_mask_n_) != n)) {
+            LOG_WARN("AdamOptimizer: mean_step_far_mask row-count mismatch (mask={}, means={}); "
+                     "ignoring binding until the strategy republishes it",
+                     mean_step_far_mask_n_, n);
+            set_mean_step_far_mask(nullptr, 0);
+        }
+    }
+
     void AdamOptimizer::set_screen_share_cap(const float* max_share, const int n,
                                              const float limit, const float penalty) {
         screen_share_max_ = max_share;
@@ -221,6 +233,7 @@ namespace lfs::training {
 
     void AdamOptimizer::step(const int iteration) {
         LFS_TRACE("kernel.adam.step");
+        validate_mean_step_far_mask();
         refresh_screen_share_buffer();
         if (fused_step_iteration_ == iteration) {
             last_step_zeroed_gradients_ = true;
@@ -834,6 +847,7 @@ namespace lfs::training {
     FastGSFusedAdamState AdamOptimizer::prepare_fastgs_fused_adam(
         const int iteration,
         const cudaStream_t execution_stream) {
+        validate_mean_step_far_mask();
         if (crop_damping_mask_.is_valid()) {
             crop_damping_mask_.sync_to_stream(execution_stream);
         }

--- a/src/training/optimizer/adam_optimizer.hpp
+++ b/src/training/optimizer/adam_optimizer.hpp
@@ -242,6 +242,7 @@ namespace lfs::training {
         void init_state(ParamType type, bool allocate_grad = false);
         void ensure_grad(ParamType type);
         void step_param(ParamType type, int iteration);
+        void validate_mean_step_far_mask();
         size_t compute_new_capacity(size_t current_capacity, size_t required_size) const;
 
         // Quantized-moment helpers. Moments are uint8 (m signed @ zero-point 128, v as

--- a/src/training/strategies/mrnf.cpp
+++ b/src/training/strategies/mrnf.cpp
@@ -2651,6 +2651,7 @@ namespace lfs::training {
 
         remap_frozen_ranges_after_compaction(*_splat_data, valid_indices, old_size);
         apply_frozen_ranges_to_optimizer(*_splat_data, *_optimizer);
+        ensure_mean_step_far_mask();
     }
 
     void MRNF::inject_noise(int /*iter*/) {
@@ -3650,6 +3651,7 @@ namespace lfs::training {
             _optimizer->set_param_lr(ParamType::Scaling, _scale_lr_current);
             sync_mean_learning_rate();
         }
+        ensure_mean_step_far_mask();
         publish_vram_attribution();
     }
 

--- a/tests/test_mrnf_strategy.cpp
+++ b/tests/test_mrnf_strategy.cpp
@@ -29,6 +29,7 @@ class MRNFStrategyTest_EdgeWindowNormalizesViewsAndClosesBeforeRefineBackward_Te
 
 #include "core/camera.hpp"
 #include "core/cuda/sh_layout.cuh"
+#include "core/logger.hpp"
 #include "core/parameters.hpp"
 #include "core/sh_value_quant.hpp"
 #include "core/splat_data.hpp"
@@ -1991,4 +1992,178 @@ TEST(MRNFStrategyTest, PermutationRepublishesFarMask) {
     EXPECT_FALSE(strategy._far_field_mask.is_valid());
     EXPECT_EQ(optimizer.mean_step_far_mask(), nullptr);
     EXPECT_EQ(optimizer.mean_step_far_mask_n(), 0);
+}
+
+TEST(MRNFStrategyTest, HardRemovalRepublishesFarMaskForDegenerateModel) {
+    auto splat = create_mrnf_test_splat_data(4, 0);
+    auto params = vanilla_mrnf_params();
+    params.background_improvements = true;
+    params.far_scene_min_fraction = 0.0f;
+    params.max_cap = 8;
+    MRNF strategy(splat);
+    strategy.initialize(params);
+    install_test_camera_hull(strategy);
+    auto& optimizer = strategy.get_optimizer();
+    ASSERT_TRUE(optimizer.per_splat_mean_step());
+    ASSERT_NE(optimizer.mean_step_far_mask(), nullptr);
+    ASSERT_EQ(optimizer.mean_step_far_mask_n(), 4);
+
+    // Keep the far row, whose label differs from the old first row.
+    const auto remove = Tensor::from_vector(
+                            std::vector<int>{1, 1, 1, 0}, TensorShape({4}), Device::CUDA)
+                            .to(DataType::Bool);
+    strategy.remove_gaussians(remove);
+    ASSERT_EQ(splat.size(), 1);
+    ASSERT_NE(optimizer.mean_step_far_mask(), nullptr);
+    ASSERT_EQ(optimizer.mean_step_far_mask_n(), splat.means().shape()[0]);
+    bool far = false;
+    ASSERT_EQ(cudaMemcpy(&far, optimizer.mean_step_far_mask(), sizeof(far),
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_TRUE(far);
+
+    optimizer.get_grad(ParamType::Means).fill_(0.2f);
+    EXPECT_NO_THROW(optimizer.step(1));
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    EXPECT_EQ(optimizer.mean_step_far_mask_n(), splat.means().shape()[0]);
+    EXPECT_LT(splat.means().cpu().ptr<float>()[0], 3.0f);
+    const auto fused = optimizer.prepare_fastgs_fused_adam(2, nullptr);
+    EXPECT_EQ(fused.mean_step_far_mask, optimizer.mean_step_far_mask());
+    EXPECT_EQ(fused.mean_step_far_mask_n, 1);
+}
+
+TEST(MRNFStrategyTest, DeserializeRepublishesFarMaskWithDegenerateBounds) {
+    auto params = vanilla_mrnf_params();
+    params.background_improvements = true;
+    params.far_scene_min_fraction = 0.0f;
+    params.max_cap = 8;
+    auto source_splat = create_mrnf_test_splat_data(1, 0);
+    source_splat.means().fill_(3.0f);
+    MRNF source(source_splat);
+    source.initialize(params);
+    install_test_camera_hull(source);
+    std::stringstream checkpoint;
+    source_splat.serialize(checkpoint);
+    source.serialize(checkpoint);
+    checkpoint.seekg(0);
+
+    auto splat = create_mrnf_test_splat_data(1, 0);
+    MRNF restored(splat);
+    restored.initialize(params);
+    install_test_camera_hull(restored);
+    auto& optimizer = restored.get_optimizer();
+    ASSERT_NE(optimizer.mean_step_far_mask(), nullptr);
+    bool far = true;
+    ASSERT_EQ(cudaMemcpy(&far, optimizer.mean_step_far_mask(), sizeof(far),
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    ASSERT_FALSE(far);
+
+    splat.deserialize(checkpoint);
+    restored.deserialize(checkpoint);
+    ASSERT_NE(optimizer.mean_step_far_mask(), nullptr);
+    ASSERT_EQ(optimizer.mean_step_far_mask_n(), splat.means().shape()[0]);
+    ASSERT_EQ(cudaMemcpy(&far, optimizer.mean_step_far_mask(), sizeof(far),
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_TRUE(far);
+    optimizer.get_grad(ParamType::Means).fill_(0.2f);
+    EXPECT_NO_THROW(optimizer.step(1));
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+}
+
+namespace {
+    class FarMaskWarningCapture {
+    public:
+        FarMaskWarningCapture() : previous_level_(Logger::get().level()) {
+            Logger::get().set_level(LogLevel::Warn);
+            token_ = Logger::get().add_log_handler(
+                [this](LogLevel level, const SourceSite&, std::string_view message) {
+                    if (level == LogLevel::Warn &&
+                        message.find("mean_step_far_mask row-count mismatch") != std::string_view::npos) {
+                        messages.emplace_back(message);
+                    }
+                });
+        }
+        ~FarMaskWarningCapture() {
+            Logger::get().remove_log_handler(token_);
+            Logger::get().set_level(previous_level_);
+        }
+        std::vector<std::string> messages;
+
+    private:
+        LogLevel previous_level_;
+        LogHandlerToken token_;
+    };
+} // namespace
+
+TEST(MRNFStrategyTest, MeanStepFarMaskMismatchIsIgnoredByExplicitAdam) {
+    for (const int mask_n : {1, 4}) {
+        SCOPED_TRACE(mask_n);
+        auto splat = create_mrnf_test_splat_data(2, 0);
+        auto control_splat = create_mrnf_test_splat_data(2, 0);
+        auto params = vanilla_mrnf_params();
+        params.max_cap = 8;
+        MRNF strategy(splat);
+        MRNF control(control_splat);
+        strategy.initialize(params);
+        control.initialize(params);
+        auto& optimizer = strategy.get_optimizer();
+        auto& control_optimizer = control.get_optimizer();
+        optimizer.set_per_splat_mean_step(true, 0.5f, 1.0f, 300.0f);
+        control_optimizer.set_per_splat_mean_step(true, 0.5f, 1.0f, 300.0f);
+        const auto mask = Tensor::ones({static_cast<size_t>(mask_n)}, Device::CUDA).to(DataType::Bool);
+        optimizer.set_mean_step_far_mask(mask.ptr<bool>(), mask_n);
+        optimizer.get_grad(ParamType::Means).fill_(0.2f);
+        control_optimizer.get_grad(ParamType::Means).fill_(0.2f);
+        FarMaskWarningCapture warnings;
+
+        EXPECT_NO_THROW(optimizer.step(1));
+        EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        EXPECT_EQ(optimizer.mean_step_far_mask(), nullptr);
+        EXPECT_EQ(optimizer.mean_step_far_mask_n(), 0);
+        control_optimizer.step(1);
+        EXPECT_EQ(means_xyz(splat), means_xyz(control_splat));
+        ASSERT_EQ(warnings.messages.size(), 1u);
+        EXPECT_NE(warnings.messages[0].find("mask=" + std::to_string(mask_n) + ", means=2"), std::string::npos);
+        optimizer.step(2);
+        EXPECT_EQ(warnings.messages.size(), 1u);
+    }
+}
+
+TEST(MRNFStrategyTest, MeanStepFarMaskMismatchIsIgnoredByFusedAdam) {
+    for (const int mask_n : {1, 4}) {
+        SCOPED_TRACE(mask_n);
+        auto splat = create_mrnf_test_splat_data(2, 0);
+        auto params = vanilla_mrnf_params();
+        params.max_cap = 8;
+        MRNF strategy(splat);
+        strategy.initialize(params);
+        auto& optimizer = strategy.get_optimizer();
+        optimizer.set_per_splat_mean_step(true, 0.5f, 1.0f, 300.0f);
+        const auto mask = Tensor::ones({static_cast<size_t>(mask_n)}, Device::CUDA).to(DataType::Bool);
+        optimizer.set_mean_step_far_mask(mask.ptr<bool>(), mask_n);
+        FarMaskWarningCapture warnings;
+
+        const auto fused = optimizer.prepare_fastgs_fused_adam(1, nullptr);
+        EXPECT_TRUE(fused.enabled);
+        EXPECT_TRUE(fused.means.enabled);
+        EXPECT_TRUE(fused.per_splat_mean_step);
+        EXPECT_EQ(fused.mean_step_far_mask, nullptr);
+        EXPECT_EQ(fused.mean_step_far_mask_n, 0);
+        EXPECT_EQ(optimizer.mean_step_far_mask(), nullptr);
+        EXPECT_EQ(optimizer.mean_step_far_mask_n(), 0);
+        ASSERT_EQ(warnings.messages.size(), 1u);
+        EXPECT_NE(warnings.messages[0].find("mask=" + std::to_string(mask_n) + ", means=2"), std::string::npos);
+        optimizer.prepare_fastgs_fused_adam(2, nullptr);
+        EXPECT_EQ(warnings.messages.size(), 1u);
+
+        const auto current_mask = Tensor::zeros_bool({2}, Device::CUDA);
+        optimizer.set_mean_step_far_mask(current_mask.ptr<bool>(), 2);
+        const auto republished = optimizer.prepare_fastgs_fused_adam(3, nullptr);
+        EXPECT_EQ(republished.mean_step_far_mask, current_mask.ptr<bool>());
+        EXPECT_EQ(republished.mean_step_far_mask_n, 2);
+        EXPECT_EQ(warnings.messages.size(), 1u);
+        EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    }
 }


### PR DESCRIPTION
Follow-up for #2069.

The reported build (7555a559) predates #2065, which fixed the stale far-field mask pointer after Morton reorders. Two gaps were left on master:

- Hard compaction and a direct checkpoint restore did not rebuild the far-field mask, so a degenerate model could keep an old, larger mask bound to the optimizer.
- The optimizer never checked that the bound mask has as many rows as the model.

This change rebuilds the mask after both paths and makes the optimizer ignore a mask with the wrong row count for that step, with one warning, instead of using stale row labels.

Tests: four new MRNF regressions fail on master and pass here; the MRNF/fused-Adam filter passes 47/47 on an RTX 4080. A 6000-iteration headless garden run with Background Improvement on (73 Morton reorders) completes with both binaries on Linux; the Windows report itself was not reproduced here.
