### PR TITLE
Masks: compare segment_and_ignore bands on the normalized mask scale

### DIFF
--- a/src/training/kernels/mask_preprocess.cu
+++ b/src/training/kernels/mask_preprocess.cu
@@ -27,10 +27,11 @@ namespace lfs::training::kernels {
             return std::min(num_blocks_1d(total), kMaxReduceBlocks);
         }
 
+        /// Float32 band masks are normalized; UInt8 masks retain their 0..255 scale.
         template <typename MaskT>
-        __device__ __forceinline__ float load_mask_raw(const MaskT* mask, const int idx) {
+        __device__ __forceinline__ float load_mask_normalized(const MaskT* mask, const int idx) {
             if constexpr (std::is_same_v<std::remove_cv_t<MaskT>, uint8_t>) {
-                return static_cast<float>(mask[idx]);
+                return static_cast<float>(mask[idx]) / 255.0f;
             } else {
                 return mask[idx];
             }
@@ -51,17 +52,17 @@ namespace lfs::training::kernels {
             const MaskT* mask,
             const int idx,
             const MaskPhotoMode mode) {
-            const float v = load_mask_raw(mask, idx);
             if (mode == MaskPhotoMode::SegmentAndIgnore) {
-                // After trainer remap: >250 kept as 255 → weight 1; else 0.
-                return v > 250.0f ? 1.0f : 0.0f;
+                const float v = load_mask_normalized(mask, idx);
+                // Keep band (authored > 250) is the only photometric contributor.
+                return v > kMaskKeepMin ? 1.0f : 0.0f;
             }
             // BinaryGt0 matches the reference weight composition:
             //   UInt8/Bool → (v != 0) as float; Float32 → pass-through.
             if constexpr (std::is_same_v<std::remove_cv_t<MaskT>, uint8_t>) {
                 return mask[idx] != 0 ? 1.0f : 0.0f;
             } else {
-                return v;
+                return mask[idx];
             }
         }
 
@@ -72,9 +73,9 @@ namespace lfs::training::kernels {
             const int idx,
             const MaskOpacityMode mode) {
             if (mode == MaskOpacityMode::SegmentAndIgnore) {
-                const float v = load_mask_raw(mask, idx);
-                // After trainer remaps: [128,250] → BG (penalty), else FG (no penalty).
-                return (v >= 128.0f && v <= 250.0f) ? 1.0f : 0.0f;
+                const float v = load_mask_normalized(mask, idx);
+                // Segment band (authored [128,250]) → BG (penalty), else FG (no penalty).
+                return (v >= kMaskSegmentMin && v <= kMaskKeepMin) ? 1.0f : 0.0f;
             }
             return 1.0f - mask_as_float(mask, idx);
         }

--- a/src/training/kernels/mask_preprocess.hpp
+++ b/src/training/kernels/mask_preprocess.hpp
@@ -10,9 +10,22 @@
 
 namespace lfs::training::kernels {
 
+    /// SegmentAndIgnore band bounds for Float32 masks in [0,1], as returned by
+    /// the pipelined loader. UInt8 masks (including Camera::load_and_get_mask)
+    /// still carry 0..255 samples and are normalized by the fused kernels.
+    ///
+    ///   value > 250       → keep    (photometric weight 1, no opacity penalty)
+    ///   128 ≤ value ≤ 250 → segment (opacity penalty, no photometric weight)
+    ///   value < 128       → ignore  (no loss at all)
+    ///
+    /// Midpoints between adjacent eight-bit levels preserve their classification
+    /// despite floating-point error in the normalization by 255.
+    inline constexpr float kMaskKeepMin = 250.5f / 255.0f;
+    inline constexpr float kMaskSegmentMin = 127.5f / 255.0f;
+
     /// Photometric mask weight modes for the fused preprocess kernel.
     /// BinaryGt0: weight = (mask > 0)  — Segment / Ignore after binarize
-    /// SegmentAndIgnore: weight = (mask > 250) — keep only the "keep" band
+    /// SegmentAndIgnore: weight = (mask > kMaskKeepMin) — keep only the "keep" band
     enum class MaskPhotoMode : int {
         BinaryGt0 = 0,
         SegmentAndIgnore = 1,
@@ -20,7 +33,8 @@ namespace lfs::training::kernels {
 
     /// Opacity-penalty band modes.
     /// BinaryGt0: bg = 1 - mask_as_float (UInt8/Bool → 0/1; Float32 pass-through)
-    /// SegmentAndIgnore: bg = 1 iff 128 ≤ mask ≤ 250 (Ignore band is FG for penalty)
+    /// SegmentAndIgnore: bg = 1 iff kMaskSegmentMin ≤ mask ≤ kMaskKeepMin
+    /// (the Ignore band is FG for the penalty)
     enum class MaskOpacityMode : int {
         BinaryGt0 = 0,
         SegmentAndIgnore = 1,
@@ -29,8 +43,10 @@ namespace lfs::training::kernels {
     /// Fuse SegmentAndIgnore / Segment / Ignore photometric remapping + optional ROI
     /// into a single float32 [H,W] weight map (allocation-free; writes into `out`).
     ///
-    /// UInt8: nonzero → 1 (BinaryGt0) or value>250 → 1 (SegmentAndIgnore)
-    /// Float32: same comparisons on the raw float value.
+    /// UInt8 samples are scaled by 1/255 before the band comparison, so both
+    /// entry points share one value domain:
+    /// BinaryGt0 — UInt8: nonzero → 1; Float32: pass-through.
+    /// SegmentAndIgnore — value > kMaskKeepMin → 1.
     void launch_fuse_photometric_mask_weight_u8(
         const uint8_t* mask,
         const float* roi_weight, // nullable

--- a/src/training/trainer.cpp
+++ b/src/training/trainer.cpp
@@ -62,6 +62,7 @@
 #include "training/kernels/camera_loss_heatmap.cuh"
 #include "training/kernels/depth_loss.hpp"
 #include "training/kernels/grad_alpha.hpp"
+#include "training/kernels/mask_preprocess.hpp"
 #include "training/kernels/mrnf_kernels.hpp"
 #include "training/kernels/normal_consistency_loss.hpp"
 #include "training/kernels/normal_loss.hpp"
@@ -7487,7 +7488,15 @@ namespace lfs::training {
 
                             if (use_mask &&
                                 params_.optimization.mask_mode == lfs::core::param::MaskMode::SegmentAndIgnore) {
-                                const auto mask_for_error = mask_tile.gt(250).to(lfs::core::DataType::Float32);
+                                // The pipelined loader returns normalized Float32 masks;
+                                // Camera masks retain their raw UInt8 band levels.
+                                const float keep_min =
+                                    (mask_tile.dtype() == lfs::core::DataType::UInt8 ||
+                                     mask_tile.dtype() == lfs::core::DataType::Bool)
+                                        ? 250.0f
+                                        : lfs::training::kernels::kMaskKeepMin;
+                                const auto mask_for_error =
+                                    mask_tile.gt(keep_min).to(lfs::core::DataType::Float32);
                                 tile_error_map.mul_(mask_for_error);
                             }
 

--- a/tests/test_mask_preprocess_fusion.cpp
+++ b/tests/test_mask_preprocess_fusion.cpp
@@ -28,6 +28,11 @@ namespace {
         return Tensor::from_vector(data, {H, W}, Device::CUDA);
     }
 
+    /// Use the same CUDA Tensor normalization as the pipelined loader.
+    Tensor normalized_mask_from(const std::vector<uint8_t>& data, size_t H, size_t W) {
+        return u8_mask_from(data, H, W).to(DataType::Float32) / 255.0f;
+    }
+
     /// Reference: SegmentAndIgnore photometric remap (old trainer chain) + ROI compose.
     Tensor ref_photometric_sai(const Tensor& mask_u8, const Tensor& roi) {
         auto m = mask_u8;
@@ -122,6 +127,53 @@ TEST(MaskPreprocessFusionTest, SegmentAndIgnorePhotometricMatchesReference) {
     expect_near_vec(fused, ref, 1e-6f, "photo_sai");
 }
 
+TEST(MaskPreprocessFusionTest, SegmentAndIgnorePhotometricMatchesReferenceForNormalizedMask) {
+    // Same bands as above, but handed over the way the pipelined loader does:
+    // Float32 in [0,1]. Must classify identically to the raw eight-bit mask.
+    const std::vector<uint8_t> bands{0, 100, 180, 255, 200, 40, 255, 128};
+    const auto roi = f32_from({1.f, 0.5f, 0.25f, 0.f, 1.f, 1.f, 0.1f, 0.75f}, 2, 4);
+
+    const auto ref = ref_photometric_sai(u8_mask_from(bands, 2, 4), roi);
+
+    MaskPreprocessWorkspace ws;
+    const auto fused = fuse_photometric_mask_weight(
+        ws, normalized_mask_from(bands, 2, 4), roi, /*segment_and_ignore=*/true);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    expect_near_vec(fused, ref, 1e-6f, "photo_sai_normalized");
+}
+
+TEST(MaskPreprocessFusionTest, SegmentAndIgnoreBandLevelsMatchForBothMaskTypes) {
+    // Cover all eight-bit levels, including 127/128 and 250/251 band edges.
+    constexpr size_t n = 256;
+    std::vector<uint8_t> bands(n);
+    std::vector<float> photo_weights(n);
+    std::vector<float> background_weights(n);
+    for (size_t i = 0; i < n; ++i) {
+        bands[i] = static_cast<uint8_t>(i);
+        photo_weights[i] = i > 250 ? 1.0f : 0.0f;
+        background_weights[i] = i >= 128 && i <= 250 ? 1.0f : 0.0f;
+    }
+    const auto expected_photo = f32_from(photo_weights, 1, n);
+    const auto expected_background = f32_from(background_weights, 1, n);
+    const auto alpha = Tensor::full({size_t{1}, n}, 1.0f, Device::CUDA);
+    const Tensor no_roi{};
+
+    MaskPreprocessWorkspace ws;
+    for (const auto& mask : {u8_mask_from(bands, 1, n), normalized_mask_from(bands, 1, n)}) {
+        const auto photo = fuse_photometric_mask_weight(ws, mask, no_roi, /*segment_and_ignore=*/true);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        expect_near_vec(photo, expected_photo, 1e-6f, "photo_levels");
+
+        // power = 1 and scale = n make grad_alpha the per-pixel background weight.
+        const auto penalty = fuse_mask_opacity_penalty(
+            ws, alpha, mask, no_roi, /*power=*/1.0f, /*scale=*/static_cast<float>(n),
+            /*segment_and_ignore=*/true);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        expect_near_vec(penalty.grad_alpha, expected_background, 1e-6f, "opacity_levels");
+    }
+}
+
 TEST(MaskPreprocessFusionTest, SegmentOpacityPenaltyMatchesReference) {
     const auto alpha = f32_from({0.2f, 0.4f, 0.6f, 0.8f}, 2, 2);
     // UInt8 binary-ish mask (object=1, bg=0)
@@ -158,6 +210,25 @@ TEST(MaskPreprocessFusionTest, SegmentAndIgnoreOpacityPenaltyMatchesReference) {
 
     EXPECT_NEAR(fused.loss.item<float>(), ref.loss.item<float>(), 1e-5f);
     expect_near_vec(fused.grad_alpha, ref.grad_alpha, 1e-5f, "opacity_sai");
+}
+
+TEST(MaskPreprocessFusionTest, SegmentAndIgnoreOpacityPenaltyMatchesReferenceForNormalizedMask) {
+    const auto alpha = f32_from({0.1f, 0.3f, 0.5f, 0.7f, 0.9f, 0.2f}, 2, 3);
+    const std::vector<uint8_t> bands{40, 180, 255, 128, 200, 10};
+    const auto roi = f32_from({1.f, 1.f, 0.5f, 0.f, 0.25f, 1.f}, 2, 3);
+    constexpr float power = 2.0f;
+    constexpr float scale = 1.5f;
+
+    const auto ref = ref_opacity_sai(alpha, u8_mask_from(bands, 2, 3), roi, power, scale);
+
+    MaskPreprocessWorkspace ws;
+    const auto fused = fuse_mask_opacity_penalty(
+        ws, alpha, normalized_mask_from(bands, 2, 3), roi, power, scale,
+        /*segment_and_ignore=*/true);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    EXPECT_NEAR(fused.loss.item<float>(), ref.loss.item<float>(), 1e-5f);
+    expect_near_vec(fused.grad_alpha, ref.grad_alpha, 1e-5f, "opacity_sai_normalized");
 }
 
 TEST(MaskPreprocessFusionTest, SoftFloatOpacityPenaltyMatchesReference) {


### PR DESCRIPTION
## Problem

`--mask-mode segment_and_ignore` drops every pixel from the photometric loss and never applies the opacity penalty. Training runs to completion with the loss pinned at ~0 from the first logged iteration, and nothing reports an error.

A three-band mask is authored on the eight-bit scale — `< 128` ignore, `128..250` segment, `> 250` keep — and the fused preprocess kernel still compares against those raw levels (`v > 250.0f`, `128 <= v <= 250`). The pipelined loader stopped delivering them: `io::process_mask` returns `mask.to(Float32) / 255.0f`, so a keep sample of 255 arrives as `1.0`, the band comparisons are false for every pixel, and the mode degenerates to "ignore everything".

Sidecar masks under `masks/` take that path, so the mode is dead for the common case. In-memory masks still work, because they arrive through `Camera::load_and_get_mask`, which still hands over `UInt8` 0..255.

## Root cause

`9169a2a0` (#1588) fused the trainer's `masked_fill` band remap into `mask_preprocess.cu`, carrying the `250` / `128` bounds over unchanged — the kernel comments still describe the remap it replaced (`// After trainer remap: >250 kept as 255`), and `tests/test_mask_preprocess_fusion.cpp` still checks against that "old trainer chain". The same commit rewrote `process_mask` to normalize to `[0,1]`. The consumers kept the eight-bit domain; the producer left it.

The existing tests do not catch this because they feed `UInt8` samples straight into the kernel, bypassing the loader.

## Fix

Express the band bounds on the `[0,1]` scale in one place (`kMaskKeepMin`, `kMaskSegmentMin` in `mask_preprocess.hpp`), and scale `UInt8` samples the same way when reading a band, so both kernel entry points share one value domain.

The bounds sit on the midpoints between neighbouring eight-bit levels (`250.5/255`, `127.5/255`) rather than on the levels themselves, so the rounding in the normalization cannot move an authored level across a band edge. Classification is unchanged for raw eight-bit input — `v/255 > 250.5/255` iff `v > 250` — which is what keeps the existing `UInt8` fusion tests passing untouched.

The tile error mask in `trainer.cpp` picks its bound by dtype for the same reason: masks that come through `Camera` still arrive as raw levels, and the eval mask in `metrics.cpp` reads those, so both stay correct without a change.

## Tests

`tests/test_mask_preprocess_fusion.cpp` gains coverage of the shape masks actually arrive in:

- `SegmentAndIgnorePhotometricMatchesReferenceForNormalizedMask` and `SegmentAndIgnoreOpacityPenaltyMatchesReferenceForNormalizedMask` — a `Float32` `[0,1]` mask must classify identically to the raw eight-bit reference
- `SegmentAndIgnoreBandLevelsMatchForBothMaskTypes` — sweeps all 256 levels through both entry points and pins the `127/128` and `250/251` band edges

All three fail on `master` and pass with this change; the seven existing fusion tests are untouched and still pass.

Beyond the unit tests, I drove the pipelined loader over an eight-bit three-band PNG — as a sidecar mask and as an RGBA alpha channel, on the first load and on the cached reload — and checked the delivered mask through the fused entry points: every band classifies correctly with this change and collapses to Ignore without it.

## Reproducing

Point any COLMAP dataset at a `masks/` directory of eight-bit three-band PNGs (255 keep, 200 background, 0 ignore) and train with `--mask-mode segment_and_ignore`. Every sample lands outside both bands, so the photometric weight map is identically zero and the opacity penalty never fires: the reported loss sits at ~0.0000 from the first logged iteration, while `--mask-mode none` on the same data trains normally.
