### PR TITLE
Fix viewport export use-after-free and device-loss handling

### DIFF
--- a/src/core/crash_handler.cpp
+++ b/src/core/crash_handler.cpp
@@ -11,6 +11,7 @@
 #include "core/pinned_memory_allocator.hpp"
 #include "core/tensor.hpp"
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cstdio>
@@ -129,6 +130,7 @@ namespace lfs::core {
 
         std::filesystem::path g_crash_log_path;
         std::once_flag g_install_once;
+        std::mutex g_crash_log_mutex;
 
 #ifdef _WIN32
         HANDLE g_crash_log = INVALID_HANDLE_VALUE;
@@ -217,7 +219,7 @@ namespace lfs::core {
                 ::backtrace_symbols_fd(frames.data(), count, g_crash_log_fd);
             }
 
-            struct sigaction action {};
+            struct sigaction action{};
             action.sa_handler = SIG_DFL;
             sigemptyset(&action.sa_mask);
             action.sa_flags = 0;
@@ -287,6 +289,34 @@ namespace lfs::core {
 
     } // namespace
 
+    void write_crash_diagnostic(const std::string_view text) noexcept {
+        try {
+            const std::lock_guard lock(g_crash_log_mutex);
+#ifdef _WIN32
+            if (g_crash_log == INVALID_HANDLE_VALUE)
+                return;
+            size_t offset = 0;
+            while (offset < text.size()) {
+                const DWORD chunk = static_cast<DWORD>(std::min<size_t>(text.size() - offset, MAXDWORD));
+                DWORD written = 0;
+                if (!WriteFile(g_crash_log, text.data() + offset, chunk, &written, nullptr) || written == 0)
+                    return;
+                offset += written;
+            }
+            DWORD written = 0;
+            WriteFile(g_crash_log, "\n", 1, &written, nullptr);
+            FlushFileBuffers(g_crash_log);
+#else
+            write_signal_text(text.data(), text.size());
+            write_signal_text("\n", 1);
+            if (g_crash_log_fd >= 0)
+                (void)::fsync(g_crash_log_fd);
+#endif
+        } catch (...) {
+            // Diagnostics must not replace the original failure.
+        }
+    }
+
     void install_crash_handlers() {
         std::call_once(g_install_once, [] {
             if (crash_handlers_disabled()) {
@@ -301,14 +331,14 @@ namespace lfs::core {
                                                    ? std::filesystem::path(temp_path.data())
                                                    : std::filesystem::current_path();
             g_crash_log_path = base / std::format("lichtfeld-studio-crash-{}.log", GetCurrentProcessId());
-            g_crash_log = CreateFileW(g_crash_log_path.c_str(), GENERIC_WRITE, FILE_SHARE_READ,
+            g_crash_log = CreateFileW(g_crash_log_path.c_str(), FILE_APPEND_DATA, FILE_SHARE_READ,
                                       nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
             SetUnhandledExceptionFilter(unhandled_exception_filter);
 #else
             g_crash_log_path = std::filesystem::temp_directory_path() /
                                std::format("lichtfeld-studio-crash-{}.log", ::getpid());
             g_crash_log_fd = ::open(g_crash_log_path.c_str(),
-                                    O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+                                    O_WRONLY | O_CREAT | O_TRUNC | O_APPEND | O_CLOEXEC, 0600);
             if (g_crash_log_fd >= 0) {
                 std::array<void*, 1> warmup{};
                 (void)::backtrace(warmup.data(), static_cast<int>(warmup.size()));
@@ -323,6 +353,10 @@ namespace lfs::core {
             }
 #endif
 
+            write_crash_diagnostic(
+                "LichtFeld Studio crash diagnostics initialized.\n"
+                "Records native crashes and the first report of each handled failure.\n"
+                "A forced process termination cannot invoke a crash handler.");
             std::set_terminate(terminate_handler);
             const std::string path = g_crash_log_path.string();
             std::fprintf(stderr, "Crash diagnostics: %s\n", path.c_str());

--- a/src/core/crash_handler.cpp
+++ b/src/core/crash_handler.cpp
@@ -313,7 +313,8 @@ namespace lfs::core {
                 (void)::fsync(g_crash_log_fd);
 #endif
         } catch (...) {
-            // Diagnostics must not replace the original failure.
+            // LFS-CENSUS-OK(empty-catch): A diagnostic sink failure must not recurse
+            // into failure reporting or replace the original failure.
         }
     }
 

--- a/src/core/cuda/diagnostics_compile_check.cpp
+++ b/src/core/cuda/diagnostics_compile_check.cpp
@@ -136,7 +136,7 @@ namespace lfs::core::compile_check {
             }
 
         private:
-            [[nodiscard]] bool setVkFailure(std::string) { return false; }
+            [[nodiscard]] bool setVkFailure(std::string, VkResult) { return false; }
         };
 
         void compile_vk_debug_assert_arities(const int value) {

--- a/src/core/failure_report.cpp
+++ b/src/core/failure_report.cpp
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/failure_report.hpp"
+#include "core/crash_handler.hpp"
 
 #include "core/logger.hpp"
 
@@ -254,7 +255,10 @@ namespace lfs::core {
             const std::string stacktrace = report.capture_stack
                                                ? capture_host_stacktrace(report.stacktrace_skip_frames)
                                                : std::string{};
-            Logger::get().log_internal(level, report.location, format_failure_report(report, stacktrace));
+            const auto formatted = format_failure_report(report, stacktrace);
+            if (decision.count == 1)
+                write_crash_diagnostic(formatted);
+            Logger::get().log_internal(level, report.location, formatted);
         } else {
             emit_failure_repeat_notice(decision, report.location, level);
         }

--- a/src/core/include/core/crash_handler.hpp
+++ b/src/core/include/core/crash_handler.hpp
@@ -5,12 +5,17 @@
 #include "core/export.hpp"
 
 #include <functional>
+#include <string_view>
 
 namespace lfs::core {
 
     // Installs process-wide last-resort diagnostics. Call only after the ABI
     // tripwire: a stale core must never execute current-core startup hooks.
     LFS_CORE_API void install_crash_handlers();
+
+    // Appends a handled failure to the non-rotating crash log. No-op until
+    // crash handlers are installed; never throws or calls the regular logger.
+    LFS_CORE_API void write_crash_diagnostic(std::string_view text) noexcept;
 
     // Flushes the logger and any other flushable diagnostic sink. Swallows
     // all exceptions; safe to call before the logger has been initialized.

--- a/src/rendering/rasterizer/vulkan/src/gs_pipeline.cpp
+++ b/src/rendering/rasterizer/vulkan/src/gs_pipeline.cpp
@@ -156,7 +156,7 @@ namespace {
         code = lfs::ErrorCode::Cancelled;
         break;
     case lfs::rendering::WaitOutcome::Quarantined:
-        code = lfs::ErrorCode::Unavailable;
+        code = lfs::ErrorCode::DeadlineExceeded;
         break;
     }
     throw lfs::Exception(lfs::make_error(lfs::ErrorInit{
@@ -1149,17 +1149,17 @@ void VulkanGSPipeline::collectTimestampResults(CommandBatchSlot& slot,
     if (timestamp_count == 0)
         return;
     [[maybe_unused]] auto cpu_timer = timeCpuStage("vksplat.command_batch.query_results");
-    VkPhysicalDeviceProperties deviceProperties;
-    vkGetPhysicalDeviceProperties(physical_device, &deviceProperties);
-    double timestampPeriod = deviceProperties.limits.timestampPeriod;
-
     std::vector<uint64_t> timestamps(timestamp_count);
-    const VkResult result = vkGetQueryPoolResults(
+    const VkResult result = vulkan_dispatch_.get_query_pool_results(
         device, slot.timestamp_query_pool,
         0, timestamp_count,
         sizeof(uint64_t) * timestamp_count,
         timestamps.data(), sizeof(uint64_t),
-        VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+        VK_QUERY_RESULT_64_BIT);
+    // Profiling must never add an unbounded wait after batch retirement.
+    // Missing timestamps can be dropped without affecting the rendered image.
+    if (result == VK_NOT_READY)
+        return;
     if (result != VK_SUCCESS) {
         lfs::rendering::throw_vk_result(
             result,
@@ -1173,6 +1173,10 @@ void VulkanGSPipeline::collectTimestampResults(CommandBatchSlot& slot,
                 static_cast<int>(result)),
             LFS_SOURCE_SITE_CURRENT());
     }
+    VkPhysicalDeviceProperties deviceProperties;
+    vkGetPhysicalDeviceProperties(physical_device, &deviceProperties);
+    double timestampPeriod = deviceProperties.limits.timestampPeriod;
+
     std::vector<double> times(timestamp_count);
     for (uint32_t i = 0; i < timestamp_count; i++)
         times[i] = 1e-9 * double(timestamps[i] - timestamps[0]) * timestampPeriod;

--- a/src/rendering/vulkan_wait.cpp
+++ b/src/rendering/vulkan_wait.cpp
@@ -221,6 +221,7 @@ namespace lfs::rendering {
         d.cmd_pipeline_barrier2 = ::vkCmdPipelineBarrier2;
         d.cmd_reset_query_pool = ::vkCmdResetQueryPool;
         d.cmd_write_timestamp = ::vkCmdWriteTimestamp;
+        d.get_query_pool_results = ::vkGetQueryPoolResults;
         d.queue_submit = +[](VkQueue queue, uint32_t submit_count, const VkSubmitInfo* submits, VkFence fence) {
             return vk_queue_submit_synced(queue, submit_count, submits, fence);
         };

--- a/src/rendering/vulkan_wait.hpp
+++ b/src/rendering/vulkan_wait.hpp
@@ -150,6 +150,7 @@ namespace lfs::rendering {
         PFN_vkCmdPipelineBarrier2 cmd_pipeline_barrier2 = nullptr;
         PFN_vkCmdResetQueryPool cmd_reset_query_pool = nullptr;
         PFN_vkCmdWriteTimestamp cmd_write_timestamp = nullptr;
+        PFN_vkGetQueryPoolResults get_query_pool_results = nullptr;
         PFN_vkQueueSubmit queue_submit = nullptr;
         PFN_vkQueueWaitIdle queue_wait_idle = nullptr;
 

--- a/src/training/rasterization/fastgs/rasterization/src/forward.cu
+++ b/src/training/rasterization/fastgs/rasterization/src/forward.cu
@@ -77,10 +77,6 @@ namespace {
             return base ? base + cub_workspace_offset_bytes : nullptr;
         }
 
-        bool owns_sorted_indices(const void* ptr) const noexcept {
-            return ptr != nullptr && ptr == retained_indices();
-        }
-
         void bind_layout(char* allocation,
                          int instance_count,
                          size_t cub_bytes,

--- a/src/visualizer/gui/gui_manager.cpp
+++ b/src/visualizer/gui/gui_manager.cpp
@@ -7383,7 +7383,8 @@ namespace lfs::vis::gui {
             } else if (vulkan_context) {
                 rmlui_manager_.clearVulkanQueue();
                 clearLineRendererCommands();
-                if (!vulkan_context->lastError().empty()) {
+                if (vulkan_context->rendererTerminalState() == RendererTerminalState::Running &&
+                    !vulkan_context->lastError().empty()) {
                     LOG_WARN("Vulkan GUI frame begin failed: {} (ui_hidden={}, fullscreen_pending={}, ui_pending={}, settling={}, resume_training_pending={})",
                              vulkan_context->lastError(),
                              ui_hidden_,

--- a/src/visualizer/rendering/rendering_manager_viewport.cpp
+++ b/src/visualizer/rendering/rendering_manager_viewport.cpp
@@ -805,6 +805,10 @@ namespace lfs::vis {
                                          std::nullopt,
                                          request.orthographic_override,
                                          request.ortho_scale_override);
+        if (last_vulkan_context_ &&
+            last_vulkan_context_->rendererTerminalState() != RendererTerminalState::Running) {
+            return std::unexpected("renderer is unavailable after a GPU failure; restart LichtFeld Studio");
+        }
         releasePreviewImageResources();
 
         lfs::core::Tensor image;
@@ -938,6 +942,9 @@ namespace lfs::vis {
         }
         if (!last_vulkan_context_) {
             return std::unexpected("no Vulkan context is available");
+        }
+        if (last_vulkan_context_->rendererTerminalState() != RendererTerminalState::Running) {
+            return std::unexpected("renderer is unavailable after a GPU failure; restart LichtFeld Studio");
         }
         if (!hasRenderableGaussians(&model)) {
             return std::unexpected("no renderable Gaussian model is available");

--- a/src/visualizer/rendering/vksplat_viewport_renderer.cpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.cpp
@@ -1957,9 +1957,13 @@ namespace lfs::vis {
         try {
             reset();
         } catch (const lfs::Exception& e) {
+            if (context_)
+                context_->noteFailure(e);
             LOG_ERROR("VkSplat viewport renderer reset failed during destruction: {}",
                       lfs::format_for_developer(e.error()));
         } catch (const std::exception& e) {
+            if (context_)
+                context_->noteFailure(e);
             LOG_ERROR("VkSplat viewport renderer reset failed during destruction: {}", e.what());
         } catch (...) {
             LOG_ERROR("VkSplat viewport renderer reset failed during destruction with an unknown error");
@@ -2044,6 +2048,8 @@ namespace lfs::vis {
         try {
             renderer_.waitForPendingBatch();
         } catch (const std::exception& e) {
+            if (context_)
+                context_->noteFailure(e);
             LOG_WARN("VkSplat scene resource release falling back to device idle: {}", e.what());
             safe_to_release = false;
         }
@@ -2172,9 +2178,13 @@ namespace lfs::vis {
                 renderer_.cleanupBuffers(buffers_);
                 renderer_.cleanup();
             } catch (const lfs::Exception& e) {
+                if (context_)
+                    context_->noteFailure(e);
                 LOG_ERROR("VkSplat renderer cleanup during reset failed: {}",
                           lfs::format_for_developer(e.error()));
             } catch (const std::exception& e) {
+                if (context_)
+                    context_->noteFailure(e);
                 LOG_ERROR("VkSplat renderer cleanup during reset failed: {}", e.what());
             } catch (...) {
                 LOG_ERROR("VkSplat renderer cleanup during reset failed with an unknown error");
@@ -2896,6 +2906,8 @@ namespace lfs::vis {
                 }
             }
         } catch (const std::exception& e) {
+            if (context_)
+                context_->noteFailure(e);
             releaseGpuLodTreeStorage();
             return std::unexpected(std::format("VkSplat GPU LOD tree storage upload failed: {}", e.what()));
         }
@@ -3902,16 +3914,22 @@ namespace lfs::vis {
             render_complete_timeline_ == VK_NULL_HANDLE || last_submitted_render_value_ == 0;
         const auto release = [&](auto& typed_buffer) {
             auto& dev = typed_buffer.deviceBuffer;
-            if (dev.buffer == VK_NULL_HANDLE || dev.allocation == VK_NULL_HANDLE) {
+            if (dev.buffer == VK_NULL_HANDLE) {
                 return;
             }
-            released_bytes += dev.allocSize;
             const char* const label = dev.label;
+            const auto extra_usage = dev.extra_usage;
             _VulkanBuffer owned = dev;
             dev = {};
             dev.label = label;
+            dev.extra_usage = extra_usage;
             typed_buffer.clear();
             typed_buffer.shrink_to_fit();
+            // Aliases carry capacity but do not own an allocation. Clear them
+            // with their owners, or the next resize can reuse a retired handle.
+            if (owned.allocation == VK_NULL_HANDLE)
+                return;
+            released_bytes += owned.allocSize;
             if (destroy_now) {
                 renderer_.destroyBuffer(owned);
             } else {
@@ -4166,7 +4184,9 @@ namespace lfs::vis {
         }
         try {
             return renderer_.timelineValueComplete(render_complete_timeline_, value);
-        } catch (const std::exception&) {
+        } catch (const std::exception& e) {
+            if (context_)
+                context_->noteFailure(e);
             return false;
         }
     }
@@ -4714,6 +4734,8 @@ namespace lfs::vis {
             reset();
         }
         context_ = &context;
+        if (context.rendererTerminalState() != RendererTerminalState::Running)
+            return std::unexpected("renderer is unavailable after a GPU failure; restart LichtFeld Studio");
         if (initialized_) {
             return {};
         }
@@ -4834,6 +4856,8 @@ namespace lfs::vis {
                                        "vksplat.timeline.render.vulkan");
             last_submitted_render_value_ = 0;
         } catch (const std::exception& e) {
+            if (context_)
+                context_->noteFailure(e);
             return std::unexpected(std::format("VkSplat initialization failed: {}", e.what()));
         }
 
@@ -6510,6 +6534,8 @@ namespace lfs::vis {
         try {
             readback_ring_.markSubmitted(cell, std::move(meta));
         } catch (const std::exception& e) {
+            if (context_)
+                context_->noteFailure(e);
             return std::unexpected(std::format(
                 "VkSplat {} readback ticket bookkeeping failed: {}",
                 operation_label,
@@ -8048,6 +8074,8 @@ namespace lfs::vis {
                     }
                 }
             } catch (const std::exception& e) {
+                if (context_)
+                    context_->noteFailure(e);
                 return std::unexpected(std::format("VkSplat selection query failed: {}", e.what()));
             }
         }
@@ -8242,6 +8270,8 @@ namespace lfs::vis {
             try {
                 overlay_arena_guard.emplace();
             } catch (const std::exception& e) {
+                if (context_)
+                    context_->noteFailure(e);
                 return std::unexpected(std::format(
                     "VkSplat selection overlay arena unavailable: {}", e.what()));
             }
@@ -8318,6 +8348,8 @@ namespace lfs::vis {
                 }
             }
         } catch (const std::exception& e) {
+            if (context_)
+                context_->noteFailure(e);
             // Recording failures cancel without reserving a timeline value.
             // If post-submit bookkeeping threw, the pipeline's host-side record
             // proves that vkQueueSubmit accepted the signal; no completion wait
@@ -9044,6 +9076,8 @@ namespace lfs::vis {
                              sort_region_elems,
                              active_splat_count);
                 } catch (const std::exception& e) {
+                    if (context_)
+                        context_->noteFailure(e);
                     shared_arena_guard.reset();
                     detachSharedScratchBuffers();
                     return std::unexpected(std::format(
@@ -9380,6 +9414,8 @@ namespace lfs::vis {
             // On try-block exit, `batch` submits and publishes its timeline signal before the
             // outer batch_total timer logs.
         } catch (const std::exception& e) {
+            if (context_)
+                context_->noteFailure(e);
             // Recording failures cancel without reserving a value. A rare
             // post-submit bookkeeping failure is distinguished by the pipeline's
             // host-side submission record, so neither path waits on the GPU.

--- a/src/visualizer/rendering/vksplat_viewport_renderer.hpp
+++ b/src/visualizer/rendering/vksplat_viewport_renderer.hpp
@@ -42,6 +42,8 @@ namespace lfs::vis {
     LFS_VIS_API void preloadVkSplatSpirvFiles();
 
     class VksplatViewportRenderer {
+        friend struct VksplatScratchReleaseTestAccess;
+
     public:
         struct RenderResult {
             VkImage image = VK_NULL_HANDLE;

--- a/src/visualizer/visualizer_impl.cpp
+++ b/src/visualizer/visualizer_impl.cpp
@@ -4,6 +4,7 @@
 
 #include "visualizer_impl.hpp"
 #include "core/animatable_property.hpp"
+#include "core/crash_handler.hpp"
 #include "core/cuda_error.hpp"
 #include "core/data_loading_service.hpp"
 #include "core/error.hpp"
@@ -1233,22 +1234,19 @@ namespace lfs::vis {
             code, lfs::ErrorDomain::Vulkan, lfs::Severity::Fatal, lfs::ErrorSurface::Modal,
             LOC(body_key), std::move(detail), std::move(actions), LFS_SOURCE_SITE_CURRENT()));
 
-        if (device_lost) {
-            SDL_Window* const window = window_manager_ ? window_manager_->getWindow() : nullptr;
-            if (!SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
-                                          LOC(ErrModalKeys::RENDERER_DEVICE_LOST),
-                                          LOC(ErrModalKeys::RENDERER_DEVICE_LOST_BODY), window)) {
-                LOG_ERROR("Failed to present device-lost dialog: {}", SDL_GetError());
-            }
-        }
+        if (auto* window = window_manager_ ? window_manager_->getWindow() : nullptr)
+            SDL_SetWindowTitle(window, LOC(device_lost ? ErrModalKeys::RENDERER_DEVICE_LOST
+                                                       : ErrModalKeys::RENDERER_STALLED));
+        lfs::core::flush_diagnostics_noexcept();
     }
 
     void VisualizerImpl::onFrameCompleted() noexcept {
         frame_state_.on_frame_success();
-        lfs::core::MemoryPressureCoordinator::instance().maybe_recover();
         if (auto* const ctx = window_manager_ ? window_manager_->getVulkanContext() : nullptr) {
             applyFrameStateEffects(frame_state_.on_renderer_terminal(ctx->rendererTerminalState()));
         }
+        if (frame_state_.state() != FrameStateMachine::State::RendererDead)
+            lfs::core::MemoryPressureCoordinator::instance().maybe_recover();
     }
 
     void VisualizerImpl::beginShutdown([[maybe_unused]] const std::string_view reason) {
@@ -2055,7 +2053,8 @@ namespace lfs::vis {
 
         if (pipeline_cache_flush_due_ && update_started_at >= *pipeline_cache_flush_due_) {
             pipeline_cache_flush_due_.reset();
-            if (auto* const context = window_manager_->getVulkanContext())
+            if (auto* const context = window_manager_->getVulkanContext();
+                context && context->rendererTerminalState() == RendererTerminalState::Running)
                 context->flushPipelineCache();
         }
 
@@ -2194,6 +2193,10 @@ namespace lfs::vis {
         if (render_work.empty())
             return;
 
+        if (frame_state_.state() == FrameStateMachine::State::RendererDead) {
+            cancelRemainingWork(render_work, 0, "render", viewer_thread_id_);
+            return;
+        }
         processing_render_work_ = true;
         runPostedWork(render_work, "render", viewer_thread_id_);
         processing_render_work_ = false;
@@ -2396,6 +2399,16 @@ namespace lfs::vis {
     }
 
     void VisualizerImpl::render() {
+
+        if (auto* const ctx = window_manager_ ? window_manager_->getVulkanContext() : nullptr)
+            applyFrameStateEffects(frame_state_.on_renderer_terminal(ctx->rendererTerminalState()));
+        if (frame_state_.state() == FrameStateMachine::State::RendererDead) {
+            // Keep the CPU event and MCP queues responsive without issuing another GPU frame.
+            processRenderWorkQueue();
+            if (window_manager_)
+                window_manager_->waitEvents(0.1);
+            return;
+        }
 
         if (motion_only_wake_skipped_) {
             motion_only_wake_skipped_ = false;

--- a/src/visualizer/visualizer_impl.hpp
+++ b/src/visualizer/visualizer_impl.hpp
@@ -603,6 +603,7 @@ namespace lfs::vis {
         std::unique_ptr<MainLoop> main_loop_;
 
         // Frame exception boundary state (viewer thread only).
+        friend class VisualizerImplResetTest_RendererDeadCancelsGpuWorkWithoutDrawing_Test;
         FrameStateMachine frame_state_;
         uint64_t suppressed_frame_errors_ = 0;
         std::chrono::steady_clock::time_point last_frame_error_log_{};

--- a/src/visualizer/window/vulkan_context.cpp
+++ b/src/visualizer/window/vulkan_context.cpp
@@ -4,6 +4,7 @@
 
 #include "vulkan_context.hpp"
 
+#include "core/crash_handler.hpp"
 #include "core/cuda_error.hpp"
 #include "core/environment.hpp"
 #include "core/exportable_storage.hpp"
@@ -549,18 +550,43 @@ namespace lfs::vis {
     }
 
     bool VulkanContext::fail(std::string message, const std::source_location location) {
+        if (rendererTerminalState() != RendererTerminalState::Running &&
+            terminal_failure_reported_.exchange(true, std::memory_order_acq_rel))
+            return false;
         last_error_ = std::format("{} ({}:{})",
                                   std::move(message),
                                   location.file_name(),
                                   location.line());
+        if (rendererTerminalState() != RendererTerminalState::Running)
+            lfs::core::write_crash_diagnostic("Vulkan terminal: " + last_error_);
         LOG_ERROR("Vulkan: {}", last_error_);
         return false;
     }
 
-    bool VulkanContext::setVkFailure(std::string message) {
-        last_error_ = std::move(message);
-        LOG_ERROR("Vulkan: {}", last_error_);
-        return false;
+    bool VulkanContext::setVkFailure(std::string message, const VkResult result,
+                                     const std::source_location location) {
+        if (result == VK_ERROR_DEVICE_LOST) {
+            gpu_device_lost_.store(true, std::memory_order_release);
+            gpu_wait_quarantined_.store(true, std::memory_order_release);
+        }
+        return fail(std::move(message), location);
+    }
+
+    void VulkanContext::noteFailure(const std::exception& exception) {
+        const auto* failure = dynamic_cast<const lfs::Exception*>(&exception);
+        if (!failure)
+            return;
+        const auto& error = failure->error();
+        if (error.code() == lfs::ErrorCode::DeviceLost) {
+            gpu_device_lost_.store(true, std::memory_order_release);
+            gpu_wait_quarantined_.store(true, std::memory_order_release);
+        } else if (error.domain() == lfs::ErrorDomain::Vulkan &&
+                   error.code() == lfs::ErrorCode::DeadlineExceeded) {
+            gpu_wait_quarantined_.store(true, std::memory_order_release);
+        } else {
+            return;
+        }
+        fail(lfs::format_for_developer(error));
     }
 
     lfs::rendering::WaitContext VulkanContext::makeWaitContext(const std::string_view fingerprint) {
@@ -1013,6 +1039,9 @@ namespace lfs::vis {
     }
 
     bool VulkanContext::beginFrame(const VkClearValue& clear_value, Frame& frame) {
+        if (rendererTerminalState() != RendererTerminalState::Running)
+            return false;
+
         if (frame_active_) {
             return fail(std::format(
                 "beginFrame called while another frame is active (frame_active={}, rendering_active={}, frame_index={}, active_frame_index={}, active_image_index={}, active_acquire_index={})",
@@ -1275,12 +1304,13 @@ namespace lfs::vis {
         VkResult result = vkResetCommandPool(device_, command_pools_[current_frame], 0);
         if (result != VK_SUCCESS) {
             framebuffer_resized_ = true;
-            return fail(std::format(
-                "vkResetCommandPool failed before frame recording (frame_index={}, command_pool={:#x}, result={}({}))",
-                current_frame,
-                vkHandleValue(command_pools_[current_frame]),
-                vkResultToString(result),
-                static_cast<int>(result)));
+            return setVkFailure(std::format(
+                                    "vkResetCommandPool failed before frame recording (frame_index={}, command_pool={:#x}, result={}({}))",
+                                    current_frame,
+                                    vkHandleValue(command_pools_[current_frame]),
+                                    vkResultToString(result),
+                                    static_cast<int>(result)),
+                                result);
         }
 
         VkCommandBufferBeginInfo begin_info{};
@@ -1289,13 +1319,14 @@ namespace lfs::vis {
         result = vkBeginCommandBuffer(command_buffers_[current_frame], &begin_info);
         if (result != VK_SUCCESS) {
             framebuffer_resized_ = true;
-            return fail(std::format(
-                "vkBeginCommandBuffer failed before frame recording (frame_index={}, command_buffer={:#x}, flags={:#x}, result={}({}))",
-                current_frame,
-                vkHandleValue(command_buffers_[current_frame]),
-                static_cast<std::uint32_t>(begin_info.flags),
-                vkResultToString(result),
-                static_cast<int>(result)));
+            return setVkFailure(std::format(
+                                    "vkBeginCommandBuffer failed before frame recording (frame_index={}, command_buffer={:#x}, flags={:#x}, result={}({}))",
+                                    current_frame,
+                                    vkHandleValue(command_buffers_[current_frame]),
+                                    static_cast<std::uint32_t>(begin_info.flags),
+                                    vkResultToString(result),
+                                    static_cast<int>(result)),
+                                result);
         }
 
         const VkExtent2D render_extent = framebufferExtent();
@@ -1431,6 +1462,9 @@ namespace lfs::vis {
     }
 
     bool VulkanContext::endFrame() {
+        if (rendererTerminalState() != RendererTerminalState::Running)
+            return false;
+
         if (!frame_active_) {
             return fail(std::format(
                 "endFrame called with no active frame (frame_active={}, rendering_active={}, frame_index={}, active_frame_index={}, active_image_index={}): beginFrame must succeed first",
@@ -1511,13 +1545,14 @@ namespace lfs::vis {
         if (result != VK_SUCCESS) {
             frame_active_ = false;
             framebuffer_resized_ = true;
-            return fail(std::format(
-                "vkEndCommandBuffer failed for the active frame (frame_slot={}, command_buffer={:#x}, image_index={}, result={}({}))",
-                current_frame,
-                vkHandleValue(command_buffer),
-                active_image_index_,
-                vkResultToString(result),
-                static_cast<int>(result)));
+            return setVkFailure(std::format(
+                                    "vkEndCommandBuffer failed for the active frame (frame_slot={}, command_buffer={:#x}, image_index={}, result={}({}))",
+                                    current_frame,
+                                    vkHandleValue(command_buffer),
+                                    active_image_index_,
+                                    vkResultToString(result),
+                                    static_cast<int>(result)),
+                                result);
         }
 
         std::vector<VkSemaphore> wait_semaphores;
@@ -1616,13 +1651,15 @@ namespace lfs::vis {
         if (result != VK_SUCCESS) {
             frame_active_ = false;
             framebuffer_resized_ = true;
-            const bool fence_recovered = replaceFrameFenceSignaled(current_frame);
-            return fail(std::format("vkResetFences(frame slot {}, submit_id {}) failed: {}",
-                                    current_frame,
-                                    submit_id,
-                                    vkResultToString(result)) +
-                        (fence_recovered ? "; frame fence replaced and swapchain retirement scheduled"
-                                         : "; frame fence recovery failed"));
+            const bool fence_recovered = result != VK_ERROR_DEVICE_LOST &&
+                                         replaceFrameFenceSignaled(current_frame);
+            return setVkFailure(std::format("vkResetFences(frame slot {}, submit_id {}) failed: {}",
+                                            current_frame,
+                                            submit_id,
+                                            vkResultToString(result)) +
+                                    (fence_recovered ? "; frame fence replaced and swapchain retirement scheduled"
+                                                     : "; frame fence recovery failed"),
+                                result);
         }
         LOG_PERF("Vulkan endFrame submit: submit_id={}, frame_slot={}, image={}, acquire_index={}, waits={}, timeline_waits={}, immediates={}, framebuffer={}x{}, extent={}x{}",
                  submit_id,
@@ -1651,14 +1688,16 @@ namespace lfs::vis {
             // be returned directly. Retire the swapchain before another acquire; replace the reset
             // frame fence now so recreation cannot block forever waiting on an unsignaled fence.
             framebuffer_resized_ = true;
-            const bool fence_recovered = replaceFrameFenceSignaled(current_frame);
-            return fail(std::format("vkQueueSubmit(frame slot {}, submit_id {}, image {}) failed: {}",
-                                    current_frame,
-                                    submit_id,
-                                    active_image_index_,
-                                    vkResultToString(result)) +
-                        (fence_recovered ? "; frame fence replaced and swapchain retirement scheduled"
-                                         : "; frame fence recovery failed"));
+            const bool fence_recovered = result != VK_ERROR_DEVICE_LOST &&
+                                         replaceFrameFenceSignaled(current_frame);
+            return setVkFailure(std::format("vkQueueSubmit(frame slot {}, submit_id {}, image {}) failed: {}",
+                                            current_frame,
+                                            submit_id,
+                                            active_image_index_,
+                                            vkResultToString(result)) +
+                                    (fence_recovered ? "; frame fence replaced and swapchain retirement scheduled"
+                                                     : "; frame fence recovery failed"),
+                                result);
         }
         frame_submit_serials_[current_frame] = submit_id;
         last_successful_frame_submit_serial_ = submit_id;
@@ -1706,10 +1745,11 @@ namespace lfs::vis {
         }
         frame_suboptimal_ = false;
         if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
-            return fail(std::format("vkQueuePresentKHR(image {}, frame slot {}) failed: {}",
-                                    active_image_index_,
-                                    current_frame,
-                                    vkResultToString(result)));
+            return setVkFailure(std::format("vkQueuePresentKHR(image {}, frame slot {}) failed: {}",
+                                            active_image_index_,
+                                            current_frame,
+                                            vkResultToString(result)),
+                                result);
         }
 
         return true;
@@ -2039,11 +2079,12 @@ namespace lfs::vis {
                                                 VK_TRUE,
                                                 kRetiredSerialWaitTimeoutNs);
         if (result != VK_SUCCESS) {
-            return fail(std::format(
-                "vkWaitForFences(retired frame serial {}) failed: {} (fences={})",
-                serial,
-                vkResultToString(result),
-                fences.size()));
+            return setVkFailure(std::format(
+                                    "vkWaitForFences(retired frame serial {}) failed: {} (fences={})",
+                                    serial,
+                                    vkResultToString(result),
+                                    fences.size()),
+                                result);
         }
         return true;
     }
@@ -2068,8 +2109,9 @@ namespace lfs::vis {
                                                     VK_TRUE,
                                                     kImmediateWaitTimeoutNs);
             if (result != VK_SUCCESS) {
-                return fail(std::format("vkWaitForFences(immediate submits) failed: {}",
-                                        vkResultToString(result)));
+                return setVkFailure(std::format("vkWaitForFences(immediate submits) failed: {}",
+                                                vkResultToString(result)),
+                                    result);
             }
         }
 
@@ -2092,7 +2134,7 @@ namespace lfs::vis {
         }
         const VkResult result = vkDeviceWaitIdle(device_);
         if (result != VK_SUCCESS) {
-            return fail(std::format("vkDeviceWaitIdle failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkDeviceWaitIdle failed: {}", vkResultToString(result)), result);
         }
         last_error_.clear();
         return true;
@@ -2231,7 +2273,7 @@ namespace lfs::vis {
 
         const VkResult result = vkCreateInstance(&create_info, nullptr, &instance_);
         if (result != VK_SUCCESS) {
-            return fail(std::format("vkCreateInstance failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateInstance failed: {}", vkResultToString(result)), result);
         }
         if (validation_enabled_ && !createDebugMessenger()) {
             return false;
@@ -2818,7 +2860,7 @@ namespace lfs::vis {
 
         const VkResult result = vkCreateDevice(physical_device_, &create_info, nullptr, &device_);
         if (result != VK_SUCCESS) {
-            return fail(std::format("vkCreateDevice failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateDevice failed: {}", vkResultToString(result)), result);
         }
 
         if (debug_utils_enabled_) {
@@ -2958,7 +3000,7 @@ namespace lfs::vis {
         const VkResult result = vmaCreateAllocator(&create_info, &allocator_);
         if (result != VK_SUCCESS) {
             allocator_ = VK_NULL_HANDLE;
-            return fail(std::format("vmaCreateAllocator failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vmaCreateAllocator failed: {}", vkResultToString(result)), result);
         }
         return true;
     }
@@ -3217,7 +3259,7 @@ namespace lfs::vis {
 
         VkResult result = vkGetPhysicalDeviceImageFormatProperties2(physical_device_, &format_info, &format_properties);
         if (result != VK_SUCCESS) {
-            return fail(std::format("External Vulkan image format is unsupported: {}", vkResultToString(result)));
+            return setVkFailure(std::format("External Vulkan image format is unsupported: {}", vkResultToString(result)), result);
         }
         const VkExtent3D max_extent = format_properties.imageFormatProperties.maxExtent;
         if (extent.width > max_extent.width || extent.height > max_extent.height) {
@@ -3293,7 +3335,7 @@ namespace lfs::vis {
         result = vkCreateImage(device_, &image_info, nullptr, &out.image);
         if (result != VK_SUCCESS) {
             out = {};
-            return fail(std::format("vkCreateImage(external) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateImage(external) failed: {}", vkResultToString(result)), result);
         }
         setDebugObjectNamef(VK_OBJECT_TYPE_IMAGE,
                             out.image,
@@ -3336,7 +3378,7 @@ namespace lfs::vis {
         result = vkAllocateMemory(device_, &allocate_info, nullptr, &out.memory);
         if (result != VK_SUCCESS) {
             destroyExternalImage(out);
-            return fail(std::format("vkAllocateMemory(external image) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkAllocateMemory(external image) failed: {}", vkResultToString(result)), result);
         }
         setDebugObjectNamef(VK_OBJECT_TYPE_DEVICE_MEMORY,
                             out.memory,
@@ -3348,7 +3390,7 @@ namespace lfs::vis {
         result = vkBindImageMemory(device_, out.image, out.memory, 0);
         if (result != VK_SUCCESS) {
             destroyExternalImage(out);
-            return fail(std::format("vkBindImageMemory(external image) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkBindImageMemory(external image) failed: {}", vkResultToString(result)), result);
         }
 
 #ifdef _WIN32
@@ -3382,7 +3424,7 @@ namespace lfs::vis {
 #endif
         if (result != VK_SUCCESS) {
             destroyExternalImage(out);
-            return fail(std::format("Exporting external image memory handle failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("Exporting external image memory handle failed: {}", vkResultToString(result)), result);
         }
 
         VkImageViewCreateInfo view_info{};
@@ -3397,7 +3439,7 @@ namespace lfs::vis {
         result = vkCreateImageView(device_, &view_info, nullptr, &out.view);
         if (result != VK_SUCCESS) {
             destroyExternalImage(out);
-            return fail(std::format("vkCreateImageView(external image) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateImageView(external image) failed: {}", vkResultToString(result)), result);
         }
         setDebugObjectNamef(VK_OBJECT_TYPE_IMAGE_VIEW,
                             out.view,
@@ -3498,7 +3540,7 @@ namespace lfs::vis {
         VkResult result = vkCreateBuffer(device_, &buffer_info, nullptr, &out.buffer);
         if (result != VK_SUCCESS) {
             out = {};
-            return fail(std::format("vkCreateBuffer(imported) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateBuffer(imported) failed: {}", vkResultToString(result)), result);
         }
         setDebugObjectNamef(VK_OBJECT_TYPE_BUFFER,
                             out.buffer,
@@ -3550,8 +3592,8 @@ namespace lfs::vis {
         // exporter's handle. A stale handle must assert instead of being hidden
         // by the VUID-01742 suppression below.
         {
-            struct stat st_src {};
-            struct stat st_dup {};
+            struct stat st_src{};
+            struct stat st_dup{};
             const int st_src_rc = ::fstat(handle, &st_src);
             const int st_dup_rc = ::fstat(dup_fd, &st_dup);
             int kcmp_rc = 0;
@@ -3625,7 +3667,7 @@ namespace lfs::vis {
             ::close(dup_fd);
 #endif
             destroyExternalBuffer(out);
-            return fail(std::format("vkAllocateMemory(import) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkAllocateMemory(import) failed: {}", vkResultToString(result)), result);
         }
         setDebugObjectNamef(VK_OBJECT_TYPE_DEVICE_MEMORY,
                             out.memory,
@@ -3635,7 +3677,7 @@ namespace lfs::vis {
         result = vkBindBufferMemory(device_, out.buffer, out.memory, 0);
         if (result != VK_SUCCESS) {
             destroyExternalBuffer(out);
-            return fail(std::format("vkBindBufferMemory(import) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkBindBufferMemory(import) failed: {}", vkResultToString(result)), result);
         }
 
         // We do NOT own the handle; the exporter retains it. Leave native_handle invalid.
@@ -3715,7 +3757,7 @@ namespace lfs::vis {
         VkResult result = vkCreateBuffer(device_, &buffer_info, nullptr, &out.buffer);
         if (result != VK_SUCCESS) {
             out = {};
-            return fail(std::format("vkCreateBuffer(sparse import) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateBuffer(sparse import) failed: {}", vkResultToString(result)), result);
         }
         out.size = static_cast<VkDeviceSize>(block.reserved_bytes);
         out.sparse = true;
@@ -3840,7 +3882,7 @@ namespace lfs::vis {
                 ::close(dup_fd);
 #endif
                 rollback_new();
-                return fail(std::format("vkAllocateMemory(sparse chunk) failed: {}", vkResultToString(result)));
+                return setVkFailure(std::format("vkAllocateMemory(sparse chunk) failed: {}", vkResultToString(result)), result);
             }
             setDebugObjectNamef(VK_OBJECT_TYPE_DEVICE_MEMORY,
                                 memory,
@@ -3873,14 +3915,14 @@ namespace lfs::vis {
         VkResult result = vkCreateFence(device_, &fence_info, nullptr, &fence);
         if (result != VK_SUCCESS) {
             rollback_new();
-            return fail(std::format("vkCreateFence(sparse bind) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateFence(sparse bind) failed: {}", vkResultToString(result)), result);
         }
 
         result = lfs::rendering::vk_queue_bind_sparse_synced(graphics_queue_, 1, &bind_info, fence);
         if (result != VK_SUCCESS) {
             vkDestroyFence(device_, fence, nullptr);
             rollback_new();
-            return fail(std::format("vkQueueBindSparse failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkQueueBindSparse failed: {}", vkResultToString(result)), result);
         }
         auto outcome = lfs::rendering::wait_fence_bounded(
             device_, fence, std::stop_token{}, lfs::rendering::VulkanWaitPolicy{},
@@ -3990,7 +4032,7 @@ namespace lfs::vis {
         VkResult result = vkCreateSemaphore(device_, &create_info, nullptr, &out.semaphore);
         if (result != VK_SUCCESS) {
             out = {};
-            return fail(std::format("vkCreateSemaphore(external timeline) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateSemaphore(external timeline) failed: {}", vkResultToString(result)), result);
         }
         {
             const std::lock_guard lock(timeline_value_tracker_mutex_);
@@ -4034,7 +4076,7 @@ namespace lfs::vis {
 #endif
         if (result != VK_SUCCESS) {
             destroyExternalSemaphore(out);
-            return fail(std::format("Exporting external timeline semaphore handle failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("Exporting external timeline semaphore handle failed: {}", vkResultToString(result)), result);
         }
         gpu_object_census_.onCreate(GpuObjectKind::ExternalSemaphore, out.diagnostic_scope);
         out.census_counted = true;
@@ -4286,7 +4328,7 @@ namespace lfs::vis {
         VkCommandBuffer command_buffer = VK_NULL_HANDLE;
         VkResult result = vkAllocateCommandBuffers(device_, &allocate_info, &command_buffer);
         if (result != VK_SUCCESS) {
-            return fail(std::format("vkAllocateCommandBuffers(layout transition) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkAllocateCommandBuffers(layout transition) failed: {}", vkResultToString(result)), result);
         }
         setDebugObjectNamef(VK_OBJECT_TYPE_COMMAND_BUFFER,
                             command_buffer,
@@ -4299,7 +4341,7 @@ namespace lfs::vis {
         result = vkBeginCommandBuffer(command_buffer, &begin_info);
         if (result != VK_SUCCESS) {
             vkFreeCommandBuffers(device_, immediate_command_pool_, 1, &command_buffer);
-            return fail(std::format("vkBeginCommandBuffer(layout transition) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkBeginCommandBuffer(layout transition) failed: {}", vkResultToString(result)), result);
         }
 
         std::vector<VkImageMemoryBarrier2> barriers;
@@ -4337,7 +4379,7 @@ namespace lfs::vis {
         result = vkEndCommandBuffer(command_buffer);
         if (result != VK_SUCCESS) {
             vkFreeCommandBuffers(device_, immediate_command_pool_, 1, &command_buffer);
-            return fail(std::format("vkEndCommandBuffer(layout transition) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkEndCommandBuffer(layout transition) failed: {}", vkResultToString(result)), result);
         }
 
         std::vector<VkSemaphore> wait_semaphores;
@@ -4398,7 +4440,7 @@ namespace lfs::vis {
         result = vkCreateFence(device_, &fence_info, nullptr, &submit_fence);
         if (result != VK_SUCCESS) {
             vkFreeCommandBuffers(device_, immediate_command_pool_, 1, &command_buffer);
-            return fail(std::format("vkCreateFence(layout transition) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateFence(layout transition) failed: {}", vkResultToString(result)), result);
         }
         setDebugObjectNamef(VK_OBJECT_TYPE_FENCE,
                             submit_fence,
@@ -4409,7 +4451,7 @@ namespace lfs::vis {
         if (result != VK_SUCCESS) {
             vkDestroyFence(device_, submit_fence, nullptr);
             vkFreeCommandBuffers(device_, immediate_command_pool_, 1, &command_buffer);
-            return fail(std::format("Immediate Vulkan image layout transition submit failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("Immediate Vulkan image layout transition submit failed: {}", vkResultToString(result)), result);
         }
         {
             const std::lock_guard timeline_value_lock(timeline_value_tracker_mutex_);
@@ -4544,7 +4586,7 @@ namespace lfs::vis {
             result = vkCreateSwapchainKHR(device_, &create_info, nullptr, &swapchain_);
         }
         if (result != VK_SUCCESS) {
-            return fail(std::format("vkCreateSwapchainKHR failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateSwapchainKHR failed: {}", vkResultToString(result)), result);
         }
         setDebugObjectName(VK_OBJECT_TYPE_SWAPCHAIN_KHR, swapchain_, "swapchain.main");
 
@@ -4700,7 +4742,7 @@ namespace lfs::vis {
 
             const VkResult result = vkCreateImageView(device_, &create_info, nullptr, &swapchain_image_views_[i]);
             if (result != VK_SUCCESS) {
-                return fail(std::format("vkCreateImageView failed: {}", vkResultToString(result)));
+                return setVkFailure(std::format("vkCreateImageView failed: {}", vkResultToString(result)), result);
             }
             setDebugObjectNamef(VK_OBJECT_TYPE_IMAGE_VIEW,
                                 swapchain_image_views_[i],
@@ -4783,7 +4825,7 @@ namespace lfs::vis {
                                              &created_allocation_info);
             if (result != VK_SUCCESS) {
                 destroy_created();
-                return fail(std::format("vmaCreateImage(depth/stencil frame {}) failed: {}", i, vkResultToString(result)));
+                return setVkFailure(std::format("vmaCreateImage(depth/stencil frame {}) failed: {}", i, vkResultToString(result)), result);
             }
             setDebugObjectNamef(VK_OBJECT_TYPE_IMAGE,
                                 resource.image,
@@ -4799,7 +4841,7 @@ namespace lfs::vis {
             result = vkCreateImageView(device_, &view_info, nullptr, &resource.view);
             if (result != VK_SUCCESS) {
                 destroy_created();
-                return fail(std::format("vkCreateImageView(depth/stencil frame {}) failed: {}", i, vkResultToString(result)));
+                return setVkFailure(std::format("vkCreateImageView(depth/stencil frame {}) failed: {}", i, vkResultToString(result)), result);
             }
             setDebugObjectNamef(VK_OBJECT_TYPE_IMAGE_VIEW,
                                 resource.view,
@@ -4822,7 +4864,7 @@ namespace lfs::vis {
             create_info.queueFamilyIndex = graphics_queue_family_;
             const VkResult result = vkCreateCommandPool(device_, &create_info, nullptr, &command_pools_[i]);
             if (result != VK_SUCCESS) {
-                return fail(std::format("vkCreateCommandPool(frame {}) failed: {}", i, vkResultToString(result)));
+                return setVkFailure(std::format("vkCreateCommandPool(frame {}) failed: {}", i, vkResultToString(result)), result);
             }
             setDebugObjectNamef(VK_OBJECT_TYPE_COMMAND_POOL,
                                 command_pools_[i],
@@ -4836,7 +4878,7 @@ namespace lfs::vis {
         immediate_info.queueFamilyIndex = graphics_queue_family_;
         const VkResult result = vkCreateCommandPool(device_, &immediate_info, nullptr, &immediate_command_pool_);
         if (result != VK_SUCCESS) {
-            return fail(std::format("vkCreateCommandPool(immediate) failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateCommandPool(immediate) failed: {}", vkResultToString(result)), result);
         }
         setDebugObjectName(VK_OBJECT_TYPE_COMMAND_POOL,
                            immediate_command_pool_,
@@ -4853,7 +4895,7 @@ namespace lfs::vis {
             allocate_info.commandBufferCount = 1;
             const VkResult result = vkAllocateCommandBuffers(device_, &allocate_info, &command_buffers_[i]);
             if (result != VK_SUCCESS) {
-                return fail(std::format("vkAllocateCommandBuffers(frame {}) failed: {}", i, vkResultToString(result)));
+                return setVkFailure(std::format("vkAllocateCommandBuffers(frame {}) failed: {}", i, vkResultToString(result)), result);
             }
             setDebugObjectNamef(VK_OBJECT_TYPE_COMMAND_BUFFER,
                                 command_buffers_[i],
@@ -4871,7 +4913,7 @@ namespace lfs::vis {
         for (std::size_t i = 0; i < kFramesInFlight; ++i) {
             const VkResult result = vkCreateFence(device_, &fence_info, nullptr, &in_flight_[i]);
             if (result != VK_SUCCESS) {
-                return fail(std::format("vkCreateFence(frame {}) failed: {}", i, vkResultToString(result)));
+                return setVkFailure(std::format("vkCreateFence(frame {}) failed: {}", i, vkResultToString(result)), result);
             }
             setDebugObjectNamef(VK_OBJECT_TYPE_FENCE,
                                 in_flight_[i],
@@ -4945,7 +4987,7 @@ namespace lfs::vis {
         populateDebugMessengerCreateInfo(create_info, &validation_errors_fatal_);
         const VkResult result = create_debug_utils_messenger(instance_, &create_info, nullptr, &debug_messenger_);
         if (result != VK_SUCCESS) {
-            return fail(std::format("vkCreateDebugUtilsMessengerEXT failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreateDebugUtilsMessengerEXT failed: {}", vkResultToString(result)), result);
         }
         return true;
     }
@@ -5005,7 +5047,7 @@ namespace lfs::vis {
             result = vkCreatePipelineCache(device_, &create_info, nullptr, &pipeline_cache_);
         }
         if (result != VK_SUCCESS) {
-            return fail(std::format("vkCreatePipelineCache failed: {}", vkResultToString(result)));
+            return setVkFailure(std::format("vkCreatePipelineCache failed: {}", vkResultToString(result)), result);
         }
 
         setDebugObjectName(VK_OBJECT_TYPE_PIPELINE_CACHE,
@@ -5150,9 +5192,9 @@ namespace lfs::vis {
     }
 
     bool VulkanContext::waitForFrameFences() {
-        // Bound the wait so a wedged GPU surfaces as a swapchain-recreate failure rather
-        // than a hang. 2 s is generous; healthy frames complete in <16 ms.
-        constexpr std::uint64_t kSwapchainWaitTimeoutNs = 2'000'000'000ull;
+        if (rendererTerminalState() != RendererTerminalState::Running)
+            return false;
+
         std::vector<VkFence> fences;
         fences.reserve(kFramesInFlight + swapchain_images_in_flight_.size());
         std::size_t frame_fence_count = 0;
@@ -5198,25 +5240,14 @@ namespace lfs::vis {
                   swapchain_extent_.height,
                   framebuffer_resized_);
         const auto wait_start = std::chrono::steady_clock::now();
-        const VkResult result = vkWaitForFences(device_,
-                                                static_cast<std::uint32_t>(fences.size()),
-                                                fences.data(),
-                                                VK_TRUE,
-                                                kSwapchainWaitTimeoutNs);
-        if (result != VK_SUCCESS) {
-            return fail(std::format("vkWaitForFences(submitted frames) failed after {:.1f} ms: {} (fences={}, frame_fences={}, image_aliases={}, frame_index={}, last_submit_id={}, framebuffer={}x{}, extent={}x{}, resized={})",
-                                    elapsedMs(wait_start),
-                                    vkResultToString(result),
-                                    fences.size(),
-                                    frame_fence_count,
-                                    image_alias_count,
-                                    frame_index_,
-                                    last_frame_submit_id,
-                                    framebuffer_width_,
-                                    framebuffer_height_,
-                                    swapchain_extent_.width,
-                                    swapchain_extent_.height,
-                                    framebuffer_resized_));
+        for (const VkFence fence : fences) {
+            auto outcome = lfs::rendering::wait_fence_bounded(
+                device_, fence, {}, {}, makeWaitContext("vulkan.submitted_frames"));
+            if (!mapWaitOutcome(std::move(outcome),
+                                std::format("submitted frames (fences={}, frame_index={}, last_submit_id={})",
+                                            fences.size(), frame_index_, last_frame_submit_id))) {
+                return false;
+            }
         }
         LOG_DEBUG("Vulkan waitForSubmittedFrames complete: fences={}, elapsed_ms={:.1f}",
                   fences.size(),

--- a/src/visualizer/window/vulkan_context.hpp
+++ b/src/visualizer/window/vulkan_context.hpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <expected>
 #include <format>
 #include <mutex>
@@ -45,6 +46,8 @@ struct SDL_Window;
 namespace lfs::vis {
 
     class VulkanContext {
+        friend struct VulkanContextTestAccess;
+
     public:
         enum class ResizeIntent {
             Interactive,
@@ -61,6 +64,8 @@ namespace lfs::vis {
         void shutdown();
         void notifyFramebufferResized(int width, int height, ResizeIntent intent = ResizeIntent::Exact);
         [[nodiscard]] bool hasPendingSwapchainResize() const {
+            if (rendererTerminalState() != RendererTerminalState::Running)
+                return false;
             // A forced rebuild is pending work too, otherwise render-on-demand can idle for
             // half a second holding an out-of-date swapchain. Zero framebuffers are excluded:
             // beginFrame skips those without rebuilding, so they would never clear the flag.
@@ -72,6 +77,8 @@ namespace lfs::vis {
 
         [[nodiscard]] bool presentBootstrapFrame(float r, float g, float b, float a);
         [[nodiscard]] const std::string& lastError() const { return last_error_; }
+        // Preserve terminal errors crossing a renderer's legacy string-result boundary.
+        void noteFailure(const std::exception& exception);
 
         // Typed terminal-renderer state polled by the frame state machine. Acquire
         // loads of the two 7B cause latches; DeviceLost dominates a bare quarantine.
@@ -368,7 +375,8 @@ namespace lfs::vis {
     private:
         bool fail(std::string message,
                   std::source_location location = std::source_location::current());
-        bool setVkFailure(std::string message);
+        bool setVkFailure(std::string message, VkResult result,
+                          std::source_location location = std::source_location::current());
 
         // Phase 7B: shared WaitContext for the six UI-frame bounded waits.
         [[nodiscard]] lfs::rendering::WaitContext makeWaitContext(std::string_view fingerprint);
@@ -563,6 +571,7 @@ namespace lfs::vis {
         std::atomic<bool> gpu_wait_quarantined_{false};
         // Phase 8 P3: second cause latch — set only at the three DeviceLost sites so
         // rendererTerminalState() distinguishes a lost device from a bare stall.
+        std::atomic<bool> terminal_failure_reported_{false};
         std::atomic<bool> gpu_device_lost_{false};
         // Phase 7B AMB-B3: set at shutdown() entry so mid-teardown waits yield Shutdown.
         std::atomic<bool> context_shutdown_started_{false};

--- a/src/visualizer/window/vulkan_result.hpp
+++ b/src/visualizer/window/vulkan_result.hpp
@@ -128,14 +128,15 @@ namespace lfs::vis {
 
 } // namespace lfs::vis
 
-#define LFS_VK_CONTEXT_CHECK_MSG(expr, ...)                              \
-    do {                                                                 \
-        const VkResult lfs_vk_check_result_ = (expr);                    \
-        if (lfs_vk_check_result_ != VK_SUCCESS) {                        \
-            return this->setVkFailure(::lfs::vis::formatVkCheckFailure(  \
-                #expr, lfs_vk_check_result_,                             \
-                ::lfs::rendering::formatVulkanDiagnostic(__VA_ARGS__))); \
-        }                                                                \
+#define LFS_VK_CONTEXT_CHECK_MSG(expr, ...)                                                       \
+    do {                                                                                          \
+        const VkResult lfs_vk_check_result_ = (expr);                                             \
+        if (lfs_vk_check_result_ != VK_SUCCESS) {                                                 \
+            return this->setVkFailure(::lfs::vis::formatVkCheckFailure(                           \
+                                          #expr, lfs_vk_check_result_,                            \
+                                          ::lfs::rendering::formatVulkanDiagnostic(__VA_ARGS__)), \
+                                      lfs_vk_check_result_);                                      \
+        }                                                                                         \
     } while (false)
 
 #ifndef LFS_VK_DEBUG_ASSERT

--- a/tests/test_crash_handler.cpp
+++ b/tests/test_crash_handler.cpp
@@ -5,7 +5,18 @@
 
 #include "core/crash_handler.hpp"
 
+#include "core/failure_report.hpp"
+#include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <stdexcept>
+#include <string>
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <csignal>
+#include <unistd.h>
+#endif
 
 namespace {
 
@@ -40,4 +51,37 @@ TEST(CrashHandlerTest, ExceptionFirewallPropagatesNormalReturnValue) {
         return 7;
     });
     EXPECT_EQ(result, 7);
+}
+
+TEST(CrashHandlerTest, HandledGpuFailureIsSavedOutsideRotatingLogs) {
+    EXPECT_EXIT(([] {
+                    lfs::core::install_crash_handlers();
+                    lfs::core::reset_failure_report_dedup_for_testing();
+                    const lfs::core::FailureReport report{
+                        .family = "CUDA",
+                        .contract = "test handled device failure",
+                        .message = "injected driver reset",
+                        .location = LFS_SOURCE_SITE_CURRENT(),
+                        .capture_stack = false};
+                    for (int i = 0; i < 200; ++i)
+                        lfs::core::emit_failure_report(report, lfs::core::FailureReportSeverity::Error);
+#ifdef _WIN32
+                    const auto pid = _getpid();
+#else
+                    const auto pid = getpid();
+#endif
+                    const auto path = std::filesystem::temp_directory_path() /
+                                      ("lichtfeld-studio-crash-" + std::to_string(pid) + ".log");
+                    std::ifstream file(path);
+                    const std::string text((std::istreambuf_iterator<char>(file)), {});
+                    const auto first = text.find("injected driver reset");
+                    const bool valid = text.find("diagnostics initialized") != std::string::npos &&
+                                       first != std::string::npos &&
+                                       text.find("injected driver reset", first + 1) == std::string::npos;
+                    file.close();
+                    std::error_code ec;
+                    std::filesystem::remove(path, ec);
+                    lfs::core::flush_and_exit(valid ? 0 : 1);
+                }()),
+                ::testing::ExitedWithCode(0), "");
 }

--- a/tests/test_visualizer_post_work.cpp
+++ b/tests/test_visualizer_post_work.cpp
@@ -14876,3 +14876,18 @@ namespace {
     }
 
 } // namespace
+
+namespace lfs::vis {
+    TEST_F(VisualizerImplResetTest, RendererDeadCancelsGpuWorkWithoutDrawing) {
+        VisualizerImpl viewer(projectOptions());
+        (void)viewer.frame_state_.on_fault(FrameFault::DeviceLost);
+        int ran = 0, cancelled = 0;
+        viewer.render_work_queue_.push_back({.run = [&] { ++ran; }, .cancel = [&] { ++cancelled; }});
+        // No initialized window or Vulkan device: touching a GPU frame would fail.
+        EXPECT_NO_THROW(viewer.render());
+        EXPECT_EQ(ran, 0);
+        EXPECT_EQ(cancelled, 1);
+        EXPECT_FALSE(viewer.hasPendingRenderWork());
+        EXPECT_EQ(viewer.frame_state_.state(), FrameStateMachine::State::RendererDead);
+    }
+} // namespace lfs::vis

--- a/tests/test_vksplat_buffer_retire.cpp
+++ b/tests/test_vksplat_buffer_retire.cpp
@@ -6,6 +6,7 @@
 
 #include "rendering/rasterizer/vulkan/src/barrier_planner.h"
 #include "rendering/rasterizer/vulkan/src/gs_pipeline.h"
+#include "rendering/vksplat_viewport_renderer.hpp"
 #include "rendering/vulkan_wait.hpp"
 
 #include <gtest/gtest.h>
@@ -444,4 +445,48 @@ TEST(VkSplatBufferRetire, DrainForceMatchesCleanupContract) {
     EXPECT_EQ(pipeline.retired_shell_count(), 0u);
 
     pipeline.destroyBufferRetired(a);
+}
+
+namespace lfs::vis {
+    struct VksplatScratchReleaseTestAccess {
+        static void checkAliasesAreCleared() {
+            VksplatViewportRenderer renderer;
+            auto& keys = renderer.buffers_.primitive_depth_keys.deviceBuffer;
+            auto& tiles = renderer.buffers_.tiles_touched.deviceBuffer;
+            keys.buffer = fakeVkHandle<VkBuffer>(0x101);
+            keys.allocation = fakeVkHandle<VmaAllocation>(0x201);
+            keys.size = keys.capacity = keys.allocSize = 4096;
+            tiles = keys;
+            tiles.buffer = fakeVkHandle<VkBuffer>(0x102);
+            tiles.allocation = fakeVkHandle<VmaAllocation>(0x202);
+            auto& indices = renderer.buffers_.primitive_sort_indices.deviceBuffer;
+            auto& offsets = renderer.buffers_.index_buffer_offset.deviceBuffer;
+            aliasDeviceView(indices, keys);
+            aliasDeviceView(offsets, tiles);
+            indices.extra_usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+            renderer.render_complete_timeline_ = fakeVkHandle<VkSemaphore>(0x301);
+            renderer.last_submitted_render_value_ = 7;
+
+            renderer.releasePrivateScratchBuffers();
+            for (const auto* buffer : {&keys, &tiles, &indices, &offsets}) {
+                EXPECT_EQ(buffer->buffer, VK_NULL_HANDLE);
+                EXPECT_EQ(buffer->allocation, VK_NULL_HANDLE);
+                EXPECT_EQ(buffer->capacity, 0u);
+                EXPECT_EQ(buffer->size, 0u);
+            }
+            EXPECT_EQ(indices.extra_usage, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT);
+            EXPECT_EQ(renderer.retired_private_scratch_buffers_.size(), 2u);
+            for (const auto& [value, buffer] : renderer.retired_private_scratch_buffers_) {
+                EXPECT_EQ(value, 7u);
+                EXPECT_NE(buffer.allocation, VK_NULL_HANDLE);
+            }
+            // The handles above are scripted; they must never reach Vulkan teardown.
+            renderer.retired_private_scratch_buffers_.clear();
+            renderer.render_complete_timeline_ = VK_NULL_HANDLE;
+        }
+    };
+} // namespace lfs::vis
+
+TEST(VksplatScratchReleaseTest, RetiresOwnersAndInvalidatesAliasesBeforeReuse) {
+    lfs::vis::VksplatScratchReleaseTestAccess::checkAliasesAreCleared();
 }

--- a/tests/test_vksplat_failed_submit_no_publish.cpp
+++ b/tests/test_vksplat_failed_submit_no_publish.cpp
@@ -34,6 +34,17 @@ namespace {
         int begin_calls = 0;
         int reset_cb_calls = 0;
         VkResult first_submit_result = VK_ERROR_DEVICE_LOST;
+        VkResult query_result = VK_NOT_READY;
+        int query_calls = 0;
+        VkQueryResultFlags query_flags = 0;
+
+        static VKAPI_ATTR VkResult VKAPI_CALL query_results(VkDevice, VkQueryPool, uint32_t,
+                                                            uint32_t, size_t, void*, VkDeviceSize,
+                                                            VkQueryResultFlags flags) {
+            ++active()->query_calls;
+            active()->query_flags = flags;
+            return active()->query_result;
+        }
 
         static SubmitScript*& active() {
             static SubmitScript* ptr = nullptr;
@@ -102,6 +113,8 @@ namespace {
             // paths on our forged handles. Disarm first.
             disarm_for_destruction();
         }
+
+        void collect_timestamps() { collectTimestampResults(command_batch_slots_[0], 2); }
 
         void install_fake_handles() {
             device = fakeVkHandle<VkDevice>(0x1001);
@@ -239,4 +252,24 @@ TEST(VkSplatFailedSubmitNoPublish, QW6_FailThenSuccessNoFalsePublication) {
     // false pre-submit publication; value_fail must still be absent.
     EXPECT_NE(pipeline.pending_signal_of_active(), VK_NULL_HANDLE);
     EXPECT_EQ(pipeline.pending_signal_value_of_active(), value_ok);
+}
+
+TEST(VksplatTimestampTest, MissingProfilingResultsNeverBlockOrFailRendering) {
+    SubmitScript script;
+    BindSubmit bind(script);
+    TestablePipeline pipeline;
+    pipeline.install_fake_handles();
+    auto dispatch = lfs::rendering::VulkanDispatch::real();
+    dispatch.get_query_pool_results = SubmitScript::query_results;
+    pipeline.setVulkanDispatch(dispatch);
+    EXPECT_NO_THROW(pipeline.collect_timestamps());
+    EXPECT_EQ(script.query_calls, 1);
+    EXPECT_EQ(script.query_flags & VK_QUERY_RESULT_WAIT_BIT, 0u);
+    script.query_result = VK_ERROR_DEVICE_LOST;
+    try {
+        pipeline.collect_timestamps();
+        FAIL() << "device loss must remain a typed error";
+    } catch (const lfs::Exception& error) {
+        EXPECT_EQ(error.error().code(), lfs::ErrorCode::DeviceLost);
+    }
 }

--- a/tests/test_vulkan_wait_bounded.cpp
+++ b/tests/test_vulkan_wait_bounded.cpp
@@ -3,7 +3,9 @@
 
 // Phase 7A: fake-clock bounded-wait matrix (spec §4.4) — GPU-free.
 
+#include "core/logger.hpp"
 #include "rendering/vulkan_wait.hpp"
+#include "window/vulkan_context.hpp"
 
 #include <gtest/gtest.h>
 
@@ -1086,4 +1088,43 @@ TEST(FrameTimelineWaitCursor, WithinFrameDuplicateIsAlreadySatisfied) {
     EXPECT_EQ(cursor.pending, 11u);
     cursor.submit_accepted();
     EXPECT_EQ(cursor.committed, 11u);
+}
+
+namespace lfs::vis {
+    struct VulkanContextTestAccess {
+        static void loseDevice(VulkanContext& context) {
+            (void)context.mapWaitOutcome(lfs::make_error({.code = ErrorCode::DeviceLost, .domain = ErrorDomain::Vulkan, .detail = "injected device loss", .detection = LFS_SOURCE_SITE_CURRENT()}), "test fence");
+        }
+        static void quarantine(VulkanContext& context) {
+            context.gpu_wait_quarantined_.store(true);
+        }
+    };
+} // namespace lfs::vis
+
+TEST(VulkanContextTerminalTest, LostOrQuarantinedDeviceStopsFramesAndFenceRetries) {
+    for (const bool lost : {true, false}) {
+        lfs::vis::VulkanContext context;
+        if (lost)
+            lfs::vis::VulkanContextTestAccess::loseDevice(context);
+        else
+            lfs::vis::VulkanContextTestAccess::quarantine(context);
+        const auto first_error = context.lastError();
+        size_t error_count = 0;
+        const auto token = lfs::core::Logger::get().add_log_handler(
+            [&](lfs::core::LogLevel level, const lfs::core::SourceSite&, std::string_view) {
+                if (level == lfs::core::LogLevel::Error || level == lfs::core::LogLevel::Warn)
+                    ++error_count;
+            });
+        for (int frame = 0; frame < 1000; ++frame) {
+            lfs::vis::VulkanContext::Frame output;
+            EXPECT_FALSE(context.beginFrame({}, output));
+            EXPECT_FALSE(context.endFrame());
+            EXPECT_FALSE(context.waitForSubmittedFrames());
+        }
+        lfs::core::Logger::get().remove_log_handler(token);
+        EXPECT_EQ(error_count, 0u);
+        EXPECT_EQ(context.lastError(), first_error);
+        EXPECT_EQ(context.rendererTerminalState(), lost ? lfs::vis::RendererTerminalState::DeviceLost
+                                                        : lfs::vis::RendererTerminalState::Quarantined);
+    }
 }


### PR DESCRIPTION
Clear non-owning VkSplat scratch aliases when retiring their allocations. This fixes repeated image exports reusing destroyed buffers, producing black images and Vulkan device loss.

Stop frame retries after device loss, keep MCP responsive, remove the unbounded timestamp-query wait, and preserve the first failure outside rotating logs.

Fixes #2081. Related to #2080.

Validated with renderer/lifecycle regression tests, four repeated exports, and normal/collapsed-window exports from all seven latest Mip-NeRF 360 reconstructions with zero Vulkan validation errors. An injected device loss triggered one fence failure; MCP and Python remained responsive. The reported Windows driver-level TDR remains unconfirmed.
