### PR TITLE
Fix MRNF saturated opacity and PLY export

### DIFF
--- a/src/io/formats/ply.cpp
+++ b/src/io/formats/ply.cpp
@@ -2611,7 +2611,8 @@ namespace lfs::io {
                 return;
 
             // CPU export tensors may alias the live model. Repair a private
-            // host copy, using the same finite endpoints as PLY import.
+            // pageable host copy so repair adds no VRAM, using the same
+            // finite endpoints as PLY import.
             Tensor repaired = Tensor::empty_pageable_host(opacity.shape(), DataType::Float32);
             float* const output = repaired.ptr<float>();
             tbb::parallel_for(tbb::blocked_range<size_t>(0, opacity.numel(), ply_constants::FINITE_SCAN_BLOCK_SIZE),

--- a/src/io/formats/ply.cpp
+++ b/src/io/formats/ply.cpp
@@ -566,7 +566,7 @@ namespace lfs::io {
                 return false;
             }
 
-            struct stat st {};
+            struct stat st{};
             if (fstat(fd, &st) < 0) {
                 return false;
             }
@@ -2484,10 +2484,8 @@ namespace lfs::io {
                 size_t end = 0;
             };
             std::vector<ScanBlock> scan_blocks;
-            size_t total_floats = 0;
             for (size_t target_index = 0; target_index < scan_targets.size(); ++target_index) {
                 const auto& target = scan_targets[target_index];
-                total_floats += target.value_count;
                 for (size_t begin = 0; begin < target.value_count;
                      begin += ply_constants::FINITE_SCAN_BLOCK_SIZE) {
                     scan_blocks.push_back({target_index,
@@ -2605,6 +2603,25 @@ namespace lfs::io {
             return std::nullopt;
         }
 
+        void repair_export_opacity(Tensor& opacity) {
+            if (!opacity.is_valid() || opacity.numel() == 0)
+                return;
+            const float* const data = opacity.ptr<float>();
+            if (std::none_of(data, data + opacity.numel(), [](const float v) { return std::isinf(v); }))
+                return;
+
+            // CPU export tensors may alias the live model. Repair a private
+            // host copy, using the same finite endpoints as PLY import.
+            Tensor repaired = Tensor::empty_pageable_host(opacity.shape(), DataType::Float32);
+            float* const output = repaired.ptr<float>();
+            tbb::parallel_for(tbb::blocked_range<size_t>(0, opacity.numel(), ply_constants::FINITE_SCAN_BLOCK_SIZE),
+                              [&](const tbb::blocked_range<size_t>& range) {
+                                  for (size_t i = range.begin(); i != range.end(); ++i)
+                                      output[i] = repair_infinite_opacity_logit(data[i], nullptr);
+                              });
+            opacity = std::move(repaired);
+        }
+
         Result<void> validate_point_cloud_for_ply_write(PointCloud& pc,
                                                         const std::filesystem::path& output_path) {
             if (!pc.means.is_valid()) {
@@ -2685,6 +2702,8 @@ namespace lfs::io {
                 download(pc.rotation);
                 download(pc.colors);
             }
+
+            repair_export_opacity(pc.opacity);
 
             std::vector<FloatValidationTarget> finite_targets;
             finite_targets.reserve(7);

--- a/src/training/kernels/mrnf_kernels.cu
+++ b/src/training/kernels/mrnf_kernels.cu
@@ -32,6 +32,10 @@ namespace lfs::training::mrnf_strategy {
         }
 
         __device__ __forceinline__ float d_logit(float p) {
+            if (isnan(p))
+                return p;
+            // The upper bound must be representable below 1 in float32.
+            p = fminf(fmaxf(p, 1e-12f), nextafterf(1.0f, 0.0f));
             return logf(p / (1.0f - p));
         }
 
@@ -138,9 +142,12 @@ namespace lfs::training::mrnf_strategy {
 
         const float t_shrink = 1.0f - train_t;
 
-        float opac = d_sigmoid(raw_opacities[idx]) - opac_decay * t_shrink;
-        opac = fminf(fmaxf(opac, 1e-12f), 1.0f - 1e-12f);
-        raw_opacities[idx] = d_logit(opac);
+        const float opacity_delta = opac_decay * t_shrink;
+        // A sigmoid/logit round trip loses finite saturated logits even when
+        // decay is disabled. Still repair infinities from older checkpoints.
+        if (opacity_delta != 0.0f || isinf(raw_opacities[idx])) {
+            raw_opacities[idx] = d_logit(d_sigmoid(raw_opacities[idx]) - opacity_delta);
+        }
 
         const float decay_factor = 1.0f - scl_decay * t_shrink;
         for (int d = 0; d < 3; ++d) {

--- a/tests/test_mrnf_strategy.cpp
+++ b/tests/test_mrnf_strategy.cpp
@@ -1461,7 +1461,7 @@ TEST(MRNFStrategyTest, FarDecayScaleAppliesOnlyToFarUnfrozenRows) {
     const auto expected_raw = [](const float raw, const float decay, const float train_t) {
         const float opac = 1.0f / (1.0f + std::exp(-raw));
         float next = opac - decay * (1.0f - train_t);
-        next = std::min(std::max(next, 1e-12f), 1.0f - 1e-12f);
+        next = std::min(std::max(next, 1e-12f), std::nextafter(1.0f, 0.0f));
         return std::log(next / (1.0f - next));
     };
     const auto expected_log_s = [](const float log_s, const float decay, const float train_t) {
@@ -2409,4 +2409,67 @@ TEST(MRNFStrategyTest, CheckpointLoadPreservesDatasetFarFieldProtection) {
                          actual_mask.size(), cudaMemcpyDeviceToHost),
               cudaSuccess);
     EXPECT_EQ(actual_mask, expected_mask);
+}
+
+TEST(MRNFDecayTest, ZeroDecayPreservesFiniteLogitsAndStillDecaysScales) {
+    const std::vector<float> original{-80.0f, -20.0f, 0.0f, 16.85f, 20.0f, 80.0f};
+    for (const auto [decay, train_t] : {std::pair{0.0f, 0.5f}, std::pair{0.004f, 1.0f}}) {
+        auto opacity = Tensor::from_vector(original, {original.size()}, Device::CUDA);
+        auto scales = Tensor::zeros({original.size(), 3}, Device::CUDA);
+        for (int step = 0; step < 100; ++step) {
+            mrnf_strategy::launch_mrnf_decay(opacity.ptr<float>(), scales.ptr<float>(),
+                                             nullptr, 0, nullptr, 0, decay, 0.01f, 1.0f,
+                                             train_t, original.size());
+        }
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        const auto actual = opacity.cpu().to_vector();
+        for (size_t i = 0; i < original.size(); ++i)
+            EXPECT_FLOAT_EQ(actual[i], original[i]) << "row " << i;
+        const auto actual_scales = scales.cpu().to_vector();
+        EXPECT_NEAR(actual_scales[0], 100.0f * std::log(1.0f - 0.01f * (1.0f - train_t)), 1e-5f);
+    }
+}
+
+TEST(MRNFDecayTest, SaturatedAndLegacyInfiniteLogitsStayFinite) {
+    const float inf = std::numeric_limits<float>::infinity();
+    const std::vector<float> original{16.85f, 20.0f, 80.0f, inf, -inf};
+    for (const float decay : {0.0f, 1e-12f, 0.004f}) {
+        auto opacity = Tensor::from_vector(original, {original.size()}, Device::CUDA);
+        auto scales = Tensor::zeros({original.size(), 3}, Device::CUDA);
+        mrnf_strategy::launch_mrnf_decay(opacity.ptr<float>(), scales.ptr<float>(),
+                                         nullptr, 0, nullptr, 0, decay, 0.0f, 1.0f,
+                                         0.5f, original.size());
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        const auto actual = opacity.cpu().to_vector();
+        for (size_t i = 0; i < original.size(); ++i) {
+            EXPECT_TRUE(std::isfinite(actual[i])) << "row " << i << ", decay " << decay;
+            if (decay == 1e-12f && i + 1 < original.size()) {
+                const float upper = std::nextafter(1.0f, 0.0f);
+                EXPECT_NEAR(actual[i], std::log(upper / (1.0f - upper)), 1e-5f);
+            }
+            const double expected = i + 1 == original.size() ? 0.0 : 1.0 - decay * 0.5;
+            EXPECT_NEAR(1.0 / (1.0 + std::exp(-double(actual[i]))), expected, 2e-7);
+        }
+    }
+}
+
+TEST(MRNFDecayTest, FrozenRowsAndZeroFarDecayRemainUnchangedWhileNaNsStayVisible) {
+    const float inf = std::numeric_limits<float>::infinity();
+    auto opacity = Tensor::from_vector(std::vector<float>{inf, 20.0f, std::nanf(""), 20.0f}, {4}, Device::CUDA);
+    auto scales = Tensor::zeros({4, 3}, Device::CUDA);
+    const auto frozen = Tensor::from_vector(std::vector<bool>{true, false, false, false}, {4}, Device::CUDA);
+    const auto far = Tensor::from_vector(std::vector<bool>{false, true, false, false}, {4}, Device::CUDA);
+    mrnf_strategy::launch_mrnf_decay(opacity.ptr<float>(), scales.ptr<float>(),
+                                     frozen.ptr<bool>(), 4, far.ptr<bool>(), 4,
+                                     0.004f, 0.01f, 0.0f, 0.5f, 4);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    const auto values = opacity.cpu().to_vector();
+    EXPECT_EQ(values[0], inf);
+    EXPECT_FLOAT_EQ(values[1], 20.0f);
+    EXPECT_TRUE(std::isnan(values[2]));
+    EXPECT_NEAR(1.0 / (1.0 + std::exp(-double(values[3]))), 0.998, 2e-7);
+    const auto actual_scales = scales.cpu().to_vector();
+    EXPECT_FLOAT_EQ(actual_scales[0], 0.0f);
+    EXPECT_FLOAT_EQ(actual_scales[3], 0.0f);
+    EXPECT_LT(actual_scales[9], 0.0f);
 }

--- a/tests/test_ply_error_taxonomy.cpp
+++ b/tests/test_ply_error_taxonomy.cpp
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
+#include "core/alloc_counter.hpp"
 #include "core/failure_report.hpp"
 #include "core/logger.hpp"
 #include "core/path_utils.hpp"
@@ -799,7 +800,7 @@ namespace {
 
 } // namespace
 
-TEST_F(PlyErrorTaxonomyTest, ExportRepairsInfiniteOpacityWithoutChangingSource) {
+TEST_F(PlyErrorTaxonomyTest, ExportRepairsInfiniteOpacityWithoutChangingSourceOrAllocatingVram) {
     using namespace lfs::core;
     const float inf = std::numeric_limits<float>::infinity();
     const std::vector<float> original{inf, -inf, 16.85f, -30.0f};
@@ -809,8 +810,11 @@ TEST_F(PlyErrorTaxonomyTest, ExportRepairsInfiniteOpacityWithoutChangingSource) 
             pc.means = Tensor::zeros({4, 3}, device);
             pc.opacity = Tensor::from_vector(original, {4, 1}, device);
             const auto output = path("infinite_export.ply");
+            const auto allocations_before = alloc_counter::snapshot();
             const auto saved = lfs::io::save_ply(pc, {.output_path = output, .binary = binary});
             ASSERT_TRUE(saved.has_value()) << saved.error().format();
+            EXPECT_EQ(alloc_counter::delta_since(allocations_before), 0u)
+                << "Opacity repair must not allocate VRAM, including transient driver allocations";
             const auto unchanged = pc.opacity.cpu().to_vector();
             EXPECT_EQ(unchanged, original);
             // Inspect the serialized values, without relying on the importer's repair.

--- a/tests/test_ply_error_taxonomy.cpp
+++ b/tests/test_ply_error_taxonomy.cpp
@@ -798,3 +798,96 @@ namespace {
     }
 
 } // namespace
+
+TEST_F(PlyErrorTaxonomyTest, ExportRepairsInfiniteOpacityWithoutChangingSource) {
+    using namespace lfs::core;
+    const float inf = std::numeric_limits<float>::infinity();
+    const std::vector<float> original{inf, -inf, 16.85f, -30.0f};
+    for (const auto device : {Device::CPU, Device::CUDA}) {
+        for (const bool binary : {true, false}) {
+            PointCloud pc;
+            pc.means = Tensor::zeros({4, 3}, device);
+            pc.opacity = Tensor::from_vector(original, {4, 1}, device);
+            const auto output = path("infinite_export.ply");
+            const auto saved = lfs::io::save_ply(pc, {.output_path = output, .binary = binary});
+            ASSERT_TRUE(saved.has_value()) << saved.error().format();
+            const auto unchanged = pc.opacity.cpu().to_vector();
+            EXPECT_EQ(unchanged, original);
+            // Inspect the serialized values, without relying on the importer's repair.
+            std::ifstream stream(output, std::ios::binary);
+            std::string line;
+            size_t columns = 0, opacity_column = 0;
+            while (std::getline(stream, line) && line != "end_header") {
+                if (line.starts_with("property ")) {
+                    if (line == "property float opacity")
+                        opacity_column = columns;
+                    ++columns;
+                }
+            }
+            ASSERT_GT(columns, opacity_column);
+            for (size_t row = 0; row < original.size(); ++row) {
+                float value = 0.0f;
+                for (size_t col = 0; col < columns; ++col) {
+                    if (binary)
+                        stream.read(reinterpret_cast<char*>(&value), sizeof(value));
+                    else
+                        stream >> value;
+                    ASSERT_TRUE(stream.good());
+                    if (col == opacity_column) {
+                        ASSERT_TRUE(std::isfinite(value));
+                        EXPECT_NEAR(value, row < 2 ? std::copysign(20.0f, original[row]) : original[row], 1e-5f);
+                    }
+                }
+            }
+        }
+    }
+}
+
+TEST_F(PlyErrorTaxonomyTest, ExportStillRejectsNaNOpacityAndInfinitePositions) {
+    using namespace lfs::core;
+    for (const bool bad_opacity : {true, false}) {
+        PointCloud pc;
+        pc.means = Tensor::zeros({1, 3}, Device::CPU);
+        pc.opacity = Tensor::from_vector(std::vector<float>{std::numeric_limits<float>::infinity()}, {1, 1}, Device::CPU);
+        if (bad_opacity)
+            pc.opacity.ptr<float>()[0] = std::numeric_limits<float>::quiet_NaN();
+        else
+            pc.means.ptr<float>()[0] = std::numeric_limits<float>::infinity();
+        const auto output = path("invalid_export.ply");
+        const auto saved = lfs::io::save_ply(pc, {.output_path = output, .binary = true});
+        ASSERT_FALSE(saved.has_value());
+        EXPECT_NE(saved.error().format().find(bad_opacity ? "PointCloud.opacity" : "PointCloud.means"), std::string::npos);
+        EXPECT_FALSE(fs::exists(output));
+    }
+}
+
+TEST_F(PlyErrorTaxonomyTest, SplatExportRepairsOpacityAfterDeletedRowFiltering) {
+    using namespace lfs::core;
+    std::string body;
+    for (int i = 0; i < 4; ++i)
+        append_gaussian_row(body, float(i), -2.0f, 0.0f, 1.0f);
+    const auto input = path("splat_export_input.ply");
+    write_binary_file(input, make_binary_header(4, gaussian_properties_with_dc()), body);
+    auto loaded = lfs::io::load_ply(input, cpu_splat_load_options());
+    ASSERT_TRUE(loaded.has_value());
+    auto& splat = loaded->value;
+    const float inf = std::numeric_limits<float>::infinity();
+    const std::vector<float> original{inf, -inf, 16.85f, std::numeric_limits<float>::quiet_NaN()};
+    splat.opacity_raw() = Tensor::from_vector(original, {4, 1}, Device::CPU);
+    splat.deleted() = Tensor::from_vector(std::vector<bool>{false, false, false, true}, {4}, Device::CPU);
+    const auto output = path("splat_export_output.ply");
+    const auto saved = lfs::io::save_ply(splat, {.output_path = output, .binary = true});
+    ASSERT_TRUE(saved.has_value()) << saved.error().format();
+    auto roundtrip = lfs::io::load_ply(output, cpu_splat_load_options());
+    ASSERT_TRUE(roundtrip.has_value()) << lfs::format_for_developer(roundtrip.error());
+    const auto values = opacity_values(roundtrip->value);
+    ASSERT_EQ(values.size(), 3u);
+    EXPECT_NEAR(values[0], 20.0f, 1e-5f);
+    EXPECT_NEAR(values[1], -20.0f, 1e-5f);
+    EXPECT_NEAR(values[2], 16.85f, 1e-5f);
+    const auto unchanged = splat.opacity_raw().to_vector();
+    EXPECT_EQ(unchanged[0], inf);
+    EXPECT_EQ(unchanged[1], -inf);
+    EXPECT_FLOAT_EQ(unchanged[2], original[2]);
+    EXPECT_TRUE(std::isnan(unchanged[3]));
+}


### PR DESCRIPTION
Preserve finite MRNF opacity logits when decay is disabled and use a representable float32 bound when converting probabilities back to logits. Repair infinite opacity values in a private pageable CPU copy with no additional VRAM; continue rejecting NaNs and non-finite geometry.

Fixes #2079.

Validated with 156 passing focused tests (20 skipped), CUDA memcheck, and PLY exports from all seven latest Mip-NeRF 360 reconstructions after inserting infinite logits. Export leaves the loaded models unchanged.

The export regression also checks zero new device allocations for CPU/CUDA inputs in both binary and ASCII formats.
