### PR TITLE
Priors: accept depth and normal maps of any resolution, log the normal-estimation device

### DIFF
--- a/src/core/camera.cpp
+++ b/src/core/camera.cpp
@@ -633,33 +633,9 @@ namespace lfs::core {
                 LFS_CUDA_TRY(cudaStreamSynchronize(_stream), _stream, "depth upload sync");
             }
             free_image_float(gray);
-
-            int target_w = native_w;
-            int target_h = native_h;
-            if (resize_factor > 1) {
-                target_w /= resize_factor;
-                target_h /= resize_factor;
-            }
-            if (max_width > 0 && (target_w > max_width || target_h > max_width)) {
-                if (target_w > target_h) {
-                    target_h = std::max(1, max_width * target_h / target_w);
-                    target_w = max_width;
-                } else {
-                    target_w = std::max(1, max_width * target_w / target_h);
-                    target_h = max_width;
-                }
-            }
-            if (target_w != native_w || target_h != native_h) {
-                depth = lanczos_resize_grayscale(depth, target_h, target_w, 2, _stream);
-                if (_stream) {
-                    LFS_CUDA_TRY(cudaStreamSynchronize(_stream), _stream, "depth resize sync");
-                }
-            }
         } else {
             const ImageLoadParams params{
                 .path = _depth_path,
-                .resize_factor = resize_factor,
-                .max_width = max_width,
                 .stream = _stream};
 
             depth = load_image_cached(params);
@@ -689,6 +665,10 @@ namespace lfs::core {
         } else if (depth.ndim() == 3 && depth.shape()[2] == 1) {
             depth = depth.squeeze(2);
         }
+
+        if (!_image_size_loaded)
+            load_image_size(resize_factor, max_width);
+        depth = resize_depth_prior(depth.contiguous(), _image_height, _image_width, _stream);
 
         if (_undistort_prepared) {
             const auto scaled = scale_undistort_params(
@@ -766,8 +746,7 @@ namespace lfs::core {
             }
         }
 
-        // Decode the v = n*0.5 + 0.5 file encoding; the loss re-normalizes per
-        // pixel, so quantization/resampling shrinkage is harmless here.
+        // Decode vectors before validity-aware resampling and normalization.
         normal = normal.mul(2.0f).sub(1.0f);
 
         if (decode.srgb || decode.flip_yz || decode.world_space) {
@@ -802,29 +781,9 @@ namespace lfs::core {
             }
         }
 
-        const int native_h = static_cast<int>(normal.shape()[1]);
-        const int native_w = static_cast<int>(normal.shape()[2]);
-        int target_w = native_w;
-        int target_h = native_h;
-        if (resize_factor > 1) {
-            target_w /= resize_factor;
-            target_h /= resize_factor;
-        }
-        if (max_width > 0 && (target_w > max_width || target_h > max_width)) {
-            if (target_w > target_h) {
-                target_h = std::max(1, max_width * target_h / target_w);
-                target_w = max_width;
-            } else {
-                target_w = std::max(1, max_width * target_w / target_h);
-                target_h = max_width;
-            }
-        }
-        if (target_w != native_w || target_h != native_h) {
-            normal = lanczos_resize_float_chw(normal, target_h, target_w, 2, _stream);
-            if (_stream) {
-                LFS_CUDA_TRY(cudaStreamSynchronize(_stream), _stream, "normal resize sync");
-            }
-        }
+        if (!_image_size_loaded)
+            load_image_size(resize_factor, max_width);
+        normal = resize_normal_prior(normal.contiguous(), _image_height, _image_width, _stream);
 
         if (_undistort_prepared) {
             const auto scaled = scale_undistort_params(
@@ -832,6 +791,7 @@ namespace lfs::core {
                 static_cast<int>(normal.shape()[2]),
                 static_cast<int>(normal.shape()[1]));
             normal = undistort_image(normal, scaled, _stream);
+            normal = resize_normal_prior(normal.contiguous(), normal.shape()[1], normal.shape()[2], _stream);
         }
 
         _cached_normal = normal.contiguous();

--- a/src/core/cuda/lanczos_resize/lanczos_resize.cu
+++ b/src/core/cuda/lanczos_resize/lanczos_resize.cu
@@ -25,6 +25,51 @@
 namespace cg = cooperative_groups;
 
 namespace {
+    template <int Channels>
+    __device__ bool prior_valid(const float* src, size_t i, size_t plane) {
+        if constexpr (Channels == 1) {
+            return isfinite(src[i]) && src[i] > 0.0f;
+        } else {
+            const float x = src[i], y = src[plane + i], z = src[2 * plane + i];
+            // Matches kNormalLossMinPriorNorm, including quantized neutral PNGs.
+            return isfinite(x) && isfinite(y) && isfinite(z) && x * x + y * y + z * z >= 0.25f;
+        }
+    }
+
+    template <int Channels>
+    __global__ void resize_prior_kernel(const float* src, float* dst, int sw, int sh, int dw, int dh) {
+        const int x = blockIdx.x * blockDim.x + threadIdx.x;
+        const int y = blockIdx.y * blockDim.y + threadIdx.y;
+        if (x >= dw || y >= dh)
+            return;
+        const size_t sp = static_cast<size_t>(sw) * sh, dp = static_cast<size_t>(dw) * dh;
+        const size_t out = static_cast<size_t>(y) * dw + x;
+        const float sx = fmaxf(0.0f, fminf(sw - 1.0f, (x + 0.5f) * sw / dw - 0.5f));
+        const float sy = fmaxf(0.0f, fminf(sh - 1.0f, (y + 0.5f) * sh / dh - 0.5f));
+        const int x0 = static_cast<int>(sx), y0 = static_cast<int>(sy);
+        const size_t nearest = static_cast<size_t>(static_cast<int>(sy + 0.5f)) * sw + static_cast<int>(sx + 0.5f);
+        float value[Channels] = {}, weight = 0.0f;
+        if (prior_valid<Channels>(src, nearest, sp)) {
+            for (int j = 0; j < 2; ++j) {
+                for (int i = 0; i < 2; ++i) {
+                    const size_t index = static_cast<size_t>(min(y0 + j, sh - 1)) * sw + min(x0 + i, sw - 1);
+                    if (!prior_valid<Channels>(src, index, sp))
+                        continue;
+                    const float w = (i ? sx - x0 : 1.0f - (sx - x0)) * (j ? sy - y0 : 1.0f - (sy - y0));
+                    weight += w;
+                    for (int c = 0; c < Channels; ++c)
+                        value[c] += w * src[c * sp + index];
+                }
+            }
+        }
+        if constexpr (Channels == 3) {
+            const float norm = sqrtf(value[0] * value[0] + value[1] * value[1] + value[2] * value[2]);
+            weight = norm > 1e-8f ? norm : 0.0f;
+        }
+        for (int c = 0; c < Channels; ++c)
+            dst[c * dp + out] = weight > 1e-8f ? value[c] / weight : 0.0f;
+    }
+
     struct CoefficientLayout {
         uint32_t stride;
         size_t count;
@@ -586,6 +631,37 @@ namespace lfs::core {
         LFS_CUDA_CHECK_MSG(cudaStreamSynchronize(cuda_stream), "Lanczos CHW resample completion");
 
         return output;
+    }
+
+    template <int Channels>
+    Tensor resize_prior(const Tensor& input, int output_h, int output_w, cudaStream_t stream) {
+        if (!input.is_valid() || input.device() != Device::CUDA || input.dtype() != DataType::Float32 ||
+            !input.is_contiguous() || output_h <= 0 || output_w <= 0 ||
+            input.ndim() != (Channels == 1 ? 2 : 3) || (Channels == 3 && input.size(0) != 3)) {
+            throw std::invalid_argument("Prior resize requires contiguous CUDA float depth [H,W] or normals [3,H,W]");
+        }
+        const int h = static_cast<int>(input.size(input.ndim() - 2));
+        const int w = static_cast<int>(input.size(input.ndim() - 1));
+        const auto shape = Channels == 1
+                               ? TensorShape({static_cast<size_t>(output_h), static_cast<size_t>(output_w)})
+                               : TensorShape({3, static_cast<size_t>(output_h), static_cast<size_t>(output_w)});
+        auto output = Tensor::empty(shape, Device::CUDA, DataType::Float32);
+        output.set_stream(stream);
+        const dim3 block(16, 16);
+        const dim3 grid((output_w + 15) / 16, (output_h + 15) / 16);
+        resize_prior_kernel<Channels><<<grid, block, 0, stream>>>(input.ptr<float>(), output.ptr<float>(), w, h, output_w, output_h);
+        LFS_CUDA_CHECK_MSG(cudaGetLastError(), "Prior resample kernel launch");
+        // Match the existing resize helpers' lifetime/stream completion contract.
+        LFS_CUDA_CHECK_MSG(cudaStreamSynchronize(stream), "Prior resample completion");
+        return output;
+    }
+
+    Tensor resize_depth_prior(const Tensor& input, int output_h, int output_w, cudaStream_t stream) {
+        return resize_prior<1>(input, output_h, output_w, stream);
+    }
+
+    Tensor resize_normal_prior(const Tensor& input, int output_h, int output_w, cudaStream_t stream) {
+        return resize_prior<3>(input, output_h, output_w, stream);
     }
 
 } // namespace lfs::core

--- a/src/core/cuda/lanczos_resize/lanczos_resize.hpp
+++ b/src/core/cuda/lanczos_resize/lanczos_resize.hpp
@@ -61,4 +61,12 @@ namespace lfs::core {
         int kernel_size = 2,
         cudaStream_t cuda_stream = nullptr);
 
+    // Bilinear prior resampling excludes invalid neighbors and carries validity
+    // with nearest sampling. Depth <= 0/nonfinite and normal norms < 0.5 are
+    // invalid; outputs use zero sentinels and valid normals have unit length.
+    Tensor resize_depth_prior(const Tensor& input, int output_h, int output_w,
+                              cudaStream_t cuda_stream = nullptr);
+    Tensor resize_normal_prior(const Tensor& input, int output_h, int output_w,
+                               cudaStream_t cuda_stream = nullptr);
+
 } // namespace lfs::core

--- a/src/io/formats/colmap.cpp
+++ b/src/io/formats/colmap.cpp
@@ -9,6 +9,7 @@
 #include "core/path_utils.hpp"
 #include "io/atomic_output.hpp"
 #include "io/filesystem_utils.hpp"
+#include "io/loaders/loader_utils.hpp"
 #include "io/loaders/missing_dataset_images.hpp"
 #include <algorithm>
 #include <array>
@@ -2840,6 +2841,7 @@ namespace lfs::io {
         std::vector<const CameraDataIntermediate*> camera_data;
         camera_images.reserve(images.size());
         camera_data.reserve(images.size());
+        PriorResolutionSummary prior_resolutions;
         SkipTally image_tally;
         std::vector<std::string> missing_images;
 
@@ -2851,6 +2853,7 @@ namespace lfs::io {
             bool missing_image = false;
             bool depth_matched = false;
             bool normal_matched = false;
+            std::array<int, 4> depth_sizes{}, normal_sizes{};
             size_t undistort_crop_failures = 0;
             size_t undistort_fisheye_crop_failures = 0;
         };
@@ -3080,31 +3083,22 @@ namespace lfs::io {
                 if (image_file_present && options.load_depths && !depth_path.empty()) {
                     auto [img_w, img_h, img_c] = get_image_info_cached();
                     auto [depth_w, depth_h, depth_c] = lfs::core::get_image_info(depth_path);
-                    if (!sidecar_dimensions_match_contract(depth_w,
-                                                           depth_h,
-                                                           img_w,
-                                                           img_h,
-                                                           cam_data.original_width,
-                                                           cam_data.original_height)) {
+                    if (depth_c != 1 || !sidecar_dimensions_match_contract(depth_w, depth_h, img_w, img_h)) {
                         errors[i] = make_error(
                                         ErrorCode::DEPTH_SIZE_MISMATCH,
-                                        std::format("Depth map '{}' is {}x{} but image '{}' is {}x{}",
+                                        std::format("Depth map '{}' is {}x{} but image '{}' is {}x{}; expected a 1-channel map with aspect ratio within 1%",
                                                     lfs::core::path_to_utf8(depth_path.filename()), depth_w, depth_h,
                                                     img.name, img_w, img_h),
                                         depth_path)
                                         .error();
                         return;
                     }
+                    output.depth_sizes = {depth_w, depth_h, img_w, img_h};
                 }
                 if (image_file_present && options.load_normals && !normal_path.empty()) {
                     auto [img_w, img_h, img_c] = get_image_info_cached();
                     auto [normal_w, normal_h, normal_c] = lfs::core::get_image_info(normal_path);
-                    if (!sidecar_dimensions_match_contract(normal_w,
-                                                           normal_h,
-                                                           img_w,
-                                                           img_h,
-                                                           cam_data.original_width,
-                                                           cam_data.original_height)) {
+                    if (normal_c != 3 || !sidecar_dimensions_match_contract(normal_w, normal_h, img_w, img_h)) {
                         if (options.normal_auto_generate) {
                             LOG_WARN("Normal map '{}' is {}x{} but image '{}' is {}x{}; "
                                      "ignoring it so auto-generate can overwrite that file",
@@ -3115,7 +3109,7 @@ namespace lfs::io {
                         } else {
                             errors[i] = make_error(
                                             ErrorCode::NORMAL_SIZE_MISMATCH,
-                                            std::format("Normal map '{}' is {}x{} but image '{}' is {}x{}",
+                                            std::format("Normal map '{}' is {}x{} but image '{}' is {}x{}; expected a 3-channel map with aspect ratio within 1%",
                                                         lfs::core::path_to_utf8(normal_path.filename()), normal_w, normal_h,
                                                         img.name, img_w, img_h),
                                             normal_path)
@@ -3123,6 +3117,8 @@ namespace lfs::io {
                             return;
                         }
                     }
+                    if (!normal_path.empty())
+                        output.normal_sizes = {normal_w, normal_h, img_w, img_h};
                 }
 
                 // Create Camera
@@ -3192,6 +3188,8 @@ namespace lfs::io {
                 if (output.missing_image) {
                     missing_images.push_back(output.image->name);
                 }
+                prior_resolutions.add(output.depth_sizes, false);
+                prior_resolutions.add(output.normal_sizes, true);
                 depth_matched_count += output.depth_matched ? 1 : 0;
                 normal_matched_count += output.normal_matched ? 1 : 0;
                 undistort_camera_count += 1;
@@ -3199,6 +3197,8 @@ namespace lfs::io {
                 undistort_fisheye_crop_failures += output.undistort_fisheye_crop_failures;
             }
         }
+
+        prior_resolutions.log();
 
         std::atomic<bool> observation_cancelled = false;
         {

--- a/src/io/include/io/filesystem_utils.hpp
+++ b/src/io/include/io/filesystem_utils.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cmath>
 #include <filesystem>
 #include <functional>
 #include <span>
@@ -98,26 +99,18 @@ namespace lfs::io {
         ".tiff",
     };
 
-    // Depth/normal sidecars are accepted at the COLMAP original image size, or at
-    // any integer multiple of the currently loaded training image. Original-size
-    // maps therefore work for every --images folder (images_2, images_8, ...).
+    // Priors may use any resolution, with up to 1% aspect-ratio rounding error.
     [[nodiscard]] inline bool sidecar_dimensions_match_contract(
         const int sidecar_width,
         const int sidecar_height,
         const int requested_width,
-        const int requested_height,
-        const int original_width,
-        const int original_height) noexcept {
-        if (sidecar_width == original_width && sidecar_height == original_height) {
-            return true;
-        }
+        const int requested_height) noexcept {
         if (requested_width <= 0 || requested_height <= 0 || sidecar_width <= 0 || sidecar_height <= 0) {
             return false;
         }
-        if (sidecar_width % requested_width != 0 || sidecar_height % requested_height != 0) {
-            return false;
-        }
-        return sidecar_width / requested_width == sidecar_height / requested_height;
+        const double ratio = (static_cast<double>(sidecar_width) * requested_height) /
+                             (static_cast<double>(sidecar_height) * requested_width);
+        return std::abs(ratio - 1.0) <= 0.01;
     }
 
     // Safe filesystem operations that don't throw

--- a/src/io/loaders/blender_loader.cpp
+++ b/src/io/loaders/blender_loader.cpp
@@ -192,6 +192,7 @@ namespace lfs::io {
             LOG_DEBUG("Creating {} camera objects", camera_infos.size());
 
             // Convert CameraData to Camera objects
+            PriorResolutionSummary prior_resolutions;
             std::vector<std::shared_ptr<lfs::core::Camera>> cameras;
             cameras.reserve(camera_infos.size());
 
@@ -310,18 +311,19 @@ namespace lfs::io {
                     if (info._has_image && options.load_depths && !depth_path.empty()) {
                         auto [img_w, img_h, img_c] = get_image_info_cached();
                         auto [depth_w, depth_h, depth_c] = lfs::core::get_image_info(depth_path);
-                        if (img_w != depth_w || img_h != depth_h) {
+                        if (depth_c != 1 || !sidecar_dimensions_match_contract(depth_w, depth_h, img_w, img_h)) {
                             return make_error(ErrorCode::DEPTH_SIZE_MISMATCH,
-                                              std::format("Depth map '{}' is {}x{} but image '{}' is {}x{}",
+                                              std::format("Depth map '{}' is {}x{} but image '{}' is {}x{}; expected a 1-channel map with aspect ratio within 1%",
                                                           lfs::core::path_to_utf8(depth_path.filename()), depth_w, depth_h,
                                                           info._image_name, img_w, img_h),
                                               depth_path);
                         }
+                        prior_resolutions.add({depth_w, depth_h, img_w, img_h}, false);
                     }
                     if (info._has_image && options.load_normals && !normal_path.empty()) {
                         auto [img_w, img_h, img_c] = get_image_info_cached();
                         auto [normal_w, normal_h, normal_c] = lfs::core::get_image_info(normal_path);
-                        if (img_w != normal_w || img_h != normal_h) {
+                        if (normal_c != 3 || !sidecar_dimensions_match_contract(normal_w, normal_h, img_w, img_h)) {
                             if (options.normal_auto_generate) {
                                 LOG_WARN("Normal map '{}' is {}x{} but image '{}' is {}x{}; "
                                          "ignoring it so auto-generate can overwrite that file",
@@ -330,12 +332,14 @@ namespace lfs::io {
                                 normal_path.clear();
                             } else {
                                 return make_error(ErrorCode::NORMAL_SIZE_MISMATCH,
-                                                  std::format("Normal map '{}' is {}x{} but image '{}' is {}x{}",
+                                                  std::format("Normal map '{}' is {}x{} but image '{}' is {}x{}; expected a 3-channel map with aspect ratio within 1%",
                                                               lfs::core::path_to_utf8(normal_path.filename()), normal_w, normal_h,
                                                               info._image_name, img_w, img_h),
                                                   normal_path);
                             }
                         }
+                        if (!normal_path.empty())
+                            prior_resolutions.add({normal_w, normal_h, img_w, img_h}, true);
                     }
 
                     auto cam = std::make_shared<lfs::core::Camera>(
@@ -369,6 +373,8 @@ namespace lfs::io {
             if (!missing_images.empty()) {
                 notify_missing_dataset_images(missing_images);
             }
+
+            prior_resolutions.log();
 
             const bool images_have_alpha = detect_camera_alpha(cameras, options.cancel_requested);
 

--- a/src/io/loaders/loader_utils.hpp
+++ b/src/io/loaders/loader_utils.hpp
@@ -13,13 +13,38 @@
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <format>
 #include <glm/glm.hpp>
+#include <map>
 #include <memory>
 #include <random>
 #include <span>
 #include <vector>
 
 namespace lfs::io {
+
+    // Collected from admission probes. Source/image sizes do not depend on
+    // training resize settings; COLMAP merges its per-camera records serially.
+    struct PriorResolutionSummary {
+        std::map<std::array<int, 4>, std::array<size_t, 2>> counts;
+
+        void add(const std::array<int, 4>& sizes, const bool normal) {
+            if (sizes[0] > 0 && (sizes[0] != sizes[2] || sizes[1] != sizes[3]))
+                ++counts[sizes][normal ? 1 : 0];
+        }
+
+        void log() const {
+            std::string summary;
+            for (const auto& [sizes, count] : counts) {
+                if (!summary.empty())
+                    summary += "; ";
+                summary += std::format("{} depth maps / {} normal maps are {}x{} while the images are {}x{}; resampled to the training size",
+                                       count[0], count[1], sizes[0], sizes[1], sizes[2], sizes[3]);
+            }
+            if (!summary.empty())
+                LOG_INFO("{}", summary);
+        }
+    };
 
     inline bool detect_camera_alpha(const std::vector<std::shared_ptr<lfs::core::Camera>>& cameras,
                                     const CancelCallback& cancel_requested = nullptr) {

--- a/src/io/pipelined_image_loader.cpp
+++ b/src/io/pipelined_image_loader.cpp
@@ -1387,7 +1387,7 @@ namespace lfs::io {
             decoded.ptr<float>(), normal.ptr<float>(), height, width,
             static_cast<cudaStream_t>(cuda_stream));
         normal.set_stream(static_cast<cudaStream_t>(cuda_stream));
-        return normal;
+        return lfs::core::resize_normal_prior(normal, height, width, static_cast<cudaStream_t>(cuda_stream));
     }
 
     cudaEvent_t PipelinedImageLoader::record_sidecar_ready_event(cudaStream_t stream) {
@@ -1414,6 +1414,8 @@ namespace lfs::io {
         const PrefetchedImage& item,
         const int src_w,
         const int src_h) const {
+        if (!item.is_mask && item.aux_target_width > 0 && item.aux_target_height > 0)
+            return {item.aux_target_width, item.aux_target_height};
         int target_w = src_w;
         int target_h = src_h;
         if (item.params.resize_factor > 1) {
@@ -2798,7 +2800,11 @@ namespace lfs::io {
 
                         const auto [target_w, target_h] = sidecar_target_size(item, src_w, src_h);
 
-                        if (target_w != src_w || target_h != src_h) {
+                        if (item.is_depth) {
+                            if (gpu_gray.dtype() == lfs::core::DataType::UInt8)
+                                gpu_gray = gpu_gray.to(lfs::core::DataType::Float32).div(255.0f);
+                            aux_tensor = lfs::core::resize_depth_prior(gpu_gray, target_h, target_w, aux_stream);
+                        } else if (target_w != src_w || target_h != src_h) {
                             aux_tensor = lfs::core::lanczos_resize_grayscale(gpu_gray, target_h, target_w, 2, aux_stream);
                         } else if (gpu_gray.dtype() == lfs::core::DataType::Float32) {
                             aux_tensor = std::move(gpu_gray);
@@ -2855,8 +2861,8 @@ namespace lfs::io {
                             aux_tensor.ndim() == 2 &&
                             (static_cast<int>(aux_tensor.shape()[1]) != item.aux_target_width ||
                              static_cast<int>(aux_tensor.shape()[0]) != item.aux_target_height)) {
-                            aux_tensor = lfs::core::lanczos_resize_grayscale(
-                                aux_tensor, item.aux_target_height, item.aux_target_width, 2, aux_stream);
+                            aux_tensor = lfs::core::resize_depth_prior(
+                                aux_tensor, item.aux_target_height, item.aux_target_width, aux_stream);
                         }
                         aux_tensor = aux_tensor.contiguous();
                     }
@@ -2945,9 +2951,7 @@ namespace lfs::io {
                     }
 
                     const auto [target_w, target_h] = sidecar_target_size(item, src_w, src_h);
-                    if (target_w != src_w || target_h != src_h) {
-                        normal_tensor = lfs::core::lanczos_resize_float_chw(normal_tensor, target_h, target_w, 2, sidecar_stream);
-                    }
+                    normal_tensor = lfs::core::resize_normal_prior(normal_tensor, target_h, target_w, sidecar_stream);
 
                     if (!normal_tensor.is_valid() || normal_tensor.ndim() != 3 || normal_tensor.shape()[0] != 3) {
                         throw std::runtime_error("Normal preprocessing produced an invalid tensor");
@@ -2958,14 +2962,15 @@ namespace lfs::io {
                             static_cast<int>(normal_tensor.shape()[2]),
                             static_cast<int>(normal_tensor.shape()[1]));
                         normal_tensor = lfs::core::undistort_image(normal_tensor, scaled, sidecar_stream);
+                        normal_tensor = lfs::core::resize_normal_prior(normal_tensor.contiguous(), normal_tensor.shape()[1], normal_tensor.shape()[2], sidecar_stream);
                     }
 
                     if (item.aux_target_width > 0 && item.aux_target_height > 0 &&
                         normal_tensor.ndim() == 3 &&
                         (static_cast<int>(normal_tensor.shape()[2]) != item.aux_target_width ||
                          static_cast<int>(normal_tensor.shape()[1]) != item.aux_target_height)) {
-                        normal_tensor = lfs::core::lanczos_resize_float_chw(
-                            normal_tensor, item.aux_target_height, item.aux_target_width, 2, sidecar_stream);
+                        normal_tensor = lfs::core::resize_normal_prior(
+                            normal_tensor, item.aux_target_height, item.aux_target_width, sidecar_stream);
                     }
                     normal_tensor = normal_tensor.contiguous();
                     if (!normal_tensor.is_valid() || normal_tensor.ndim() != 3 || normal_tensor.shape()[0] != 3) {

--- a/src/preprocessing/preprocess.cpp
+++ b/src/preprocessing/preprocess.cpp
@@ -744,6 +744,13 @@ namespace {
                                          path_to_string(lfw_path) + ": " +
                                          std::string(loaded.error().detail()));
             model_ = std::move(*loaded);
+            int device = 0;
+            cudaDeviceProp properties{};
+            if (cudaGetDevice(&device) != cudaSuccess ||
+                cudaGetDeviceProperties(&properties, device) != cudaSuccess) {
+                throw std::runtime_error("Failed to query native MoGe CUDA device");
+            }
+            LOG_INFO("Normal estimation: native engine on CUDA device {} ({})", device, properties.name);
         }
 
         HeadMaps run(const Image& image, int64_t num_tokens) {
@@ -1247,6 +1254,9 @@ namespace lfs::preprocessing {
     }
 
     int run_preprocess(const lfs::core::param::PreprocessParameters& params) {
+        // The standalone CLI bypasses training's logger setup.
+        if (!lfs::core::Logger::get().is_ready())
+            lfs::core::Logger::get().init();
         const auto result = run_preprocess_ex(params, {});
         if (!result.ok) {
             std::cerr << "preprocess: " << result.error << "\n";

--- a/tests/test_colmap_image_layout.cpp
+++ b/tests/test_colmap_image_layout.cpp
@@ -1,10 +1,14 @@
 /* SPDX-FileCopyrightText: 2025 LichtFeld Studio Authors
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "core/cuda/lanczos_resize/lanczos_resize.hpp"
 #include "core/image_io.hpp"
 #include "io/filesystem_utils.hpp"
 #include "io/formats/colmap.hpp"
+#include "io/loaders/blender_loader.hpp"
 #include "io/loaders/colmap_loader.hpp"
+#include "io/pipelined_image_loader.hpp"
+#include <cmath>
 
 #include <atomic>
 #include <cuda_runtime.h>
@@ -365,7 +369,9 @@ TEST_F(ColmapImageLayoutTest, ResolvesDepthMapsByImageName) {
 
     write_minimal_colmap_text_dataset(dataset_dir, "frame_0000.png");
     write_png(image_path);
-    write_png(depth_path);
+    fs::create_directories(depth_path.parent_path());
+    const uint16_t depth_value = 32768;
+    ASSERT_TRUE(lfs::core::save_png(depth_path, &depth_value, 1, 1, 1, 16, 6));
 
     auto result =
         lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images", {.load_depths = true});
@@ -393,6 +399,7 @@ TEST_F(ColmapImageLayoutTest, BrokenDepthIsIgnoredUnlessDepthLoadingIsEnabled) {
     const auto with_depth =
         lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images", {.load_depths = true});
     ASSERT_FALSE(with_depth.has_value());
+    EXPECT_EQ(with_depth.error().code, lfs::io::ErrorCode::CORRUPTED_DATA);
 }
 
 TEST_F(ColmapImageLayoutTest, AmbiguousMaskOnlyFailsWhenMaskLoadingEnabled) {
@@ -467,7 +474,7 @@ TEST_F(ColmapImageLayoutTest, AcceptsIntegerRatioDepthForScaledImages) {
     EXPECT_TRUE(std::get<0>(result->value)[0]->has_depth());
 }
 
-TEST_F(ColmapImageLayoutTest, RejectsNonIntegerRatioDepthForScaledImages) {
+TEST_F(ColmapImageLayoutTest, RejectsAspectMismatchedDepthForScaledImages) {
     if (!has_cuda_device()) {
         GTEST_SKIP() << "CUDA device required for COLMAP camera load";
     }
@@ -482,7 +489,7 @@ TEST_F(ColmapImageLayoutTest, RejectsNonIntegerRatioDepthForScaledImages) {
                         " 1000 1000 618.5 411\n");
     write_text_file(dataset_dir / "images.txt", "1 1 0 0 0 0 0 0 1 frame.png\n");
     write_derived_image(image_path, source, source.width / 2, source.height / 2);
-    write_derived_depth(depth_path, source, source.width, source.height - 1);
+    write_derived_depth(depth_path, source, source.width, source.height / 2);
 
     const auto result =
         lfs::io::read_colmap_cameras_and_images_text(dataset_dir, "images_2", {.load_depths = true});
@@ -491,13 +498,109 @@ TEST_F(ColmapImageLayoutTest, RejectsNonIntegerRatioDepthForScaledImages) {
 }
 
 TEST(SidecarDimensionsContract, OriginalSizePassesForSmallerTrainingImage) {
-    // 1237x822 is a typical COLMAP original; images_8 is 154x102 and 1237 % 154 != 0,
-    // so only the original-size branch of the contract accepts a full-res map.
-    EXPECT_TRUE(lfs::io::sidecar_dimensions_match_contract(1237, 822, 154, 102, 1237, 822));
-    EXPECT_TRUE(lfs::io::sidecar_dimensions_match_contract(400, 200, 50, 25, 400, 200));
-    EXPECT_TRUE(lfs::io::sidecar_dimensions_match_contract(100, 50, 50, 25, 400, 200));
-    EXPECT_FALSE(lfs::io::sidecar_dimensions_match_contract(154, 102, 1237, 822, 1237, 822));
-    EXPECT_FALSE(lfs::io::sidecar_dimensions_match_contract(51, 25, 50, 25, 400, 200));
+    // Integer rounding in selected image folders stays inside the 1% tolerance.
+    EXPECT_TRUE(lfs::io::sidecar_dimensions_match_contract(1237, 822, 154, 102));
+    EXPECT_TRUE(lfs::io::sidecar_dimensions_match_contract(400, 200, 50, 25));
+    EXPECT_TRUE(lfs::io::sidecar_dimensions_match_contract(100, 50, 50, 25));
+    EXPECT_TRUE(lfs::io::sidecar_dimensions_match_contract(154, 102, 1237, 822));
+    EXPECT_FALSE(lfs::io::sidecar_dimensions_match_contract(51, 25, 50, 25));
+    EXPECT_TRUE(lfs::io::sidecar_dimensions_match_contract(75, 50, 300, 200));
+    EXPECT_TRUE(lfs::io::sidecar_dimensions_match_contract(201, 100, 200, 100));
+    EXPECT_FALSE(lfs::io::sidecar_dimensions_match_contract(203, 100, 200, 100));
+    EXPECT_FALSE(lfs::io::sidecar_dimensions_match_contract(0, 0, 200, 100));
+}
+
+TEST_F(ColmapImageLayoutTest, HalfResolutionDepthAndNormalReachTrainingSize) {
+    if (!has_cuda_device())
+        GTEST_SKIP() << "CUDA device required";
+    const auto source = read_bicycle_pixels();
+    for (const bool blender : {false, true}) {
+        for (const int bits : {8, 16}) {
+            const auto dataset = temp_dir_ / (std::to_string(blender) + "_" + std::to_string(bits));
+            write_derived_image(dataset / "images/frame.png", source, 154, 102);
+            fs::create_directories(dataset / "depth");
+            fs::create_directories(dataset / "normals");
+            std::vector<uint16_t> depth(77 * 51, 49151);
+            std::vector<uint16_t> normals(77 * 51 * 3, 32768);
+            for (size_t i = 0; i < depth.size(); ++i) {
+                if (i % 77 < 25)
+                    depth[i] = 0;
+                else
+                    normals[i * 3 + 2] = 65535;
+            }
+            ASSERT_TRUE(lfs::core::save_png(dataset / "depth/frame.png", depth.data(), 77, 51, 1, 16, 6));
+            if (bits == 16) {
+                ASSERT_TRUE(lfs::core::save_png(dataset / "normals/frame.png", normals.data(), 77, 51, 3, 16, 6));
+            } else {
+                std::vector<uint8_t> normal8(normals.size());
+                std::transform(normals.begin(), normals.end(), normal8.begin(), [](uint16_t v) { return v >> 8; });
+                ASSERT_TRUE(lfs::core::save_png(dataset / "normals/frame.png", normal8.data(), 77, 51, 3, 8, 6));
+            }
+            const lfs::io::LoadOptions options{.max_width = 120, .load_depths = true, .load_normals = true};
+            std::shared_ptr<lfs::core::Camera> camera;
+            if (blender) {
+                write_text_file(dataset / "transforms.json", R"({"w":154,"h":102,"fl_x":100,"fl_y":100,"cx":77,"cy":51,"frames":[{"file_path":"images/frame.png","transform_matrix":[[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]}]})");
+                lfs::io::BlenderLoader loader;
+                auto result = loader.load(dataset, options);
+                ASSERT_TRUE(result.has_value()) << result.error().format();
+                camera = std::get<lfs::io::LoadedScene>(result->data).cameras.at(0);
+            } else {
+                write_text_file(dataset / "cameras.txt", "1 PINHOLE 154 102 100 100 77 51\n");
+                write_text_file(dataset / "images.txt", "1 1 0 0 0 0 0 0 1 frame.png\n");
+                const auto result = lfs::io::read_colmap_cameras_and_images_text(dataset, "images", options);
+                ASSERT_TRUE(result.has_value()) << result.error().format();
+                camera = std::get<0>(result->value).at(0);
+            }
+            const auto check = [](const lfs::core::Tensor& d, const lfs::core::Tensor& n) {
+                ASSERT_EQ(d.shape(), lfs::core::TensorShape({79, 120}));
+                ASSERT_EQ(n.shape(), lfs::core::TensorShape({3, 79, 120}));
+                const auto dv = d.cpu().to_vector();
+                const auto nv = n.cpu().to_vector();
+                for (size_t i = 0; i < dv.size(); ++i) {
+                    const size_t x = i % 120;
+                    const int nearest = static_cast<int>((x + 0.5f) * 77 / 120);
+                    const bool valid = nearest >= 25;
+                    ASSERT_NEAR(dv[i], valid ? 49151.0f / 65535.0f : 0.0f, 2e-5f) << i;
+                    const float norm = std::sqrt(nv[i] * nv[i] + nv[dv.size() + i] * nv[dv.size() + i] + nv[2 * dv.size() + i] * nv[2 * dv.size() + i]);
+                    ASSERT_NEAR(norm, valid ? 1.0f : 0.0f, 5e-5f) << i;
+                }
+            };
+            // Exercise fallback with no preceding RGB pixel load.
+            ASSERT_NO_FATAL_FAILURE(check(camera->load_and_get_depth(1, 120), camera->load_and_get_normal(1, 120, {})));
+            const auto rgb = camera->load_and_get_image(1, 120);
+            ASSERT_EQ(rgb.shape()[1], 79u);
+            ASSERT_EQ(rgb.shape()[2], 120u);
+            lfs::io::PipelinedLoaderConfig config;
+            config.io_threads = 1;
+            config.cold_process_threads = 1;
+            config.decoder_pool_size = 1;
+            lfs::io::PipelinedImageLoader pipeline(config);
+            lfs::io::ImageRequest request;
+            request.path = camera->image_path();
+            request.depth_path = camera->depth_path();
+            request.normal_path = camera->normal_path();
+            request.params.max_width = 120;
+            request.aux_target_width = camera->image_width();
+            request.aux_target_height = camera->image_height();
+            for (size_t sequence = 0; sequence < 2; ++sequence) {
+                request.sequence_id = sequence;
+                pipeline.prefetch({request});
+                const auto ready = pipeline.get();
+                ASSERT_TRUE(ready.error.empty()) << ready.error;
+                ASSERT_TRUE(ready.depth.has_value());
+                ASSERT_TRUE(ready.normal.has_value());
+                ASSERT_NO_FATAL_FAILURE(check(*ready.depth, *ready.normal));
+            }
+            // Both loaders must retain their existing failure codes.
+            write_derived_image(dataset / "normals/frame.png", source, 32, 32);
+            if (blender) {
+                lfs::io::BlenderLoader loader;
+                const auto result = loader.load(dataset, options);
+                ASSERT_FALSE(result.has_value());
+                EXPECT_EQ(result.error().code, lfs::io::ErrorCode::NORMAL_SIZE_MISMATCH);
+            }
+        }
+    }
 }
 
 TEST_F(ColmapImageLayoutTest, AcceptsOriginalSizeNormalForScaledImages) {
@@ -539,7 +642,7 @@ TEST_F(ColmapImageLayoutTest, RejectsMismatchedNormalWithoutAutoGenerate) {
                         " 1000 1000 618.5 411\n");
     write_text_file(dataset_dir / "images.txt", "1 1 0 0 0 0 0 0 1 frame.png\n");
     write_derived_image(image_path, source, source.width / 2, source.height / 2);
-    // Neither original size nor an integer multiple of the training image.
+    // Square prior does not match the image aspect ratio.
     write_derived_image(normal_path, source, 8, 8);
 
     const auto result =
@@ -1158,4 +1261,23 @@ TEST_F(ColmapImageLayoutTest, WriteBackDropsImagesForDeletedCamerasAndClearsTrac
     int track_image_id = 0;
     EXPECT_FALSE(point_record >> track_image_id)
         << "tracks must be cleared after dropping images so no dangling image_id remains";
+}
+
+TEST(SidecarResampling, InvalidDepthAndNormalVectorsStayZero) {
+    if (!has_cuda_device())
+        GTEST_SKIP() << "CUDA device required";
+    using namespace lfs::core;
+    const std::vector<float> depth{0.0f, -1.0f, std::numeric_limits<float>::quiet_NaN(),
+                                   std::numeric_limits<float>::infinity(), 0.75f, 0.75f};
+    auto d = Tensor::from_blob(const_cast<float*>(depth.data()), TensorShape({1, 6}), Device::CPU, DataType::Float32).to(Device::CUDA);
+    const auto result = resize_depth_prior(d, 2, 12).cpu().to_vector();
+    for (size_t i = 0; i < result.size(); ++i)
+        EXPECT_FLOAT_EQ(result[i], i % 12 < 8 ? 0.0f : 0.75f);
+    // Opposing valid vectors cancel at the center: the epsilon guard yields zero.
+    std::vector<float> normal{1, -1, 0, 0, 0, 0};
+    auto n = Tensor::from_blob(normal.data(), TensorShape({3, 1, 2}), Device::CPU, DataType::Float32).to(Device::CUDA);
+    const auto resized = resize_normal_prior(n, 1, 3).cpu().to_vector();
+    EXPECT_FLOAT_EQ(resized[0], 1.0f);
+    EXPECT_FLOAT_EQ(resized[1], 0.0f);
+    EXPECT_FLOAT_EQ(resized[2], -1.0f);
 }


### PR DESCRIPTION
From a Discord report about external normal and depth maps.

Before, external depth and normal maps had to match the image size exactly (Blender) or the original size or an integer multiple of the selected image folder (COLMAP). Other sizes stopped the load with a size mismatch error.

Now any map with the same aspect ratio (within 1%) is accepted and resampled to the training size. Invalid pixels (zero depth, zero normals) stay invalid instead of bleeding into their neighbours, and resampled normals keep unit length. One log line per dataset says how many maps were resampled and from which size.

The same reporter thought normal maps were generated on the CPU. They run on the native CUDA engine, but the app never said so. Generation now logs the CUDA device once, also from the GUI.

Tests: loader tests cover half-resolution maps on both loaders at 8 and 16 bit, sentinel preservation and aspect-ratio rejection (173 passed, 1 skipped). Runtime: garden30 with half-size normal maps fails on master with the size mismatch and trains 300 iterations on this branch.
