### PR TITLE
Startup overlay: ignore clicks while a modal or context menu is open

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -6102,6 +6102,8 @@ namespace lfs::vis::gui {
             LOG_TIMER_THRESHOLD("gui_render.panel_setup.frame_input", 0.25);
             frame_input = buildPanelInputFromSDL(sdl_input);
             startup_overlay_input = frame_input;
+            if (modal_overlay_open || modal_overlay_pending || context_menu_open)
+                startup_overlay_input = maskInputForBlockedUi(std::move(startup_overlay_input));
             if (startup_overlay_blocking)
                 frame_input = maskInputForBlockedUi(std::move(frame_input));
             else if (menu_blocks_underlay_pointer)


### PR DESCRIPTION
Discord report (nightly 12802b8fa): on the first start the "make LichtFeld the default program for .ply/.sog/..." prompt sits on top of the startup overlay. Clicking any prompt button also clicked the overlay underneath: the Discord/X/YouTube/donate link under the pointer opened a browser and the overlay dismissed.

Cause: the overlay gets its own copy of the frame input, taken before any masking, so a modal or context menu never blocked it (this came back with the Vulkan hardening change that split the overlay input from the shared panel input).

Fix: mask the overlay input while a modal is open or pending, or the global context menu is open. Two lines, same helper the rest of the UI uses.

Verified on a Linux Xvfb rig with a fake `xdg-open`: before the fix, a click on the Discord link while a modal was open wrote the Discord URL to the fake opener and a click elsewhere logged `StartupOverlay: dismissed by mouse click`. After the fix, neither happens while the modal is open; after pressing the modal button the overlay is still there, links open, and a click elsewhere dismisses it as before.