### PR TITLE
Selection: never draw the software brush ring while the cursor ring is showing

### DIFF
--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -4257,21 +4257,18 @@ namespace lfs::vis::gui {
         return selection_ring_cursor_cache_.parameters;
     }
 
-    bool GuiManager::selectionRingCursorActive(const float mouse_x, const float mouse_y) const {
-        const SDL_Cursor* const current_cursor = SDL_GetCursor();
-        const bool ring_is_current = current_cursor == selection_ring_cursor_ ||
-                                     current_cursor == selection_ring_cursor_pending_destroy_;
-        const bool ring_was_selected = last_selection_cursor_ == selection_ring_cursor_ ||
-                                       last_selection_cursor_ == selection_ring_cursor_pending_destroy_;
-        return selection_ring_cursor_ && (ring_is_current || ring_was_selected) &&
-               selectionRingCursorParameters(mouse_x, mouse_y).has_value();
+    bool GuiManager::isHardwareSelectionRingActive() const {
+        // Eligibility decides which cursor to install, not whether an installed
+        // ring still suppresses the software fallback (including during replacement).
+        return isSelectionRingCursorCurrent(SDL_GetCursor(), selection_ring_cursor_,
+                                            selection_ring_cursor_pending_destroy_);
     }
 
-    bool GuiManager::isHardwareSelectionRingActive() const {
-        if (!selection_ring_cursor_ || !viewer_ || !viewer_->getWindowManager())
-            return false;
-        const auto& input = viewer_->getWindowManager()->frameInput();
-        return selectionRingCursorParameters(input.mouse_x, input.mouse_y).has_value();
+    bool GuiManager::selectionCursorNeedsRender(const float mouse_x, const float mouse_y) const {
+        // A current ring suppresses overlays, but leaving its eligible region
+        // must still wake the GUI so it can install the appropriate cursor.
+        return !isHardwareSelectionRingActive() ||
+               !selectionRingCursorParameters(mouse_x, mouse_y).has_value();
     }
 
     void GuiManager::prepareSelectionRingCursor(const float mouse_x, const float mouse_y) {
@@ -5340,28 +5337,18 @@ namespace lfs::vis::gui {
             rendering_manager->bindViewportInteropParams(params, frame_slot, export_locked);
         }
 
-        // Sample mouse pos with SDL_GetGlobalMouseState here, after all panel/tool overlay
-        // queueing and just before the GPU command buffer is recorded. Global polling hits
-        // the OS directly, so the cursor ring tracks the hardware pointer without waiting
-        // for another event-pump tick.
+        // Use the same window-relative snapshot as cursor selection and hit tests.
+        // Wayland global coordinates are synthesized, not a late pointer sample.
         if (viewer_ && !ui_hidden_ && !guiFocusState().want_capture_mouse) {
             if (auto* const sel = viewer_->getSelectionTool(); sel && sel->isEnabled()) {
-                SDL_Window* const window = viewer_->getWindow();
-                int win_x = 0;
-                int win_y = 0;
-                if (window) {
-                    SDL_GetWindowPosition(window, &win_x, &win_y);
-                }
-                float gx = 0.0f;
-                float gy = 0.0f;
-                SDL_GetGlobalMouseState(&gx, &gy);
-                const glm::vec2 mp{gx - static_cast<float>(win_x), gy - static_cast<float>(win_y)};
+                const auto& input = viewer_->getWindowManager()->frameInput();
+                const glm::vec2 mp{input.mouse_x, input.mouse_y};
                 if (isPositionInViewport(mp.x, mp.y)) {
                     auto* const rm = viewer_->getRenderingManager();
                     const auto mode = rm ? rm->getSelectionPreviewMode()
                                          : lfs::vis::SelectionPreviewMode::Centers;
                     const bool hardware_selection_ring =
-                        selectionRingCursorActive(mp.x, mp.y);
+                        isHardwareSelectionRingActive();
                     const auto& palette = lfs::vis::theme().palette;
                     const auto& base = (SDL_GetModState() & SDL_KMOD_CTRL) ? palette.error : palette.primary;
                     const glm::vec4 color{base.x * 0.85f, base.y * 0.85f, base.z * 0.85f, 0.85f};
@@ -7217,6 +7204,13 @@ namespace lfs::vis::gui {
         if (!vulkan_gui_)
             renderFloatingPanelDragCursor();
         if (overlay_renderer && needs_screen_overlay_frame) {
+            // Selection labels must observe the final cursor too, otherwise a
+            // label queued before installing a ring can persist on idle frames.
+            if (!ui_hidden_ && !isViewportExportLocked()) {
+                if (auto* const tool = viewer_->getSelectionTool(); tool && tool->isEnabled()) {
+                    tool->renderUI(ctx, nullptr);
+                }
+            }
             LOG_TIMER_THRESHOLD("gui_render.screen_overlay_renderer.endFrame", 0.25);
             overlay_renderer->endFrame();
         }
@@ -7432,10 +7426,6 @@ namespace lfs::vis::gui {
             return;
         }
 
-        if (auto* const tool = ctx.viewer->getSelectionTool(); tool && tool->isEnabled() && !ui_hidden_) {
-            tool->renderUI(ctx, nullptr);
-        }
-
         // Node rectangle-drag outline. Uses the same ScreenOverlayRenderer path
         // as the cursor preview / align tool so it stays consistent with the
         // other native viewport overlays.
@@ -7551,7 +7541,11 @@ namespace lfs::vis::gui {
             };
 
             const bool hardware_selection_ring = isHardwareSelectionRingActive();
-            if (rm && rm->isCursorPreviewActive() && !hardware_selection_ring) {
+            // The Centers brush fallback is emitted once by the late shape pass,
+            // after the final SDL cursor is chosen. Queuing it here can leave a
+            // software ring underneath a hardware ring installed later this frame.
+            if (rm && rm->getSelectionPreviewMode() != SelectionPreviewMode::Centers &&
+                rm->isCursorPreviewActive() && !hardware_selection_ring) {
                 const auto& t = theme();
                 float bx, by, br;
                 bool add_mode;
@@ -8183,7 +8177,7 @@ namespace lfs::vis::gui {
 
         if (!guiFocusState().want_capture_mouse && isPositionInViewport(mouse_x, mouse_y)) {
             if (auto* const sel = viewer_ ? viewer_->getSelectionTool() : nullptr; sel && sel->isEnabled()) {
-                return !selectionRingCursorActive(mouse_x, mouse_y);
+                return selectionCursorNeedsRender(mouse_x, mouse_y);
             }
         }
 

--- a/src/visualizer/gui/gui_manager.hpp
+++ b/src/visualizer/gui/gui_manager.hpp
@@ -204,8 +204,8 @@ namespace lfs::vis {
 
             bool isCapturingInput() const;
             bool isModalWindowOpen() const;
-            [[nodiscard]] bool selectionRingCursorActive(float mouse_x, float mouse_y) const;
             [[nodiscard]] bool isHardwareSelectionRingActive() const;
+            [[nodiscard]] bool selectionCursorNeedsRender(float mouse_x, float mouse_y) const;
             [[nodiscard]] bool passiveMouseMoveNeedsRender(float mouse_x, float mouse_y) const;
             [[nodiscard]] std::optional<double> secondsUntilTooltipReveal() const;
             [[nodiscard]] bool isStartupVisible() const { return startup_overlay_.isVisible(); }

--- a/src/visualizer/gui/selection_cursor.cpp
+++ b/src/visualizer/gui/selection_cursor.cpp
@@ -62,6 +62,12 @@ namespace lfs::vis::gui {
 
     } // namespace
 
+    bool isSelectionRingCursorCurrent(const SDL_Cursor* const current,
+                                      const SDL_Cursor* const ring,
+                                      const SDL_Cursor* const retiring_ring) {
+        return current && (current == ring || current == retiring_ring);
+    }
+
     bool useHardwareSelectionRing(const bool preview_active,
                                   const SelectionPreviewMode mode,
                                   const int radius_px) {

--- a/src/visualizer/gui/selection_cursor.hpp
+++ b/src/visualizer/gui/selection_cursor.hpp
@@ -10,6 +10,8 @@
 #include <span>
 #include <vector>
 
+struct SDL_Cursor;
+
 namespace lfs::vis::gui {
 
     enum class SelectionCursorOperation : uint8_t {
@@ -48,6 +50,11 @@ namespace lfs::vis::gui {
     [[nodiscard]] constexpr int selectionCursorMaxSize() {
         return 256;
     }
+
+    // Cursor identity is independent of pointer position and preview eligibility.
+    // A retiring ring can remain current until its replacement is installed.
+    [[nodiscard]] LFS_VIS_API bool isSelectionRingCursorCurrent(
+        const SDL_Cursor* current, const SDL_Cursor* ring, const SDL_Cursor* retiring_ring);
 
     [[nodiscard]] LFS_VIS_API bool useHardwareSelectionRing(bool preview_active,
                                                             SelectionPreviewMode mode,

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -2269,7 +2269,7 @@ namespace lfs::vis {
 
         if (selection_tool_ && selection_tool_->isEnabled() && gui_manager_ &&
             gui_manager_->isPositionInViewport(input.mouse_x, input.mouse_y)) {
-            return !gui_manager_->selectionRingCursorActive(input.mouse_x, input.mouse_y);
+            return gui_manager_->selectionCursorNeedsRender(input.mouse_x, input.mouse_y);
         }
 
         if (gui_manager_ && gui_manager_->passiveMouseMoveNeedsRender(input.mouse_x, input.mouse_y)) {

--- a/tests/test_selection_cursor.cpp
+++ b/tests/test_selection_cursor.cpp
@@ -53,6 +53,26 @@ namespace {
         EXPECT_EQ(selectionOpForModifiers(bindings, ToolMode::SELECTION, MODIFIER_ALT), SelectionOp::Add);
     }
 
+    TEST(SelectionCursorStateTest, CurrentRingSuppressesFallbackWithoutPreviewEligibility) {
+        // Opaque identities only: this decision needs neither SDL initialization
+        // nor coordinates, a preview cache, or a compositor.
+        const int identities[3] = {};
+        const auto* ring = reinterpret_cast<const SDL_Cursor*>(&identities[0]);
+        const auto* replacement = reinterpret_cast<const SDL_Cursor*>(&identities[1]);
+        const auto* arrow = reinterpret_cast<const SDL_Cursor*>(&identities[2]);
+        using lfs::vis::gui::isSelectionRingCursorCurrent;
+
+        EXPECT_TRUE(isSelectionRingCursorCurrent(ring, ring, nullptr));
+        EXPECT_TRUE(isSelectionRingCursorCurrent(ring, replacement, ring));
+        EXPECT_TRUE(isSelectionRingCursorCurrent(ring, nullptr, ring));
+        EXPECT_TRUE(isSelectionRingCursorCurrent(replacement, replacement, ring));
+        // Prepared or previously selected cursors cannot hide the fallback.
+        EXPECT_FALSE(isSelectionRingCursorCurrent(arrow, replacement, ring));
+        EXPECT_FALSE(isSelectionRingCursorCurrent(arrow, nullptr, nullptr));
+        EXPECT_FALSE(isSelectionRingCursorCurrent(nullptr, ring, nullptr));
+        EXPECT_FALSE(isSelectionRingCursorCurrent(nullptr, nullptr, nullptr));
+    }
+
     TEST(SelectionCursorImageTest, BuildsCenteredAntiAliasedRingAndDot) {
         constexpr int radius = 24;
         const auto image = makeSelectionCursorImage(radius, {255, 32, 64, 204});


### PR DESCRIPTION
Discord report (Linux, native Wayland): two brush rings a few pixels apart, the screen recorder captures only one, forcing X11 fixes it.

Cause: one ring is the hardware cursor image (compositors draw it on the cursor plane, which recorders skip), the other is the app's software ring. Two different checks decided whether the hardware ring was showing, one from the cursor identity plus a per-frame eligibility cache, the other from eligibility alone. The software ring was also positioned from `SDL_GetGlobalMouseState` minus the window position, which SDL only synthesizes on Wayland and which can disagree with the frame input. Whenever those disagreed, both rings were drawn.

Fix
- The software ring is suppressed whenever the ring cursor (or the one being retired) is the current SDL cursor, independent of the eligibility cache.
- The overlay uses the same frame input position as the rest of the GUI, no global mouse polling.
- The Centers fallback is queued once, by the late pass after the final cursor choice, so an early pass cannot leave a ring under a cursor installed later in the frame.
- The selection label is drawn after the final cursor choice; otherwise it could stay on idle frames.

Checks: X11 rig on Xvfb. Forcing the old decision mismatch reproduces the double ring on the previous code and not on this one; the normal ring is byte-identical to before at the same position; the oversized-brush fallback shows one software circle; leaving the viewport restores the arrow. 98 selection/cursor tests pass, plus a new unit test for the cursor-identity rule. The other global-mouse users (titlebar drag/restore in window_manager.cpp) are unchanged and may need their own look on native Wayland.

The reporter's compositor was not reproduced locally, so a native Wayland confirmation from them is still wanted.