### PR TITLE
Speed up Vulkan byte conversion and packing

### DIFF
--- a/src/core/tensor/backend/vulkan/shaders/convert.slang
+++ b/src/core/tensor/backend/vulkan/shaders/convert.slang
@@ -22,24 +22,6 @@ uint loadByte(uint64_t address, uint64_t index)
     return (((Ptr<uint, Access.Read>)(byteAddress & ~uint64_t(3)))[0] >> shift) & 255u;
 }
 
-void storeByte(uint64_t address, uint64_t index, uint value)
-{
-    const uint64_t byteAddress = address + index;
-    const uint shift = uint(byteAddress & uint64_t(3)) * 8u;
-    const uint mask = 255u << shift;
-    Ptr<uint, Access.ReadWrite> word =
-        (Ptr<uint, Access.ReadWrite>)(byteAddress & ~uint64_t(3));
-    uint assumed = word[0];
-    uint observed;
-    do
-    {
-        const uint replacement = (assumed & ~mask) | ((value & 255u) << shift);
-        InterlockedCompareExchange(word[0], assumed, replacement, observed);
-        if (observed == assumed) return;
-        assumed = observed;
-    } while (true);
-}
-
 float loadAsFloat(uint64_t address, uint index)
 {
     if (kInputDType == 0) return ((Ptr<float, Access.Read>)address)[index];
@@ -70,11 +52,83 @@ uint torchUInt8Cast(float value)
     return uint(wrapped);
 }
 
+uint convertToByte(uint64_t inputAddress, uint index)
+{
+    if (kInputDType == kOutputDType)
+    {
+        const uint value = loadByte(inputAddress, index);
+        if (kInputDType == 5)
+            return value != 0u ? 1u : 0u;
+        return value;
+    }
+    if (kOutputDType == 4)
+    {
+        if (kInputDType == 0 || kInputDType == 1)
+            return torchUInt8Cast(loadAsFloat(inputAddress, index));
+        return uint(loadAsInt64(inputAddress, index)) & 255u;
+    }
+    return loadAsFloat(inputAddress, index) != 0.0f ? 1u : 0u;
+}
+
+void storeMaskedWord(uint64_t wordAddress, uint packed, uint mask)
+{
+    Ptr<uint, Access.ReadWrite> word =
+        (Ptr<uint, Access.ReadWrite>)wordAddress;
+    uint assumed = word[0];
+    uint observed;
+    do
+    {
+        const uint replacement = (assumed & ~mask) | packed;
+        InterlockedCompareExchange(word[0], assumed, replacement, observed);
+        if (observed == assumed) return;
+        assumed = observed;
+    } while (true);
+}
+
 [numthreads(LFS_LOCAL_SIZE_X, 1, 1)]
 void main(uint3 dispatchThreadId : SV_DispatchThreadID, uniform Parameters parameters)
 {
     const uint3 numWorkgroups = spirv_asm { result:$$uint3 = OpLoad builtin(NumWorkgroups:uint3); };
     const uint stride = numWorkgroups.x * LFS_LOCAL_SIZE_X;
+    // UInt8/Bool: one invocation owns one aligned output word. A word fully
+    // inside the output range is a direct store; a leading/trailing partial
+    // word uses CAS so neighboring bytes that are not this conversion stay
+    // intact. Host dispatch is the number of covering words, not elements.
+    if (kOutputDType == 4 || kOutputDType == 5)
+    {
+        const uint64_t start = parameters.outputAddress;
+        const uint64_t end = start + uint64_t(parameters.count);
+        const uint64_t firstWord = start & ~uint64_t(3);
+        const uint wordCount =
+            uint(((end - uint64_t(1)) >> 2) - (start >> 2) + uint64_t(1));
+        for (uint wordIndex = dispatchThreadId.x; wordIndex < wordCount;
+             wordIndex += stride)
+        {
+            const uint64_t wordAddress =
+                firstWord + uint64_t(wordIndex) * uint64_t(4);
+            uint packed = 0;
+            uint mask = 0;
+            for (uint lane = 0; lane < 4u; ++lane)
+            {
+                const uint64_t byteAddress = wordAddress + uint64_t(lane);
+                if (byteAddress >= start && byteAddress < end)
+                {
+                    const uint elementIndex = uint(byteAddress - start);
+                    packed |= (convertToByte(parameters.inputAddress, elementIndex) &
+                               255u)
+                              << (lane * 8u);
+                    mask |= 255u << (lane * 8u);
+                }
+            }
+            if (mask == 0u)
+                continue;
+            if (mask == 0xffffffffu)
+                ((Ptr<uint, Access.ReadWrite>)wordAddress)[0] = packed;
+            else
+                storeMaskedWord(wordAddress, packed, mask);
+        }
+        return;
+    }
     for (uint index = dispatchThreadId.x; index < parameters.count; index += stride)
     {
         if (kInputDType == kOutputDType)
@@ -91,15 +145,9 @@ void main(uint3 dispatchThreadId : SV_DispatchThreadID, uniform Parameters param
             else if (kInputDType == 3)
                 ((Ptr<int64_t, Access.ReadWrite>)parameters.outputAddress)[index] =
                     ((Ptr<int64_t, Access.Read>)parameters.inputAddress)[index];
-            else if (kInputDType == 6)
+            else
                 ((Ptr<uint, Access.ReadWrite>)parameters.outputAddress)[index] =
                     ((Ptr<uint, Access.Read>)parameters.inputAddress)[index];
-            else if (kInputDType == 5)
-                storeByte(parameters.outputAddress, index,
-                          loadByte(parameters.inputAddress, index) != 0u ? 1u : 0u);
-            else
-                storeByte(parameters.outputAddress, index,
-                          loadByte(parameters.inputAddress, index));
             continue;
         }
         if (kOutputDType == 0)
@@ -114,16 +162,6 @@ void main(uint3 dispatchThreadId : SV_DispatchThreadID, uniform Parameters param
         else if (kOutputDType == 3)
             ((Ptr<int64_t, Access.ReadWrite>)parameters.outputAddress)[index] =
                 loadAsInt64(parameters.inputAddress, index);
-        else if (kOutputDType == 4)
-        {
-            const uint value = kInputDType == 0 || kInputDType == 1
-                                   ? torchUInt8Cast(loadAsFloat(parameters.inputAddress, index))
-                                   : uint(loadAsInt64(parameters.inputAddress, index)) & 255u;
-            storeByte(parameters.outputAddress, index, value);
-        }
-        else if (kOutputDType == 5)
-            storeByte(parameters.outputAddress, index,
-                      loadAsFloat(parameters.inputAddress, index) != 0.0f ? 1u : 0u);
         else
             ((Ptr<uint, Access.ReadWrite>)parameters.outputAddress)[index] =
                 uint(loadAsInt64(parameters.inputAddress, index));

--- a/src/core/tensor/backend/vulkan/shaders/strided_copy.slang
+++ b/src/core/tensor/backend/vulkan/shaders/strided_copy.slang
@@ -43,6 +43,21 @@ void storeByte(uint64_t address, uint64_t index, uint value)
     } while (true);
 }
 
+void storeMaskedWord(uint64_t wordAddress, uint packed, uint mask)
+{
+    Ptr<uint, Access.ReadWrite> word =
+        (Ptr<uint, Access.ReadWrite>)wordAddress;
+    uint assumed = word[0];
+    uint observed;
+    do
+    {
+        const uint replacement = (assumed & ~mask) | packed;
+        InterlockedCompareExchange(word[0], assumed, replacement, observed);
+        if (observed == assumed) return;
+        assumed = observed;
+    } while (true);
+}
+
 uint64_t logicalOffset(uint linear, uniform Parameters parameters)
 {
     uint64_t offset = 0;
@@ -61,6 +76,49 @@ void main(uint3 dispatchThreadId : SV_DispatchThreadID, uniform Parameters param
 {
     const uint3 numWorkgroups = spirv_asm { result:$$uint3 = OpLoad builtin(NumWorkgroups:uint3); };
     const uint stride = numWorkgroups.x * LFS_LOCAL_SIZE_X;
+    // UInt8/Bool gather: one invocation owns one aligned output word. A word
+    // fully inside the contiguous output range is a direct store; a
+    // leading/trailing partial word uses CAS so neighboring bytes stay intact.
+    // Scatter keeps per-byte CAS because strided stores can share a word.
+    // Host dispatch for this path is the number of covering words, not elements.
+    if (kScatter == 0 && (kInputDType == 4 || kInputDType == 5) &&
+        (kOutputDType == 4 || kOutputDType == 5))
+    {
+        if (parameters.count == 0u)
+            return;
+        const uint64_t start = parameters.outputAddress;
+        const uint64_t end = start + uint64_t(parameters.count);
+        const uint64_t firstWord = start & ~uint64_t(3);
+        const uint wordCount =
+            uint(((end - uint64_t(1)) >> 2) - (start >> 2) + uint64_t(1));
+        for (uint wordIndex = dispatchThreadId.x; wordIndex < wordCount;
+             wordIndex += stride)
+        {
+            const uint64_t wordAddress =
+                firstWord + uint64_t(wordIndex) * uint64_t(4);
+            uint packed = 0;
+            uint mask = 0;
+            for (uint lane = 0; lane < 4u; ++lane)
+            {
+                const uint64_t byteAddress = wordAddress + uint64_t(lane);
+                if (byteAddress >= start && byteAddress < end)
+                {
+                    const uint elementIndex = uint(byteAddress - start);
+                    packed |= loadByte(parameters.inputAddress,
+                                       logicalOffset(elementIndex, parameters))
+                              << (lane * 8u);
+                    mask |= 255u << (lane * 8u);
+                }
+            }
+            if (mask == 0u)
+                continue;
+            if (mask == 0xffffffffu)
+                ((Ptr<uint, Access.ReadWrite>)wordAddress)[0] = packed;
+            else
+                storeMaskedWord(wordAddress, packed, mask);
+        }
+        return;
+    }
     for (uint index = dispatchThreadId.x; index < parameters.count; index += stride)
     {
         const uint64_t strided = logicalOffset(index, parameters);

--- a/src/core/tensor/backend/vulkan/vk_memory.cpp
+++ b/src/core/tensor/backend/vulkan/vk_memory.cpp
@@ -25,6 +25,8 @@ namespace lfs::core::internal {
         constexpr VkDeviceSize kInitialStagingSize = 64ull * kMib;
         constexpr VkDeviceSize kSlabLimit = 1ull * kMib;
         constexpr VkDeviceSize kDirectLimit = 16ull * kMib;
+        // loadByte/storeByte and packed convert/gather RMW an aligned uint32.
+        constexpr VkDeviceSize kByteWordBytes = 4;
         constexpr VkBufferUsageFlags kStorageUsage =
             VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
             VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
@@ -60,7 +62,24 @@ namespace lfs::core::internal {
             if (bytes < kDirectLimit) {
                 return std::bit_ceil(bytes);
             }
-            return bytes;
+            // Byte shaders RMW the aligned uint32 covering the last logical
+            // byte; the VkBuffer must include that word.
+            return align_up(bytes, kByteWordBytes);
+        }
+
+        [[noreturn]] void throw_storage_allocation_error(
+            const size_t bytes, const size_t alignment, const ExecContext& context,
+            const VkResult result) {
+            throw MemoryAllocationError(AllocationFailure{
+                .domain = MemoryDomain::VulkanDevice,
+                .requested_bytes = bytes,
+                .alignment = alignment,
+                .device = 0,
+                .stream = 0,
+                .label = context.allocation_label,
+                .operation = context.allocation_operation,
+                .native_error = static_cast<long long>(result),
+            });
         }
 
         bool storage_buffer_exportable(const VkPhysicalDevice physical) {
@@ -289,6 +308,14 @@ namespace lfs::core::internal {
         LFS_ASSERT_MSG(bytes > 0, "Vulkan allocation requires a non-zero byte count");
         LFS_ASSERT_MSG(alignment == 0 || (alignment & (alignment - 1)) == 0,
                        "Vulkan allocation alignment must be zero or a power of two");
+        // Rounding a near-max direct-range size up to a uint32 word can wrap
+        // VkDeviceSize; refuse before vmaCreateBuffer sees a truncated size.
+        if (bytes >= kDirectLimit &&
+            static_cast<VkDeviceSize>(bytes) >
+                std::numeric_limits<VkDeviceSize>::max() - (kByteWordBytes - 1)) {
+            throw_storage_allocation_error(
+                bytes, alignment, context, VK_ERROR_OUT_OF_DEVICE_MEMORY);
+        }
         const VkDeviceSize bucket_size = allocation_size(bytes);
         const bool direct = bucket_size >= kDirectLimit && !host_visible;
         std::unique_ptr<AllocationRecord> record;
@@ -362,16 +389,7 @@ namespace lfs::core::internal {
                 result == VK_ERROR_FRAGMENTED_POOL) {
                 // The same typed failure the CUDA services raise, so callers
                 // that retry or report on MemoryAllocationError see one contract.
-                throw MemoryAllocationError(AllocationFailure{
-                    .domain = MemoryDomain::VulkanDevice,
-                    .requested_bytes = bytes,
-                    .alignment = alignment,
-                    .device = 0,
-                    .stream = 0,
-                    .label = context.allocation_label,
-                    .operation = context.allocation_operation,
-                    .native_error = static_cast<long long>(result),
-                });
+                throw_storage_allocation_error(bytes, alignment, context, result);
             }
             vk_check(&context_, result, "vmaCreateBuffer(storage)");
             if (host_visible) {

--- a/src/core/tensor/backend/vulkan/vk_ops_movement.cpp
+++ b/src/core/tensor/backend/vulkan/vk_ops_movement.cpp
@@ -62,6 +62,28 @@ namespace lfs::core::internal {
             return last + 1;
         }
 
+        bool packed_byte_gather(const bool scatter, const DataType dtype) {
+            return !scatter &&
+                   (dtype == DataType::UInt8 || dtype == DataType::Bool);
+        }
+
+        void assert_packed_byte_alignment(const StorageRef storage) {
+            LFS_ASSERT_MSG(storage.meta != nullptr,
+                           "Vulkan packed byte gather requires a native storage descriptor");
+            LFS_ASSERT_MSG((storage.meta->gpu_descriptor.base_address & 3ull) == 0ull,
+                           "Vulkan packed byte gather requires a 4-byte aligned buffer device address");
+        }
+
+        // One invocation owns one aligned output word covering [output, output+count).
+        // Count is elements; UInt8/Bool are one byte each. Partial first/last words
+        // are included so unaligned byte_offset still maps onto 4-byte stores.
+        size_t packed_byte_gather_work(const StorageRef output, const size_t count) {
+            assert_packed_byte_alignment(output);
+            const uint64_t start = address(output);
+            const uint64_t last = start + static_cast<uint64_t>(count) - 1ull;
+            return static_cast<size_t>((last >> 2) - (start >> 2) + 1ull);
+        }
+
         void dispatch_strided(const StorageRef input, const StorageRef output,
                               const StridedLayout& layout, const bool scatter,
                               const DataType input_dtype,
@@ -82,6 +104,13 @@ namespace lfs::core::internal {
             const std::array constants{static_cast<uint32_t>(input_dtype),
                                        static_cast<uint32_t>(output_dtype),
                                        scatter ? 1u : 0u};
+            const bool packed = packed_byte_gather(scatter, input_dtype) &&
+                                packed_byte_gather(false, output_dtype);
+            size_t work = layout.element_count;
+            if (packed) {
+                assert_packed_byte_alignment(input);
+                work = packed_byte_gather_work(output, layout.element_count);
+            }
             const auto context = acquire_vulkan_context();
             const VulkanPipeline& pipeline = context->pipelines().specialized(
                 "strided_copy", sizeof(StridedPush), constants);
@@ -94,9 +123,7 @@ namespace lfs::core::internal {
                     vkCmdPushConstants(command, pipeline.layout,
                                        VK_SHADER_STAGE_COMPUTE_BIT, 0,
                                        sizeof(push), &push);
-                    vkCmdDispatch(command,
-                                  dispatch_groups(*context, layout.element_count),
-                                  1, 1);
+                    vkCmdDispatch(command, dispatch_groups(*context, work), 1, 1);
                 });
         }
 

--- a/src/core/tensor/backend/vulkan/vk_ops_pointwise.cpp
+++ b/src/core/tensor/backend/vulkan/vk_ops_pointwise.cpp
@@ -299,6 +299,18 @@ namespace lfs::core::internal {
             uint32_t padding;
         };
         static_assert(sizeof(ConvertPush) == 24);
+
+        // Byte outputs pack four converted values per aligned word. Dispatch
+        // the number of words covering [output, output+count), including a
+        // leading/trailing partial word when the byte range is unaligned.
+        size_t convert_work_items(const StorageRef& output, const size_t count) {
+            if (output.dtype != DataType::UInt8 && output.dtype != DataType::Bool) {
+                return count;
+            }
+            const uint64_t start = address(output);
+            const uint64_t last = start + static_cast<uint64_t>(count) - 1ull;
+            return static_cast<size_t>((last >> 2) - (start >> 2) + 1ull);
+        }
     } // namespace
 
     void VulkanBackendOps::unary(const PointwiseProgram& program,
@@ -522,6 +534,7 @@ namespace lfs::core::internal {
             .output_address = address(output),
             .count = checked_u32(count, "Vulkan conversion count exceeds uint32"),
         };
+        const size_t work = convert_work_items(output, count);
         const std::array reads{input};
         const std::array writes{output};
         context->recorders().record(
@@ -531,7 +544,7 @@ namespace lfs::core::internal {
                 vkCmdPushConstants(command, pipeline.layout,
                                    VK_SHADER_STAGE_COMPUTE_BIT, 0,
                                    sizeof(push), &push);
-                vkCmdDispatch(command, dispatch_groups(*context, count), 1, 1);
+                vkCmdDispatch(command, dispatch_groups(*context, work), 1, 1);
             });
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -608,6 +608,7 @@ if(LFS_TENSOR_VULKAN)
     list(APPEND TEST_FILES
         test_tensor_backend_validators.cpp
         test_tensor_vulkan_runtime.cpp
+        test_tensor_vulkan_allocation_padding.cpp
         test_tensor_vulkan_adoption.cpp
         test_tensor_vulkan_pointwise.cpp
         test_tensor_vulkan_reduce.cpp
@@ -1286,6 +1287,26 @@ target_link_libraries(bench_tensor_launch_overhead PRIVATE
     CUDA::cudart
 )
 
+# Standalone GUI-workload tensor bench. Built with tests; NOT registered with
+# ctest. Public tensor API plus tensor_backend selection/sync.
+add_executable(bench_tensor_gui
+    bench_tensor_gui.cpp
+)
+set_target_properties(bench_tensor_gui PROPERTIES
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON
+)
+target_include_directories(bench_tensor_gui PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_BINARY_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+    ${CUDAToolkit_INCLUDE_DIRS}
+)
+target_link_libraries(bench_tensor_gui PRIVATE
+    lfs_core
+    CUDA::cudart
+)
+
 add_executable(tensor_backend_corpus
     tensor_backend_corpus.cpp
 )
@@ -1363,7 +1384,7 @@ message(STATUS "  Unit tests: ${TEST_COUNT} files -> lichtfeld_tests")
 message(STATUS "  Build tests: ninja lichtfeld_tests")
 message(STATUS "  Run tests: ninja run_tests")
 message(STATUS "  Run full tests: ninja run_full_tests")
-message(STATUS "  Bench (not ctest): bench_tensor_launch_overhead")
+message(STATUS "  Bench (not ctest): bench_tensor_launch_overhead bench_tensor_gui")
 message(STATUS "  Phase 6C device-fault tests: test_device_fault.cpp + device_fault_cuda_utils.cu")
 
 add_test(NAME lichtfeld.decimate.perf

--- a/tests/bench_tensor_gui.cpp
+++ b/tests/bench_tensor_gui.cpp
@@ -1,0 +1,613 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+// Standalone GUI-workload tensor bench. Built with tests, NOT registered with
+// ctest. Times CUDA or Vulkan through tensor_backend public selection plus
+// internal GpuBackendOps::synchronize_device() — never CUDA-only events.
+//
+// Invocation:
+//   bench_tensor_gui --backend cuda|vulkan [--repetitions N] [--case NAME]
+//
+// Default N=5, ten warmups per case. Validate host-equivalent output outside
+// the timed region (fatal on mismatch), then report median wall-time that
+// includes device completion. Lazy expressions are materialized inside the
+// timed region via data_ptr().
+
+#include "core/tensor.hpp"
+#include "core/tensor/backend/gpu_backend_ops.hpp"
+#include "core/tensor_backend.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <format>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+using lfs::core::DataType;
+using lfs::core::Device;
+using lfs::core::GpuBackend;
+using lfs::core::GpuBackendScope;
+using lfs::core::Tensor;
+using lfs::core::TensorShape;
+
+namespace {
+
+    constexpr int kDefaultRepetitions = 5;
+    constexpr int kWarmup = 10;
+    constexpr int kSmallDispatchInner = 256;
+    constexpr size_t kMaskItems = 1'000'000;
+    constexpr size_t kDispatchElems = 64;
+    constexpr float kGain = 1.15f;
+    constexpr float kBias = -0.02f;
+    constexpr float kContrast = 0.98f;
+    constexpr float kFloatAbsTol = 1.0e-6f;
+
+    [[noreturn]] void fail(const std::string& message) {
+        std::fprintf(stderr, "bench_tensor_gui: %s\n", message.c_str());
+        std::fflush(stderr);
+        std::exit(1);
+    }
+
+    [[noreturn]] void usage_error(const std::string& message) {
+        std::fprintf(stderr,
+                     "bench_tensor_gui: %s\n"
+                     "Usage: bench_tensor_gui --backend cuda|vulkan "
+                     "[--repetitions N] [--case NAME]\n",
+                     message.c_str());
+        std::fflush(stderr);
+        std::exit(2);
+    }
+
+    void wait_complete(const GpuBackend backend) {
+        lfs::core::internal::backend_ops(backend).synchronize_device();
+    }
+
+    // Deferred expressions must not escape the timed region unevaluated.
+    void materialize(const Tensor& tensor) {
+        (void)tensor.data_ptr();
+    }
+
+    [[nodiscard]] const char* backend_csv_id(const GpuBackend backend) {
+        switch (backend) {
+        case GpuBackend::CUDA:
+            return "cuda";
+        case GpuBackend::Vulkan:
+            return "vulkan";
+        }
+        return "unknown";
+    }
+
+    [[nodiscard]] std::optional<GpuBackend> parse_backend(const std::string_view text) {
+        if (text == "cuda" || text == "CUDA" || text == "Cuda") {
+            return GpuBackend::CUDA;
+        }
+        if (text == "vulkan" || text == "Vulkan" || text == "VULKAN") {
+            return GpuBackend::Vulkan;
+        }
+        return std::nullopt;
+    }
+
+    [[nodiscard]] double median_ms(std::vector<double> samples) {
+        std::sort(samples.begin(), samples.end());
+        const size_t n = samples.size();
+        if (n == 0) {
+            return 0.0;
+        }
+        if (n % 2 == 1) {
+            return samples[n / 2];
+        }
+        return 0.5 * (samples[n / 2 - 1] + samples[n / 2]);
+    }
+
+    template <typename Fn>
+    [[nodiscard]] double time_ms(const GpuBackend backend, Fn&& fn) {
+        wait_complete(backend);
+        const auto t0 = std::chrono::steady_clock::now();
+        fn();
+        wait_complete(backend);
+        const auto t1 = std::chrono::steady_clock::now();
+        return std::chrono::duration<double, std::milli>(t1 - t0).count();
+    }
+
+    void print_csv_row(const GpuBackend backend, const char* name, const double median,
+                       const int repetitions) {
+        std::printf("%s,%s,%.6f,%d\n", backend_csv_id(backend), name, median, repetitions);
+        std::fflush(stdout);
+    }
+
+    void require_backend(const Tensor& tensor, const GpuBackend expected, const char* what) {
+        const auto tagged = lfs::core::gpu_backend_of(tensor);
+        if (!tagged.has_value() || *tagged != expected) {
+            fail(std::format("{} is not a {} GPU tensor (tag={})",
+                             what,
+                             backend_csv_id(expected),
+                             tagged ? lfs::core::gpu_backend_name(*tagged) : "none"));
+        }
+    }
+
+    // Deterministic values spanning below 0, (0,1), and above 1 for clamp paths.
+    [[nodiscard]] float pattern(const size_t i) {
+        return static_cast<float>(static_cast<int>(i % 401) - 50) / 300.0f;
+    }
+
+    [[nodiscard]] std::vector<float> patterned(const size_t n) {
+        std::vector<float> values(n);
+        for (size_t i = 0; i < n; ++i) {
+            values[i] = pattern(i);
+        }
+        return values;
+    }
+
+    Tensor upload_gpu(const std::vector<float>& host, const TensorShape& shape,
+                      const GpuBackend backend) {
+        Tensor gpu = Tensor::from_vector(host, shape, Device::GPU);
+        require_backend(gpu, backend, "upload");
+        return gpu;
+    }
+
+    // Matches export_post_process / image_io: clamp[0,1] * 255 + 0.5, then uint8.
+    [[nodiscard]] uint8_t image_path_u8(const float value) {
+        return static_cast<uint8_t>(std::clamp(value, 0.0f, 1.0f) * 255.0f + 0.5f);
+    }
+
+    void expect_u8_eq(const std::vector<uint8_t>& got, const std::vector<uint8_t>& expected,
+                      const char* name) {
+        if (got.size() != expected.size()) {
+            fail(std::format("{} size mismatch: got {} expected {}", name, got.size(),
+                             expected.size()));
+        }
+        for (size_t i = 0; i < got.size(); ++i) {
+            if (got[i] != expected[i]) {
+                fail(std::format("{} mismatch at {}: got {} expected {}", name, i,
+                                 static_cast<unsigned>(got[i]),
+                                 static_cast<unsigned>(expected[i])));
+            }
+        }
+    }
+
+    void expect_f32_eq(const std::vector<float>& got, const std::vector<float>& expected,
+                       const char* name) {
+        if (got.size() != expected.size()) {
+            fail(std::format("{} size mismatch: got {} expected {}", name, got.size(),
+                             expected.size()));
+        }
+        for (size_t i = 0; i < got.size(); ++i) {
+            if (!(std::isfinite(got[i]) && std::isfinite(expected[i])) ||
+                std::abs(got[i] - expected[i]) > kFloatAbsTol) {
+                fail(std::format("{} mismatch at {}: got {} expected {}", name, i, got[i],
+                                 expected[i]));
+            }
+        }
+    }
+
+    template <typename Work, typename Validate>
+    void run_timed(const char* name, const GpuBackend backend, const int repetitions, Work work,
+                   Validate validate) {
+        for (int w = 0; w < kWarmup; ++w) {
+            auto warmup_out = work();
+            wait_complete(backend);
+            validate(warmup_out);
+        }
+
+        std::vector<double> samples;
+        samples.reserve(static_cast<size_t>(repetitions));
+        for (int i = 0; i < repetitions; ++i) {
+            samples.push_back(time_ms(backend, [&] { (void)work(); }));
+        }
+        print_csv_row(backend, name, median_ms(std::move(samples)), repetitions);
+    }
+
+    Tensor chw_rgb_to_hwc_u8(const Tensor& chw) {
+        Tensor bytes = chw.clamp(0.0f, 1.0f).mul(255.0f).add(0.5f).to(DataType::UInt8);
+        Tensor hwc = bytes.permute({1, 2, 0}).contiguous();
+        materialize(hwc);
+        return hwc;
+    }
+
+    std::vector<uint8_t> cpu_chw_rgb_to_hwc_u8(const std::vector<float>& chw, const size_t height,
+                                               const size_t width) {
+        const size_t pixels = height * width;
+        std::vector<uint8_t> hwc(pixels * 3);
+        for (size_t y = 0; y < height; ++y) {
+            for (size_t x = 0; x < width; ++x) {
+                const size_t p = y * width + x;
+                for (size_t c = 0; c < 3; ++c) {
+                    hwc[p * 3 + c] = image_path_u8(chw[c * pixels + p]);
+                }
+            }
+        }
+        return hwc;
+    }
+
+    Tensor fused_pointwise(const Tensor& input) {
+        Tensor out = input.mul(kGain).add(kBias).mul(kContrast).clamp(0.0f, 1.0f);
+        materialize(out);
+        return out;
+    }
+
+    std::vector<float> cpu_fused_pointwise(const std::vector<float>& input) {
+        std::vector<float> out(input.size());
+        for (size_t i = 0; i < input.size(); ++i) {
+            // GPU: mul/add/mul fuse, then eager clamp — same algebra, no mid clamp.
+            out[i] = std::clamp((input[i] * kGain + kBias) * kContrast, 0.0f, 1.0f);
+        }
+        return out;
+    }
+
+    struct CopyResult {
+        Tensor hwc;
+        Tensor chw;
+    };
+
+    CopyResult noncontig_chw_hwc_copy(const Tensor& chw) {
+        Tensor hwc = chw.permute({1, 2, 0}).contiguous();
+        Tensor chw_back = hwc.permute({2, 0, 1}).contiguous();
+        materialize(hwc);
+        materialize(chw_back);
+        return CopyResult{std::move(hwc), std::move(chw_back)};
+    }
+
+    std::vector<float> cpu_chw_to_hwc(const std::vector<float>& chw, const size_t height,
+                                      const size_t width) {
+        const size_t pixels = height * width;
+        std::vector<float> hwc(pixels * 3);
+        for (size_t y = 0; y < height; ++y) {
+            for (size_t x = 0; x < width; ++x) {
+                const size_t p = y * width + x;
+                for (size_t c = 0; c < 3; ++c) {
+                    hwc[p * 3 + c] = chw[c * pixels + p];
+                }
+            }
+        }
+        return hwc;
+    }
+
+    struct MaskResult {
+        size_t count = 0;
+        Tensor mask;
+    };
+
+    MaskResult mask_logical_reduce(const Tensor& values) {
+        Tensor pred_hi = values.gt(0.0f);
+        Tensor pred_lo = values.lt(0.5f);
+        materialize(pred_hi);
+        materialize(pred_lo);
+        Tensor both = pred_hi.logical_and(pred_lo);
+        materialize(both);
+        MaskResult result;
+        result.count = both.count_nonzero();
+        result.mask = std::move(both);
+        return result;
+    }
+
+    size_t cpu_mask_count(const std::vector<float>& values) {
+        size_t count = 0;
+        for (const float v : values) {
+            if (v > 0.0f && v < 0.5f) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    Tensor small_dispatch_add(const Tensor& a, const Tensor& b) {
+        Tensor c;
+        for (int k = 0; k < kSmallDispatchInner; ++k) {
+            c = a.add(b);
+            materialize(c);
+        }
+        materialize(c);
+        return c;
+    }
+
+    std::vector<float> cpu_add(const std::vector<float>& a, const std::vector<float>& b) {
+        std::vector<float> out(a.size());
+        for (size_t i = 0; i < a.size(); ++i) {
+            out[i] = a[i] + b[i];
+        }
+        return out;
+    }
+
+    void bench_chw_rgb_to_hwc_u8(const GpuBackend backend, const int repetitions,
+                                 const size_t height, const size_t width, const char* name) {
+        const TensorShape chw_shape({size_t{3}, height, width});
+        const auto host = patterned(chw_shape.elements());
+        const auto expected = cpu_chw_rgb_to_hwc_u8(host, height, width);
+        const Tensor gpu = upload_gpu(host, chw_shape, backend);
+
+        run_timed(
+            name, backend, repetitions, [&] { return chw_rgb_to_hwc_u8(gpu); },
+            [&](const Tensor& out) {
+                require_backend(out, backend, name);
+                if (out.dtype() != DataType::UInt8 || out.ndim() != 3 ||
+                    out.shape()[0] != height || out.shape()[1] != width || out.shape()[2] != 3) {
+                    fail(std::format("{} produced unexpected shape/dtype", name));
+                }
+                expect_u8_eq(out.to_vector_uint8(), expected, name);
+            });
+    }
+
+    void bench_fused_pointwise(const GpuBackend backend, const int repetitions,
+                               const size_t height, const size_t width, const char* name) {
+        const TensorShape shape({size_t{3}, height, width});
+        const auto host = patterned(shape.elements());
+        const auto expected = cpu_fused_pointwise(host);
+        const Tensor gpu = upload_gpu(host, shape, backend);
+
+        run_timed(
+            name, backend, repetitions, [&] { return fused_pointwise(gpu); },
+            [&](const Tensor& out) {
+                require_backend(out, backend, name);
+                expect_f32_eq(out.to_vector(), expected, name);
+            });
+    }
+
+    void bench_noncontig_copy(const GpuBackend backend, const int repetitions,
+                              const size_t height, const size_t width, const char* name) {
+        const TensorShape chw_shape({size_t{3}, height, width});
+        const TensorShape hwc_shape({height, width, size_t{3}});
+        const auto host = patterned(chw_shape.elements());
+        const auto expected_hwc = cpu_chw_to_hwc(host, height, width);
+        const Tensor gpu = upload_gpu(host, chw_shape, backend);
+
+        run_timed(
+            name, backend, repetitions, [&] { return noncontig_chw_hwc_copy(gpu); },
+            [&](const CopyResult& out) {
+                require_backend(out.hwc, backend, name);
+                require_backend(out.chw, backend, name);
+                if (out.hwc.shape() != hwc_shape) {
+                    fail(std::format("{} HWC shape mismatch", name));
+                }
+                if (out.chw.shape() != chw_shape) {
+                    fail(std::format("{} CHW shape mismatch", name));
+                }
+                expect_f32_eq(out.hwc.to_vector(), expected_hwc, name);
+                expect_f32_eq(out.chw.to_vector(), host, name);
+            });
+    }
+
+    void bench_mask_logical_reduce(const GpuBackend backend, const int repetitions,
+                                   const size_t items = kMaskItems,
+                                   const char* name = "mask_logical_reduce_1m") {
+        const auto host = patterned(items);
+        const size_t expected = cpu_mask_count(host);
+        const Tensor gpu = upload_gpu(host, TensorShape({items}), backend);
+
+        run_timed(
+            name, backend, repetitions, [&] { return mask_logical_reduce(gpu); },
+            [&](const MaskResult& out) {
+                require_backend(out.mask, backend, name);
+                if (out.count != expected) {
+                    fail(std::format("{} count mismatch: got {} expected {}", name, out.count,
+                                     expected));
+                }
+                const auto bits = out.mask.to_vector_bool();
+                if (bits.size() != host.size()) {
+                    fail(std::format("{} mask size mismatch: got {} expected {}", name, bits.size(),
+                                     host.size()));
+                }
+                for (size_t i = 0; i < host.size(); ++i) {
+                    const bool want = host[i] > 0.0f && host[i] < 0.5f;
+                    if (static_cast<bool>(bits[i]) != want) {
+                        fail(std::format("{} mask mismatch at {}: got {} expected {}", name, i,
+                                         static_cast<int>(bits[i]), static_cast<int>(want)));
+                    }
+                }
+            });
+    }
+
+    void bench_dispatch_overhead_small(const GpuBackend backend, const int repetitions) {
+        const char* name = "dispatch_overhead_small";
+        const auto host_a = patterned(kDispatchElems);
+        auto host_b = patterned(kDispatchElems);
+        for (size_t i = 0; i < host_b.size(); ++i) {
+            host_b[i] = pattern(i + 17);
+        }
+        const auto expected = cpu_add(host_a, host_b);
+        const Tensor a = upload_gpu(host_a, TensorShape({kDispatchElems}), backend);
+        const Tensor b = upload_gpu(host_b, TensorShape({kDispatchElems}), backend);
+
+        run_timed(
+            name, backend, repetitions, [&] { return small_dispatch_add(a, b); },
+            [&](const Tensor& out) {
+                require_backend(out, backend, name);
+                expect_f32_eq(out.to_vector(), expected, name);
+            });
+    }
+
+    void bench_byte_conversion(const GpuBackend backend, const int repetitions,
+                               const size_t elements, const char* name) {
+        std::vector<float> host(elements);
+        std::vector<uint8_t> expected(elements);
+        for (size_t i = 0; i < elements; ++i) {
+            host[i] = static_cast<float>(i % 256);
+            expected[i] = static_cast<uint8_t>(i % 256);
+        }
+        const Tensor input = upload_gpu(host, TensorShape({elements}), backend);
+        run_timed(name, backend, repetitions, [&] {
+            Tensor result = input.to(DataType::UInt8);
+            materialize(result);
+            return result; }, [&](const Tensor& result) {
+            require_backend(result, backend, name);
+            expect_u8_eq(result.to_vector_uint8(), expected, name); });
+    }
+
+    struct CaseSpec {
+        const char* name;
+        void (*run)(GpuBackend, int);
+    };
+
+    void run_rgb_720p(const GpuBackend backend, const int reps) {
+        bench_chw_rgb_to_hwc_u8(backend, reps, 720, 1280, "chw_rgb_to_hwc_u8_720p");
+    }
+    void run_rgb_1080p(const GpuBackend backend, const int reps) {
+        bench_chw_rgb_to_hwc_u8(backend, reps, 1080, 1920, "chw_rgb_to_hwc_u8_1080p");
+    }
+    void run_fused_720p(const GpuBackend backend, const int reps) {
+        bench_fused_pointwise(backend, reps, 720, 1280, "fused_pointwise_720p");
+    }
+    void run_fused_1080p(const GpuBackend backend, const int reps) {
+        bench_fused_pointwise(backend, reps, 1080, 1920, "fused_pointwise_1080p");
+    }
+    void run_copy_720p(const GpuBackend backend, const int reps) {
+        bench_noncontig_copy(backend, reps, 720, 1280, "noncontig_chw_hwc_copy_720p");
+    }
+    void run_copy_1080p(const GpuBackend backend, const int reps) {
+        bench_noncontig_copy(backend, reps, 1080, 1920, "noncontig_chw_hwc_copy_1080p");
+    }
+    void run_mask(const GpuBackend backend, const int reps) {
+        bench_mask_logical_reduce(backend, reps);
+    }
+    void run_mask_16m(const GpuBackend backend, const int reps) {
+        bench_mask_logical_reduce(backend, reps, 16'000'000, "mask_logical_reduce_16m");
+    }
+    void run_convert_1080p(const GpuBackend backend, const int reps) {
+        bench_byte_conversion(backend, reps, 1920 * 1080 * 3, "float_to_uint8_1080p");
+    }
+    void run_dispatch(const GpuBackend backend, const int reps) {
+        bench_dispatch_overhead_small(backend, reps);
+    }
+
+    constexpr CaseSpec kCases[] = {
+        {"chw_rgb_to_hwc_u8_720p", run_rgb_720p},
+        {"chw_rgb_to_hwc_u8_1080p", run_rgb_1080p},
+        {"mask_logical_reduce_1m", run_mask},
+        {"mask_logical_reduce_16m", run_mask_16m},
+        {"float_to_uint8_1080p", run_convert_1080p},
+        {"fused_pointwise_720p", run_fused_720p},
+        {"fused_pointwise_1080p", run_fused_1080p},
+        {"noncontig_chw_hwc_copy_720p", run_copy_720p},
+        {"noncontig_chw_hwc_copy_1080p", run_copy_1080p},
+        {"dispatch_overhead_small", run_dispatch},
+    };
+
+    void print_help() {
+        std::printf(
+            "Usage: bench_tensor_gui --backend cuda|vulkan [--repetitions N] [--case NAME]\n"
+            "\n"
+            "Standalone GUI-workload tensor benchmark (not ctest).\n"
+            "  --backend cuda|vulkan   Required. Public tensor_backend selection.\n"
+            "  --repetitions N         Timed samples per case (default %d). Median reported.\n"
+            "  --case NAME             Run one case (default: all).\n"
+            "\n"
+            "Cases:\n",
+            kDefaultRepetitions);
+        for (const CaseSpec& spec : kCases) {
+            std::printf("  %s\n", spec.name);
+        }
+        std::printf(
+            "\nStdout CSV:\n"
+            "  tensor_backend,<cuda|vulkan>\n"
+            "  gpu_backend_name,<CUDA|Vulkan>\n"
+            "  backend,case,median_ms,repetitions\n"
+            "  ...\n");
+        std::fflush(stdout);
+    }
+
+    [[nodiscard]] std::string_view take_value(const int argc, char** argv, int& i,
+                                              const std::string_view arg,
+                                              const std::string_view flag) {
+        const std::string prefix = std::string(flag) + "=";
+        if (arg.starts_with(prefix)) {
+            return arg.substr(prefix.size());
+        }
+        if (arg != flag) {
+            return {};
+        }
+        if (i + 1 >= argc) {
+            usage_error(std::format("{} requires a value", flag));
+        }
+        ++i;
+        return argv[i];
+    }
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        std::optional<GpuBackend> backend;
+        int repetitions = kDefaultRepetitions;
+        std::string case_filter;
+
+        for (int i = 1; i < argc; ++i) {
+            const std::string_view arg = argv[i];
+            if (arg == "--help" || arg == "-h") {
+                print_help();
+                return 0;
+            }
+            if (arg == "--backend" || arg.starts_with("--backend=")) {
+                const auto value = take_value(argc, argv, i, arg, "--backend");
+                backend = parse_backend(value);
+                if (!backend) {
+                    usage_error(std::format("invalid --backend '{}'", value));
+                }
+                continue;
+            }
+            if (arg == "--repetitions" || arg.starts_with("--repetitions=")) {
+                const auto value = take_value(argc, argv, i, arg, "--repetitions");
+                int parsed = 0;
+                const auto result =
+                    std::from_chars(value.data(), value.data() + value.size(), parsed);
+                if (result.ec != std::errc{} || result.ptr != value.data() + value.size() ||
+                    parsed < 1) {
+                    usage_error(std::format("invalid --repetitions '{}'", value));
+                }
+                repetitions = parsed;
+                continue;
+            }
+            if (arg == "--case" || arg.starts_with("--case=")) {
+                case_filter = std::string(take_value(argc, argv, i, arg, "--case"));
+                if (case_filter.empty()) {
+                    usage_error("--case requires a name");
+                }
+                continue;
+            }
+            usage_error(std::format("unknown argument '{}'", arg));
+        }
+
+        if (!backend) {
+            usage_error("missing required --backend cuda|vulkan");
+        }
+
+        if (!lfs::core::gpu_backend_available(*backend)) {
+            fail(std::format("GPU backend '{}' is unavailable",
+                             lfs::core::gpu_backend_name(*backend)));
+        }
+
+        const lfs::Status status = lfs::core::set_default_gpu_backend(*backend);
+        if (!status.has_value()) {
+            fail(std::string(status.error().user_message()));
+        }
+        GpuBackendScope scope(*backend);
+
+        std::printf("tensor_backend,%s\n", backend_csv_id(*backend));
+        std::printf("gpu_backend_name,%s\n", lfs::core::gpu_backend_name(*backend));
+        std::printf("backend,case,median_ms,repetitions\n");
+        std::fflush(stdout);
+
+        bool ran = false;
+        for (const CaseSpec& spec : kCases) {
+            if (!case_filter.empty() && case_filter != spec.name) {
+                continue;
+            }
+            spec.run(*backend, repetitions);
+            ran = true;
+        }
+        if (!ran) {
+            usage_error(std::format("unknown --case '{}'", case_filter));
+        }
+        return 0;
+    } catch (const std::exception& ex) {
+        fail(ex.what());
+    }
+}

--- a/tests/test_tensor_vulkan_allocation_padding.cpp
+++ b/tests/test_tensor_vulkan_allocation_padding.cpp
@@ -1,0 +1,145 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/memory_pressure.hpp"
+#include "core/tensor.hpp"
+#include "core/tensor/backend/gpu_backend_ops.hpp"
+#include "core/tensor/backend/vulkan/vk_context.hpp"
+#include "core/tensor_backend.hpp"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+#include <vulkan/vulkan.h>
+
+namespace {
+    using namespace lfs::core;
+
+    constexpr size_t kDirectLimitBytes = 16ull * 1024ull * 1024ull;
+
+    class TensorVulkanAllocationPadding : public testing::Test {
+    protected:
+        void SetUp() override {
+            ASSERT_TRUE(gpu_backend_available(GpuBackend::Vulkan));
+        }
+
+        void TearDown() override {
+            const auto status = shutdown_gpu_backend(GpuBackend::Vulkan);
+            EXPECT_TRUE(status.has_value());
+            EXPECT_EQ(internal::vulkan_live_vma_objects_for_testing(), 0u);
+            for (const std::string& message :
+                 internal::vulkan_validation_messages_for_testing()) {
+                ADD_FAILURE() << message;
+            }
+        }
+    };
+
+    void expect_logical_bytes_unchanged(const Tensor& tensor, const size_t logical) {
+        EXPECT_EQ(tensor.bytes(), logical);
+        const internal::StorageRef storage = internal::storage_ref(tensor);
+        ASSERT_NE(storage.meta, nullptr);
+        EXPECT_EQ(storage.meta->gpu_descriptor.byte_size, logical);
+        EXPECT_EQ(storage.byte_offset, 0u);
+
+        const auto queried = tensor_vulkan_buffer(tensor);
+        ASSERT_TRUE(queried.has_value());
+        EXPECT_EQ(queried->bytes, logical);
+        EXPECT_EQ(queried->offset, 0u);
+        ASSERT_NE(queried->buffer, nullptr);
+    }
+
+    // vkCmdCopyBuffer of the last covering uint32; API validation flags a
+    // VkBuffer whose create size is the unpadded logical tail.
+    void copy_covering_word(const Tensor& tensor, const size_t logical) {
+        std::array<std::byte, 4> word{};
+        internal::StorageRef src = internal::storage_ref(tensor);
+        src.byte_offset = logical & ~size_t{3};
+        internal::backend_ops(GpuBackend::Vulkan)
+            .copy_device_to_host(internal::CopyRequest{
+                .src = src,
+                .dst = internal::raw_storage_ref(word.data()),
+                .bytes = sizeof(word),
+                .synchronous = true,
+            });
+    }
+
+    TEST_F(TensorVulkanAllocationPadding,
+           DirectRangeOddByteBufferCoversLastWordAndKeepsLogicalSize) {
+        GpuBackendScope scope(GpuBackend::Vulkan);
+        auto& ops = internal::backend_ops(GpuBackend::Vulkan);
+        ops.trim();
+        const uint64_t live_before = internal::vulkan_live_vma_objects_for_testing();
+
+        {
+            const Tensor slab = Tensor::empty({255}, Device::GPU, DataType::UInt8);
+            expect_logical_bytes_unchanged(slab, 255);
+        }
+        EXPECT_GT(internal::vulkan_live_vma_objects_for_testing(), live_before);
+        ops.trim();
+        const uint64_t live_baseline = internal::vulkan_live_vma_objects_for_testing();
+
+        for (const size_t extra : {size_t{0}, size_t{1}, size_t{2}, size_t{3}}) {
+            SCOPED_TRACE(extra);
+            const size_t logical = kDirectLimitBytes + extra;
+            Tensor tensor = Tensor::empty({logical}, Device::GPU, DataType::UInt8);
+            expect_logical_bytes_unchanged(tensor, logical);
+            if (extra != 0) {
+                copy_covering_word(tensor, logical);
+            }
+            ops.synchronize_device();
+            tensor = Tensor();
+            EXPECT_EQ(internal::vulkan_live_vma_objects_for_testing(), live_baseline);
+        }
+    }
+
+    TEST_F(TensorVulkanAllocationPadding, DirectRangeOddByteConvertRoundtrip) {
+        GpuBackendScope scope(GpuBackend::Vulkan);
+        for (const size_t extra : {size_t{1}, size_t{2}, size_t{3}}) {
+            SCOPED_TRACE(extra);
+            const size_t logical = kDirectLimitBytes + extra;
+            const Tensor source =
+                Tensor::full({logical}, 165.0f, Device::GPU, DataType::UInt8);
+            expect_logical_bytes_unchanged(source, logical);
+            copy_covering_word(source, logical);
+
+            const Tensor as_bool = source.to(DataType::Bool);
+            expect_logical_bytes_unchanged(as_bool, logical);
+            copy_covering_word(as_bool, logical);
+
+            const Tensor roundtrip = as_bool.to(DataType::UInt8);
+            EXPECT_EQ(roundtrip.bytes(), logical);
+            const Tensor roundtrip_head = roundtrip.slice(0, 0, 8).contiguous().cpu();
+            const Tensor roundtrip_tail =
+                roundtrip.slice(0, logical - 8, logical).contiguous().cpu();
+            EXPECT_EQ(roundtrip_head.to_vector_uint8(), std::vector<uint8_t>(8, 1));
+            EXPECT_EQ(roundtrip_tail.to_vector_uint8(), std::vector<uint8_t>(8, 1));
+        }
+    }
+
+    TEST_F(TensorVulkanAllocationPadding,
+           DirectRangeWordPaddingOverflowThrowsTypedError) {
+        GpuBackendScope scope(GpuBackend::Vulkan);
+        auto& ops = internal::backend_ops(GpuBackend::Vulkan);
+        // Initialize the backend before counting its staging allocations.
+        const Tensor warmup = Tensor::empty({1}, Device::GPU, DataType::UInt8);
+        const uint64_t live = internal::vulkan_live_vma_objects_for_testing();
+        const size_t too_big = std::numeric_limits<size_t>::max() - 1;
+        try {
+            const internal::StorageRef storage = ops.allocate(too_big, 16, {});
+            ops.deallocate(storage, {});
+            FAIL() << "expected MemoryAllocationError for word-padding overflow";
+        } catch (const MemoryAllocationError& error) {
+            EXPECT_EQ(error.domain(), MemoryDomain::VulkanDevice);
+            EXPECT_EQ(error.requested_bytes(), too_big);
+            EXPECT_EQ(error.failure().alignment, 16u);
+            EXPECT_EQ(error.failure().native_error,
+                      static_cast<long long>(VK_ERROR_OUT_OF_DEVICE_MEMORY));
+        }
+        EXPECT_EQ(internal::vulkan_live_vma_objects_for_testing(), live);
+    }
+
+} // namespace

--- a/tests/test_tensor_vulkan_pointwise.cpp
+++ b/tests/test_tensor_vulkan_pointwise.cpp
@@ -10,6 +10,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <bit>
 #include <cmath>
@@ -30,6 +31,36 @@ namespace {
 
     Tensor upload_float(const std::vector<float>& values, const TensorShape& shape) {
         return upload_vulkan(Tensor::from_vector(values, shape, Device::CPU));
+    }
+
+    Tensor cpu_bytes(const std::vector<uint8_t>& values, const DataType dtype) {
+        std::vector<uint8_t> copy = values;
+        return Tensor::from_blob(copy.data(), {copy.size()}, Device::CPU, dtype).clone();
+    }
+
+    std::vector<uint8_t> guarded_payload(const std::vector<uint8_t>& payload,
+                                         const size_t prefix, const size_t suffix) {
+        std::vector<uint8_t> expected(prefix + payload.size() + suffix, 0xA5);
+        std::copy(payload.begin(), payload.end(), expected.begin() + prefix);
+        return expected;
+    }
+
+    std::vector<uint8_t> convert_into_guarded(const Tensor& cpu_input,
+                                              const DataType output_dtype,
+                                              const size_t prefix,
+                                              const size_t suffix) {
+        GpuBackendScope scope(GpuBackend::Vulkan);
+        const size_t count = cpu_input.numel();
+        const size_t total = prefix + count + suffix;
+        const Tensor input = cpu_input.to(Device::GPU);
+        Tensor dest = cpu_bytes(std::vector<uint8_t>(total, 0xA5), DataType::UInt8)
+                          .to(Device::GPU);
+        internal::StorageRef out =
+            internal::offset_storage_ref(internal::storage_ref(dest), prefix);
+        out.dtype = output_dtype;
+        internal::backend_ops(GpuBackend::Vulkan)
+            .convert_type(internal::storage_ref(input), out, count, {});
+        return dest.cpu().to_vector_uint8();
     }
 
     void expect_close(const Tensor& actual, const Tensor& expected,
@@ -411,5 +442,144 @@ namespace {
         EXPECT_EQ(padded.shape(), TensorShape({4, 6}));
         EXPECT_EQ(padded.slice(0, 1, 3).slice(1, 2, 5).to_vector(),
                   base.to_vector());
+    }
+
+    TEST_F(TensorVulkanPointwise, ConversionPackedByteOutputPreservesGuardsAtEveryAlignment) {
+        std::vector<float> values(16);
+        for (size_t i = 0; i < values.size(); ++i) {
+            values[i] = static_cast<float>(static_cast<int>(i) * 17 - 40);
+        }
+        const Tensor cpu = Tensor::from_vector(values, {values.size()}, Device::CPU);
+        constexpr std::array counts{size_t{1}, size_t{2}, size_t{3}, size_t{4},
+                                    size_t{5}, size_t{7}, size_t{8}, size_t{15}};
+        constexpr size_t kGuard = 8;
+        for (const size_t count : counts) {
+            const Tensor cpu_slice = cpu.slice(0, 0, count).contiguous();
+            const std::vector<uint8_t> payload =
+                cpu_slice.to(DataType::UInt8).to_vector_uint8();
+            for (size_t align = 0; align < 4; ++align) {
+                SCOPED_TRACE(count);
+                SCOPED_TRACE(align);
+                const size_t prefix = kGuard + align;
+                const std::vector<uint8_t> actual =
+                    convert_into_guarded(cpu_slice, DataType::UInt8, prefix, kGuard);
+                EXPECT_EQ(actual, guarded_payload(payload, prefix, kGuard));
+            }
+        }
+
+        std::vector<float> large(4099);
+        for (size_t i = 0; i < large.size(); ++i) {
+            large[i] = static_cast<float>(static_cast<int>(i % 511) - 200);
+        }
+        const Tensor cpu_large = Tensor::from_vector(large, {large.size()}, Device::CPU);
+        const std::vector<uint8_t> large_payload =
+            cpu_large.to(DataType::UInt8).to_vector_uint8();
+        for (size_t align = 0; align < 4; ++align) {
+            SCOPED_TRACE(align);
+            const size_t prefix = kGuard + align;
+            EXPECT_EQ(convert_into_guarded(cpu_large, DataType::UInt8, prefix, kGuard),
+                      guarded_payload(large_payload, prefix, kGuard));
+        }
+    }
+
+    TEST_F(TensorVulkanPointwise, ConversionPackedByteOutputMatchesDtypeReferenceAndUnalignedInput) {
+        const std::vector<float> float_values{
+            0.0f, 1.9f, -1.9f, 255.9f, 256.0f, -256.0f, 257.0f, -257.0f,
+            511.0f, -0.1f, 127.0f, 128.0f,
+            std::numeric_limits<float>::infinity(),
+            -std::numeric_limits<float>::infinity(),
+            std::numeric_limits<float>::quiet_NaN(),
+            std::numeric_limits<float>::denorm_min()};
+        const Tensor cpu_f32 =
+            Tensor::from_vector(float_values, {float_values.size()}, Device::CPU);
+        const std::vector<uint8_t> f32_payload =
+            cpu_f32.to(DataType::UInt8).to_vector_uint8();
+        EXPECT_EQ(upload_vulkan(cpu_f32).to(DataType::UInt8).to_vector_uint8(), f32_payload);
+        EXPECT_EQ(convert_into_guarded(cpu_f32, DataType::UInt8, 9, 8),
+                  guarded_payload(f32_payload, 9, 8));
+
+        const Tensor cpu_f16 = cpu_f32.to(DataType::Float16);
+        const std::vector<uint8_t> f16_payload =
+            cpu_f16.to(DataType::UInt8).to_vector_uint8();
+        EXPECT_EQ(upload_vulkan(cpu_f16).to(DataType::UInt8).to_vector_uint8(), f16_payload);
+        EXPECT_EQ(convert_into_guarded(cpu_f16, DataType::UInt8, 1, 8),
+                  guarded_payload(f16_payload, 1, 8));
+
+        const Tensor cpu_i32 = Tensor::from_vector(
+            std::vector<int>{-1, 0, 1, 255, 256, 257, -256, 511, -257},
+            {9}, Device::CPU);
+        const std::vector<uint8_t> i32_payload =
+            cpu_i32.to(DataType::UInt8).to_vector_uint8();
+        EXPECT_EQ(i32_payload, (std::vector<uint8_t>{255, 0, 1, 255, 0, 1, 0, 255, 255}));
+        EXPECT_EQ(upload_vulkan(cpu_i32).to(DataType::UInt8).to_vector_uint8(), i32_payload);
+        EXPECT_EQ(convert_into_guarded(cpu_i32, DataType::UInt8, 2, 8),
+                  guarded_payload(i32_payload, 2, 8));
+
+        const std::vector<int64_t> i64_values{
+            0, -1, 256, 511, std::numeric_limits<int64_t>::min(),
+            std::numeric_limits<int64_t>::max(), 0x100000001LL};
+        const Tensor cpu_i64 =
+            Tensor::from_blob(const_cast<int64_t*>(i64_values.data()),
+                              {i64_values.size()}, Device::CPU, DataType::Int64)
+                .clone();
+        const std::vector<uint8_t> i64_payload =
+            cpu_i64.to(DataType::UInt8).to_vector_uint8();
+        EXPECT_EQ(upload_vulkan(cpu_i64).to(DataType::UInt8).to_vector_uint8(), i64_payload);
+        EXPECT_EQ(convert_into_guarded(cpu_i64, DataType::UInt8, 3, 8),
+                  guarded_payload(i64_payload, 3, 8));
+
+        const std::vector<uint8_t> raw{0, 1, 2, 127, 255, 0, 3, 8};
+        const Tensor cpu_u8 = cpu_bytes(raw, DataType::UInt8);
+        const std::vector<uint8_t> bool_payload =
+            cpu_u8.to(DataType::Bool).to_vector_uint8();
+        EXPECT_EQ(bool_payload, (std::vector<uint8_t>{0, 1, 1, 1, 1, 0, 1, 1}));
+        EXPECT_EQ(upload_vulkan(cpu_u8).to(DataType::Bool).to_vector_uint8(), bool_payload);
+        EXPECT_EQ(convert_into_guarded(cpu_u8, DataType::Bool, 1, 8),
+                  guarded_payload(bool_payload, 1, 8));
+
+        GpuBackendScope scope(GpuBackend::Vulkan);
+        for (size_t input_align = 0; input_align < 4; ++input_align) {
+            SCOPED_TRACE(input_align);
+            std::vector<uint8_t> padded(4 + raw.size(), 0x3C);
+            std::copy(raw.begin(), raw.end(), padded.begin() + input_align);
+            Tensor input = cpu_bytes(padded, DataType::UInt8).to(Device::GPU);
+            const size_t out_prefix = 8 + input_align;
+            constexpr size_t suffix = 8;
+            Tensor dest =
+                cpu_bytes(std::vector<uint8_t>(out_prefix + raw.size() + suffix, 0xA5),
+                          DataType::UInt8)
+                    .to(Device::GPU);
+            internal::StorageRef in = internal::offset_storage_ref(
+                internal::storage_ref(input), input_align);
+            internal::StorageRef out = internal::offset_storage_ref(
+                internal::storage_ref(dest), out_prefix);
+            out.dtype = DataType::Bool;
+            internal::backend_ops(GpuBackend::Vulkan)
+                .convert_type(in, out, raw.size(), {});
+            EXPECT_EQ(dest.cpu().to_vector_uint8(),
+                      guarded_payload(bool_payload, out_prefix, suffix));
+        }
+    }
+
+    TEST_F(TensorVulkanPointwise, ConversionPackedByteOutputInPlaceNormalizesWithoutClobber) {
+        GpuBackendScope scope(GpuBackend::Vulkan);
+        const std::vector<uint8_t> host{0xA5, 0xA5, 0, 2, 255, 1, 0, 7, 0xA5, 0xA5};
+        Tensor tensor = cpu_bytes(host, DataType::UInt8).to(Device::GPU);
+        internal::StorageRef region =
+            internal::offset_storage_ref(internal::storage_ref(tensor), 2);
+        internal::StorageRef as_bool = region;
+        as_bool.dtype = DataType::Bool;
+        internal::backend_ops(GpuBackend::Vulkan)
+            .convert_type(region, as_bool, 6, {});
+        EXPECT_EQ(tensor.cpu().to_vector_uint8(),
+                  (std::vector<uint8_t>{0xA5, 0xA5, 0, 1, 1, 1, 0, 1, 0xA5, 0xA5}));
+
+        Tensor bool_tensor = cpu_bytes(host, DataType::Bool).to(Device::GPU);
+        internal::StorageRef bool_region =
+            internal::offset_storage_ref(internal::storage_ref(bool_tensor), 2);
+        internal::backend_ops(GpuBackend::Vulkan)
+            .convert_type(bool_region, bool_region, 6, {});
+        EXPECT_EQ(bool_tensor.cpu().to_vector_uint8(),
+                  (std::vector<uint8_t>{0xA5, 0xA5, 0, 1, 1, 1, 0, 1, 0xA5, 0xA5}));
     }
 } // namespace

--- a/tests/test_tensor_vulkan_runtime.cpp
+++ b/tests/test_tensor_vulkan_runtime.cpp
@@ -681,4 +681,213 @@ namespace {
         EXPECT_EQ(internal::vulkan_live_vma_objects_for_testing(), baseline);
     }
 
+    Tensor cpu_bytes(const std::vector<uint8_t>& values, const TensorShape& shape,
+                     const DataType dtype = DataType::UInt8) {
+        std::vector<uint8_t> copy = values;
+        return Tensor::from_blob(copy.data(), shape, Device::CPU, dtype).clone();
+    }
+
+    std::vector<uint8_t> sequential_bytes(const size_t count, const uint8_t seed = 0) {
+        std::vector<uint8_t> values(count);
+        for (size_t i = 0; i < count; ++i) {
+            values[i] = static_cast<uint8_t>((i * 37 + 11 + seed) & 0xff);
+        }
+        return values;
+    }
+
+    std::vector<uint8_t> hwc_from_chw(const std::vector<uint8_t>& chw, const size_t channels,
+                                      const size_t height, const size_t width) {
+        std::vector<uint8_t> hwc(chw.size());
+        const size_t plane = height * width;
+        for (size_t y = 0; y < height; ++y) {
+            for (size_t x = 0; x < width; ++x) {
+                for (size_t c = 0; c < channels; ++c) {
+                    hwc[(y * width + x) * channels + c] = chw[c * plane + y * width + x];
+                }
+            }
+        }
+        return hwc;
+    }
+
+    std::vector<uint8_t> guarded_payload(const std::vector<uint8_t>& payload,
+                                         const size_t prefix, const size_t suffix) {
+        std::vector<uint8_t> expected(prefix + payload.size() + suffix, 0xA5);
+        std::copy(payload.begin(), payload.end(), expected.begin() + static_cast<ptrdiff_t>(prefix));
+        return expected;
+    }
+
+    std::vector<uint8_t> gather_into_guarded(const Tensor& gpu_input, const size_t prefix,
+                                             const size_t suffix) {
+        GpuBackendScope scope(GpuBackend::Vulkan);
+        const size_t count = gpu_input.numel();
+        Tensor dest = cpu_bytes(std::vector<uint8_t>(prefix + count + suffix, 0xA5),
+                                {prefix + count + suffix})
+                          .to(Device::GPU);
+        internal::StorageRef out =
+            internal::offset_storage_ref(internal::storage_ref(dest), prefix);
+        out.dtype = gpu_input.dtype();
+        internal::backend_ops(GpuBackend::Vulkan)
+            .strided_copy(internal::storage_ref(gpu_input), out,
+                          internal::strided_layout(gpu_input), {});
+        return dest.cpu().to_vector_uint8();
+    }
+
+    void expect_bytes(const Tensor& actual, const std::vector<uint8_t>& expected,
+                      const std::string_view label) {
+        const Tensor cpu = actual.cpu();
+        ASSERT_EQ(cpu.bytes(), expected.size()) << label;
+        ASSERT_NE(cpu.data_ptr(), nullptr) << label;
+        EXPECT_EQ(std::memcmp(cpu.data_ptr(), expected.data(), expected.size()), 0) << label;
+        EXPECT_EQ(cpu.to_vector_uint8(), expected) << label;
+    }
+
+    TEST_F(TensorVulkanRuntime, PackedByteGatherMatchesDirectCpuLayoutForOddChannelPermutes) {
+        // Catches a packed gather that round-trips GPU logical order but writes the
+        // wrong contiguous HWC/NCHW byte layout, or that mishandles C=1/3/4 tails.
+        constexpr std::array channels{size_t{1}, size_t{3}, size_t{4}};
+        constexpr std::array heights{size_t{1}, size_t{2}, size_t{5}, size_t{17}};
+        constexpr std::array widths{size_t{1}, size_t{3}, size_t{7}, size_t{19}};
+        constexpr std::array dtypes{DataType::UInt8, DataType::Bool};
+        GpuBackendScope scope(GpuBackend::Vulkan);
+        for (const DataType dtype : dtypes) {
+            for (const size_t c : channels) {
+                for (const size_t h : heights) {
+                    for (const size_t w : widths) {
+                        SCOPED_TRACE(static_cast<int>(dtype));
+                        SCOPED_TRACE(c);
+                        SCOPED_TRACE(h);
+                        SCOPED_TRACE(w);
+                        const auto chw = sequential_bytes(c * h * w);
+                        const Tensor cpu = cpu_bytes(chw, {c, h, w}, dtype);
+                        const std::vector<uint8_t> expected = hwc_from_chw(chw, c, h, w);
+                        const Tensor cpu_hwc = cpu.permute({1, 2, 0}).contiguous();
+                        ASSERT_EQ(std::memcmp(cpu_hwc.data_ptr(), expected.data(), expected.size()),
+                                  0);
+                        const Tensor gpu_hwc =
+                            cpu.to(Device::GPU).permute({1, 2, 0}).contiguous();
+                        EXPECT_TRUE(gpu_hwc.is_contiguous());
+                        expect_bytes(gpu_hwc, expected, "chw->hwc");
+                    }
+                }
+            }
+        }
+
+        const auto nchw = sequential_bytes(2 * 3 * 5 * 7, 3);
+        const Tensor cpu_nchw = cpu_bytes(nchw, {2, 3, 5, 7});
+        const Tensor cpu_nhwc = cpu_nchw.permute({0, 2, 3, 1}).contiguous();
+        expect_bytes(cpu_nchw.to(Device::GPU).permute({0, 2, 3, 1}).contiguous(),
+                     cpu_nhwc.to_vector_uint8(), "nchw->nhwc");
+    }
+
+    TEST_F(TensorVulkanRuntime, PackedByteGatherPreservesNeighborSentinelsAndUnalignedOffsets) {
+        // Catches a full-word store that clobbers prefix/suffix bytes, a tail that
+        // drops the last 1-3 elements, or an unaligned view offset that rounds the
+        // device address the wrong way.
+        constexpr std::array counts{size_t{1}, size_t{2}, size_t{3}, size_t{4},
+                                    size_t{5}, size_t{7}, size_t{8}, size_t{15}};
+        constexpr size_t kGuard = 8;
+        GpuBackendScope scope(GpuBackend::Vulkan);
+        for (const size_t count : counts) {
+            const auto values = sequential_bytes(count);
+            const Tensor cpu = cpu_bytes(values, {1, count}).transpose(0, 1);
+            const std::vector<uint8_t> payload = cpu.contiguous().to_vector_uint8();
+            EXPECT_EQ(payload, values);
+            const Tensor gpu =
+                cpu_bytes(values, {1, count}).to(Device::GPU).transpose(0, 1);
+            for (size_t align = 0; align < 4; ++align) {
+                SCOPED_TRACE(count);
+                SCOPED_TRACE(align);
+                const size_t prefix = kGuard + align;
+                EXPECT_EQ(gather_into_guarded(gpu, prefix, kGuard),
+                          guarded_payload(payload, prefix, kGuard));
+            }
+        }
+
+        const std::vector<uint8_t> bool_raw{0, 1, 2, 127, 255, 0, 3, 8};
+        const Tensor cpu_bool = cpu_bytes(bool_raw, {2, 4}, DataType::Bool).transpose(0, 1);
+        const std::vector<uint8_t> bool_payload = cpu_bool.contiguous().to_vector_uint8();
+        EXPECT_EQ(bool_payload, (std::vector<uint8_t>{0, 255, 1, 0, 2, 3, 127, 8}));
+        const Tensor gpu_bool =
+            cpu_bytes(bool_raw, {2, 4}, DataType::Bool).to(Device::GPU).transpose(0, 1);
+        for (size_t align = 0; align < 4; ++align) {
+            SCOPED_TRACE(align);
+            EXPECT_EQ(gather_into_guarded(gpu_bool, kGuard + align, kGuard),
+                      guarded_payload(bool_payload, kGuard + align, kGuard));
+        }
+
+        for (size_t input_align = 0; input_align < 4; ++input_align) {
+            SCOPED_TRACE(input_align);
+            const auto payload = sequential_bytes(3 * 5 * 7, 9);
+            std::vector<uint8_t> padded(input_align + payload.size(), 0x3C);
+            std::copy(payload.begin(), payload.end(), padded.begin() + static_cast<ptrdiff_t>(input_align));
+            const Tensor input =
+                cpu_bytes(padded, {padded.size()})
+                    .to(Device::GPU)
+                    .slice(0, input_align, input_align + payload.size())
+                    .reshape({3, 5, 7})
+                    .permute({1, 2, 0});
+            const std::vector<uint8_t> expected = hwc_from_chw(payload, 3, 5, 7);
+            expect_bytes(input.contiguous(), expected, "unaligned input");
+            const size_t out_prefix = kGuard + input_align;
+            Tensor dest =
+                cpu_bytes(std::vector<uint8_t>(out_prefix + expected.size() + kGuard, 0xA5),
+                          {out_prefix + expected.size() + kGuard})
+                    .to(Device::GPU);
+            internal::StorageRef out =
+                internal::offset_storage_ref(internal::storage_ref(dest), out_prefix);
+            internal::backend_ops(GpuBackend::Vulkan)
+                .strided_copy(internal::storage_ref(input), out,
+                              internal::strided_layout(input), {});
+            EXPECT_EQ(dest.cpu().to_vector_uint8(),
+                      guarded_payload(expected, out_prefix, kGuard));
+        }
+    }
+
+    TEST_F(TensorVulkanRuntime, PackedByteGatherCoversRanksStridesEmptyAndLeavesScatterSafe) {
+        // Catches a packed path that only handles rank-3 image permutes, skips
+        // zero-element work, or accidentally takes word ownership on scatter.
+        GpuBackendScope scope(GpuBackend::Vulkan);
+        const Tensor cpu_rank2 = cpu_bytes(sequential_bytes(12), {3, 4});
+        expect_bytes(cpu_rank2.to(Device::GPU).transpose(0, 1).contiguous(),
+                     cpu_rank2.transpose(0, 1).contiguous().to_vector_uint8(), "rank2");
+
+        const Tensor cpu_rank5 = cpu_bytes(sequential_bytes(16), {1, 1, 1, 4, 2});
+        expect_bytes(cpu_rank5.to(Device::GPU).transpose(3, 4).contiguous(),
+                     cpu_rank5.transpose(3, 4).contiguous().to_vector_uint8(), "rank5");
+
+        const Tensor cpu_volume = cpu_bytes(sequential_bytes(3 * 6 * 5), {3, 6, 5});
+        const Tensor cpu_sliced = cpu_volume.slice(1, 1, 5).permute({1, 2, 0});
+        expect_bytes(cpu_volume.to(Device::GPU).slice(1, 1, 5).permute({1, 2, 0}).contiguous(),
+                     cpu_sliced.contiguous().to_vector_uint8(), "sliced strides");
+
+        const Tensor cpu_row = cpu_bytes(std::vector<uint8_t>{7}, {1});
+        const Tensor expanded = cpu_row.to(Device::GPU).expand({9});
+        EXPECT_FALSE(expanded.is_contiguous());
+        expect_bytes(expanded.contiguous(), cpu_row.expand({9}).contiguous().to_vector_uint8(),
+                     "expand");
+
+        const auto large = sequential_bytes(3 * 41 * 33);
+        const Tensor cpu_large = cpu_bytes(large, {3, 41, 33});
+        expect_bytes(cpu_large.to(Device::GPU).permute({1, 2, 0}).contiguous(),
+                     hwc_from_chw(large, 3, 41, 33), "large chw");
+
+        const Tensor empty = Tensor::empty({2, 0, 3}, Device::GPU, DataType::UInt8)
+                                 .permute({1, 2, 0});
+        EXPECT_EQ(empty.contiguous().numel(), 0u);
+        EXPECT_EQ(Tensor::empty({0}, Device::GPU, DataType::UInt8).contiguous().numel(), 0u);
+
+        Tensor destination = Tensor::zeros({2, 3}, Device::GPU, DataType::UInt8);
+        destination.transpose(0, 1).copy_from(
+            cpu_bytes(std::vector<uint8_t>{7, 8, 9, 10, 11, 12}, {3, 2}).to(Device::GPU));
+        expect_bytes(destination, std::vector<uint8_t>{7, 9, 11, 8, 10, 12}, "scatter");
+
+        Tensor rank5_destination =
+            Tensor::zeros({1, 1, 1, 4, 2}, Device::GPU, DataType::UInt8);
+        rank5_destination.transpose(3, 4).copy_from(
+            cpu_bytes(std::vector<uint8_t>{8, 7, 6, 5, 4, 3, 2, 1}, {1, 1, 1, 2, 4})
+                .to(Device::GPU));
+        expect_bytes(rank5_destination,
+                     std::vector<uint8_t>{8, 4, 7, 3, 6, 2, 5, 1}, "rank5 scatter");
+    }
+
 } // namespace


### PR DESCRIPTION
Pack Vulkan byte conversion and strided copies four bytes at a time, preserving neighboring bytes in unaligned views. Pad large buffers so their last byte can be accessed safely.

On an RTX 4080, float-to-byte conversion is 2.1× faster. Full RGB packing improves 10% at 1080p and 19% at 720p across five paired runs. Adds a repeatable CUDA/Vulkan benchmark and tests for byte boundaries, offsets and allocation overflow.

Validation: 96 Vulkan tests passed with synchronization validation; two existing capability skips. The buffer-tail regression fails against the original library and passes with this change.
