### PR TITLE
Fix CUDA concatenation for non-float tensors

### DIFF
--- a/src/core/tensor/backend/cuda/kernels/tensor_ops.cu
+++ b/src/core/tensor/backend/cuda/kernels/tensor_ops.cu
@@ -2331,6 +2331,97 @@ namespace lfs::core::tensor_ops {
         }
     }
 
+    template <typename Fn>
+    void dispatch_cat_copy_type(const size_t element_size, Fn&& fn) {
+        // Cat copies dtype-width units. Last/middle extents are element counts.
+        switch (element_size) {
+        case sizeof(uint8_t):
+            fn.template operator()<uint8_t>();
+            return;
+        case sizeof(uint16_t):
+            fn.template operator()<uint16_t>();
+            return;
+        case sizeof(float):
+            fn.template operator()<float>();
+            return;
+        case sizeof(int64_t):
+            fn.template operator()<int64_t>();
+            return;
+        default:
+            LFS_ASSERT_MSG(false, "unsupported CUDA cat element size");
+        }
+    }
+
+    template <typename T>
+    void launch_cat_last_dim_typed(
+        T* output,
+        const std::vector<Tensor>& tensors,
+        size_t num_rows,
+        size_t row_size,
+        cudaStream_t stream) {
+        const size_t num_tensors = tensors.size();
+
+        const T** d_input_ptrs = static_cast<const T**>(
+            CudaMemoryPool::instance().allocate(num_tensors * sizeof(T*), stream));
+        size_t* d_input_sizes = static_cast<size_t*>(
+            CudaMemoryPool::instance().allocate(num_tensors * sizeof(size_t), stream));
+
+        if (!d_input_ptrs || !d_input_sizes) {
+            LOG_ERROR("Failed to allocate cat metadata from memory pool");
+            if (d_input_ptrs)
+                CudaMemoryPool::instance().deallocate(const_cast<T**>(d_input_ptrs), stream);
+            if (d_input_sizes)
+                CudaMemoryPool::instance().deallocate(d_input_sizes, stream);
+            return;
+        }
+
+        std::vector<const T*> h_input_ptrs(num_tensors);
+        std::vector<size_t> h_input_sizes(num_tensors);
+
+        for (size_t i = 0; i < num_tensors; ++i) {
+            h_input_ptrs[i] = static_cast<const T*>(tensors[i].data_ptr());
+            h_input_sizes[i] = tensors[i].shape()[tensors[i].shape().rank() - 1];
+        }
+
+        LFS_CUDA_CHECK_MSG(
+            cudaMemcpyAsync(const_cast<T**>(d_input_ptrs), h_input_ptrs.data(),
+                            num_tensors * sizeof(T*), cudaMemcpyHostToDevice, stream),
+            "cat metadata pointer copy (tensor_count={})", num_tensors);
+        LFS_CUDA_CHECK_MSG(
+            cudaMemcpyAsync(d_input_sizes, h_input_sizes.data(),
+                            num_tensors * sizeof(size_t), cudaMemcpyHostToDevice, stream),
+            "cat metadata size copy (tensor_count={})", num_tensors);
+
+        int block_size = 256;
+        size_t num_blocks = (num_rows + block_size - 1) / block_size;
+        const size_t max_blocks_x = 65535; // Safe limit for all CUDA devices
+
+        if (num_blocks <= max_blocks_x) {
+            cat_last_dim_kernel_vectorized<<<num_blocks, block_size, 0, stream>>>(
+                output,
+                d_input_ptrs,
+                d_input_sizes,
+                num_tensors,
+                num_rows,
+                row_size);
+            LFS_CUDA_LAUNCH_CHECK(stream, "tensor.ops.cat_last_dim");
+        } else {
+            dim3 grid(std::min(num_blocks, max_blocks_x),
+                      (num_blocks + max_blocks_x - 1) / max_blocks_x);
+            cat_last_dim_kernel_vectorized<<<grid, block_size, 0, stream>>>(
+                output,
+                d_input_ptrs,
+                d_input_sizes,
+                num_tensors,
+                num_rows,
+                row_size);
+            LFS_CUDA_LAUNCH_CHECK(stream, "tensor.ops.cat_last_dim");
+        }
+
+        CudaMemoryPool::instance().deallocate(const_cast<T**>(d_input_ptrs), stream);
+        CudaMemoryPool::instance().deallocate(d_input_sizes, stream);
+    }
+
     void launch_cat_last_dim(
         void* output,
         const std::vector<Tensor>& tensors,
@@ -2341,6 +2432,10 @@ namespace lfs::core::tensor_ops {
         for (const auto& tensor : tensors)
             pin_operands({&tensor});
         size_t num_tensors = tensors.size();
+        if (!tensors.empty()) {
+            LFS_ASSERT_MSG(element_size == dtype_size(tensors[0].dtype()),
+                           "CUDA cat element_size does not match input dtype");
+        }
 
         // FAST PATH: RGB→RGBA conversion (adding alpha channel)
         // This is the most common case in image processing pipelines
@@ -2364,70 +2459,10 @@ namespace lfs::core::tensor_ops {
             return;
         }
 
-        // GENERIC PATH: Use memory pool for metadata (NO thrust::device_vector!)
-        // Allocate from memory pool (fast, cached, no synchronization)
-        const float** d_input_ptrs = static_cast<const float**>(
-            CudaMemoryPool::instance().allocate(num_tensors * sizeof(float*), stream));
-        size_t* d_input_sizes = static_cast<size_t*>(
-            CudaMemoryPool::instance().allocate(num_tensors * sizeof(size_t), stream));
-
-        if (!d_input_ptrs || !d_input_sizes) {
-            LOG_ERROR("Failed to allocate cat metadata from memory pool");
-            if (d_input_ptrs)
-                CudaMemoryPool::instance().deallocate(const_cast<float**>(d_input_ptrs), stream);
-            if (d_input_sizes)
-                CudaMemoryPool::instance().deallocate(d_input_sizes, stream);
-            return;
-        }
-
-        // Copy metadata to device
-        std::vector<const float*> h_input_ptrs(num_tensors);
-        std::vector<size_t> h_input_sizes(num_tensors);
-
-        for (size_t i = 0; i < num_tensors; ++i) {
-            h_input_ptrs[i] = static_cast<const float*>(tensors[i].data_ptr());
-            h_input_sizes[i] = tensors[i].shape()[tensors[i].shape().rank() - 1];
-        }
-
-        LFS_CUDA_CHECK_MSG(
-            cudaMemcpyAsync(const_cast<float**>(d_input_ptrs), h_input_ptrs.data(),
-                            num_tensors * sizeof(float*), cudaMemcpyHostToDevice, stream),
-            "cat metadata pointer copy (tensor_count={})", num_tensors);
-        LFS_CUDA_CHECK_MSG(
-            cudaMemcpyAsync(d_input_sizes, h_input_sizes.data(),
-                            num_tensors * sizeof(size_t), cudaMemcpyHostToDevice, stream),
-            "cat metadata size copy (tensor_count={})", num_tensors);
-
-        int block_size = 256;
-        size_t num_blocks = (num_rows + block_size - 1) / block_size;
-        const size_t max_blocks_x = 65535; // Safe limit for all CUDA devices
-
-        // Use 2D grid for large arrays to avoid exceeding grid dimension limits
-        if (num_blocks <= max_blocks_x) {
-            cat_last_dim_kernel_vectorized<<<num_blocks, block_size, 0, stream>>>(
-                static_cast<float*>(output),
-                d_input_ptrs,
-                d_input_sizes,
-                num_tensors,
-                num_rows,
-                row_size);
-            LFS_CUDA_LAUNCH_CHECK(stream, "tensor.ops.cat_last_dim");
-        } else {
-            dim3 grid(std::min(num_blocks, max_blocks_x),
-                      (num_blocks + max_blocks_x - 1) / max_blocks_x);
-            cat_last_dim_kernel_vectorized<<<grid, block_size, 0, stream>>>(
-                static_cast<float*>(output),
-                d_input_ptrs,
-                d_input_sizes,
-                num_tensors,
-                num_rows,
-                row_size);
-            LFS_CUDA_LAUNCH_CHECK(stream, "tensor.ops.cat_last_dim");
-        }
-
-        // Return metadata arrays to memory pool (instant, cached for reuse)
-        CudaMemoryPool::instance().deallocate(const_cast<float**>(d_input_ptrs), stream);
-        CudaMemoryPool::instance().deallocate(d_input_sizes, stream);
+        dispatch_cat_copy_type(element_size, [&]<typename T>() {
+            launch_cat_last_dim_typed(
+                static_cast<T*>(output), tensors, num_rows, row_size, stream);
+        });
     }
 
     template <typename T>
@@ -2465,51 +2500,43 @@ namespace lfs::core::tensor_ops {
         }
     }
 
-    void launch_cat_middle_dim(
-        void* output,
+    template <typename T>
+    void launch_cat_middle_dim_typed(
+        T* output,
         const std::vector<Tensor>& tensors,
         size_t outer_size,
         size_t inner_size,
         int resolved_dim,
-        size_t element_size,
+        size_t total_dim_size,
         cudaStream_t stream) {
-        for (const auto& tensor : tensors)
-            pin_operands({&tensor});
-        size_t num_tensors = tensors.size();
-        size_t total_dim_size = 0;
-        for (const auto& t : tensors) {
-            total_dim_size += t.shape()[resolved_dim];
-        }
+        const size_t num_tensors = tensors.size();
+        const size_t total_elements = outer_size * total_dim_size * inner_size;
 
-        size_t total_elements = outer_size * total_dim_size * inner_size;
-
-        // OPTIMIZED: Use memory pool instead of thrust::device_vector
-        const float** d_input_ptrs = static_cast<const float**>(
-            CudaMemoryPool::instance().allocate(num_tensors * sizeof(float*), stream));
+        const T** d_input_ptrs = static_cast<const T**>(
+            CudaMemoryPool::instance().allocate(num_tensors * sizeof(T*), stream));
         size_t* d_input_sizes = static_cast<size_t*>(
             CudaMemoryPool::instance().allocate(num_tensors * sizeof(size_t), stream));
 
         if (!d_input_ptrs || !d_input_sizes) {
             LOG_ERROR("Failed to allocate cat_middle_dim metadata from memory pool");
             if (d_input_ptrs)
-                CudaMemoryPool::instance().deallocate(const_cast<float**>(d_input_ptrs), stream);
+                CudaMemoryPool::instance().deallocate(const_cast<T**>(d_input_ptrs), stream);
             if (d_input_sizes)
                 CudaMemoryPool::instance().deallocate(d_input_sizes, stream);
             return;
         }
 
-        // Copy metadata to device
-        std::vector<const float*> h_input_ptrs(num_tensors);
+        std::vector<const T*> h_input_ptrs(num_tensors);
         std::vector<size_t> h_input_sizes(num_tensors);
 
         for (size_t i = 0; i < num_tensors; ++i) {
-            h_input_ptrs[i] = static_cast<const float*>(tensors[i].data_ptr());
+            h_input_ptrs[i] = static_cast<const T*>(tensors[i].data_ptr());
             h_input_sizes[i] = tensors[i].shape()[resolved_dim];
         }
 
         LFS_CUDA_CHECK_MSG(
-            cudaMemcpyAsync(const_cast<float**>(d_input_ptrs), h_input_ptrs.data(),
-                            num_tensors * sizeof(float*), cudaMemcpyHostToDevice, stream),
+            cudaMemcpyAsync(const_cast<T**>(d_input_ptrs), h_input_ptrs.data(),
+                            num_tensors * sizeof(T*), cudaMemcpyHostToDevice, stream),
             "cat-middle metadata pointer copy (tensor_count={})", num_tensors);
         LFS_CUDA_CHECK_MSG(
             cudaMemcpyAsync(d_input_sizes, h_input_sizes.data(),
@@ -2520,10 +2547,9 @@ namespace lfs::core::tensor_ops {
         size_t num_blocks = (total_elements + block_size - 1) / block_size;
         const size_t max_blocks_x = 65535; // Safe limit for all CUDA devices
 
-        // Use 2D grid for large arrays to avoid exceeding grid dimension limits
         if (num_blocks <= max_blocks_x) {
             cat_middle_dim_kernel<<<num_blocks, block_size, 0, stream>>>(
-                static_cast<float*>(output),
+                output,
                 d_input_ptrs,
                 d_input_sizes,
                 num_tensors,
@@ -2535,7 +2561,7 @@ namespace lfs::core::tensor_ops {
             dim3 grid(std::min(num_blocks, max_blocks_x),
                       (num_blocks + max_blocks_x - 1) / max_blocks_x);
             cat_middle_dim_kernel<<<grid, block_size, 0, stream>>>(
-                static_cast<float*>(output),
+                output,
                 d_input_ptrs,
                 d_input_sizes,
                 num_tensors,
@@ -2545,9 +2571,34 @@ namespace lfs::core::tensor_ops {
             LFS_CUDA_LAUNCH_CHECK(stream, "tensor.ops.cat_middle_dim");
         }
 
-        // Return metadata arrays to memory pool
-        CudaMemoryPool::instance().deallocate(const_cast<float**>(d_input_ptrs), stream);
+        CudaMemoryPool::instance().deallocate(const_cast<T**>(d_input_ptrs), stream);
         CudaMemoryPool::instance().deallocate(d_input_sizes, stream);
+    }
+
+    void launch_cat_middle_dim(
+        void* output,
+        const std::vector<Tensor>& tensors,
+        size_t outer_size,
+        size_t inner_size,
+        int resolved_dim,
+        size_t element_size,
+        cudaStream_t stream) {
+        for (const auto& tensor : tensors)
+            pin_operands({&tensor});
+        if (!tensors.empty()) {
+            LFS_ASSERT_MSG(element_size == dtype_size(tensors[0].dtype()),
+                           "CUDA cat element_size does not match input dtype");
+        }
+        size_t total_dim_size = 0;
+        for (const auto& t : tensors) {
+            total_dim_size += t.shape()[resolved_dim];
+        }
+
+        dispatch_cat_copy_type(element_size, [&]<typename T>() {
+            launch_cat_middle_dim_typed(
+                static_cast<T*>(output), tensors, outer_size, inner_size,
+                resolved_dim, total_dim_size, stream);
+        });
     }
 
     // ============= EXPLICIT TEMPLATE INSTANTIATIONS =============

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -388,6 +388,7 @@ set(TEST_FILES
     test_training_cropbox_mask.cpp
     test_training_parameters.cpp
     test_tensor_index_select_uint8.cpp
+    test_tensor_cuda_byte_image.cpp
     test_tensor_uint8_inversion.cpp
     test_tensor_uint8_masking.cpp
     test_tensor_serialization.cpp

--- a/tests/test_tensor_cuda_byte_image.cpp
+++ b/tests/test_tensor_cuda_byte_image.cpp
@@ -1,0 +1,278 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "core/tensor.hpp"
+#include "core/tensor_backend.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+namespace {
+    using lfs::core::DataType;
+    using lfs::core::Device;
+    using lfs::core::gpu_backend_available;
+    using lfs::core::gpu_backend_of;
+    using lfs::core::GpuBackend;
+    using lfs::core::GpuBackendScope;
+    using lfs::core::Tensor;
+    using lfs::core::TensorShape;
+
+    Tensor cpu_u8(const std::vector<std::uint8_t>& bytes, const TensorShape& shape) {
+        Tensor tensor = Tensor::empty(shape, Device::CPU, DataType::UInt8);
+        if (!bytes.empty()) {
+            std::memcpy(tensor.ptr<std::uint8_t>(), bytes.data(), bytes.size());
+        }
+        return tensor;
+    }
+
+    Tensor to_cuda(const Tensor& host) {
+        return host.to(Device::GPU);
+    }
+
+    void expect_uint8_eq(const Tensor& actual, const std::vector<std::uint8_t>& expected) {
+        ASSERT_TRUE(actual.is_valid());
+        EXPECT_EQ(actual.dtype(), DataType::UInt8);
+        const auto got = actual.to_vector_uint8();
+        ASSERT_EQ(got.size(), expected.size());
+        for (size_t i = 0; i < expected.size(); ++i) {
+            EXPECT_EQ(got[i], expected[i]) << "index=" << i;
+        }
+    }
+
+    // 2x2 HWC RGB / gray fixtures matching the image-prepare failure case.
+    const std::vector<std::uint8_t> kRgbHwc{
+        255,
+        0,
+        0,
+        0,
+        255,
+        0,
+        0,
+        0,
+        255,
+        255,
+        255,
+        0,
+    };
+    const std::vector<std::uint8_t> kRgbHwcRgba{
+        255,
+        0,
+        0,
+        255,
+        0,
+        255,
+        0,
+        255,
+        0,
+        0,
+        255,
+        255,
+        255,
+        255,
+        0,
+        255,
+    };
+    const std::vector<std::uint8_t> kRgbHwcRgbaFlipped{
+        0,
+        0,
+        255,
+        255,
+        255,
+        255,
+        0,
+        255,
+        255,
+        0,
+        0,
+        255,
+        0,
+        255,
+        0,
+        255,
+    };
+    const std::vector<std::uint8_t> kGrayHwc{10, 20, 30, 40};
+    const std::vector<std::uint8_t> kGrayHwcRgb{
+        10,
+        10,
+        10,
+        20,
+        20,
+        20,
+        30,
+        30,
+        30,
+        40,
+        40,
+        40,
+    };
+    const std::vector<std::uint8_t> kGrayHwcRgba{
+        10,
+        10,
+        10,
+        255,
+        20,
+        20,
+        20,
+        255,
+        30,
+        30,
+        30,
+        255,
+        40,
+        40,
+        40,
+        255,
+    };
+} // namespace
+
+class TensorCudaByteImage : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!gpu_backend_available(GpuBackend::CUDA)) {
+            GTEST_SKIP() << "CUDA tensor backend required";
+            return;
+        }
+        cuda_scope_.emplace(GpuBackend::CUDA);
+    }
+
+    std::optional<GpuBackendScope> cuda_scope_;
+};
+
+TEST_F(TensorCudaByteImage, UInt8CatLastDimRgbPlusOpaqueAlpha) {
+    const Tensor rgb = to_cuda(cpu_u8(kRgbHwc, {2, 2, 3}));
+    const Tensor alpha = Tensor::full_like(rgb.slice(2, 0, 1), 255.0f);
+    const Tensor out = Tensor::cat({rgb, alpha}, 2);
+
+    EXPECT_EQ(out.device(), Device::GPU);
+    EXPECT_EQ(gpu_backend_of(out), GpuBackend::CUDA);
+    ASSERT_EQ(out.ndim(), 3u);
+    EXPECT_EQ(out.size(0), 2u);
+    EXPECT_EQ(out.size(1), 2u);
+    EXPECT_EQ(out.size(2), 4u);
+    expect_uint8_eq(out, kRgbHwcRgba);
+
+    const auto bytes = out.to_vector_uint8();
+    for (size_t pixel = 0; pixel < 4; ++pixel) {
+        EXPECT_EQ(bytes[pixel * 4 + 3], 255) << "alpha pixel=" << pixel;
+    }
+}
+
+TEST_F(TensorCudaByteImage, UInt8CatLastDimGrayReplicateThenAlpha) {
+    const Tensor gray = to_cuda(cpu_u8(kGrayHwc, {2, 2, 1}));
+    const Tensor rgb = Tensor::cat({gray, gray, gray}, 2);
+    expect_uint8_eq(rgb, kGrayHwcRgb);
+
+    const Tensor alpha = Tensor::full_like(gray, 255.0f);
+    const Tensor out = Tensor::cat({rgb, alpha}, 2);
+    expect_uint8_eq(out, kGrayHwcRgba);
+}
+
+TEST_F(TensorCudaByteImage, UInt8FullLikeWritesByte255) {
+    const Tensor gray = to_cuda(cpu_u8(kGrayHwc, {2, 2, 1}));
+    const Tensor alpha = Tensor::full_like(gray, 255.0f);
+    EXPECT_EQ(alpha.dtype(), DataType::UInt8);
+    expect_uint8_eq(alpha, {255, 255, 255, 255});
+}
+
+TEST_F(TensorCudaByteImage, UInt8IndexSelectFlipsHwcRows) {
+    const Tensor rgb = to_cuda(cpu_u8(kRgbHwc, {2, 2, 3}));
+    const Tensor indices = Tensor::from_vector(std::vector<int>{1, 0}, {2}, Device::GPU);
+    const Tensor flipped = rgb.index_select(0, indices).contiguous();
+
+    EXPECT_EQ(flipped.dtype(), DataType::UInt8);
+    expect_uint8_eq(flipped, {0, 0, 255, 255, 255, 0, 255, 0, 0, 0, 255, 0});
+}
+
+TEST_F(TensorCudaByteImage, UInt8FlipThenCatAlpha) {
+    const Tensor rgb = to_cuda(cpu_u8(kRgbHwc, {2, 2, 3}));
+    const Tensor indices = Tensor::from_vector(std::vector<int>{1, 0}, {2}, Device::GPU);
+    const Tensor flipped = rgb.index_select(0, indices).contiguous();
+    const Tensor alpha = Tensor::full_like(flipped.slice(2, 0, 1), 255.0f);
+    const Tensor out = Tensor::cat({flipped, alpha}, 2);
+    expect_uint8_eq(out, kRgbHwcRgbaFlipped);
+}
+
+TEST_F(TensorCudaByteImage, FloatToUint8ThenCatAlpha) {
+    const Tensor rgb_f32 = Tensor::from_vector(
+        std::vector<float>{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 0.0f},
+        {2, 2, 3}, Device::GPU);
+    const Tensor rgb = (rgb_f32.clamp(0.0f, 1.0f) * 255.0f).to(DataType::UInt8);
+    const Tensor alpha = Tensor::full_like(rgb.slice(2, 0, 1), 255.0f);
+    const Tensor out = Tensor::cat({rgb, alpha}, 2);
+    expect_uint8_eq(out, kRgbHwcRgba);
+}
+
+TEST_F(TensorCudaByteImage, UInt8CatMiddleDimInterleavesRows) {
+    const Tensor a = to_cuda(cpu_u8({1, 2, 3, 4, 5, 6}, {2, 1, 3}));
+    const Tensor b = to_cuda(cpu_u8({7, 8, 9, 10, 11, 12}, {2, 1, 3}));
+    const Tensor out = Tensor::cat({a, b}, 1);
+    ASSERT_EQ(out.size(0), 2u);
+    ASSERT_EQ(out.size(1), 2u);
+    ASSERT_EQ(out.size(2), 3u);
+    expect_uint8_eq(out, {1, 2, 3, 7, 8, 9, 4, 5, 6, 10, 11, 12});
+}
+
+TEST_F(TensorCudaByteImage, Float32CatLastDimRgbPlusAlphaUnchanged) {
+    const Tensor rgb = Tensor::from_vector(
+        std::vector<float>{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 0.0f},
+        {2, 2, 3}, Device::GPU);
+    const Tensor alpha = Tensor::full_like(rgb.slice(2, 0, 1), 1.0f);
+    const Tensor out = Tensor::cat({rgb, alpha}, 2);
+    ASSERT_EQ(out.dtype(), DataType::Float32);
+    ASSERT_EQ(out.size(2), 4u);
+    const auto values = out.to_vector();
+    const std::vector<float> expected{
+        1.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        1.0f,
+        1.0f,
+        1.0f,
+        0.0f,
+        1.0f,
+    };
+    ASSERT_EQ(values.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_FLOAT_EQ(values[i], expected[i]) << "index=" << i;
+    }
+}
+
+TEST_F(TensorCudaByteImage, CatPreservesRawBitsAtEveryElementWidth) {
+    for (const auto dtype : {DataType::Bool, DataType::UInt8, DataType::Float16,
+                             DataType::Int32, DataType::UInt32, DataType::Float32,
+                             DataType::Int64}) {
+        for (const int dim : {1, 2}) {
+            SCOPED_TRACE(static_cast<int>(dtype));
+            SCOPED_TRACE(dim);
+            Tensor host = Tensor::empty(dim == 1 ? TensorShape{2, 1, 3}
+                                                 : TensorShape{2, 3, 1},
+                                        Device::CPU, dtype);
+            auto* raw = static_cast<uint8_t*>(host.data_ptr());
+            for (size_t i = 0; i < host.bytes(); ++i)
+                raw[i] = dtype == DataType::Bool ? i % 2 : (i * 73 + 19) % 256;
+            const size_t group_bytes = dim == 1 ? host.bytes() / 2 : host.bytes() / 6;
+            std::vector<uint8_t> expected;
+            for (size_t start = 0; start < host.bytes(); start += group_bytes) {
+                expected.insert(expected.end(), raw + start, raw + start + group_bytes);
+                expected.insert(expected.end(), raw + start, raw + start + group_bytes);
+            }
+            const Tensor input = host.to(Device::GPU);
+            const Tensor actual = Tensor::cat({input, input}, dim).cpu();
+            ASSERT_EQ(actual.bytes(), expected.size());
+            EXPECT_EQ(std::memcmp(actual.data_ptr(), expected.data(), expected.size()), 0);
+        }
+    }
+}


### PR DESCRIPTION
CUDA concatenation copied float-sized elements for every dtype, corrupting byte images when adding an alpha channel or combining rows. Dispatch by element width and keep the existing float RGB fast path.

Nine focused tests pass, including raw-bit checks for all supported dtypes. The shared image and selection checks also pass (44 tests total).
