### PR TITLE
Restore SH Degree to the primary training settings

### DIFF
--- a/docs/docs/development/training-panel-layout.md
+++ b/docs/docs/development/training-panel-layout.md
@@ -61,8 +61,8 @@ and Normal never share a parameter group. Evaluation owns its interval; random
 initialization owns point count and extent. Shared appearance tuning is visible
 under Exposure Correction when managed correction is enabled, otherwise under
 the enabled standalone PPISP/Grid section. These mutually exclusive views use
-the same parameter bindings and do not create additional enable controls. SH degree,
-optimization, losses, initialization and save steps live inside Advanced. No artificial enable
+the same parameter bindings and do not create additional enable controls. SH degree remains in
+Training Method for direct access; optimization, losses, initialization and save steps live inside Advanced. No artificial enable
 flag is added to always-applicable settings.
 
 Generated rows retain their property metadata, numeric editing, tooltips and

--- a/src/python/lfs_plugins/training_panel.py
+++ b/src/python/lfs_plugins/training_panel.py
@@ -519,7 +519,7 @@ class TrainingPanel(Panel):
     _BESPOKE_SEARCH = {
         "strategy": ("basic_params", "strategy mrnf igs+ mcmc", ("training_params.strategy",)),
         "backend": ("basic_params", "raster backend 3dgs 3dgut gut", ("training.backend",)),
-        "sh_degree": ("optimization", "sh_degree spherical harmonics", ("training_params.sh_degree",)),
+        "sh_degree": ("basic_params", "sh_degree spherical harmonics", ("training_params.sh_degree",)),
         "depth_loss_mode": ("depth", "depth_loss_mode ssi disparity", ("training.tooltip.depth_loss_mode",)),
         "background_fields": ("background", "bg_color bg_image background color image", ("training.tooltip.bg_color", "training.tooltip.bg_image_path")),
         "appearance": ("ppisp", "ppisp", ("training.section.appearance",)),

--- a/src/visualizer/gui/rmlui/resources/training.rml
+++ b/src/visualizer/gui/rmlui/resources/training.rml
@@ -193,6 +193,15 @@
           <img data-attr-src="steps_scaling_lock_icon" />
         </button>
       </div>
+      <div class="setting-row" data-tooltip="training.tooltip.sh_degree" data-if="pv_show_sh_degree">
+        <span class="prop-label">{{label_sh_degree}}</span>
+        <select data-value="sh_degree_str">
+          <option value="0" data-tooltip="training.tooltip.opt.sh_degree.0">0</option>
+          <option value="1" data-tooltip="training.tooltip.opt.sh_degree.1">1</option>
+          <option value="2" data-tooltip="training.tooltip.opt.sh_degree.2">2</option>
+          <option value="3" data-tooltip="training.tooltip.opt.sh_degree.3">3</option>
+        </select>
+      </div>
     </div>
   </div>
   <div class="training-panel-block" data-if="pv_section_camera_visible">
@@ -706,15 +715,7 @@
         <span class="section-arrow text-accent" id="arrow-optimization">&#x25B6;</span>
         <span class="text-accent">{{pv_header_optimization}}</span>
       </div>
-      <div class="section-content collapsed" id="sec-optimization"><div data-class-disabled-overlay="live_disabled"><div class="setting-row" data-tooltip="training.tooltip.sh_degree" data-if="pv_show_sh_degree">
-        <span class="prop-label">{{label_sh_degree}}</span>
-        <select data-value="sh_degree_str">
-          <option value="0" data-tooltip="training.tooltip.opt.sh_degree.0">0</option>
-          <option value="1" data-tooltip="training.tooltip.opt.sh_degree.1">1</option>
-          <option value="2" data-tooltip="training.tooltip.opt.sh_degree.2">2</option>
-          <option value="3" data-tooltip="training.tooltip.opt.sh_degree.3">3</option>
-        </select>
-      </div></div>
+      <div class="section-content collapsed" id="sec-optimization">
         <div data-class-disabled-overlay="adv_disabled">
           <div class="setting-row" data-tooltip="training.tooltip.opt_strategy_display" data-if="pv_show_save_steps">
             <span class="prop-label">{{label_opt_strategy}}</span>

--- a/tests/python/test_training_panel_regressions.py
+++ b/tests/python/test_training_panel_regressions.py
@@ -936,7 +936,7 @@ def test_rejected_enable_does_not_change_other_features(training_panel_module, m
 @pytest.mark.parametrize("query,section,field", [
     ("3DGS", "basic_params", "backend"),
     ("strategy", "basic_params", "strategy"),
-    ("SH_degree", "optimization", "sh_degree"),
+    ("SH_degree", "basic_params", "sh_degree"),
     ("bg_image", "background", "background_fields"),
     ("ppisp", "ppisp", "appearance"),
     ("resize_factor", "dataset", "dataset_fields"),
@@ -2756,6 +2756,12 @@ def test_enabled_features_have_independent_parameter_sections():
     assert sections["normal"].find(".//*[@data-for='row : pv_basic_depth_weight_rows']") is None
     assert sections["evaluation"].find(".//*[@data-value='test_every_str']") is not None
     assert sections["random-init"].find(".//*[@data-for='row : pv_init_random_rows']") is not None
+    basic_params = document.find(
+        ".//div[@class='training-panel-block'][@data-if='pv_section_basic_params_visible']"
+    )
+    assert basic_params is not None
+    assert basic_params.find(".//*[@data-value='sh_degree_str']") is not None
+    assert advanced.find(".//*[@data-value='sh_degree_str']") is None
     advanced_children = list(advanced)
     feature_heading = next(
         node for node in advanced_children


### PR DESCRIPTION
## Summary

This is a focused follow-up to #2072, which reorganized the Training panel and improved its information hierarchy.

During that reorganization, the SH Degree selector was moved into Advanced Optimization. SH Degree is a frequently adjusted core training setting, so hiding it behind the Advanced section made it less accessible than it was before #2072.

This follow-up restores SH Degree to the primary Training Method section while preserving its existing behavior.

## Changes

- move SH Degree from Advanced Optimization back to Training Method
- preserve the existing value binding, available options, tooltips, and training-state edit lock
- route searches for SH Degree to the primary Training Method section
- update the Training panel layout documentation
- add structural regression coverage ensuring SH Degree remains in the primary section and outside Advanced

## Testing

- `179` Training panel and property-view tests passed
- `git diff --check` passed

A native UI check is still recommended to confirm the final spacing and placement in the compiled application.

Follow-up to #2072.