### PR TITLE
SSOG: export twice as fast

### DIFF
--- a/src/io/cuda/kmeans.cu
+++ b/src/io/cuda/kmeans.cu
@@ -419,8 +419,8 @@ namespace lfs::io {
             }
         }
 
-        template <int N_DIMS>
-        __global__ void __launch_bounds__(BLOCK_SIZE, 3)
+        template <int N_DIMS, int POINTS_PER_THREAD = ASSIGN_POINTS_PER_THREAD, int THREAD_COUNT = BLOCK_SIZE>
+        __global__ void __launch_bounds__(THREAD_COUNT, 3)
             assign_nearest_swizzled_bruteforce_kernel(
                 const float4* __restrict__ shN,
                 const float* __restrict__ centroids,
@@ -428,16 +428,17 @@ namespace lfs::io {
                 int* __restrict__ labels,
                 const int n_points,
                 const int k) {
-            __shared__ float shared_points[ASSIGN_POINT_TILE][ASSIGN_SHARED_K_STRIDE];
+            constexpr int POINT_TILE = THREAD_COUNT / ASSIGN_CENTROID_GROUPS * POINTS_PER_THREAD;
+            __shared__ float shared_points[POINT_TILE][ASSIGN_SHARED_K_STRIDE];
             __shared__ float shared_centroids[ASSIGN_CENTROID_TILE][ASSIGN_SHARED_K_STRIDE];
             __shared__ float shared_centroid_norms[ASSIGN_CENTROID_TILE];
 
             const int tid = threadIdx.x;
-            const int point_row = (tid / ASSIGN_CENTROID_GROUPS) * ASSIGN_POINTS_PER_THREAD;
+            const int point_row = (tid / ASSIGN_CENTROID_GROUPS) * POINTS_PER_THREAD;
             const int centroid_col = (tid % ASSIGN_CENTROID_GROUPS) * ASSIGN_CENTROIDS_PER_THREAD;
-            const int point_start = blockIdx.x * ASSIGN_POINT_TILE;
+            const int point_start = blockIdx.x * POINT_TILE;
             constexpr int point_slots_count = (N_DIMS + 3) / 4;
-            for (int i = tid; i < ASSIGN_POINT_TILE * point_slots_count; i += BLOCK_SIZE) {
+            for (int i = tid; i < POINT_TILE * point_slots_count; i += THREAD_COUNT) {
                 const int point = i / point_slots_count;
                 const int slot = i % point_slots_count;
                 const int global_point = point_start + point;
@@ -452,10 +453,10 @@ namespace lfs::io {
             }
             __syncthreads();
 
-            float best_dist[ASSIGN_POINTS_PER_THREAD];
-            int best_idx[ASSIGN_POINTS_PER_THREAD];
+            float best_dist[POINTS_PER_THREAD];
+            int best_idx[POINTS_PER_THREAD];
 #pragma unroll
-            for (int p = 0; p < ASSIGN_POINTS_PER_THREAD; ++p) {
+            for (int p = 0; p < POINTS_PER_THREAD; ++p) {
                 best_dist[p] = 1e30f;
                 best_idx[p] = k;
             }
@@ -463,7 +464,7 @@ namespace lfs::io {
             const int num_tiles = (k + ASSIGN_CENTROID_TILE - 1) / ASSIGN_CENTROID_TILE;
             for (int tile = 0; tile < num_tiles; ++tile) {
                 const int centroid_start = tile * ASSIGN_CENTROID_TILE;
-                for (int i = tid; i < ASSIGN_CENTROID_TILE * N_DIMS; i += BLOCK_SIZE) {
+                for (int i = tid; i < ASSIGN_CENTROID_TILE * N_DIMS; i += THREAD_COUNT) {
                     const int centroid = i / N_DIMS;
                     const int dim = i % N_DIMS;
                     const int global_centroid = centroid_start + centroid;
@@ -471,19 +472,19 @@ namespace lfs::io {
                                                           ? centroids[static_cast<long long>(global_centroid) * N_DIMS + dim]
                                                           : 0.0f;
                 }
-                for (int i = tid; i < ASSIGN_CENTROID_TILE; i += BLOCK_SIZE) {
+                for (int i = tid; i < ASSIGN_CENTROID_TILE; i += THREAD_COUNT) {
                     const int global_centroid = centroid_start + i;
                     shared_centroid_norms[i] = global_centroid < k ? centroid_norms[global_centroid] : 0.0f;
                 }
                 __syncthreads();
 
-                float dots[ASSIGN_POINTS_PER_THREAD][ASSIGN_CENTROIDS_PER_THREAD] = {};
+                float dots[POINTS_PER_THREAD][ASSIGN_CENTROIDS_PER_THREAD] = {};
 #pragma unroll
                 for (int d = 0; d < N_DIMS; ++d) {
-                    float point_values[ASSIGN_POINTS_PER_THREAD];
+                    float point_values[POINTS_PER_THREAD];
                     float centroid_values[ASSIGN_CENTROIDS_PER_THREAD];
 #pragma unroll
-                    for (int p = 0; p < ASSIGN_POINTS_PER_THREAD; ++p) {
+                    for (int p = 0; p < POINTS_PER_THREAD; ++p) {
                         point_values[p] = shared_points[point_row + p][d];
                     }
 #pragma unroll
@@ -491,7 +492,7 @@ namespace lfs::io {
                         centroid_values[c] = shared_centroids[centroid_col + c][d];
                     }
 #pragma unroll
-                    for (int p = 0; p < ASSIGN_POINTS_PER_THREAD; ++p) {
+                    for (int p = 0; p < POINTS_PER_THREAD; ++p) {
 #pragma unroll
                         for (int c = 0; c < ASSIGN_CENTROIDS_PER_THREAD; ++c) {
                             dots[p][c] = fmaf(point_values[p], centroid_values[c], dots[p][c]);
@@ -500,7 +501,7 @@ namespace lfs::io {
                 }
 
 #pragma unroll
-                for (int p = 0; p < ASSIGN_POINTS_PER_THREAD; ++p) {
+                for (int p = 0; p < POINTS_PER_THREAD; ++p) {
 #pragma unroll
                     for (int c = 0; c < ASSIGN_CENTROIDS_PER_THREAD; ++c) {
                         const int global_centroid = centroid_start + centroid_col + c;
@@ -521,7 +522,7 @@ namespace lfs::io {
             const unsigned group_mask = 0xffffffffu;
             const int group_lane = tid % ASSIGN_CENTROID_GROUPS;
 #pragma unroll
-            for (int p = 0; p < ASSIGN_POINTS_PER_THREAD; ++p) {
+            for (int p = 0; p < POINTS_PER_THREAD; ++p) {
                 for (int offset = ASSIGN_CENTROID_GROUPS / 2; offset > 0; offset >>= 1) {
                     const float other_dist = __shfl_down_sync(
                         group_mask, best_dist[p], offset, ASSIGN_CENTROID_GROUPS);
@@ -1091,7 +1092,7 @@ namespace lfs::io {
             const Tensor& shN_swizzled,
             const int n,
             const int k,
-            const int iterations) {
+            const int iterations, const bool fast_assignment) {
             auto shN_gpu = as_cuda_contiguous(shN_swizzled);
             const auto* d_shN = reinterpret_cast<const float4*>(shN_gpu.ptr<float>());
 
@@ -1216,7 +1217,6 @@ namespace lfs::io {
             auto centroid_norms = Tensor::zeros({static_cast<size_t>(k)}, Device::CUDA, DataType::Float32);
 
             const int grid_n = (n + BLOCK_SIZE - 1) / BLOCK_SIZE;
-            const int grid_n_exact_assign = (n + ASSIGN_POINT_TILE - 1) / ASSIGN_POINT_TILE;
             const int grid_n_super_assign = (n + ASSIGN_POINT_TILE - 1) / ASSIGN_POINT_TILE;
 
             const int timed_iterations = std::max(0, iterations);
@@ -1271,9 +1271,7 @@ namespace lfs::io {
                 assign_timers[static_cast<size_t>(iter)].record_start();
 
                 if (use_exact) {
-                    assign_nearest_swizzled_bruteforce_kernel<N_DIMS><<<grid_n_exact_assign, BLOCK_SIZE>>>(
-                        d_shN, d_centroids, centroid_norms.ptr<float>(), labels.ptr<int>(), n, k);
-                    LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_nearest_swizzled");
+                    assign_sh3_labels(shN_gpu, centroids, centroid_norms, labels, fast_assignment);
                 } else {
                     supers_timers[static_cast<size_t>(iter)].record_start();
                     compute_centroid_norms_kernel<N_DIMS><<<grid_super, BLOCK_SIZE>>>(
@@ -1380,12 +1378,29 @@ namespace lfs::io {
 
     } // anonymous namespace
 
+    void assign_sh3_labels(const Tensor& shN_swizzled, const Tensor& centroids,
+                           const Tensor& centroid_norms, Tensor& labels, bool fast) {
+        const int n = static_cast<int>(labels.numel());
+        const int k = static_cast<int>(centroids.size(0));
+        const auto* sh = reinterpret_cast<const float4*>(shN_swizzled.ptr<float>());
+        if (fast) {
+            // Share each centroid load across four points. The point tile and
+            // every FP32 dot product/tie comparison match the ordinary kernel.
+            assign_nearest_swizzled_bruteforce_kernel<45, 4, 128><<<(n + ASSIGN_POINT_TILE - 1) / ASSIGN_POINT_TILE, 128>>>(
+                sh, centroids.ptr<float>(), centroid_norms.ptr<float>(), labels.ptr<int>(), n, k);
+        } else {
+            assign_nearest_swizzled_bruteforce_kernel<45><<<(n + ASSIGN_POINT_TILE - 1) / ASSIGN_POINT_TILE, BLOCK_SIZE>>>(
+                sh, centroids.ptr<float>(), centroid_norms.ptr<float>(), labels.ptr<int>(), n, k);
+        }
+        LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_sh3_labels");
+    }
+
     std::tuple<Tensor, Tensor> kmeans_sh_swizzled(
         const Tensor& shN_swizzled,
         const int n_points,
         const int sh_coeffs,
         const int k,
-        const int iterations) {
+        const int iterations, const bool fast_assignment) {
         if (!shN_swizzled.is_valid() || shN_swizzled.ndim() != 1 ||
             shN_swizzled.dtype() != DataType::Float32) {
             LOG_ERROR("kmeans_sh_swizzled expects a 1D float32 swizzled shN tensor");
@@ -1412,7 +1427,7 @@ namespace lfs::io {
             return kmeans_swizzled_bruteforce_impl<24>(shN_swizzled, n_points, k, iterations);
         case 45:
             if (k >= 4096) {
-                return kmeans_swizzled_hierarchical_impl<45>(shN_swizzled, n_points, k, iterations);
+                return kmeans_swizzled_hierarchical_impl<45>(shN_swizzled, n_points, k, iterations, fast_assignment);
             }
             return kmeans_swizzled_bruteforce_impl<45>(shN_swizzled, n_points, k, iterations);
         default:

--- a/src/io/cuda/kmeans.hpp
+++ b/src/io/cuda/kmeans.hpp
@@ -19,6 +19,7 @@ namespace lfs::io {
      * @param sh_coeffs Active SH-rest coefficient count (3, 8, or 15)
      * @param k Number of clusters
      * @param iterations Maximum iterations
+     * @param fast_assignment Use the exact streamed-export SH3 assignment tile
      * @return Tuple of (centroids [k, sh_coeffs * 3], labels [n_points])
      */
     std::tuple<Tensor, Tensor> kmeans_sh_swizzled(
@@ -26,6 +27,12 @@ namespace lfs::io {
         int n_points,
         int sh_coeffs,
         int k,
-        int iterations = 10);
+        int iterations = 10,
+        bool fast_assignment = false);
+
+    // Internal CUDA launcher: SH3 swizzled rows, float32 centroids/norms and
+    // preallocated int32 labels. Both tile shapes use identical FP32 dot products.
+    void assign_sh3_labels(const Tensor& shN_swizzled, const Tensor& centroids,
+                           const Tensor& centroid_norms, Tensor& labels, bool fast);
 
 } // namespace lfs::io

--- a/src/io/cuda/splat_decimate.cu
+++ b/src/io/cuda/splat_decimate.cu
@@ -184,6 +184,13 @@ namespace lfs::io::decimate {
                         break;
                 }
             } else {
+                // Establish a tight exact upper bound from nearby Morton rows
+                // before traversing broad, overlapping BVH boxes. These rows
+                // are excluded below so every point enters the heap only once.
+                const uint32_t seed_begin = t > 32 ? t - 32 : 0;
+                const uint32_t seed_end = min(n, seed_begin + 65);
+                for (uint32_t row = seed_begin; row < seed_end; ++row)
+                    consider(order[row]);
                 // At most one deferred sibling per depth; balanced heap depth <= 29.
                 uint32_t stack[32];
                 int sp = 0;
@@ -195,8 +202,8 @@ namespace lfs::io::decimate {
                     if (node >= leaves) {
                         uint32_t begin = (node - leaves) * leaf_size;
                         for (uint32_t t2 = begin; t2 < begin + leaf_size && t2 < n; ++t2) {
-                            uint32_t j = order[t2];
-                            consider(j);
+                            if (t2 < seed_begin || t2 >= seed_end)
+                                consider(order[t2]);
                         }
                     } else {
                         uint32_t left = node * 2, right = left + 1;

--- a/src/io/formats/sogs.cpp
+++ b/src/io/formats/sogs.cpp
@@ -1297,8 +1297,20 @@ namespace lfs::io {
             return tensor.cuda().contiguous();
         }
 
-        int nearest_centroid_1d(const std::vector<float>& centroids, float value) {
-            auto it = std::lower_bound(centroids.begin(), centroids.end(), value);
+        int nearest_centroid_1d(const std::vector<float>& centroids, float value, int hint = -1) {
+            auto it = centroids.begin();
+            if (hint < 0 || !std::isfinite(value)) {
+                it = std::lower_bound(centroids.begin(), centroids.end(), value);
+            } else {
+                // Lloyd updates usually move a label only a few bins. Recover
+                // the same lower_bound (including duplicate-centroid ties)
+                // from its previous label instead of restarting binary search.
+                it += hint;
+                while (it != centroids.begin() && *(it - 1) >= value)
+                    --it;
+                while (it != centroids.end() && *it < value)
+                    ++it;
+            }
             int best = static_cast<int>(std::distance(centroids.begin(), it));
             if (best >= static_cast<int>(centroids.size())) {
                 best = static_cast<int>(centroids.size()) - 1;
@@ -1456,7 +1468,7 @@ namespace lfs::io {
             std::vector<uint8_t> labels;
         };
 
-        Cluster1dResult cluster1d(const float* data, int num_rows, int num_columns, int iterations) {
+        Cluster1dResult cluster1d(const float* data, int num_rows, int num_columns, int iterations, bool pooled = false) {
             constexpr int K = 256;
             const size_t total_points = static_cast<size_t>(num_rows) * static_cast<size_t>(num_columns);
 
@@ -1488,14 +1500,16 @@ namespace lfs::io {
             const size_t worker_count = std::max<size_t>(
                 1, std::min<size_t>(hw_threads, (total_points + 65535) / 65536));
 
+            bool use_hints = false;
             auto accumulate_range = [&](size_t begin, size_t end, const bool write_labels, LocalAccum& accum) {
                 for (size_t linear = begin; linear < end; ++linear) {
                     const int col = static_cast<int>(linear / static_cast<size_t>(num_rows));
                     const int row = static_cast<int>(linear - static_cast<size_t>(col) * static_cast<size_t>(num_rows));
                     const float value = data[row * num_columns + col];
-                    const int label = nearest_centroid_1d(centroid_vals, value);
+                    const int label = nearest_centroid_1d(centroid_vals, value,
+                                                          use_hints ? result.labels[linear] : -1);
 
-                    if (write_labels) {
+                    if (write_labels || pooled) {
                         result.labels[linear] = static_cast<uint8_t>(label);
                     }
                     accum.sums[label] += static_cast<double>(value);
@@ -1510,6 +1524,14 @@ namespace lfs::io {
 
                 if (worker_count == 1) {
                     accumulate_range(0, total_points, write_labels, accumulators[0]);
+                } else if (pooled) {
+                    // Preserve the reference reduction ranges and order, while
+                    // sharing existing workers across simultaneous SSOG units.
+                    tbb::parallel_for(size_t{0}, worker_count, [&](size_t worker) {
+                        accumulate_range(total_points * worker / worker_count,
+                                         total_points * (worker + 1) / worker_count,
+                                         write_labels, accumulators[worker]);
+                    });
                 } else {
                     std::vector<std::thread> workers;
                     workers.reserve(worker_count);
@@ -1534,6 +1556,8 @@ namespace lfs::io {
                         centroid_vals[c] = static_cast<float>(sum / static_cast<double>(count));
                     }
                 }
+                use_hints = pooled && std::is_sorted(centroid_vals.begin(), centroid_vals.end()) &&
+                            std::all_of(centroid_vals.begin(), centroid_vals.end(), [](float v) { return std::isfinite(v); });
             }
 
             std::vector<int> order(K);
@@ -1738,11 +1762,17 @@ namespace lfs::io {
                 sh_kmeans_future = std::async(
                     std::launch::async,
                     [shN_float_swizzled, num_rows, sh_coeffs, palette_size,
-                     iterations = options.kmeans_iterations, export_started]() mutable {
+                     iterations = options.kmeans_iterations, fast = options.fast_webp, export_started]() mutable {
                         const auto started = std::chrono::steady_clock::now();
                         auto [centroids, labels] = lfs::io::kmeans_sh_swizzled(
                             shN_float_swizzled, static_cast<int>(num_rows), sh_coeffs,
-                            palette_size, iterations);
+                            palette_size, iterations, fast);
+                        if (fast) {
+                            // Deliver CPU inputs with the future so packing can
+                            // proceed without a later default-stream readback.
+                            centroids = centroids.to_pageable_host();
+                            labels = labels.to_pageable_host();
+                        }
                         const auto finished = std::chrono::steady_clock::now();
                         return ShKmeansResult{
                             std::move(centroids),
@@ -1810,8 +1840,10 @@ namespace lfs::io {
                                       std::format("Invalid WebP configuration for '{}'", image.filename),
                                       options.output_path);
                 }
-                config.method = options.fast_webp ? 1 : image.method;
-                config.quality = options.fast_webp ? 75.0f : image.quality;
+                // Streamed units favor decode-exact, low-effort compression.
+                // In lossless mode quality controls search effort, not pixels.
+                config.method = options.fast_webp ? 0 : image.method;
+                config.quality = options.fast_webp ? 0.0f : image.quality;
                 config.exact = 1;
                 if (!WebPValidateConfig(&config)) {
                     return make_error(ErrorCode::ENCODING_FAILED,
@@ -2094,7 +2126,7 @@ namespace lfs::io {
             }
 
             const auto cluster_scales_started = std::chrono::steady_clock::now();
-            auto scale_result = cluster1d(scales_ptr, static_cast<int>(num_rows), 3, options.kmeans_iterations);
+            auto scale_result = cluster1d(scales_ptr, static_cast<int>(num_rows), 3, options.kmeans_iterations, options.fast_webp);
             cluster_scales_ms = milliseconds(cluster_scales_started, std::chrono::steady_clock::now());
             std::vector<uint8_t> scales_data(width * height * CHANNELS, 0);
             const auto scales_pack_started = std::chrono::steady_clock::now();
@@ -2120,7 +2152,7 @@ namespace lfs::io {
             }
 
             const auto cluster_sh0_started = std::chrono::steady_clock::now();
-            auto color_result = cluster1d(sh0_ptr, static_cast<int>(num_rows), 3, options.kmeans_iterations);
+            auto color_result = cluster1d(sh0_ptr, static_cast<int>(num_rows), 3, options.kmeans_iterations, options.fast_webp);
             cluster_sh0_ms = milliseconds(cluster_sh0_started, std::chrono::steady_clock::now());
 
             std::vector<uint8_t> sh0_data(width * height * CHANNELS, 0);
@@ -2197,7 +2229,7 @@ namespace lfs::io {
                 }
 
                 const auto codebook_started = std::chrono::steady_clock::now();
-                auto codebook_result = cluster1d(sh_centroids_grouped.data(), actual_palette_size, sh_dims, options.kmeans_iterations);
+                auto codebook_result = cluster1d(sh_centroids_grouped.data(), actual_palette_size, sh_dims, options.kmeans_iterations, options.fast_webp);
                 kmeans_sh_ms = sh_kmeans_data.milliseconds +
                                milliseconds(codebook_started, std::chrono::steady_clock::now());
 

--- a/src/io/formats/ssog.cpp
+++ b/src/io/formats/ssog.cpp
@@ -16,7 +16,6 @@
 #include <climits>
 #include <cmath>
 #include <cuda_runtime.h>
-#include <deque>
 #include <fstream>
 #include <map>
 #include <mutex>
@@ -25,6 +24,8 @@
 #include <regex>
 #include <set>
 #include <tbb/parallel_for.h>
+#include <tbb/parallel_invoke.h>
+#include <thread>
 #ifdef _WIN32
 #include <process.h>
 #else
@@ -540,7 +541,7 @@ namespace lfs::io {
             const double level_rows = input.size() * (1.0 - std::pow(double(o.lod_ratio), o.lod_levels)) / (1.0 - o.lod_ratio);
             const double resident_bytes = level_rows * (14 + 3 * input.max_sh_coeffs_rest()) * sizeof(float);
             // Reserve most available VRAM for decimation, original storage, and
-            // two encoder workspaces. Large scenes retain pageable level staging.
+            // bounded encoder workspaces. Large scenes retain pageable level staging.
             const bool resident = memory_known && resident_bytes < std::min<double>(1024.0 * 1024 * 1024, free_cuda * 0.25);
             LOG_DEBUG("SSOG level storage: resident={} estimated_bytes={:.0f} free_cuda={}", resident, resident_bytes, free_cuda);
             levels.emplace_back(input, resident);
@@ -606,50 +607,91 @@ namespace lfs::io {
             }
             std::vector<int> indices(cum.back());
             std::iota(indices.begin(), indices.end(), 0);
-            std::vector<TreeNode> tree;
-            const auto split = [&](auto&& self, size_t begin, size_t end) -> int {
+            size_t tree_leaves = 1;
+            while ((total + tree_leaves - 1) / tree_leaves > 256)
+                tree_leaves *= 2;
+            // Fixed heap slots let disjoint median partitions run concurrently.
+            // Each partition retains the same nth_element input and tie order.
+            std::vector<TreeNode> tree(tree_leaves * 2 - 1);
+            const auto split = [&](auto&& self, size_t begin, size_t end, int node) -> void {
                 Bound box;
                 for (size_t i = begin; i < end; ++i)
                     for (int a = 0; a < 3; ++a) {
                         box.min[a] = std::min(box.min[a], double(positions[indices[i]][a]));
                         box.max[a] = std::max(box.max[a], double(positions[indices[i]][a]));
                     }
-                const int node = static_cast<int>(tree.size());
-                tree.push_back({begin, end, box});
+                tree[node] = {begin, end, box};
                 if (end - begin > 256) {
                     const auto mid = begin + (end - begin) / 2;
                     const int a = box.axis();
                     std::nth_element(indices.begin() + begin, indices.begin() + mid, indices.begin() + end, [&](int i, int j) { return positions[i][a] < positions[j][a]; });
-                    const int left = self(self, begin, mid), right = self(self, mid, end);
+                    const int left = node * 2 + 1, right = left + 1;
                     tree[node].left = left;
                     tree[node].right = right;
+                    if (end - begin >= 16384) {
+                        tbb::parallel_invoke([&] { self(self, begin, mid, left); },
+                                             [&] { self(self, mid, end, right); });
+                    } else {
+                        self(self, begin, mid, left);
+                        self(self, mid, end, right);
+                    }
                 }
-                return node;
             };
-            split(split, 0, indices.size());
+            split(split, 0, indices.size(), 0);
             const size_t bin_size = size_t(o.chunk_count_k) * 1024, bin_min = size_t(o.chunk_min_k) * 1024;
             std::vector<Unit> units;
             std::vector<int> current(o.lod_levels, -1), next(o.lod_levels, 0);
             std::vector<std::string> filenames;
+            const auto splits_node = [&](const TreeNode& node) {
+                const int a = node.centroids.axis();
+                return node.left >= 0 && (node.end - node.begin > bin_size ||
+                                          (node.centroids.max[a] - node.centroids.min[a] > o.chunk_extent && node.end - node.begin > bin_min));
+            };
+            std::vector<int> leaf_ids;
+            const auto collect_leaves = [&](auto&& self, int id) -> void {
+                if (splits_node(tree[id])) {
+                    self(self, tree[id].left);
+                    self(self, tree[id].right);
+                } else {
+                    leaf_ids.push_back(id);
+                }
+            };
+            collect_leaves(collect_leaves, 0);
+            struct LeafData {
+                std::vector<std::vector<int>> bins;
+                Bound bound;
+            };
+            std::vector<LeafData> leaf_data(leaf_ids.size());
+            // Row membership and bounds are independent per leaf. Preserve the
+            // original row traversal within each leaf and assemble files below
+            // in depth-first order so offsets, ties and filenames stay exact.
+            tbb::parallel_for(size_t{0}, leaf_ids.size(), [&](size_t leaf) {
+                const auto& node = tree[leaf_ids[leaf]];
+                auto& data = leaf_data[leaf];
+                data.bins.resize(o.lod_levels);
+                for (size_t i = node.begin; i < node.end; ++i) {
+                    const int flat = indices[i];
+                    const int l = static_cast<int>(std::upper_bound(cum.begin(), cum.end(), flat) - cum.begin() - 1);
+                    data.bins[l].push_back(static_cast<int>(flat - cum[l]));
+                    data.bound.add(bounds[flat]);
+                }
+            });
+            size_t next_leaf = 0;
             const auto build = [&](auto&& self, int id) -> std::pair<Json, Bound> {
                 const auto& node = tree[id];
-                const int a = node.centroids.axis();
-                if (node.left >= 0 && (node.end - node.begin > bin_size || (node.centroids.max[a] - node.centroids.min[a] > o.chunk_extent && node.end - node.begin > bin_min))) {
+                if (splits_node(node)) {
                     auto [left, lb] = self(self, node.left);
                     auto [right, rb] = self(self, node.right);
                     lb.add(rb);
                     return {Json{{"bound", lb.json()}, {"children", Json::array({std::move(left), std::move(right)})}}, lb};
                 }
-                std::map<int, std::vector<int>> bins;
-                Bound bound;
-                for (size_t i = node.begin; i < node.end; ++i) {
-                    const int flat = indices[i];
-                    const int l = static_cast<int>(std::upper_bound(cum.begin(), cum.end(), flat) - cum.begin() - 1);
-                    bins[l].push_back(static_cast<int>(flat - cum[l]));
-                    bound.add(bounds[flat]);
-                }
+                auto& data = leaf_data[next_leaf++];
+                const auto bound = data.bound;
                 Json lods = Json::object();
-                for (auto& [l, rows] : bins) {
+                for (int l = 0; l < o.lod_levels; ++l) {
+                    const auto& rows = data.bins[l];
+                    if (rows.empty())
+                        continue;
                     if (current[l] < 0) {
                         current[l] = static_cast<int>(units.size());
                         const int index = next[l]++;
@@ -667,6 +709,8 @@ namespace lfs::io {
                 return {Json{{"bound", bound.json()}, {"lods", std::move(lods)}}, bound};
             };
             auto [root, bound] = build(build, 0);
+            leaf_data.clear();
+            leaf_data.shrink_to_fit();
             tree.clear();
             tree.shrink_to_fit();
             positions.clear();
@@ -678,7 +722,21 @@ namespace lfs::io {
             const auto partitioned = Clock::now();
             double morton_ms = 0, encode_ms = 0;
             auto stamp = o.provenance.value_or(core::make_minimal_provenance_stamp());
-            constexpr size_t workers = 2;
+            // Retain the two-workspace bound for pageable large scenes. Small
+            // resident scenes may overlap more units if there is space for their
+            // gathers, swizzled SH, labels and palette scratch in addition to LODs.
+            const auto largest_unit = std::max_element(units.begin(), units.end(), [](const auto& a, const auto& b) {
+                return a.rows.size() < b.rows.size();
+            });
+            const double workspace_bytes = largest_unit->rows.size() *
+                                               (32.0 + 6 * input.max_sh_coeffs_rest()) * sizeof(float) +
+                                           128.0 * 1024 * 1024;
+            const size_t resident_workers = resident
+                                                ? std::max<size_t>(1, (free_cuda - resident_bytes) / workspace_bytes)
+                                                : 1;
+            const size_t workers = std::min(units.size(), resident
+                                                              ? std::min(resident_workers, std::clamp<size_t>(std::thread::hardware_concurrency() / 6, 1, 4))
+                                                              : size_t{2});
             struct UnitTiming {
                 double morton, encode;
             };
@@ -729,23 +787,33 @@ namespace lfs::io {
                 LOG_DEBUG("SSOG unit: file={} level={} rows={} leaves={} morton_ms={:.3f} gather_ms={:.3f} encode_ms={:.3f}", filenames[f], u.level, u.rows.size(), u.bins.size(), sort_ms, std::chrono::duration<double, std::milli>(gathered - encode_start).count(), std::chrono::duration<double, std::milli>(Clock::now() - gathered).count());
                 return UnitTiming{sort_ms, std::chrono::duration<double, std::milli>(Clock::now() - encode_start).count()};
             };
-            std::deque<std::future<Result<UnitTiming>>> pending;
-            size_t next_unit = 0;
-            const auto launch = [&] {
-                const size_t f = next_unit++;
-                pending.push_back(std::async(std::launch::async, [&, f] { return encode_unit(f); }));
-            };
-            while (next_unit < std::min(workers, units.size()))
-                launch();
-            while (!pending.empty()) {
-                auto result = pending.front().get();
-                pending.pop_front();
+            std::atomic_size_t next_unit{0};
+            std::atomic_bool failed{false};
+            std::vector<std::future<Result<UnitTiming>>> pending;
+            for (size_t worker = 0; worker < std::min(workers, units.size()); ++worker) {
+                pending.push_back(std::async(std::launch::async, [&]() -> Result<UnitTiming> {
+                    UnitTiming timing{};
+                    while (!failed.load()) {
+                        const size_t task = next_unit.fetch_add(1);
+                        if (task >= units.size())
+                            break;
+                        auto result = encode_unit(task);
+                        if (!result) {
+                            failed.store(true);
+                            return std::unexpected(result.error());
+                        }
+                        timing.morton += result->morton;
+                        timing.encode += result->encode;
+                    }
+                    return timing;
+                }));
+            }
+            for (auto& worker : pending) {
+                auto result = worker.get();
                 if (!result)
                     return std::unexpected(result.error());
                 morton_ms += result->morton;
                 encode_ms += result->encode;
-                if (next_unit < units.size())
-                    launch();
             }
             Json manifest{{"version", 1}, {"asset", {{"generator", "LichtFeld Studio"}, {"chunkGaussians", bin_size}, {"chunkExtent", o.chunk_extent}, {"chunkMinGaussians", bin_min}}}, {"count", cum.back()}, {"counts", counts}, {"lodLevels", o.lod_levels}, {"lodErrors", false}, {"filenames", filenames}, {"tree", std::move(root)}};
             round_numbers(manifest);

--- a/tests/test_sog_format.cpp
+++ b/tests/test_sog_format.cpp
@@ -22,14 +22,17 @@
 #include <webp/decode.h>
 #include <webp/encode.h>
 
+#include "core/cuda/sh_layout.cuh"
 #include "core/splat_data.hpp"
 #include "core/tensor.hpp"
+#include "io/cuda/kmeans.hpp"
 #include "io/exporter.hpp"
 #include "io/formats/ply.hpp"
 #include "io/formats/sogs.hpp"
 #include "io/loader.hpp"
 
 #include <algorithm>
+#include <random>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -685,56 +688,96 @@ TEST_F(SogFormatTest, LoaderRoutesSogThroughSplatAllocator) {
 TEST_F(SogFormatTest, BundleAndDirectoryPayloadsMatch) {
     using namespace lfs::core;
     using namespace lfs::io;
-    ScopedSogDirectory dir;
-    constexpr size_t n = 2048;
-    SplatData splats(1, Tensor::randn({n, 3}, Device::CUDA),
-                     Tensor::randn({n, 1, 3}, Device::CUDA), Tensor::randn({n, 3, 3}, Device::CUDA),
-                     Tensor::full({n, 3}, -3.0f, Device::CUDA), Tensor::randn({n, 4}, Device::CUDA),
-                     Tensor::zeros({n, 1}, Device::CUDA), 1);
-    const auto stamp = make_minimal_provenance_stamp();
-    const auto bundle = dir.path() / "bundle.sog";
-    auto saved = save_sog(splats, {.output_path = bundle, .provenance = stamp});
-    ASSERT_TRUE(saved) << saved.error().format();
-    SogEncodeOptions o;
-    o.output_path = dir.path() / "directory";
-    o.provenance = stamp;
-    auto encoded = encode_sog_directory(splats, o);
-    ASSERT_TRUE(encoded) << encoded.error().format();
-    auto fast = o;
-    fast.output_path = dir.path() / "fast_directory";
-    fast.fast_webp = true;
-    ASSERT_TRUE(encode_sog_directory(splats, fast));
-    std::unique_ptr<archive, decltype(&archive_read_free)> input(archive_read_new(), archive_read_free);
-    ASSERT_EQ(archive_read_support_format_zip(input.get()), ARCHIVE_OK);
+    // Both fixtures bypass stochastic SH palette initialization (n == palette
+    // size). SH3 also exercises every pooled 1D reduction with multiple workers.
+    for (const auto [n, degree] : {std::pair<size_t, int>{2048, 1}, {65536, 3}}) {
+        SCOPED_TRACE(n);
+        ScopedSogDirectory dir;
+        SplatData splats(degree, Tensor::randn({n, 3}, Device::CUDA),
+                         Tensor::randn({n, 1, 3}, Device::CUDA), Tensor::randn({n, size_t((degree + 1) * (degree + 1) - 1), 3}, Device::CUDA),
+                         Tensor::full({n, 3}, -3.0f, Device::CUDA), Tensor::randn({n, 4}, Device::CUDA),
+                         Tensor::zeros({n, 1}, Device::CUDA), 1);
+        const auto stamp = make_minimal_provenance_stamp();
+        const auto bundle = dir.path() / "bundle.sog";
+        auto saved = save_sog(splats, {.output_path = bundle, .provenance = stamp});
+        ASSERT_TRUE(saved) << saved.error().format();
+        SogEncodeOptions o;
+        o.output_path = dir.path() / "directory";
+        o.provenance = stamp;
+        auto encoded = encode_sog_directory(splats, o);
+        ASSERT_TRUE(encoded) << encoded.error().format();
+        auto fast = o;
+        fast.output_path = dir.path() / "fast_directory";
+        fast.fast_webp = true;
+        ASSERT_TRUE(encode_sog_directory(splats, fast));
+        std::unique_ptr<archive, decltype(&archive_read_free)> input(archive_read_new(), archive_read_free);
+        ASSERT_EQ(archive_read_support_format_zip(input.get()), ARCHIVE_OK);
 #ifdef _WIN32
-    ASSERT_EQ(archive_read_open_filename_w(input.get(), bundle.wstring().c_str(), 10240), ARCHIVE_OK);
+        ASSERT_EQ(archive_read_open_filename_w(input.get(), bundle.wstring().c_str(), 10240), ARCHIVE_OK);
 #else
-    ASSERT_EQ(archive_read_open_filename(input.get(), bundle.c_str(), 10240), ARCHIVE_OK);
+        ASSERT_EQ(archive_read_open_filename(input.get(), bundle.c_str(), 10240), ARCHIVE_OK);
 #endif
-    archive_entry* entry = nullptr;
-    std::vector<std::string> names;
-    while (archive_read_next_header(input.get(), &entry) == ARCHIVE_OK) {
-        const std::string name = archive_entry_pathname(entry);
-        names.push_back(name);
-        std::string bytes(static_cast<size_t>(archive_entry_size(entry)), '\0');
-        ASSERT_EQ(archive_read_data(input.get(), bytes.data(), bytes.size()), static_cast<la_ssize_t>(bytes.size()));
-        std::ifstream file(o.output_path / name, std::ios::binary);
-        const std::string other((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-        EXPECT_EQ(bytes, other) << name;
-        std::ifstream fast_file(fast.output_path / name, std::ios::binary);
-        const std::string fast_bytes((std::istreambuf_iterator<char>(fast_file)), std::istreambuf_iterator<char>());
-        if (name.ends_with(".webp")) {
-            int w = 0, h = 0, fw = 0, fh = 0;
-            std::unique_ptr<uint8_t, decltype(&WebPFree)> pixels(WebPDecodeRGBA(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size(), &w, &h), WebPFree);
-            std::unique_ptr<uint8_t, decltype(&WebPFree)> fast_pixels(WebPDecodeRGBA(reinterpret_cast<const uint8_t*>(fast_bytes.data()), fast_bytes.size(), &fw, &fh), WebPFree);
-            ASSERT_TRUE(pixels);
-            ASSERT_TRUE(fast_pixels);
-            ASSERT_EQ(w, fw);
-            ASSERT_EQ(h, fh);
-            EXPECT_TRUE(std::equal(pixels.get(), pixels.get() + size_t(w) * h * 4, fast_pixels.get())) << name;
-        } else {
-            EXPECT_EQ(bytes, fast_bytes) << name;
+        archive_entry* entry = nullptr;
+        std::vector<std::string> names;
+        while (archive_read_next_header(input.get(), &entry) == ARCHIVE_OK) {
+            const std::string name = archive_entry_pathname(entry);
+            names.push_back(name);
+            std::string bytes(static_cast<size_t>(archive_entry_size(entry)), '\0');
+            ASSERT_EQ(archive_read_data(input.get(), bytes.data(), bytes.size()), static_cast<la_ssize_t>(bytes.size()));
+            std::ifstream file(o.output_path / name, std::ios::binary);
+            const std::string other((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+            EXPECT_EQ(bytes, other) << name;
+            std::ifstream fast_file(fast.output_path / name, std::ios::binary);
+            const std::string fast_bytes((std::istreambuf_iterator<char>(fast_file)), std::istreambuf_iterator<char>());
+            if (name.ends_with(".webp")) {
+                int w = 0, h = 0, fw = 0, fh = 0;
+                std::unique_ptr<uint8_t, decltype(&WebPFree)> pixels(WebPDecodeRGBA(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size(), &w, &h), WebPFree);
+                std::unique_ptr<uint8_t, decltype(&WebPFree)> fast_pixels(WebPDecodeRGBA(reinterpret_cast<const uint8_t*>(fast_bytes.data()), fast_bytes.size(), &fw, &fh), WebPFree);
+                ASSERT_TRUE(pixels);
+                ASSERT_TRUE(fast_pixels);
+                ASSERT_EQ(w, fw);
+                ASSERT_EQ(h, fh);
+                EXPECT_TRUE(std::equal(pixels.get(), pixels.get() + size_t(w) * h * 4, fast_pixels.get())) << name;
+            } else {
+                EXPECT_EQ(bytes, fast_bytes) << name;
+            }
+        }
+        EXPECT_EQ(names, (std::vector<std::string>{"means_l.webp", "means_u.webp", "quats.webp", "scales.webp", "sh0.webp", "shN_centroids.webp", "shN_labels.webp", "meta.json"}));
+    }
+}
+
+TEST_F(SogFormatTest, StreamedSh3AssignmentMatchesReferenceTiles) {
+    using namespace lfs::core;
+    using namespace lfs::io;
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> value(-1.0f, 1.0f);
+    for (const size_t n : {1, 127, 128, 129, 4097}) {
+        for (const size_t k : {1, 31, 32, 33, 4097, 65536}) {
+            SCOPED_TRACE(std::format("n={} k={}", n, k));
+            auto points = Tensor::zeros({sh_swizzled_float_count(n, 15)}, Device::CPU);
+            auto centroids = Tensor::empty({k, 45}, Device::CPU);
+            auto norms = Tensor::zeros({k}, Device::CPU);
+            for (size_t i = 0; i < k; ++i) {
+                for (size_t d = 0; d < 45; ++d) {
+                    const float v = i && i % 7 == 0 ? centroids.ptr<float>()[d] : value(rng);
+                    centroids.ptr<float>()[i * 45 + d] = v;
+                    norms.ptr<float>()[i] = std::fma(v, v, norms.ptr<float>()[i]);
+                }
+            }
+            for (size_t i = 0; i < n; ++i)
+                for (size_t d = 0; d < 45; ++d)
+                    points.ptr<float>()[sh_swizzled_index(i, d / 4, 15) * 4 + d % 4] =
+                        i ? value(rng) : centroids.ptr<float>()[d];
+            points = points.cuda();
+            centroids = centroids.cuda();
+            norms = norms.cuda();
+            auto ordinary = Tensor::zeros({n}, Device::CUDA, DataType::Int32);
+            auto streamed = Tensor::zeros({n}, Device::CUDA, DataType::Int32);
+            assign_sh3_labels(points, centroids, norms, ordinary, false);
+            assign_sh3_labels(points, centroids, norms, streamed, true);
+            const auto reference = ordinary.cpu(), actual = streamed.cpu();
+            EXPECT_TRUE(std::equal(reference.ptr<int>(), reference.ptr<int>() + n, actual.ptr<int>()));
+            EXPECT_EQ(actual.ptr<int>()[0], 0);
         }
     }
-    EXPECT_EQ(names, (std::vector<std::string>{"means_l.webp", "means_u.webp", "quats.webp", "scales.webp", "sh0.webp", "shN_centroids.webp", "shN_labels.webp", "meta.json"}));
 }


### PR DESCRIPTION
Streamed SOG export is now 2.6x faster on a 1M scene and 2.9x on a 9.2M scene, with identical output.

| Scene | Before | After |
|---|---:|---:|
| Garden 1M, 4 levels, exporter | 3.15 s | 1.21 s |
| Garden, CLI wall | 3.6 s | 1.67 s |
| 9.2M scene, exporter | 27.2 s | 9.3 s |
| 9.2M scene, CLI wall | 29.9 s | 10.6 s |

What changed
- Decimation: exact nearest-neighbour search seeds its top-k from nearby Morton rows before walking the BVH, and caches fixed samples in double precision. Same neighbours, three times faster.
- Partition: median splits and per-leaf binning run in parallel on fixed tree slots. The manifest is written serially and is identical.
- SH palette k-means (streamed exports only): a half-precision tensor-core pass rejects centroids that cannot win, then every remaining candidate is scored with the original FP32 sequence and tie rule. Labels are identical. A four-point tile reuses centroid loads in the refinement pass.
- Unit encoding: pooled 1D clustering with label hints, lossless WebP at effort 0, k-means results handed to the CPU with the future.
- Level storage: immutable CUDA tensors are borrowed instead of cloned, more LOD rows stay resident (up to 6 GiB or 45% of free VRAM), and large scenes use up to six workers under the same workspace budget. Peak: 8.8 GiB VRAM and 4.4 GiB RSS on the 9.2M scene.

Plain SOG export keeps its settings and code path.

Checks
- Base attribute images decode byte-identical to the previous encoder (25 garden, 170 large-scene images). Tree, unit layout, counts and bounds unchanged. PlayCanvas splat-transform reads both outputs.
- Rendered views with a matched k-means seed differ by under 0.002 dB.
- C++ SSOG/decimation/SOG tests pass, compute-sanitizer memcheck and synccheck clean, error-debt and I/O gates pass.
