### PR TITLE
SSOG: fix the error-debt gate and take export to 2.6x

### DIFF
--- a/src/io/cuda/kmeans.cu
+++ b/src/io/cuda/kmeans.cu
@@ -1388,11 +1388,12 @@ namespace lfs::io {
             // every FP32 dot product/tie comparison match the ordinary kernel.
             assign_nearest_swizzled_bruteforce_kernel<45, 4, 128><<<(n + ASSIGN_POINT_TILE - 1) / ASSIGN_POINT_TILE, 128>>>(
                 sh, centroids.ptr<float>(), centroid_norms.ptr<float>(), labels.ptr<int>(), n, k);
+            LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_sh3_labels");
         } else {
             assign_nearest_swizzled_bruteforce_kernel<45><<<(n + ASSIGN_POINT_TILE - 1) / ASSIGN_POINT_TILE, BLOCK_SIZE>>>(
                 sh, centroids.ptr<float>(), centroid_norms.ptr<float>(), labels.ptr<int>(), n, k);
+            LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_sh3_labels");
         }
-        LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_sh3_labels");
     }
 
     std::tuple<Tensor, Tensor> kmeans_sh_swizzled(

--- a/src/io/cuda/kmeans.cu
+++ b/src/io/cuda/kmeans.cu
@@ -8,7 +8,9 @@
 #include "kmeans.hpp"
 #include <algorithm>
 #include <cmath>
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#include <mma.h>
 #include <numeric>
 #include <optional>
 #include <random>
@@ -419,6 +421,127 @@ namespace lfs::io {
             }
         }
 
+        __global__ void prepare_half_sh_kernel(const float4* sh, const float* centroids, half* points, half* palette, int n, int k) {
+            const int i = blockIdx.x * blockDim.x + threadIdx.x;
+            const int row = i / 48, d = i % 48;
+            const int np = (n + 127) / 128 * 128, kp = (k + 31) / 32 * 32;
+            if (row < np) {
+                float v = 0;
+                if (row < n && d < 45) {
+                    const auto slot = sh[shAt_device(row, d / 4, 12)];
+                    v = reinterpret_cast<const float*>(&slot)[d % 4];
+                }
+                points[i] = __float2half_rn(v);
+            }
+            if (row < kp)
+                palette[i] = __float2half_rn(row < k && d < 45 ? centroids[row * 45 + d] : 0);
+        }
+
+        // Half-precision products only reject distant candidates. Every possible
+        // winner is evaluated with the reference FP32 FMA sequence and tie rule.
+        __global__ void assign_sh3_screened_kernel(
+            const float4* __restrict__ shN, const float* __restrict__ centroids,
+            const float* __restrict__ centroid_norms, int* __restrict__ labels,
+            const int n, const int k, const half* half_points, const half* half_centroids, bool have_labels) {
+            constexpr int P = 128, C = 32, D = 48;
+            __shared__ float points[P][49];
+            // Four lanes consume each row; padding avoids eight-way bank
+            // conflicts between the eight different rows read by a warp.
+            __shared__ __align__(32) float approx[P][C + 4];
+            __shared__ float point_norm[P], norms[C];
+            __shared__ int point_safe[P];
+            const int tid = threadIdx.x;
+            const int row = tid / 4, lane = tid % 4;
+            const int start = blockIdx.x * P;
+            for (int i = tid; i < P * D; i += 512) {
+                const int p = i / D, d = i % D;
+                float v = 0;
+                if (start + p < n && d < 45) {
+                    const auto slot = shN[shAt_device(start + p, d / 4, 12)];
+                    v = reinterpret_cast<const float*>(&slot)[d % 4];
+                }
+                points[p][d] = v;
+            }
+            __syncthreads();
+            if (tid < P) {
+                float norm = 0;
+                int safe = 1;
+                for (int d = 0; d < 45; ++d) {
+                    const float v = points[tid][d];
+                    norm = fmaf(v, v, norm);
+                    safe &= isfinite(v) && fabsf(v) <= 65000;
+                }
+                point_norm[tid] = norm;
+                point_safe[tid] = safe;
+            }
+            float best = 1e30f;
+            int best_id = k;
+            if (have_labels && start + row < n) {
+                const int seed = labels[start + row];
+                if (seed >= 0 && seed < k) {
+                    float dot = 0;
+#pragma unroll
+                    for (int d = 0; d < 45; ++d)
+                        dot = fmaf(points[row][d], centroids[seed * 45 + d], dot);
+                    const float dist = fmaf(-2.0f, dot, centroid_norms[seed]);
+                    if (dist <= best) {
+                        best = dist;
+                        best_id = seed;
+                    }
+                }
+            }
+            __syncthreads();
+            const int warp = tid / 32;
+            nvcuda::wmma::fragment<nvcuda::wmma::matrix_a, 16, 16, 16, half, nvcuda::wmma::row_major> a[3];
+            for (int d = 0; d < D; d += 16)
+                nvcuda::wmma::load_matrix_sync(a[d / 16], half_points + (start + (warp / 2) * 16) * D + d, D);
+            for (int base = 0; base < k; base += C) {
+                if (tid < C)
+                    norms[tid] = base + tid < k ? centroid_norms[base + tid] : 0;
+                nvcuda::wmma::fragment<nvcuda::wmma::matrix_b, 16, 16, 16, half, nvcuda::wmma::col_major> b;
+                nvcuda::wmma::fragment<nvcuda::wmma::accumulator, 16, 16, 16, float> acc;
+                nvcuda::wmma::fill_fragment(acc, 0.0f);
+                for (int d = 0; d < D; d += 16) {
+                    nvcuda::wmma::load_matrix_sync(b, half_centroids + (base + (warp % 2) * 16) * D + d, D);
+                    nvcuda::wmma::mma_sync(acc, a[d / 16], b, acc);
+                }
+                nvcuda::wmma::store_matrix_sync(&approx[(warp / 2) * 16][(warp % 2) * 16], acc, C + 4, nvcuda::wmma::mem_row_major);
+                __syncthreads();
+                for (int c = lane; c < C && base + c < k; c += 4) {
+                    const float estimate = fmaf(-2.0f, approx[row][c], norms[c]);
+                    // Half rounding contributes at most (2*u+u*u)*(||x||^2+
+                    // ||c||^2), u=2^-11, to the score. The remaining relative
+                    // allowance and 1e-8 cover half subnormals and FP32
+                    // accumulation/norm/score rounding (45 coefficients).
+                    // Out-of-range values always take the reference path.
+                    const float margin = 0.0011f * (point_norm[row] + norms[c]) + 1e-8f;
+                    if (!point_safe[row] || !(norms[c] >= 0 && norms[c] < 4.0e9f) || !isfinite(estimate) || estimate <= best + margin) {
+                        float dot = 0;
+#pragma unroll
+                        for (int d = 0; d < 45; ++d)
+                            dot = fmaf(points[row][d], centroids[(base + c) * 45 + d], dot);
+                        const float dist = fmaf(-2.0f, dot, norms[c]);
+                        const int id = base + c;
+                        if (dist < best || (dist == best && id < best_id)) {
+                            best = dist;
+                            best_id = id;
+                        }
+                    }
+                }
+                for (int delta = 2; delta > 0; delta /= 2) {
+                    const float other = __shfl_xor_sync(0xffffffffu, best, delta, 4);
+                    const int id = __shfl_xor_sync(0xffffffffu, best_id, delta, 4);
+                    if (other < best || (other == best && id < best_id)) {
+                        best = other;
+                        best_id = id;
+                    }
+                }
+                __syncthreads();
+            }
+            if (lane == 0 && start + row < n)
+                labels[start + row] = best_id;
+        }
+
         template <int N_DIMS, int POINTS_PER_THREAD = ASSIGN_POINTS_PER_THREAD, int THREAD_COUNT = BLOCK_SIZE>
         __global__ void __launch_bounds__(THREAD_COUNT, 3)
             assign_nearest_swizzled_bruteforce_kernel(
@@ -808,8 +931,8 @@ namespace lfs::io {
             }
         }
 
-        template <int N_DIMS>
-        __global__ void __launch_bounds__(BLOCK_SIZE, 3)
+        template <int N_DIMS, int POINTS_PER_THREAD = ASSIGN_POINTS_PER_THREAD, int THREAD_COUNT = BLOCK_SIZE>
+        __global__ void __launch_bounds__(THREAD_COUNT, 3)
             assign_grouped_swizzled_kernel(
                 const float4* __restrict__ shN,
                 const float* __restrict__ centroids,
@@ -824,6 +947,7 @@ namespace lfs::io {
                 int* __restrict__ labels,
                 const int n_points,
                 const int k) {
+            static_assert(THREAD_COUNT / ASSIGN_CENTROID_GROUPS * POINTS_PER_THREAD == ASSIGN_POINT_TILE);
             __shared__ float shared_points[ASSIGN_POINT_TILE][ASSIGN_SHARED_K_STRIDE];
             __shared__ float shared_centroids[ASSIGN_CENTROID_TILE][ASSIGN_SHARED_K_STRIDE];
             __shared__ float shared_centroid_norms[ASSIGN_CENTROID_TILE];
@@ -850,10 +974,10 @@ namespace lfs::io {
             }
 
             const int tid = threadIdx.x;
-            const int point_row = (tid / ASSIGN_CENTROID_GROUPS) * ASSIGN_POINTS_PER_THREAD;
+            const int point_row = (tid / ASSIGN_CENTROID_GROUPS) * POINTS_PER_THREAD;
             const int centroid_col = (tid % ASSIGN_CENTROID_GROUPS) * ASSIGN_CENTROIDS_PER_THREAD;
             constexpr int point_slots_count = (N_DIMS + 3) / 4;
-            for (int i = tid; i < ASSIGN_POINT_TILE * point_slots_count; i += BLOCK_SIZE) {
+            for (int i = tid; i < ASSIGN_POINT_TILE * point_slots_count; i += THREAD_COUNT) {
                 const int point = i / point_slots_count;
                 const int slot = i % point_slots_count;
                 const bool valid = point < point_count;
@@ -869,10 +993,10 @@ namespace lfs::io {
             }
             __syncthreads();
 
-            float best_dist[ASSIGN_POINTS_PER_THREAD];
-            int best_idx[ASSIGN_POINTS_PER_THREAD];
+            float best_dist[POINTS_PER_THREAD];
+            int best_idx[POINTS_PER_THREAD];
 #pragma unroll
-            for (int p = 0; p < ASSIGN_POINTS_PER_THREAD; ++p) {
+            for (int p = 0; p < POINTS_PER_THREAD; ++p) {
                 best_dist[p] = 1e30f;
                 best_idx[p] = k;
             }
@@ -883,7 +1007,7 @@ namespace lfs::io {
                                   ASSIGN_CENTROID_TILE;
             for (int tile = 0; tile < num_tiles; ++tile) {
                 const int tile_start = tile * ASSIGN_CENTROID_TILE;
-                for (int i = tid; i < ASSIGN_CENTROID_TILE; i += BLOCK_SIZE) {
+                for (int i = tid; i < ASSIGN_CENTROID_TILE; i += THREAD_COUNT) {
                     const int candidate_pos = tile_start + i;
                     int candidate_idx = -1;
                     if (candidate_pos < candidate_count) {
@@ -917,13 +1041,13 @@ namespace lfs::io {
                 }
                 __syncthreads();
 
-                float dots[ASSIGN_POINTS_PER_THREAD][ASSIGN_CENTROIDS_PER_THREAD] = {};
+                float dots[POINTS_PER_THREAD][ASSIGN_CENTROIDS_PER_THREAD] = {};
 #pragma unroll
                 for (int d = 0; d < N_DIMS; ++d) {
-                    float point_values[ASSIGN_POINTS_PER_THREAD];
+                    float point_values[POINTS_PER_THREAD];
                     float centroid_values[ASSIGN_CENTROIDS_PER_THREAD];
 #pragma unroll
-                    for (int p = 0; p < ASSIGN_POINTS_PER_THREAD; ++p) {
+                    for (int p = 0; p < POINTS_PER_THREAD; ++p) {
                         point_values[p] = shared_points[point_row + p][d];
                     }
 #pragma unroll
@@ -931,7 +1055,7 @@ namespace lfs::io {
                         centroid_values[c] = shared_centroids[centroid_col + c][d];
                     }
 #pragma unroll
-                    for (int p = 0; p < ASSIGN_POINTS_PER_THREAD; ++p) {
+                    for (int p = 0; p < POINTS_PER_THREAD; ++p) {
 #pragma unroll
                         for (int c = 0; c < ASSIGN_CENTROIDS_PER_THREAD; ++c) {
                             dots[p][c] = fmaf(point_values[p], centroid_values[c], dots[p][c]);
@@ -940,7 +1064,7 @@ namespace lfs::io {
                 }
 
 #pragma unroll
-                for (int p = 0; p < ASSIGN_POINTS_PER_THREAD; ++p) {
+                for (int p = 0; p < POINTS_PER_THREAD; ++p) {
 #pragma unroll
                     for (int c = 0; c < ASSIGN_CENTROIDS_PER_THREAD; ++c) {
                         const int candidate_idx = shared_candidate_ids[centroid_col + c];
@@ -961,7 +1085,7 @@ namespace lfs::io {
             const unsigned group_mask = 0xffffffffu;
             const int group_lane = tid % ASSIGN_CENTROID_GROUPS;
 #pragma unroll
-            for (int p = 0; p < ASSIGN_POINTS_PER_THREAD; ++p) {
+            for (int p = 0; p < POINTS_PER_THREAD; ++p) {
                 for (int offset = ASSIGN_CENTROID_GROUPS / 2; offset > 0; offset >>= 1) {
                     const float other_dist = __shfl_down_sync(
                         group_mask, best_dist[p], offset, ASSIGN_CENTROID_GROUPS);
@@ -1271,7 +1395,7 @@ namespace lfs::io {
                 assign_timers[static_cast<size_t>(iter)].record_start();
 
                 if (use_exact) {
-                    assign_sh3_labels(shN_gpu, centroids, centroid_norms, labels, fast_assignment);
+                    assign_sh3_labels(shN_gpu, centroids, centroid_norms, labels, fast_assignment, iterations > 1);
                 } else {
                     supers_timers[static_cast<size_t>(iter)].record_start();
                     compute_centroid_norms_kernel<N_DIMS><<<grid_super, BLOCK_SIZE>>>(
@@ -1302,13 +1426,23 @@ namespace lfs::io {
                         // Refinement is approximate: each point is searched only in the
                         // union of the four supers nearest to its assigned super. The
                         // final iteration below remains an exact argmin over all k.
-                        assign_grouped_swizzled_kernel<N_DIMS><<<num_group_tasks, BLOCK_SIZE>>>(
-                            d_shN, d_centroids, centroid_norms.ptr<float>(),
-                            sorted_point_idx.ptr<int>(), group_offsets.ptr<int>(),
-                            group_task_offsets.ptr<int>(), group_candidate_offsets.ptr<int>(),
-                            group_candidate_supers.ptr<int>(), super_offsets.ptr<int>(),
-                            super_indices.ptr<int>(), labels.ptr<int>(), n, k);
-                        LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_grouped_candidates");
+                        if (fast_assignment) {
+                            assign_grouped_swizzled_kernel<N_DIMS, 4, 128><<<num_group_tasks, 128>>>(
+                                d_shN, d_centroids, centroid_norms.ptr<float>(),
+                                sorted_point_idx.ptr<int>(), group_offsets.ptr<int>(),
+                                group_task_offsets.ptr<int>(), group_candidate_offsets.ptr<int>(),
+                                group_candidate_supers.ptr<int>(), super_offsets.ptr<int>(),
+                                super_indices.ptr<int>(), labels.ptr<int>(), n, k);
+                            LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_grouped_candidates");
+                        } else {
+                            assign_grouped_swizzled_kernel<N_DIMS><<<num_group_tasks, BLOCK_SIZE>>>(
+                                d_shN, d_centroids, centroid_norms.ptr<float>(),
+                                sorted_point_idx.ptr<int>(), group_offsets.ptr<int>(),
+                                group_task_offsets.ptr<int>(), group_candidate_offsets.ptr<int>(),
+                                group_candidate_supers.ptr<int>(), super_offsets.ptr<int>(),
+                                super_indices.ptr<int>(), labels.ptr<int>(), n, k);
+                            LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_grouped_candidates");
+                        }
                     }
                 }
                 assign_timers[static_cast<size_t>(iter)].record_stop();
@@ -1379,15 +1513,21 @@ namespace lfs::io {
     } // anonymous namespace
 
     void assign_sh3_labels(const Tensor& shN_swizzled, const Tensor& centroids,
-                           const Tensor& centroid_norms, Tensor& labels, bool fast) {
+                           const Tensor& centroid_norms, Tensor& labels, bool fast, bool have_labels) {
         const int n = static_cast<int>(labels.numel());
         const int k = static_cast<int>(centroids.size(0));
         const auto* sh = reinterpret_cast<const float4*>(shN_swizzled.ptr<float>());
         if (fast) {
-            // Share each centroid load across four points. The point tile and
-            // every FP32 dot product/tie comparison match the ordinary kernel.
-            assign_nearest_swizzled_bruteforce_kernel<45, 4, 128><<<(n + ASSIGN_POINT_TILE - 1) / ASSIGN_POINT_TILE, 128>>>(
-                sh, centroids.ptr<float>(), centroid_norms.ptr<float>(), labels.ptr<int>(), n, k);
+            // Half products screen distant candidates only. Possible winners
+            // retain the ordinary FP32 dot-product order and lowest-index tie.
+            const size_t np = (n + 127) / 128 * 128, kp = (k + 31) / 32 * 32;
+            auto half_storage = Tensor::empty({(np + kp) * 24}, Device::CUDA, DataType::Float32);
+            auto* half_points = reinterpret_cast<half*>(half_storage.ptr<float>());
+            auto* half_centroids = half_points + np * 48;
+            prepare_half_sh_kernel<<<(std::max(np, kp) * 48 + 255) / 256, 256>>>(sh, centroids.ptr<float>(), half_points, half_centroids, n, k);
+            LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.prepare_half_sh");
+            assign_sh3_screened_kernel<<<(n + 127) / 128, 512>>>(
+                sh, centroids.ptr<float>(), centroid_norms.ptr<float>(), labels.ptr<int>(), n, k, half_points, half_centroids, have_labels);
             LFS_CUDA_LAUNCH_CHECK(nullptr, "io.kmeans.assign_sh3_labels");
         } else {
             assign_nearest_swizzled_bruteforce_kernel<45><<<(n + ASSIGN_POINT_TILE - 1) / ASSIGN_POINT_TILE, BLOCK_SIZE>>>(

--- a/src/io/cuda/kmeans.hpp
+++ b/src/io/cuda/kmeans.hpp
@@ -19,7 +19,7 @@ namespace lfs::io {
      * @param sh_coeffs Active SH-rest coefficient count (3, 8, or 15)
      * @param k Number of clusters
      * @param iterations Maximum iterations
-     * @param fast_assignment Use the exact streamed-export SH3 assignment tile
+     * @param fast_assignment Use exact screened SH3 assignment for streamed exports
      * @return Tuple of (centroids [k, sh_coeffs * 3], labels [n_points])
      */
     std::tuple<Tensor, Tensor> kmeans_sh_swizzled(
@@ -31,8 +31,10 @@ namespace lfs::io {
         bool fast_assignment = false);
 
     // Internal CUDA launcher: SH3 swizzled rows, float32 centroids/norms and
-    // preallocated int32 labels. Both tile shapes use identical FP32 dot products.
+    // preallocated int32 labels. Norms must be FP32 squared centroid norms.
+    // Screening preserves FP32 winners; have_labels permits valid prior labels
+    // as search hints (invalid hints are ignored).
     void assign_sh3_labels(const Tensor& shN_swizzled, const Tensor& centroids,
-                           const Tensor& centroid_norms, Tensor& labels, bool fast);
+                           const Tensor& centroid_norms, Tensor& labels, bool fast, bool have_labels = false);
 
 } // namespace lfs::io

--- a/src/io/cuda/splat_decimate_math.hpp
+++ b/src/io/cuda/splat_decimate_math.hpp
@@ -11,10 +11,12 @@
 #endif
 
 namespace lfs::io::decimate {
-    // CPU cost-cache entries in splat-transform are Float32Array, even though
-    // formulas run in double. Keep these rounding points on both backends.
+    // Reference covariance/mass cache entries are Float32Array, even though
+    // formulas run in double. Keep these rounding points on both backends;
+    // derived samples and self-densities retain their original double precision.
     struct Cache {
         float r[9], v[3], inv[3], sigma[9], logdet, mass;
+        double sample[3], self_logpdf;
     };
     DEC_HD inline double hi(double a, double b) { return a > b ? a : b; }
     DEC_HD inline double lo(double a, double b) { return a < b ? a : b; }
@@ -52,6 +54,7 @@ namespace lfs::io::decimate {
         const float* s = v.scale + size_t(i) * 3;
         return sigmoid(v.opacity[i]) * area(hi(exp(double(s[0])), 1e-12), hi(exp(double(s[1])), 1e-12), hi(exp(double(s[2])), 1e-12)) + eps;
     }
+    DEC_HD inline double logpdf(const double* x, const float* m, const Cache& c);
     DEC_HD inline Cache cache_one(View v, uint32_t i) {
         Cache c;
         double variance[3], ld = 0;
@@ -66,6 +69,16 @@ namespace lfs::io::decimate {
         c.mass = mass(v, i, 1e-12);
         rotation(v.rot + size_t(i) * 4, c.r);
         covariance(c.r, variance, c.sigma);
+        // Each edge uses the same fixed sample and its density under this
+        // Gaussian. Cache them in double, retaining the original rounding.
+        const double z[3] = {1.6264323081902676, 0.0033697340332619848, 1.0509958442185130};
+        double scaled[3];
+        for (int a = 0; a < 3; ++a)
+            scaled[a] = z[a] * sqrt(hi(c.v[a], 0));
+        const float* position = v.pos + size_t(i) * 3;
+        for (int a = 0; a < 3; ++a)
+            c.sample[a] = position[a] + scaled[0] * c.r[a * 3] + scaled[1] * c.r[a * 3 + 1] + scaled[2] * c.r[a * 3 + 2];
+        c.self_logpdf = logpdf(c.sample, position, c);
         return c;
     }
     DEC_HD inline double det(const double* a) {
@@ -105,18 +118,7 @@ namespace lfs::io::decimate {
         s[0] += 1e-8;
         s[4] += 1e-8;
         s[8] += 1e-8;
-        // Fixed binary64 sample from makeGaussianSamples(1, 0).
-        const double z[3] = {1.6264323081902676, 0.0033697340332619848, 1.0509958442185130};
-        double x[3], y[3], sa[3], sb[3];
-        for (int c = 0; c < 3; ++c) {
-            sa[c] = z[c] * sqrt(hi(a.v[c], 0));
-            sb[c] = z[c] * sqrt(hi(b.v[c], 0));
-        }
-        for (int c = 0; c < 3; ++c) {
-            x[c] = u[c] + sa[0] * a.r[c * 3] + sa[1] * a.r[c * 3 + 1] + sa[2] * a.r[c * 3 + 2];
-            y[c] = t[c] + sb[0] * b.r[c * 3] + sb[1] * b.r[c * 3 + 1] + sb[2] * b.r[c * 3 + 2];
-        }
-        double cost = p * logadd(lp + logpdf(x, u, a), lq + logpdf(x, t, b)) + q * logadd(lp + logpdf(y, u, a), lq + logpdf(y, t, b)) + 0.5 * (3 * 1.8378770664093453 + log(hi(det(s), 1e-30)) + 3);
+        double cost = p * logadd(lp + a.self_logpdf, lq + logpdf(a.sample, t, b)) + q * logadd(lp + logpdf(b.sample, u, a), lq + b.self_logpdf) + 0.5 * (3 * 1.8378770664093453 + log(hi(det(s), 1e-30)) + 3);
         for (int c = 0; c < 3 + v.rest * 3; ++c) {
             double delta = double(color(v, i, c)) - color(v, j, c);
             cost += delta * delta;

--- a/src/io/formats/ssog.cpp
+++ b/src/io/formats/ssog.cpp
@@ -296,8 +296,8 @@ namespace lfs::io {
             return m;
         }
 
-        // Pageable levels bound large-scene VRAM. Small exports may additionally
-        // retain CUDA attributes for device row gathers.
+        // Keep partition attributes on the host. Memory-budgeted exports also
+        // retain immutable CUDA attributes for device row gathers.
         struct HostSplats {
             int degree = 0;
             float scale = 1;
@@ -307,12 +307,15 @@ namespace lfs::io {
             explicit HostSplats(const SplatData& s, bool resident = false)
                 : degree(s.get_max_sh_degree()), scale(s.get_scene_scale()), means(s.means().to_pageable_host()), sh0(resident ? Tensor{} : s.sh0().to_pageable_host()), shN(resident ? Tensor{} : s.shN_canonical_cpu()), scaling(s.scaling_raw().to_pageable_host()), rotation(s.rotation_raw().to_pageable_host()), opacity(resident ? Tensor{} : s.opacity_raw().to_pageable_host()) {
                 if (resident) {
-                    device_means = s.means().cuda();
-                    device_sh0 = s.sh0().cuda();
-                    device_shN = s.shN_canonical().cuda();
-                    device_scaling = s.scaling_raw().cuda();
-                    device_rotation = s.rotation_raw().cuda();
-                    device_opacity = s.opacity_raw().cuda();
+                    const auto borrow_cuda = [](const Tensor& t) {
+                        return t.device() == Device::CUDA ? t : t.cuda();
+                    };
+                    device_means = borrow_cuda(s.means());
+                    device_sh0 = borrow_cuda(s.sh0());
+                    device_shN = borrow_cuda(s.shN_canonical());
+                    device_scaling = borrow_cuda(s.scaling_raw());
+                    device_rotation = borrow_cuda(s.rotation_raw());
+                    device_opacity = borrow_cuda(s.opacity_raw());
                 }
             }
             HostSplats() = default;
@@ -320,7 +323,8 @@ namespace lfs::io {
                 const bool resident = device_means.is_valid();
                 const auto indices = Tensor::from_vector(rows, {rows.size()}, resident ? Device::CUDA : Device::CPU);
                 const auto gather = [&](const Tensor& host, const Tensor& device) {
-                    return (resident ? device : host).index_select(0, indices).cuda();
+                    auto selected = (resident ? device : host).index_select(0, indices);
+                    return resident ? selected : selected.cuda();
                 };
                 auto rest = degree ? gather(shN, device_shN) : Tensor::empty({rows.size(), 0, 3}, Device::CUDA);
                 return SplatData(degree, gather(means, device_means), gather(sh0, device_sh0), std::move(rest), gather(scaling, device_scaling), gather(rotation, device_rotation), gather(opacity, device_opacity), scale);
@@ -540,9 +544,9 @@ namespace lfs::io {
             const bool memory_known = cudaMemGetInfo(&free_cuda, &total_cuda) == cudaSuccess;
             const double level_rows = input.size() * (1.0 - std::pow(double(o.lod_ratio), o.lod_levels)) / (1.0 - o.lod_ratio);
             const double resident_bytes = level_rows * (14 + 3 * input.max_sh_coeffs_rest()) * sizeof(float);
-            // Reserve most available VRAM for decimation, original storage, and
-            // bounded encoder workspaces. Large scenes retain pageable level staging.
-            const bool resident = memory_known && resident_bytes < std::min<double>(1024.0 * 1024 * 1024, free_cuda * 0.25);
+            // Leave most free VRAM for decimation and bounded unit workspaces.
+            // Larger resident exports avoid full SH downloads and host gathers.
+            const bool resident = memory_known && resident_bytes < std::min<double>(6.0 * 1024 * 1024 * 1024, free_cuda * 0.45);
             LOG_DEBUG("SSOG level storage: resident={} estimated_bytes={:.0f} free_cuda={}", resident, resident_bytes, free_cuda);
             levels.emplace_back(input, resident);
             if (input.has_deleted_mask())
@@ -722,20 +726,23 @@ namespace lfs::io {
             const auto partitioned = Clock::now();
             double morton_ms = 0, encode_ms = 0;
             auto stamp = o.provenance.value_or(core::make_minimal_provenance_stamp());
-            // Retain the two-workspace bound for pageable large scenes. Small
-            // resident scenes may overlap more units if there is space for their
-            // gathers, swizzled SH, labels and palette scratch in addition to LODs.
+            // Pageable scenes retain two workspaces. Resident scenes may overlap
+            // more units within the budget for gathers, SH, prepared half inputs,
+            // labels and palettes in addition to retained LODs.
             const auto largest_unit = std::max_element(units.begin(), units.end(), [](const auto& a, const auto& b) {
                 return a.rows.size() < b.rows.size();
             });
             const double workspace_bytes = largest_unit->rows.size() *
-                                               (32.0 + 6 * input.max_sh_coeffs_rest()) * sizeof(float) +
+                                               (56.0 + 6 * input.max_sh_coeffs_rest()) * sizeof(float) +
                                            128.0 * 1024 * 1024;
             const size_t resident_workers = resident
                                                 ? std::max<size_t>(1, (free_cuda - resident_bytes) / workspace_bytes)
                                                 : 1;
+            const size_t cpu_workers = units.size() > 6
+                                           ? std::clamp<size_t>(std::thread::hardware_concurrency() / 4, 1, 6)
+                                           : std::clamp<size_t>(std::thread::hardware_concurrency() / 6, 1, 4);
             const size_t workers = std::min(units.size(), resident
-                                                              ? std::min(resident_workers, std::clamp<size_t>(std::thread::hardware_concurrency() / 6, 1, 4))
+                                                              ? std::min(resident_workers, cpu_workers)
                                                               : size_t{2});
             struct UnitTiming {
                 double morton, encode;

--- a/tests/test_sog_format.cpp
+++ b/tests/test_sog_format.cpp
@@ -781,3 +781,51 @@ TEST_F(SogFormatTest, StreamedSh3AssignmentMatchesReferenceTiles) {
         }
     }
 }
+
+TEST_F(SogFormatTest, StreamedSh3ScreeningMatchesReferenceNearTiesAndHalfLimits) {
+    using namespace lfs::core;
+    using namespace lfs::io;
+    std::mt19937 rng(1741);
+    std::uniform_real_distribution<float> random(-1.0f, 1.0f);
+    constexpr size_t n = 257, k = 1025;
+    for (const float scale : {1e-20f, 1e-8f, 1e-4f, 0.01f, 1.0f, 100.0f, 100000.0f}) {
+        SCOPED_TRACE(scale);
+        auto points = Tensor::zeros({sh_swizzled_float_count(n, 15)}, Device::CPU);
+        auto centroids = Tensor::empty({k, 45}, Device::CPU);
+        auto norms = Tensor::zeros({k}, Device::CPU);
+        for (size_t i = 0; i < k; ++i) {
+            for (size_t d = 0; d < 45; ++d) {
+                // Many centroids round to the same half value. Others exceed
+                // half's finite range and must use the complete FP32 path.
+                const float v = scale * (0.75f + random(rng) * 0.0001f);
+                centroids.ptr<float>()[i * 45 + d] = v;
+                norms.ptr<float>()[i] = std::fma(v, v, norms.ptr<float>()[i]);
+            }
+        }
+        for (size_t i = 0; i < n; ++i) {
+            for (size_t d = 0; d < 45; ++d) {
+                const float a = centroids.ptr<float>()[((i * 17) % k) * 45 + d];
+                const float b = centroids.ptr<float>()[((i * 17 + 1) % k) * 45 + d];
+                points.ptr<float>()[sh_swizzled_index(i, d / 4, 15) * 4 + d % 4] =
+                    i % 2 ? a : (a + b) * 0.5f;
+            }
+        }
+        points = points.cuda();
+        centroids = centroids.cuda();
+        norms = norms.cuda();
+        auto reference = Tensor::zeros({n}, Device::CUDA, DataType::Int32);
+        auto screened = Tensor::zeros({n}, Device::CUDA, DataType::Int32);
+        assign_sh3_labels(points, centroids, norms, reference, false);
+        assign_sh3_labels(points, centroids, norms, screened, true);
+        const auto expected = reference.cpu(), actual = screened.cpu();
+        EXPECT_TRUE(std::equal(expected.ptr<int>(), expected.ptr<int>() + n, actual.ptr<int>()));
+        std::vector<int> seeds(n);
+        for (size_t i = 0; i < n; ++i)
+            seeds[i] = i % 3 == 0 ? -1 : i % 3 == 1 ? int(k + 1)
+                                                    : int(i % k);
+        screened = Tensor::from_vector(seeds, {n}, Device::CUDA);
+        assign_sh3_labels(points, centroids, norms, screened, true, true);
+        const auto seeded = screened.cpu();
+        EXPECT_TRUE(std::equal(expected.ptr<int>(), expected.ptr<int>() + n, seeded.ptr<int>()));
+    }
+}


### PR DESCRIPTION
Two follow-ups to #2075, which merged before these landed on its branch.

1. Error-debt gate on master: the new SH assignment launcher had one launch check after an if/else with two kernel launches. Each launch now has its own check. The gate passes locally again.

2. More speed, same output:

| Scene | #2075 | Now |
|---|---:|---:|
| Garden 1M, 4 levels, exporter | 1.52 s | 1.21 s |
| Garden, CLI wall | 1.95 s | 1.67 s |
| 9.2M scene, exporter | 15.0 s | 9.3 s |
| 9.2M scene, CLI wall | 16.7 s | 10.6 s |

- SH palette k-means (streamed exports only): a half-precision tensor-core pass rejects centroids that cannot win, then every remaining candidate is scored with the original FP32 sequence and tie rule. Labels are identical. A four-point tile reuses centroid loads in the refinement pass.
- Level storage: immutable CUDA tensors are borrowed instead of cloned, more LOD rows stay resident (up to 6 GiB or 45% of free VRAM), and large scenes use up to six workers under the same workspace budget. Peak on the 9.2M scene: 8.8 GiB VRAM, 4.4 GiB RSS.
- Decimation caches fixed samples and self-density in double precision.

Checks: base attribute images and manifests byte-identical for both scenes, PlayCanvas reads the output, seeded renders differ by under 0.002 dB, SSOG/decimation/SOG tests pass, compute-sanitizer memcheck and synccheck clean, error-debt and I/O gates pass. Plain SOG export is unchanged.
