### PR TITLE
Override checkpoint data [Volinga]

### DIFF
--- a/src/training/checkpoint.cpp
+++ b/src/training/checkpoint.cpp
@@ -534,6 +534,25 @@ namespace lfs::training {
             if (auto* loaded_adopter = dynamic_cast<ICheckpointStateAdopter*>(loaded_strategy.get());
                 loaded_adopter && loaded_adopter->has_checkpoint_runtime_state()) {
                 loaded_strategy->get_optimizer().set_frozen_lr_scale(loaded_params.freeze_lr_scale);
+
+                // Overwrite restored learning rates with this run's params
+                auto& reopt = loaded_strategy->get_optimizer();
+                const auto& current = params.optimization;
+                const float scene_scale = loaded_strategy->get_model().get_scene_scale();
+                const float means_lr = current.means_lr * scene_scale;
+                reopt.set_lr(means_lr); // global LR: drives means AND MCMC positional noise
+                reopt.set_param_lr(ParamType::Means, means_lr);
+                reopt.set_param_lr(ParamType::Sh0, current.shs_lr);
+                reopt.set_param_lr(ParamType::ShN, current.shs_lr / 20.0f);
+                reopt.set_param_lr(ParamType::Scaling, current.scaling_lr);
+                reopt.set_param_lr(ParamType::Rotation, current.rotation_lr);
+                reopt.set_param_lr(ParamType::Opacity, current.opacity_lr);
+                LOG_INFO("Checkpoint resume LR re-applied (current run): means={:.3e} "
+                         "(= means_lr {:.3e} x scene_scale {:.3f}) sh0={:.3e} shN={:.3e} "
+                         "scaling={:.3e} rotation={:.3e} opacity={:.3e}",
+                         means_lr, current.means_lr, scene_scale, current.shs_lr,
+                         current.shs_lr / 20.0f, current.scaling_lr, current.rotation_lr,
+                         current.opacity_lr);
             }
 
             std::unique_ptr<BilateralGrid> loaded_bilateral_grid;

--- a/src/training/strategies/improved_gs_plus.cpp
+++ b/src/training/strategies/improved_gs_plus.cpp
@@ -193,7 +193,10 @@ namespace lfs::training {
         const int64_t budget = _params->max_cap;
         this->_initial_points = _splat_data->size();
 
-        this->_total_steps = static_cast<int>((_params->stop_refine - _params->start_refine) / _params->refine_every) + 2;
+        this->_total_steps = 2;
+        if (_params->stop_refine > _params->start_refine) {
+            this->_total_steps += static_cast<int>((_params->stop_refine - _params->start_refine) / _params->refine_every);
+        }
 
         std::vector<int64_t> values;
         values.reserve(_total_steps);

--- a/src/training/strategies/mcmc.cpp
+++ b/src/training/strategies/mcmc.cpp
@@ -702,6 +702,10 @@ namespace lfs::training {
         LFS_TRACE("kernel.mcmc.add_noise");
         using namespace lfs::core;
 
+        if (_params->means_lr <= 0.0f) {
+            return;
+        }
+
         // Get current learning rate from optimizer (after scheduler has updated it)
         const float current_lr = _optimizer->get_lr() * NOISE_LR;
         const size_t n = static_cast<size_t>(_splat_data->size());

--- a/src/training/strategies/mrnf.cpp
+++ b/src/training/strategies/mrnf.cpp
@@ -3728,12 +3728,8 @@ namespace lfs::training {
         const bool background_changed = background_improvements_enabled() != params.background_improvements;
         _params = std::make_unique<const lfs::core::param::OptimizationParameters>(params);
 
-        if (_mean_lr_unscaled <= 0.0) {
-            _mean_lr_unscaled = params.means_lr;
-        }
-        if (_scale_lr_current <= 0.0) {
-            _scale_lr_current = params.scaling_lr;
-        }
+        _mean_lr_unscaled = params.means_lr;
+        _scale_lr_current = params.scaling_lr;
 
         refresh_decay_schedule_from_current_state();
         if (_splat_data) {


### PR DESCRIPTION
Allow for override of optimizer checkpoint data from params for easier experiments. Allow zeroing of means_lr and scaling_lr.