### PR TITLE
MRNF: hand the far-field mask to Adam as a tensor, rebuild it on Background Improvement toggles

### DIFF
--- a/src/training/optimizer/adam_optimizer.cpp
+++ b/src/training/optimizer/adam_optimizer.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <cmath>
 #include <cuda_runtime.h>
+#include <limits>
 #include <optional>
 #include <stdexcept>
 #include <type_traits>
@@ -188,14 +189,33 @@ namespace lfs::training {
         mean_step_r_min_ = r_min;
         mean_step_r_max_ = r_max;
         if (!enabled) {
-            mean_step_far_mask_ = nullptr;
-            mean_step_far_mask_n_ = 0;
+            set_mean_step_far_mask({});
         }
     }
 
-    void AdamOptimizer::set_mean_step_far_mask(const bool* mask, const int n) {
-        mean_step_far_mask_ = mask;
-        mean_step_far_mask_n_ = mask != nullptr ? n : 0;
+    void AdamOptimizer::set_mean_step_far_mask(lfs::core::Tensor mask) {
+        if (!mask.is_valid() || mask.numel() == 0) {
+            mean_step_far_mask_ = nullptr;
+            mean_step_far_mask_n_ = 0;
+            mean_step_far_mask_storage_ = {};
+            return;
+        }
+        LFS_ASSERT_MSG(mask.dtype() == lfs::core::DataType::Bool && mask.ndim() == 1,
+                       "AdamOptimizer mean-step far mask must be a 1D bool tensor");
+        LFS_ASSERT_MSG(mask.numel() <= static_cast<size_t>(std::numeric_limits<int>::max()),
+                       "AdamOptimizer mean-step far mask exceeds the supported row count");
+        // Construct fresh handles: assignment to a view copies into its existing
+        // storage, even for mask = mask.cuda() or mask = mask.clone().
+        auto uploaded = mask.device() == lfs::core::Device::CUDA ? mask : mask.cuda();
+        auto storage = uploaded.is_contiguous() && uploaded.owns_memory()
+                           ? uploaded
+                           : uploaded.clone();
+        const auto* pointer = storage.ptr<bool>();
+        LFS_VALIDATE_CUDA_DEVICE_POINTER(pointer, "mean_step_far_mask");
+        // A raw pointer alone cannot keep a replaced strategy tensor alive.
+        mean_step_far_mask_storage_ = std::move(storage);
+        mean_step_far_mask_ = pointer;
+        mean_step_far_mask_n_ = static_cast<int>(mean_step_far_mask_storage_.numel());
     }
 
     void AdamOptimizer::validate_mean_step_far_mask() {
@@ -206,7 +226,7 @@ namespace lfs::training {
             LOG_WARN("AdamOptimizer: mean_step_far_mask row-count mismatch (mask={}, means={}); "
                      "ignoring binding until the strategy republishes it",
                      mean_step_far_mask_n_, n);
-            set_mean_step_far_mask(nullptr, 0);
+            set_mean_step_far_mask({});
         }
     }
 
@@ -323,6 +343,9 @@ namespace lfs::training {
             prepare_contiguous(type);
         }
         if (n_entries > 0) {
+            if (mean_step_far_mask_storage_.is_valid()) {
+                mean_step_far_mask_storage_.sync_to_stream(batch_stream);
+            }
             if (frozen_mask_.is_valid()) {
                 lfs::core::waitForCUDAStream(batch_stream, frozen_mask_.stream());
             }
@@ -780,6 +803,9 @@ namespace lfs::training {
                 throw std::runtime_error("Optimizer state desync: " + name);
             }
             const size_t feature_dim = param_live.numel() / param_size;
+            if (mean_step_far_mask_storage_.is_valid()) {
+                mean_step_far_mask_storage_.sync_to_stream(execution_stream);
+            }
             const float* mean_step_scale_raw = nullptr;
             int mean_step_scale_n = 0;
             if (type == ParamType::Means && per_splat_mean_step_) {
@@ -848,6 +874,9 @@ namespace lfs::training {
         const int iteration,
         const cudaStream_t execution_stream) {
         validate_mean_step_far_mask();
+        if (mean_step_far_mask_storage_.is_valid()) {
+            mean_step_far_mask_storage_.sync_to_stream(execution_stream);
+        }
         if (crop_damping_mask_.is_valid()) {
             crop_damping_mask_.sync_to_stream(execution_stream);
         }

--- a/src/training/optimizer/adam_optimizer.hpp
+++ b/src/training/optimizer/adam_optimizer.hpp
@@ -144,7 +144,8 @@ namespace lfs::training {
                                      float median_extent,
                                      float r_min,
                                      float r_max);
-        void set_mean_step_far_mask(const bool* mask, int n);
+        // Retain the allocation for both explicit and fused Adam; CPU inputs are uploaded.
+        void set_mean_step_far_mask(lfs::core::Tensor mask);
         void set_screen_share_cap(const float* max_share, int n, float limit, float penalty);
         void refresh_screen_share_buffer();
         [[nodiscard]] bool per_splat_mean_step() const noexcept { return per_splat_mean_step_; }
@@ -228,6 +229,7 @@ namespace lfs::training {
         float mean_step_median_extent_ = 0.0f;
         float mean_step_r_min_ = 1.0f;
         float mean_step_r_max_ = 300.0f;
+        lfs::core::Tensor mean_step_far_mask_storage_;
         const bool* mean_step_far_mask_ = nullptr;
         int mean_step_far_mask_n_ = 0;
         const float* screen_share_max_ = nullptr;

--- a/src/training/strategies/mrnf.cpp
+++ b/src/training/strategies/mrnf.cpp
@@ -1760,16 +1760,16 @@ namespace lfs::training {
             return;
         }
         if (!background_improvements_enabled()) {
-            _optimizer->set_mean_step_far_mask(nullptr, 0);
+            _optimizer->set_mean_step_far_mask({});
             return;
         }
         const size_t n = _splat_data ? static_cast<size_t>(_splat_data->size()) : 0;
         if (!_camera_hull_valid || n == 0 || !_far_field_mask.is_valid() ||
             _far_field_mask.numel() != n) {
-            _optimizer->set_mean_step_far_mask(nullptr, 0);
+            _optimizer->set_mean_step_far_mask({});
             return;
         }
-        _optimizer->set_mean_step_far_mask(_far_field_mask.ptr<bool>(), static_cast<int>(n));
+        _optimizer->set_mean_step_far_mask(_far_field_mask);
     }
 
     void MRNF::ensure_mean_step_far_mask() {
@@ -3724,6 +3724,7 @@ namespace lfs::training {
     }
 
     void MRNF::set_optimization_params(const lfs::core::param::OptimizationParameters& params) {
+        const bool background_changed = background_improvements_enabled() != params.background_improvements;
         _params = std::make_unique<const lfs::core::param::OptimizationParameters>(params);
 
         if (_mean_lr_unscaled <= 0.0) {
@@ -3738,6 +3739,10 @@ namespace lfs::training {
             ensure_densification_info_shape();
         }
 
+        if (background_changed) {
+            refresh_camera_hull();
+            ensure_mean_step_far_mask();
+        }
         if (_optimizer) {
             _optimizer->set_param_lr(ParamType::Scaling, _scale_lr_current);
             sync_mean_learning_rate();

--- a/tests/test_dual_rep_optimizer.cpp
+++ b/tests/test_dual_rep_optimizer.cpp
@@ -508,7 +508,7 @@ TEST(DualRepOptimizer, MRNF_PerSplatMeanStepWithQuantizedAdamIsFinite) {
     EXPECT_TRUE(means_st->is_joint());
 
     auto far_mask = Tensor::zeros_bool({size_t{8}}, Device::CUDA).logical_not();
-    opt.set_mean_step_far_mask(far_mask.ptr<bool>(), 8);
+    opt.set_mean_step_far_mask(far_mask);
     EXPECT_NE(opt.mean_step_far_mask(), nullptr);
     EXPECT_EQ(opt.mean_step_far_mask_n(), 8);
 

--- a/tests/test_mrnf_strategy.cpp
+++ b/tests/test_mrnf_strategy.cpp
@@ -2113,7 +2113,7 @@ TEST(MRNFStrategyTest, MeanStepFarMaskMismatchIsIgnoredByExplicitAdam) {
         optimizer.set_per_splat_mean_step(true, 0.5f, 1.0f, 300.0f);
         control_optimizer.set_per_splat_mean_step(true, 0.5f, 1.0f, 300.0f);
         const auto mask = Tensor::ones({static_cast<size_t>(mask_n)}, Device::CUDA).to(DataType::Bool);
-        optimizer.set_mean_step_far_mask(mask.ptr<bool>(), mask_n);
+        optimizer.set_mean_step_far_mask(mask);
         optimizer.get_grad(ParamType::Means).fill_(0.2f);
         control_optimizer.get_grad(ParamType::Means).fill_(0.2f);
         FarMaskWarningCapture warnings;
@@ -2142,7 +2142,7 @@ TEST(MRNFStrategyTest, MeanStepFarMaskMismatchIsIgnoredByFusedAdam) {
         auto& optimizer = strategy.get_optimizer();
         optimizer.set_per_splat_mean_step(true, 0.5f, 1.0f, 300.0f);
         const auto mask = Tensor::ones({static_cast<size_t>(mask_n)}, Device::CUDA).to(DataType::Bool);
-        optimizer.set_mean_step_far_mask(mask.ptr<bool>(), mask_n);
+        optimizer.set_mean_step_far_mask(mask);
         FarMaskWarningCapture warnings;
 
         const auto fused = optimizer.prepare_fastgs_fused_adam(1, nullptr);
@@ -2159,11 +2159,171 @@ TEST(MRNFStrategyTest, MeanStepFarMaskMismatchIsIgnoredByFusedAdam) {
         EXPECT_EQ(warnings.messages.size(), 1u);
 
         const auto current_mask = Tensor::zeros_bool({2}, Device::CUDA);
-        optimizer.set_mean_step_far_mask(current_mask.ptr<bool>(), 2);
+        optimizer.set_mean_step_far_mask(current_mask);
         const auto republished = optimizer.prepare_fastgs_fused_adam(3, nullptr);
         EXPECT_EQ(republished.mean_step_far_mask, current_mask.ptr<bool>());
         EXPECT_EQ(republished.mean_step_far_mask_n, 2);
         EXPECT_EQ(warnings.messages.size(), 1u);
         EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
     }
+}
+
+TEST(MRNFStrategyTest, MeanStepFarMaskUploadsHostStorageBeforeAdam) {
+    for (const bool pinned : {false, true}) {
+        SCOPED_TRACE(pinned);
+        auto splat = create_mrnf_test_splat_data(2, 0);
+        auto control_splat = create_mrnf_test_splat_data(2, 0);
+        const auto params = vanilla_mrnf_params();
+        MRNF strategy(splat);
+        MRNF control(control_splat);
+        strategy.initialize(params);
+        control.initialize(params);
+        auto& optimizer = strategy.get_optimizer();
+        auto& control_optimizer = control.get_optimizer();
+        optimizer.set_per_splat_mean_step(true, 0.5f, 1.0f, 300.0f);
+        control_optimizer.set_per_splat_mean_step(true, 0.5f, 1.0f, 300.0f);
+        {
+            // A strided CPU view exercises both pageable/pinned upload and packing.
+            auto host = Tensor::empty({2, 2}, Device::CPU, DataType::Bool, pinned);
+            const bool values[] = {true, false, false, true};
+            std::memcpy(host.ptr<bool>(), values, sizeof(values));
+            auto mask = host.slice(1, 0, 1).squeeze(1);
+            ASSERT_FALSE(mask.is_contiguous());
+            optimizer.set_mean_step_far_mask(mask);
+            control_optimizer.set_mean_step_far_mask(mask.cuda().contiguous());
+            EXPECT_NE(optimizer.mean_step_far_mask(), mask.ptr<bool>());
+        }
+        cudaPointerAttributes attributes{};
+        ASSERT_EQ(cudaPointerGetAttributes(&attributes, optimizer.mean_step_far_mask()), cudaSuccess);
+        EXPECT_EQ(attributes.type, cudaMemoryTypeDevice);
+        bool values[2] = {};
+        ASSERT_EQ(cudaMemcpy(values, optimizer.mean_step_far_mask(), sizeof(values),
+                             cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        EXPECT_TRUE(values[0]);
+        EXPECT_FALSE(values[1]);
+        const auto fused = optimizer.prepare_fastgs_fused_adam(1, nullptr);
+        EXPECT_EQ(fused.mean_step_far_mask, optimizer.mean_step_far_mask());
+        EXPECT_EQ(fused.mean_step_far_mask_n, 2);
+        optimizer.get_grad(ParamType::Means).fill_(0.2f);
+        control_optimizer.get_grad(ParamType::Means).fill_(0.2f);
+        optimizer.step(1);
+        control_optimizer.step(1);
+        EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        EXPECT_EQ(means_xyz(splat), means_xyz(control_splat));
+    }
+}
+
+TEST(MRNFStrategyTest, MeanStepFarMaskRetainsAllocationUntilBindingIsCleared) {
+    auto splat = create_mrnf_test_splat_data(2, 0);
+    MRNF strategy(splat);
+    strategy.initialize(vanilla_mrnf_params());
+    auto& optimizer = strategy.get_optimizer();
+    optimizer.set_per_splat_mean_step(true, 0.5f, 1.0f, 300.0f);
+    std::weak_ptr<Tensor> allocation;
+    {
+        auto owner = std::make_shared<Tensor>(Tensor::ones_bool({2}, Device::CUDA));
+        allocation = owner;
+        auto mask = Tensor::from_external_owner(
+            owner->ptr<bool>(), TensorShape({2}), Device::CUDA, DataType::Bool, owner);
+        optimizer.set_mean_step_far_mask(mask);
+        EXPECT_EQ(optimizer.mean_step_far_mask(), owner->ptr<bool>());
+    }
+    // This observes ownership directly, independent of allocator address reuse.
+    ASSERT_FALSE(allocation.expired());
+    optimizer.get_grad(ParamType::Means).fill_(0.2f);
+    optimizer.step(1);
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    optimizer.set_per_splat_mean_step(false, 0.0f, 1.0f, 300.0f);
+    EXPECT_TRUE(allocation.expired());
+    EXPECT_EQ(optimizer.mean_step_far_mask(), nullptr);
+    EXPECT_EQ(optimizer.mean_step_far_mask_n(), 0);
+
+    // A from_blob view has no allocation owner to retain, so the binding must copy it.
+    for (const bool strided : {false, true}) {
+        SCOPED_TRACE(strided);
+        {
+            auto source = Tensor::ones_bool({2, 2}, Device::CUDA);
+            auto borrowed = strided
+                                ? source.slice(1, 0, 1).squeeze(1)
+                                : Tensor::from_blob(source.ptr<bool>(), TensorShape({2}), Device::CUDA, DataType::Bool);
+            ASSERT_FALSE(borrowed.owns_memory());
+            optimizer.set_mean_step_far_mask(borrowed);
+            EXPECT_NE(optimizer.mean_step_far_mask(), source.ptr<bool>());
+            // Also prove independence while the source is still allocated.
+            source.zero_();
+            EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        }
+        bool values[2] = {};
+        ASSERT_EQ(cudaMemcpy(values, optimizer.mean_step_far_mask(), sizeof(values),
+                             cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        EXPECT_TRUE(values[0]);
+        EXPECT_TRUE(values[1]);
+    }
+    optimizer.set_mean_step_far_mask({});
+}
+
+TEST(MRNFStrategyTest, MeanStepFarMaskEmptyBindingsClearExplicitAndFusedAdam) {
+    auto splat = create_mrnf_test_splat_data(2, 0);
+    MRNF strategy(splat);
+    strategy.initialize(vanilla_mrnf_params());
+    auto& optimizer = strategy.get_optimizer();
+    optimizer.set_per_splat_mean_step(true, 0.5f, 1.0f, 300.0f);
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        optimizer.set_mean_step_far_mask(Tensor::ones_bool({2}, Device::CUDA));
+        optimizer.set_mean_step_far_mask(Tensor::empty({0}, device, DataType::Bool));
+        EXPECT_EQ(optimizer.mean_step_far_mask(), nullptr);
+        EXPECT_EQ(optimizer.mean_step_far_mask_n(), 0);
+        const auto fused = optimizer.prepare_fastgs_fused_adam(1, nullptr);
+        EXPECT_EQ(fused.mean_step_far_mask, nullptr);
+        EXPECT_EQ(fused.mean_step_far_mask_n, 0);
+        optimizer.get_grad(ParamType::Means).fill_(0.2f);
+        optimizer.step(1);
+    }
+    // External zero-size views may have non-null host storage. Do not query or upload it.
+    auto owner = std::make_shared<bool>(true);
+    auto empty = Tensor::from_external_owner(
+        owner.get(), TensorShape({0}), Device::CPU, DataType::Bool, owner);
+    ASSERT_NE(empty.data_ptr(), nullptr);
+    optimizer.set_mean_step_far_mask(Tensor::ones_bool({2}, Device::CUDA));
+    optimizer.set_mean_step_far_mask(empty);
+    EXPECT_EQ(optimizer.mean_step_far_mask(), nullptr);
+    EXPECT_EQ(optimizer.mean_step_far_mask_n(), 0);
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+}
+
+TEST(MRNFStrategyTest, BackgroundToggleBuildsAndClearsFarMaskBeforeNextAdamStep) {
+    auto splat = create_mrnf_test_splat_data(4, 0);
+    auto params = vanilla_mrnf_params();
+    params.far_scene_min_fraction = 0.0f;
+    MRNF strategy(splat);
+    strategy.initialize(params);
+    install_test_camera_hull(strategy);
+    auto& optimizer = strategy.get_optimizer();
+    EXPECT_EQ(optimizer.mean_step_far_mask(), nullptr);
+
+    for (int iteration = 1; iteration <= 2; ++iteration) {
+        params.background_improvements = true;
+        strategy.set_optimization_params(params);
+        ASSERT_NE(optimizer.mean_step_far_mask(), nullptr);
+        ASSERT_EQ(optimizer.mean_step_far_mask_n(), 4);
+        bool values[4] = {};
+        ASSERT_EQ(cudaMemcpy(values, optimizer.mean_step_far_mask(), sizeof(values),
+                             cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        EXPECT_FALSE(values[0]);
+        EXPECT_TRUE(values[3]);
+        const auto fused = optimizer.prepare_fastgs_fused_adam(iteration, nullptr);
+        EXPECT_EQ(fused.mean_step_far_mask, optimizer.mean_step_far_mask());
+        optimizer.get_grad(ParamType::Means).fill_(0.2f);
+        optimizer.step(iteration);
+
+        params.background_improvements = false;
+        strategy.set_optimization_params(params);
+        EXPECT_EQ(optimizer.mean_step_far_mask(), nullptr);
+        EXPECT_EQ(optimizer.mean_step_far_mask_n(), 0);
+        EXPECT_FALSE(optimizer.per_splat_mean_step());
+    }
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 }

--- a/tests/test_tensor_memory.cpp
+++ b/tests/test_tensor_memory.cpp
@@ -242,6 +242,66 @@ TEST_F(TensorMemoryTest, DeviceTransferOwnsMemory) {
     compare_tensors(custom_cuda2, torch_cuda2, 1e-6f, 1e-7f, "CUDATransfer");
 }
 
+TEST_F(TensorMemoryTest, BoolViewTransferResultsAndAssignmentStorage) {
+    for (const bool pinned : {false, true}) {
+        SCOPED_TRACE(pinned);
+        auto host = Tensor::empty({2, 2}, Device::CPU, DataType::Bool, pinned);
+        host.ptr<bool>()[0] = true;
+        host.ptr<bool>()[1] = false;
+        host.ptr<bool>()[2] = false;
+        host.ptr<bool>()[3] = true;
+        auto view = host.slice(1, 0, 1).squeeze(1);
+        const auto* host_pointer = view.ptr<bool>();
+        ASSERT_TRUE(view.is_view());
+        ASSERT_FALSE(view.is_contiguous());
+
+        const auto uploaded = view.cuda();
+        const auto packed = uploaded.contiguous();
+        const auto cloned = packed.clone();
+        for (const auto* result : {&uploaded, &packed, &cloned}) {
+            ASSERT_EQ(result->device(), Device::CUDA);
+            EXPECT_TRUE(result->is_contiguous());
+            EXPECT_TRUE(result->owns_memory());
+            cudaPointerAttributes attributes{};
+            ASSERT_EQ(cudaPointerGetAttributes(&attributes, result->ptr<bool>()), cudaSuccess);
+            EXPECT_EQ(attributes.type, cudaMemoryTypeDevice);
+            const auto values = result->cpu();
+            EXPECT_TRUE(values.ptr<bool>()[0]);
+            EXPECT_FALSE(values.ptr<bool>()[1]);
+        }
+        EXPECT_NE(cloned.ptr<bool>(), packed.ptr<bool>());
+
+        // View assignment writes through; none of these rebind the host view.
+        view = view.cuda();
+        EXPECT_EQ(view.device(), Device::CPU);
+        EXPECT_EQ(view.ptr<bool>(), host_pointer);
+        view = view.contiguous();
+        EXPECT_FALSE(view.is_contiguous());
+        EXPECT_EQ(view.ptr<bool>(), host_pointer);
+        view = view.clone();
+        EXPECT_EQ(view.device(), Device::CPU);
+        EXPECT_EQ(view.ptr<bool>(), host_pointer);
+        EXPECT_FALSE(view.owns_memory());
+    }
+}
+
+TEST_F(TensorMemoryTest, BoolFromBlobCloneResultOwnsStorage) {
+    auto source = Tensor::ones_bool({2}, Device::CUDA);
+    auto borrowed = Tensor::from_blob(source.ptr<bool>(), {2}, Device::CUDA, DataType::Bool);
+    ASSERT_TRUE(borrowed.is_view());
+    ASSERT_FALSE(borrowed.owns_memory());
+    const auto cloned = borrowed.clone();
+    EXPECT_TRUE(cloned.owns_memory());
+    EXPECT_NE(cloned.ptr<bool>(), source.ptr<bool>());
+    borrowed = borrowed.clone();
+    EXPECT_EQ(borrowed.ptr<bool>(), source.ptr<bool>());
+    EXPECT_FALSE(borrowed.owns_memory());
+    source.zero_();
+    const auto values = cloned.cpu();
+    EXPECT_TRUE(values.ptr<bool>()[0]);
+    EXPECT_TRUE(values.ptr<bool>()[1]);
+}
+
 TEST_F(TensorMemoryTest, DeviceTransferRoundtrip) {
     auto custom_original = Tensor::randn({10, 10}, Device::CUDA);
     auto custom_data = custom_original.to_vector(); // Save original data


### PR DESCRIPTION
Follow-up for #2069 (training fails with Background Improvement on Windows: `mean_step_far_mask` has memory type 0). The reporter's latest nightly (2026-09-09, 12802b8fa) was built before #2070 merged, so it is unknown whether #2070 already covers their case. This PR removes the remaining ways the optimizer could end up with a dead or host pointer.

What changed
- Adam takes the far-field mask as a tensor instead of a raw pointer and row count. It shares owned CUDA storage, uploads or clones anything else, checks the pointer is device memory at bind time, and orders its use on the execution streams. A replaced strategy tensor can no longer leave a dangling pointer behind.
- MRNF rebuilds the camera hull and the mask when the Background Improvement flag changes through the parameter setter, so turning it on from the GUI after start binds a mask.
- Tests: host pageable and pinned uploads, views and `from_blob` inputs, allocation retention until clear, empty masks, repeated flag transitions, plus two tensor tests documenting that assigning into a view copies into its storage (the binding must build fresh handles).

Verified: 94 tests in the MRNF, fused Adam, dual-rep optimizer, tensor memory and Morton reorder suites pass on an RTX 4090.