### PR TITLE
Enable Vulkan tensor selection fallbacks

### DIFF
--- a/src/rendering/selection_ops.cu
+++ b/src/rendering/selection_ops.cu
@@ -36,6 +36,11 @@ namespace lfs::rendering {
             return static_cast<int>(value);
         }
 
+        [[nodiscard]] bool isCudaGpu(const Tensor& tensor) {
+            return tensor.is_valid() && tensor.device() == lfs::core::Device::GPU &&
+                   lfs::core::gpu_backend_of(tensor) == lfs::core::GpuBackend::CUDA;
+        }
+
         [[nodiscard]] cudaStream_t currentSelectionStream(const Tensor* const tensor = nullptr) {
             if (const cudaStream_t stream = lfs::core::getCurrentCUDAStream()) {
                 return stream;
@@ -847,12 +852,20 @@ namespace lfs::rendering {
             means.dtype() != lfs::core::DataType::Float32 ||
             means.ndim() != 2 ||
             means.size(1) != 3) {
-            throw std::runtime_error("project_screen_positions_tensor expects a CUDA Float32 [N, 3] means tensor");
+            throw std::runtime_error("project_screen_positions_tensor expects a GPU Float32 [N, 3] means tensor");
         }
         if (width <= 0 || height <= 0) {
             return {};
         }
+        if (!isCudaGpu(means)) {
+            return project_screen_positions_tensor_program(
+                means, width, height, view_rotation_rows, translation,
+                pixel_focal_x, pixel_focal_y, center_x, center_y,
+                camera_model, ortho_scale, model_transforms, transform_indices,
+                node_visibility_mask);
+        }
 
+        lfs::core::GpuBackendScope cuda_scope(lfs::core::GpuBackend::CUDA);
         const int n = checkedToInt(means.size(0), "screen position count exceeds int range");
         const Tensor means_contig = means.is_contiguous() ? means : means.contiguous();
         Tensor output = Tensor::empty(
@@ -867,8 +880,9 @@ namespace lfs::rendering {
             if (model_transforms_contig.dtype() != lfs::core::DataType::Float32) {
                 model_transforms_contig = model_transforms_contig.to(lfs::core::DataType::Float32);
             }
-            if (model_transforms_contig.device() != lfs::core::Device::GPU) {
-                model_transforms_contig = model_transforms_contig.gpu();
+            if (model_transforms_contig.device() != lfs::core::Device::GPU ||
+                lfs::core::gpu_backend_of(model_transforms_contig) != lfs::core::GpuBackend::CUDA) {
+                model_transforms_contig = model_transforms_contig.cpu().to(lfs::core::Device::GPU);
             }
             if (!model_transforms_contig.is_contiguous()) {
                 model_transforms_contig = model_transforms_contig.contiguous();
@@ -885,8 +899,9 @@ namespace lfs::rendering {
             if (transform_indices_contig.dtype() != lfs::core::DataType::Int32) {
                 transform_indices_contig = transform_indices_contig.to(lfs::core::DataType::Int32);
             }
-            if (transform_indices_contig.device() != lfs::core::Device::GPU) {
-                transform_indices_contig = transform_indices_contig.gpu();
+            if (transform_indices_contig.device() != lfs::core::Device::GPU ||
+                lfs::core::gpu_backend_of(transform_indices_contig) != lfs::core::GpuBackend::CUDA) {
+                transform_indices_contig = transform_indices_contig.cpu().to(lfs::core::Device::GPU);
             }
             if (!transform_indices_contig.is_contiguous()) {
                 transform_indices_contig = transform_indices_contig.contiguous();
@@ -903,7 +918,7 @@ namespace lfs::rendering {
             visibility_count = checkedToInt(node_visibility_mask.size(), "node visibility count exceeds int range");
         }
 
-        const int grid_size = std::min((n + kBlockSize - 1) / kBlockSize, kCountMaxBlocks);
+        const int grid_size = (n + kBlockSize - 1) / kBlockSize;
         const cudaStream_t stream = currentSelectionStream(&output);
         projectScreenPositionsKernel<<<grid_size, kBlockSize, 0, stream>>>(
             reinterpret_cast<const float3*>(means_contig.ptr<float>()),
@@ -940,16 +955,12 @@ namespace lfs::rendering {
         const float mouse_y,
         const float radius,
         Tensor& selection_out) {
-        if (lfs::core::gpu_backend_of(screen_positions) == lfs::core::GpuBackend::Vulkan ||
-            lfs::core::gpu_backend_of(selection_out) == lfs::core::GpuBackend::Vulkan) {
-            static bool logged = false;
-            if (!logged) {
-                logged = true;
-                LOG_WARN("Brush selection is unavailable on the Vulkan tensor backend");
-            }
+        if (!screen_positions.is_valid() || screen_positions.size(0) == 0) {
             return;
         }
-        if (!screen_positions.is_valid() || screen_positions.size(0) == 0) {
+        if (!isCudaGpu(screen_positions) || !isCudaGpu(selection_out)) {
+            brush_select_tensor_program(
+                screen_positions, mouse_x, mouse_y, radius, selection_out);
             return;
         }
         const int n = checkedToInt(screen_positions.size(0), "n_primitives exceeds int range");
@@ -965,20 +976,15 @@ namespace lfs::rendering {
         const Tensor& screen_positions,
         const Tensor& polygon_vertices,
         Tensor& selection_out) {
-        if (lfs::core::gpu_backend_of(screen_positions) == lfs::core::GpuBackend::Vulkan ||
-            lfs::core::gpu_backend_of(polygon_vertices) == lfs::core::GpuBackend::Vulkan ||
-            lfs::core::gpu_backend_of(selection_out) == lfs::core::GpuBackend::Vulkan) {
-            static bool logged = false;
-            if (!logged) {
-                logged = true;
-                LOG_WARN("Polygon selection is unavailable on the Vulkan tensor backend");
-            }
-            return;
-        }
         if (!screen_positions.is_valid() || screen_positions.size(0) == 0) {
             return;
         }
         if (!polygon_vertices.is_valid() || polygon_vertices.size(0) < 3) {
+            return;
+        }
+        if (!isCudaGpu(screen_positions) || !isCudaGpu(polygon_vertices) ||
+            !isCudaGpu(selection_out)) {
+            polygon_select_tensor_program(screen_positions, polygon_vertices, selection_out);
             return;
         }
         const int num_vertices = checkedToInt(polygon_vertices.size(0), "polygon vertex count exceeds int range");

--- a/src/rendering/selection_ops.hpp
+++ b/src/rendering/selection_ops.hpp
@@ -100,6 +100,21 @@ namespace lfs::rendering {
         const Tensor* model_transforms,
         const Tensor* transform_indices,
         const std::vector<bool>& node_visibility_mask);
+    [[nodiscard]] Tensor project_screen_positions_tensor_program(
+        const Tensor& means,
+        int width,
+        int height,
+        const std::array<float, 9>& view_rotation_rows,
+        const std::array<float, 3>& translation,
+        float pixel_focal_x,
+        float pixel_focal_y,
+        float center_x,
+        float center_y,
+        ScreenWindowCameraModel camera_model,
+        float ortho_scale,
+        const Tensor* model_transforms,
+        const Tensor* transform_indices,
+        const std::vector<bool>& node_visibility_mask);
     [[nodiscard]] int pick_projected_gaussian_tensor(
         const Tensor& screen_positions,
         float x,
@@ -112,6 +127,18 @@ namespace lfs::rendering {
         float mouse_y,
         float radius,
         Tensor& selection_out);
+    void brush_select_tensor_program(
+        const Tensor& screen_positions,
+        float mouse_x,
+        float mouse_y,
+        float radius,
+        Tensor& selection_out);
+    // Union of disks. Iterates samples; does not allocate an N x stroke matrix.
+    void brush_select_disks_tensor(
+        const Tensor& screen_positions,
+        const std::vector<float>& disk_xy,
+        float radius,
+        Tensor& selection_out);
 
     void rect_select_tensor(
         const Tensor& screen_positions,
@@ -122,6 +149,10 @@ namespace lfs::rendering {
         Tensor& selection_out);
 
     void polygon_select_tensor(
+        const Tensor& screen_positions,
+        const Tensor& polygon_vertices,
+        Tensor& selection_out);
+    void polygon_select_tensor_program(
         const Tensor& screen_positions,
         const Tensor& polygon_vertices,
         Tensor& selection_out);

--- a/src/rendering/selection_screen_ops.cpp
+++ b/src/rendering/selection_screen_ops.cpp
@@ -7,6 +7,8 @@
 #include "core/tensor_backend.hpp"
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <limits>
 #include <stdexcept>
 #include <vector>
@@ -16,7 +18,12 @@ namespace lfs::rendering {
     namespace {
         using lfs::core::DataType;
         using lfs::core::Device;
+        using lfs::core::GpuBackend;
+        using lfs::core::GpuBackendScope;
         using lfs::core::Tensor;
+
+        constexpr float kPi = 3.14159265358979323846f;
+        constexpr float kInvalidScreenFill = kInvalidScreenPositionThreshold * 100000.0f;
 
         struct ScreenAxes {
             Tensor x;
@@ -32,6 +39,160 @@ namespace lfs::rendering {
             axes.valid = (axes.x >= kInvalidScreenPositionThreshold)
                              .logical_and(axes.y >= kInvalidScreenPositionThreshold);
             return axes;
+        }
+
+        [[nodiscard]] bool isCudaGpu(const Tensor& tensor) {
+            return tensor.is_valid() && tensor.device() == Device::GPU &&
+                   lfs::core::gpu_backend_of(tensor) == GpuBackend::CUDA;
+        }
+
+        [[nodiscard]] GpuBackend requireGpuBackend(const Tensor& tensor, const char* message) {
+            const auto backend = lfs::core::gpu_backend_of(tensor);
+            if (!backend) {
+                throw std::runtime_error(message);
+            }
+            return *backend;
+        }
+
+        [[nodiscard]] Tensor matchBackend(const Tensor& src, const GpuBackend backend) {
+            const auto src_backend = lfs::core::gpu_backend_of(src);
+            if (src.device() == Device::GPU && src_backend && *src_backend == backend) {
+                return src.is_contiguous() ? src : src.contiguous();
+            }
+            GpuBackendScope scope(backend);
+            if (src.device() == Device::CPU) {
+                return src.to(Device::GPU);
+            }
+            return src.cpu().to(Device::GPU);
+        }
+
+        [[nodiscard]] Tensor asBool(const Tensor& tensor) {
+            if (tensor.dtype() == DataType::Bool) {
+                return tensor;
+            }
+            return tensor != 0;
+        }
+
+        [[nodiscard]] Tensor col1(const Tensor& matrix, const int start) {
+            return matrix.slice(1, start, start + 1).flatten();
+        }
+
+        [[nodiscard]] Tensor stackXY(const Tensor& x, const Tensor& y) {
+            const auto n = static_cast<std::size_t>(x.numel());
+            return Tensor::cat({x.reshape(lfs::core::TensorShape({n, std::size_t{1}})),
+                                y.reshape(lfs::core::TensorShape({n, std::size_t{1}}))},
+                               1);
+        }
+
+        [[nodiscard]] Tensor stackXYZ(const Tensor& x, const Tensor& y, const Tensor& z) {
+            const auto n = static_cast<std::size_t>(x.numel());
+            return Tensor::cat({x.reshape(lfs::core::TensorShape({n, std::size_t{1}})),
+                                y.reshape(lfs::core::TensorShape({n, std::size_t{1}})),
+                                z.reshape(lfs::core::TensorShape({n, std::size_t{1}}))},
+                               1);
+        }
+
+        [[nodiscard]] Tensor applyOneRowMajorMat4(const Tensor& x,
+                                                  const Tensor& y,
+                                                  const Tensor& z,
+                                                  const float* const m) {
+            return stackXYZ(x * m[0] + y * m[1] + z * m[2] + m[3],
+                            x * m[4] + y * m[5] + z * m[6] + m[7],
+                            x * m[8] + y * m[9] + z * m[10] + m[11]);
+        }
+
+        // Match atan2f, including atan2(y, -0) == ±π. Equirect hits that seam when
+        // vis view_z is +0 (eq_z = -view_z is -0). Treating ±0 as +0 would write
+        // width/2 instead of width.
+        [[nodiscard]] Tensor atan2Tensor(const Tensor& y, const Tensor& x) {
+            const Tensor x_zero = x == 0.0f;
+            const Tensor safe_x = Tensor::where(x_zero, Tensor::ones_like(x), x);
+            const Tensor base = (y / safe_x).atan();
+            const Tensor negative_y = (y < 0.0f).logical_or(
+                (y == 0.0f).logical_and(y.reciprocal() < 0.0f));
+            const Tensor from_neg_x = Tensor::where(negative_y, base - kPi, base + kPi);
+            const Tensor from_pos_zero = Tensor::where(
+                y > 0.0f,
+                Tensor::full_like(y, kPi * 0.5f),
+                Tensor::where(y < 0.0f, Tensor::full_like(y, -kPi * 0.5f), Tensor::zeros_like(y)));
+            const Tensor x_neg_zero = x_zero.logical_and(x.reciprocal() < 0.0f);
+            const Tensor from_neg_zero = Tensor::where(
+                negative_y, Tensor::full_like(y, -kPi), Tensor::full_like(y, kPi));
+            return Tensor::where(
+                x > 0.0f,
+                base,
+                Tensor::where(x < 0.0f, from_neg_x,
+                              Tensor::where(x_neg_zero.logical_and(y == 0.0f),
+                                            from_neg_zero, from_pos_zero)));
+        }
+
+        [[nodiscard]] Tensor meansNx3(const Tensor& means, const std::size_t n, const GpuBackend backend) {
+            Tensor contig = matchBackend(means, backend);
+            if (contig.dtype() != DataType::Float32) {
+                contig = contig.to(DataType::Float32);
+            }
+            contig = contig.contiguous();
+            if (contig.ndim() == 2 && contig.size(1) == 3 && contig.size(0) == n) {
+                return contig;
+            }
+            if (contig.numel() == n * 3) {
+                return contig.reshape(lfs::core::TensorShape({n, std::size_t{3}}));
+            }
+            throw std::runtime_error("project_screen_positions_tensor expects a GPU Float32 [N, 3] means tensor");
+        }
+
+        // KEEP IN SYNC with projectScreenPositionsKernel model-transform multiply.
+        [[nodiscard]] Tensor applyRowMajorModelTransforms(const Tensor& means,
+                                                          const Tensor* const model_transforms,
+                                                          const Tensor& idx,
+                                                          const GpuBackend backend) {
+            if (model_transforms == nullptr || !model_transforms->is_valid() ||
+                model_transforms->numel() == 0) {
+                return means;
+            }
+            Tensor mats = matchBackend(*model_transforms, backend);
+            if (mats.dtype() != DataType::Float32) {
+                mats = mats.to(DataType::Float32);
+            }
+            if (mats.numel() % 16 != 0) {
+                throw std::runtime_error(
+                    "model_transforms tensor must contain a multiple of 16 float values (N x 4 x 4).");
+            }
+            const int count = static_cast<int>(mats.numel() / 16);
+            if (count <= 0) {
+                return means;
+            }
+            mats = mats.contiguous().reshape(
+                lfs::core::TensorShape({static_cast<std::size_t>(count), std::size_t{16}}));
+            const Tensor x = col1(means, 0);
+            const Tensor y = col1(means, 1);
+            const Tensor z = col1(means, 2);
+            // A single scene transform needs only 16 scalars, avoiding an
+            // [N,16] expansion (about 1 GiB for 16 million points).
+            if (count == 1) {
+                const auto host = mats.cpu().contiguous().to_vector();
+                return applyOneRowMajorMat4(x, y, z, host.data());
+            }
+            const Tensor clamped =
+                idx.to(DataType::Int32).clamp(0.0f, static_cast<float>(count - 1)).to(DataType::Int32);
+            const Tensor m = mats.index_select(0, clamped);
+            const Tensor ox = col1(m, 0) * x + col1(m, 1) * y + col1(m, 2) * z + col1(m, 3);
+            const Tensor oy = col1(m, 4) * x + col1(m, 5) * y + col1(m, 6) * z + col1(m, 7);
+            const Tensor oz = col1(m, 8) * x + col1(m, 9) * y + col1(m, 10) * z + col1(m, 11);
+            return stackXYZ(ox, oy, oz);
+        }
+
+        void orDiskIntoSelection(const Tensor& x,
+                                 const Tensor& y,
+                                 const Tensor& valid,
+                                 const float mouse_x,
+                                 const float mouse_y,
+                                 const float radius,
+                                 Tensor& selection_out) {
+            const Tensor dx = x - mouse_x;
+            const Tensor dy = y - mouse_y;
+            const Tensor inside = valid.logical_and((dx * dx + dy * dy) <= radius * radius).flatten();
+            selection_out.masked_fill_(inside, 1.0f);
         }
     } // namespace
 
@@ -67,7 +228,7 @@ namespace lfs::rendering {
             screen_positions.dtype() != DataType::Float32 ||
             screen_positions.ndim() != 2 ||
             screen_positions.size(1) != 2) {
-            throw std::runtime_error("pick_projected_gaussian_tensor expects a CUDA Float32 [N, 2] tensor");
+            throw std::runtime_error("pick_projected_gaussian_tensor expects a GPU Float32 [N, 2] tensor");
         }
         const ScreenAxes axes = screen_axes(screen_positions);
         const Tensor finite = axes.valid.logical_and(axes.x.isfinite()).logical_and(axes.y.isfinite());
@@ -91,11 +252,229 @@ namespace lfs::rendering {
             return;
         }
         if (lfs::core::gpu_backend_of(selection) == lfs::core::GpuBackend::Vulkan) {
+            lfs::core::GpuBackendScope scope(lfs::core::GpuBackend::Vulkan);
             Tensor idx = Tensor::from_vector(std::vector<int>{index}, {1}, selection.device());
             selection.index_fill_(0, idx, value ? 1.0f : 0.0f);
             return;
         }
         set_selection_element(selection.ptr<bool>(), index, value);
+    }
+
+    void brush_select_tensor_program(
+        const Tensor& screen_positions,
+        const float mouse_x,
+        const float mouse_y,
+        const float radius,
+        Tensor& selection_out) {
+        if (!screen_positions.is_valid() || screen_positions.size(0) == 0 ||
+            !selection_out.is_valid() || selection_out.numel() == 0) {
+            return;
+        }
+        if (screen_positions.device() != Device::GPU || selection_out.device() != Device::GPU) {
+            return;
+        }
+        const GpuBackend backend =
+            requireGpuBackend(selection_out, "brush_select_tensor requires a GPU selection tensor");
+        GpuBackendScope scope(backend);
+        const Tensor positions = matchBackend(screen_positions, backend);
+        const ScreenAxes axes = screen_axes(positions);
+        orDiskIntoSelection(axes.x, axes.y, axes.valid, mouse_x, mouse_y, radius, selection_out);
+    }
+
+    void brush_select_disks_tensor(
+        const Tensor& screen_positions,
+        const std::vector<float>& disk_xy,
+        const float radius,
+        Tensor& selection_out) {
+        if (disk_xy.size() < 2 || !screen_positions.is_valid() || screen_positions.size(0) == 0 ||
+            !selection_out.is_valid() || selection_out.numel() == 0) {
+            return;
+        }
+        const std::size_t disk_count = disk_xy.size() / 2;
+        if (isCudaGpu(screen_positions) && isCudaGpu(selection_out)) {
+            for (std::size_t i = 0; i < disk_count; ++i) {
+                brush_select_tensor(
+                    screen_positions, disk_xy[i * 2], disk_xy[i * 2 + 1], radius, selection_out);
+            }
+            return;
+        }
+        if (screen_positions.device() != Device::GPU || selection_out.device() != Device::GPU) {
+            return;
+        }
+        const GpuBackend backend =
+            requireGpuBackend(selection_out, "brush_select_disks_tensor requires a GPU selection tensor");
+        GpuBackendScope scope(backend);
+        const Tensor positions = matchBackend(screen_positions, backend);
+        const ScreenAxes axes = screen_axes(positions);
+        for (std::size_t i = 0; i < disk_count; ++i) {
+            orDiskIntoSelection(
+                axes.x, axes.y, axes.valid, disk_xy[i * 2], disk_xy[i * 2 + 1], radius, selection_out);
+        }
+    }
+
+    void polygon_select_tensor_program(
+        const Tensor& screen_positions,
+        const Tensor& polygon_vertices,
+        Tensor& selection_out) {
+        if (!screen_positions.is_valid() || screen_positions.size(0) == 0 ||
+            !polygon_vertices.is_valid() || polygon_vertices.size(0) < 3 ||
+            !selection_out.is_valid() || selection_out.numel() == 0) {
+            return;
+        }
+        if (screen_positions.device() != Device::GPU || selection_out.device() != Device::GPU) {
+            return;
+        }
+        const GpuBackend backend =
+            requireGpuBackend(selection_out, "polygon_select_tensor requires a GPU selection tensor");
+        GpuBackendScope scope(backend);
+        const Tensor positions = matchBackend(screen_positions, backend);
+        const ScreenAxes axes = screen_axes(positions);
+        const Tensor px = axes.x.flatten();
+        const Tensor py = axes.y.flatten();
+        const Tensor valid = axes.valid.flatten();
+        const auto verts = matchBackend(polygon_vertices, backend).cpu().contiguous().to_vector();
+        const int num_verts = static_cast<int>(polygon_vertices.size(0));
+        if (static_cast<int>(verts.size()) < num_verts * 2 || num_verts < 3) {
+            return;
+        }
+        Tensor inside = Tensor::full_bool({static_cast<std::size_t>(px.numel())}, false, Device::GPU);
+        // Even-odd inclusion matching polygonSelectKernel. Iterate edges so we
+        // never allocate an N x vertex matrix.
+        for (int i = 0, j = num_verts - 1; i < num_verts; j = i++) {
+            const float xi = verts[static_cast<std::size_t>(i) * 2];
+            const float yi = verts[static_cast<std::size_t>(i) * 2 + 1];
+            const float xj = verts[static_cast<std::size_t>(j) * 2];
+            const float yj = verts[static_cast<std::size_t>(j) * 2 + 1];
+            // polygonSelectKernel: (yi > py) != (yj > py) is false when yi == yj.
+            if (yi == yj) {
+                continue;
+            }
+            const Tensor crosses = (py < yi).logical_xor(py < yj);
+            const Tensor hit_x = (py - yi) * (xj - xi) / (yj - yi) + xi;
+            const Tensor hit = crosses.logical_and(px < hit_x);
+            inside = inside.logical_xor(hit);
+        }
+        selection_out.masked_fill_(valid.logical_and(inside), 1.0f);
+    }
+
+    Tensor project_screen_positions_tensor_program(
+        const Tensor& means,
+        const int width,
+        const int height,
+        const std::array<float, 9>& view_rotation_rows,
+        const std::array<float, 3>& translation,
+        const float pixel_focal_x,
+        const float pixel_focal_y,
+        const float center_x,
+        const float center_y,
+        const ScreenWindowCameraModel camera_model,
+        const float ortho_scale,
+        const Tensor* const model_transforms,
+        const Tensor* const transform_indices,
+        const std::vector<bool>& node_visibility_mask) {
+        if (!means.is_valid() || means.size(0) == 0) {
+            return {};
+        }
+        if (means.device() != Device::GPU ||
+            means.dtype() != DataType::Float32 ||
+            means.ndim() != 2 ||
+            means.size(1) != 3) {
+            throw std::runtime_error("project_screen_positions_tensor expects a GPU Float32 [N, 3] means tensor");
+        }
+        if (width <= 0 || height <= 0) {
+            return {};
+        }
+
+        const GpuBackend backend =
+            requireGpuBackend(means, "project_screen_positions_tensor requires GPU means");
+        GpuBackendScope scope(backend);
+        const auto n = static_cast<std::size_t>(means.size(0));
+        const Tensor world_means = meansNx3(means, n, backend);
+
+        Tensor idx;
+        const bool has_indices = transform_indices != nullptr && transform_indices->is_valid() &&
+                                 transform_indices->numel() >= n;
+        if (has_indices) {
+            idx = matchBackend(*transform_indices, backend).flatten().to(DataType::Int32);
+            if (idx.numel() > n) {
+                idx = idx.slice(0, 0, static_cast<int>(n));
+            }
+        } else {
+            idx = Tensor::zeros({n}, Device::GPU, DataType::Int32);
+        }
+
+        Tensor valid = Tensor::full_bool({n}, true, Device::GPU);
+        if (has_indices && !node_visibility_mask.empty()) {
+            const int vis_count = static_cast<int>(node_visibility_mask.size());
+            const Tensor table = asBool(
+                Tensor::from_vector(node_visibility_mask, {node_visibility_mask.size()}, Device::GPU));
+            const Tensor in_range = (idx >= 0).logical_and(idx < vis_count);
+            const Tensor safe = Tensor::where(in_range, idx, Tensor::zeros_like(idx));
+            const Tensor visible = asBool(table.index_select(0, safe));
+            valid = in_range.logical_and(visible);
+        }
+
+        // KEEP IN SYNC with projectScreenPositionsKernel: vis view is +X right,
+        // +Y up, -Z forward. Invalid fill is kInvalidScreenPositionThreshold * 1e5.
+        const Tensor world = applyRowMajorModelTransforms(world_means, model_transforms, idx, backend);
+        const Tensor dx = col1(world, 0) - translation[0];
+        const Tensor dy = col1(world, 1) - translation[1];
+        const Tensor dz = col1(world, 2) - translation[2];
+        // view_rotation_rows is R^T rows (GLM columns of viewport.rotation).
+        const Tensor view_x =
+            dx * view_rotation_rows[0] + dy * view_rotation_rows[1] + dz * view_rotation_rows[2];
+        const Tensor view_y =
+            dx * view_rotation_rows[3] + dy * view_rotation_rows[4] + dz * view_rotation_rows[5];
+        const Tensor view_z =
+            dx * view_rotation_rows[6] + dy * view_rotation_rows[7] + dz * view_rotation_rows[8];
+        const Tensor finite = view_x.isfinite().logical_and(view_y.isfinite()).logical_and(view_z.isfinite());
+        valid = valid.logical_and(finite);
+
+        const bool equirectangular = camera_model == ScreenWindowCameraModel::Equirectangular;
+        const bool orthographic = camera_model == ScreenWindowCameraModel::Orthographic;
+        const float image_width = static_cast<float>(width);
+        const float image_height = static_cast<float>(height);
+
+        Tensor px;
+        Tensor py;
+        if (equirectangular) {
+            // Same vis→vk negation as projectScreenPositionsKernel.
+            const Tensor eq_x = view_x;
+            const Tensor eq_y = -view_y;
+            const Tensor eq_z = -view_z;
+            const Tensor len = (eq_x * eq_x + eq_y * eq_y + eq_z * eq_z).sqrt();
+            const Tensor bad = (len <= 1.0e-6f).logical_or(len.isfinite().logical_not());
+            valid = valid.logical_and(bad.logical_not());
+            const Tensor safe_len = Tensor::where(bad, Tensor::ones_like(len), len);
+            const Tensor dir_x = eq_x / safe_len;
+            const Tensor dir_y = eq_y / safe_len;
+            const Tensor dir_z = eq_z / safe_len;
+            px = (atan2Tensor(dir_x, dir_z) / (2.0f * kPi) + 0.5f) * image_width;
+            py = (dir_y.clamp(-1.0f, 1.0f).asin() / kPi + 0.5f) * image_height;
+        } else {
+            // Pinhole/ortho reject at or behind the camera (visualizer -Z forward).
+            valid = valid.logical_and(view_z < -1.0e-6f);
+            if (orthographic) {
+                if (!std::isfinite(ortho_scale) || ortho_scale <= 0.0f) {
+                    valid = Tensor::full_bool({n}, false, Device::GPU);
+                    px = Tensor::full({n}, kInvalidScreenFill, Device::GPU, DataType::Float32);
+                    py = Tensor::full({n}, kInvalidScreenFill, Device::GPU, DataType::Float32);
+                } else {
+                    px = view_x * ortho_scale + center_x;
+                    py = -view_y * ortho_scale + center_y;
+                }
+            } else {
+                const Tensor depth = -view_z;
+                const Tensor safe_depth = Tensor::where(valid, depth, Tensor::ones_like(depth));
+                px = view_x * pixel_focal_x / safe_depth + center_x;
+                py = -view_y * pixel_focal_y / safe_depth + center_y;
+            }
+        }
+
+        const Tensor invalid = Tensor::full_like(px, kInvalidScreenFill);
+        px = Tensor::where(valid, px, invalid);
+        py = Tensor::where(valid, py, invalid);
+        return stackXY(px, py);
     }
 
 } // namespace lfs::rendering

--- a/src/visualizer/selection/selection_service.cpp
+++ b/src/visualizer/selection/selection_service.cpp
@@ -266,23 +266,48 @@ namespace lfs::vis {
             return seed;
         }
 
+        [[nodiscard]] std::optional<core::GpuBackend> gpuBackendOf(const core::Tensor& tensor) {
+            if (!tensor.is_valid() || tensor.device() != core::Device::GPU) {
+                return std::nullopt;
+            }
+            return core::gpu_backend_of(tensor);
+        }
+
+        [[nodiscard]] core::GpuBackend resolveGpuBackend(const core::Tensor* const affinity) {
+            if (affinity) {
+                if (const auto backend = gpuBackendOf(*affinity)) {
+                    return *backend;
+                }
+            }
+            return core::default_gpu_backend();
+        }
+
+        [[nodiscard]] bool bufferMatchesBackend(const core::Tensor& buffer, const core::GpuBackend backend) {
+            const auto got = gpuBackendOf(buffer);
+            return got.has_value() && *got == backend;
+        }
+
         [[nodiscard]] core::Tensor& uploadFloat2PointsToBuffer(
             const std::vector<glm::vec2>& points,
             std::vector<float>& host_buffer,
-            core::Tensor& device_buffer) {
+            core::Tensor& device_buffer,
+            const core::Tensor* const affinity = nullptr) {
             host_buffer.resize(points.size() * 2);
             for (size_t i = 0; i < points.size(); ++i) {
                 host_buffer[i * 2] = points[i].x;
                 host_buffer[i * 2 + 1] = points[i].y;
             }
 
+            const auto backend = resolveGpuBackend(affinity);
             const bool needs_realloc = !device_buffer.is_valid() ||
                                        device_buffer.device() != core::Device::GPU ||
                                        device_buffer.dtype() != core::DataType::Float32 ||
                                        device_buffer.shape().rank() != 2 ||
                                        device_buffer.size(0) != points.size() ||
-                                       device_buffer.size(1) != 2;
+                                       device_buffer.size(1) != 2 ||
+                                       !bufferMatchesBackend(device_buffer, backend);
             if (needs_realloc) {
+                core::GpuBackendScope scope(backend);
                 device_buffer = core::Tensor::empty({points.size(), size_t{2}},
                                                     core::Device::GPU,
                                                     core::DataType::Float32);
@@ -335,11 +360,14 @@ namespace lfs::vis {
         }
 
         [[nodiscard]] core::Tensor& ensureCudaByteScratchBuffer(core::Tensor& buffer, const size_t size) {
+            const auto backend = core::default_gpu_backend();
             const bool needs_realloc = !buffer.is_valid() ||
                                        buffer.device() != core::Device::GPU ||
                                        buffer.dtype() != core::DataType::UInt8 ||
-                                       buffer.numel() != size;
+                                       buffer.numel() != size ||
+                                       !bufferMatchesBackend(buffer, backend);
             if (needs_realloc) {
+                core::GpuBackendScope scope(backend);
                 buffer = core::Tensor::empty({size}, core::Device::GPU, core::DataType::UInt8);
             }
             return buffer;
@@ -664,7 +692,9 @@ namespace lfs::vis {
             };
         }
 
-        [[nodiscard]] core::Tensor uploadModelTransformsToCuda(const std::vector<glm::mat4>& model_transforms) {
+        [[nodiscard]] core::Tensor uploadModelTransformsToGpu(
+            const std::vector<glm::mat4>& model_transforms,
+            const core::GpuBackend backend) {
             std::vector<float> transform_data(model_transforms.size() * 16);
             for (size_t i = 0; i < model_transforms.size(); ++i) {
                 const auto& transform = model_transforms[i];
@@ -674,6 +704,7 @@ namespace lfs::vis {
                     }
                 }
             }
+            core::GpuBackendScope scope(backend);
             return core::Tensor::from_vector(
                        transform_data,
                        {model_transforms.size(), size_t{4}, size_t{4}},
@@ -846,37 +877,38 @@ namespace lfs::vis {
                 if (means.dtype() != core::DataType::Float32) {
                     means = means.to(core::DataType::Float32);
                 }
-                if (means.device() == core::Device::GPU &&
-                    lfs::core::gpu_backend_available(lfs::core::GpuBackend::CUDA) &&
-                    lfs::core::gpu_backend_of(means) != lfs::core::GpuBackend::Vulkan) {
+                if (means.device() == core::Device::GPU) {
                     try {
                         if (!means.is_valid() || means.numel() == 0 ||
                             means.storage_ptr() == nullptr) {
                             return nullptr;
                         }
+                        const auto backend = resolveGpuBackend(&means);
+                        core::GpuBackendScope scope(backend);
 
-                        core::Tensor model_transforms_cuda;
+                        core::Tensor model_transforms_gpu;
                         const core::Tensor* model_transforms_ptr = nullptr;
                         if (scene.model_transforms && !scene.model_transforms->empty()) {
-                            model_transforms_cuda = uploadModelTransformsToCuda(*scene.model_transforms);
-                            model_transforms_ptr = &model_transforms_cuda;
+                            model_transforms_gpu = uploadModelTransformsToGpu(*scene.model_transforms, backend);
+                            model_transforms_ptr = &model_transforms_gpu;
                         }
 
-                        core::Tensor transform_indices_cuda;
+                        core::Tensor transform_indices_gpu;
                         const core::Tensor* transform_indices_ptr = nullptr;
                         if (scene.transform_indices && scene.transform_indices->is_valid() &&
                             scene.transform_indices->numel() >= count) {
-                            transform_indices_cuda = *scene.transform_indices;
-                            if (transform_indices_cuda.dtype() != core::DataType::Int32) {
-                                transform_indices_cuda = transform_indices_cuda.to(core::DataType::Int32);
+                            transform_indices_gpu = *scene.transform_indices;
+                            if (transform_indices_gpu.dtype() != core::DataType::Int32) {
+                                transform_indices_gpu = transform_indices_gpu.to(core::DataType::Int32);
                             }
-                            if (transform_indices_cuda.device() != core::Device::GPU) {
-                                transform_indices_cuda = transform_indices_cuda.gpu();
+                            if (transform_indices_gpu.device() != core::Device::GPU ||
+                                !bufferMatchesBackend(transform_indices_gpu, backend)) {
+                                transform_indices_gpu = transform_indices_gpu.cpu().to(core::Device::GPU);
                             }
-                            if (!transform_indices_cuda.is_contiguous()) {
-                                transform_indices_cuda = transform_indices_cuda.contiguous();
+                            if (!transform_indices_gpu.is_contiguous()) {
+                                transform_indices_gpu = transform_indices_gpu.contiguous();
                             }
-                            transform_indices_ptr = &transform_indices_cuda;
+                            transform_indices_ptr = &transform_indices_gpu;
                         }
 
                         const auto [derived_focal_x, derived_focal_y] =
@@ -926,7 +958,7 @@ namespace lfs::vis {
                                 transform_indices_ptr,
                                 scene.node_visibility_mask));
                     } catch (const std::exception& e) {
-                        LOG_DEBUG("SelectionService: CUDA screen-position projection unavailable, falling back to CPU: {}",
+                        LOG_DEBUG("SelectionService: GPU screen-position projection unavailable, falling back to CPU: {}",
                                   e.what());
                     }
                 }
@@ -1032,7 +1064,7 @@ namespace lfs::vis {
                         screen_positions, cursor_pos.x, cursor_pos.y, radius_px);
                     return picked >= 0 ? std::optional<int>{picked} : std::nullopt;
                 } catch (const std::exception& e) {
-                    LOG_DEBUG("SelectionService: CUDA projected pick unavailable, falling back to CPU scan: {}",
+                    LOG_DEBUG("SelectionService: GPU projected pick unavailable, falling back to CPU scan: {}",
                               e.what());
                 }
             }
@@ -1327,7 +1359,8 @@ namespace lfs::vis {
             return {false, 0, "No screen positions"};
         }
 
-        auto& selection = resetBoolScratchBuffer(command_selection_buffer_, screen_positions->size(0));
+        auto& selection = resetBoolScratchBuffer(command_selection_buffer_, screen_positions->size(0),
+                                                 screen_positions.get());
         rendering::brush_select_tensor(*screen_positions, x, y, radius, selection);
         return commitSelection(selection, mode, effectiveNodeMask(true), filters, projection_context, "selection.brush");
     }
@@ -1365,7 +1398,8 @@ namespace lfs::vis {
             return {false, 0, "No screen positions"};
         }
 
-        auto& selection = resetBoolScratchBuffer(command_selection_buffer_, screen_positions->size(0));
+        auto& selection = resetBoolScratchBuffer(command_selection_buffer_, screen_positions->size(0),
+                                                 screen_positions.get());
         {
             LOG_TIMER_THRESHOLD("SelectionService::selectRect.rect_select_kernel", 1.0);
             rendering::rect_select_tensor(*screen_positions,
@@ -1407,8 +1441,10 @@ namespace lfs::vis {
             return {false, 0, "No screen positions"};
         }
 
-        auto& selection = resetBoolScratchBuffer(command_selection_buffer_, screen_positions->size(0));
-        auto& polygon = uploadFloat2PointsToBuffer(vertices, polygon_vertex_host_buffer_, polygon_vertex_device_buffer_);
+        auto& selection = resetBoolScratchBuffer(command_selection_buffer_, screen_positions->size(0),
+                                                 screen_positions.get());
+        auto& polygon = uploadFloat2PointsToBuffer(
+            vertices, polygon_vertex_host_buffer_, polygon_vertex_device_buffer_, screen_positions.get());
         rendering::polygon_select_tensor(*screen_positions, polygon, selection);
         return commitSelection(selection, mode, effectiveNodeMask(true), filters, projection_context, "selection.polygon");
     }
@@ -3104,12 +3140,16 @@ namespace lfs::vis {
         return hovered_id;
     }
 
-    core::Tensor& SelectionService::resetBoolScratchBuffer(core::Tensor& buffer, const size_t size) {
+    core::Tensor& SelectionService::resetBoolScratchBuffer(core::Tensor& buffer, const size_t size,
+                                                           const core::Tensor* const affinity) {
+        const auto backend = resolveGpuBackend(affinity);
         const bool needs_realloc = !buffer.is_valid() ||
                                    buffer.device() != core::Device::GPU ||
                                    buffer.dtype() != core::DataType::Bool ||
-                                   buffer.numel() != size;
+                                   buffer.numel() != size ||
+                                   !bufferMatchesBackend(buffer, backend);
         if (needs_realloc) {
+            core::GpuBackendScope scope(backend);
             buffer = core::Tensor::zeros({size}, core::Device::GPU, core::DataType::Bool);
             return buffer;
         }
@@ -3131,16 +3171,19 @@ namespace lfs::vis {
             return false;
         }
 
+        const auto preview_backend = core::default_gpu_backend();
         const bool needs_working_realloc =
             !session.working_selection.is_valid() ||
             session.working_selection.device() != core::Device::GPU ||
             session.working_selection.dtype() != core::DataType::Bool ||
-            session.working_selection.numel() != total;
+            session.working_selection.numel() != total ||
+            !bufferMatchesBackend(session.working_selection, preview_backend);
         const auto node_mask = effectiveNodeMask(session.filters.restrict_to_selected_nodes);
         const bool node_scope_changed =
             session.preview_brush_point_count > 0 &&
             node_mask != session.live_preview_node_mask;
         if (needs_working_realloc) {
+            core::GpuBackendScope scope(preview_backend);
             session.working_selection = core::Tensor::zeros({total}, core::Device::GPU, core::DataType::Bool);
             session.preview_brush_point_count = 0;
         } else if (session.preview_brush_point_count > session.points.size() || node_scope_changed) {
@@ -3184,8 +3227,10 @@ namespace lfs::vis {
             !session.live_delta_selection.is_valid() ||
             session.live_delta_selection.device() != core::Device::GPU ||
             session.live_delta_selection.dtype() != core::DataType::Bool ||
-            session.live_delta_selection.numel() != total;
+            session.live_delta_selection.numel() != total ||
+            !bufferMatchesBackend(session.live_delta_selection, preview_backend);
         if (needs_delta_realloc) {
+            core::GpuBackendScope scope(preview_backend);
             session.live_delta_selection = core::Tensor::zeros({total}, core::Device::GPU, core::DataType::Bool);
         }
         auto& delta_selection = session.live_delta_selection;
@@ -3340,6 +3385,8 @@ namespace lfs::vis {
         constexpr float STEP_FACTOR = 0.5f;
         constexpr int MAX_BRUSH_STEPS = 128;
 
+        std::vector<float> disk_xy;
+        disk_xy.reserve(points.size() * 4);
         for (size_t i = 0; i < points.size(); ++i) {
             const glm::vec2 from = (i == 0) ? points[i] : points[i - 1];
             const glm::vec2 to = points[i];
@@ -3353,9 +3400,11 @@ namespace lfs::vis {
                                                  : static_cast<float>(step + 1) / static_cast<float>(num_steps);
                 const glm::vec2 sample = from + delta * t;
                 const auto render = screenToRender(sample, info);
-                rendering::brush_select_tensor(*screen_positions, render.x, render.y, scaled_radius, selection_out);
+                disk_xy.push_back(render.x);
+                disk_xy.push_back(render.y);
             }
         }
+        rendering::brush_select_disks_tensor(*screen_positions, disk_xy, scaled_radius, selection_out);
 
         return true;
     }
@@ -3436,8 +3485,8 @@ namespace lfs::vis {
             return false;
         }
 
-        auto& polygon =
-            uploadFloat2PointsToBuffer(render_points, polygon_vertex_host_buffer_, polygon_vertex_device_buffer_);
+        auto& polygon = uploadFloat2PointsToBuffer(
+            render_points, polygon_vertex_host_buffer_, polygon_vertex_device_buffer_, screen_positions.get());
         rendering::polygon_select_tensor(*screen_positions, polygon, selection_out);
         return true;
     }
@@ -3488,8 +3537,8 @@ namespace lfs::vis {
             return false;
         }
 
-        auto& polygon =
-            uploadFloat2PointsToBuffer(render_points, polygon_vertex_host_buffer_, polygon_vertex_device_buffer_);
+        auto& polygon = uploadFloat2PointsToBuffer(
+            render_points, polygon_vertex_host_buffer_, polygon_vertex_device_buffer_, screen_positions.get());
         rendering::polygon_select_tensor(*screen_positions, polygon, selection_out);
         return true;
     }
@@ -4107,8 +4156,9 @@ namespace lfs::vis {
         core::Tensor model_transforms_cuda;
         const core::Tensor* model_transforms_ptr = nullptr;
         if (!render_state.model_transforms.empty()) {
-            LOG_TIMER("applyCropFilter.uploadModelTransformsToCuda");
-            model_transforms_cuda = uploadModelTransformsToCuda(render_state.model_transforms);
+            LOG_TIMER("applyCropFilter.uploadModelTransformsToGpu");
+            model_transforms_cuda = uploadModelTransformsToGpu(
+                render_state.model_transforms, resolveGpuBackend(&selection));
             model_transforms_ptr = &model_transforms_cuda;
         }
 
@@ -4119,8 +4169,9 @@ namespace lfs::vis {
             if (render_state.transform_indices->device() == core::Device::GPU) {
                 transform_indices_ptr = render_state.transform_indices.get();
             } else {
-                LOG_TIMER("applyCropFilter.transform_indices_to_cuda");
-                transform_indices_cuda = render_state.transform_indices->cuda();
+                LOG_TIMER("applyCropFilter.transform_indices_to_gpu");
+                core::GpuBackendScope scope(resolveGpuBackend(&selection));
+                transform_indices_cuda = render_state.transform_indices->cpu().to(core::Device::GPU);
                 transform_indices_ptr = &transform_indices_cuda;
             }
         }
@@ -4174,8 +4225,9 @@ namespace lfs::vis {
         core::Tensor model_transforms_cuda;
         const core::Tensor* model_transforms_ptr = nullptr;
         if (!render_state.model_transforms.empty()) {
-            LOG_TIMER("applyDepthFilter.uploadModelTransformsToCuda");
-            model_transforms_cuda = uploadModelTransformsToCuda(render_state.model_transforms);
+            LOG_TIMER("applyDepthFilter.uploadModelTransformsToGpu");
+            model_transforms_cuda = uploadModelTransformsToGpu(
+                render_state.model_transforms, resolveGpuBackend(&selection));
             model_transforms_ptr = &model_transforms_cuda;
         }
 
@@ -4186,8 +4238,9 @@ namespace lfs::vis {
             if (render_state.transform_indices->device() == core::Device::GPU) {
                 transform_indices_ptr = render_state.transform_indices.get();
             } else {
-                LOG_TIMER("applyDepthFilter.transform_indices_to_cuda");
-                transform_indices_cuda = render_state.transform_indices->cuda();
+                LOG_TIMER("applyDepthFilter.transform_indices_to_gpu");
+                core::GpuBackendScope scope(resolveGpuBackend(&selection));
+                transform_indices_cuda = render_state.transform_indices->cpu().to(core::Device::GPU);
                 transform_indices_ptr = &transform_indices_cuda;
             }
         }

--- a/src/visualizer/selection/selection_service.hpp
+++ b/src/visualizer/selection/selection_service.hpp
@@ -295,7 +295,8 @@ namespace lfs::vis {
                                                       const SelectionProjectionContext& projection_context,
                                                       const char* undo_name,
                                                       SelectionCommitOptions options = {});
-        [[nodiscard]] core::Tensor& resetBoolScratchBuffer(core::Tensor& buffer, size_t size);
+        [[nodiscard]] core::Tensor& resetBoolScratchBuffer(core::Tensor& buffer, size_t size,
+                                                           const core::Tensor* affinity = nullptr);
         [[nodiscard]] std::optional<ViewerViewportContext> resolveViewerViewportContext(
             std::optional<glm::vec2> screen_point = std::nullopt,
             std::optional<SplitViewPanelId> panel_override = std::nullopt) const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -346,6 +346,7 @@ set(TEST_FILES
     test_tensor_integer_and_reduce_policy.cpp
     test_selection_attribute_ops.cpp
     test_selection_screen_ops.cpp
+    test_selection_tensor_projection.cpp
     test_export_band_pack.cpp
     test_point_cloud_merge.cpp
     test_display_tensors.cpp
@@ -1285,6 +1286,14 @@ target_link_libraries(bench_tensor_launch_overhead PRIVATE
     lfs_core
     CUDA::cudart
 )
+
+add_executable(bench_selection_tensor EXCLUDE_FROM_ALL bench_selection_tensor.cpp)
+set_target_properties(bench_selection_tensor PROPERTIES
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON
+)
+target_include_directories(bench_selection_tensor PRIVATE ${CMAKE_SOURCE_DIR}/external)
+target_link_libraries(bench_selection_tensor PRIVATE lfs_rendering CUDA::cudart)
 
 add_executable(tensor_backend_corpus
     tensor_backend_corpus.cpp

--- a/tests/bench_selection_tensor.cpp
+++ b/tests/bench_selection_tensor.cpp
@@ -1,0 +1,578 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+// Completed-work selection benchmark with full-scene CPU references.
+// Build: cmake --build build --target bench_selection_tensor
+// Run: build/tests/bench_selection_tensor scene.ply --backend cuda|vulkan|all
+// Uses three warmups and eleven measured samples. Not registered with ctest.
+
+#include "core/tensor.hpp"
+#include "core/tensor/backend/gpu_backend_ops.hpp"
+#include "core/tensor_backend.hpp"
+#include "rendering/selection_ops.hpp"
+#define TINYPLY_IMPLEMENTATION
+#include "tinyply.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using lfs::core::DataType;
+using lfs::core::Device;
+using lfs::core::GpuBackend;
+using lfs::core::GpuBackendScope;
+using lfs::core::Tensor;
+using lfs::core::TensorShape;
+using lfs::rendering::ScreenWindowCameraModel;
+
+namespace {
+
+    constexpr int kWarmup = 3;
+    constexpr int kSamples = 11;
+    constexpr int kWidth = 1920;
+    constexpr int kHeight = 1080;
+    constexpr float kFx = 1200.0f;
+    constexpr float kFy = 1200.0f;
+    constexpr float kCx = 960.0f;
+    constexpr float kCy = 540.0f;
+    constexpr float kBrushRadius = 80.0f;
+    constexpr float kInvalidThreshold = lfs::rendering::kInvalidScreenPositionThreshold;
+    constexpr float kInvalidFill = kInvalidThreshold * 100000.0f;
+    // Sub-pixel floor (matches SelectionTensorProjection pinhole), relative
+    // scale for large off-screen coords, hard cap of one pixel.
+    constexpr float kPixelAbsTol = 1.0e-3f;
+    constexpr std::array<float, 9> kIdentity{
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+    };
+    constexpr std::array<float, 3> kOrigin{0.0f, 0.0f, 0.0f};
+    const std::vector<float> kQuad{
+        200.0f,
+        100.0f,
+        1700.0f,
+        100.0f,
+        1700.0f,
+        980.0f,
+        200.0f,
+        980.0f,
+    };
+
+    [[noreturn]] void fail(const std::string& message) {
+        std::fprintf(stderr, "bench_selection_tensor: %s\n", message.c_str());
+        std::fflush(stderr);
+        std::exit(1);
+    }
+
+    void wait_complete(const GpuBackend backend) {
+        lfs::core::internal::backend_ops(backend).synchronize_device();
+    }
+
+    void materialize(const Tensor& tensor) {
+        if (tensor.is_valid()) {
+            (void)tensor.data_ptr();
+        }
+    }
+
+    [[nodiscard]] const char* backend_name(const GpuBackend backend) {
+        return backend == GpuBackend::CUDA ? "cuda" : "vulkan";
+    }
+
+    [[nodiscard]] double median_ms(std::vector<double> samples) {
+        std::sort(samples.begin(), samples.end());
+        const size_t n = samples.size();
+        if (n == 0) {
+            return 0.0;
+        }
+        if (n % 2 == 1) {
+            return samples[n / 2];
+        }
+        return 0.5 * (samples[n / 2 - 1] + samples[n / 2]);
+    }
+
+    [[nodiscard]] std::vector<float> load_ply_xyz(const char* const path) {
+        std::ifstream file(path, std::ios::binary);
+        if (!file) {
+            fail(std::string("failed to open ") + path);
+        }
+        tinyply::PlyFile ply;
+        ply.parse_header(file);
+        std::shared_ptr<tinyply::PlyData> verts;
+        try {
+            verts = ply.request_properties_from_element("vertex", {"x", "y", "z"});
+        } catch (const std::exception& e) {
+            fail(std::string("PLY has no vertex x,y,z: ") + e.what());
+        }
+        ply.read(file);
+        if (!verts || verts->count == 0) {
+            fail("PLY has no vertices");
+        }
+        if (verts->t != tinyply::Type::FLOAT32) {
+            fail("vertex x,y,z must be float32");
+        }
+        std::vector<float> xyz(static_cast<size_t>(verts->count) * 3);
+        std::memcpy(xyz.data(), verts->buffer.get(), xyz.size() * sizeof(float));
+        return xyz;
+    }
+
+    [[nodiscard]] bool is_invalid(const float x, const float y) {
+        return !(x >= kInvalidThreshold) || !(y >= kInvalidThreshold);
+    }
+
+    [[nodiscard]] bool coords_near(const float got, const float expected) {
+        const float abs_err = std::abs(got - expected);
+        const float mag = std::max(std::abs(got), std::abs(expected));
+        // Off-screen projections can exceed millions of pixels. Compare in
+        // float32 ULPs there; subpixel coordinates keep an absolute tolerance.
+        const float ulp = std::nextafter(mag, std::numeric_limits<float>::infinity()) - mag;
+        const float tol = std::max(kPixelAbsTol, 8.0f * ulp);
+        return abs_err <= tol;
+    }
+
+    void cpu_project_pinhole(const std::vector<float>& means, std::vector<float>& out_xy) {
+        const size_t n = means.size() / 3;
+        out_xy.assign(n * 2, kInvalidFill);
+        for (size_t i = 0; i < n; ++i) {
+            const float view_x = means[i * 3];
+            const float view_y = means[i * 3 + 1];
+            const float view_z = means[i * 3 + 2];
+            if (!std::isfinite(view_x) || !std::isfinite(view_y) || !std::isfinite(view_z)) {
+                continue;
+            }
+            if (view_z >= -1.0e-6f) {
+                continue;
+            }
+            const float depth = -view_z;
+            out_xy[i * 2] = kCx + view_x * kFx / depth;
+            out_xy[i * 2 + 1] = kCy - view_y * kFy / depth;
+        }
+    }
+
+    [[nodiscard]] bool cpu_disk(const float x, const float y, const float mx, const float my,
+                                const float radius) {
+        if (is_invalid(x, y) || !std::isfinite(x) || !std::isfinite(y)) {
+            return false;
+        }
+        const float dx = x - mx;
+        const float dy = y - my;
+        return dx * dx + dy * dy <= radius * radius;
+    }
+
+    // Even-odd, same as polygonSelectKernel / polygon_select_tensor_program.
+    // Horizontal edges (yi == yj) never cross; no N×vertex matrix.
+    [[nodiscard]] bool cpu_even_odd(const float px, const float py, const std::vector<float>& poly) {
+        if (is_invalid(px, py) || !std::isfinite(px) || !std::isfinite(py)) {
+            return false;
+        }
+        const int n = static_cast<int>(poly.size() / 2);
+        bool inside = false;
+        for (int i = 0, j = n - 1; i < n; j = i++) {
+            const float yi = poly[static_cast<size_t>(i) * 2 + 1];
+            const float yj = poly[static_cast<size_t>(j) * 2 + 1];
+            if (yi == yj) {
+                continue;
+            }
+            if ((yi > py) != (yj > py)) {
+                const float xi = poly[static_cast<size_t>(i) * 2];
+                const float xj = poly[static_cast<size_t>(j) * 2];
+                if (px < (xj - xi) * (py - yi) / (yj - yi) + xi) {
+                    inside = !inside;
+                }
+            }
+        }
+        return inside;
+    }
+
+    [[nodiscard]] size_t count_valid(const std::vector<float>& xy) {
+        size_t n = 0;
+        for (size_t i = 0; i + 1 < xy.size(); i += 2) {
+            if (!is_invalid(xy[i], xy[i + 1]) && std::isfinite(xy[i]) && std::isfinite(xy[i + 1])) {
+                ++n;
+            }
+        }
+        return n;
+    }
+
+    [[nodiscard]] size_t cpu_disk_count(const std::vector<float>& xy, const float mx, const float my,
+                                        const float radius) {
+        size_t n = 0;
+        for (size_t i = 0; i + 1 < xy.size(); i += 2) {
+            n += cpu_disk(xy[i], xy[i + 1], mx, my, radius) ? 1 : 0;
+        }
+        return n;
+    }
+
+    [[nodiscard]] size_t cpu_even_odd_count(const std::vector<float>& xy, const std::vector<float>& poly) {
+        size_t n = 0;
+        for (size_t i = 0; i + 1 < xy.size(); i += 2) {
+            n += cpu_even_odd(xy[i], xy[i + 1], poly) ? 1 : 0;
+        }
+        return n;
+    }
+
+    void assert_projected(const std::vector<float>& got, const std::vector<float>& expected,
+                          const char* const tag) {
+        if (got.size() != expected.size()) {
+            fail(std::string(tag) + " projected size mismatch: got " + std::to_string(got.size()) +
+                 " expected " + std::to_string(expected.size()));
+        }
+        const size_t n = got.size() / 2;
+        size_t nan_count = 0;
+        size_t mask_mismatch = 0;
+        size_t coord_mismatch = 0;
+        size_t first = n;
+        float max_abs_err = 0.0f;
+        for (size_t i = 0; i < n; ++i) {
+            const float gx = got[i * 2];
+            const float gy = got[i * 2 + 1];
+            const float ex = expected[i * 2];
+            const float ey = expected[i * 2 + 1];
+            if (!std::isfinite(gx) || !std::isfinite(gy)) {
+                ++nan_count;
+                if (first == n) {
+                    first = i;
+                }
+                continue;
+            }
+            const bool g_inv = is_invalid(gx, gy);
+            const bool e_inv = is_invalid(ex, ey) || !std::isfinite(ex) || !std::isfinite(ey);
+            if (g_inv != e_inv) {
+                ++mask_mismatch;
+                if (first == n) {
+                    first = i;
+                }
+                continue;
+            }
+            if (g_inv) {
+                continue;
+            }
+            const float dx = std::abs(gx - ex);
+            const float dy = std::abs(gy - ey);
+            max_abs_err = std::max(max_abs_err, std::max(dx, dy));
+            if (!coords_near(gx, ex) || !coords_near(gy, ey)) {
+                ++coord_mismatch;
+                if (first == n) {
+                    first = i;
+                }
+            }
+        }
+        std::printf("check=%s n=%zu valid=%zu nan=%zu invalid_mask_mismatch=%zu "
+                    "coord_mismatch=%zu max_abs_err=%.6g first=%zu\n",
+                    tag, n, count_valid(got), nan_count, mask_mismatch, coord_mismatch, max_abs_err,
+                    first);
+        std::fflush(stdout);
+        if (nan_count != 0 || mask_mismatch != 0 || coord_mismatch != 0) {
+            const size_t i = first < n ? first : 0;
+            fail(std::string(tag) + " projection mismatch at " + std::to_string(i) + " got=(" +
+                 std::to_string(got[i * 2]) + "," + std::to_string(got[i * 2 + 1]) + ") expected=(" +
+                 std::to_string(expected[i * 2]) + "," + std::to_string(expected[i * 2 + 1]) +
+                 ") nan=" + std::to_string(nan_count) +
+                 " mask=" + std::to_string(mask_mismatch) +
+                 " coord=" + std::to_string(coord_mismatch));
+        }
+    }
+
+    template <typename Pred>
+    void assert_selection_counts(const std::vector<bool>& gpu_mask, const std::vector<float>& gpu_xy,
+                                 const std::vector<float>& cpu_xy, const size_t cpu_on_gpu_xy,
+                                 const size_t cpu_on_cpu_xy, const char* const tag, Pred&& predicate) {
+        if (gpu_mask.size() * 2 != gpu_xy.size() || gpu_xy.size() != cpu_xy.size()) {
+            fail(std::string(tag) + " selection size mismatch");
+        }
+        size_t gpu_count = 0;
+        size_t first = gpu_mask.size();
+        for (size_t i = 0; i < gpu_mask.size(); ++i) {
+            const bool expected = predicate(gpu_xy[i * 2], gpu_xy[i * 2 + 1]);
+            const bool got = gpu_mask[i];
+            gpu_count += got ? 1 : 0;
+            if (got != expected && first == gpu_mask.size()) {
+                first = i;
+            }
+        }
+        std::printf("check=%s gpu_count=%zu cpu_on_gpu_xy=%zu cpu_on_cpu_xy=%zu first_mask=%zu\n",
+                    tag, gpu_count, cpu_on_gpu_xy, cpu_on_cpu_xy, first);
+        std::fflush(stdout);
+        if (first != gpu_mask.size()) {
+            fail(std::string(tag) + " GPU mask != CPU predicate on GPU xy at " +
+                 std::to_string(first));
+        }
+        if (gpu_count != cpu_on_gpu_xy) {
+            fail(std::string(tag) + " GPU count " + std::to_string(gpu_count) +
+                 " != CPU on GPU xy " + std::to_string(cpu_on_gpu_xy));
+        }
+        if (gpu_count != cpu_on_cpu_xy) {
+            fail(std::string(tag) + " GPU count " + std::to_string(gpu_count) +
+                 " != CPU on CPU xy " + std::to_string(cpu_on_cpu_xy) +
+                 " (end-to-end; not a GPU==CPU-fallback timing comparison)");
+        }
+    }
+
+    template <typename Fn>
+    [[nodiscard]] double time_ms(const GpuBackend backend, Fn&& fn) {
+        wait_complete(backend);
+        const auto t0 = std::chrono::steady_clock::now();
+        fn();
+        wait_complete(backend);
+        const auto t1 = std::chrono::steady_clock::now();
+        return std::chrono::duration<double, std::milli>(t1 - t0).count();
+    }
+
+    template <typename Fn>
+    [[nodiscard]] double time_median_gpu(const GpuBackend backend, Fn&& fn) {
+        for (int i = 0; i < kWarmup; ++i) {
+            fn();
+            wait_complete(backend);
+        }
+        std::vector<double> samples;
+        samples.reserve(static_cast<size_t>(kSamples));
+        for (int i = 0; i < kSamples; ++i) {
+            samples.push_back(time_ms(backend, fn));
+        }
+        return median_ms(std::move(samples));
+    }
+
+    template <typename Fn>
+    [[nodiscard]] double time_median_cpu(Fn&& fn) {
+        for (int i = 0; i < kWarmup; ++i) {
+            fn();
+        }
+        std::vector<double> samples;
+        samples.reserve(static_cast<size_t>(kSamples));
+        for (int i = 0; i < kSamples; ++i) {
+            const auto t0 = std::chrono::steady_clock::now();
+            fn();
+            const auto t1 = std::chrono::steady_clock::now();
+            samples.push_back(std::chrono::duration<double, std::milli>(t1 - t0).count());
+        }
+        return median_ms(std::move(samples));
+    }
+
+    void print_gpu_metric(const GpuBackend backend, const char* const name, const double median_ms,
+                          const char* const extra) {
+        std::printf("backend=%s %s_median_ms=%.3f warmup=%d samples=%d%s\n", backend_name(backend),
+                    name, median_ms, kWarmup, kSamples, extra);
+        std::fflush(stdout);
+    }
+
+    Tensor project_dispatch(const Tensor& means) {
+        Tensor out = lfs::rendering::project_screen_positions_tensor(
+            means, kWidth, kHeight, kIdentity, kOrigin, kFx, kFy, kCx, kCy,
+            ScreenWindowCameraModel::Pinhole, 1.0f, nullptr, nullptr, {});
+        materialize(out);
+        return out;
+    }
+
+    Tensor project_program(const Tensor& means) {
+        Tensor out = lfs::rendering::project_screen_positions_tensor_program(
+            means, kWidth, kHeight, kIdentity, kOrigin, kFx, kFy, kCx, kCy,
+            ScreenWindowCameraModel::Pinhole, 1.0f, nullptr, nullptr, {});
+        materialize(out);
+        return out;
+    }
+
+    void bench_backend(const GpuBackend backend, const std::vector<float>& xyz,
+                       const std::vector<float>& cpu_xy, const size_t cpu_brush_count,
+                       const size_t cpu_polygon_count) {
+        if (!lfs::core::gpu_backend_available(backend)) {
+            std::printf("backend=%s skipped (unavailable)\n", backend_name(backend));
+            std::fflush(stdout);
+            return;
+        }
+        GpuBackendScope scope(backend);
+        const size_t n = xyz.size() / 3;
+
+        const auto t_up0 = std::chrono::steady_clock::now();
+        const Tensor means = Tensor::from_vector(xyz, TensorShape{n, 3}, Device::CPU).to(Device::GPU);
+        wait_complete(backend);
+        const auto t_up1 = std::chrono::steady_clock::now();
+        const double upload_ms = std::chrono::duration<double, std::milli>(t_up1 - t_up0).count();
+        std::printf("backend=%s n=%zu upload_means_ms=%.3f note=host_to_device_not_gpu_kernel\n",
+                    backend_name(backend), n, upload_ms);
+        std::fflush(stdout);
+
+        Tensor screen = project_dispatch(means);
+        wait_complete(backend);
+        std::vector<float> gpu_xy = screen.to_vector();
+        assert_projected(gpu_xy, cpu_xy, (std::string(backend_name(backend)) + ".project").c_str());
+
+        const double project_gpu_ms = time_median_gpu(backend, [&] { screen = project_dispatch(means); });
+        print_gpu_metric(backend, "project_gpu", project_gpu_ms,
+                         " includes=device_sync_materialize note=no_download");
+
+        Tensor fallback_screen;
+        std::vector<float> host_means;
+        std::vector<float> host_screen;
+        const double host_fallback_ms = time_median_gpu(backend, [&] {
+            host_means = means.to_vector();
+            cpu_project_pinhole(host_means, host_screen);
+            fallback_screen = Tensor::from_vector(host_screen, TensorShape{n, 2}, Device::CPU)
+                                  .to(Device::GPU);
+        });
+        assert_projected(fallback_screen.to_vector(), cpu_xy,
+                         (std::string(backend_name(backend)) + ".host_fallback").c_str());
+        print_gpu_metric(backend, "cpu_projection_roundtrip", host_fallback_ms,
+                         " includes=means_download_cpu_projection_screen_upload");
+
+        std::vector<float> downloaded;
+        const double project_fallback_ms = time_median_gpu(backend, [&] {
+            screen = project_dispatch(means);
+            downloaded = screen.to_vector();
+        });
+        print_gpu_metric(backend, "project_with_download", project_fallback_ms,
+                         " includes=download note=not_equivalent_to_project_gpu");
+
+        if (backend == GpuBackend::CUDA) {
+            Tensor program_screen = project_program(means);
+            wait_complete(backend);
+            assert_projected(program_screen.to_vector(), cpu_xy,
+                             (std::string(backend_name(backend)) + ".project_program").c_str());
+            const double program_gpu_ms =
+                time_median_gpu(backend, [&] { program_screen = project_program(means); });
+            print_gpu_metric(backend, "project_program_gpu", program_gpu_ms,
+                             " includes=device_sync_materialize note=no_download");
+            const double program_fallback_ms = time_median_gpu(backend, [&] {
+                program_screen = project_program(means);
+                downloaded = program_screen.to_vector();
+            });
+            print_gpu_metric(backend, "project_program_with_download", program_fallback_ms,
+                             " includes=download note=not_equivalent_to_project_program_gpu");
+        }
+
+        screen = project_dispatch(means);
+        wait_complete(backend);
+        gpu_xy = screen.to_vector();
+        assert_projected(gpu_xy, cpu_xy,
+                         (std::string(backend_name(backend)) + ".project_for_select").c_str());
+
+        Tensor selection = Tensor::zeros({n}, Device::GPU, DataType::Bool);
+        auto run_brush = [&] {
+            selection.zero_();
+            lfs::rendering::brush_select_tensor(screen, kCx, kCy, kBrushRadius, selection);
+            materialize(selection);
+        };
+        run_brush();
+        wait_complete(backend);
+        const auto brush_mask = selection.to_vector_bool();
+        const size_t cpu_brush_on_gpu_xy = cpu_disk_count(gpu_xy, kCx, kCy, kBrushRadius);
+        assert_selection_counts(
+            brush_mask, gpu_xy, cpu_xy, cpu_brush_on_gpu_xy, cpu_brush_count,
+            (std::string(backend_name(backend)) + ".brush").c_str(),
+            [](const float x, const float y) { return cpu_disk(x, y, kCx, kCy, kBrushRadius); });
+
+        const double brush_gpu_ms = time_median_gpu(backend, run_brush);
+        print_gpu_metric(backend, "brush_gpu", brush_gpu_ms,
+                         " includes=device_sync_materialize note=no_download");
+        std::vector<bool> downloaded_mask;
+        const double brush_fallback_ms = time_median_gpu(backend, [&] {
+            run_brush();
+            downloaded_mask = selection.to_vector_bool();
+        });
+        print_gpu_metric(backend, "brush_with_download", brush_fallback_ms,
+                         " includes=download note=not_equivalent_to_brush_gpu");
+
+        const Tensor polygon = Tensor::from_vector(kQuad, TensorShape{4, 2}, Device::CPU).to(Device::GPU);
+        wait_complete(backend);
+        auto run_polygon = [&] {
+            selection.zero_();
+            lfs::rendering::polygon_select_tensor(screen, polygon, selection);
+            materialize(selection);
+        };
+        run_polygon();
+        wait_complete(backend);
+        const auto polygon_mask = selection.to_vector_bool();
+        const size_t cpu_poly_on_gpu_xy = cpu_even_odd_count(gpu_xy, kQuad);
+        assert_selection_counts(
+            polygon_mask, gpu_xy, cpu_xy, cpu_poly_on_gpu_xy, cpu_polygon_count,
+            (std::string(backend_name(backend)) + ".polygon").c_str(),
+            [](const float x, const float y) { return cpu_even_odd(x, y, kQuad); });
+
+        const double polygon_gpu_ms = time_median_gpu(backend, run_polygon);
+        print_gpu_metric(backend, "polygon_gpu", polygon_gpu_ms,
+                         " includes=device_sync_materialize note=no_NxV_matrix");
+        const double polygon_fallback_ms = time_median_gpu(backend, [&] {
+            run_polygon();
+            downloaded_mask = selection.to_vector_bool();
+        });
+        print_gpu_metric(backend, "polygon_with_download", polygon_fallback_ms,
+                         " includes=download note=not_equivalent_to_polygon_gpu");
+        (void)downloaded;
+        (void)downloaded_mask;
+    }
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr,
+                     "Usage: bench_selection_tensor PLY [--backend cuda|vulkan|all]\n");
+        return 2;
+    }
+    const char* ply_path = argv[1];
+    std::string backend_flag = "all";
+    for (int i = 2; i < argc; ++i) {
+        const std::string_view arg{argv[i]};
+        if (arg == "--backend" && i + 1 < argc) {
+            backend_flag = argv[++i];
+        } else {
+            fail(std::string("unknown argument: ") + argv[i]);
+        }
+    }
+
+    const auto xyz = load_ply_xyz(ply_path);
+    const size_t n = xyz.size() / 3;
+    std::printf("ply=%s n=%zu downsample=0 warmup=%d samples=%d\n", ply_path, n, kWarmup, kSamples);
+    std::fflush(stdout);
+
+    std::vector<float> cpu_xy;
+    const double cpu_project_ms = time_median_cpu([&] { cpu_project_pinhole(xyz, cpu_xy); });
+    std::printf("cpu_project_median_ms=%.3f valid=%zu warmup=%d samples=%d\n", cpu_project_ms,
+                count_valid(cpu_xy), kWarmup, kSamples);
+    std::fflush(stdout);
+
+    size_t cpu_brush_count = 0;
+    const double cpu_brush_ms =
+        time_median_cpu([&] { cpu_brush_count = cpu_disk_count(cpu_xy, kCx, kCy, kBrushRadius); });
+    std::printf("cpu_brush_median_ms=%.3f count=%zu rule=disk warmup=%d samples=%d\n", cpu_brush_ms,
+                cpu_brush_count, kWarmup, kSamples);
+    std::fflush(stdout);
+
+    size_t cpu_polygon_count = 0;
+    const double cpu_polygon_ms =
+        time_median_cpu([&] { cpu_polygon_count = cpu_even_odd_count(cpu_xy, kQuad); });
+    std::printf("cpu_polygon_median_ms=%.3f count=%zu rule=evenodd warmup=%d samples=%d "
+                "note=no_NxV_matrix\n",
+                cpu_polygon_ms, cpu_polygon_count, kWarmup, kSamples);
+    std::fflush(stdout);
+
+    const bool want_cuda = backend_flag == "all" || backend_flag == "cuda";
+    const bool want_vk = backend_flag == "all" || backend_flag == "vulkan";
+    if (!want_cuda && !want_vk) {
+        fail("backend must be cuda, vulkan, or all");
+    }
+    if (want_cuda) {
+        bench_backend(GpuBackend::CUDA, xyz, cpu_xy, cpu_brush_count, cpu_polygon_count);
+    }
+    if (want_vk) {
+        bench_backend(GpuBackend::Vulkan, xyz, cpu_xy, cpu_brush_count, cpu_polygon_count);
+    }
+    return 0;
+}

--- a/tests/test_selection_screen_ops.cpp
+++ b/tests/test_selection_screen_ops.cpp
@@ -2,16 +2,18 @@
  *
  * SPDX-License-Identifier: GPL-3.0-or-later */
 
-// Rectangle selection and the hover pick are tensor programs over projected
-// screen positions; both run on every GPU backend and follow the CPU rules:
+// Rectangle, brush, polygon, and hover pick are tensor programs over projected
+// screen positions; they run on every GPU backend and follow the CPU rules:
 // invalid positions never select, the pick wants a finite position inside the
-// radius, and equal distances pick the largest index.
+// radius, and equal distances pick the largest index. Brush inclusion is the
+// CUDA disk test dx^2+dy^2 <= r^2. Polygon inclusion is even-odd.
 
 #include "core/tensor.hpp"
 #include "core/tensor_backend.hpp"
 #include "rendering/selection_ops.hpp"
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cmath>
 #include <limits>
 #include <string>
@@ -21,6 +23,7 @@ namespace {
     using namespace lfs::core;
 
     constexpr float kInvalid = -1.0e8f;
+    constexpr float kInvalidThreshold = -1000.0f;
 
     std::vector<GpuBackend> backends_under_test() {
         std::vector<GpuBackend> backends{GpuBackend::CUDA};
@@ -39,6 +42,11 @@ namespace {
         return Tensor::from_vector(values, shape, Device::CPU).to(Device::GPU);
     }
 
+    Tensor uploadBool(const std::vector<bool>& values, const GpuBackend backend) {
+        GpuBackendScope scope(backend);
+        return Tensor::from_vector(values, TensorShape{values.size()}, Device::CPU).to(Device::GPU);
+    }
+
     std::vector<float> positions(const size_t count) {
         std::vector<float> values(count * 2);
         for (size_t i = 0; i < count; ++i) {
@@ -46,6 +54,32 @@ namespace {
             values[i * 2 + 1] = static_cast<float>((i * 53) % 480);
         }
         return values;
+    }
+
+    bool cpuDisk(const float x, const float y, const float mx, const float my, const float radius) {
+        if (!(x >= kInvalidThreshold) || !(y >= kInvalidThreshold)) {
+            return false;
+        }
+        const float dx = x - mx;
+        const float dy = y - my;
+        return dx * dx + dy * dy <= radius * radius;
+    }
+
+    bool cpuPointInPolygon(const float px, const float py, const std::vector<float>& poly) {
+        const int n = static_cast<int>(poly.size() / 2);
+        bool inside = false;
+        for (int i = 0, j = n - 1; i < n; j = i++) {
+            const float yi = poly[static_cast<size_t>(i) * 2 + 1];
+            const float yj = poly[static_cast<size_t>(j) * 2 + 1];
+            if ((yi > py) != (yj > py)) {
+                const float xi = poly[static_cast<size_t>(i) * 2];
+                const float xj = poly[static_cast<size_t>(j) * 2];
+                if (px < (xj - xi) * (py - yi) / (yj - yi) + xi) {
+                    inside = !inside;
+                }
+            }
+        }
+        return inside;
     }
 } // namespace
 
@@ -95,5 +129,204 @@ TEST(SelectionScreenOps, PickFindsTheNearestValidPositionAndBreaksTiesHigh) {
         EXPECT_EQ(lfs::rendering::pick_projected_gaussian_tensor(screen, -5000.0f, -5000.0f, 4.0f), -1);
         const Tensor none = upload(std::vector<float>(8, kInvalid), TensorShape{4, 2}, backend);
         EXPECT_EQ(lfs::rendering::pick_projected_gaussian_tensor(none, 0.0f, 0.0f, 1.0e9f), -1);
+    }
+}
+
+TEST(SelectionScreenOps, BrushMatchesCpuDiskAndSkipsInvalid) {
+    constexpr size_t n = 2003;
+    auto values = positions(n);
+    values[10 * 2] = kInvalid;
+    values[11 * 2 + 1] = kInvalid;
+    values[12 * 2] = std::numeric_limits<float>::quiet_NaN();
+    values[13 * 2] = 200.0f;
+    values[13 * 2 + 1] = 150.0f;
+    values[14 * 2] = std::numeric_limits<float>::infinity();
+    values[14 * 2 + 1] = 150.0f;
+    values[15 * 2] = 200.0f;
+    values[15 * 2 + 1] = -std::numeric_limits<float>::infinity();
+    constexpr float mx = 200.0f;
+    constexpr float my = 150.0f;
+    constexpr float radius = 12.5f;
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor screen = upload(values, TensorShape{n, 2}, backend);
+        std::vector<bool> seed(n, false);
+        seed[5] = true;
+        Tensor selection = uploadBool(seed, backend);
+        lfs::rendering::brush_select_tensor(screen, mx, my, radius, selection);
+        const auto got = selection.to_vector_bool();
+        size_t selected = 0;
+        for (size_t i = 0; i < n; ++i) {
+            const bool expected = seed[i] || cpuDisk(values[i * 2], values[i * 2 + 1], mx, my, radius);
+            EXPECT_EQ(got[i], expected) << "index=" << i;
+            selected += got[i] ? 1 : 0;
+        }
+        EXPECT_GT(selected, 1u);
+        EXPECT_TRUE(got[13]);
+        EXPECT_FALSE(got[10]);
+        EXPECT_FALSE(got[12]);
+        EXPECT_FALSE(got[14]);
+        EXPECT_FALSE(got[15]);
+    }
+}
+
+TEST(SelectionScreenOps, BrushProgramMatchesCudaKernel) {
+    if (!gpu_backend_available(GpuBackend::CUDA)) {
+        GTEST_SKIP() << "CUDA backend required for kernel vs program parity";
+    }
+    constexpr size_t n = 1024;
+    auto values = positions(n);
+    values[3 * 2] = kInvalid;
+    values[4 * 2] = 40.0f;
+    values[4 * 2 + 1] = 40.0f;
+    constexpr float mx = 40.0f;
+    constexpr float my = 40.0f;
+    constexpr float radius = 8.0f;
+    const Tensor screen = upload(values, TensorShape{n, 2}, GpuBackend::CUDA);
+    Tensor kernel_sel = uploadBool(std::vector<bool>(n, false), GpuBackend::CUDA);
+    Tensor program_sel = uploadBool(std::vector<bool>(n, false), GpuBackend::CUDA);
+    lfs::rendering::brush_select_tensor(screen, mx, my, radius, kernel_sel);
+    lfs::rendering::brush_select_tensor_program(screen, mx, my, radius, program_sel);
+    EXPECT_EQ(kernel_sel.to_vector_bool(), program_sel.to_vector_bool());
+}
+
+TEST(SelectionScreenOps, BrushStrokeUnionIsBoundedOrNotMatrix) {
+    constexpr size_t n = 64;
+    std::vector<float> values(n * 2, 0.0f);
+    values[0] = 10.0f;
+    values[1] = 10.0f;
+    values[2] = 18.0f;
+    values[3] = 10.0f;
+    values[4] = 50.0f;
+    values[5] = 50.0f;
+    values[6] = kInvalid;
+    values[7] = 10.0f;
+    const std::vector<float> disks{10.0f, 10.0f, 18.0f, 10.0f};
+    constexpr float radius = 3.0f;
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor screen = upload(values, TensorShape{n, 2}, backend);
+        Tensor selection = uploadBool(std::vector<bool>(n, false), backend);
+        lfs::rendering::brush_select_disks_tensor(screen, disks, radius, selection);
+        const auto got = selection.to_vector_bool();
+        EXPECT_TRUE(got[0]);
+        EXPECT_TRUE(got[1]);
+        EXPECT_FALSE(got[2]);
+        EXPECT_FALSE(got[3]);
+    }
+}
+
+TEST(SelectionScreenOps, BrushEmptyAndZeroRadius) {
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        Tensor empty_sel;
+        Tensor empty_screen;
+        lfs::rendering::brush_select_tensor(empty_screen, 0.0f, 0.0f, 4.0f, empty_sel);
+
+        std::vector<float> values{5.0f, 5.0f, 6.0f, 5.0f};
+        const Tensor screen = upload(values, TensorShape{2, 2}, backend);
+        Tensor selection = uploadBool(std::vector<bool>{false, false}, backend);
+        lfs::rendering::brush_select_tensor(screen, 5.0f, 5.0f, 0.0f, selection);
+        const auto got = selection.to_vector_bool();
+        EXPECT_TRUE(got[0]);
+        EXPECT_FALSE(got[1]);
+    }
+}
+
+TEST(SelectionScreenOps, PolygonEvenOddMatchesCpuAndSkipsInvalid) {
+    constexpr size_t n = 32;
+    std::vector<float> values(n * 2, 0.0f);
+    values[0] = 5.0f;
+    values[1] = 5.0f;
+    values[2] = 50.0f;
+    values[3] = 50.0f;
+    values[4] = kInvalid;
+    values[5] = 5.0f;
+    values[6] = 1.0f;
+    values[7] = 1.0f;
+    values[8] = 9.0f;
+    values[9] = 9.0f;
+    const std::vector<float> square{0.0f, 0.0f, 10.0f, 0.0f, 10.0f, 10.0f, 0.0f, 10.0f};
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor screen = upload(values, TensorShape{n, 2}, backend);
+        const Tensor polygon = upload(square, TensorShape{4, 2}, backend);
+        std::vector<bool> seed(n, false);
+        seed[2] = true;
+        Tensor selection = uploadBool(seed, backend);
+        lfs::rendering::polygon_select_tensor(screen, polygon, selection);
+        const auto got = selection.to_vector_bool();
+        for (size_t i = 0; i < n; ++i) {
+            const float x = values[i * 2];
+            const float y = values[i * 2 + 1];
+            const bool valid = x >= kInvalidThreshold && y >= kInvalidThreshold;
+            const bool expected = seed[i] || (valid && cpuPointInPolygon(x, y, square));
+            EXPECT_EQ(got[i], expected) << "index=" << i;
+        }
+        EXPECT_TRUE(got[0]);
+        EXPECT_FALSE(got[1]);
+        EXPECT_TRUE(got[2]);
+        Tensor short_poly_sel = uploadBool(std::vector<bool>(n, false), backend);
+        const Tensor line = upload({0.0f, 0.0f, 10.0f, 0.0f}, TensorShape{2, 2}, backend);
+        lfs::rendering::polygon_select_tensor(screen, line, short_poly_sel);
+        EXPECT_EQ(short_poly_sel.to_vector_bool(), std::vector<bool>(n, false));
+    }
+}
+
+TEST(SelectionScreenOps, PolygonProgramMatchesCudaKernel) {
+    if (!gpu_backend_available(GpuBackend::CUDA)) {
+        GTEST_SKIP() << "CUDA backend required for kernel vs program parity";
+    }
+    constexpr size_t n = 64;
+    auto values = positions(n);
+    const std::vector<float> bowtie{
+        0.0f,
+        0.0f,
+        40.0f,
+        40.0f,
+        40.0f,
+        0.0f,
+        0.0f,
+        40.0f,
+    };
+    const Tensor screen = upload(values, TensorShape{n, 2}, GpuBackend::CUDA);
+    const Tensor polygon = upload(bowtie, TensorShape{4, 2}, GpuBackend::CUDA);
+    Tensor kernel_sel = uploadBool(std::vector<bool>(n, false), GpuBackend::CUDA);
+    Tensor program_sel = uploadBool(std::vector<bool>(n, false), GpuBackend::CUDA);
+    lfs::rendering::polygon_select_tensor(screen, polygon, kernel_sel);
+    lfs::rendering::polygon_select_tensor_program(screen, polygon, program_sel);
+    EXPECT_EQ(kernel_sel.to_vector_bool(), program_sel.to_vector_bool());
+}
+
+TEST(SelectionScreenOps, ProjectPinholeMarksBehindCameraInvalid) {
+    constexpr std::array<float, 9> rotation{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+    constexpr std::array<float, 3> translation{0.0f, 0.0f, 0.0f};
+    const std::vector<float> means{
+        0.0f,
+        0.0f,
+        -2.0f,
+        0.0f,
+        0.0f,
+        2.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+    };
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor gpu_means = upload(means, TensorShape{3, 3}, backend);
+        const auto projected = lfs::rendering::project_screen_positions_tensor(
+            gpu_means, 640, 480, rotation, translation, 500.0f, 500.0f,
+            320.0f, 240.0f, lfs::rendering::ScreenWindowCameraModel::Pinhole, 1.0f,
+            nullptr, nullptr, {});
+        ASSERT_TRUE(projected.is_valid());
+        const auto xy = projected.cpu().to_vector();
+        ASSERT_EQ(xy.size(), 6u);
+        EXPECT_GE(xy[0], kInvalidThreshold);
+        EXPECT_GE(xy[1], kInvalidThreshold);
+        EXPECT_LT(xy[2], kInvalidThreshold);
+        EXPECT_LT(xy[3], kInvalidThreshold);
+        EXPECT_LT(xy[4], kInvalidThreshold);
+        EXPECT_LT(xy[5], kInvalidThreshold);
     }
 }

--- a/tests/test_selection_tensor_projection.cpp
+++ b/tests/test_selection_tensor_projection.cpp
@@ -1,0 +1,616 @@
+/* SPDX-FileCopyrightText: 2026 LichtFeld Studio Authors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+
+// Screen-position projection as a tensor program. CPU reference copies
+// projectScreenPositionsKernel: pinhole/ortho reject view_z >= -1e-6, equirect
+// does not, hidden nodes and non-finite views write the invalid marker.
+
+#include "core/tensor.hpp"
+#include "core/tensor_backend.hpp"
+#include "rendering/selection_ops.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace {
+    using namespace lfs::core;
+    using lfs::rendering::ScreenWindowCameraModel;
+
+    constexpr float kInvalidFill = -1.0e8f;
+    constexpr float kInvalidThreshold = -1000.0f;
+    constexpr float kPi = 3.14159265358979323846f;
+
+    std::vector<GpuBackend> backends_under_test() {
+        std::vector<GpuBackend> backends{GpuBackend::CUDA};
+        if (gpu_backend_available(GpuBackend::Vulkan)) {
+            backends.push_back(GpuBackend::Vulkan);
+        }
+        return backends;
+    }
+
+    std::string label(const GpuBackend backend) {
+        return backend == GpuBackend::CUDA ? "cuda" : "vulkan";
+    }
+
+    Tensor upload(const std::vector<float>& values, const TensorShape& shape, const GpuBackend backend) {
+        GpuBackendScope scope(backend);
+        return Tensor::from_vector(values, shape, Device::CPU).to(Device::GPU);
+    }
+
+    Tensor uploadI32(const std::vector<int>& values, const GpuBackend backend) {
+        GpuBackendScope scope(backend);
+        return Tensor::from_vector(values, TensorShape{values.size()}, Device::CPU).to(Device::GPU);
+    }
+
+    bool isInvalid(const float x, const float y) {
+        return x < kInvalidThreshold || y < kInvalidThreshold;
+    }
+
+    void cpuProject(const std::vector<float>& means,
+                    const int width,
+                    const int height,
+                    const std::array<float, 9>& rotation,
+                    const std::array<float, 3>& translation,
+                    const float fx,
+                    const float fy,
+                    const float cx,
+                    const float cy,
+                    const ScreenWindowCameraModel model,
+                    const float ortho_scale,
+                    const std::vector<float>* const transforms,
+                    const std::vector<int>* const indices,
+                    const std::vector<bool>& visibility,
+                    std::vector<float>& out_xy) {
+        const size_t n = means.size() / 3;
+        out_xy.assign(n * 2, kInvalidFill);
+        const int transform_count = transforms ? static_cast<int>(transforms->size() / 16) : 0;
+        for (size_t i = 0; i < n; ++i) {
+            int transform_idx = indices ? (*indices)[i] : 0;
+            if (!visibility.empty() && indices) {
+                if (transform_idx < 0 ||
+                    transform_idx >= static_cast<int>(visibility.size()) ||
+                    !visibility[static_cast<size_t>(transform_idx)]) {
+                    continue;
+                }
+            }
+            float px = means[i * 3];
+            float py = means[i * 3 + 1];
+            float pz = means[i * 3 + 2];
+            if (transforms && transform_count > 0) {
+                transform_idx = std::clamp(transform_idx, 0, transform_count - 1);
+                const float* const m = transforms->data() + static_cast<size_t>(transform_idx) * 16;
+                const float ox = m[0] * px + m[1] * py + m[2] * pz + m[3];
+                const float oy = m[4] * px + m[5] * py + m[6] * pz + m[7];
+                const float oz = m[8] * px + m[9] * py + m[10] * pz + m[11];
+                px = ox;
+                py = oy;
+                pz = oz;
+            }
+            const float dx = px - translation[0];
+            const float dy = py - translation[1];
+            const float dz = pz - translation[2];
+            const float view_x = rotation[0] * dx + rotation[1] * dy + rotation[2] * dz;
+            const float view_y = rotation[3] * dx + rotation[4] * dy + rotation[5] * dz;
+            const float view_z = rotation[6] * dx + rotation[7] * dy + rotation[8] * dz;
+            if (!std::isfinite(view_x) || !std::isfinite(view_y) || !std::isfinite(view_z)) {
+                continue;
+            }
+            const bool equirect = model == ScreenWindowCameraModel::Equirectangular;
+            if (!equirect && view_z >= -1.0e-6f) {
+                continue;
+            }
+            if (equirect) {
+                const float eq_x = view_x;
+                const float eq_y = -view_y;
+                const float eq_z = -view_z;
+                const float len = std::sqrt(eq_x * eq_x + eq_y * eq_y + eq_z * eq_z);
+                if (len <= 1.0e-6f || !std::isfinite(len)) {
+                    continue;
+                }
+                const float dir_x = eq_x / len;
+                const float dir_y = eq_y / len;
+                const float dir_z = eq_z / len;
+                out_xy[i * 2] = (std::atan2(dir_x, dir_z) / (2.0f * kPi) + 0.5f) * static_cast<float>(width);
+                out_xy[i * 2 + 1] =
+                    (std::asin(std::clamp(dir_y, -1.0f, 1.0f)) / kPi + 0.5f) * static_cast<float>(height);
+                continue;
+            }
+            if (model == ScreenWindowCameraModel::Orthographic) {
+                if (!std::isfinite(ortho_scale) || ortho_scale <= 0.0f) {
+                    continue;
+                }
+                out_xy[i * 2] = cx + view_x * ortho_scale;
+                out_xy[i * 2 + 1] = cy - view_y * ortho_scale;
+                continue;
+            }
+            const float depth = -view_z;
+            out_xy[i * 2] = cx + view_x * fx / depth;
+            out_xy[i * 2 + 1] = cy - view_y * fy / depth;
+        }
+    }
+
+    void expectProjectedNear(const std::vector<float>& got,
+                             const std::vector<float>& expected,
+                             const float abs_tol,
+                             const char* tag) {
+        ASSERT_EQ(got.size(), expected.size()) << tag;
+        for (size_t i = 0; i < got.size(); i += 2) {
+            const bool got_invalid = isInvalid(got[i], got[i + 1]);
+            const bool exp_invalid = isInvalid(expected[i], expected[i + 1]);
+            EXPECT_EQ(got_invalid, exp_invalid) << tag << " index=" << (i / 2);
+            if (got_invalid || exp_invalid) {
+                continue;
+            }
+            EXPECT_NEAR(got[i], expected[i], abs_tol) << tag << " x index=" << (i / 2);
+            EXPECT_NEAR(got[i + 1], expected[i + 1], abs_tol) << tag << " y index=" << (i / 2);
+        }
+    }
+
+    constexpr std::array<float, 9> kRotation{
+        0.9393727f,
+        0.0f,
+        -0.3428978f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.3428978f,
+        0.0f,
+        0.9393727f,
+    };
+    constexpr std::array<float, 3> kTranslation{1.0f, -2.0f, 0.5f};
+} // namespace
+
+TEST(SelectionTensorProjection, EmptyMeans) {
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        GpuBackendScope scope(backend);
+        const Tensor means = Tensor::empty({0, 3}, Device::GPU, DataType::Float32);
+        const auto projected = lfs::rendering::project_screen_positions_tensor(
+            means, 64, 64, kRotation, kTranslation, 50.0f, 50.0f, 32.0f, 32.0f,
+            ScreenWindowCameraModel::Pinhole, 1.0f, nullptr, nullptr, {});
+        EXPECT_FALSE(projected.is_valid() && projected.numel() > 0);
+    }
+}
+
+TEST(SelectionTensorProjection, PinholeOrthoEquirectMatchCpu) {
+    const std::vector<float> means{
+        0.4f,
+        -0.2f,
+        -3.0f,
+        2.0f,
+        1.5f,
+        4.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        std::numeric_limits<float>::quiet_NaN(),
+        0.0f,
+        -2.0f,
+        -1.0f,
+        0.5f,
+        -8.0f,
+        0.1f,
+        -0.4f,
+        0.5f,
+    };
+    constexpr int width = 640;
+    constexpr int height = 480;
+    constexpr float fx = 500.0f;
+    constexpr float fy = 480.0f;
+    constexpr float cx = 320.0f;
+    constexpr float cy = 240.0f;
+    const ScreenWindowCameraModel models[] = {
+        ScreenWindowCameraModel::Pinhole,
+        ScreenWindowCameraModel::Orthographic,
+        ScreenWindowCameraModel::Equirectangular,
+    };
+    for (const auto model : models) {
+        std::vector<float> expected;
+        cpuProject(means, width, height, kRotation, kTranslation, fx, fy, cx, cy, model, 42.0f,
+                   nullptr, nullptr, {}, expected);
+        const float tol = model == ScreenWindowCameraModel::Equirectangular ? 2.0e-3f * width : 1.0e-3f;
+        for (const GpuBackend backend : backends_under_test()) {
+            SCOPED_TRACE(label(backend) + std::string(" model=") + std::to_string(static_cast<int>(model)));
+            const Tensor gpu_means = upload(means, TensorShape{6, 3}, backend);
+            const auto projected = lfs::rendering::project_screen_positions_tensor(
+                gpu_means, width, height, kRotation, kTranslation, fx, fy, cx, cy, model, 42.0f,
+                nullptr, nullptr, {});
+            ASSERT_TRUE(projected.is_valid());
+            expectProjectedNear(projected.cpu().to_vector(), expected, tol, "dispatch");
+            const auto program = lfs::rendering::project_screen_positions_tensor_program(
+                gpu_means, width, height, kRotation, kTranslation, fx, fy, cx, cy, model, 42.0f,
+                nullptr, nullptr, {});
+            expectProjectedNear(program.cpu().to_vector(), expected, tol, "program");
+        }
+    }
+}
+
+TEST(SelectionTensorProjection, HiddenNodesAndClampedTransforms) {
+    const std::vector<float> means{
+        0.0f,
+        0.0f,
+        -2.0f,
+        0.2f,
+        0.0f,
+        -2.0f,
+        -0.2f,
+        0.1f,
+        -2.0f,
+        0.0f,
+        0.2f,
+        -2.0f,
+    };
+    const std::vector<float> transforms{
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        1.5f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+    };
+    const std::vector<int> indices{0, 1, -4, 99};
+    const std::vector<bool> visibility{true, false};
+    std::vector<float> expected;
+    cpuProject(means, 320, 240, kRotation, kTranslation, 200.0f, 200.0f, 160.0f, 120.0f,
+               ScreenWindowCameraModel::Pinhole, 1.0f, &transforms, &indices, visibility, expected);
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor gpu_means = upload(means, TensorShape{4, 3}, backend);
+        const Tensor gpu_transforms = upload(transforms, TensorShape{2, 4, 4}, backend);
+        const Tensor gpu_indices = uploadI32(indices, backend);
+        const auto projected = lfs::rendering::project_screen_positions_tensor(
+            gpu_means, 320, 240, kRotation, kTranslation, 200.0f, 200.0f, 160.0f, 120.0f,
+            ScreenWindowCameraModel::Pinhole, 1.0f, &gpu_transforms, &gpu_indices, visibility);
+        expectProjectedNear(projected.cpu().to_vector(), expected, 1.0e-3f, "hidden");
+        EXPECT_TRUE(isInvalid(expected[2], expected[3]));
+        EXPECT_TRUE(isInvalid(expected[4], expected[5]));
+        EXPECT_TRUE(isInvalid(expected[6], expected[7]));
+    }
+}
+
+TEST(SelectionTensorProjection, NegativeOrthoScaleIsInvalid) {
+    const std::vector<float> means{0.0f, 0.0f, -2.0f};
+    const float bad_scales[] = {-5.0f, 0.0f, std::numeric_limits<float>::infinity()};
+    for (const float scale : bad_scales) {
+        for (const GpuBackend backend : backends_under_test()) {
+            SCOPED_TRACE(label(backend) + std::string(" scale=") + std::to_string(scale));
+            const Tensor gpu_means = upload(means, TensorShape{1, 3}, backend);
+            const auto projected = lfs::rendering::project_screen_positions_tensor(
+                gpu_means, 64, 64, kRotation, kTranslation, 10.0f, 10.0f, 32.0f, 32.0f,
+                ScreenWindowCameraModel::Orthographic, scale, nullptr, nullptr, {});
+            const auto xy = projected.cpu().to_vector();
+            ASSERT_EQ(xy.size(), 2u);
+            EXPECT_TRUE(isInvalid(xy[0], xy[1]));
+        }
+    }
+}
+
+TEST(SelectionTensorProjection, EquirectProjectsBehindCamera) {
+    const std::vector<float> means{0.0f, 0.0f, 2.0f};
+    constexpr std::array<float, 9> identity{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+    constexpr std::array<float, 3> origin{0.0f, 0.0f, 0.0f};
+    std::vector<float> expected;
+    cpuProject(means, 256, 128, identity, origin, 1.0f, 1.0f, 128.0f, 64.0f,
+               ScreenWindowCameraModel::Equirectangular, 1.0f, nullptr, nullptr, {}, expected);
+    ASSERT_FALSE(isInvalid(expected[0], expected[1]));
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor gpu_means = upload(means, TensorShape{1, 3}, backend);
+        const auto projected = lfs::rendering::project_screen_positions_tensor(
+            gpu_means, 256, 128, identity, origin, 1.0f, 1.0f, 128.0f, 64.0f,
+            ScreenWindowCameraModel::Equirectangular, 1.0f, nullptr, nullptr, {});
+        expectProjectedNear(projected.cpu().to_vector(), expected, 1.0f, "equirect-behind");
+    }
+}
+
+TEST(SelectionTensorProjection, CudaKernelMatchesProgramOnPinhole) {
+    if (!gpu_backend_available(GpuBackend::CUDA)) {
+        GTEST_SKIP() << "CUDA backend required for kernel vs program parity";
+    }
+    const std::vector<float> means{
+        0.3f,
+        -0.1f,
+        -1.5f,
+        -0.4f,
+        0.2f,
+        -4.0f,
+        1.0f,
+        0.0f,
+        3.0f,
+    };
+    const Tensor gpu_means = upload(means, TensorShape{3, 3}, GpuBackend::CUDA);
+    const auto kernel = lfs::rendering::project_screen_positions_tensor(
+        gpu_means, 800, 600, kRotation, kTranslation, 600.0f, 600.0f, 400.0f, 300.0f,
+        ScreenWindowCameraModel::Pinhole, 1.0f, nullptr, nullptr, {});
+    const auto program = lfs::rendering::project_screen_positions_tensor_program(
+        gpu_means, 800, 600, kRotation, kTranslation, 600.0f, 600.0f, 400.0f, 300.0f,
+        ScreenWindowCameraModel::Pinhole, 1.0f, nullptr, nullptr, {});
+    expectProjectedNear(kernel.cpu().to_vector(), program.cpu().to_vector(), 1.0e-4f, "cuda-vs-program");
+}
+
+TEST(SelectionTensorProjection, SingleModelTransformBroadcastsWithoutGather) {
+    const std::vector<float> means{0.0f, 0.0f, -2.0f, 0.4f, -0.2f, -3.0f};
+    const std::vector<float> transforms{
+        1.0f,
+        0.0f,
+        0.0f,
+        1.5f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+    };
+    const std::vector<int> indices{0, 0};
+    std::vector<float> expected;
+    cpuProject(means, 320, 240, kRotation, kTranslation, 200.0f, 200.0f, 160.0f, 120.0f,
+               ScreenWindowCameraModel::Pinhole, 1.0f, &transforms, &indices, {}, expected);
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor gpu_means = upload(means, TensorShape{2, 3}, backend);
+        const Tensor gpu_transforms = upload(transforms, TensorShape{1, 4, 4}, backend);
+        const Tensor gpu_indices = uploadI32(indices, backend);
+        const auto projected = lfs::rendering::project_screen_positions_tensor(
+            gpu_means, 320, 240, kRotation, kTranslation, 200.0f, 200.0f, 160.0f, 120.0f,
+            ScreenWindowCameraModel::Pinhole, 1.0f, &gpu_transforms, &gpu_indices, {});
+        expectProjectedNear(projected.cpu().to_vector(), expected, 1.0e-3f, "broadcast");
+        const auto program = lfs::rendering::project_screen_positions_tensor_program(
+            gpu_means, 320, 240, kRotation, kTranslation, 200.0f, 200.0f, 160.0f, 120.0f,
+            ScreenWindowCameraModel::Pinhole, 1.0f, &gpu_transforms, &gpu_indices, {});
+        expectProjectedNear(program.cpu().to_vector(), expected, 1.0e-3f, "broadcast-program");
+    }
+}
+
+TEST(SelectionTensorProjection, VisibleModelTransformsApplyPerIndex) {
+    const std::vector<float> means{
+        0.0f,
+        0.0f,
+        -2.0f,
+        0.0f,
+        0.0f,
+        -2.0f,
+        0.4f,
+        0.1f,
+        -3.0f,
+    };
+    const std::vector<float> transforms{
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        1.5f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        1.0f,
+    };
+    const std::vector<int> indices{0, 1, 1};
+    const std::vector<bool> visibility{true, true};
+    std::vector<float> expected;
+    cpuProject(means, 320, 240, kRotation, kTranslation, 200.0f, 200.0f, 160.0f, 120.0f,
+               ScreenWindowCameraModel::Pinhole, 1.0f, &transforms, &indices, visibility, expected);
+    ASSERT_FALSE(isInvalid(expected[0], expected[1]));
+    ASSERT_FALSE(isInvalid(expected[2], expected[3]));
+    EXPECT_GT(std::abs(expected[2] - expected[0]), 1.0f);
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor gpu_means = upload(means, TensorShape{3, 3}, backend);
+        const Tensor gpu_transforms = upload(transforms, TensorShape{2, 4, 4}, backend);
+        const Tensor gpu_indices = uploadI32(indices, backend);
+        const auto projected = lfs::rendering::project_screen_positions_tensor(
+            gpu_means, 320, 240, kRotation, kTranslation, 200.0f, 200.0f, 160.0f, 120.0f,
+            ScreenWindowCameraModel::Pinhole, 1.0f, &gpu_transforms, &gpu_indices, visibility);
+        expectProjectedNear(projected.cpu().to_vector(), expected, 1.0e-3f, "per-index");
+        const auto program = lfs::rendering::project_screen_positions_tensor_program(
+            gpu_means, 320, 240, kRotation, kTranslation, 200.0f, 200.0f, 160.0f, 120.0f,
+            ScreenWindowCameraModel::Pinhole, 1.0f, &gpu_transforms, &gpu_indices, visibility);
+        expectProjectedNear(program.cpu().to_vector(), expected, 1.0e-3f, "per-index-program");
+    }
+}
+
+TEST(SelectionTensorProjection, NonFiniteMeansAreInvalid) {
+    const std::vector<float> means{
+        std::numeric_limits<float>::infinity(),
+        0.0f,
+        -2.0f,
+        -std::numeric_limits<float>::infinity(),
+        0.0f,
+        -2.0f,
+        0.0f,
+        std::numeric_limits<float>::quiet_NaN(),
+        -2.0f,
+        0.0f,
+        0.0f,
+        std::numeric_limits<float>::infinity(),
+    };
+    std::vector<float> expected;
+    cpuProject(means, 64, 64, kRotation, kTranslation, 10.0f, 10.0f, 32.0f, 32.0f,
+               ScreenWindowCameraModel::Pinhole, 1.0f, nullptr, nullptr, {}, expected);
+    for (size_t i = 0; i < expected.size(); i += 2) {
+        EXPECT_TRUE(isInvalid(expected[i], expected[i + 1])) << "cpu index=" << (i / 2);
+    }
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor gpu_means = upload(means, TensorShape{4, 3}, backend);
+        const auto projected = lfs::rendering::project_screen_positions_tensor(
+            gpu_means, 64, 64, kRotation, kTranslation, 10.0f, 10.0f, 32.0f, 32.0f,
+            ScreenWindowCameraModel::Pinhole, 1.0f, nullptr, nullptr, {});
+        expectProjectedNear(projected.cpu().to_vector(), expected, 1.0e-3f, "nonfinite");
+    }
+}
+
+TEST(SelectionTensorProjection, EquirectViewZZeroMatchesAtan2Seam) {
+    const std::vector<float> means{1.0f, 0.0f, 0.0f};
+    constexpr std::array<float, 9> identity{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+    constexpr std::array<float, 3> origin{0.0f, 0.0f, 0.0f};
+    constexpr int width = 256;
+    std::vector<float> expected;
+    cpuProject(means, width, 128, identity, origin, 1.0f, 1.0f, 128.0f, 64.0f,
+               ScreenWindowCameraModel::Equirectangular, 1.0f, nullptr, nullptr, {}, expected);
+    ASSERT_FALSE(isInvalid(expected[0], expected[1]));
+    // A direction along +X maps to three quarters of the panorama width.
+    EXPECT_NEAR(expected[0], static_cast<float>(width) * 0.75f, 1.0e-3f);
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor gpu_means = upload(means, TensorShape{1, 3}, backend);
+        const auto projected = lfs::rendering::project_screen_positions_tensor(
+            gpu_means, width, 128, identity, origin, 1.0f, 1.0f, 128.0f, 64.0f,
+            ScreenWindowCameraModel::Equirectangular, 1.0f, nullptr, nullptr, {});
+        expectProjectedNear(projected.cpu().to_vector(), expected, 1.0f, "equirect-seam");
+        const auto program = lfs::rendering::project_screen_positions_tensor_program(
+            gpu_means, width, 128, identity, origin, 1.0f, 1.0f, 128.0f, 64.0f,
+            ScreenWindowCameraModel::Equirectangular, 1.0f, nullptr, nullptr, {});
+        expectProjectedNear(program.cpu().to_vector(), expected, 1.0f, "equirect-seam-program");
+    }
+}
+
+TEST(SelectionTensorProjection, MoreThanOneMillionExceedsOldCudaGridCap) {
+    // Old projectScreenPositionsKernel launch was
+    // min(ceil(n / 256), 4096) → 1,048,576 threads. n=1,100,003 leaves
+    // [1,048,576, n) unwritten under that cap; Tensor::empty tail would not
+    // match the CPU / program / Vulkan values.
+    constexpr int n = 1'100'003;
+    constexpr int kOldCudaThreadCap = 4096 * 256;
+    static_assert(n > kOldCudaThreadCap);
+    constexpr int width = 640;
+    constexpr int height = 480;
+    constexpr float fx = 500.0f;
+    constexpr float fy = 500.0f;
+    constexpr float cx = 320.0f;
+    constexpr float cy = 240.0f;
+    constexpr std::array<float, 9> identity{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+    constexpr std::array<float, 3> origin{0.0f, 0.0f, 0.0f};
+
+    std::vector<float> means(static_cast<size_t>(n) * 3);
+    for (int i = 0; i < n; ++i) {
+        means[static_cast<size_t>(i) * 3] = 0.25f + static_cast<float>(i) * 1.0e-6f;
+        means[static_cast<size_t>(i) * 3 + 1] = -0.1f;
+        means[static_cast<size_t>(i) * 3 + 2] = -2.0f;
+    }
+    std::vector<float> expected;
+    cpuProject(means, width, height, identity, origin, fx, fy, cx, cy,
+               ScreenWindowCameraModel::Pinhole, 1.0f, nullptr, nullptr, {}, expected);
+
+    const int probes[] = {0, kOldCudaThreadCap - 1, kOldCudaThreadCap, kOldCudaThreadCap + 1, n - 1};
+    auto tailMismatches = [&](const std::vector<float>& got, const char* tag) {
+        EXPECT_EQ(got.size(), expected.size()) << tag;
+        if (got.size() != expected.size()) {
+            return;
+        }
+        for (const int i : probes) {
+            const size_t x = static_cast<size_t>(i) * 2;
+            EXPECT_NEAR(got[x], expected[x], 1.0e-3f) << tag << " x index=" << i;
+            EXPECT_NEAR(got[x + 1], expected[x + 1], 1.0e-3f) << tag << " y index=" << i;
+        }
+        size_t mismatches = 0;
+        size_t first = static_cast<size_t>(n);
+        for (int i = kOldCudaThreadCap; i < n; ++i) {
+            const size_t x = static_cast<size_t>(i) * 2;
+            if (std::abs(got[x] - expected[x]) > 1.0e-3f ||
+                std::abs(got[x + 1] - expected[x + 1]) > 1.0e-3f) {
+                if (first == static_cast<size_t>(n)) {
+                    first = static_cast<size_t>(i);
+                }
+                ++mismatches;
+            }
+        }
+        EXPECT_EQ(mismatches, 0u) << tag << " first tail mismatch index=" << first;
+    };
+
+    std::vector<float> cuda_tail;
+    for (const GpuBackend backend : backends_under_test()) {
+        SCOPED_TRACE(label(backend));
+        const Tensor gpu_means = upload(means, TensorShape{static_cast<size_t>(n), 3}, backend);
+        const auto projected = lfs::rendering::project_screen_positions_tensor(
+            gpu_means, width, height, identity, origin, fx, fy, cx, cy,
+            ScreenWindowCameraModel::Pinhole, 1.0f, nullptr, nullptr, {});
+        ASSERT_TRUE(projected.is_valid());
+        const auto got = projected.cpu().to_vector();
+        tailMismatches(got, "dispatch");
+        const auto program = lfs::rendering::project_screen_positions_tensor_program(
+            gpu_means, width, height, identity, origin, fx, fy, cx, cy,
+            ScreenWindowCameraModel::Pinhole, 1.0f, nullptr, nullptr, {});
+        tailMismatches(program.cpu().to_vector(), "program");
+        if (backend == GpuBackend::CUDA) {
+            cuda_tail = got;
+        } else if (!cuda_tail.empty()) {
+            tailMismatches(got, "vulkan-vs-cpu");
+            ASSERT_EQ(got.size(), cuda_tail.size());
+            size_t mismatches = 0;
+            size_t first = static_cast<size_t>(n);
+            for (int i = kOldCudaThreadCap; i < n; ++i) {
+                const size_t x = static_cast<size_t>(i) * 2;
+                if (std::abs(got[x] - cuda_tail[x]) > 1.0e-3f ||
+                    std::abs(got[x + 1] - cuda_tail[x + 1]) > 1.0e-3f) {
+                    if (first == static_cast<size_t>(n)) {
+                        first = static_cast<size_t>(i);
+                    }
+                    ++mismatches;
+                }
+            }
+            EXPECT_EQ(mismatches, 0u) << "vulkan vs cuda first tail mismatch index=" << first;
+        }
+    }
+}


### PR DESCRIPTION
Enable Vulkan tensor projection, brush and polygon selection instead of downloading positions or rejecting the operation. Keep scratch buffers on the source backend and fix CUDA projection leaving points beyond the old one-million-point limit unwritten.

On all 16 million Pier90 points, masks and counts match CPU references. Vulkan projection takes about 51 ms versus 211 ms for the CPU round trip; the CUDA kernel stays in place. Includes camera/visibility tests and a repeatable selection benchmark.

Validation: 20 focused selection tests passed, including all supported camera models and a 1.1-million-point tail regression.
