### PR TITLE
fix: add Pascal viewer compatibility and avoid scratch cleanup deadlock

### DIFF
--- a/docs/pascal_compatibility.md
+++ b/docs/pascal_compatibility.md
@@ -12,7 +12,7 @@ The same device also lacked the Vulkan16-bit capabilities required for q16 SH. W
 
 ## Executed validation
 
-Environment: Windows, GTX1060 6GB/SM6.1, driver571.96, CUDA12.8.61, VS2022 17.14.37/MSVC14.44.35207, clang-format19.1.5, native Release with `CMAKE_CUDA_ARCHITECTURES=61`, Python3.12.13. All results below precede a final whitespace-only clang-format pass.
+Environment: Windows, GTX1060 6GB/SM6.1, driver571.96, CUDA12.8.61, VS2022 17.14.37/MSVC14.44.35207, clang-format19.1.5, native Release with `CMAKE_CUDA_ARCHITECTURES=61`, Python3.12.13. The initial validation table below preceded a final whitespace-only clang-format pass. Later validation is recorded separately below.
 
 | Check | Observed result |
 |---|---|
@@ -43,8 +43,32 @@ assert p.get('sh_degree_interval') == 10
 
 Verify active SH degree2 in the trained model, not just configured maximum degree. Use an isolated profile and explicit new project save path: importing a dataset may retain the currently open project's save destination. Treat Python tracebacks as failures even if an editor tool's outer response reports success.
 
+## Shared-scratch cleanup deadlock
+
+Full-resolution GUI training exposed a separate lock inversion after the earlier short acceptance run. The viewer's recovery path called `GlobalArenaManager::clear_external_backing()` while holding `init_mutex_`; arena cleanup waited for active frames to finish. FastGS backward needed `get_arena()` and that same mutex before it could release the active frame. Native stacks identified both wait paths. The five decisive machine-code ranges matched the diagnostic symbol mapping; the entire diagnostic binary was not identical.
+
+Obtain the arena through `try_get_arena()`, release the manager mutex, then call arena-level cleanup. Preserve the existing synchronization and runtime-owned lifetime contract: shutdown follows active-user shutdown. This does not support concurrent manager reset/destruction or change training mathematics, precision selection, losses, optimizer settings or splat limits.
+
+A standalone compiled concurrency regression passed: manager lookup completed while cleanup awaited an active frame, then cleanup completed after release. Independent review found no blocking issue. The native Release rebuild and installed-binary hash checks passed. No new test or rebuild was needed solely to publish this already-tested change.
+
+The old isolated full-resolution GUI reproduction stalled at iteration 641 with 317,006 splats. The repaired run reached 21,425 iterations and 1,000,000 splats on 713 images, full resolution, MRNF and SH3. It was configured for 71,300 iterations and intentionally stopped by the user. Shared scratch/storage growth, camera-view changes, checkpoint saving, clean stopping and saved-state reopening passed. The old reproduction used 30,000 total iterations with the scaled early refinement schedule, so it was not an exact full-schedule A/B comparison.
+
+The earlier 600-step GUI and headless tests did not establish stability of this longer GUI workload. User Stop did not automatically save in this configuration; an explicit stopped-state project save was verified before reopening.
+
+## Bounded training-quality comparison
+
+Four fresh headless runs compared q16/FP32 storage in q16, FP32, FP32, q16 order using the same patched executable: 3,000 iterations, resize factor 2, SH2, MRNF, 623 training images and 90 held-out images. All completed and exported finite models with learned SH-rest coefficients.
+
+| Mean metric | q16 | FP32 |
+|---|---:|---:|
+| PSNR (dB, higher is better) |20.697513|20.778174|
+| SSIM (higher is better) |0.719228|0.719667|
+| LPIPS (lower is better) |0.387395|0.386986|
+
+No mean quality regression was detected. Differences were smaller than the larger within-mode repeat gap for each metric. These numerically different models do not prove statistical equivalence, a causal quality improvement, full converged-quality parity, or equivalence of all compatibility changes to an untouched upstream executable. The deadlock change concerns synchronization rather than model mathematics.
+
 ## Limits
 
-The full approximately71300-step workload, upstream full test suite, other GPU models and all model formats were not tested. Vulkan validation layers were unavailable. The non-conditional fallback uses16 depth waves rather than the conditional path's64; FP32 SH requires more VRAM than q16. The tests establish a useful compatibility patch for the reproduced machine/workload, not a general driver diagnosis or complete legacy-GPU support claim.
+The full 71,300-step workload was intentionally stopped at 21,425 steps; completion remains unverified. The upstream full test suite, other GPU models and all model formats were not tested. Vulkan validation layers were unavailable. The non-conditional fallback uses16 depth waves rather than the conditional path's64; FP32 SH requires more VRAM than q16. The tests establish a useful compatibility patch for the reproduced machine/workload, not a general driver diagnosis or complete legacy-GPU support claim.
 
 Related reproduction: [upstream issue1681](https://github.com/MrNeRF/LichtFeld-Studio/issues/1681).

--- a/docs/pascal_compatibility.md
+++ b/docs/pascal_compatibility.md
@@ -1,0 +1,50 @@
+# Pascal source-build compatibility: tested GTX 1060 case
+
+This patch enables a locally tested Windows/GTX 1060 source-build workflow on top of master `da2fb643b6f049b10c4a68eeaf28ae96296b45a1`. It does not change the project's official supported-hardware policy or establish support for every pre-Volta GPU.
+
+## Problems and behavior
+
+SM61 cannot compile/run the WMMA convolution and SH-assignment paths. Guard those device bodies and provide equivalent scalar/SIMT work. Select SIMT below SM70 before dispatch benchmarking so empty WMMA kernels cannot win the benchmark and leave output unwritten. Newer-device implementations remain available.
+
+On the tested GTX 1060, Gaussian display/live training crashed in `nvoglv64.dll` (`0xc0000005`, module32.0.15.7196, offset0xf276d4). Headless training passed. Disabling Vulkan conditional rendering allowed the same GUI workload to complete; re-enabling it with q16 still disabled crashed a separate513-Gaussian fixture. Disable that extension/feature consistently by default on the selected pre-Volta CUDA device, using the existing fallback. `LFS_VK_DISABLE_CONDITIONAL_RENDERING` remains an explicit diagnostic override.
+
+The same device also lacked the Vulkan16-bit capabilities required for q16 SH. When either `shaderFloat16` or `storageBuffer16BitAccess` is unavailable and no explicit `LFS_SH_VALUE_QUANT` is set, select FP32 SH before viewer storage creation. Decode q16 through canonical coefficients, convert ordinary IEEE half numerically, and retain correct exportable ownership/capacity/swizzled layout through saved-project loading and storage rebinding. Headless defaults remain unchanged. The automatic flag is process-global; a future in-process GPU-switching design should revisit that scope.
+
+## Executed validation
+
+Environment: Windows, GTX1060 6GB/SM6.1, driver571.96, CUDA12.8.61, VS2022 17.14.37/MSVC14.44.35207, clang-format19.1.5, native Release with `CMAKE_CUDA_ARCHITECTURES=61`, Python3.12.13. All results below precede a final whitespace-only clang-format pass.
+
+| Check | Observed result |
+|---|---|
+| Full native Release build and installed runtime | Passed; Python/stdlib imports and CUDA tensor arithmetic passed |
+| LPIPS RGB convolution | Six SM61 GPU cases,41344 outputs, exact agreement with independent CPU reference |
+| SH assignment | Eight SM61 GPU cases covering padding, seeds, candidate counts and ties matched independent FP32/FMA reference |
+| Full LPIPS model | Identical/distinct image cases passed with default and forced-WMMA settings; SM61 correctly selected SIMT |
+| Retained SM75 kernel paths | Compiled; no SM75 GPU execution |
+| Baseline viewer plus CUDA synchronization | Still crashed |
+| Conditional rendering disabled only | Ten GUI training iterations and visible rendering passed |
+| Conditional rendering disabled plus FP32 SH | Saved SH2 PLY rendering and600-step GUI refinement passed |
+| Conditional rendering re-enabled, FP32 SH retained | Synthetic513-splat SH2 scene reproduced driver access violation |
+| Automatic settings, installed build |713-image COLMAP dataset;600 MRNF iterations;2M splat cap; SH2; mask-ignore; refinement296267 to317006 splats; final loss0.132077; saved and reopened |
+| q16 saved-project conversion |513 splats and12312 nonzero SH coefficients across quantization blocks; maximum absolute error0.0; visible rendering |
+| Review and source hygiene | Independent read-only review had no blocking findings; clang-format and git diff --check passed |
+
+For the short GUI acceptance run, dataset preparation reset the CLI SH schedule. Set the test schedule after loading through the existing Python API:
+
+```python
+p = lf.optimization_params()
+p.iterations = 600
+p.steps_scaler = 1.0
+p.max_cap = 2000000
+p.sh_degree = 2
+p.set('sh_degree_interval', 10)
+assert p.get('sh_degree_interval') == 10
+```
+
+Verify active SH degree2 in the trained model, not just configured maximum degree. Use an isolated profile and explicit new project save path: importing a dataset may retain the currently open project's save destination. Treat Python tracebacks as failures even if an editor tool's outer response reports success.
+
+## Limits
+
+The full approximately71300-step workload, upstream full test suite, other GPU models and all model formats were not tested. Vulkan validation layers were unavailable. The non-conditional fallback uses16 depth waves rather than the conditional path's64; FP32 SH requires more VRAM than q16. The tests establish a useful compatibility patch for the reproduced machine/workload, not a general driver diagnosis or complete legacy-GPU support claim.
+
+Related reproduction: [upstream issue1681](https://github.com/MrNeRF/LichtFeld-Studio/issues/1681).

--- a/src/core/cuda/memory_arena.cu
+++ b/src/core/cuda/memory_arena.cu
@@ -2296,9 +2296,12 @@ namespace lfs::core {
     }
 
     void GlobalArenaManager::clear_external_backing(const void* device_ptr) {
-        std::lock_guard<std::mutex> lock(init_mutex_);
-        if (arena_) {
-            arena_->clear_external_backing(device_ptr);
+        // Clearing waits for active frames to finish. Their owners may need
+        // get_arena() to release those frames, so never hold init_mutex_ across
+        // that wait. As with install/grow, arena lifetime is owned by the
+        // runtime and shutdown must happen after its users have stopped.
+        if (auto* arena = try_get_arena()) {
+            arena->clear_external_backing(device_ptr);
         }
     }
 

--- a/src/core/nn/conv.cu
+++ b/src/core/nn/conv.cu
@@ -793,6 +793,12 @@ namespace lfs::core::nn::kernels {
         int major = 0;
         LFS_CUDA_CHECK(cudaGetDevice(&device));
         LFS_CUDA_CHECK(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device));
+        // WMMA kernels compile to no-op branches before Volta. Do not benchmark
+        // or honor a forced WMMA/MMA path when the device cannot execute them.
+        if (major < 7) {
+            launch_simt();
+            return;
+        }
         static std::once_flag auto_once[16];
         static std::atomic<int> auto_choice[16] = {};
         if (!force_wmma && !force_mma && (auto75 || major < 8) && device >= 0 && device < 16) {

--- a/src/core/nn/lpips_kernels.cu
+++ b/src/core/nn/lpips_kernels.cu
@@ -40,6 +40,7 @@ namespace lfs::core::nn::kernels {
                                      const __half* __restrict__ bias, __half* __restrict__ Y,
                                      const float3 shift, const float3 scale,
                                      const bool official, const int h, const int w) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
             __shared__ __align__(128) unsigned char smem_raw[kRgbSmemBytes];
             auto* tile = reinterpret_cast<__half*>(smem_raw);
             auto* As = tile + kRgbTileHalves;
@@ -149,6 +150,56 @@ namespace lfs::core::nn::kernels {
                     Yn[n * plane + static_cast<long long>(oh) * w + ow] = __float2half_rn(v);
                 }
             }
+#else
+            // Pascal and earlier GPUs have no WMMA support. Keep the launch
+            // geometry, but calculate the same fp16-input/fp16-weight product
+            // directly so every thread owns independent output elements.
+            const int tid = static_cast<int>(threadIdx.x);
+            const int ni = static_cast<int>(blockIdx.z);
+            const int tiles_w = (w + kRgbTileW - 1) / kRgbTileW;
+            const int oh0 = (static_cast<int>(blockIdx.y) / tiles_w) * kRgbTileH;
+            const int ow0 = (static_cast<int>(blockIdx.y) % tiles_w) * kRgbTileW;
+            const long long plane = static_cast<long long>(h) * w;
+            const float* Xn = X + static_cast<long long>(ni) * 3 * plane;
+            __half* Yn = Y + static_cast<long long>(ni) * kRgbCout * plane;
+
+            for (int i = tid; i < kRgbCout * kRgbTileM; i += kRgbThreads) {
+                const int oc = i / kRgbTileM;
+                const int m = i - oc * kRgbTileM;
+                const int oh = oh0 + m / kRgbTileW;
+                const int ow = ow0 + (m - (m / kRgbTileW) * kRgbTileW);
+                if (oh >= h || ow >= w) {
+                    continue;
+                }
+
+                float sum = 0.0f;
+#pragma unroll
+                for (int ic = 0; ic < 3; ++ic) {
+                    const float s = ic == 0 ? shift.x : (ic == 1 ? shift.y : shift.z);
+                    const float d = ic == 0 ? scale.x : (ic == 1 ? scale.y : scale.z);
+#pragma unroll
+                    for (int kh = 0; kh < 3; ++kh) {
+#pragma unroll
+                        for (int kw = 0; kw < 3; ++kw) {
+                            const int ih = oh + kh - 1;
+                            const int iw = ow + kw - 1;
+                            if (static_cast<unsigned>(ih) < static_cast<unsigned>(h) &&
+                                static_cast<unsigned>(iw) < static_cast<unsigned>(w)) {
+                                float x = Xn[ic * plane + static_cast<long long>(ih) * w + iw];
+                                if (official) {
+                                    x = x * 2.0f - 1.0f;
+                                }
+                                const __half xh = __float2half_rn((x - s) / d);
+                                const __half wh = W[oc * kRgbK + ic * 9 + kh * 3 + kw];
+                                sum += __half2float(xh) * __half2float(wh);
+                            }
+                        }
+                    }
+                }
+                const float v = fmaxf(sum + __half2float(bias[oc]), 0.0f);
+                Yn[oc * plane + static_cast<long long>(oh) * w + ow] = __float2half_rn(v);
+            }
+#endif
         }
 
         constexpr int kReduceWarps = 8;

--- a/src/core/sh_value_quant.cpp
+++ b/src/core/sh_value_quant.cpp
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
 #include "core/sh_value_quant.hpp"
+#include "core/environment.hpp"
 
 #include <atomic>
 
@@ -25,6 +26,6 @@ namespace lfs::core::sh_value_quant {
         const int o = override_flag().load(std::memory_order_relaxed);
         if (o >= 0)
             return o != 0;
-        return true; // production default: always ON
+        return environment::flag("LFS_SH_VALUE_QUANT", true);
     }
 } // namespace lfs::core::sh_value_quant

--- a/src/core/splat_exportable_storage.cpp
+++ b/src/core/splat_exportable_storage.cpp
@@ -710,74 +710,93 @@ namespace lfs::core {
                 static_cast<std::uint32_t>(model.max_sh_coeffs_rest());
             const size_t n_live = static_cast<size_t>(model.size());
             if (layout_rest > 0 && model.shN_raw().is_valid() && model.shN_raw().numel() > 0) {
-                // Pad-dropped q16 codes + per-256 float2 bounds live in the block.
-                // Same-block rebind only re-views. Cross-allocator install
-                // copies q16 codes when the source is already quantized.
-                // Float densify temps (ensure_shN_fp32) are kept outside the block —
-                // commit_shN_after_mutation re-encodes into exportable after mutation.
-                const size_t shN_cap = sh_value_quant::sh_value_u16_count(capacity_, layout_rest);
-                const size_t shN_logical = sh_value_quant::sh_value_u16_count(n_live, layout_rest);
-                const size_t bounds_cap = sh_value_quant::n_bounds_for_prims(capacity_) * 2u;
-                const size_t bounds_logical = sh_value_quant::n_bounds_for_prims(n_live) * 2u;
+                const bool quant_enabled = sh_value_quant::enabled();
+                const bool shN_is_float16 = model.shN_raw().dtype() == DataType::Float16;
+                if (!quant_enabled && shN_is_float16) {
+                    if (model.shN_value_quantized()) {
+                        model.shN_set_from_canonical(model.shN_canonical(), capacity_);
+                    } else {
+                        model.shN_raw() = model.shN_raw().to(DataType::Float32);
+                    }
+                }
 
                 const Tensor& shN_src = model.shN_raw();
                 const bool aliases = tensor_aliases_exportable_block(shN_src, block_ref);
                 const bool src_is_q16 = model.shN_value_quantized();
 
-                if (!aliases && !src_is_q16) {
-                    // Densify expand path: preserve float/f16 temp; do not zero-fill.
-                    shN = shN_src;
-                    if (shN.device() != Device::CUDA) {
-                        shN = shN.cuda();
-                    }
-                    if (!shN.is_contiguous()) {
-                        shN = shN.contiguous();
-                    }
-                    // Bounds stay empty until commit re-encodes.
-                    shN_bounds = Tensor{};
+                if (!quant_enabled) {
+                    const size_t shN_cap = sh_swizzled_float_count(capacity_, layout_rest);
+                    const size_t shN_logical = sh_swizzled_float_count(n_live, layout_rest);
+                    shN = install_param(shN_src,
+                                        TensorShape({shN_logical}),
+                                        shN_cap,
+                                        "SplatData.shN");
                 } else {
-                    Tensor dst = allocator(
-                        TensorShape({shN_logical}),
-                        shN_cap,
-                        DataType::Float16,
-                        "SplatData.shN");
-                    dst.set_name("SplatData.shN");
-                    if (!aliases && src_is_q16 && shN_src.is_valid() && shN_src.numel() > 0) {
-                        Tensor src = shN_src;
-                        if (src.device() != Device::CUDA) {
-                            src = src.cuda();
-                        }
-                        if (!src.is_contiguous()) {
-                            src = src.contiguous();
-                        }
-                        dst.copy_from(src);
-                    }
-                    shN = std::move(dst);
+                    // Pad-dropped q16 codes + per-256 float2 bounds live in the block.
+                    // Same-block rebind only re-views. Cross-allocator install
+                    // copies q16 codes when the source is already quantized.
+                    // Float densify temps (ensure_shN_fp32) are kept outside the block —
+                    // commit_shN_after_mutation re-encodes into exportable after mutation.
+                    const size_t shN_cap = sh_value_quant::sh_value_u16_count(capacity_, layout_rest);
+                    const size_t shN_logical = sh_value_quant::sh_value_u16_count(n_live, layout_rest);
+                    const size_t bounds_cap = sh_value_quant::n_bounds_for_prims(capacity_) * 2u;
+                    const size_t bounds_logical = sh_value_quant::n_bounds_for_prims(n_live) * 2u;
 
-                    Tensor bounds_dst = allocator(
-                        TensorShape({bounds_logical}),
-                        bounds_cap,
-                        DataType::Float32,
-                        "SplatData.shN_value_bounds");
-                    bounds_dst.set_name("SplatData.shN_value_bounds");
-                    const Tensor& bounds_src = model.shN_value_bounds();
-                    const bool bounds_alias =
-                        bounds_src.is_valid() &&
-                        tensor_aliases_exportable_block(bounds_src, block_ref);
-                    if (!bounds_alias && bounds_src.is_valid() && bounds_src.numel() > 0) {
-                        Tensor bsrc = bounds_src;
-                        if (bsrc.device() != Device::CUDA) {
-                            bsrc = bsrc.cuda();
+                    if (!aliases && !src_is_q16) {
+                        // Densify expand path: preserve float/f16 temp; do not zero-fill.
+                        shN = shN_src;
+                        if (shN.device() != Device::CUDA) {
+                            shN = shN.cuda();
                         }
-                        if (!bsrc.is_contiguous()) {
-                            bsrc = bsrc.contiguous();
+                        if (!shN.is_contiguous()) {
+                            shN = shN.contiguous();
                         }
-                        if (bsrc.dtype() != DataType::Float32) {
-                            bsrc = bsrc.to(DataType::Float32);
+                        // Bounds stay empty until commit re-encodes.
+                        shN_bounds = Tensor{};
+                    } else {
+                        Tensor dst = allocator(
+                            TensorShape({shN_logical}),
+                            shN_cap,
+                            DataType::Float16,
+                            "SplatData.shN");
+                        dst.set_name("SplatData.shN");
+                        if (!aliases && src_is_q16 && shN_src.is_valid() && shN_src.numel() > 0) {
+                            Tensor src = shN_src;
+                            if (src.device() != Device::CUDA) {
+                                src = src.cuda();
+                            }
+                            if (!src.is_contiguous()) {
+                                src = src.contiguous();
+                            }
+                            dst.copy_from(src);
                         }
-                        bounds_dst.copy_from(bsrc);
+                        shN = std::move(dst);
+
+                        Tensor bounds_dst = allocator(
+                            TensorShape({bounds_logical}),
+                            bounds_cap,
+                            DataType::Float32,
+                            "SplatData.shN_value_bounds");
+                        bounds_dst.set_name("SplatData.shN_value_bounds");
+                        const Tensor& bounds_src = model.shN_value_bounds();
+                        const bool bounds_alias =
+                            bounds_src.is_valid() &&
+                            tensor_aliases_exportable_block(bounds_src, block_ref);
+                        if (!bounds_alias && bounds_src.is_valid() && bounds_src.numel() > 0) {
+                            Tensor bsrc = bounds_src;
+                            if (bsrc.device() != Device::CUDA) {
+                                bsrc = bsrc.cuda();
+                            }
+                            if (!bsrc.is_contiguous()) {
+                                bsrc = bsrc.contiguous();
+                            }
+                            if (bsrc.dtype() != DataType::Float32) {
+                                bsrc = bsrc.to(DataType::Float32);
+                            }
+                            bounds_dst.copy_from(bsrc);
+                        }
+                        shN_bounds = std::move(bounds_dst);
                     }
-                    shN_bounds = std::move(bounds_dst);
                 }
             }
 

--- a/src/io/cuda/kmeans.cu
+++ b/src/io/cuda/kmeans.cu
@@ -491,13 +491,16 @@ namespace lfs::io {
                 }
             }
             __syncthreads();
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
             const int warp = tid / 32;
             nvcuda::wmma::fragment<nvcuda::wmma::matrix_a, 16, 16, 16, half, nvcuda::wmma::row_major> a[3];
             for (int d = 0; d < D; d += 16)
                 nvcuda::wmma::load_matrix_sync(a[d / 16], half_points + (start + (warp / 2) * 16) * D + d, D);
+#endif
             for (int base = 0; base < k; base += C) {
                 if (tid < C)
                     norms[tid] = base + tid < k ? centroid_norms[base + tid] : 0;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
                 nvcuda::wmma::fragment<nvcuda::wmma::matrix_b, 16, 16, 16, half, nvcuda::wmma::col_major> b;
                 nvcuda::wmma::fragment<nvcuda::wmma::accumulator, 16, 16, 16, float> acc;
                 nvcuda::wmma::fill_fragment(acc, 0.0f);
@@ -507,7 +510,11 @@ namespace lfs::io {
                 }
                 nvcuda::wmma::store_matrix_sync(&approx[(warp / 2) * 16][(warp % 2) * 16], acc, C + 4, nvcuda::wmma::mem_row_major);
                 __syncthreads();
+#else
+                __syncthreads();
+#endif
                 for (int c = lane; c < C && base + c < k; c += 4) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
                     const float estimate = fmaf(-2.0f, approx[row][c], norms[c]);
                     // Half rounding contributes at most (2*u+u*u)*(||x||^2+
                     // ||c||^2), u=2^-11, to the score. The remaining relative
@@ -516,6 +523,7 @@ namespace lfs::io {
                     // Out-of-range values always take the reference path.
                     const float margin = 0.0011f * (point_norm[row] + norms[c]) + 1e-8f;
                     if (!point_safe[row] || !(norms[c] >= 0 && norms[c] < 4.0e9f) || !isfinite(estimate) || estimate <= best + margin) {
+#endif
                         float dot = 0;
 #pragma unroll
                         for (int d = 0; d < 45; ++d)
@@ -526,7 +534,9 @@ namespace lfs::io {
                             best = dist;
                             best_id = id;
                         }
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
                     }
+#endif
                 }
                 for (int delta = 2; delta > 0; delta /= 2) {
                     const float other = __shfl_xor_sync(0xffffffffu, best, delta, 4);

--- a/src/io/loader_service.cpp
+++ b/src/io/loader_service.cpp
@@ -84,12 +84,24 @@ namespace lfs::io {
                      model.lod_tree->chunk_count());
             return {};
         }
-        if (splatTensorsRendererReady(model)) {
-            model.set_tensor_allocator(allocator);
-            return {};
-        }
-
         try {
+            const bool shN_is_float16 = model.shN_raw().is_valid() &&
+                                        model.shN_raw().dtype() == lfs::core::DataType::Float16;
+            if (!lfs::core::sh_value_quant::enabled() && shN_is_float16) {
+                const size_t capacity = model.means_raw().is_valid()
+                                            ? std::max(model.means_raw().capacity(), static_cast<size_t>(model.size()))
+                                            : static_cast<size_t>(model.size());
+                if (model.shN_value_quantized()) {
+                    model.shN_set_from_canonical(model.shN_canonical(), capacity);
+                } else {
+                    model.shN_raw() = model.shN_raw().to(lfs::core::DataType::Float32);
+                }
+            }
+            if (splatTensorsRendererReady(model)) {
+                model.set_tensor_allocator(allocator);
+                return {};
+            }
+
             const auto copy_to_allocator =
                 [&](const lfs::core::Tensor& source, const std::string_view name) -> lfs::core::Tensor {
                 lfs::core::Tensor source_contiguous = source.is_contiguous() ? source : source.contiguous();

--- a/src/visualizer/scene/viewer_splat_quantize.cpp
+++ b/src/visualizer/scene/viewer_splat_quantize.cpp
@@ -73,6 +73,37 @@ namespace lfs::vis {
             throw std::runtime_error(std::move(message));
         }
 
+        void decodeViewerSplatShNIfNeeded(const std::filesystem::path& path,
+                                          lfs::core::SplatData& model) {
+            const bool shN_is_float16 = model.shN_raw().is_valid() &&
+                                        model.shN_raw().dtype() == lfs::core::DataType::Float16;
+            if (lfs::core::sh_value_quant::enabled() || !shN_is_float16) {
+                return;
+            }
+            const size_t capacity = model.means_raw().is_valid()
+                                        ? std::max(model.means_raw().capacity(), static_cast<size_t>(model.size()))
+                                        : static_cast<size_t>(model.size());
+            if (model.shN_value_quantized()) {
+                model.shN_set_from_canonical(model.shN_canonical(), capacity);
+            } else {
+                model.shN_raw() = model.shN_raw().to(lfs::core::DataType::Float32);
+            }
+            if (!model.has_tensor_allocator() || !model.shN_raw().is_valid() ||
+                model.shN_raw().numel() == 0) {
+                return;
+            }
+            const lfs::core::Tensor source = model.shN_raw().is_contiguous()
+                                                 ? model.shN_raw()
+                                                 : model.shN_raw().contiguous();
+            lfs::core::Tensor destination = model.allocate_named_param(
+                source.shape(), source.capacity(), lfs::core::DataType::Float32, "SplatData.shN");
+            destination.set_name("SplatData.shN");
+            destination.copy_from(source);
+            model.shN_raw() = std::move(destination);
+            LOG_INFO("Viewer SH q16 disabled for '{}'; decoded SH rest into FP32 Vulkan-external storage",
+                     lfs::core::path_to_utf8(path));
+        }
+
         void encodeViewerSplatShNIfNeeded(const std::filesystem::path& path,
                                           lfs::core::SplatData& model) {
             if (!model.has_tensor_allocator()) {
@@ -81,9 +112,12 @@ namespace lfs::vis {
                 return;
             }
 
+            decodeViewerSplatShNIfNeeded(path, model);
+
             const bool shN_only_not_ready =
                 baseAttrsRendererReady(model) && !shNStorageRendererReady(model);
             const bool should_encode =
+                lfs::core::sh_value_quant::enabled() &&
                 (isPlyPath(path) || shN_only_not_ready) &&
                 !model.shN_value_quantized() &&
                 model.shN_raw().is_valid() &&

--- a/src/visualizer/window/vulkan_context.cpp
+++ b/src/visualizer/window/vulkan_context.cpp
@@ -2741,6 +2741,17 @@ namespace lfs::vis {
         supported_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
         supported_features2.pNext = &supported_features11;
         vkGetPhysicalDeviceFeatures2(physical_device_, &supported_features2);
+        const bool sh_value_quant_explicit =
+            lfs::core::environment::value("LFS_SH_VALUE_QUANT").has_value();
+        if (!sh_value_quant_explicit &&
+            (supported_features12.shaderFloat16 != VK_TRUE ||
+             supported_features11.storageBuffer16BitAccess != VK_TRUE)) {
+            if (lfs::core::environment::set_value("LFS_SH_VALUE_QUANT", "0")) {
+                LOG_INFO("Vulkan: disabling SH value quantization because shaderFloat16 or storageBuffer16BitAccess is unsupported");
+            } else {
+                return fail("Vulkan: could not disable SH value quantization after detecting unsupported shaderFloat16 or storageBuffer16BitAccess");
+            }
+        }
 
         if (opt_supported_head != nullptr) {
             VkPhysicalDeviceFeatures2 opt_query{};
@@ -2805,7 +2816,19 @@ namespace lfs::vis {
             enabled_chain_head = &swapchain_maintenance1_features;
         }
 
+        const bool conditional_rendering_explicit =
+            lfs::core::environment::value("LFS_VK_DISABLE_CONDITIONAL_RENDERING").has_value();
+        const bool disable_conditional_rendering = lfs::core::environment::flag(
+            "LFS_VK_DISABLE_CONDITIONAL_RENDERING", isPreVoltaCudaDevice(device_uuid_));
+        if (disable_conditional_rendering) {
+            LOG_INFO("Vulkan: disabling VK_EXT_conditional_rendering ({})",
+                     conditional_rendering_explicit
+                         ? "requested by LFS_VK_DISABLE_CONDITIONAL_RENDERING"
+                         : "pre-Volta compatibility default");
+        }
+
         const bool enable_conditional_rendering =
+            !disable_conditional_rendering &&
             conditional_rendering_available &&
             supported_conditional_rendering.conditionalRendering == VK_TRUE;
         VkPhysicalDeviceConditionalRenderingFeaturesEXT conditional_rendering_features{};
@@ -3592,8 +3615,8 @@ namespace lfs::vis {
         // exporter's handle. A stale handle must assert instead of being hidden
         // by the VUID-01742 suppression below.
         {
-            struct stat st_src {};
-            struct stat st_dup {};
+            struct stat st_src{};
+            struct stat st_dup{};
             const int st_src_rc = ::fstat(handle, &st_src);
             const int st_dup_rc = ::fstat(dup_fd, &st_dup);
             int kcmp_rc = 0;


### PR DESCRIPTION
On a Windows GTX 1060 6 GB (SM 6.1, driver 571.96), master `da2fb64` could complete headless training but crashed in `nvoglv64.dll` when displaying Gaussians. After addressing that compatibility path, full-resolution GUI training exposed a separate shared-scratch cleanup deadlock. This draft fixes both reproduced failures while preserving the existing supported-device paths.

Related to #1681. This does not propose changing the project's official SM75+ support policy. Feedback on the maintenance suitability of these fallbacks is welcome.

### Changes

- Guard WMMA convolution/SH-assignment device code and retain scalar/SIMT work below SM70. Select SIMT before benchmarking so an empty architecture-guarded WMMA kernel cannot be chosen.
- Disable Vulkan conditional rendering by default on the selected pre-Volta CUDA device, retaining an explicit diagnostic override and the existing fallback renderer.
- Select FP32 SH when Vulkan lacks `shaderFloat16` or `storageBuffer16BitAccess`. Decode q16/IEEE-half data correctly and preserve exportable storage capacity/layout through loading, hydration and rebinding.
- Release the global arena initialization mutex before waiting in `clear_external_backing()`. An active training frame may need `get_arena()` to finish and release itself; holding the manager mutex across that wait deadlocked the viewer and trainer. The change follows the existing runtime-owned arena lifetime contract and does not change training mathematics or quality settings.
- Document the reproduction, executed validation and limits in `docs/pascal_compatibility.md`.

### Evidence

Executed on GTX 1060 with CUDA 12.8.61, MSVC 14.44.35207 and native Release/SM61:

- Conditional-rendering A/B: disabling it allowed GUI training/rendering; re-enabling it with q16 still disabled reproduced the access violation on an independent 513-Gaussian SH2 fixture. This isolates the failing path without claiming knowledge of the driver's internal defect.
- Deadlock: native stacks showed the renderer holding the manager mutex inside scratch cleanup while the trainer waited for that mutex in `get_arena()` during FastGS frame release. The five decisive machine-code ranges matched the diagnostic symbol mapping; no whole-binary identity is claimed.
- A standalone compiled concurrency regression passed: manager lookup completed while clear awaited an active frame, then clear completed after the frame was released. Independent review found no blocking issue.
- The old isolated GUI reproduction stalled at iteration 641. The repaired GUI completed 21,425 iterations with 713 full-resolution images, MRNF, SH3 and a 1,000,000-splat cap before the user intentionally stopped it. Repeated storage/scratch growth, camera-view changes, checkpoint saving, clean stopping and reopening the saved state passed. The repaired run was configured for 71,300 iterations; the old reproduction used 30,000 total steps with the scaled early refinement schedule, so this was not an exact full-schedule A/B test.
- Four 3,000-step headless runs compared q16 and FP32 using the same patched executable, resize factor 2, SH2, 623 training and 90 held-out images. Mean q16/FP32 scores: PSNR 20.697513/20.778174 dB, SSIM 0.719228/0.719667, LPIPS 0.387395/0.386986. No mean quality regression was detected; the differences were smaller than the larger within-mode repeat gap for each metric. This does not establish equivalence to an untouched upstream build or a causal quality improvement.
- Earlier CUDA checks: six LPIPS convolution GPU cases (41,344 outputs) matched an independent CPU reference; eight SH-assignment GPU cases matched an independent FP32/FMA reference; full LPIPS identical/distinct-image checks passed.
- Saved q16 conversion preserved 12,312 coefficients exactly. The earlier 600-step GUI save/reopen test passed but did not expose the later deadlock.
- Native Release rebuild and installed-binary hash verification passed. Retained SM75 kernel paths compiled but were not executed. The original compatibility commit passed clang-format 19.1.5; the additional focused change passed `git diff --check` and independent review.

No build or training workload was repeated solely for this PR update. Private datasets, profiles, local paths, captures and binary artifacts are excluded.

### Limits and tradeoffs

The user stopped validation at 21,425 of 71,300 iterations; full-run completion and converged-quality parity remain unverified. The upstream full test suite, other GPU models and all formats have not been tested. Vulkan validation layers were unavailable.

FP32 SH uses more VRAM; the existing non-conditional renderer uses 16 depth waves rather than 64. Automatic quantization selection is process-global, so future in-process GPU switching needs reassessment. Arena lifetime still requires shutdown after active users stop; concurrent manager reset/destruction is not newly supported.