### PR TITLE
Fix fresh panel depth window defaults

### DIFF
--- a/src/visualizer/rendering/rendering_manager.cpp
+++ b/src/visualizer/rendering/rendering_manager.cpp
@@ -58,9 +58,14 @@ namespace lfs::vis {
         constexpr float kDepthMax = 1000.0f;
 
         [[nodiscard]] DepthWindowState depthWindowFromProjection(const RenderSettings& settings) {
+            // Fresh disabled settings still carry the legacy positive-Z sentinel.
+            // Decode it before seeding panel slots, just as the legacy getter does.
+            const bool legacy_default = !settings.depth_filter_enabled &&
+                                        settings.depth_filter_min.z == 0.0f &&
+                                        settings.depth_filter_max.z == 100.0f;
             return {
-                .near_plane = -settings.depth_filter_max.z,
-                .far_plane = -settings.depth_filter_min.z,
+                .near_plane = legacy_default ? 0.0f : -settings.depth_filter_max.z,
+                .far_plane = legacy_default ? 100.0f : -settings.depth_filter_min.z,
                 .scale_x = settings.depth_filter_scale_x,
                 .scale_y = settings.depth_filter_scale_y,
                 .offset_x = settings.depth_filter_offset_x,

--- a/tests/test_python_integration.cpp
+++ b/tests/test_python_integration.cpp
@@ -1397,6 +1397,33 @@ namespace {
     };
 } // namespace
 
+TEST_F(PythonIntegrationTest, FreshDepthWindowPanelRangeSurvivesReadModifyEnable) {
+    for (const char* panel : {"main", "left", "right"}) {
+        SCOPED_TRACE(panel);
+        DepthWindowBindingState state;
+        const lfs::python::GilAcquire gil;
+        const auto decref = [](PyObject* object) { Py_XDECREF(object); };
+        std::unique_ptr<PyObject, decltype(decref)> globals(PyDict_New(), decref);
+        ASSERT_NE(globals, nullptr);
+        ASSERT_EQ(PyDict_SetItemString(globals.get(), "__builtins__", PyEval_GetBuiltins()), 0);
+        std::unique_ptr<PyObject, decltype(decref)> name(PyUnicode_FromString(panel), decref);
+        ASSERT_EQ(PyDict_SetItemString(globals.get(), "panel", name.get()), 0);
+        ASSERT_NO_THROW(execPythonInGlobals(globals.get(), R"PY(
+import lichtfeld as lf
+legacy = lf.selection.get_depth_filter_window()
+window = lf.selection.get_depth_filter_window(panel=panel)
+assert not window[0]
+assert window[1:3] == legacy[1:3] == (0.0, 100.0), (panel, window, legacy)
+_, near, far, sx, sy, ox, oy = window
+lf.selection.set_depth_filter_window(True, near, far, sx, ox, oy, sy, panel=panel)
+assert lf.selection.get_depth_filter_window(panel=panel) == (True, *window[1:])
+# A configured window remains intact while disabled.
+lf.selection.set_depth_filter_window(False, 2.0, 25.0, 0.5, 0.25, -0.25, 0.75, panel=panel)
+assert lf.selection.get_depth_filter_window(panel=panel) == (False, 2.0, 25.0, 0.5, 0.75, 0.25, -0.25)
+)PY"));
+    }
+}
+
 TEST_F(PythonIntegrationTest, ParkedGtPanelWindowRequestsAreAtomicallyRefused) {
     DepthWindowBindingState state;
     ASSERT_EQ(state.viewer->getSelectionTool(), nullptr);


### PR DESCRIPTION
Fresh named depth windows decoded the disabled legacy default as -100..0, so reading and enabling a panel could collapse its depth range to 0..0.01. Decode that default as 0..100 when seeding panel state, while preserving configured disabled windows. Follow-up to #2058.

Validation: reproduced the failure before the fix; app and test builds passed, along with 308 focused native tests and 364 Python tests. Includes a compiled Python binding regression for main, left, and right panels.
