### PR TITLE
Fix image loader setup in sidecar resize test

### DIFF
--- a/tests/test_colmap_image_layout.cpp
+++ b/tests/test_colmap_image_layout.cpp
@@ -3,6 +3,8 @@
 
 #include "core/cuda/lanczos_resize/lanczos_resize.hpp"
 #include "core/image_io.hpp"
+#include "core/image_loader.hpp"
+#include "io/cache_image_loader.hpp"
 #include "io/filesystem_utils.hpp"
 #include "io/formats/colmap.hpp"
 #include "io/loaders/blender_loader.hpp"
@@ -172,6 +174,24 @@ namespace {
     bool has_cuda_device() {
         int device_count = 0;
         return cudaGetDeviceCount(&device_count) == cudaSuccess && device_count > 0;
+    }
+
+    // Camera pixel loads require the process-wide CacheLoader callback.
+    void ensure_image_loader() {
+        static bool initialized = false;
+        if (initialized) {
+            return;
+        }
+        lfs::io::CacheLoader::getInstance(false);
+        lfs::core::set_image_loader([](const lfs::core::ImageLoadParams& p) {
+            return lfs::io::CacheLoader::getInstance().load_cached_image(
+                p.path,
+                {.resize_factor = p.resize_factor,
+                 .max_width = p.max_width,
+                 .cuda_stream = p.stream,
+                 .output_uint8 = p.output_uint8});
+        });
+        initialized = true;
     }
 
     struct BicyclePixels {
@@ -513,6 +533,7 @@ TEST(SidecarDimensionsContract, OriginalSizePassesForSmallerTrainingImage) {
 TEST_F(ColmapImageLayoutTest, HalfResolutionDepthAndNormalReachTrainingSize) {
     if (!has_cuda_device())
         GTEST_SKIP() << "CUDA device required";
+    ensure_image_loader();
     const auto source = read_bicycle_pixels();
     for (const bool blender : {false, true}) {
         for (const int bits : {8, 16}) {


### PR DESCRIPTION
Register the image loader before the depth/normal resize test loads camera pixels. The test previously threw `bad_function_call` when run on its own.

Tested: all 38 sidecar and image-layout tests pass.
